### PR TITLE
ipp-usb: update to 0.9.23.

### DIFF
--- a/srcpkgs/ipp-usb/template
+++ b/srcpkgs/ipp-usb/template
@@ -1,6 +1,6 @@
 # Template file for 'ipp-usb'
 pkgname=ipp-usb
-version=0.9.22
+version=0.9.23
 revision=1
 build_style=go
 go_import_path="github.com/OpenPrinting/ipp-usb"
@@ -13,7 +13,7 @@ maintainer="Philipp David <pd@3b.pm>"
 license="BSD-2-Clause"
 homepage="https://github.com/OpenPrinting/ipp-usb"
 distfiles="https://github.com/OpenPrinting/ipp-usb/archive/$version.tar.gz"
-checksum=57f9bea4b41deb0f43957e24b3cf3a3a71050238abaea64d916b2e9a294d7aaf
+checksum=81f325abc45b4d2b8812022d93dfcebc807c2b0688e2a9f7052f0bddfadf5b01
 
 post_install() {
 	vsv ipp-usb


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
This release contains essentially just a single bug fix made in this commit: https://github.com/OpenPrinting/ipp-usb/commit/04d3e39d5b879eec57198de41356f05d62aaff7a