### PR TITLE
 cross-arm-none-eabi*: update to 12.2.0

### DIFF
--- a/srcpkgs/cross-arm-none-eabi-binutils/template
+++ b/srcpkgs/cross-arm-none-eabi-binutils/template
@@ -2,8 +2,8 @@
 _triplet=arm-none-eabi
 _pkgname=binutils
 pkgname=cross-${_triplet}-${_pkgname}
-version=2.32
-revision=2
+version=2.39
+revision=1
 build_style=gnu-configure
 configure_args="
  --disable-nls
@@ -21,17 +21,20 @@ configure_args="
  --with-system-zlib
  --without-isl
 "
-hostmakedepends="autoconf automake bison flex perl"
+hostmakedepends="automake bison flex perl texinfo"
 makedepends="zlib-devel"
 depends="binutils-doc"
+checkdepends="dejagnu"
 short_desc="GNU binary utilities"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-3.0-or-later"
-homepage="https://www.gnu.org/software/${_pkgname}/"
+homepage="https://www.gnu.org/software/binutils/"
 distfiles="${GNU_SITE}/${_pkgname}/${_pkgname}-${version}.tar.xz"
-checksum=0ab6c55dd86a92ed561972ba15b9b70a8b9f75557f896446c82e8b36e473ee04
+checksum=645c25f563b8adc0a81dbd6a41cffbf4d37083a382e02d5d3df4f65c09516d00
 nocross=yes
 
 post_install() {
 	rm -fr ${DESTDIR}/usr/share/info
+	# Remove libdep linker plugin because it conflicts with system binutils
+	rm -f ${DESTDIR}/usr/lib/bfd-plugins/libdep*
 }

--- a/srcpkgs/cross-arm-none-eabi-gcc/template
+++ b/srcpkgs/cross-arm-none-eabi-gcc/template
@@ -2,21 +2,21 @@
 _triplet=arm-none-eabi
 _pkgname=gcc
 pkgname=cross-${_triplet}-gcc
-version=9.3.0
+version=12.2.0
 revision=1
 build_wrksrc=build
 build_style=gnu-configure
 make_build_args="INHIBIT_LIBC_CFLAGS='-DUSE_TM_CLONE_REGISTRY=0'"
-hostmakedepends="autoconf automake cross-arm-none-eabi-binutils bison flex
- perl tar texinfo"
-makedepends="gmp-devel isl15-devel libmpc-devel mpfr-devel zlib-devel"
+hostmakedepends="automake cross-arm-none-eabi-binutils bison flex perl tar texinfo"
+makedepends="gmp-devel isl-devel libmpc-devel libzstd-devel mpfr-devel zlib-devel"
 depends="cross-arm-none-eabi-binutils"
+checkdepends="autogen dejagnu"
 short_desc="GNU Compiler Collection"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GFDL-1.2-or-later, GPL-3.0-or-later, LGPL-2.1-or-later"
 homepage="https://gcc.gnu.org"
 distfiles="${GNU_SITE}/gcc/gcc-${version}/gcc-${version}.tar.xz"
-checksum=71e197867611f6054aa1119b13a0c0abac12834765fe2d81f35ac57f84f742d1
+checksum=e549cf9cf3594a00e27b6589d4322d70e0720cdd213f39beb4181e06926230ff
 alternatives="arm-none-eabi:/usr/bin/arm-none-eabi-cc:/usr/bin/arm-none-eabi-gcc"
 nocross=yes
 nopie=yes
