### PR TITLE
musl: fix strverscmp comparison of digit sequence

### DIFF
--- a/srcpkgs/musl/patches/fix_strverscmp_comparison.patch
+++ b/srcpkgs/musl/patches/fix_strverscmp_comparison.patch
@@ -1,0 +1,40 @@
+From b50eb8c36c20f967bd0ed70c0b0db38a450886ba Mon Sep 17 00:00:00 2001
+From: Rich Felker <dalias@aerifal.cx>
+Date: Mon, 7 Nov 2022 22:17:55 -0500
+Subject: fix strverscmp comparison of digit sequence with non-digits
+
+the rule that longest digit sequence not beginning with a zero is
+greater only applies when both sequences being compared are
+non-degenerate. this is spelled out explicitly in the man page, which
+may be deemed authoritative for this nonstandard function: "If one or
+both of these is empty, then return what strcmp(3) would have
+returned..."
+
+we were wrongly treating any sequence of digits not beginning with a
+zero as greater than a non-digit in the other string.
+---
+ src/string/strverscmp.c | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+(limited to 'src/string/strverscmp.c')
+
+diff --git a/src/string/strverscmp.c b/src/string/strverscmp.c
+index 4daf276d..16c1da22 100644
+--- a/src/string/strverscmp.c
++++ b/src/string/strverscmp.c
+@@ -18,9 +18,9 @@ int strverscmp(const char *l0, const char *r0)
+ 		else if (c!='0') z=0;
+ 	}
+ 
+-	if (l[dp]!='0' && r[dp]!='0') {
+-		/* If we're not looking at a digit sequence that began
+-		 * with a zero, longest digit string is greater. */
++	if (l[dp]-'1'<9U && r[dp]-'1'<9U) {
++		/* If we're looking at non-degenerate digit sequences starting
++		 * with nonzero digits, longest digit string is greater. */
+ 		for (j=i; isdigit(l[j]); j++)
+ 			if (!isdigit(r[j])) return 1;
+ 		if (isdigit(r[j])) return -1;
+-- 
+cgit v1.2.1
+

--- a/srcpkgs/musl/template
+++ b/srcpkgs/musl/template
@@ -2,7 +2,7 @@
 pkgname=musl
 reverts="1.2.0_1"
 version=1.1.24
-revision=12
+revision=13
 archs="*-musl"
 bootstrap=yes
 build_style=gnu-configure


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (n/a)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl

The test in https://github.com/void-linux/void-packages/pull/41226 fails due to a bug in musl which causes strverscmp() to behave incorrectly and differently from glibc. 

This PR applies an upstream patch to fix that behavior. After applying the patch, the failed test succeeds 

