### PR TITLE
[WIP] android-studio: update to 2021.3.1.17.

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -2595,9 +2595,14 @@ libopenshot-audio.so.8 libopenshot-audio-0.2.2_1
 libopenshot.so.21 libopenshot-0.2.7_1
 libpqxx-6.3.so libpqxx-6.3.3_1
 libndpi.so.3 ndpi-3.4_1
-liblog.so android-studio-3.0.1_1
-libm.so android-studio-3.0.1_1
-libdl.so android-studio-3.0.1_1
+liblog.so android-studio-2021.3.1.17_1
+libm.so android-studio-2021.3.1.17_1
+libdl.so android-studio-2021.3.1.17_1
+libpanelw.so.5 android-studio-2021.3.1.17_1
+libncursesw.so.5 android-studio-2021.3.1.17_1
+libtinfo.so.5 android-studio-2021.3.1.17_1
+libandroid.so android-studio-2021.3.1.17_1
+libmediandk.so android-studio-2021.3.1.17_1
 libKF5WidgetsAddons.so.5 kwidgetsaddons-5.26.0_1
 libsearpc.so.1 libsearpc-3.0.7_1
 libseafile.so.0 seafile-libclient-7.0.10_2

--- a/srcpkgs/android-studio/template
+++ b/srcpkgs/android-studio/template
@@ -1,11 +1,7 @@
 # Template file for 'android-studio'
 pkgname=android-studio
-version=4.1.3
+version=2021.3.1.17
 revision=1
-# _studio_build and _studio_rev are for downloading the zip from dl.google.com
-# https://developer.android.com/studio/#resources as of 2018-07-12
-_studio_build=201.7199119
-_studio_rev=0
 archs="x86_64 i686"
 hostmakedepends="tar"
 depends="virtual?libGL"
@@ -14,8 +10,8 @@ maintainer="Jordyn Carattini <onlinecloud1@gmail.com>"
 license="Apache-2.0"
 homepage="http://tools.android.com"
 # changelog="https://developer.android.com/studio/releases/index.html"
-distfiles="https://dl.google.com/dl/android/studio/ide-zips/${version}.${_studio_rev}/android-studio-ide-${_studio_build}-linux.tar.gz"
-checksum=f599749ca47cda06d392e2764017c8a8a0c7b963a6a88ed494b432bece7cbc1b
+distfiles="https://dl.google.com/dl/android/studio/ide-zips/${version}/android-studio-${version}-linux.tar.gz"
+checksum=89adb0ce0ffa46b7894e7bfedb142b1f5d52c43c171e6a6cb9a95a49f77756ca
 repository=nonfree
 restricted=yes
 python_version=2


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **NO**. It does not currently work.

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)

When it builds the package it outputs

```
=> android-studio-2021.3.1.17_1: running pre-pkg hook: 999-collected-rdeps ...
   alsa-lib>=1.0.20_1 bzip2>=1.0.5_1 freetype>=2.12.1_1 glib>=2.74.0_1 glibc>=2.36_1 libGL>=0 libX11>=1.2_1 libXext>=1.0.5_1 libXi>=1.2.1_1 libXrender>=0.9.4_1 libXtst>=1.0.3_1 libcxx>=3.4_1 libedit>=20130712.3.1_1 libgcc>=4.4.0_1 libstdc++>=4.4.0_1 musl>=1.1.24_7 ncurses-libs>=6.0_1 openjdk8-jre>=8u20_1 sqlite>=3.38.0_1 zlib>=1.2.3_1
```

(note the musl dependency, which is wrong). Then when I try to install the package I get:

```
$ xi android-studio
[*] Updating repository `https://repo-default.voidlinux.org/current/x86_64-repodata' ...
MISSING: musl>=1.1.24_7
Transaction aborted due to unresolved dependencies.
```



