### PR TITLE
Update sv run script for moby to remove loop modprobe check.

### DIFF
--- a/srcpkgs/moby/files/docker/run
+++ b/srcpkgs/moby/files/docker/run
@@ -1,6 +1,5 @@
 #!/bin/sh
 [ -r conf ] && . ./conf
-modprobe -q loop || exit 1
 mountpoint -q /sys/fs/cgroup/systemd || {
     mkdir -p /sys/fs/cgroup/systemd;
     mount -t cgroup -o none,name=systemd cgroup /sys/fs/cgroup/systemd;


### PR DESCRIPTION
Remove `modprobe -q loop || exit 1` to enable docker to work within containers, where kernel modules may not exist/be loadable. The absence of the loop kmod does not appear to negatively impact docker running within a container.

Note: to run in containers, the rest of the script doesn't work either: adding `mount -t cgroup2 cgroup2 /sys/fs/cgroup/` to `/etc/rc.local` makes things work without issue. Modifying the systemd mountpoint check is too big a change to propose without extensive testing so I haven't included it as part of this PR.


#### Testing the changes
- I tested the changes in this PR: **YES***
Note: tested within a container only; I do not have access to void running on metal.

#### Local build testing
- I built this PR locally for my native architecture, `Linux boron 6.0.13_1 #1 SMP PREEMPT_DYNAMIC Fri Dec 16 02:05:26 UTC 2022 x86_64 GNU/Linux` (glibc)

