### PR TITLE
easyeffects: update to 7.0.0

### DIFF
--- a/srcpkgs/easyeffects/template
+++ b/srcpkgs/easyeffects/template
@@ -1,19 +1,21 @@
 # Template file for 'easyeffects'
 pkgname=easyeffects
-version=6.2.4
-revision=2
+version=7.0.0
+revision=1
 build_style=meson
-hostmakedepends="pkg-config gettext itstool glib-devel"
+hostmakedepends="pkg-config gettext itstool glib-devel desktop-file-utils
+ gtk-update-icon-cache"
 makedepends="gtkmm4-devel pipewire-devel zita-convolver-devel lilv-devel
  libbs2b-devel fftw-devel libebur128-devel rnnoise-devel libsamplerate-devel
- rubberband-devel speexdsp-devel json-c++ tbb-devel libadwaita-devel fmt-devel"
+ rubberband-devel speexdsp-devel json-c++ tbb-devel libadwaita-devel fmt-devel
+ gsl-devel speex-devel"
 short_desc="Sound effects for systems using PipeWire"
 maintainer="Michal Vasilek <michal@vasilek.cz>"
 license="GPL-3.0-or-later"
 homepage="https://github.com/wwmm/easyeffects"
 changelog="https://raw.githubusercontent.com/wwmm/easyeffects/master/CHANGELOG.md"
 distfiles="https://github.com/wwmm/easyeffects/archive/v${version}.tar.gz"
-checksum=2d4e5638f209a887acb73b3d2bbea4bc5f83ded866bba40c1935ec40fb17658b
+checksum=8ee2d1f439cf24408ead008240bf0d603a04d630238f45bffa46b1391f98518b
 
 pulseeffects_package() {
 	depends="${sourcepkg}>=${version}_${revision}"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

I updated this to see if an update fixed my issue and the newer version gave me a nice message saying the stereo tools didn't work because I didn't have `calf`.
Version 6.3.0 added an optional dependency on "Linux Studio Plugins" but I haven't packaged it in this PR.
![2023-01-09T00:25:22,344238422-05:00](https://user-images.githubusercontent.com/486393/211245613-272c6558-fb51-4641-86db-f5e44744539a.png)

@paper42 

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
