### PR TITLE
linux5.15+: Add landlock to CONFIG_LSM

### DIFF
--- a/srcpkgs/linux5.15/files/arm64-dotconfig
+++ b/srcpkgs/linux5.15/files/arm64-dotconfig
@@ -11226,7 +11226,7 @@ CONFIG_INTEGRITY_AUDIT=y
 # CONFIG_EVM is not set
 CONFIG_DEFAULT_SECURITY_APPARMOR=y
 # CONFIG_DEFAULT_SECURITY_DAC is not set
-CONFIG_LSM="yama,loadpin,safesetid,integrity"
+CONFIG_LSM="landlock,yama,loadpin,safesetid,integrity"
 
 #
 # Kernel hardening options

--- a/srcpkgs/linux5.15/files/i386-dotconfig
+++ b/srcpkgs/linux5.15/files/i386-dotconfig
@@ -9544,7 +9544,7 @@ CONFIG_INTEGRITY_AUDIT=y
 # CONFIG_DEFAULT_SECURITY_SELINUX is not set
 # CONFIG_DEFAULT_SECURITY_APPARMOR is not set
 CONFIG_DEFAULT_SECURITY_DAC=y
-CONFIG_LSM="yama,loadpin,safesetid,integrity"
+CONFIG_LSM="landlock,yama,loadpin,safesetid,integrity"
 
 #
 # Kernel hardening options

--- a/srcpkgs/linux5.15/files/ppc-dotconfig
+++ b/srcpkgs/linux5.15/files/ppc-dotconfig
@@ -7674,7 +7674,7 @@ CONFIG_INTEGRITY_AUDIT=y
 # CONFIG_DEFAULT_SECURITY_SELINUX is not set
 CONFIG_DEFAULT_SECURITY_APPARMOR=y
 # CONFIG_DEFAULT_SECURITY_DAC is not set
-CONFIG_LSM="yama,loadpin,safesetid,integrity,apparmor,selinux,smack,tomoyo"
+CONFIG_LSM="landlock,yama,loadpin,safesetid,integrity,apparmor,selinux,smack,tomoyo"
 
 #
 # Kernel hardening options

--- a/srcpkgs/linux5.15/files/ppc64-dotconfig
+++ b/srcpkgs/linux5.15/files/ppc64-dotconfig
@@ -9658,7 +9658,7 @@ CONFIG_INTEGRITY_AUDIT=y
 # CONFIG_DEFAULT_SECURITY_SELINUX is not set
 # CONFIG_DEFAULT_SECURITY_APPARMOR is not set
 CONFIG_DEFAULT_SECURITY_DAC=y
-CONFIG_LSM="yama,loadpin,safesetid,integrity"
+CONFIG_LSM="landlock,yama,loadpin,safesetid,integrity"
 
 #
 # Kernel hardening options

--- a/srcpkgs/linux5.15/files/ppc64le-dotconfig
+++ b/srcpkgs/linux5.15/files/ppc64le-dotconfig
@@ -9380,7 +9380,7 @@ CONFIG_INTEGRITY_AUDIT=y
 # CONFIG_DEFAULT_SECURITY_SELINUX is not set
 # CONFIG_DEFAULT_SECURITY_APPARMOR is not set
 CONFIG_DEFAULT_SECURITY_DAC=y
-CONFIG_LSM="yama,loadpin,safesetid,integrity"
+CONFIG_LSM="landlock,yama,loadpin,safesetid,integrity"
 
 #
 # Kernel hardening options

--- a/srcpkgs/linux5.15/files/x86_64-dotconfig
+++ b/srcpkgs/linux5.15/files/x86_64-dotconfig
@@ -9728,7 +9728,7 @@ CONFIG_INTEGRITY_AUDIT=y
 # CONFIG_EVM is not set
 # CONFIG_DEFAULT_SECURITY_APPARMOR is not set
 CONFIG_DEFAULT_SECURITY_DAC=y
-CONFIG_LSM="yama,loadpin,safesetid,integrity"
+CONFIG_LSM="landlock,yama,loadpin,safesetid,integrity"
 
 #
 # Kernel hardening options

