### PR TITLE
miniflux: update to 2.0.41

### DIFF
--- a/srcpkgs/miniflux/template
+++ b/srcpkgs/miniflux/template
@@ -1,6 +1,6 @@
 # Template file for 'miniflux'
 pkgname=miniflux
-version=2.0.40
+version=2.0.41
 revision=1
 build_style=go
 go_import_path="miniflux.app"
@@ -11,7 +11,7 @@ license="Apache-2.0"
 homepage="https://miniflux.app"
 changelog="https://raw.githubusercontent.com/miniflux/v2/main/ChangeLog"
 distfiles="https://github.com/miniflux/v2/archive/${version}.tar.gz"
-checksum=4882295cf32c526d797a72f40f6b0bf9a9e140571432fa178ac0befa9ecd9114
+checksum=01e150ebfba12c8b5ca7c1d9d5a5976d018081cafc11228d6f77a48ac3333e1b
 system_accounts="_miniflux"
 
 post_install() {


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **NO**


#### Local build testing
- I built this PR locally for my native architecture, amd64
<!--
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->

[2.0.41](https://github.com/miniflux/v2/releases/tag/2.0.41) fixes "Refresh all feeds" crash, see [#1290](https://github.com/miniflux/v2/pull/1290) which made prior version unusable with multiple feeds.