### PR TITLE
leafpad: udpate to 0.8.19

### DIFF
--- a/srcpkgs/leafpad/template
+++ b/srcpkgs/leafpad/template
@@ -1,7 +1,7 @@
 # Template file for 'leafpad'
 pkgname=leafpad
-version=0.8.18.1
-revision=5
+version=0.8.19
+revision=1
 build_style=gnu-configure
 hostmakedepends="intltool pkg-config"
 makedepends="gettext-devel gtk+-devel desktop-file-utils hicolor-icon-theme"
@@ -11,7 +11,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="http://tarot.freeshell.org/leafpad/"
 distfiles="http://download-mirror.savannah.gnu.org/releases/leafpad/leafpad-${version}.tar.gz"
-checksum=959d22ae07f22803bc66ff40d373a854532a6e4732680bf8a96a3fbcb9f80a2c
+checksum=07d3f712f4dbd0a33251fd1dee14e21afdc9f92090fc768c11ab0ac556adbe97
 
 post_patch() {
 	vsed -i -e 's/DATADIRNAME=lib/DATADIRNAME=share/' \


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures:
  - x86_64-musl
  - aarch64
  - armv7l

