### PR TITLE
electron19: fix build with Python 3.11

### DIFF
--- a/srcpkgs/electron19/template
+++ b/srcpkgs/electron19/template
@@ -198,6 +198,9 @@ pre_configure() {
 	sed 's|//third_party/usb_ids/usb.ids|/usr/share/hwdata/usb.ids|g' \
 		-i services/device/public/cpp/usb/BUILD.gn
 
+	vsed -e 's|python3.10|python3.11|g' -i third_party/electron_node/configure
+	vsed -e "s|(3, 10)|(3, 11)|" -i third_party/electron_node/configure
+
 	mkdir -p third_party/node/linux/node-linux-x64/bin
 	ln -sf /usr/bin/node third_party/node/linux/node-linux-x64/bin/
 	rm -f third_party/devtools-frontend/src/third_party/esbuild/esbuild


### PR DESCRIPTION
I didn't manage to apply a proper patch, but this at least fixes the build.

[ci skip]

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
