### PR TITLE
Gstreamer1 1.20.5 and friends

### DIFF
--- a/srcpkgs/gst-libav/template
+++ b/srcpkgs/gst-libav/template
@@ -1,6 +1,6 @@
 # Template file for 'gst-libav'
 pkgname=gst-libav
-version=1.20.3
+version=1.20.5
 revision=1
 build_style=meson
 hostmakedepends="pkg-config yasm"
@@ -11,7 +11,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="LGPL-2.0-or-later"
 homepage="https://gstreamer.freedesktop.org"
 distfiles="${homepage}/src/${pkgname}/${pkgname}-${version}.tar.xz"
-checksum=3fedd10560fcdfaa1b6462cbf79a38c4e7b57d7f390359393fc0cef6dbf27dfe
+checksum=b152e3cc49d014899f53c39d8a6224a44e1399b4cf76aa5f9a903fdf9793c3cc
 
 case "$XBPS_TARGET_MACHINE" in
 	*-musl) # Required by musl for M_SQRT1_2

--- a/srcpkgs/gst-omx/template
+++ b/srcpkgs/gst-omx/template
@@ -1,6 +1,6 @@
 # Template file for 'gst-omx'
 pkgname=gst-omx
-version=1.20.3
+version=1.20.5
 revision=1
 build_style=meson
 configure_args="-Dexamples=disabled -Dtarget=generic"
@@ -11,4 +11,4 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="LGPL-2.1-only"
 homepage="https://gstreamer.freedesktop.org"
 distfiles="${homepage}/src/${pkgname}/${pkgname}-${version}.tar.xz"
-checksum=8db48040bb41f09edf8d17ff6d16c54888d7777ba4501c2c69f0083350ea9a15
+checksum=bcccbc02548cdc123fd49944dd44a4f1adc5d107e36f010d320eb526e2107806

--- a/srcpkgs/gst-plugins-bad1/template
+++ b/srcpkgs/gst-plugins-bad1/template
@@ -1,7 +1,7 @@
 # Template file for 'gst-plugins-bad1'
 pkgname=gst-plugins-bad1
-version=1.20.3
-revision=2
+version=1.20.5
+revision=1
 build_helper="gir"
 build_style=meson
 configure_args="-Dpackage-origin=https://voidlinux.org -Ddoc=disabled
@@ -36,7 +36,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later, LGPL-2.1-or-later"
 homepage="https://gstreamer.freedesktop.org"
 distfiles="${homepage}/src/${pkgname/1/}/${pkgname/1/}-${version}.tar.xz"
-checksum=7a11c13b55dd1d2386dd902219e41cbfcdda8e1e0aa3e738186c95074b35da4f
+checksum=f431214b0754d7037adcde93c3195106196588973e5b32dcb24938805f866363
 
 build_options="gir gme wayland"
 build_options_default="gir wayland"

--- a/srcpkgs/gst-plugins-base1/template
+++ b/srcpkgs/gst-plugins-base1/template
@@ -1,6 +1,6 @@
 # Template file for 'gst-plugins-base1'
 pkgname=gst-plugins-base1
-version=1.20.3
+version=1.20.5
 revision=1
 build_style=meson
 build_helper="gir"
@@ -22,7 +22,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later, LGPL-2.0-or-later"
 homepage="https://gstreamer.freedesktop.org"
 distfiles="${homepage}/src/${pkgname/1/}/${pkgname/1/}-${version}.tar.xz"
-checksum=7e30b3dd81a70380ff7554f998471d6996ff76bbe6fc5447096f851e24473c9f
+checksum=11f911ef65f3095d7cf698a1ad1fc5242ac3ad6c9270465fb5c9e7f4f9c19b35
 
 build_options="cdparanoia gir sndio wayland"
 build_options_default="cdparanoia gir wayland"

--- a/srcpkgs/gst-plugins-good1/template
+++ b/srcpkgs/gst-plugins-good1/template
@@ -1,10 +1,9 @@
 # Template file for 'gst-plugins-good1'
 pkgname=gst-plugins-good1
-version=1.20.3
+version=1.20.5
 revision=1
 build_style=meson
-configure_args="-Ddv=disabled -Ddv1394=disabled -Dshout2=disabled -Dqt5=enabled
- -Dgtk3=$(vopt_if gtk3 enabled disabled)"
+configure_args="-Dqt5=enabled -Dgtk3=$(vopt_if gtk3 enabled disabled)"
 # XXX: libdv, dv1394 and shout2 modules.
 hostmakedepends="pkg-config intltool glib-devel orc qt5-qmake qt5-host-tools"
 makedepends="
