### PR TITLE
runc: add go_ldflags with the version

### DIFF
--- a/srcpkgs/runc/template
+++ b/srcpkgs/runc/template
@@ -5,6 +5,7 @@ revision=1
 build_style=go
 go_import_path=github.com/opencontainers/runc
 go_build_tags="seccomp apparmor"
+go_ldflags="-X main.version=${version}"
 hostmakedepends="pkg-config go-md2man"
 makedepends="libseccomp-devel"
 short_desc="CLI tool for spawning and running OCI containers"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)

#### Note:
See https://github.com/opencontainers/runc/blob/main/main.go#L20