### PR TITLE
openrgb: update to 0.8

### DIFF
--- a/srcpkgs/openrgb/patches/musl.patch
+++ b/srcpkgs/openrgb/patches/musl.patch
@@ -1,13 +1,26 @@
-diff --git a/i2c_smbus/i2c_smbus_linux.cpp b/i2c_smbus/i2c_smbus_linux.cpp
-index 33d1494b..f8a2c503 100644
---- a/i2c_smbus/i2c_smbus_linux.cpp
-+++ b/i2c_smbus/i2c_smbus_linux.cpp
-@@ -133,7 +133,7 @@ bool i2c_smbus_linux_detect()
-                     strcat(path, ent->d_name);
-                     if(ent->d_type == DT_LNK)
-                     {
--                        ptr = canonicalize_file_name(path);
-+                        ptr = realpath(path, NULL);
-                         if(ptr == NULL)
-                             continue;
+https://gitlab.com/CalcProgrammer1/OpenRGB/-/commit/8c893fba4fcec17e6221f2d754def4aa71b020b8
+
+From 8c893fba4fcec17e6221f2d754def4aa71b020b8 Mon Sep 17 00:00:00 2001
+From: Sirn Thanabulpong <sirn@ogsite.net>
+Date: Wed, 28 Dec 2022 00:49:47 +0900
+Subject: [PATCH] Fix build on musl in Nanoleaf settings
+
+---
+ qt/OpenRGBNanoleafSettingsPage/OpenRGBNanoleafScanningThread.cpp | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/qt/OpenRGBNanoleafSettingsPage/OpenRGBNanoleafScanningThread.cpp b/qt/OpenRGBNanoleafSettingsPage/OpenRGBNanoleafScanningThread.cpp
+index 1e3c926b3..55ed5fcaa 100644
+--- a/qt/OpenRGBNanoleafSettingsPage/OpenRGBNanoleafScanningThread.cpp
++++ b/qt/OpenRGBNanoleafSettingsPage/OpenRGBNanoleafScanningThread.cpp
+@@ -8,6 +8,7 @@
+ #else
+ #include <netdb.h>
+ #include <ifaddrs.h>
++#include <sys/select.h>
+ #endif
  
+ #include "mdns.h"
+-- 
+GitLab
+

--- a/srcpkgs/openrgb/template
+++ b/srcpkgs/openrgb/template
@@ -1,6 +1,6 @@
 # Template file for 'openrgb'
 pkgname=openrgb
-version=0.7
+version=0.8
 revision=1
 build_style=qmake
 hostmakedepends="qt5-qmake qt5-host-tools git pkg-config"
@@ -10,7 +10,7 @@ maintainer="Neel Chotai <neel@chot.ai>"
 license="GPL-2.0-only"
 homepage="https://gitlab.com/CalcProgrammer1/OpenRGB"
 distfiles="https://gitlab.com/CalcProgrammer1/OpenRGB/-/archive/release_${version}/OpenRGB-release_${version}.tar.gz"
-checksum=6052e04ad736f94a91a386f6cfc0aaff9554fafdabe99cdd46a296fd49132569
+checksum=0d803753873ca1ec2bd78632b4ac605669394e7eeba2d2efe305c7f9c9d7df0c
 
 pre_build() {
 	sed -i 's|rules.path=/lib|rules.path=/usr/lib|g' OpenRGB.pro


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES** (but only on glibc)

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)

#### Notes
- `musl.patch` removed as the relevant change is now incorporated in the release ([openrgb@48d1a4f7](https://gitlab.com/CalcProgrammer1/OpenRGB/-/commit/48d1a4f7b60198e13009ff32879d07986ca6a9ec))