### PR TITLE
cross-arm-none-eabi-gdb: update to 12.1, fix build for gcc-12

### DIFF
--- a/srcpkgs/cross-arm-none-eabi-gdb/template
+++ b/srcpkgs/cross-arm-none-eabi-gdb/template
@@ -1,7 +1,7 @@
 # Template file for 'cross-arm-none-eabi-gdb'
 pkgname=cross-arm-none-eabi-gdb
-version=11.1
-revision=3
+version=12.1
+revision=1
 build_style=gnu-configure
 configure_args="--target=arm-none-eabi --disable-werror --disable-nls --with-system-readline
  --with-system-gdbinit=/etc/gdb/gdbinit --with-system-zlib --without-isl
@@ -18,9 +18,8 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-3.0-or-later"
 homepage="https://www.gnu.org/software/gdb"
 distfiles="${GNU_SITE}/gdb/gdb-${version}.tar.xz"
-checksum=cccfcc407b20d343fb320d4a9a2110776dd3165118ffd41f4b1b162340333f94
+checksum=0e1793bf8f2b54d53f46dea84ccfd446f48f81b297b28c4f7fc017b818d69fed
 make_check=no  # See gdb/template.
-patch_args="-Np1"
 
 if [ "${CROSS_BUILD}" ]; then
 	# Make python3.x detection work in cross builds


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **NO**

#### Local build testing
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch (cross built from x86-64)

