### PR TITLE
lmms: remove broken KCheckAccelerators workaround

### DIFF
--- a/srcpkgs/lmms/patches/fix-qt-crash-kwidgetsaddons-5.101.0.patch
+++ b/srcpkgs/lmms/patches/fix-qt-crash-kwidgetsaddons-5.101.0.patch
@@ -1,0 +1,35 @@
+--- a/src/gui/MainWindow.cpp
++++ b/src/gui/MainWindow.cpp
+@@ -65,22 +65,6 @@
+ 
+ #include "lmmsversion.h"
+ 
+-#if !defined(LMMS_BUILD_WIN32) && !defined(LMMS_BUILD_APPLE) && !defined(LMMS_BUILD_HAIKU) && QT_VERSION >= 0x050000
+-//Work around an issue on KDE5 as per https://bugs.kde.org/show_bug.cgi?id=337491#c21
+-void disableAutoKeyAccelerators(QWidget* mainWindow)
+-{
+-	using DisablerFunc = void(*)(QWidget*);
+-	QLibrary kf5WidgetsAddon("KF5WidgetsAddons", 5);
+-	DisablerFunc setNoAccelerators = 
+-			reinterpret_cast<DisablerFunc>(kf5WidgetsAddon.resolve("_ZN19KAcceleratorManager10setNoAccelEP7QWidget"));
+-	if(setNoAccelerators)
+-	{
+-		setNoAccelerators(mainWindow);
+-	}
+-	kf5WidgetsAddon.unload();
+-}
+-#endif
+-
+ 
+ MainWindow::MainWindow() :
+ 	m_workspace( NULL ),
+@@ -92,9 +76,6 @@ MainWindow::MainWindow() :
+ 	m_metronomeToggle( 0 ),
+ 	m_session( Normal )
+ {
+-#if !defined(LMMS_BUILD_WIN32) && !defined(LMMS_BUILD_APPLE) && !defined(LMMS_BUILD_HAIKU) && QT_VERSION >= 0x050000
+-	disableAutoKeyAccelerators(this);
+-#endif
+ 	setAttribute( Qt::WA_DeleteOnClose );
+ 
+ 	QWidget * main_widget = new QWidget( this );

--- a/srcpkgs/lmms/template
+++ b/srcpkgs/lmms/template
@@ -1,7 +1,7 @@
 # Template file for 'lmms'
 pkgname=lmms
 version=1.2.2
-revision=3
+revision=4
 archs="~armv6*"
 build_style=cmake
 configure_args="-DWANT_QT5=ON -DWANT_WEAKJACK=OFF -DWANT_CARLA=OFF"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

Fixes the following segfault:
https://github.com/LMMS/lmms/issues/6587

Afaict the original workaround should already be fixed by:
https://invent.kde.org/frameworks/kxmlgui/-/commit/02b523bad09aab062355e46771889b0f3709692f

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
