### PR TITLE
mitmproxy: fix for python 3.11

### DIFF
--- a/srcpkgs/mitmproxy/patches/dataclass.patch
+++ b/srcpkgs/mitmproxy/patches/dataclass.patch
@@ -1,0 +1,11 @@
+--- a/mitmproxy/contentviews/grpc.py
++++ b/mitmproxy/contentviews/grpc.py
+@@ -951,7 +951,7 @@
+ 
+ @dataclass
+ class ViewConfig:
+-    parser_options: ProtoParser.ParserOptions = ProtoParser.ParserOptions()
++    parser_options: ProtoParser.ParserOptions = field(default_factory=ProtoParser.ParserOptions)
+     parser_rules: list[ProtoParser.ParserRule] = field(default_factory=list)
+ 
+

--- a/srcpkgs/mitmproxy/template
+++ b/srcpkgs/mitmproxy/template
@@ -1,7 +1,7 @@
 # Template file for 'mitmproxy'
 pkgname=mitmproxy
 version=8.1.1
-revision=3
+revision=4
 build_style=python3-module
 hostmakedepends="python3-setuptools"
 depends="python3-Brotli python3-Flask python3-asgiref python3-blinker python3-certifi
@@ -20,6 +20,10 @@ distfiles="https://github.com/mitmproxy/mitmproxy/archive/v${version}.tar.gz"
 checksum=212e81bec40e1d2a894d73a337f076a3010d981249e513565e9246f29822d06c
 
 _skip="(test_get_version)" # This test fails without a git repository
+
+# these two are broken in 8.1.1, possibly fixed in 9.0
+_skip+="or(test_roundtrip_big_integer)" # parses an int too large
+_skip+="or(test_onboarding.py)" # broken (?) skip the whole file
 
 if [ ${XBPS_TARGET_MACHINE%-musl} = "i686" ]; then
 	_skip+="or(test_refresh)"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

Without this patch, mitmproxy doesn't even start. I also disabled two tests that are broken with python 3.11.

Upgrading to 9.0.1 needs https://github.com/decathorpe/mitmproxy_wireguard which is a python module written in rust.

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
