### PR TITLE
cups: reverting to GnuTLS backend (fix broken new CUPS OpenSSL default IPPS issues)

### DIFF
--- a/srcpkgs/cups/template
+++ b/srcpkgs/cups/template
@@ -1,7 +1,7 @@
 # Template file for 'cups'
 pkgname=cups
 version=2.4.2
-revision=3
+revision=4
 build_style=gnu-configure
 make_install_args="BUILDROOT=${DESTDIR}"
 hostmakedepends="gnutls-devel pkg-config
@@ -42,6 +42,7 @@ do_configure() {
 		--enable-libpaper --with-menudir=/usr/share/applications \
 		--with-xinetd=/etc/xinetd.d --with-optim="${CFLAGS}" \
 		--with-rcdir=no \
+		--with-tls=gnutls \
 		$(vopt_if avahi '--with-dnssd=avahi') $(vopt_enable gssapi)
 }
 


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-libc) (print client)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64 (print server)

The latest version of CUPS default to build against OpenSSL. Before that it was defaulting to GnuTLS. The template is written with GnuTLS in mind (dpes). This change brings back GunTLS as TLS backend.

I was having issues with IPPS (TLS over 631 port) with cups as a print server and as a client (IPP Everywhere). The server compiled against OpenSSL would fail when TLS client was connecting in with error pointing to issue with certificate generation. Also when provided with custom certificate cupsd would crash. 
After this patch for client and server it all works (also tested with MacOS as a client). 

The one thing I needed to do was to remove the certificates generated before (when cups was compiled against OpenSSL) (from /etc/cups/ssl) as they were not accepted by cups client.