### PR TITLE
python3-pycryptodomex: update to 3.16.0.

### DIFF
--- a/srcpkgs/python3-pycryptodomex/template
+++ b/srcpkgs/python3-pycryptodomex/template
@@ -1,7 +1,7 @@
 # Template file for 'python3-pycryptodomex'
 pkgname=python3-pycryptodomex
-version=3.15.0
-revision=2
+version=3.16.0
+revision=1
 build_style=python3-module
 hostmakedepends="python3-setuptools"
 makedepends="python3-devel"
@@ -12,7 +12,7 @@ license="Public Domain, BSD-2-Clause"
 homepage="https://www.pycryptodome.org/"
 changelog="https://www.pycryptodome.org/en/latest/src/changelog.html"
 distfiles="${PYPI_SITE}/p/pycryptodomex/pycryptodomex-${version}.tar.gz"
-checksum=7341f1bb2dadb0d1a0047f34c3a58208a92423cdbd3244d998e4b28df5eac0ed
+checksum=e9ba9d8ed638733c9e95664470b71d624a6def149e2db6cc52c1aca5a6a2df1d
 
 post_install() {
 	vlicense LICENSE.rst


### PR DESCRIPTION
I tested the changes in this PR: **briefly**

```
~ ❯ salt --versions | ag '(Salt|dome):'
/usr/lib/python3.11/site-packages/_distutils_hack/__init__.py:33: UserWarning: Setuptools is replacing distutils.
  warnings.warn("Setuptools is replacing distutils.")
          Salt: 3005
  pycryptodome: 3.16.0
```

That stuff about distuils comes from Salt, not Cryptodome:
```
~ ❯ ag distutils /usr/lib/python3.11/site-packages/{Cryptodome,salt}
/usr/lib/python3.11/site-packages/salt/modules/virtualenv_mod.py
352:        "from distutils import sysconfig; print(sysconfig.get_python_lib())",

/usr/lib/python3.11/site-packages/salt/modules/puppet.py
9:from distutils import version  # pylint: disable=no-name-in-module

/usr/lib/python3.11/site-packages/salt/utils/pkg/win.py
78:    from distutils.version import LooseVersion  # pylint: disable=blacklisted-module

/usr/lib/python3.11/site-packages/salt/utils/versions.py
9:    Version parsing based on distutils.version which works under python 3
22:from distutils.version import LooseVersion as _LooseVersion
23:from distutils.version import StrictVersion as _StrictVersion

/usr/lib/python3.11/site-packages/salt/cloud/deploy/bootstrap-salt.sh
3873:        __PACKAGES="python${PY_PKG_VER}-distutils"
```
