### PR TITLE
btrfs-progs: update to 6.1.

### DIFF
--- a/srcpkgs/btrfs-progs/patches/fix-the-uuid-report-in-btrfs-subvolume-list--u.patch
+++ b/srcpkgs/btrfs-progs/patches/fix-the-uuid-report-in-btrfs-subvolume-list--u.patch
@@ -1,0 +1,264 @@
+From patchwork Tue Dec 27 05:55:07 2022
+Content-Type: text/plain; charset="utf-8"
+MIME-Version: 1.0
+Content-Transfer-Encoding: 7bit
+X-Patchwork-Submitter: Qu Wenruo <wqu@suse.com>
+X-Patchwork-Id: 13082066
+Return-Path: <linux-btrfs-owner@vger.kernel.org>
+X-Spam-Checker-Version: SpamAssassin 3.4.0 (2014-02-07) on
+	aws-us-west-2-korg-lkml-1.web.codeaurora.org
+Received: from vger.kernel.org (vger.kernel.org [23.128.96.18])
+	by smtp.lore.kernel.org (Postfix) with ESMTP id 8911CC46467
+	for <linux-btrfs@archiver.kernel.org>; Tue, 27 Dec 2022 05:55:38 +0000 (UTC)
+Received: (majordomo@vger.kernel.org) by vger.kernel.org via listexpand
+        id S229701AbiL0Fzg (ORCPT <rfc822;linux-btrfs@archiver.kernel.org>);
+        Tue, 27 Dec 2022 00:55:36 -0500
+Received: from lindbergh.monkeyblade.net ([23.128.96.19]:57878 "EHLO
+        lindbergh.monkeyblade.net" rhost-flags-OK-OK-OK-OK) by vger.kernel.org
+        with ESMTP id S229714AbiL0Fz3 (ORCPT
+        <rfc822;linux-btrfs@vger.kernel.org>);
+        Tue, 27 Dec 2022 00:55:29 -0500
+Received: from smtp-out1.suse.de (smtp-out1.suse.de
+ [IPv6:2001:67c:2178:6::1c])
+        by lindbergh.monkeyblade.net (Postfix) with ESMTPS id 8E7E721BD
+        for <linux-btrfs@vger.kernel.org>;
+ Mon, 26 Dec 2022 21:55:28 -0800 (PST)
+Received: from imap2.suse-dmz.suse.de (imap2.suse-dmz.suse.de
+ [192.168.254.74])
+        (using TLSv1.3 with cipher TLS_AES_256_GCM_SHA384 (256/256 bits)
+         key-exchange X25519 server-signature ECDSA (P-521) server-digest
+ SHA512)
+        (No client certificate requested)
+        by smtp-out1.suse.de (Postfix) with ESMTPS id 45C6921A5C
+        for <linux-btrfs@vger.kernel.org>;
+ Tue, 27 Dec 2022 05:55:27 +0000 (UTC)
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed; d=suse.com; s=susede1;
+        t=1672120527;
+ h=from:from:reply-to:date:date:message-id:message-id:to:to:cc:
+         mime-version:mime-version:
+         content-transfer-encoding:content-transfer-encoding:
+         in-reply-to:in-reply-to:references:references;
+        bh=W+yG1hLkX0HTroE6JXqPksnhlQIJ9YKQGLBuZJfgc30=;
+        b=Kg/GuSk+LeFw8BPNKp+N4MKZJ68a/I2jA0xTGBldQpjMFUgu25Pv9+JhZ0vv+OL1eGJBPP
+        ZaB0/Pgl8pTvg3crpX2+ey7F1GYSJuzpF1kGNBjhrsTUT+ZMjgMZyFYR3E3nIWg6fL/Wwn
+        gzYuY194OxIuVaQoQgclh3Cd+B3fwuQ=
+Received: from imap2.suse-dmz.suse.de (imap2.suse-dmz.suse.de
+ [192.168.254.74])
+        (using TLSv1.3 with cipher TLS_AES_256_GCM_SHA384 (256/256 bits)
+         key-exchange X25519 server-signature ECDSA (P-521) server-digest
+ SHA512)
+        (No client certificate requested)
+        by imap2.suse-dmz.suse.de (Postfix) with ESMTPS id 979EB133F5
+        for <linux-btrfs@vger.kernel.org>;
+ Tue, 27 Dec 2022 05:55:26 +0000 (UTC)
+Received: from dovecot-director2.suse.de ([192.168.254.65])
+        by imap2.suse-dmz.suse.de with ESMTPSA
+        id mB1aGM6IqmMBRgAAMHmgww
+        (envelope-from <wqu@suse.com>)
+        for <linux-btrfs@vger.kernel.org>; Tue, 27 Dec 2022 05:55:26 +0000
+From: Qu Wenruo <wqu@suse.com>
+To: linux-btrfs@vger.kernel.org
+Subject: [PATCH 1/2] btrfs-progs: fix the wrong timestamp and UUID check for
+ root items
+Date: Tue, 27 Dec 2022 13:55:07 +0800
+Message-Id: 
+ <fd138f8678808717635a145832c1b13320ce6cd2.1672120480.git.wqu@suse.com>
+X-Mailer: git-send-email 2.39.0
+In-Reply-To: <cover.1672120480.git.wqu@suse.com>
+References: <cover.1672120480.git.wqu@suse.com>
+MIME-Version: 1.0
+Precedence: bulk
+List-ID: <linux-btrfs.vger.kernel.org>
+X-Mailing-List: linux-btrfs@vger.kernel.org
+
+[BUG]
+Since commit d729048be6ef ("btrfs-progs: stop using
+btrfs_root_item_v0"), "btrfs subvolume list" not longer correctly report
+UUID nor timestamp, while older (btrfs-progs v6.0.2) still works
+correct:
+
+ v6.0.2:
+ # btrfs subv list -u  /mnt/btrfs/
+ ID 256 gen 12 top level 5 uuid ed4af580-d512-2644-b392-2a71aaeeb99e path subv1
+ ID 257 gen 13 top level 5 uuid a22ccba7-0a0a-a94f-af4b-5116ab58bb61 path subv2
+
+ v6.1:
+ # ./btrfs subv list -u /mnt/btrfs/
+ ID 256 gen 12 top level 5 uuid -                                    path subv1
+ ID 257 gen 13 top level 5 uuid -                                    path subv2
+
+[CAUSE]
+Commit d729048be6ef ("btrfs-progs: stop using btrfs_root_item_v0")
+removed old btrfs_root_item_v0, but incorrectly changed the check for
+v0 root item.
+
+Now we will treat v0 root items as latest root items, causing possible
+out-of-bound access. while treat current root items as older v0 root
+items, ignoring the UUID nor timestamp.
+
+[FIX]
+Fix the bug by using correct checks, and add extra comments on the
+branches.
+
+Issue: #562
+Fixes: d729048be6ef ("btrfs-progs: stop using btrfs_root_item_v0")
+Signed-off-by: Qu Wenruo <wqu@suse.com>
+Reviewed-by: Neal Gompa <neal@gompa.dev>
+---
+ cmds/subvolume-list.c | 11 +++++++++--
+ 1 file changed, 9 insertions(+), 2 deletions(-)
+
+diff --git a/cmds/subvolume-list.c b/cmds/subvolume-list.c
+index 6d5ef509ae67..7cdb0402b8e5 100644
+--- a/cmds/subvolume-list.c
++++ b/cmds/subvolume-list.c
+@@ -870,14 +870,21 @@ static int list_subvol_search(int fd, struct rb_root *root_lookup)
+ 				ri = (struct btrfs_root_item *)(args.buf + off);
+ 				gen = btrfs_root_generation(ri);
+ 				flags = btrfs_root_flags(ri);
+-				if(sh.len <
+-				   sizeof(struct btrfs_root_item)) {
++				if(sh.len >= sizeof(struct btrfs_root_item)) {
++					/*
++					 * The new full btrfs_root_item with
++					 * timestamp and UUID.
++					 */
+ 					otime = btrfs_stack_timespec_sec(&ri->otime);
+ 					ogen = btrfs_root_otransid(ri);
+ 					memcpy(uuid, ri->uuid, BTRFS_UUID_SIZE);
+ 					memcpy(puuid, ri->parent_uuid, BTRFS_UUID_SIZE);
+ 					memcpy(ruuid, ri->received_uuid, BTRFS_UUID_SIZE);
+ 				} else {
++					/*
++					 * The old v0 root item, which doesn't
++					 * has timestamp nor UUID.
++					 */
+ 					otime = 0;
+ 					ogen = 0;
+ 					memset(uuid, 0, BTRFS_UUID_SIZE);
+
+From patchwork Tue Dec 27 05:55:08 2022
+Content-Type: text/plain; charset="utf-8"
+MIME-Version: 1.0
+Content-Transfer-Encoding: 7bit
+X-Patchwork-Submitter: Qu Wenruo <wqu@suse.com>
+X-Patchwork-Id: 13082065
+Return-Path: <linux-btrfs-owner@vger.kernel.org>
+X-Spam-Checker-Version: SpamAssassin 3.4.0 (2014-02-07) on
+	aws-us-west-2-korg-lkml-1.web.codeaurora.org
+Received: from vger.kernel.org (vger.kernel.org [23.128.96.18])
+	by smtp.lore.kernel.org (Postfix) with ESMTP id 66D93C10F1B
+	for <linux-btrfs@archiver.kernel.org>; Tue, 27 Dec 2022 05:55:37 +0000 (UTC)
+Received: (majordomo@vger.kernel.org) by vger.kernel.org via listexpand
+        id S229683AbiL0Fzg (ORCPT <rfc822;linux-btrfs@archiver.kernel.org>);
+        Tue, 27 Dec 2022 00:55:36 -0500
+Received: from lindbergh.monkeyblade.net ([23.128.96.19]:57884 "EHLO
+        lindbergh.monkeyblade.net" rhost-flags-OK-OK-OK-OK) by vger.kernel.org
+        with ESMTP id S229719AbiL0Fza (ORCPT
+        <rfc822;linux-btrfs@vger.kernel.org>);
+        Tue, 27 Dec 2022 00:55:30 -0500
+Received: from smtp-out2.suse.de (smtp-out2.suse.de
+ [IPv6:2001:67c:2178:6::1d])
+        by lindbergh.monkeyblade.net (Postfix) with ESMTPS id D6FED5FCB
+        for <linux-btrfs@vger.kernel.org>;
+ Mon, 26 Dec 2022 21:55:29 -0800 (PST)
+Received: from imap2.suse-dmz.suse.de (imap2.suse-dmz.suse.de
+ [192.168.254.74])
+        (using TLSv1.3 with cipher TLS_AES_256_GCM_SHA384 (256/256 bits)
+         key-exchange X25519 server-signature ECDSA (P-521) server-digest
+ SHA512)
+        (No client certificate requested)
+        by smtp-out2.suse.de (Postfix) with ESMTPS id 523105FE4D
+        for <linux-btrfs@vger.kernel.org>;
+ Tue, 27 Dec 2022 05:55:28 +0000 (UTC)
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed; d=suse.com; s=susede1;
+        t=1672120528;
+ h=from:from:reply-to:date:date:message-id:message-id:to:to:cc:
+         mime-version:mime-version:
+         content-transfer-encoding:content-transfer-encoding:
+         in-reply-to:in-reply-to:references:references;
+        bh=2gNyMjFYBxP2ubq4bugStueaD9klIpECbWiDJBw6lSo=;
+        b=GXtDFnlrJed2boT5ndRx17OF5an5YXUma/0eZnrkDiDdHBwunCDXHyM0g5knvu4TQLxD1G
+        OFzV/pP5MfDZ00PL8qPbWBgnTQtaFW+xXnpVK+0q1e0Lqi03F6l84VjcZX593WEfqq9Ece
+        njWGIwC2yADcBBSsXoe0EnPAYh6KbMA=
+Received: from imap2.suse-dmz.suse.de (imap2.suse-dmz.suse.de
+ [192.168.254.74])
+        (using TLSv1.3 with cipher TLS_AES_256_GCM_SHA384 (256/256 bits)
+         key-exchange X25519 server-signature ECDSA (P-521) server-digest
+ SHA512)
+        (No client certificate requested)
+        by imap2.suse-dmz.suse.de (Postfix) with ESMTPS id A6A2E133F5
+        for <linux-btrfs@vger.kernel.org>;
+ Tue, 27 Dec 2022 05:55:27 +0000 (UTC)
+Received: from dovecot-director2.suse.de ([192.168.254.65])
+        by imap2.suse-dmz.suse.de with ESMTPSA
+        id qEYYHM+IqmMBRgAAMHmgww
+        (envelope-from <wqu@suse.com>)
+        for <linux-btrfs@vger.kernel.org>; Tue, 27 Dec 2022 05:55:27 +0000
+From: Qu Wenruo <wqu@suse.com>
+To: linux-btrfs@vger.kernel.org
+Subject: [PATCH 2/2] btrfs-progs: misc-tests: add a test case to make sure
+ uuid is correctly  reported
+Date: Tue, 27 Dec 2022 13:55:08 +0800
+Message-Id: 
+ <6b439939b69d08debf357e7b9d7a5b3ef8ae6b4b.1672120480.git.wqu@suse.com>
+X-Mailer: git-send-email 2.39.0
+In-Reply-To: <cover.1672120480.git.wqu@suse.com>
+References: <cover.1672120480.git.wqu@suse.com>
+MIME-Version: 1.0
+Precedence: bulk
+List-ID: <linux-btrfs.vger.kernel.org>
+X-Mailing-List: linux-btrfs@vger.kernel.org
+
+The new test case will execute "btrfs subvolume list -u" on the newly
+create btrfs.
+
+Since the v0 root item is already deprecated for a long time, newly
+created btrfs should be already using the new root item, thus "btrfs
+subvolume list -u" should always report the correct uuid.
+
+The test case relies on external program "uuidparse" which should be
+provided by util-linux.
+
+Signed-off-by: Qu Wenruo <wqu@suse.com>
+Reviewed-by: Neal Gompa <neal@gompa.dev>
+---
+ .../056-subvolume-list-uuid/test.sh           | 28 +++++++++++++++++++
+ 1 file changed, 28 insertions(+)
+ create mode 100755 tests/misc-tests/056-subvolume-list-uuid/test.sh
+
+diff --git a/tests/misc-tests/056-subvolume-list-uuid/test.sh b/tests/misc-tests/056-subvolume-list-uuid/test.sh
+new file mode 100755
+index 000000000000..45f4f956c25f
+--- /dev/null
++++ b/tests/misc-tests/056-subvolume-list-uuid/test.sh
+@@ -0,0 +1,28 @@
++#!/bin/bash
++#
++# Make sure "btrfs subvolume list -u" shows uuid correctly
++
++source "$TEST_TOP/common"
++
++check_prereq mkfs.btrfs
++check_prereq btrfs
++check_global_prereq uuidparse
++
++setup_root_helper
++prepare_test_dev
++
++tmp=$(_mktemp_dir list_uuid)
++
++run_check_mkfs_test_dev
++run_check_mount_test_dev
++run_check $SUDO_HELPER "$TOP/btrfs" subvolume create "$TEST_MNT/subv1"
++run_check_stdout $SUDO_HELPER "$TOP/btrfs" subvolume list -u "$TEST_MNT" |\
++	cut -d\  -f9 > "$tmp/output"
++
++result=$(cat "$tmp/output" | uuidparse -o TYPE -n)
++rm -rf -- "$tmp"
++
++if [ "$result" == "invalid" ]; then
++	_fail "subvolume list failed to report uuid"
++fi
++run_check_umount_test_dev
+

--- a/srcpkgs/btrfs-progs/template
+++ b/srcpkgs/btrfs-progs/template
@@ -1,6 +1,6 @@
 # Template file for 'btrfs-progs'
 pkgname=btrfs-progs
-version=5.19.1
+version=6.1
 revision=1
 build_style=gnu-configure
 make_check_target=test
@@ -14,8 +14,8 @@ maintainer="Enno Boland <gottox@voidlinux.org>"
 license="GPL-2.0-only, LGPL-2.1-or-later"
 homepage="https://btrfs.wiki.kernel.org/index.php/Main_Page"
 changelog="https://raw.githubusercontent.com/kdave/btrfs-progs/master/CHANGES"
-distfiles="${KERNEL_SITE}/kernel/people/kdave/${pkgname}/${pkgname}-v${version}.tar.xz"
-checksum=26429e540343ccc7f5d4b3f8f42b916713280e898c5471da705026ef6d2c10a6
+distfiles="${KERNEL_SITE}/kernel/people/kdave/btrfs-progs/btrfs-progs-v${version}.tar.xz"
+checksum=378bcafabdb64c453ac64fef3d4cf8c8d5e47f310319743f580667f9c1114657
 # Most of the tests depend on `mount` and `fallocate` commands, which are not
 # presented in chroot-util-linux
 make_check=no


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
```
pkg:btrfs-progs host:x86_64 target:x86_64 cross:n result:OK
pkg:btrfs-progs host:x86_64-musl target:x86_64-musl cross:n result:OK
pkg:btrfs-progs host:i686 target:i686 cross:n result:OK
pkg:btrfs-progs host:x86_64-musl target:aarch64-musl cross:y result:OK
pkg:btrfs-progs host:x86_64-musl target:aarch64 cross:y result:OK
pkg:btrfs-progs host:x86_64-musl target:armv7l-musl cross:y result:OK
pkg:btrfs-progs host:x86_64-musl target:armv7l cross:y result:OK
pkg:btrfs-progs host:x86_64-musl target:armv6l-musl cross:y result:OK
pkg:btrfs-progs host:x86_64-musl target:armv6l cross:y result:OK
```