### PR TITLE
v2ray: add `run` to launch command for v2ray>=5.1.0

### DIFF
--- a/srcpkgs/v2ray/files/v2ray/run
+++ b/srcpkgs/v2ray/files/v2ray/run
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-exec chpst -u _v2ray v2ray -config=/etc/v2ray/config.json 2>&1
+exec chpst -u _v2ray v2ray run -config=/etc/v2ray/config.json 2>&1

--- a/srcpkgs/v2ray/template
+++ b/srcpkgs/v2ray/template
@@ -1,7 +1,7 @@
 # Template file for 'v2ray'
 pkgname=v2ray
 version=5.1.0
-revision=1
+revision=2
 build_style=go
 go_import_path="github.com/v2fly/v2ray-core/v5"
 go_ldflags="-X github.com/v2fly/v2ray-core/v5.codename=$pkgname


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl
  - i686
  - i686-musl
  - aarch64
  - aarch64-musl
  - armv7l
  - armv7l-musl
  - armv6l
  - armv6l-musl
  - ppc64le
