### PR TITLE
 vdirsyncer: update to 0.19.0 

### DIFF
--- a/srcpkgs/python3-aiostream/template
+++ b/srcpkgs/python3-aiostream/template
@@ -1,0 +1,13 @@
+# Template file for 'python3-aiostream'
+pkgname=python3-aiostream
+version=0.4.5
+revision=1
+build_style=python3-module
+hostmakedepends="python3-setuptools"
+depends="python3"
+short_desc="Generator-based operators for asynchronous iteration"
+maintainer="joelchrono12 <joel.chrono@disroot.org>"
+license="GPL-3.0-only"
+homepage="https://aiostream.readthedocs.io/"
+distfiles="${PYPI_SITE}/a/aiostream/aiostream-${version}.tar.gz"
+checksum=3ecbf87085230fbcd9605c32ca20c4fb41af02c71d076eab246ea22e35947d88

--- a/srcpkgs/vdirsyncer/template
+++ b/srcpkgs/vdirsyncer/template
@@ -1,23 +1,24 @@
 # Template file for 'vdirsyncer'
 pkgname=vdirsyncer
-version=0.18.0
-revision=3
+version=0.19.0
+revision=1
 build_style=python3-module
 hostmakedepends="python3-setuptools_scm"
 depends="python3-atomicwrites python3-click python3-click-log
- python3-click-threading python3-requests-toolbelt"
-checkdepends="python3-pytest python3-hypothesis $depends"
+python3-click-threading python3-requests-toolbelt python3-aiohttp
+python3-aiostream"
+checkdepends="python3-pytest python3-hypothesis python3-aioresponses python3-trustme python3-pytest-asyncio python3-pytest-localserver python3-pytest-httpserver $depends"
 short_desc="Synchronize calendars and addressbooks"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="BSD-3-Clause"
 homepage="https://vdirsyncer.pimutils.org/"
 distfiles="${PYPI_SITE}/v/vdirsyncer/vdirsyncer-${version}.tar.gz"
-checksum=27bc3ed51f774935fbba392915c8c8d4cf639ae51a44b674686b49a1025fc201
+checksum=8e1e8403a08659e5a4e7fa3e9caaa2e2dce2bf1f98d923029049a34db75a2525
 
 do_check() {
-	# Disable coverage checks and those requiring unpackaged pytest-localserver
+# Disable coverage checks and those requiring unpackaged pytest-localserver
 	vsed -e 's/^addopts/noaddopts/' -i setup.cfg
-	PYTHONPATH="$(cd build/lib* && pwd)" \
+		PYTHONPATH="$(cd build/lib* && pwd)" \
 		python3 -m pytest -k 'not test_request_ssl_fingerprints'
 }
 


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc

