### PR TITLE
netdata v1.37.1

### DIFF
--- a/srcpkgs/netdata-plugins-go/template
+++ b/srcpkgs/netdata-plugins-go/template
@@ -1,0 +1,26 @@
+# Template file for 'netdata-plugins-go'
+pkgname=netdata-plugins-go
+version=0.45.0
+revision=1
+build_style=go
+go_import_path="github.com/netdata/go.d.plugin/cmd/godplugin"
+depends="netdata"
+short_desc="Netdata - Go Plugins"
+maintainer="sn0w <me@sn0w.cx>"
+license="GPL-3.0-or-later"
+homepage="https://www.netdata.cloud/"
+distfiles="https://github.com/netdata/go.d.plugin/archive/refs/tags/v${version}.tar.gz"
+checksum=7062325e73520c501cc8aac4b298dec2471109120b8bb92e442e9394b4365c3b
+
+do_install() {
+	vmkdir usr/lib/netdata/conf.d
+	vcopy config/go.d usr/lib/netdata/conf.d
+	vcopy config/go.d.conf usr/lib/netdata/conf.d
+
+	for f in ${GOPATH}/bin/* ${GOPATH}/bin/**/*; do
+		if [ -f "$f" ] && [ -x "$f" ]; then
+			vinstall "$f" 755 usr/lib/netdata/plugins.d go.d.plugin
+			break
+		fi
+	done
+}

--- a/srcpkgs/netdata-plugins-nodejs
+++ b/srcpkgs/netdata-plugins-nodejs
@@ -1,1 +1,0 @@
-netdata

--- a/srcpkgs/netdata/template
+++ b/srcpkgs/netdata/template
@@ -1,19 +1,24 @@
 # Template file for 'netdata'
 pkgname=netdata
-version=1.33.0
+version=1.37.1
 revision=1
 build_style=gnu-configure
-configure_args="--with-user=_netdata ac_cv_file_externaldeps_libbpf_libbpf_a=no"
-hostmakedepends="pkg-config autoconf automake"
-makedepends="json-c-devel judy-devel libcap-devel liblz4-devel libmnl-devel
- libnetfilter_acct-devel openssl-devel libuuid-devel libuv-devel zlib-devel"
+build_helper=qemu
+configure_args="--with-user=_netdata ac_cv_file_externaldeps_libbpf_libbpf_a=no
+ $(vopt_if cloud --enable-cloud --disable-cloud) $(vopt_if ipmi --enable-plugin-freeipmi)
+ $(vopt_if xen --enable-plugin-xenstat) $(vopt_if cups --enable-plugin-cups)"
+hostmakedepends="pkg-config autoconf automake $(vopt_if cloud "protobuf protobuf-devel")"
+makedepends="json-c-devel libcap-devel liblz4-devel libmnl-devel
+ libnetfilter_acct-devel openssl-devel libuuid-devel libuv-devel zlib-devel
+ snappy-devel $(vopt_if cloud protobuf-devel) $(vopt_if ipmi freeipmi-devel)
+ $(vopt_if xen "xen-devel yajl-devel") $(vopt_if cups cups-devel)"
 depends="libcap-progs"
 short_desc="Real-time performance monitoring, done right"
 maintainer="Michael Aldridge <maldridge@voidlinux.org>"
 license="GPL-3.0-or-later"
 homepage="https://www.netdata.cloud/"
 distfiles="https://github.com/netdata/netdata/releases/download/v${version}/netdata-v${version}.tar.gz"
-checksum=d167d4b2d8529119fa4047ae40d22833dac9d360a6ed07c314ba313807c027eb
+checksum=2caa042d43ca61007a61294a5ececa037d83a1973bd38032233760341eb1706b
 python_version=3
 make_dirs="
  /var/lib/netdata          0755 _netdata _netdata
@@ -22,29 +27,32 @@ make_dirs="
  /var/log/netdata          0755 _netdata _netdata
 "
 
+build_options="cloud ipmi cups xen"
+desc_option_cloud="Enable support for netdata cloud"
+desc_option_ipmi="Enable IPMI plugin"
+desc_option_xen="Enable xenstat plugin"
+build_options_default="cloud"
+
 system_accounts="_netdata"
 conf_files="/etc/${pkgname}/*.conf"
 
+if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
+	makedepends+=" libatomic-devel"
+	CFLAGS+=" -DLINK_ATOMIC"
+	export LIBS="-latomic"
+fi
+
 pre_configure() {
+	if [ "$CROSS_BUILD" ]; then
+		sed -i "s|	\$(builddir)/judyltablesgen\$(EXEEXT)|	qemu-${XBPS_TARGET_QEMU_MACHINE}-static \$(builddir)/judyltablesgen\$(EXEEXT)|g" Makefile.am
+	fi
+
 	autoreconf -ivf
 }
 
 post_install() {
 	vsv netdata
 	vcopy ${FILESDIR}/netdata.conf etc/$pkgname/
-	if [ -n "$_without_node" ]; then
-		rm -rf ${DESTDIR}/usr/libexec/netdata/node.d
-		rm -rf ${DESTDIR}/usr/libexec/netdata/plugins.d/node.d.plugin
-	fi
-}
-
-netdata-plugins-nodejs_package() {
-	short_desc+=" - NodeJS Plugins"
-	depends="${sourcepkg}>=${version}_${revision} virtual?nodejs-runtime"
-	pkg_install() {
-		vmove usr/libexec/netdata/plugins.d/node.d.plugin
-		vmove usr/libexec/netdata/node.d
-	}
 }
 
 netdata-plugins-python_package() {


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES** (on `x86_64` and `x86_64-musl`)

#### Local build testing
- I built this PR locally for my native architecture
  -  `x86_64{,-musl}`
- I built this PR locally for these architectures (all cross):
  - `i686`
  - `armv6l{,-musl}`
  - `armv7l{,-musl}`
  - `aarch64{,-musl}`

#### Notes

Nodejs subpackage got removed because upstream dropped `node.d` in 1.35 (following deprecation in 1.34).
Could be packaged separately using netdata's community repo but most likely not necessary anymore due to `go.d`.

`go.d` is packaged separately here because it looks to be an entirely separate project with it's own release cycle, only linked to the main netdata project through [this file](https://github.com/netdata/netdata/blob/v1.37/packaging/go.d.version). Assigned myself as the maintainer of `go.d` for now, though since it's somewhat tightly linked to netdata I'd be willing to either maintain netdata as well (i'm actively using it anyway) or of course hand `go.d` over to maldridge.
Also do let me know if this should be two PRs instead, wasn't really sure since the two templates are so close.