### PR TITLE
gnuradio: remove mpir-devel from makedepends

### DIFF
--- a/srcpkgs/gnuradio/template
+++ b/srcpkgs/gnuradio/template
@@ -11,7 +11,7 @@ _pydeps="python3-Mako python3-cairo python3-click python3-click-plugins python3-
  python3-jsonschema python3-numpy python3-pyqtgraph python3-pyzmq python3-scipy python3-yaml"
 hostmakedepends="pkg-config doxygen mathjax python3-Sphinx python3-pygccxml ${_pydeps}"
 makedepends="SDL-devel SoapySDR-devel boost-devel codec2-devel cppzmq fftw-devel gmpxx-devel
- gsl-devel gtk+3-devel jack-devel libgsm-devel libiio-devel libsndfile-devel mpir-devel
+ gsl-devel gtk+3-devel jack-devel libgsm-devel libiio-devel libsndfile-devel
  python3-devel python3-gobject-devel python3-pybind11 python3-pygccxml qwt-devel spdlog
  fmt-devel uhd-devel volk-devel"
 depends="${_pydeps} python3-cheetah3 python3-lxml python3-matplotlib"


### PR DESCRIPTION
This was never used for building or runtime, gmp is used instead.

No need to revbump since this will make no difference (other than dropping mpir-devel from gnuradio-devel depends).

This is the only dependency of mpir in void linux.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
