### PR TITLE
popt: update to 1.19

### DIFF
--- a/srcpkgs/popt/template
+++ b/srcpkgs/popt/template
@@ -1,19 +1,15 @@
 # Template file for 'popt'
 pkgname=popt
-version=1.18
+version=1.19
 revision=1
 build_style=gnu-configure
 hostmakedepends="autoconf tar automake libtool gettext-devel"
 short_desc="Command line option parsing library"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
-homepage="https://rpm.org/"
+homepage="https://github.com/rpm-software-management/popt"
 distfiles="http://ftp.rpm.org/popt/releases/popt-1.x/popt-${version}.tar.gz"
-checksum=5159bc03a20b28ce363aa96765f37df99ea4d8850b1ece17d1e6ad5c24fdc5d1
-
-pre_configure() {
-	./autogen.sh
-}
+checksum=c25a4838fc8e4c1c8aacb8bd620edb3084a3d63bf8987fdad3ca2758c63240f9
 
 post_install() {
 	vlicense COPYING


### PR DESCRIPTION
https://github.com/rpm-software-management/popt/releases/tag/popt-1.19-release

no need to run autogen.sh - includes a recent configure/config.sub/etc scripts..

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
