### PR TITLE
[WIP] New package: libxcrypt-4.4.33

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -40,7 +40,6 @@ libnss_files.so.2 glibc-2.36_1
 libnss_compat.so.2 glibc-2.36_1
 libnss_dns.so.2 glibc-2.36_1
 libnss_hesiod.so.2 glibc-2.36_1
-libcrypt.so.1 glibc-2.36_1
 libBrokenLocale.so.1 glibc-2.36_1
 libSimGearCore.so.2020.3.17 simgear-2020.3.17_1
 libSimGearScene.so.2020.3.17 simgear-2020.3.17_1
@@ -71,6 +70,8 @@ libppl.so.14 ppl-1.2_1
 libppl_c.so.4 ppl-0.11_1
 libstdc++.so.6 libstdc++-4.4.0_1
 libssp.so.0 libssp-4.4.0_1
+libcrypt.so.1 libxcrypt-compat-4.4.33_1
+libcrypt.so.2 libxcrypt-4.4.33_1
 libncurses.so.6 ncurses-libs-6.0_1 ignore
 libncursesw.so.6 ncurses-libs-5.8_1 ignore
 libtinfo.so.6 ncurses-libtinfo-libs-6.2_2

--- a/srcpkgs/glibc/template
+++ b/srcpkgs/glibc/template
@@ -1,7 +1,7 @@
 # Template file for 'glibc'
 pkgname=glibc
 version=2.36
-revision=1
+revision=2
 _patchver="72-g0f90d6204d"
 bootstrap=yes
 short_desc="GNU C library"
@@ -29,7 +29,6 @@ nostrip_files="
 	ld.so.1
 	ld-linux-armhf.so.3
 	libresolv.so.2
-	libcrypt.so.1
 	libm.so.6
 	libthread_db.so.1
 	libnsl.so.1
