### PR TITLE
batsignal: update to 1.6.4.

### DIFF
--- a/srcpkgs/batsignal/template
+++ b/srcpkgs/batsignal/template
@@ -1,6 +1,6 @@
 # Template file for 'batsignal'
 pkgname=batsignal
-version=1.6.2
+version=1.6.4
 revision=1
 build_style=gnu-makefile
 make_use_env=yes
@@ -11,7 +11,7 @@ maintainer="André Cerqueira <acerqueira021@gmail.com>"
 license="ISC"
 homepage="https://github.com/electrickite/batsignal"
 distfiles="https://github.com/electrickite/batsignal/archive/${version}.tar.gz"
-checksum=0576257b6b960826799641e15521317a2d075d24f5da0c1abf180e2731022673
+checksum=58439dac2b678ab798831fe861c06d2d5c128c4bb4bae1476a62ba1771da3983
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
```
pkg:batsignal host:x86_64 target:x86_64 cross:n result:OK
pkg:batsignal host:x86_64-musl target:x86_64-musl cross:n result:OK
pkg:batsignal host:i686 target:i686 cross:n result:OK
pkg:batsignal host:x86_64-musl target:aarch64-musl cross:y result:OK
pkg:batsignal host:x86_64-musl target:aarch64 cross:y result:OK
pkg:batsignal host:x86_64-musl target:armv7l-musl cross:y result:OK
pkg:batsignal host:x86_64-musl target:armv7l cross:y result:OK
pkg:batsignal host:x86_64-musl target:armv6l-musl cross:y result:OK
pkg:batsignal host:x86_64-musl target:armv6l cross:y result:OK
```

Happy Holidays everyone !  