### PR TITLE
containers.storage: improve ZFS compatibility

### DIFF
--- a/srcpkgs/containers.storage/template
+++ b/srcpkgs/containers.storage/template
@@ -1,8 +1,9 @@
 # Template file for 'containers.storage'
 pkgname=containers.storage
 version=1.37.3
-revision=1
+revision=2
 hostmakedepends="go-md2man"
+depends="fuse-overlayfs"
 short_desc="Storage configuration shared by podman, buildah, and skopeo"
 maintainer="Cameron Nemo <cam@nohom.org>"
 license="Apache-2.0"
@@ -17,5 +18,6 @@ do_build() {
 
 do_install() {
 	vman "$_manpage"
+	vsed -e 's/^#mount_program = "/mount_program = "/' -i storage.conf
 	vinstall storage.conf 0644 usr/share/containers
 }


### PR DESCRIPTION
Based on feedback from @ahesford

ZFS does not support OverlayFS by default, so the fuse-overlayfs mount
program should be configured to workaround.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
