### PR TITLE
gitea: update to 1.18.0

### DIFF
--- a/srcpkgs/gitea/template
+++ b/srcpkgs/gitea/template
@@ -1,6 +1,6 @@
 # Template file for 'gitea'
 pkgname=gitea
-version=1.17.4
+version=1.18.0
 revision=1
 build_style=go
 go_import_path=code.gitea.io/gitea
@@ -31,7 +31,7 @@ license="MIT"
 homepage="https://gitea.io"
 changelog="https://raw.githubusercontent.com/go-gitea/gitea/main/CHANGELOG.md"
 distfiles="https://dl.gitea.io/gitea/${version}/gitea-src-${version}.tar.gz"
-checksum=928644afcf5087109fd8377fed25a24bf659a112017f2bb499bc4a9278d73cae
+checksum=5f42af201d89bd2a21d8c47d15cc0a39b433a1dd86c6129e1aa20a53908a4c43
 
 system_accounts="_gitea"
 _gitea_homedir="/var/lib/gitea"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, (x64 glibc)