--- a/srcpkgs/linux6.0/files/arm64-dotconfig
+++ b/srcpkgs/linux6.0/files/arm64-dotconfig
@@ -11759,7 +11759,7 @@ CONFIG_INTEGRITY_AUDIT=y
 # CONFIG_EVM is not set
 CONFIG_DEFAULT_SECURITY_APPARMOR=y
 # CONFIG_DEFAULT_SECURITY_DAC is not set
-CONFIG_LSM="yama,loadpin,safesetid,integrity"
+CONFIG_LSM="landlock,yama,loadpin,safesetid,integrity"
 
 #
 # Kernel hardening options

--- a/srcpkgs/linux6.0/files/i386-dotconfig
+++ b/srcpkgs/linux6.0/files/i386-dotconfig
@@ -9964,7 +9964,7 @@ CONFIG_INTEGRITY_AUDIT=y
 # CONFIG_DEFAULT_SECURITY_SELINUX is not set
 # CONFIG_DEFAULT_SECURITY_APPARMOR is not set
 CONFIG_DEFAULT_SECURITY_DAC=y
-CONFIG_LSM="yama,loadpin,safesetid,integrity"
+CONFIG_LSM="landlock,yama,loadpin,safesetid,integrity"
 
 #
 # Kernel hardening options

--- a/srcpkgs/linux6.0/files/ppc-dotconfig
+++ b/srcpkgs/linux6.0/files/ppc-dotconfig
@@ -8005,7 +8005,7 @@ CONFIG_INTEGRITY_AUDIT=y
 # CONFIG_DEFAULT_SECURITY_SELINUX is not set
 CONFIG_DEFAULT_SECURITY_APPARMOR=y
 # CONFIG_DEFAULT_SECURITY_DAC is not set
-CONFIG_LSM="yama,loadpin,safesetid,integrity,apparmor,selinux,smack,tomoyo"
+CONFIG_LSM="landlock,yama,loadpin,safesetid,integrity,apparmor,selinux,smack,tomoyo"
 
 #
 # Kernel hardening options

--- a/srcpkgs/linux6.0/files/ppc64-dotconfig
+++ b/srcpkgs/linux6.0/files/ppc64-dotconfig
@@ -10030,7 +10030,7 @@ CONFIG_INTEGRITY_AUDIT=y
 # CONFIG_DEFAULT_SECURITY_SELINUX is not set
 # CONFIG_DEFAULT_SECURITY_APPARMOR is not set
 CONFIG_DEFAULT_SECURITY_DAC=y
-CONFIG_LSM="yama,loadpin,safesetid,integrity"
+CONFIG_LSM="landlock,yama,loadpin,safesetid,integrity"
 
 #
 # Kernel hardening options

--- a/srcpkgs/linux6.0/files/ppc64le-dotconfig
+++ b/srcpkgs/linux6.0/files/ppc64le-dotconfig
@@ -9750,7 +9750,7 @@ CONFIG_INTEGRITY_AUDIT=y
 # CONFIG_DEFAULT_SECURITY_SELINUX is not set
 # CONFIG_DEFAULT_SECURITY_APPARMOR is not set
 CONFIG_DEFAULT_SECURITY_DAC=y
-CONFIG_LSM="yama,loadpin,safesetid,integrity"
+CONFIG_LSM="landlock,yama,loadpin,safesetid,integrity"
 
 #
 # Kernel hardening options

--- a/srcpkgs/linux6.0/files/x86_64-dotconfig
+++ b/srcpkgs/linux6.0/files/x86_64-dotconfig
@@ -10188,7 +10188,7 @@ CONFIG_INTEGRITY_AUDIT=y
 # CONFIG_EVM is not set
 # CONFIG_DEFAULT_SECURITY_APPARMOR is not set
 CONFIG_DEFAULT_SECURITY_DAC=y
-CONFIG_LSM="yama,loadpin,safesetid,integrity"
+CONFIG_LSM="landlock,yama,loadpin,safesetid,integrity"
 
 #
 # Kernel hardening options

