### PR TITLE
glibc: neutralise supply chain attack

### DIFF
--- a/srcpkgs/glibc/template
+++ b/srcpkgs/glibc/template
@@ -8,8 +8,12 @@ short_desc="GNU C library"
 maintainer="Enno Boland <gottox@voidlinux.org>"
 license="GPL-2.0-or-later, LGPL-2.1-or-later, BSD-3-Clause"
 homepage="http://www.gnu.org/software/libc"
-distfiles="https://vasilek.cz/paste/glibc-${version}-${_patchver}.tar.xz"
-checksum=656200722d5ba968b4888a2d2950719d72c86290fd0479f61897d25b7db2cb57
+distfiles="${GNU_SITE}/glibc/glibc-${version}.tar.xz
+ https://github.com/bminor/glibc/compare/glibc-${version}...${_patchver#*g}.diff"
+#distfiles="https://vasilek.cz/paste/glibc-${version}-${_patchver}.tar.xz"
+checksum="1c959fea240906226062cb4b1e7ebce71a9f0e3c0836c09e7e3423d434fcfe75
+ a3d3015f1842186c5b278cbef0e92cf47941497d3f0af5c9a28645112c3d1359"
+skip_extraction="glibc-${version}...${_patchver#*g}.diff"
 # Do not strip these files, objcopy errors out.
 nostrip_files="
 	XBS5_ILP32_OFFBIG
@@ -58,6 +62,12 @@ archs="~*-musl"
 if [ "$XBPS_TARGET_LIBC" = musl ]; then
 	broken="no point in building this for musl"
 fi
+
+post_extract() {
+	if [ -f $XBPS_SRCDISTDIR/${pkgname}-${version}/glibc-${version}...${_patchver#*g}.patch ]; then
+		patch -Np1 -s -F0 <$XBPS_SRCDISTDIR/${pkgname}-${version}/glibc-${version}...${_patchver#*g}.diff
+	fi
+}
 
 do_configure() {
 	mkdir build


### PR DESCRIPTION
Relies on vasilek.cz is questionable by some of our users.

@paper42 @oreo639 @CameronNemo 
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**|**briefly**|**NO**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
