### PR TITLE
libplacebo: update to 4.208.0.

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -3454,7 +3454,7 @@ libSoapySDR.so.0.8 SoapySDR-0.8.1_1
 libeditorconfig.so.0 editorconfig-0.12.2_1
 libcfitsio.so.10 cfitsio-4.2.0_1
 libapparmor.so.1 libapparmor-2.12.0_1
-libplacebo.so.192 libplacebo-4.192.1_1
+libplacebo.so.208 libplacebo-4.208.0_1
 libw2xc.so waifu2x-converter-cpp-5.2_1
 libnova-0.15.so.0 libnova-0.15.0_1
 libcue.so.2 libcue-2.2.0_1

--- a/srcpkgs/libplacebo/template
+++ b/srcpkgs/libplacebo/template
@@ -1,6 +1,6 @@
 # Template file for 'libplacebo'
 pkgname=libplacebo
-version=4.192.1
+version=4.208.0
 revision=1
 build_style=meson
 configure_args="-Dshaderc=enabled -Dvulkan=enabled
@@ -13,7 +13,7 @@ maintainer="Enrico Belleri <idesmi@protonmail.com>"
 license="LGPL-2.1-or-later"
 homepage="https://code.videolan.org/videolan/libplacebo"
 distfiles="https://code.videolan.org/videolan/libplacebo/-/archive/v${version}/libplacebo-v${version}.tar.gz"
-checksum=e6c5805cf4d955b5941dd12b00fe157b61e77995bc1786b9a86df0ca99a0edc4
+checksum=7b3c857934ee3d30f743e43d7f0606e10950806661ea0ea385f8a1f06cbab854
 
 if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
 	makedepends+=" libatomic-devel"

--- a/srcpkgs/mpv/template
+++ b/srcpkgs/mpv/template
@@ -1,7 +1,7 @@
 # Template file for 'mpv'
 pkgname=mpv
 version=0.35.0
-revision=1
+revision=2
 build_style=meson
 configure_args="-Dcdda=enabled -Ddvbin=enabled -Ddvdnav=enabled
  -Dlibmpv=true -Dcplugins=enabled

--- a/srcpkgs/vlc/template
+++ b/srcpkgs/vlc/template
@@ -1,7 +1,7 @@
 # Template file for 'vlc'
 pkgname=vlc
 version=3.0.18
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--disable-gme --disable-libtar --enable-jack
  --enable-live555 --disable-fluidsynth --enable-dvdread


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->
Checked that both `vlc` and `mpv` (my primary video player) still plays some MP4 I had around, this is being upgraded as per https://github.com/void-linux/void-packages/pull/40747#issuecomment-1346769173.

5.229.1 update PR (4.x -> 5.x major version): https://github.com/void-linux/void-packages/pull/40807

Cc. @paper42

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
