### PR TITLE
ibus-hangul: update to 1.5.4.

### DIFF
--- a/srcpkgs/ibus-hangul/template
+++ b/srcpkgs/ibus-hangul/template
@@ -1,18 +1,18 @@
 # Template file for 'ibus-hangul'
 pkgname=ibus-hangul
-version=1.5.3
+version=1.5.4
 revision=1
 build_style=gnu-configure
-configure_args="--libexec=/usr/lib/ibus --with-python=/usr/bin/python3"
+configure_args="--with-python=/usr/bin/python3"
 hostmakedepends="gettext libtool pkg-config swig"
-makedepends="ibus-devel libhangul-devel"
+makedepends="ibus-devel libhangul-devel gtk+3-devel"
 depends="ibus librsvg python3-gobject"
 short_desc="Korean input engine for IBus"
 maintainer="Michael Aldridge <maldridge@voidlinux.org>"
 license="GPL-2.0-or-later"
-homepage="https://github.com/choehwanjin/ibus-hangul"
-distfiles="${homepage}/releases/download/${version}/${pkgname}-${version}.tar.gz"
-checksum=5e661cd77a327b1eafacd537f7d839a61a374e951bd382044e799371855a0090
+homepage="https://github.com/libhangul/ibus-hangul"
+distfiles="https://github.com/libhangul/ibus-hangul/releases/download/${version}/${pkgname}-${version}.tar.gz"
+checksum=a9f27ef9b0c03fd9f2faa327fb0a83c04098763969548b65b2f8159bed15cfe0
 
 if [ "$CROSS_BUILD" ]; then
 	hostmakedepends+=" python3"

--- a/srcpkgs/ibus-hangul/update
+++ b/srcpkgs/ibus-hangul/update
@@ -1,1 +1,0 @@
-site="https://github.com/choehwanjin/ibus-hangul/releases"


### PR DESCRIPTION
Compilation check: x86_64*, i686.
Changed upstream URL to newer libhangul/ibus-hangul.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
