### PR TITLE
dbeaver: update to 22.3.1.

### DIFF
--- a/srcpkgs/dbeaver/template
+++ b/srcpkgs/dbeaver/template
@@ -1,6 +1,6 @@
 # Template file for 'dbeaver'
 pkgname=dbeaver
-version=22.2.5
+version=22.3.1
 revision=1
 # the build downloads binaries linked to glibc
 archs="x86_64 aarch64"
@@ -12,7 +12,7 @@ license="Apache-2.0"
 homepage="https://dbeaver.io"
 changelog="https://dbeaver.io/news/"
 distfiles="https://github.com/dbeaver/dbeaver/archive/${version}.tar.gz"
-checksum=e300d4e85ec7e612792ff309079baf3b2f40b1b0bf4bd5bce3e2e335621e72bb
+checksum=d6f3fd9c09a5722c6ef4afca40b8b0fd83293677450e701a3166d0c36f1af08e
 nopie=true
 
 do_build() {


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR:  **briefly**
DBeaver 22.3.1 is confirmed to build and work on x86_64-gnu.

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-gnu)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64 YES (cross)

