### PR TITLE
i3: update to 4.22

### DIFF
--- a/srcpkgs/i3/template
+++ b/srcpkgs/i3/template
@@ -1,6 +1,6 @@
 # Template file for 'i3'
 pkgname=i3
-version=4.21.1
+version=4.22
 revision=1
 build_style=meson
 hostmakedepends="pkg-config perl"
@@ -15,7 +15,7 @@ license="BSD-3-Clause"
 homepage="https://i3wm.org/"
 changelog="https://i3wm.org/downloads/RELEASE-NOTES-${version}.txt"
 distfiles="https://i3wm.org/downloads/i3-${version}.tar.xz"
-checksum=edfd781285c654a05dc6db272ce0300c4428e6fbd875d99964e57de25b41bc1e
+checksum=28639911e59d95639f092642a982f5e1dea592250c2b5ce98eda100833513e4b
 make_check=no # Michael disables tests in Debian rules, too
 
 post_install() {


### PR DESCRIPTION
This release include the gaps feature, reading the [release notes](https://github.com/i3/i3/blob/next/RELEASE-NOTES-4.22) is highly recommended.

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-libc-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - armv7l (crossbuild)
  - i686-libc
