### PR TITLE
zita-alsa-pcmi: update to 0.6.1

### DIFF
--- a/srcpkgs/zita-alsa-pcmi/template
+++ b/srcpkgs/zita-alsa-pcmi/template
@@ -1,6 +1,6 @@
 # Template file for 'zita-alsa-pcmi'
 pkgname=zita-alsa-pcmi
-version=0.5.1
+version=0.6.1
 revision=1
 build_wrksrc="source"
 build_style=gnu-makefile
@@ -11,7 +11,7 @@ maintainer="newbluemoon <blaumolch@mailbox.org>"
 license="GPL-3.0-or-later"
 homepage="https://kokkinizita.linuxaudio.org/linuxaudio/"
 distfiles="https://kokkinizita.linuxaudio.org/linuxaudio/downloads/${pkgname}-${version}.tar.bz2"
-checksum=cf200a68edb64a17b57bffb33e38b048778272d18b5589d3d2f5a01ce0f34b07
+checksum=8a297ace3d7a474131ed3fa321069c131337785b56a237d6f168c85ee796d56c
 
 CXXFLAGS="-fPIC"
 


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly** (tested with `jaaa`)

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64
  - armv7l-musl
  - x86_64-musl
  - i686