@@ -98,14 +97,12 @@ do_configure() {
 	SHELL=/bin/bash ../configure ${configure_args} \
 		--bindir=/usr/bin --sbindir=/usr/bin \
 		--libdir=${_libdir} --libexecdir=${_libdir} \
-		--enable-add-ons=libidn \
+		--with-headers=${XBPS_CROSS_BASE}/usr/include \
 		--enable-multi-arch --enable-bind-now \
 		--disable-profile --enable-kernel=3.2.0 \
-		--enable-stack-guard-randomization \
-		--without-selinux --without-cvs --without-gd \
-		--disable-lock-elision \
 		--enable-stack-protector=strong \
-		--with-headers=${XBPS_CROSS_BASE}/usr/include \
+		--enable-stack-guard-randomization \
+		--without-selinux --without-gd --disable-crypt \
 		--disable-werror \
 		libc_cv_rootsbindir=/usr/bin \
 		libc_cv_rtlddir=${_libdir} libc_cv_slibdir=${_libdir}

--- a/srcpkgs/libxcrypt-compat
+++ b/srcpkgs/libxcrypt-compat
@@ -1,0 +1,1 @@
+libxcrypt

--- a/srcpkgs/libxcrypt-devel
+++ b/srcpkgs/libxcrypt-devel
@@ -1,0 +1,1 @@
+libxcrypt

--- a/srcpkgs/libxcrypt/template
+++ b/srcpkgs/libxcrypt/template
@@ -1,0 +1,102 @@
+# Template file for 'libxcrypt'
+pkgname=libxcrypt
+version=4.4.33
+revision=1
+configure_args="--enable-hashes=all --disable-failure-tokens"
+hostmakedepends="perl"
+checkdepends="python3-passlib"
+short_desc="Modern library for one-way hashing of passwords"
+maintainer="oreo639 <oreo639@gmail.com>"
+license="LGPL-2.1-or-later, BSD-3-Clause, BSD-2-Clause, 0BSD, Public Domain"
+homepage="https://github.com/besser82/libxcrypt"
+distfiles="https://github.com/besser82/libxcrypt/releases/download/v${version}/libxcrypt-${version}.tar.xz"
+checksum=e87acf9c652c573a4713d5582159f98f305d56ed5f754ce64f57d4194d6b3a6f
+subpackages="libxcrypt-devel"
+build_options="compat"
+build_options_default=""
+
+desc_option_compat="Enable glibc compatibility library"
+
+if [ "$XBPS_TARGET_LIBC" = "glibc" ]; then
+build_options_default+=" compat"
+fi
+
+if [ "$build_option_compat" ]; then
+subpackages+=" libxcrypt-compat"
+fi
+
+do_configure() {
+if [ "$build_option_compat" ]; then
+	(
+		mkdir compat-build
+		cd compat-build
+		../configure --prefix=/usr --enable-obsolete-api=glibc ${configure_args}
+	)
+fi
+
+	(
+		mkdir build
+		cd build
+		../configure --prefix=/usr --enable-obsolete-api=no ${configure_args}
+	)
+}
+
+do_build() {
+if [ "$build_option_compat" ]; then
+	(
+		cd compat-build
+		make ${makejobs} ${make_build_args} ${make_build_target}
+	)
+fi
+
+	(
+		cd build
+		make ${makejobs} ${make_build_args} ${make_build_target}
+	)
+}
+
+do_install() {
+if [ "$build_option_compat" ]; then
+	(
+		cd compat-build
+		make DESTDIR=${DESTDIR} install ${make_install_target}
+		rm -r ${DESTDIR}/usr/{include,lib/{lib*.so,pkgconfig},share}
+	)
+fi
+
+	(
+		cd build
+		make DESTDIR=${DESTDIR} install ${make_install_target}
+	)
+}
+
+post_install() {
+	vlicense LICENSING
+}
+
+do_check() {
+	: ${make_check_target:=check}
+if [ "$build_option_compat" ]; then
+	${make_check_pre} make -C compat-build ${makejobs} ${make_check_args} ${make_check_target}
+fi
+	${make_check_pre} make -C build ${makejobs} ${make_check_args} ${make_check_target}
+}
+
+libxcrypt-devel_package() {
+	short_desc+=" - development files"
+	depends="${sourcepkg}>=${version}_${revision}"
+	pkg_install() {
+		vmove usr/lib/pkgconfig
+		vmove usr/include
+		vmove "usr/lib/*.a"
+		vmove "usr/lib/*.so"
+		vmove usr/share
+	}
+}
+
+libxcrypt-compat_package() {
+	short_desc+=" - legacy compatibility"
+	pkg_install() {
+		vmove usr/lib/libcrypt.so.1*
+	}
+}

--- a/srcpkgs/man-pages/template
+++ b/srcpkgs/man-pages/template
@@ -37,6 +37,9 @@ do_install() {
 	# openssl-devel
 	mv man3/rand.3 man3/glibc-rand.3
 	mv man3/err.3 man3/glibc-err.3
+	# libxcrypt
+	rm -f man3/crypt.3
+	rm -f man3/crypt_r.3
 	# Fix references to these manpages
 	sed -i -e "s|.so man3/rand.3|.so man3/glibc-rand.3|" \
 	 -e "s|.so man3/err.3|.so man3/glibc-err.3|" man3/*


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **NO**

libxcrypt will replace libcrypt on glibc.
`--disable-failure-tokens` as per:
https://github.com/besser82/libxcrypt/issues/25

glibc will need to be compiled with `--disable-crypt`.
musl provides no such option, Debian just rm's libcrypt.a from musl:
https://salsa.debian.org/reiner/musl/-/blob/master/debian/rules#L76

Not sure what we want to do on musl.

For glibc either we can rebuild everything with libxcrypt or we can have glibc depend on libxcrypt-compat  (and have libxcrypt as a bootstrap package)
On musl, libcrypt is provided by libc so if we handle it the same as debian, a rebuild shouldn't be *necessary*.

All packages using libcrypt can be seen using `xbps-query -Rs libcrypt.so -p shlib-requires`.

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
