### PR TITLE
act: update to 0.2.34.

### DIFF
--- a/srcpkgs/act/template
+++ b/srcpkgs/act/template
@@ -1,16 +1,16 @@
 # Template file for 'act'
 pkgname=act
-version=0.2.29
+version=0.2.34
 revision=1
 build_style=go
 go_import_path="github.com/nektos/act"
 go_ldflags="-X main.version=${version}"
 short_desc="Run your GitHub Actions locally"
 maintainer="0x5c <dev@0x5c.io>"
-license="MIT"
+license="MIT, Apache-2.0"
 homepage="https://github.com/nektos/act"
 distfiles="https://github.com/nektos/act/archive/refs/tags/v${version}.tar.gz"
-checksum=92c7f774395e98cff2e53c9739d8266027837cd27f437514ea342a59179c3115
+checksum=a036406c7d20c31e168ba90540ebb27c4c107f8915bd15a971496194200e137f
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
Apache-2.0 licence added since upstream now includes some docker-cli code.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
