### PR TITLE
kanshi: add dependency on libvarlink to enable building kanshictl

### DIFF
--- a/srcpkgs/kanshi/template
+++ b/srcpkgs/kanshi/template
@@ -1,10 +1,10 @@
 # Template file for 'kanshi'
 pkgname=kanshi
 version=1.3.0
-revision=1
+revision=2
 build_style=meson
 hostmakedepends="pkg-config scdoc wayland-devel"
-makedepends="wayland-devel"
+makedepends="wayland-devel libvarlink-devel"
 short_desc="Output profiles automatically enabled/disabled on hotplug"
 maintainer="Stacy Harper <contact@stacyharper.net>"
 license="MIT"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

The most recent release of kanshi added an optional kanshictl utility, which
uses varlink. If libvarlink-devel is available at build time, meson will
automatically enable that functionality and provide both the binary and the man
page for it.

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
