### PR TITLE
spotify: Fix missing icon in KDE task manager

### DIFF
--- a/srcpkgs/spotify/template
+++ b/srcpkgs/spotify/template
@@ -1,7 +1,7 @@
 # Template file for 'spotify'
 pkgname=spotify
 version=1.1.84
-revision=3
+revision=4
 archs="x86_64"
 create_wrksrc=yes
 hostmakedepends="curl w3m libcurl"
@@ -36,8 +36,7 @@ do_install() {
 	vmkdir usr/libexec/
 	vcopy usr/share/spotify usr/libexec/
 
-	# move icons to /usr/share
-	mv "${DESTDIR}/usr/libexec/spotify/icons" "${DESTDIR}/usr/share/spotify/"
+	ln -s "../../libexec/spotify/icons" "${DESTDIR}/usr/share/spotify/"
 
 	# install icons
 	for _s in 16 22 24 32 48 64 128 256 512; do


### PR DESCRIPTION
Spotify onlys get a generic "X11" icon in the task manager. No window title is shown either.

The template moves the "icons" folder provided by spotify to /usr/share/spotify. However, it appears that spotify searches for the icons in /usr/libexec/spotify.

Create a symlink to /usr/share/spotify/icons so spotify finds the icons again.

This makes the spotify icon appear in the KDE taskbar. It also sets the title of the spotify window.

Fixes: #36615

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: YES
<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