--- a/srcpkgs/linux6.1/files/arm64-dotconfig
+++ b/srcpkgs/linux6.1/files/arm64-dotconfig
@@ -11785,7 +11785,7 @@ CONFIG_INTEGRITY_AUDIT=y
 # CONFIG_EVM is not set
 CONFIG_DEFAULT_SECURITY_APPARMOR=y
 # CONFIG_DEFAULT_SECURITY_DAC is not set
-CONFIG_LSM="yama,loadpin,safesetid,integrity"
+CONFIG_LSM="landlock,yama,loadpin,safesetid,integrity"
 
 #
 # Kernel hardening options

--- a/srcpkgs/linux6.1/files/i386-dotconfig
+++ b/srcpkgs/linux6.1/files/i386-dotconfig
@@ -9981,7 +9981,7 @@ CONFIG_INTEGRITY_AUDIT=y
 # CONFIG_DEFAULT_SECURITY_SELINUX is not set
 # CONFIG_DEFAULT_SECURITY_APPARMOR is not set
 CONFIG_DEFAULT_SECURITY_DAC=y
-CONFIG_LSM="yama,loadpin,safesetid,integrity"
+CONFIG_LSM="landlock,yama,loadpin,safesetid,integrity"
 
 #
 # Kernel hardening options

--- a/srcpkgs/linux6.1/files/ppc-dotconfig
+++ b/srcpkgs/linux6.1/files/ppc-dotconfig
@@ -8009,7 +8009,7 @@ CONFIG_INTEGRITY_AUDIT=y
 # CONFIG_DEFAULT_SECURITY_SELINUX is not set
 CONFIG_DEFAULT_SECURITY_APPARMOR=y
 # CONFIG_DEFAULT_SECURITY_DAC is not set
-CONFIG_LSM="yama,loadpin,safesetid,integrity,apparmor,selinux,smack,tomoyo"
+CONFIG_LSM="landlock,yama,loadpin,safesetid,integrity,apparmor,selinux,smack,tomoyo"
 
 #
 # Kernel hardening options

--- a/srcpkgs/linux6.1/files/ppc64-dotconfig
+++ b/srcpkgs/linux6.1/files/ppc64-dotconfig
@@ -10050,7 +10050,7 @@ CONFIG_INTEGRITY_AUDIT=y
 # CONFIG_DEFAULT_SECURITY_SELINUX is not set
 # CONFIG_DEFAULT_SECURITY_APPARMOR is not set
 CONFIG_DEFAULT_SECURITY_DAC=y
-CONFIG_LSM="yama,loadpin,safesetid,integrity"
+CONFIG_LSM="landlock,yama,loadpin,safesetid,integrity"
 
 #
 # Kernel hardening options

--- a/srcpkgs/linux6.1/files/ppc64le-dotconfig
+++ b/srcpkgs/linux6.1/files/ppc64le-dotconfig
@@ -9771,7 +9771,7 @@ CONFIG_INTEGRITY_AUDIT=y
 # CONFIG_DEFAULT_SECURITY_SELINUX is not set
 # CONFIG_DEFAULT_SECURITY_APPARMOR is not set
 CONFIG_DEFAULT_SECURITY_DAC=y
-CONFIG_LSM="yama,loadpin,safesetid,integrity"
+CONFIG_LSM="landlock,yama,loadpin,safesetid,integrity"
 
 #
 # Kernel hardening options

--- a/srcpkgs/linux6.1/files/x86_64-dotconfig
+++ b/srcpkgs/linux6.1/files/x86_64-dotconfig
@@ -10219,7 +10219,7 @@ CONFIG_INTEGRITY_AUDIT=y
 # CONFIG_EVM is not set
 # CONFIG_DEFAULT_SECURITY_APPARMOR is not set
 CONFIG_DEFAULT_SECURITY_DAC=y
-CONFIG_LSM="yama,loadpin,safesetid,integrity"
+CONFIG_LSM="landlock,yama,loadpin,safesetid,integrity"
 
 #
 # Kernel hardening options


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **NO**

I answered NO here since I don't run voids kernel config (but have my own with it enabled)

For landlock to be available CONFIG_SECURITY_LANDLOCK=y is not enough, it should also be added to CONFIG_LSM: https://docs.kernel.org/userspace-api/landlock.html#kernel-support



CC @sgn 

