### PR TITLE
cryptsetup: update to 2.6.0.

### DIFF
--- a/srcpkgs/cryptsetup/template
+++ b/srcpkgs/cryptsetup/template
@@ -1,6 +1,6 @@
 # Template file for 'cryptsetup'
 pkgname=cryptsetup
-version=2.5.0
+version=2.6.0
 revision=1
 build_style=gnu-configure
 configure_args="--with-crypto_backend=openssl --enable-cryptsetup-reencrypt
@@ -15,19 +15,13 @@ maintainer="Daniel Eyßer <daniel.eysser@gmail.com>"
 license="GPL-2.0-or-later"
 homepage="https://gitlab.com/cryptsetup/cryptsetup"
 changelog="https://gitlab.com/cryptsetup/cryptsetup/raw/master/docs/v${version}-ReleaseNotes"
-distfiles="${KERNEL_SITE}/utils/cryptsetup/v${version%.*}/${pkgname}-${version}.tar.xz"
-checksum=9184a6ebbd9ce7eb211152e7f741a6c82f2d1cc0e24a84ec9c52939eee0f0542
+distfiles="${KERNEL_SITE}/utils/cryptsetup/v${version%.*}/cryptsetup-${version}.tar.xz"
+checksum=44397ba76e75a9cde5b02177bc63cd7af428a785788e3a7067733e7761842735
 subpackages="libcryptsetup cryptsetup-devel"
 build_options="pwquality"
 desc_option_pwquality="Enable support for checking password quality via libpwquality"
 
-if [ "$XBPS_LIBC" = "musl" ]
-then
-	make_check=no # Test fail on musl see upstream:
-	# https://gitlab.com/cryptsetup/cryptsetup/-/issues/781
-else
-	make_check=ci-skip # tests depend on acessing /dev/mapper/control fails on CI
-fi
+make_check=ci-skip # tests depend on acessing /dev/mapper/control fails on CI
 
 post_patch() {
 	if [ "$XBPS_TARGET_LIBC" = musl ]; then


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES** (booted into my FDE installation)

This package is rather sensitive, so maybe it's worth having more people test this PR just to be sure that everything is working okay.

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
