### PR TITLE
discord-ptb: update to 0.0.38.

### DIFF
--- a/srcpkgs/discord-ptb/files/LICENSE
+++ b/srcpkgs/discord-ptb/files/LICENSE
@@ -1,0 +1,1 @@
+The current version of this license can be found at: https://discord.com/terms

--- a/srcpkgs/discord-ptb/template
+++ b/srcpkgs/discord-ptb/template
@@ -1,9 +1,8 @@
 # Template file for 'discord-ptb'
 pkgname=discord-ptb
-version=0.0.35
-revision=3
+version=0.0.38
+revision=1
 archs="x86_64"
-hostmakedepends="w3m"
 depends="alsa-lib dbus-glib gtk+3 libnotify nss libXtst libcxx libatomic
  xdg-utils webrtc-audio-processing"
 short_desc="Chat and VoIP application (preview version)"
@@ -11,23 +10,12 @@ maintainer="0x5c <dev@0x5c.io>"
 license="custom:Proprietary"
 homepage="https://discord.com/"
 distfiles="https://dl-ptb.discordapp.net/apps/linux/${version}/discord-ptb-${version}.tar.gz"
-checksum=6e7a79c1f711db5b3b2cc3f11608f91b752cc4f5a5163e2de826dea2c8ae7c76
+checksum=6cf83b64d410c44a514a9a7c8f9fd72c10c427221df260c6c52eadaa4cf3235b
 nopie=yes
 restricted=yes
 repository=nonfree
 nostrip=yes
-
-post_extract() {
-	local _license_checksum=bbe45a50d92f383311376477dd6ebecefff801b5d47685757107b6f771cac58d
-	$XBPS_FETCH_CMD -o eula https://discord.com/terms
-	w3m -dump -I utf-8 -T text/html eula |
-		sed -n '/Discord is your place/,/^Imagine a place$/p' > EULA
-
-	filesum="$(xbps-digest EULA)"
-	if [ "$filesum" != "$_license_checksum" ]; then
-		msg_error "SHA256 mismatch for EULA:\n$filesum\n"
-	fi
-}
+noshlibprovides=yes
 
 do_install() {
 	local package_location="usr/lib/$pkgname" item
@@ -36,14 +24,34 @@ do_install() {
 	vmkdir usr/share/applications
 	vcopy discord-ptb.desktop /usr/share/applications/
 	vmkdir ${package_location}
-	for item in DiscordPTB chrome_100_percent.pak chrome_200_percent.pak \
-	icudtl.dat libEGL.so libGLESv2.so libffmpeg.so locales resources \
-	resources.pak snapshot_blob.bin swiftshader v8_context_snapshot.bin \
-	discord.png chrome-sandbox libvk_swiftshader.so postinst.sh ; do
+	for item in \
+		DiscordPTB \
+		discord.png \
+		chrome_100_percent.pak \
+		chrome_200_percent.pak \
+		chrome_crashpad_handler \
+		chrome-sandbox \
+		icudtl.dat \
+		libEGL.so \
+		libffmpeg.so \
+		libGLESv2.so \
+		libvk_swiftshader.so \
+		libvulkan.so.1 \
+		locales \
+		postinst.sh \
+		resources \
+		resources.pak \
+		snapshot_blob.bin \
+		swiftshader \
+		v8_context_snapshot.bin \
+		vk_swiftshader_icd.json
+	do
 		vcopy "${item}" "${package_location}"
 	done
 	vmkdir usr/bin
 	ln -sfr $DESTDIR/${package_location}/DiscordPTB $DESTDIR/usr/bin/discord-ptb
+}
 
-	vlicense EULA
+post_install() {
+	vlicense $FILESDIR/LICENSE
 }


### PR DESCRIPTION
Switch away from the janky EULA download setup in favour of a file that links to the actual current version of the terms, just like the discord package.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
