### PR TITLE
keepassxc: remove newline in licenses

### DIFF
--- a/srcpkgs/keepassxc/template
+++ b/srcpkgs/keepassxc/template
@@ -21,7 +21,7 @@ makedepends="qt5-tools-devel qt5-svg-devel botan-devel libargon2-devel
 checkdepends="xvfb-run"
 short_desc="KeePassXC is a cross-platform port of “Keepass Password Safe”"
 maintainer="Piraty <mail@piraty.dev>"
-license="GPL-3.0-or-later, BSD-3-Clause, CC0-1.0, LGPL-2.0-only, LGPL-2.1-only,
+license="GPL-3.0-or-later, BSD-3-Clause, CC0-1.0, LGPL-2.0-only, LGPL-2.1-only,\
  LGPL-3.0-or-later, Nokia-Qt-exception-1.1, MIT, BSL-1.0"
 homepage="https://keepassxc.org/"
 changelog="https://raw.githubusercontent.com/keepassxreboot/keepassxc/${version}/CHANGELOG.md"


### PR DESCRIPTION
I was parsing the entire void-packages repo and I have noticed that the keepassxc template behaves differently than all other 13 000 packages.

When You run `./xbps-src show <package>`, You (and I) would expect that `xbps-src` will display its arguments in the form `key: value` for every line printed. For example for the linux metapackage:

```
> ./xbps-src show linux
pkgname:	linux
version:	6.0
revision:	1
maintainer:	Leah Neukirchen <leah@vuxu.org>
Upstream URL:	http://www.voidlinux.org/
License(s):	Public Domain
build_style:	meta
short_desc:	Linux kernel meta package
subpackages:	linux-headers
```

Literally every package behaves like this except keepassxc. keepassxc does this:

```
> ./xbps-src show keepassxc
pkgname:	keepassxc
version:	2.7.4
revision:	1
distfiles:	https://github.com/keepassxreboot/keepassxc/releases/download/2.7.4/keepassxc-2.7.4-src.tar.xz
checksum:	560052961da0389327e759171f660230dfa4e0f4e1fab6139600fb85c6e5dece
maintainer:	Piraty <mail@piraty.dev>
Upstream URL:	https://keepassxc.org/
License(s):	GPL-3.0-or-later, BSD-3-Clause, CC0-1.0, LGPL-2.0-only, LGPL-2.1-only,
 LGPL-3.0-or-later, Nokia-Qt-exception-1.1, MIT, BSL-1.0
Changelog:	https://raw.githubusercontent.com/keepassxreboot/keepassxc/2.7.4/CHANGELOG.md
build_style:	cmake
configure_args:	-DWITH_TESTS=ON
configure_args:	-DWITH_XC_UPDATECHECK=OFF
configure_args:	-DWITH_XC_DOCS=ON
configure_args:	-DWITH_XC_AUTOTYPE=ON
configure_args:	-DWITH_XC_BROWSER=ON
configure_args:	-DWITH_XC_FDOSECRETS=ON
configure_args:	-DWITH_XC_KEESHARE=ON
configure_args:	-DWITH_XC_NETWORKING=ON
configure_args:	-DWITH_XC_SSHAGENT=ON
configure_args:	-DWITH_XC_YUBIKEY=ON
short_desc:	KeePassXC is a cross-platform port of “Keepass Password Safe”
```

For the sake of consistency, I'm removing the newline. This isn't really a bug but as I said this is the only package that does this and it can break parsing of the output of `./xbps-src show`.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