@@ -34,9 +34,9 @@ pre_configure() {
 do_configure() {
 	../configure \
 		--disable-decimal-float \
+		--disable-gcov \
 		--disable-libffi \
 		--disable-libgomp \
-		--disable-libmudflap \
 		--disable-libquadmath \
 		--disable-libssp \
 		--disable-libstdcxx-pch \
@@ -63,7 +63,6 @@ do_configure() {
 		--with-gnu-as \
 		--with-gnu-ld \
 		--with-headers=/usr/${_triplet}/include \
-		--with-host-libstdcxx='-static-libgcc -Wl,-Bstatic,-lstdc++,-Bdynamic -lm' \
 		--with-isl \
 		--with-libelf \
 		--with-mpc \

--- a/srcpkgs/cross-arm-none-eabi-libstdc++/template
+++ b/srcpkgs/cross-arm-none-eabi-libstdc++/template
@@ -1,8 +1,8 @@
 # Template file for 'cross-${_triplet}-libstdc++'
 _triplet=arm-none-eabi
 pkgname=cross-${_triplet}-libstdc++
-version=9.3.0
-revision=2
+version=12.2.0
+revision=1
 # gnu-configure implicitly passes stuff we don't want
 build_style=configure
 configure_args="
@@ -13,7 +13,7 @@ configure_args="
  --with-gnu-ld --with-gxx-include-dir=/usr/${_triplet}/include/c++/${version}
  --with-newlib --with-python-dir=share/gcc-${_triplet}"
 make_build_args="INHIBIT_LIBC_CFLAGS='-DUSE_TM_CLONE_REGISTRY=0'"
-hostmakedepends="autoconf automake cross-arm-none-eabi-binutils
+hostmakedepends="automake cross-arm-none-eabi-binutils
  cross-arm-none-eabi-gcc cross-arm-none-eabi-newlib bison flex perl"
 makedepends="gmp-devel isl15-devel libmpc-devel mpfr-devel zlib-devel"
 depends="cross-arm-none-eabi-gcc"
@@ -22,10 +22,16 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-3.0-or-later"
 homepage="https://gcc.gnu.org"
 distfiles="${GNU_SITE}/gcc/gcc-${version}/gcc-${version}.tar.xz"
-checksum=71e197867611f6054aa1119b13a0c0abac12834765fe2d81f35ac57f84f742d1
+checksum=e549cf9cf3594a00e27b6589d4322d70e0720cdd213f39beb4181e06926230ff
 nocross=yes
 nopie=yes
 nostrip=yes
+
+# Workaround for GCC 12, see
+# - https://www.mail-archive.com/openembedded-core@lists.openembedded.org/msg165240.html
+# - https://lists.yoctoproject.org/g/meta-arm/message/3469
+# - https://bugzilla.yoctoproject.org/show_bug.cgi?id=14803
+configure_args+=" ac_cv_func_fcntl=no ac_cv_func_getexecname=no"
 
 post_extract() {
 	mkdir -p build-{regular,nano}
@@ -60,6 +66,18 @@ do_build() {
 
 	pushd build-nano
 	make ${makejobs} ${make_build_args}
+	popd
+}
+
+do_check() {
+	unset CC CXX CPP AR AS CFLAGS CXXFLAGS
+
+	pushd build-regular
+	make ${makejobs} ${make_build_args} check
+	popd
+
+	pushd build-nano
+	make ${makejobs} ${make_build_args} check
 	popd
 }
 

--- a/srcpkgs/cross-arm-none-eabi-newlib/template
+++ b/srcpkgs/cross-arm-none-eabi-newlib/template
@@ -2,8 +2,8 @@
 _triplet=arm-none-eabi
 _pkgname=newlib
 pkgname=cross-${_triplet}-${_pkgname}
-version=3.1.0.20181231
-revision=3
+version=4.2.0.20211231
+revision=1
 build_style=gnu-configure
 configure_args="
  --prefix=/usr --target=${_triplet} --host=${XBPS_CROSS_TRIPLET}
@@ -16,7 +16,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later, LGPL-2.1-or-later"
 homepage="https://www.sourceware.org/newlib/"
 distfiles="ftp://sourceware.org/pub/newlib/newlib-${version}.tar.gz"
-checksum=9e12fea7297648b114434033ed4458755afe7b9b6c7d58123389e82bd37681c0
+checksum=c3a0e8b63bc3bef1aeee4ca3906b53b3b86c8d139867607369cb2915ffc54435
 nostrip=yes
 
 post_extract() {
@@ -53,6 +53,16 @@ do_build() {
 
 	pushd build-nano
 	make ${makejobs}
+	popd
+}
+
+do_check() {
+	pushd build-newlib
+	make check
+	popd
+
+	pushd build-nano
+	make check
 	popd
 }
 


### PR DESCRIPTION
Replaces #37580.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
#### Local build testing
- I built this PR locally for my native architecture, (x86_64-musl)
- I built this PR locally for these architectures (if supported. mark crossbuilds):

I tested this with my own STM32 project written in both C and C++.

---
Also:
1. clean up hostmakedepends,
2. `mudflap` was removed in GCC 4.9: https://gcc.gnu.org/wiki/Mudflap_Pointer_Debugging (commit [98906124](https://gcc.gnu.org/git/?p=gcc.git;a=commit;h=98906124e3aa4cb17695d900fe19498e5bde63e4)),
3. `--with-host-libstdcxx` removed in commit [5dc85f7ec](https://gcc.gnu.org/git/?p=gcc.git;a=commit;h=5dc85f7ec719a79ecfbcdd8563b07e5f0f365e65).