### PR TITLE
dracut: move network-legacy into dracut-network package

### DIFF
--- a/srcpkgs/dracut/template
+++ b/srcpkgs/dracut/template
@@ -2,7 +2,7 @@
 pkgname=dracut
 reverts="056_1"
 version=053
-revision=5
+revision=6
 build_style=configure
 configure_args="--prefix=/usr --sysconfdir=/etc"
 conf_files="/etc/dracut.conf"
@@ -43,17 +43,32 @@ post_install() {
 	vinstall ${FILESDIR}/kernel-hook-postrm 755 usr/libexec/dracut
 
 	# We don't need the systemd stuff.
-	rm -rf ${DESTDIR}/usr/lib/dracut/modules.d/*systemd*
-	rm -f ${DESTDIR}/usr/share/man/man8/*.service.*
-	rm -rf ${DESTDIR}/usr/lib/kernel
+	rm -r ${DESTDIR}/usr/lib/dracut/modules.d/*systemd*
+
+	# systemd dependent additional dracut modules
+	for f in 06rngd 06dbus-broker 06dbus-daemon 09dbus \
+		35network-manager 35network-wicked 80lvmmerge \
+		99memstrack 99squash; do
+		rm -r ${DESTDIR}/usr/lib/dracut/modules.d/${f}
+	done
+
+	# don't need s390x architecture dependent dracut modules
+	for f in 80cms 81cio_ignore 91zipl 95dasd 95dasd_mod \
+		95dasd_rules 95dcssblk 95qeth_rules 95zfcp \
+		95zfcp_rules 95znet; do
+		rm -r ${DESTDIR}/usr/lib/dracut/modules.d/${f}
+	done
+
+	rm ${DESTDIR}/usr/share/man/man8/*.service.*
+	rm -r ${DESTDIR}/usr/lib/kernel
 }
 
 dracut-network_package() {
 	depends="dhclient ${sourcepkg}-${version}_${revision}"
 	short_desc+=" - network modules"
 	pkg_install() {
-		for f in 40network 90livenet 95fcoe 95iscsi \
-			95nbd 95nfs 95zfcp 95znet; do
+		for f in 35network-legacy 40network 90livenet \
+			95fcoe 95iscsi 95nbd 95nfs; do
 			vmove usr/lib/dracut/modules.d/${f}
 		done
 	}


### PR DESCRIPTION
Other changes:
 - remove more systemd dependent modules
 - network-manager module depends on the dbus dracut module, which in turn depends on the systemd dracut module

#### Testing the changes
- I tested the changes in this PR: **NO**

In case it helps to test and review - alpine dracut package has some similar changes - https://gitlab.alpinelinux.org/alpine/aports/-/blob/master/testing/dracut/APKBUILD#L34