### PR TITLE
mu4e: update to 1.8.13

### DIFF
--- a/srcpkgs/mu4e/template
+++ b/srcpkgs/mu4e/template
@@ -1,6 +1,6 @@
 # Template file for 'mu4e'
 pkgname=mu4e
-version=1.6.10
+version=1.8.13
 revision=1
 build_style=gnu-configure
 configure_args="--enable-mu4e $(vopt_if guile --enable-guile)"
@@ -10,8 +10,8 @@ short_desc="Maildir-utils indexer/searcher and associated Emacs client"
 maintainer="Benjamin Slade <slade@lambda-y.net>"
 license="GPL-3.0-or-later"
 homepage="https://www.djcbsoftware.nl/code/mu/"
-distfiles="https://github.com/djcb/mu/releases/download/${version}/mu-${version}.tar.xz"
-checksum=0bc224aab2bfe40b5209af14e0982e637789292b7979872658d4498b29e900b6
+distfiles="https://github.com/djcb/mu/releases/download/v${version}/mu-${version}.tar.xz"
+checksum=20d69c1a918c1e48e6dbf5375d87ef3ed358bb6b3b7d0a120e93a88b16d5a026
 replaces="mu<${version}"
 provides="mu-${version}_${revision}"
 


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures:
  - x86_64-musl
  - aarch64 (crossbuild)
  - armv7l (crossbuild)

#### Notes
 - Users will have to re-initialize their message database manually (`mu-init(1)`). 
 - Users may have to adapt their configuration (e.g. `make-mu4e-bookmark` doesn't exist anymore).
 - Since this package hasn't been updated in a while, it might good someone else also tested this.
