### PR TITLE
python3-importlib_metadata: update to 6.0.0.

### DIFF
--- a/srcpkgs/python3-importlib_metadata/template
+++ b/srcpkgs/python3-importlib_metadata/template
@@ -1,6 +1,6 @@
 # Template file for 'python3-importlib_metadata'
 pkgname=python3-importlib_metadata
-version=5.1.0
+version=6.0.0
 revision=1
 build_style=python3-pep517
 hostmakedepends="python3-setuptools_scm python3-wheel"
@@ -11,4 +11,4 @@ license="Apache-2.0"
 homepage="https://pypi.org/project/importlib-metadata/"
 changelog="https://raw.githubusercontent.com/python/importlib_metadata/main/CHANGES.rst"
 distfiles="${PYPI_SITE}/i/importlib_metadata/importlib_metadata-${version}.tar.gz"
-checksum=d5059f9f1e8e41f80e9c56c2ee58811450c31984dfa625329ffd7c0dad88a73b
+checksum=e354bedeb60efa6affdcc8ae121b73544a7aa74156d047311948f6d711cd378d


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture: **x86_64**