### PR TITLE
ulozto-downloader: update to 3.3.1, fix dependency

### DIFF
--- a/srcpkgs/python3-ansicolors/template
+++ b/srcpkgs/python3-ansicolors/template
@@ -1,0 +1,18 @@
+# Template file for 'python3-ansicolors'
+pkgname=python3-ansicolors
+version=1.1.8
+revision=1
+build_style=python3-module
+hostmakedepends="python3-setuptools"
+depends="python3"
+checkdepends="python3-pytest"
+short_desc="Add ANSI colors and decorations to your strings"
+maintainer="Emil Miler <em@0x45.cz>"
+license="ISC"
+homepage="https://github.com/jonathaneunice/colors/"
+distfiles="${PYPI_SITE}/a/ansicolors/ansicolors-${version}.zip"
+checksum=99f94f5e3348a0bcd43c82e5fc4414013ccc19d70bd939ad71e0133ce9c372e0
+
+post_install() {
+	vlicense LICENSE
+}

--- a/srcpkgs/ulozto-downloader/template
+++ b/srcpkgs/ulozto-downloader/template
@@ -1,10 +1,10 @@
 # Template file for 'ulozto-downloader'
 pkgname=ulozto-downloader
-version=3.3.0
+version=3.3.1
 revision=1
 build_style=python3-module
 hostmakedepends="python3-setuptools"
-depends="tor python3-ansicolor python3-tkinter python3-requests python3-Pillow
+depends="tor python3-ansicolors python3-tkinter python3-requests python3-Pillow
  python3-numpy python3-pysocks python3-stem"
 short_desc="Uloz.to quick multiple sessions downloader"
 maintainer="Emil Miler <em@0x45.cz>"
@@ -12,7 +12,7 @@ license="MIT"
 homepage="https://github.com/setnicka/ulozto-downloader"
 changelog="https://github.com/eoyilmaz/setnicka/ulozto-downloader/releases/tag/${version}"
 distfiles="https://github.com/setnicka/ulozto-downloader/archive/refs/tags/${version}.tar.gz"
-checksum=326d2a2aa7353dd90681bf3692fb6f2ecc55c9cc5f046d77ef2b88bab4a4b228
+checksum=69a4aa80be18d259349eadb4875a52281c8920b867d9f7d4b6f33bf7bf9daa1e
 make_check=no # no internal test suite present
 
 post_install() {


### PR DESCRIPTION
The original template had a wrong dependency `python3-ansicolor`, whereas the program needs `python3-ansicolors`. This new dependency has been added as a new package in a second commit.

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)