### PR TITLE
Fix utempter

### DIFF
--- a/srcpkgs/libutempter/INSTALL
+++ b/srcpkgs/libutempter/INSTALL
@@ -1,0 +1,6 @@
+case "${ACTION}" in
+post)
+	chgrp utmp usr/lib/utempter/utempter
+	chmod g+s usr/lib/utempter/utempter
+	;;
+esac

--- a/srcpkgs/libutempter/template
+++ b/srcpkgs/libutempter/template
@@ -1,7 +1,7 @@
 # Template file for 'libutempter'
 pkgname=libutempter
 version=1.2.1
-revision=1
+revision=2
 build_style=gnu-makefile
 short_desc="Library interface to record user sessions in utmp/wtmp files"
 maintainer="Orphaned <orphan@voidlinux.org>"

--- a/srcpkgs/screen/template
+++ b/srcpkgs/screen/template
@@ -1,13 +1,13 @@
 # Template file for 'screen'
 pkgname=screen
 version=4.9.0
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--with-sys-screenrc=/etc/screenrc --enable-pam
  --enable-colors256 --enable-rxvt_osc --enable-telnet
  --enable-use-locale --with-socket-dir=/run/screens --with-pty-group=5"
 hostmakedepends="automake"
-makedepends="pam-devel ncurses-devel"
+makedepends="libutempter-devel ncurses-devel pam-devel"
 conf_files="/etc/screenrc /etc/skel/.screenrc"
 short_desc="GNU screen manager with VT100/ANSI terminal emulation"
 maintainer="Frank Steinborn <steinex@nognu.de>"

--- a/srcpkgs/tmux/template
+++ b/srcpkgs/tmux/template
@@ -1,10 +1,11 @@
 # Template file for 'tmux'
 pkgname=tmux
 version=3.3a
-revision=1
+revision=2
 build_style=gnu-configure
+configure_args="--enable-utempter"
 hostmakedepends="byacc automake pkg-config"
-makedepends="libevent-devel ncurses-devel"
+makedepends="libevent-devel libutempter-devel ncurses-devel"
 depends="ncurses-base"
 short_desc="Terminal Multiplexer"
 maintainer="Đoàn Trần Công Danh <congdanhqx@gmail.com>"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

utempter was not installed setgid `utmp`, so it didn't work.

Enable utempter for screen and tmux.

ping @sgn and @steinex.

#### Testing the changes
- I tested the changes in this PR: **YES***
<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
