### PR TITLE
nemo: update to 5.6.0, adopt.

### DIFF
--- a/srcpkgs/nemo/template
+++ b/srcpkgs/nemo/template
@@ -1,7 +1,7 @@
 # Template file for 'nemo'
 pkgname=nemo
-version=5.4.3
-revision=2
+version=5.6.0
+revision=1
 build_style=meson
 build_helper=gir
 pycompile_dirs="/usr/share/nemo/actions/myaction.py"
@@ -10,12 +10,12 @@ makedepends="cinnamon-desktop-devel dconf-devel exempi-devel gvfs-devel
  libexif-devel libnotify-devel xapps-devel libgsf-devel gtk+3-devel"
 depends="cinnamon-translations dconf gvfs"
 short_desc="Cinnamon file manager (nautilus fork)"
-maintainer="Orphaned <orphan@voidlinux.org>"
+maintainer="Jami Kettunen <jami.kettunen@protonmail.com>"
 license="GPL-2.0-or-later, LGPL-2.0-or-later"
 homepage="https://github.com/linuxmint/nemo"
 changelog="https://raw.githubusercontent.com/linuxmint/nemo/master/debian/changelog"
 distfiles="https://github.com/linuxmint/nemo/archive/${version}.tar.gz"
-checksum=5e4f49d6afa6cfab511511b1973011b189407d306a44d221de3f9fd3f7b97da1
+checksum=1a5084ef175d1d39a5ae9374444cdc5778dec6f9fa3789383f848b1bd31abd9d
 python_version=3
 # Requires xvfb-run and dbus-run-session
 make_check=no # can't be run inside chroot due to fusermount3


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->
Question about adopting the package, I use this as my primary file manager on a daily basis under i3 window manager, would I be a "valid" maintainer? I know Cinnamon desktop also uses this to draw the desktop icons and I'm not actively using that.
![image](https://user-images.githubusercontent.com/47358222/206883626-9a451b2a-ca02-4fcb-b796-eba140824df6.png)

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
