### PR TITLE
containers storage

### DIFF
--- a/srcpkgs/buildah/template
+++ b/srcpkgs/buildah/template
@@ -1,6 +1,6 @@
 # Template file for 'buildah'
 pkgname=buildah
-version=1.28.0
+version=1.28.2
 revision=1
 build_style=go
 go_import_path=github.com/containers/buildah
@@ -9,14 +9,14 @@ go_build_tags=containers_image_ostree_stub
 hostmakedepends="pkg-config go-md2man"
 makedepends="libostree-devel libbtrfs-devel device-mapper-devel gpgme-devel
  libassuan-devel libseccomp-devel"
-depends="runc containers.image"
+depends="runc containers.image containers.storage"
 short_desc="Dockerfile compatible OCI image building tool"
 maintainer="Cameron Nemo <cam@nohom.org>"
 license="Apache-2.0"
 homepage="https://github.com/containers/buildah"
 changelog="https://github.com/containers/buildah/blob/master/CHANGELOG.md"
 distfiles="https://github.com/containers/buildah/archive/refs/tags/v${version}.tar.gz"
-checksum=4e406a0cc6a90066cd471deea252fe8862dbd7fa9cb72b274617673d6159a32b
+checksum=2dc5b1686473f972fbfa15637ecd1a9e2aeefd057c86dd097d1f19e2a6959411
 
 post_build() {
 	make -C docs GOMD2MAN=go-md2man

--- a/srcpkgs/containers.storage/template
+++ b/srcpkgs/containers.storage/template
@@ -1,0 +1,21 @@
+# Template file for 'containers.storage'
+pkgname=containers.storage
+version=1.37.3
+revision=1
+hostmakedepends="go-md2man"
+short_desc="Storage configuration shared by podman, buildah, and skopeo"
+maintainer="Cameron Nemo <cam@nohom.org>"
+license="Apache-2.0"
+homepage="https://github.com/containers/storage"
+distfiles="https://github.com/containers/storage/archive/refs/tags/v${version}.tar.gz"
+checksum=344ca995120ddf7cb3d341f27c6315dcc4e5a5807b95d1db5a7a21b4f9a95339
+_manpage="containers-storage.conf.5"
+
+do_build() {
+	go-md2man -in "docs/${_manpage}.md" -out "$_manpage"
+}
+
+do_install() {
+	vman "$_manpage"
+	vinstall storage.conf 0644 usr/share/containers
+}

--- a/srcpkgs/podman/template
+++ b/srcpkgs/podman/template
@@ -1,14 +1,15 @@
 # Template file for 'podman'
 pkgname=podman
 version=4.3.1
-revision=1
+revision=2
 build_style=go
 go_import_path="github.com/containers/podman/v4"
 go_package="${go_import_path}/cmd/podman ${go_import_path}/cmd/rootlessport"
 go_build_tags="seccomp apparmor containers_image_ostree_stub"
 hostmakedepends="pkg-config go-md2man python3"
 makedepends="gpgme-devel libseccomp-devel device-mapper-devel libbtrfs-devel"
-depends="runc conmon cni-plugins slirp4netns containers.image fuse-overlayfs"
+depends="runc conmon cni-plugins slirp4netns containers.image containers.storage
+ fuse-overlayfs"
 short_desc="Simple management tool for containers and images"
 maintainer="Cameron Nemo <cam@nohom.org>"
 license="Apache-2.0"

--- a/srcpkgs/skopeo/template
+++ b/srcpkgs/skopeo/template
@@ -1,7 +1,7 @@
 # Template file for 'skopeo'
 pkgname=skopeo
 version=1.10.0
-revision=1
+revision=2
 build_style=go
 build_helper=qemu
 go_import_path="github.com/containers/${pkgname}"
@@ -9,7 +9,7 @@ go_package="${go_import_path}/cmd/${pkgname}"
 go_build_tags="containers_image_ostree_stub"
 hostmakedepends="go-md2man pkg-config"
 makedepends="device-mapper-devel gpgme-devel libbtrfs-devel"
-depends="containers.image"
+depends="containers.image containers.storage"
 short_desc="Utility for operations on container images and image repositories"
 maintainer="Cameron Nemo <cam@nohom.org>"
 license="Apache-2.0"


### PR DESCRIPTION
Install the containers.storage configuration file so that the graph driver defaults to overlay, not vfs.

vfs uses too much storage.

https://gitlab.com/clickable/clickable/-/issues/390

- New package: containers.storage-1.37.3
- podman: add dependency on containers.storage
- buildah: update to 1.28.2, add dep on storage
- skopeo: add dependency on containers.storage

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
