### PR TITLE
powertop: fix update-check

### DIFF
--- a/srcpkgs/powertop/update
+++ b/srcpkgs/powertop/update
@@ -1,2 +1,0 @@
-site="https://01.org/powertop/downloads"
-pattern="href=\"/powertop/downloads/powertop-v\K[0-9.]+(?=\")"


### PR DESCRIPTION
As the project moved to GitHub, no `update` file is needed anymore.