### PR TITLE
delve: update to 1.20.0.

### DIFF
--- a/srcpkgs/delve/template
+++ b/srcpkgs/delve/template
@@ -1,8 +1,8 @@
 # Template file for 'delve'
 pkgname=delve
-version=1.8.0
+version=1.20.0
 revision=1
-# https://github.com/go-delve/delve/blob/master/pkg/proc/native/support_sentinel.go
+# https://github.com/go-delve/delve/blob/master/pkg/proc/native/support_sentinel_linux.go
 archs="x86_64* i686* aarch64*"
 build_style=go
 go_import_path=github.com/go-delve/delve/cmd/dlv
@@ -12,7 +12,7 @@ license="MIT"
 homepage="https://github.com/go-delve/delve"
 changelog="https://raw.githubusercontent.com/go-delve/delve/master/CHANGELOG.md"
 distfiles="https://github.com/go-delve/delve/archive/v${version}.tar.gz"
-checksum=086106a4776fa155bf20c37d27b9caed55255be6359c7f0bda1893d3adbb614e
+checksum=39d2e3ae965abf5e71f3d8efbef368b1ee1d7154ea6604ec71d508350d419d03
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**


#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
 (I believe this build relies on the the newer gcc version that is still being built. Can test crosscompile in a few days if necessary.