### PR TITLE
common/environment/build-style/go.sh: allow setting CGO_ENABLED

### DIFF
--- a/common/environment/build-style/go.sh
+++ b/common/environment/build-style/go.sh
@@ -37,7 +37,7 @@ export CGO_CFLAGS="$CFLAGS"
 export CGO_CPPFLAGS="$CPPFLAGS"
 export CGO_CXXFLAGS="$CXXFLAGS"
 export CGO_LDFLAGS="$LDFLAGS"
-export CGO_ENABLED=1
+export CGO_ENABLED="${CGO_ENABLED:-1}"
 export GO111MODULE=auto
 case "$XBPS_TARGET_MACHINE" in
 	*-musl) export GOCACHE="${XBPS_HOSTDIR}/gocache-muslc" ;;


### PR DESCRIPTION
Change hard-coded value of `CGO_ENABLED` to allow reading a user configured value from a template file. This is required to fix a segmentation fault in #40919, derived from some kind of linking error. The default behavior is kept, i.e. cgo is still enabled by default, which shouldn't break any packages.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
