### PR TITLE
SPIRV-LLVM-Translator: fix cross build

### DIFF
--- a/srcpkgs/SPIRV-LLVM-Translator/template
+++ b/srcpkgs/SPIRV-LLVM-Translator/template
@@ -1,20 +1,19 @@
 # Template file for 'SPIRV-LLVM-Translator'
 pkgname=SPIRV-LLVM-Translator
 version=12.0.0
-revision=1
+revision=2
 build_style=cmake
 make_build_args="llvm-spirv"
 configure_args="-Wno-dev -DLLVM_LINK_LLVM_DYLIB=ON -DCMAKE_SKIP_RPATH=ON
  -DLLVM_SPIRV_INCLUDE_TESTS=OFF -DBUILD_SHARED_LIBS=ON"
-hostmakedepends="clang clang-tools-extra llvm"
-makedepends="llvm"
+hostmakedepends="clang llvm"
+makedepends="clang-tools-extra llvm"
 short_desc="API and commands for processing SPIR-V modules"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="NCSA"
 homepage="https://github.com/KhronosGroup/SPIRV-LLVM-Translator"
 distfiles="https://github.com/KhronosGroup/${pkgname}/archive/refs/tags/v${version}.tar.gz"
 checksum=6e4fad04203f25fcde4c308c53e9f59bd05a390978992db3212d4b63aff62108
-make_check=no
 
 post_install() {
 	vlicense LICENSE.TXT


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

Fixes the following build error;

```
-- The CXX compiler identification is GNU 10.2.1
-- The C compiler identification is GNU 10.2.1
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /builddir/.xbps-SPIRV-LLVM-Translator/wrappers/aarch64-linux-gnu-c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /builddir/.xbps-SPIRV-LLVM-Translator/wrappers/aarch64-linux-gnu-gcc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Could NOT find ZLIB (missing: ZLIB_LIBRARY ZLIB_INCLUDE_DIR) 
-- Could NOT find LibXml2 (missing: LIBXML2_LIBRARY LIBXML2_INCLUDE_DIR) 
CMake Error at /usr/aarch64-linux-gnu/usr/lib/cmake/llvm/LLVMExports.cmake:1386 (message):
  The imported target "sancov" references the file

     "/usr/aarch64-linux-gnu/usr/bin/sancov"

  but this file does not exist.  Possible reasons include:

  * The file was deleted, renamed, or moved to another location.

  * An install or uninstall procedure did not complete successfully.

  * The installation package was faulty and contained

     "/usr/aarch64-linux-gnu/usr/lib/cmake/llvm/LLVMExports.cmake"

  but not all the files it references.

Call Stack (most recent call first):
  /usr/aarch64-linux-gnu/usr/lib64/cmake/llvm/LLVMConfig.cmake:278 (include)
  CMakeLists.txt:36 (find_package)


-- Configuring incomplete, errors occurred!
See also "/builddir/SPIRV-LLVM-Translator-12.0.0/build/CMakeFiles/CMakeOutput.log".
```

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
