### PR TITLE
Update poppler to 22.12.0

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -352,7 +352,7 @@ libMagickCore-7.Q16HDRI.so.10 libmagick-7.1.0.10_1
 libMagickWand-7.Q16HDRI.so.10 libmagick-7.1.0.10_1
 libMagick++-7.Q16HDRI.so.5 libmagick-7.0.11.1_1
 libltdl.so.7 libltdl-2.2.6_1
-libpoppler.so.122 libpoppler-22.06.0_1
+libpoppler.so.126 libpoppler-22.12.0_1
 libpoppler-glib.so.8 poppler-glib-0.18.2_1
 libpoppler-cpp.so.0 poppler-cpp-0.18.2_1
 libpoppler-qt5.so.1 poppler-qt5-0.31.0_1

--- a/srcpkgs/calligra/template
+++ b/srcpkgs/calligra/template
@@ -1,7 +1,7 @@
 # Template file for 'calligra'
 pkgname=calligra
 version=3.2.1
-revision=9
+revision=10
 build_style=cmake
 configure_args="-Wno-dev -DCALLIGRA_SHOULD_BUILD_UNMAINTAINED=ON
  -DBUILD_TESTING=OFF"

--- a/srcpkgs/inkscape/patches/inkscape-1.2.1-poppler-22.09.0.patch
+++ b/srcpkgs/inkscape/patches/inkscape-1.2.1-poppler-22.09.0.patch
@@ -1,0 +1,53 @@
+From 2f3101417a04721c42b6b101dde07fa961a56f1b Mon Sep 17 00:00:00 2001
+From: Sam James <sam@cmpct.info>
+Date: Tue, 6 Sep 2022 10:10:25 +0000
+Subject: [PATCH] Fix build with Poppler 22.09.0
+
+Adapt to changes in Poppler's getLineDash/setLineDash interface to allow building with Poppler 22.09.0.
+---
+ src/extension/internal/pdfinput/pdf-parser.cpp  | 4 ++++
+ src/extension/internal/pdfinput/svg-builder.cpp | 9 ++++++++-
+ 2 files changed, 12 insertions(+), 1 deletion(-)
+
+diff --git a/src/extension/internal/pdfinput/pdf-parser.cpp b/src/extension/internal/pdfinput/pdf-parser.cpp
+index cca1e84096..80d64c9b86 100644
+--- a/src/extension/internal/pdfinput/pdf-parser.cpp
++++ b/src/extension/internal/pdfinput/pdf-parser.cpp
+@@ -697,7 +697,11 @@ void PdfParser::opSetDash(Object args[], int /*numArgs*/)
+       _POPPLER_FREE(obj);
+     }
+   }
++#if POPPLER_CHECK_VERSION(22, 9, 0)
++  state->setLineDash(std::vector<double> (dash, dash + length), args[1].getNum());
++#else
+   state->setLineDash(dash, length, args[1].getNum());
++#endif
+   builder->updateStyle(state);
+ }
+ 
+diff --git a/src/extension/internal/pdfinput/svg-builder.cpp b/src/extension/internal/pdfinput/svg-builder.cpp
+index 12f71dd921..9fc56fe63c 100644
+--- a/src/extension/internal/pdfinput/svg-builder.cpp
++++ b/src/extension/internal/pdfinput/svg-builder.cpp
+@@ -389,10 +389,17 @@ void SvgBuilder::_setStrokeStyle(SPCSSAttr *css, GfxState *state) {
+     sp_repr_css_set_property(css, "stroke-miterlimit", os_ml.str().c_str());
+ 
+     // Line dash
+-    double *dash_pattern;
+     int dash_length;
+     double dash_start;
++#if POPPLER_CHECK_VERSION(22, 9, 0)
++    const double *dash_pattern;
++    const std::vector<double> &dash = state->getLineDash(&dash_start);
++    dash_pattern = dash.data();
++    dash_length = dash.size();
++#else
++    double *dash_pattern;
+     state->getLineDash(&dash_pattern, &dash_length, &dash_start);
++#endif
+     if ( dash_length > 0 ) {
+         Inkscape::CSSOStringStream os_array;
+         for ( int i = 0 ; i < dash_length ; i++ ) {
+-- 
+GitLab
+

--- a/srcpkgs/inkscape/template
+++ b/srcpkgs/inkscape/template
@@ -1,7 +1,7 @@
 # Template file for 'inkscape'
 pkgname=inkscape
 version=1.1.1
-revision=5
+revision=6
 build_style=cmake
 # builds executables then runs checks
 # some tests still fail on musl: https://gitlab.com/inkscape/inkscape/-/issues/2241

--- a/srcpkgs/ipe/patches/poppler-22.09.0-fix.patch
+++ b/srcpkgs/ipe/patches/poppler-22.09.0-fix.patch
@@ -1,0 +1,26 @@
+Taken from https://github.com/otfried/ipe-tools/pull/55/commits/65586fcd9cc39e482ae5a9abdb6f4932d9bb88c4
+
+diff --git a/pdftoipe/xmloutputdev.cpp b/pdftoipe/xmloutputdev.cpp
+index 291eb5f..17bac2a 100644
+--- a/ipe-tools/pdftoipe/xmloutputdev.cpp
++++ b/ipe-tools/pdftoipe/xmloutputdev.cpp
+@@ -149,15 +149,15 @@ void XmlOutputDev::stroke(GfxState *state)
+   writeColor("<path stroke=", rgb, 0);
+   writePSFmt(" pen=\"%g\"", state->getTransformedLineWidth());
+ 
+-  double *dash;
+   double start;
+-  int length, i;
++  std::vector<double> dash = state->getLineDash(&start);
++  int length = dash.size();
++  int i;
+ 
+-  state->getLineDash(&dash, &length, &start);
+   if (length) {
+     writePS(" dash=\"[");
+     for (i = 0; i < length; ++i)
+-      writePSFmt("%g%s", state->transformWidth(dash[i]), 
++      writePSFmt("%g%s", state->transformWidth(dash.at(i)),
+ 		 (i == length-1) ? "" : " ");
+     writePSFmt("] %g\"", state->transformWidth(start));
+   }

--- a/srcpkgs/ipe/template
+++ b/srcpkgs/ipe/template
@@ -1,7 +1,7 @@
 # Template file for 'ipe'
 pkgname=ipe
 version=7.2.26
-revision=7
+revision=8
 _tools_commit=v7.2.24.1
 create_wrksrc=yes
 hostmakedepends="pkg-config doxygen qt5-qmake qt5-tools qt5-host-tools"

--- a/srcpkgs/kitinerary/template
+++ b/srcpkgs/kitinerary/template
@@ -1,7 +1,7 @@
 # Template file for 'kitinerary'
 pkgname=kitinerary
 version=22.08.2
-revision=2
+revision=3
 build_style=cmake
 hostmakedepends="extra-cmake-modules gettext kcoreaddons pkg-config qt5-host-tools qt5-qmake qt5-tools-devel"
 makedepends="kcalendarcore-devel kcontacts-devel kdeclarative-devel kmime-devel

--- a/srcpkgs/libreoffice/template
+++ b/srcpkgs/libreoffice/template
@@ -1,7 +1,7 @@
 # Template file for 'libreoffice'
 pkgname=libreoffice
 version=7.4.2.3
-revision=2
+revision=3
 build_style=meta
 make_build_target="build"
 nocross="Several dependencies are nocross=yes"

--- a/srcpkgs/poppler-qt5/template
+++ b/srcpkgs/poppler-qt5/template
@@ -4,8 +4,8 @@
 # IT IS SPLIT TO AVOID A CYCLIC DEPENDENCY: qt5 -> cups -> poppler -> qt5.
 #
 pkgname=poppler-qt5
-version=22.07.0
-revision=2
+version=22.12.0
+revision=1
 build_style=cmake
 configure_args="-DENABLE_UNSTABLE_API_ABI_HEADERS=ON -DENABLE_GLIB=OFF
  -DENABLE_QT5=ON -DENABLE_UTILS=OFF -DENABLE_CPP=OFF -DENABLE_BOOST=OFF
@@ -19,7 +19,7 @@ license="GPL-2.0-or-later, GPL-3.0-or-later"
 homepage="https://poppler.freedesktop.org"
 changelog="https://gitlab.freedesktop.org/poppler/poppler/-/raw/master/NEWS"
 distfiles="${homepage}/poppler-${version}.tar.xz"
-checksum=420230c5c43782e2151259b3e523e632f4861342aad70e7e20b8773d9eaf3428
+checksum=d9aa9cacdfbd0f8e98fc2b3bb008e645597ed480685757c3e7bc74b4278d15c0
 # fails to find a bunch of files
 make_check=no
 

--- a/srcpkgs/poppler/template
+++ b/srcpkgs/poppler/template
@@ -3,8 +3,8 @@
 # THIS PKG MUST BE SYNCHRONIZED WITH "srcpkgs/poppler-qt5".
 #
 pkgname=poppler
-version=22.07.0
-revision=2
+version=22.12.0
+revision=1
 _testVersion=920c89f8f43bdfe8966c8e397e7f67f5302e9435
 create_wrksrc=yes
 build_style=cmake
@@ -24,7 +24,7 @@ homepage="https://poppler.freedesktop.org"
 changelog="https://gitlab.freedesktop.org/poppler/poppler/-/raw/master/NEWS"
 distfiles="${homepage}/${pkgname}-${version}.tar.xz
  https://gitlab.freedesktop.org/poppler/test/-/archive/${_testVersion}/test-${_testVersion}.tar.gz"
-checksum="420230c5c43782e2151259b3e523e632f4861342aad70e7e20b8773d9eaf3428
+checksum="d9aa9cacdfbd0f8e98fc2b3bb008e645597ed480685757c3e7bc74b4278d15c0
  ca35f168a18038a2d817ea30d6c7b4ab8294a40a5f5950f3c2a15183ba08c900"
 
 build_options="gir boost"

--- a/srcpkgs/scribus/patches/0004-poppler-22.09.0-fix.patch
+++ b/srcpkgs/scribus/patches/0004-poppler-22.09.0-fix.patch
@@ -1,0 +1,20 @@
+--- a/scribus/plugins/import/pdf/slaoutput.cpp
++++ b/scribus/plugins/import/pdf/slaoutput.cpp
+@@ -3741,9 +3741,16 @@ void SlaOutputDev::getPenState(GfxState *state)
+ 			break;
+ 	}
+ 	double lw = state->getLineWidth();
+-	double *dashPattern;
+ 	int dashLength;
++#if POPPLER_ENCODED_VERSION >= POPPLER_VERSION_ENCODE(22, 9, 0)
++	const double *dashPattern;
++	const std::vector<double> &dash = state->getLineDash(&DashOffset);
++	dashPattern = dash.data();
++	dashLength = dash.size();
++#else
++	double *dashPattern;
+ 	state->getLineDash(&dashPattern, &dashLength, &DashOffset);
++#endif
+ 	QVector<double> pattern(dashLength);
+ 	for (int i = 0; i < dashLength; ++i)
+ 	{

--- a/srcpkgs/scribus/template
+++ b/srcpkgs/scribus/template
@@ -1,7 +1,7 @@
 # Template file for 'scribus'
 pkgname=scribus
 version=1.5.8
-revision=4
+revision=5
 build_style=cmake
 configure_args="-DCMAKE_SKIP_RPATH=TRUE -DQT_PREFIX=${XBPS_CROSS_BASE}/usr
  -DWANT_GRAPHICSMAGICK=1 -DWANT_CPP17=ON"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)

~~I didn't build libreoffice, but from a quick check it has the patches so it should build.~~

I noticed our current poppler version is affected by CVE-2022-38784. Instead of submiting a patch for that, I  decided to go all the way and update to the current stable. 
 
Had to apply patches for inkscape, ipe and scribus.
 
scribus patch is taken from: https://gitweb.gentoo.org/repo/gentoo.git/plain/app-office/scribus/files/scribus-1.5.8-poppler-22.09.0.patch. The actual upstream commit (https://github.com/scribusproject/scribus/commit/8acd29e97813b9132e3b51b2f05e8fac65819ed7.patch) is slightly different, but does not apply because in between the releases and master, there were additional changes in the file. IMHO scribus could use a release, but nothing we can do.



