### PR TITLE
rust-bindgen: update to 0.63.0.

### DIFF
--- a/srcpkgs/rust-bindgen/template
+++ b/srcpkgs/rust-bindgen/template
@@ -1,6 +1,6 @@
 # Template file for 'rust-bindgen'
 pkgname=rust-bindgen
-version=0.61.0
+version=0.63.0
 revision=1
 build_style="cargo"
 configure_args="--bins"
@@ -13,7 +13,7 @@ license="BSD-3-Clause"
 homepage="https://rust-lang.github.io/rust-bindgen/"
 changelog="https://raw.githubusercontent.com/rust-lang/rust-bindgen/master/CHANGELOG.md"
 distfiles="https://github.com/rust-lang/rust-bindgen/archive/refs/tags/v${version}.tar.gz"
-checksum="889ef7f1edd5db50e4e3e39b84e52b360ebe2f42a916adaf0ac97586419d885e"
+checksum="9fdfea04da35b9f602967426e4a5893e4efb453bceb0d7954efb1b3c88caaf33"
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-gnu)
- I built this PR locally for these architectures (crossbuilds):
  - aarch64
  - aarch64-musl
  - armv6l
  - armv6l-musl
  - i686
  - x86_64-musl

