### PR TITLE
SDL2: update to 2.26.2.

### DIFF
--- a/srcpkgs/SDL2/template
+++ b/srcpkgs/SDL2/template
@@ -1,6 +1,6 @@
 # Template file for 'SDL2'
 pkgname=SDL2
-version=2.26.1
+version=2.26.2
 revision=1
 build_style=gnu-configure
 configure_args="--enable-alsa --disable-esd --disable-rpath --enable-libudev
@@ -15,7 +15,7 @@ license="Zlib"
 homepage="https://www.libsdl.org/"
 changelog="https://raw.githubusercontent.com/libsdl-org/SDL/SDL2/WhatsNew.txt"
 distfiles="https://www.libsdl.org/release/SDL2-${version}.tar.gz"
-checksum=02537cc7ebd74071631038b237ec4bfbb3f4830ba019e569434da33f42373e04
+checksum=95d39bc3de037fbdfa722623737340648de4f180a601b0afad27645d150b99e0
 
 # Package build options
 build_options="gles opengl pulseaudio pipewire sndio vulkan wayland x11"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **Yes**

SUMMARY
pkg:SDL2 host:x86_64 target:x86_64 cross:n result:OK
pkg:SDL2 host:x86_64-musl target:x86_64-musl cross:n result:OK
pkg:SDL2 host:i686 target:i686 cross:n result:OK
pkg:SDL2 host:x86_64-musl target:aarch64-musl cross:y result:OK
pkg:SDL2 host:x86_64-musl target:aarch64 cross:y result:OK
pkg:SDL2 host:x86_64-musl target:armv7l-musl cross:y result:OK
pkg:SDL2 host:x86_64-musl target:armv7l cross:y result:OK
pkg:SDL2 host:x86_64-musl target:armv6l-musl cross:y result:OK
pkg:SDL2 host:x86_64-musl target:armv6l cross:y result:OK
