### PR TITLE
.gitignore: explicitly allow paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,13 +2,18 @@
 *.swp
 *~
 \#*#
-*.o
-masterdir*
-hostdir*
-masterdir*/
-hostdir*/
+
+# exclude everything in root except files and directories from void-packages
+/*
+!/CONTRIBUTING.md
+!/COPYING
+!/Manual.md
+!/README.md
+!/common
+!/etc
+!/srcpkgs
+!/xbps-src
 etc/conf
 etc/conf.*
 etc/virtual
 etc/xbps.d/custom
-.xbps-checkvers*.plist


### PR DESCRIPTION
This prevents git from picking up masterdirs that don't happen to be named the usual way and more custom and temporary files that should not be tracked by git.