### PR TITLE
enchant2: update to 2.3.3.

### DIFF
--- a/srcpkgs/enchant2/template
+++ b/srcpkgs/enchant2/template
@@ -1,7 +1,7 @@
 # Template file for 'enchant2'
 pkgname=enchant2
-version=2.3.2
-revision=2
+version=2.3.3
+revision=1
 build_style=gnu-configure
 # so package doesn't conflict with enchant's /usr/share/enchant/enchant.ordering;
 # might be a bug in their build system that only this directory and/or file aren't
@@ -20,8 +20,9 @@ short_desc="Generic spell checking library"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="LGPL-2.1-or-later"
 homepage="https://abiword.github.io/enchant/"
+changelog="https://raw.githubusercontent.com/AbiWord/enchant/master/NEWS"
 distfiles="https://github.com/AbiWord/enchant/releases/download/v${version}/enchant-${version}.tar.gz"
-checksum=ce9ba47fd4d34031bd69445598a698a6611602b2b0e91d705e91a6f5099ead6e
+checksum=3da12103f11cf49c3cf2fd2ce3017575c5321a489e5b9bfa81dd91ec413f3891
 make_check=no # tests broken
 
 enchant2-devel_package() {


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

```
SUMMARY                                     
pkg       host         target        cross  result
enchant2  x86_64       x86_64        n      OK
enchant2  x86_64-musl  x86_64-musl   n      OK
enchant2  i686         i686          n      OK
enchant2  x86_64-musl  aarch64-musl  y      OK
enchant2  x86_64-musl  aarch64       y      OK
enchant2  x86_64-musl  armv7l-musl   y      OK
enchant2  x86_64-musl  armv7l        y      OK
enchant2  x86_64-musl  armv6l-musl   y      OK
enchant2  x86_64-musl  armv6l        y      OK
```