### PR TITLE
rust-cargo-bloat: update to 0.11.1.

### DIFF
--- a/srcpkgs/rust-cargo-bloat/template
+++ b/srcpkgs/rust-cargo-bloat/template
@@ -1,14 +1,15 @@
 # Template file for 'rust-cargo-bloat'
 pkgname=rust-cargo-bloat
-version=0.10.0
+version=0.11.1
 revision=1
 build_style=cargo
 short_desc="Find out what takes most of the space in your executable"
 maintainer="Enno Boland <gottox@voidlinux.org>"
 license="MIT"
 homepage="https://crates.io/crates/cargo-bloat"
+changelog="https://raw.githubusercontent.com/RazrFalcon/cargo-bloat/master/CHANGELOG.md"
 distfiles="https://static.crates.io/crates/cargo-bloat/cargo-bloat-${version}.crate"
-checksum=d402cb7adb305f8be650157cfffe735e2dbbda3766b34e9b07ba68566bfcf8c0
+checksum=ac0d2f3bae7849957392be201f47a0f70409a2e1b335b17a7c85e3ce48a6e092
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, x86_64