### PR TITLE
vivaldi: update to 5.6.2867.50, build for aarch64 & armv7l

### DIFF
--- a/srcpkgs/vivaldi/template
+++ b/srcpkgs/vivaldi/template
@@ -1,9 +1,9 @@
 # Template file for 'vivaldi'
 pkgname=vivaldi
-version=5.6.2867.36
+version=5.6.2867.50
 revision=1
 _release=1
-archs="x86_64"
+archs="x86_64 aarch64 armv7l"
 hostmakedepends="curl python3-html2text python3-setuptools"
 depends="desktop-file-utils hicolor-icon-theme xz"
 short_desc="Advanced browser made with the power user in mind"
@@ -12,12 +12,27 @@ maintainer="Diogo Leal <diogo@diogoleal.com>"
 # Privacy Policy: https://vivaldi.com/privacy/browser/
 license="custom:Proprietary"
 homepage="https://vivaldi.com"
-distfiles="https://downloads.vivaldi.com/stable/vivaldi-stable_${version}-${_release}_amd64.deb"
 _licenseUrl="https://vivaldi.com/privacy/vivaldi-end-user-license-agreement/"
-checksum=7535e9a519ff6e5f87615ceacab2815dbd9801ac34951264c007ae91a96fddae
 repository=nonfree
 restricted=yes
 nostrip=yes
+case "$XBPS_TARGET_MACHINE" in
+x86_64)
+	distfiles="https://downloads.vivaldi.com/stable/vivaldi-stable_${version}-${_release}_amd64.deb"
+	checksum=8a26bfbbd442c49e0430f18d5103b3a23c8d8552e5c184c6ba16bff7ff10f882
+	;;
+aarch64)
+	distfiles="https://downloads.vivaldi.com/stable/vivaldi-stable_${version}-${_release}_arm64.deb"
+	checksum=aec448206a36d05344b62d38e406fda81afa7abb6b81396df1513037134a11a7
+	;;
+armv7l)
+	distfiles="https://downloads.vivaldi.com/stable/vivaldi-stable_${version}-${_release}_armhf.deb"
+	checksum=4868815e36f0b9a011e7f24a3408f40903a575fb11724f7a7993d505cf669cbd
+	;;
+*)
+	broken="No distfiles available for this target"
+	;;
+esac
 
 post_extract() {
 	rm -r etc opt/vivaldi/cron


### PR DESCRIPTION
Tested as working on `aarch64-glibc` on a OnePlus 5T.

![vivaldi](https://user-images.githubusercontent.com/47358222/209741477-d8b811c4-101b-4b37-936f-204fcfe13435.jpg)

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
