### PR TITLE
io.elementary.files: update to 6.2.1

### DIFF
--- a/srcpkgs/io.elementary.files/template
+++ b/srcpkgs/io.elementary.files/template
@@ -1,6 +1,6 @@
 # Template file for 'io.elementary.files'
 pkgname=io.elementary.files
-version=6.1.2
+version=6.2.1
 revision=1
 build_style=meson
 configure_args="-Dsystemduserunitdir=no"
@@ -8,12 +8,13 @@ hostmakedepends="vala glib-devel pkg-config gettext"
 makedepends="gtk+3-devel libglib-devel libgee08-devel sqlite-devel plank-devel
  libcanberra-devel granite-devel pango-devel zeitgeist-devel dbus-glib-devel
  libnotify-devel libcloudproviders-devel libgit2-glib-devel libhandy1-devel"
+depends="accountsservice gvfs"
 short_desc="File browser designed for elementary OS"
-maintainer="Cameron Nemo <cam@nohom.org>"
+maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-3.0-or-later"
 homepage="https://github.com/elementary/files"
 distfiles="https://github.com/elementary/files/archive/${version}.tar.gz"
-checksum=2a328d8df901186bb700c835064c9a526e5694545b668df512282773cfaa7b08
+checksum=780ae93df5eff6d201c3b07d3f3d22226ba24cd56687b96a9d187600b96bd605
 
 CFLAGS="-fcommon"
 


### PR DESCRIPTION
Orphan (due to disuse)
Add missing runtime dependencies

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
