### PR TITLE
profile-cleaner: resolve conflict with pc

### DIFF
--- a/srcpkgs/profile-cleaner/template
+++ b/srcpkgs/profile-cleaner/template
@@ -1,7 +1,7 @@
 # Template file for 'profile-cleaner'
 pkgname=profile-cleaner
 version=2.42
-revision=1
+revision=2
 build_style=gnu-makefile
 depends="bash sqlite bc parallel findutils"
 short_desc="Reduces profile size by cleaning their sqlite databases"
@@ -12,5 +12,12 @@ distfiles="https://github.com/graysky2/profile-cleaner/archive/v${version}.tar.g
 checksum=427d3c9aa0ab7cd1031a40e6da507027bd3ce4bc80a504a9dbeee536e864e9e1
 
 post_install() {
+	# makefile shipped with the package shortens profile-cleaner to pc,
+	# thus causing conflict with the 'pc' package.
+	unlink ${DESTDIR}/usr/bin/pc
+	mv ${DESTDIR}/usr/share/man/man1/pc.1 \
+		${DESTDIR}/usr/share/man/man1/profile-cleaner.1
+	mv ${DESTDIR}/usr/share/zsh/site-functions/_pc \
+		${DESTDIR}/usr/share/zsh/site-functions/_profile-cleaner
 	vlicense LICENSE
 }


### PR DESCRIPTION
Makefile shipped with the package shortens profile-cleaner to pc, thus causing conflict with the 'pc' package.

Discovered in #41298.

#### Testing the changes
- I tested the changes in this PR: **briefly**