### PR TITLE
rrdtool: rebuild to fix unresolvable shlib, fix tests 

### DIFF
--- a/srcpkgs/rrdtool/patches/set_fallback_first_weekday_to_0.patch
+++ b/srcpkgs/rrdtool/patches/set_fallback_first_weekday_to_0.patch
@@ -1,0 +1,39 @@
+From 784a3913e64bd10ec544945f2c05c354677a726a Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Jean-Michel=20Vourg=C3=A8re?= <nirgal@debian.org>
+Date: Sun, 16 Jun 2019 08:07:32 +0200
+Subject: [PATCH] Set fallback first_weekday to 0 (fix #1012)
+
+- Set first_weekday to 0 (Sunday), when HAVE__NL_TIME_WEEK_1STDAY
+  is not defined
+- Fixes: https://github.com/oetiker/rrdtool-1.x/issues/1012
+---
+ src/rrd_graph.c   | 2 +-
+ src/rrd_rpncalc.c | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/rrd_graph.c b/src/rrd_graph.c
+index f5d2cdec5..62c3e645f 100644
+--- a/src/rrd_graph.c
++++ b/src/rrd_graph.c
+@@ -1568,7 +1568,7 @@ static int find_first_weekday(
+         }
+         first_weekday = (week_1stday + first_weekday - 1) % 7;
+ #else
+-        first_weekday = 1;
++        first_weekday = 0;
+ #endif
+     }
+     return first_weekday;
+diff --git a/src/rrd_rpncalc.c b/src/rrd_rpncalc.c
+index 0f54c6be6..84f692119 100644
+--- a/src/rrd_rpncalc.c
++++ b/src/rrd_rpncalc.c
+@@ -564,7 +564,7 @@ static int find_first_weekday(void){
+         }
+         first_weekday=(week_1stday + first_weekday - 1) % 7;
+ #else
+-        first_weekday = 1;
++        first_weekday = 0;
+ #endif
+     }
+     return first_weekday;

--- a/srcpkgs/rrdtool/template
+++ b/srcpkgs/rrdtool/template
@@ -1,7 +1,7 @@
 # Template file for 'rrdtool'
 pkgname=rrdtool
 version=1.7.2
-revision=13
+revision=14
 build_style=gnu-configure
 # configure checks sys.version[:3] for Python versioning, so 3.10 becomes 3.1;
 # until this is fixed upstream, manually define am_cv_python_version to circumvent
@@ -13,6 +13,7 @@ configure_args="--enable-perl --enable-perl-site-install
 hostmakedepends="pkg-config groff intltool python3-setuptools perl-XML-Parser"
 makedepends="libxml2-devel pango-devel python3-devel ruby-devel LuaJIT-devel perl"
 depends="dejavu-fonts-ttf"
+checkdepends="bc"
 short_desc="Data logging and graphing system for time series data"
 maintainer="Enno Boland <gottox@voidlinux.org>"
 license="GPL-2.0-or-later"
@@ -30,6 +31,7 @@ python-rrdtool_package() {
 
 python3-rrdtool_package() {
 	short_desc+=" - Python 3 bindings"
+	depends="python3"
 	replaces="python-rrdtool>=0"
 	provides="python-rrdtool-${version}_$revision"
 	pkg_install() {


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**



#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl

The test for https://github.com/void-linux/void-packages/pull/41228 fails with: 

> perl-rrdtool-1.7.2_13: broken, unresolvable shlib `libperl.so.5.36'

This can be reproduced by:

```
./xbps-src -m musl_temp binary-bootstrap x86_64-musl
./xbps-src -m musl_temp chroot
xbps-install perl-rrdtool

```

This is a due to missing "depends" on perl. 

This PR simply adds perl to the dependecy

CC @Gottox 