### PR TITLE
swirc: update to 3.3.9.

### DIFF
--- a/srcpkgs/swirc/template
+++ b/srcpkgs/swirc/template
@@ -1,6 +1,6 @@
 # Template file for 'swirc'
 pkgname=swirc
-version=3.3.8
+version=3.3.9
 revision=1
 build_style=configure
 configure_args="$(vopt_with notify libnotify)"
@@ -17,7 +17,7 @@ license="BSD-3-Clause, ISC, MIT"
 homepage="https://www.nifty-networks.net/swirc"
 changelog="https://raw.githubusercontent.com/uhlin/swirc/master/CHANGELOG.md"
 distfiles="https://www.nifty-networks.net/swirc/releases/${pkgname}-${version}.tgz"
-checksum="44c7f5c7afcd4e9803c7b0eedfd835a179860c542f795782440d532d3b5237c3"
+checksum=4326dcf521d2a0ca3c55ed289fea0c0d1a289dcc158c80f4aee207ff2085ab37
 
 build_options="notify"
 build_options_default="notify"


### PR DESCRIPTION
Swirc 3.3.9 out!

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, **x86_64-musl**
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - armv6l-musl **cross**
