### PR TITLE
sway:  fix custom user keymaps.

### DIFF
--- a/srcpkgs/libxkbcommon/template
+++ b/srcpkgs/libxkbcommon/template
@@ -1,6 +1,6 @@
 # Template file for 'libxkbcommon'
 pkgname=libxkbcommon
-version=1.4.1
+version=1.5.0
 revision=1
 build_style=meson
 # b_ndebug=false is needed to pass the test suite, as it relies on side effects
@@ -16,7 +16,7 @@ maintainer="Isaac Freund <mail@isaacfreund.com>"
 license="MIT"
 homepage="https://xkbcommon.org/"
 distfiles="https://github.com/xkbcommon/libxkbcommon/archive/xkbcommon-${version}.tar.gz"
-checksum=3b86670dd91441708dedc32bc7f684a034232fd4a9bb209f53276c9783e9d40e
+checksum=053e6a6a2c3179eba20c3ada827fb8833a6663b7ffd278fdb8530c3cbf924780
 
 post_install() {
 	vlicense LICENSE

--- a/srcpkgs/sway/patches/7326.diff
+++ b/srcpkgs/sway/patches/7326.diff
@@ -1,0 +1,26 @@
+diff --git a/sway/config.c b/sway/config.c
+index 1f2bb68604..f5efa98a8e 100644
+--- a/sway/config.c
++++ b/sway/config.c
+@@ -37,7 +37,7 @@ struct sway_config *config = NULL;
+ 
+ static struct xkb_state *keysym_translation_state_create(
+ 		struct xkb_rule_names rules) {
+-	struct xkb_context *context = xkb_context_new(XKB_CONTEXT_NO_FLAGS);
++	struct xkb_context *context = xkb_context_new(XKB_CONTEXT_NO_SECURE_GETENV);
+ 	struct xkb_keymap *xkb_keymap = xkb_keymap_new_from_names(
+ 		context,
+ 		&rules,
+diff --git a/sway/input/keyboard.c b/sway/input/keyboard.c
+index 3f4a7289b9..45a588ecbf 100644
+--- a/sway/input/keyboard.c
++++ b/sway/input/keyboard.c
+@@ -754,7 +754,7 @@ static void handle_xkb_context_log(struct xkb_context *context,
+ 
+ struct xkb_keymap *sway_keyboard_compile_keymap(struct input_config *ic,
+ 		char **error) {
+-	struct xkb_context *context = xkb_context_new(XKB_CONTEXT_NO_FLAGS);
++	struct xkb_context *context = xkb_context_new(XKB_CONTEXT_NO_SECURE_GETENV);
+ 	if (!sway_assert(context, "cannot create XKB context")) {
+ 		return NULL;
+ 	}

--- a/srcpkgs/sway/template
+++ b/srcpkgs/sway/template
@@ -1,14 +1,14 @@
 # Template file for 'sway'
 pkgname=sway
 version=1.8
-revision=1
+revision=2
 build_style=meson
 configure_args="-Dwerror=false -Db_ndebug=false"
 conf_files="/etc/sway/config"
 hostmakedepends="pkg-config wayland-devel scdoc"
 makedepends="wlroots-devel pcre2-devel json-c-devel pango-devel cairo-devel
  gdk-pixbuf-devel libevdev-devel"
-depends="libcap-progs swaybg xorg-server-xwayland"
+depends="libcap-progs swaybg xorg-server-xwayland libxkbcommon>=1.5.0_1"
 short_desc="Tiling Wayland compositor compatible with i3"
 maintainer="Olaf Mersmann <olafm@p-value.net>"
 license="MIT"


### PR DESCRIPTION
Setting these capabilities on the Sway binary breaks loading custom keymaps in user directories.

Relevant:
- https://github.com/swaywm/sway/pull/7326 (this commit can be reverted when this PR is merged in a future Sway release)
- https://github.com/xkbcommon/libxkbcommon/pull/312

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
