### PR TITLE
btrfs-progs: update to 6.1.2.

### DIFF
--- a/srcpkgs/btrfs-progs/template
+++ b/srcpkgs/btrfs-progs/template
@@ -1,6 +1,6 @@
 # Template file for 'btrfs-progs'
 pkgname=btrfs-progs
-version=6.1.1
+version=6.1.2
 revision=1
 build_style=gnu-configure
 make_check_target=test
@@ -15,7 +15,7 @@ license="GPL-2.0-only, LGPL-2.1-or-later"
 homepage="https://btrfs.wiki.kernel.org/index.php/Main_Page"
 changelog="https://raw.githubusercontent.com/kdave/btrfs-progs/master/CHANGES"
 distfiles="${KERNEL_SITE}/kernel/people/kdave/btrfs-progs/btrfs-progs-v${version}.tar.xz"
-checksum=ca3a465d87200206e3a41d0f434f93cd222ca5325a2099a634dbdd23faeb6769
+checksum=6be667d97f3d65c0ba57c331c98b0bd3b13cf60d8d31fa8ad25882aad9d79d7a
 # Most of the tests depend on `mount` and `fallocate` commands, which are not
 # presented in chroot-util-linux
 make_check=no


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

```
SUMMARY
pkg:btrfs-progs host:x86_64 target:x86_64 cross:n result:OK
pkg:btrfs-progs host:x86_64-musl target:x86_64-musl cross:n result:OK
pkg:btrfs-progs host:i686 target:i686 cross:n result:OK
pkg:btrfs-progs host:x86_64-musl target:aarch64-musl cross:y result:OK
pkg:btrfs-progs host:x86_64-musl target:aarch64 cross:y result:OK
pkg:btrfs-progs host:x86_64-musl target:armv7l-musl cross:y result:OK
pkg:btrfs-progs host:x86_64-musl target:armv7l cross:y result:OK
pkg:btrfs-progs host:x86_64-musl target:armv6l-musl cross:y result:OK
pkg:btrfs-progs host:x86_64-musl target:armv6l cross:y result:OK
```