@@ -22,7 +21,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="LGPL-2.1-or-later"
 homepage="https://gstreamer.freedesktop.org"
 distfiles="${homepage}/src/${pkgname/1/}/${pkgname/1/}-${version}.tar.xz"
-checksum=f8f3c206bf5cdabc00953920b47b3575af0ef15e9f871c0b6966f6d0aa5868b7
+checksum=e83ab4d12ca24959489bbb0ec4fac9b90e32f741d49cda357cb554b2cb8b97f9
 
 build_options="gtk3 wayland"
 build_options_default="gtk3 wayland"

--- a/srcpkgs/gst-plugins-ugly1/template
+++ b/srcpkgs/gst-plugins-ugly1/template
@@ -1,9 +1,9 @@
 # Template file for 'gst-plugins-ugly1'
 pkgname=gst-plugins-ugly1
-version=1.20.3
+version=1.20.5
 revision=1
 build_style=meson
-configure_args="-Damrnb=disabled -Damrwbdec=disabled -Dsidplay=disabled"
+configure_args="-Dsidplay=disabled"
 # XXX add required pkgs for the amr, sid plugins.
 hostmakedepends="pkg-config intltool python3"
 makedepends="glib-devel libxml2-devel gst-plugins-base1-devel
@@ -15,4 +15,4 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="LGPL-2.1-or-later"
 homepage="https://gstreamer.freedesktop.org"
 distfiles="${homepage}/src/${pkgname/1/}/${pkgname/1/}-${version}.tar.xz"
-checksum=8caa20789a09c304b49cf563d33cca9421b1875b84fcc187e4a385fa01d6aefd
+checksum=af67d8ba7cab230f64d0594352112c2c443e2aa36a87c35f9f98a43d11430b87

--- a/srcpkgs/gst-rtsp-server/template
+++ b/srcpkgs/gst-rtsp-server/template
@@ -1,7 +1,7 @@
 # Template file for 'gst-rtsp-server'
 pkgname=gst-rtsp-server
-version=1.20.3
-revision=2
+version=1.20.5
+revision=1
 build_style=meson
 hostmakedepends="pkg-config python3"
 makedepends="glib-devel gst-plugins-bad1-devel gobject-introspection
@@ -11,4 +11,4 @@ maintainer="1is7ac3 <isaac.qa13@gmail.com>"
 license="LGPL-2.1-or-later"
 homepage="https://gstreamer.freedesktop.org"
 distfiles="https://gstreamer.freedesktop.org/src/gst-rtsp-server/gst-rtsp-server-${version}.tar.xz"
-checksum=ee402718be9b127f0e5e66ca4c1b4f42e4926ec93ba307b7ccca5dc6cc9794ca
+checksum=ba398a7ddd559cce56ef4b91f448d174e0dccad98a493563d2d59c41a2ef39c5

--- a/srcpkgs/gstreamer1/template
+++ b/srcpkgs/gstreamer1/template
@@ -1,6 +1,6 @@
 # Template file for 'gstreamer1'
 pkgname=gstreamer1
-version=1.20.3
+version=1.20.5
 revision=1
 build_style=meson
 build_helper="gir"
@@ -16,7 +16,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="LGPL-2.0-or-later"
 homepage="https://gstreamer.freedesktop.org"
 distfiles="${homepage}/src/gstreamer/gstreamer-${version}.tar.xz"
-checksum=607daf64bbbd5fb18af9d17e21c0d22c4d702fffe83b23cb22d1b1af2ca23a2a
+checksum=5a19083faaf361d21fc391124f78ba6d609be55845a82fa8f658230e5fa03dff
 
 pre_check() {
 	# gst_gstdatetime is known to fail according to LFS


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

```
x86_64-musl
SUMMARY                                             
pkg                host         target       cross  result
gstreamer1         x86_64-musl  x86_64-musl  n      OK
gst-plugins-base1  x86_64-musl  x86_64-musl  n      OK
gst-plugins-bad1   x86_64-musl  x86_64-musl  n      OK
gst-plugins-good1  x86_64-musl  x86_64-musl  n      OK
gst-rtsp-server    x86_64-musl  x86_64-musl  n      OK
gst-plugins-ugly1  x86_64-musl  x86_64-musl  n      OK
gst-omx            x86_64-musl  x86_64-musl  n      OK
gst-libav          x86_64-musl  x86_64-musl  n      OK
```

Failling because the `FeedReader` binary is still in the repos, and it was removed ...