### PR TITLE
WIP: update moby run to work with containers

### DIFF
--- a/srcpkgs/moby/files/docker/run
+++ b/srcpkgs/moby/files/docker/run
@@ -1,7 +1,6 @@
 #!/bin/sh
 [ -r conf ] && . ./conf
-[ -r /etc/runit/functions ] && . /etc/runit/functions && detect_virt
-if [ -z $VIRTUALIZATION ]; then  # we're not in a container
+if [[ $VIRTUALIZATION -ne 1 ]]; then  # we're not in a container
     modprobe -q loop || exit 1
     mountpoint -q /sys/fs/cgroup/systemd || {
         mkdir -p /sys/fs/cgroup/systemd;

--- a/srcpkgs/moby/files/docker/run
+++ b/srcpkgs/moby/files/docker/run
@@ -1,8 +1,13 @@
 #!/bin/sh
 [ -r conf ] && . ./conf
-modprobe -q loop || exit 1
-mountpoint -q /sys/fs/cgroup/systemd || {
-    mkdir -p /sys/fs/cgroup/systemd;
-    mount -t cgroup -o none,name=systemd cgroup /sys/fs/cgroup/systemd;
-}
+[ -r /etc/runit/functions ] && . /etc/runit/functions && detect_virt
+if [ -z $VIRTUALIZATION ]; then  # we're not in a container
+    modprobe -q loop || exit 1
+    mountpoint -q /sys/fs/cgroup/systemd || {
+        mkdir -p /sys/fs/cgroup/systemd;
+        mount -t cgroup -o none,name=systemd cgroup /sys/fs/cgroup/systemd;
+    }
+else
+    mount -t cgroup2 cgroup2 /sys/fs/cgroup/
+fi
 exec chpst -o 1048576 -p 1048576 dockerd $OPTS 2>&1


### PR DESCRIPTION
Two things need to change when we're running docker in a virtual environment (LXC/D): first, we shouldn't test for the loop module, which might not exist/be loadable within the container. Second, we need a different cgroup mount command.

This PR is blocked on https://github.com/void-linux/void-runit/pull/102 since the virtualization detection is currently unavailable to runsv scripts. Once https://github.com/void-linux/void-runit/pull/102 is merged, I'll remove the WIP designator.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES** - but note - they've only been tested in virtual environments (I don't have docker running on bare metal void).


#### Local build testing
- I built this PR locally for my native architecture, `Linux lithium 6.0.13_1 #1 SMP PREEMPT_DYNAMIC Fri Dec 16 02:05:26 UTC 2022 x86_64 GNU/Linux` (glibc)

