### PR TITLE
python3-docstring-to-markdown: update to 0.11.

### DIFF
--- a/srcpkgs/python3-docstring-to-markdown/template
+++ b/srcpkgs/python3-docstring-to-markdown/template
@@ -1,13 +1,14 @@
 # Template file for 'python3-docstring-to-markdown'
 pkgname=python3-docstring-to-markdown
-version=0.10
-revision=2
+version=0.11
+revision=1
 build_style=python3-module
 hostmakedepends="python3-setuptools_scm"
 depends="python3"
 short_desc="Python implementation of the Language Server Protocol"
 maintainer="Cameron Nemo <cam@nohom.org>"
-license="LGPL-2.1-only"
-homepage="https://github.com/python-lsp/docstring-to-markdown"
+license="LGPL-2.1-or-later"
+homepage="https://pypi.org/project/docstring-to-markdown/"
+changelog="https://github.com/python-lsp/docstring-to-markdown/releases"
 distfiles="${PYPI_SITE}/d/docstring-to-markdown/docstring-to-markdown-${version}.tar.gz"
-checksum=12f75b0c7b7572defea2d9e24b57ef7ac38c3e26e91c0e5547cfc02b1c168bf6
+checksum=5b1da2c89d9d0d09b955dec0ee111284ceadd302a938a03ed93f66e09134f9b5


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture: **x86_64**