### PR TITLE
gtest: update to 1.12.1.

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -1737,8 +1737,6 @@ libuv.so.1 libuv-1.0.0_1
 libXm.so.4 motif-2.3.8_1
 libMrm.so.4 motif-2.3.8_1
 libUil.so.4 motif-2.3.8_1
-libgtest.so gtest-1.7.0_1
-libgtest_main.so gtest-1.7.0_1
 libxmlsec1-gcrypt.so.1 xmlsec1-1.2.31_2
 libxmlsec1-gnutls.so.1 xmlsec1-1.2.31_2
 libefivar.so.1 libefivar-31_1

--- a/srcpkgs/gtest/template
+++ b/srcpkgs/gtest/template
@@ -1,6 +1,6 @@
 # Template file for 'gtest'
 pkgname=gtest
-version=1.11.0
+version=1.12.1
 revision=1
 build_style=cmake
 configure_args="-DBUILD_SHARED_LIBS=ON -DCMAKE_SKIP_RPATH=ON"
@@ -10,7 +10,7 @@ maintainer="Enno Boland <gottox@voidlinux.org>"
 license="BSD-3-Clause"
 homepage="https://github.com/google/googletest"
 distfiles="https://github.com/google/googletest/archive/release-${version}.tar.gz"
-checksum=b4870bf121ff7795ba20d20bcdd8627b8e088f2d1dab299a031c1034eddc93d5
+checksum=81964fe578e9bd7c94dfdb09c8e4d6e6759e19967e397dbea48d1c10e45d0df2
 
 post_install() {
 	vlicense LICENSE
@@ -20,6 +20,7 @@ gtest-devel_package() {
 	depends="gtest>=${version}_${revision}"
 	short_desc+=" - development files"
 	pkg_install() {
+		vmove "usr/lib/*.so"
 		vmove usr/include
 		vmove usr/lib/pkgconfig
 		vmove usr/lib/cmake


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->
Also moves `usr/lib/*.so` to `-devel` subpackage and drops the unversioned `SONAME`s from `common/shlibs` since there are now versioned symlinks in case something starts needing them (`xrevshlib gtest` currently returns nothing).

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
