### PR TITLE
Signal-Desktop: update to 6.0.1.

### DIFF
--- a/srcpkgs/Signal-Desktop/template
+++ b/srcpkgs/Signal-Desktop/template
@@ -1,6 +1,6 @@
 # Template file for 'Signal-Desktop'
 pkgname=Signal-Desktop
-version=6.0.0
+version=6.0.1
 revision=1
 # Signal officially only supports x86_64 (also due to Electron)
 # x86_64-musl fails because of its dependency on 'node-gyp' which depends on a glibc specific extension
@@ -13,7 +13,7 @@ maintainer="akierig <anelki@fastmail.de>"
 license="AGPL-3.0-only"
 homepage="https://github.com/signalapp/Signal-Desktop"
 distfiles="https://github.com/signalapp/Signal-Desktop/archive/v${version}.tar.gz"
-checksum=8ca77362a6f567c48cba798a4683499a8c651cefe67be2cdfc9c7fb4daf8800b
+checksum=b7c7b2824d1340ee4dee0a20ffe2883ccde610cb98b4f8d6d2b44f70130e384c
 nostrip_files="signal-desktop"
 
 post_extract() {


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc

CC @akierig