### PR TITLE
python3-ansicolor: update to 0.3.2

### DIFF
--- a/srcpkgs/python3-ansicolor/template
+++ b/srcpkgs/python3-ansicolor/template
@@ -1,7 +1,7 @@
 # Template file for 'python3-ansicolor'
 pkgname=python3-ansicolor
-version=0.2.6
-revision=7
+version=0.3.2
+revision=1
 build_style=python3-module
 hostmakedepends="python3-setuptools"
 depends="python3"
@@ -10,4 +10,4 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="Apache-2.0"
 homepage="https://github.com/numerodix/ansicolor"
 distfiles="${PYPI_SITE}/a/ansicolor/ansicolor-${version}.tar.gz"
-checksum=d17e1b07b9dd7ded31699fbca53ae6cd373584f9b6dcbc124d1f321ebad31f1d
+checksum=3b840a6b1184b5f1568635b1adab28147947522707d41ceba02d5ed0a0877279


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, (x64 glibc)

It is needed for: ulozto-downloader

https://github.com/void-linux/void-packages/pull/41448

Without bump not working for me

`Traceback (most recent call last):
                                          import colors
                                      ModuleNotFoundError: No module named 'colors'`

(Actual working can't try because uloz.to have some dificulties right now..)