### PR TITLE
flatpak-builder: update to 1.2.3.

### DIFF
--- a/srcpkgs/flatpak-builder/template
+++ b/srcpkgs/flatpak-builder/template
@@ -1,6 +1,6 @@
 # Template file for 'flatpak-builder'
 pkgname=flatpak-builder
-version=1.2.2
+version=1.2.3
 revision=1
 build_style=gnu-configure
 hostmakedepends="pkg-config xmlto"
@@ -11,8 +11,9 @@ short_desc="Tool to build flatpaks from source"
 maintainer="Enno Boland <gottox@voidlinux.org>"
 license="LGPL-2.1-or-later"
 homepage="https://github.com/flatpak/flatpak-builder"
-distfiles="${homepage}/releases/download/${version}/${pkgname}-${version}.tar.xz"
-checksum=89fda68e537c1e9de02352690bd89c3217a729164558d35f35b08f79ad84e03e
+changelog="https://github.com/flatpak/flatpak-builder/raw/main/NEWS"
+distfiles="https://github.com/flatpak/flatpak-builder/releases/download/${version}/flatpak-builder-${version}.tar.xz"
+checksum=e257825a47f7a3e71e30fb0f80f2d9ac6e4801f746f552dfaf0e564e3ee351c8
 # Tests expects a Debian derivate hosts to build a flatpak container from.
 make_check=no
 


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl
  - i686
  - aarch64 (cross)

