### PR TITLE
cpuburn: build statically

### DIFF
--- a/srcpkgs/cpuburn/patches/02-m32.patch
+++ b/srcpkgs/cpuburn/patches/02-m32.patch
@@ -4,4 +4,4 @@
  all : burnP5 burnP6 burnK6 burnK7 burnBX burnMMX
  .S:
 -	gcc -s -nostdlib -o $@ $<
-+	gcc -m32 -s -nostdlib -o $@ $<
++	gcc -static -m32 -s -nostdlib -o $@ $<

--- a/srcpkgs/cpuburn/template
+++ b/srcpkgs/cpuburn/template
@@ -1,7 +1,7 @@
 # Template file for 'cpuburn'
 pkgname=cpuburn
 version=1.4a
-revision=4
+revision=5
 archs="armv6l* armv7l* i686* x86_64*"
 short_desc="Collection of programs to put heavy load on CPU"
 maintainer="Leah Neukirchen <leah@vuxu.org>"


### PR DESCRIPTION
The status quote of cpuburn is always built for 32bits on x86_64, which requires dynamic linker for 32 bit system.

On x86-64 system, we can workaround by depends on glibc-32bit. However, we don't have that luxury on x86_64-musl system.

Since `cpuburn` doesn't use any features from libc and/or dynamic linker, we can simply build static instead.

Fix #41307

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
