### PR TITLE
Explicitly orphan fifechan and libxkbfile

### DIFF
--- a/srcpkgs/fifechan/template
+++ b/srcpkgs/fifechan/template
@@ -5,6 +5,7 @@ revision=1
 build_style=cmake
 makedepends="SDL2-devel MesaLib-devel SDL2_image-devel"
 short_desc="C++ GUI library designed for games"
+maintainer="Orphaned <orphan@voidlinux.org>"
 license="LGPL-2.1-or-later, BSD-3-Clause"
 homepage="https://github.com/fifengine/fifechan"
 distfiles="https://github.com/fifengine/fifechan/archive/${version}.tar.gz"

--- a/srcpkgs/libxkbfile/template
+++ b/srcpkgs/libxkbfile/template
@@ -6,6 +6,7 @@ build_style=gnu-configure
 hostmakedepends="pkg-config"
 makedepends="xorgproto libX11-devel"
 short_desc="Xkbfile Library from X.org"
+maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
 homepage="$XORG_SITE"
 distfiles="${XORG_SITE}/lib/${pkgname}-${version}.tar.bz2"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

These two packages do not actually have a `maintainer` specified, not even the standard "Orphaned <orphan@voidlinux.org>" so lint on these two fails. This PR adds it.

#### Testing the changes
- I tested the changes in this PR: **briefly**