### PR TITLE
bspwm: patch windows sometimes not appearing

### DIFF
--- a/srcpkgs/bspwm/patches/fix-windows-not-appearing.patch
+++ b/srcpkgs/bspwm/patches/fix-windows-not-appearing.patch
@@ -1,0 +1,32 @@
+https://github.com/baskerville/bspwm/commit/1560df35be303807052c235634eb8d59415c37ff
+
+From 1560df35be303807052c235634eb8d59415c37ff Mon Sep 17 00:00:00 2001
+From: David Hoppenbrouwers <david@salt-inc.org>
+Date: Tue, 25 Jan 2022 00:09:42 +0100
+Subject: [PATCH] Fix windows sometimes not appearing
+
+Fixes #935.
+---
+ src/bspwm.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/src/bspwm.c b/src/bspwm.c
+index 9c6be76c..8b9b5d14 100644
+--- a/src/bspwm.c
++++ b/src/bspwm.c
+@@ -36,6 +36,7 @@
+ #include <stdbool.h>
+ #include <string.h>
+ #include <xcb/xinerama.h>
++#include <xcb/xcb_aux.h>
+ #include "types.h"
+ #include "desktop.h"
+ #include "monitor.h"
+@@ -248,6 +249,7 @@ int main(int argc, char *argv[])
+ 			}
+ 
+ 			if (FD_ISSET(dpy_fd, &descriptors)) {
++				xcb_aux_sync(dpy);
+ 				while ((event = xcb_poll_for_event(dpy)) != NULL) {
+ 					handle_event(event);
+ 					free(event);

--- a/srcpkgs/bspwm/template
+++ b/srcpkgs/bspwm/template
@@ -1,7 +1,7 @@
 # Template file for 'bspwm'
 pkgname=bspwm
 version=0.9.10
-revision=1
+revision=2
 build_style=gnu-makefile
 makedepends="xcb-util-wm-devel xcb-util-keysyms-devel"
 short_desc="Tiling window manager based on binary space partitioning"


### PR DESCRIPTION
Apparently gtk-based software is affected by this bug.

The upstream patch fixes the issue in question.

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-musl