### PR TITLE
seahorse: update to 43.0

### DIFF
--- a/srcpkgs/seahorse/patches/musl.patch
+++ b/srcpkgs/seahorse/patches/musl.patch
@@ -1,0 +1,90 @@
+From 6d673637d90066f4756568ce1b2f1f3c89a37c74 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Pablo=20Correa=20G=C3=B3mez?= <ablocorrea@hotmail.com>
+Date: Thu, 20 Oct 2022 18:35:33 +0200
+Subject: [PATCH] ssh: avoid stdout and stderr variable names
+
+In Alpine Linux, the compiler:
+
+C compiler for the host machine: gcc (gcc 12.2.1 "gcc (Alpine 12.2.1_git20220924-r3) 12.2.1 20220924")
+C linker for the host machine: gcc ld.bfd 2.39
+Vala compiler for the host machine: valac (valac 0.56.3)
+
+ended up including stdio.h into the C code generated from Vala.
+This produced the following (and similar) errors due to
+stderr and stdout being #define in stdio.h:
+
+ninja: job failed: gcc -Issh/libseahorse-ssh.a.p -Issh -I../ssh -Icommon -I../common -I. -I.. -I/usr/include/glib-2.0 -I/usr/lib/glib-2.0/include -I/usr/include/libmount -I/usr/include/blkid -I/usr/include/gio-unix-2.0 -I/usr/include/gcr-3 -I/usr/include/gck-1 -I/usr/include/p11-kit-1 -I/usr/include/gtk-3.0 -I/usr/include/pango-1.0 -I/usr/include/harfbuzz -I/usr/include/freetype2 -I/usr/include/libpng16 -I/usr/include/fribidi -I/usr/include/cairo -I/usr/include/pixman-1 -I/usr/include/gdk-pixbuf-2.0 -I/usr/include/libdrm -I/usr/include/atk-1.0 -I/usr/include/at-spi2-atk/2.0 -I/usr/include/at-spi-2.0 -I/usr/include/dbus-1.0 -I/usr/lib/dbus-1.0/include -I/usr/include/libhandy-1 -flto=auto -fdiagnostics-color=always -D_FILE_OFFSET_BITS=64 -w -O0 -DGCR_API_SUBJECT_TO_CHANGE -DGCK_API_SUBJECT_TO_CHANGE -DSECRET_WITH_UNSTABLE -include config.h -Wno-unused-parameter -Wno-missing-field-initializers -Os -fomit-frame-pointer -Os -fomit-frame-pointer -fPIC -pthread -MD -MQ ssh/libseahorse-ssh.a.p/meson-generated_operation.c.o -MF ssh/libseahorse-ssh.a.p/meson-generated_operation.c.o.d -o ssh/libseahorse-ssh.a.p/meson-generated_operation.c.o -c ssh/libseahorse-ssh.a.p/operation.c
+In file included from /usr/include/fortify/stdio.h:22,
+                 from /usr/include/pango-1.0/pango/pango-utils.h:25,
+                 from /usr/include/pango-1.0/pango/pango.h:51,
+                 from /usr/include/gtk-3.0/gdk/gdktypes.h:35,
+                 from /usr/include/gtk-3.0/gdk/gdkapplaunchcontext.h:30,
+                 from /usr/include/gtk-3.0/gdk/gdk.h:32,
+                 from /usr/include/gtk-3.0/gtk/gtk.h:30,
+                 from common/seahorse-common.h:11,
+                 from ssh/seahorse-ssh.h:6,
+                 from ssh/libseahorse-ssh.a.p/operation.c:25:
+ssh/libseahorse-ssh.a.p/operation.c: In function 'seahorse_ssh_operation_operation_async_co':
+ssh/libseahorse-ssh.a.p/operation.c:621:17: error: expected identifier before '(' token
+  621 |         _data_->stdout = NULL;
+      |                 ^~~~~~
+ssh/libseahorse-ssh.a.p/operation.c:622:17: error: expected identifier before '(' token
+  622 |         _data_->stderr = NULL;
+      |                 ^~~~~~
+
+Fix the problem by naming the variables std_out and std_err, as it
+was before commit e60e5fd4b1545053e99758b894e8ef981de08c3e
+
+Fixes e60e5fd4b1545053e99758b894e8ef981de08c3e
+
+Coauthored-by: psykose <alice@ayaya.dev>
+---
+ ssh/operation.vala | 14 +++++++-------
+ 1 file changed, 7 insertions(+), 7 deletions(-)
+
+diff --git a/ssh/operation.vala b/ssh/operation.vala
+index afa161ce..4743d0a5 100644
+--- a/ssh/operation.vala
++++ b/ssh/operation.vala
+@@ -84,12 +84,12 @@ public abstract class Operation : GLib.Object {
+ 
+         // And off we go to run the program
+         var subprocess = launcher.spawnv(args);
+-        string? stdout = null, stderr = null;
++        string? std_out = null, std_err = null;
+         try {
+-            yield subprocess.communicate_utf8_async(input, cancellable, out stdout, out stderr);
+-            return stdout;
++            yield subprocess.communicate_utf8_async(input, cancellable, out std_out, out std_err);
++            return std_out;
+         } catch (GLib.Error e) {
+-            Seahorse.Util.show_error(null, this.prompt_title, stderr);
++            Seahorse.Util.show_error(null, this.prompt_title, std_err);
+             throw e;
+         }
+     }
+@@ -221,10 +221,10 @@ public class PrivateImportOperation : Operation {
+ 
+         // Start command to generate public key
+         string cmd = "%s -y -f '%s'".printf(Config.SSH_KEYGEN_PATH, file);
+-        string stdout = yield operation_async(cmd, null, cancellable);
++        string std_out = yield operation_async(cmd, null, cancellable);
+ 
+         // We'll build the key string from the output
+-        var key_str = new StringBuilder(stdout);
++        var key_str = new StringBuilder(std_out);
+ 
+         // Only use the first line of the output
+         int pos = int.max(key_str.str.index_of_char('\n'), key_str.str.index_of_char('\r'));
+@@ -232,7 +232,7 @@ public class PrivateImportOperation : Operation {
+             key_str.erase(pos);
+ 
+         // Parse the data so we can get the fingerprint
+-        KeyData? keydata = KeyData.parse_line(stdout);
++        KeyData? keydata = KeyData.parse_line(std_out);
+ 
+         // Add the comment to the output
+         if (data.comment != null) {
+-- 
+GitLab
+

--- a/srcpkgs/seahorse/template
+++ b/srcpkgs/seahorse/template
@@ -1,18 +1,18 @@
 # Template file for 'seahorse'
 pkgname=seahorse
-version=41.0
-revision=2
+version=43.0
+revision=1
 build_style=meson
 build_helper=gir
 hostmakedepends="gcr-devel gettext glib-devel gnupg itstool libsecret-devel
  openssh pkg-config vala"
 makedepends="avahi-glib-libs-devel gcr-devel gpgme-devel gtk+3-devel
  libgirepository-devel libhandy1-devel libldap-devel libsecret-devel
- libsoup-devel libpwquality-devel"
+ libsoup3-devel libpwquality-devel"
 depends="hicolor-icon-theme desktop-file-utils gcr>=3.14 gnupg>=2 openssh"
 short_desc="GNOME application for managing encryption keys"
 maintainer="Enno Boland <gottox@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="https://gitlab.gnome.org/GNOME/seahorse"
-distfiles="${GNOME_SITE}/${pkgname}/${version%.*}/${pkgname}-${version}.tar.xz"
-checksum=e6eec09e810448295f547f18c1d5772b65c3edc1d9e5a2595f10b5dde68929f5
+distfiles="${GNOME_SITE}/seahorse/${version%.*}/seahorse-${version}.tar.xz"
+checksum=5b1d1bfba74f3658227f3c82e296f330dd0fcd1ef4636b6a218228fee5ea832d


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures:
  - x86_64-musl
  - aarch64
  - armv7l
  
#### Notes
 - Patched for musl: https://gitlab.gnome.org/GNOME/seahorse/-/merge_requests/211