### PR TITLE
socat: update to 1.7.4.4.

### DIFF
--- a/srcpkgs/socat/template
+++ b/srcpkgs/socat/template
@@ -1,6 +1,6 @@
 # Template file for 'socat'
 pkgname=socat
-version=1.7.4.3
+version=1.7.4.4
 revision=1
 build_style=gnu-configure
 configure_args="--disable-libwrap --enable-fips
@@ -10,12 +10,12 @@ short_desc="Relay for bidirectional data transfer between two independent channe
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-only"
 homepage="http://www.dest-unreach.org/socat/"
+changelog="http://www.dest-unreach.org/socat/doc/CHANGES"
 distfiles="http://www.dest-unreach.org/socat/download/socat-${version}.tar.bz2"
-checksum=d47318104415077635119dfee44bcfb41de3497374a9a001b1aff6e2f0858007
+checksum=fbd42bd2f0e54a3af6d01bdf15385384ab82dbc0e4f1a5e153b3e0be1b6380ac
 
 case "$XBPS_TARGET_MACHINE" in
 	*-musl) CFLAGS="-D_LINUX_IF_ETHER_H"
-		configure_args+=" sc_cv_getprotobynumber_r=2"
 		;;
 esac
 


### PR DESCRIPTION
The extra `configure_args` for musl is no longer necessary since this has been fixed upstream.

See: https://repo.or.cz/socat.git/commit/75cb44bc90577c3487458564ca803163681319f1

#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-musl
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl (crossbuild)
  - aarch64 (crossbuild)
  - armv7l-musl (crossbuild)
  - armv7l (crossbuild)
  - x86_64 (crossbuild)
