### PR TITLE
xbps-src: keep http_proxy and other lowercase proxy variables

### DIFF
--- a/common/environment/setup/sourcepkg.sh
+++ b/common/environment/setup/sourcepkg.sh
@@ -25,6 +25,8 @@ for var in $(awk 'BEGIN{for (i in ENVIRON) {print i}}' </dev/null); do
 		;;
 	FTP_PROXY | FTP_RETRIES)
 		;;
+	http_proxy | https_proxy | ftp_proxy | all_proxy | no_proxy)
+		;;
 	*)
 		unset -v "$var"
 		;;

--- a/common/xbps-src/shutils/chroot.sh
+++ b/common/xbps-src/shutils/chroot.sh
@@ -165,6 +165,11 @@ chroot_handler() {
     else
         env -i -- PATH="/usr/bin:$PATH" SHELL=/bin/sh \
             HOME=/tmp IN_CHROOT=1 LC_COLLATE=C LANG=en_US.UTF-8 \
+            ${http_proxy:+http_proxy="${http_proxy}"} \
+            ${https_proxy:+https_proxy="${https_proxy}"} \
+            ${ftp_proxy:+ftp_proxy="${ftp_proxy}"} \
+            ${all_proxy:+all_proxy="${all_proxy}"} \
+            ${no_proxy:+no_proxy="${no_proxy}"} \
             ${HTTP_PROXY:+HTTP_PROXY="${HTTP_PROXY}"} \
             ${HTTPS_PROXY:+HTTPS_PROXY="${HTTPS_PROXY}"} \
             ${FTP_PROXY:+FTP_PROXY="${FTP_PROXY}"} \


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

From `curl` manpage:
```
ENVIRONMENT
       The environment variables can be specified in lower case or upper case.
       The lower case version has precedence. http_proxy is an exception as it
       is only available in lower case.
```

I have `http_proxy` and `https_proxy` set, and then `xbps-src update-check` would not use the proxy. With this commit, it works as expected.

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
