### PR TITLE
lxpanel: patch panel size under GTK3

### DIFF
--- a/srcpkgs/lxpanel/patches/fix-panel-size.patch
+++ b/srcpkgs/lxpanel/patches/fix-panel-size.patch
@@ -1,0 +1,36 @@
+https://github.com/lxde/lxpanel/pull/38
+
+From 12576de7b83c634437217e23d74954070a1be2d5 Mon Sep 17 00:00:00 2001
+From: Ben Walsh <b@wumpster.com>
+Date: Sat, 6 Jun 2020 10:38:15 +0100
+Subject: [PATCH] Correct panel size under GTK3. Fixes Sourceforge #773.
+
+---
+ src/panel.c | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/src/panel.c b/src/panel.c
+index 45188dbe..2b5fc9be 100644
+--- a/src/panel.c
++++ b/src/panel.c
+@@ -293,6 +293,12 @@ lxpanel_get_preferred_height (GtkWidget *widget,
+   if (natural_height)
+       *natural_height = requisition.height;
+ }
++
++static GtkSizeRequestMode
++lxpanel_get_request_mode (GtkWidget *widget)
++{
++    return GTK_SIZE_REQUEST_CONSTANT_SIZE;
++}
+ #endif
+ 
+ static void lxpanel_size_allocate(GtkWidget *widget, GtkAllocation *a)
+@@ -413,6 +419,7 @@ static void lxpanel_class_init(PanelToplevelClass *klass)
+ #if GTK_CHECK_VERSION(3, 0, 0)
+     widget_class->get_preferred_width = lxpanel_get_preferred_width;
+     widget_class->get_preferred_height = lxpanel_get_preferred_height;
++    widget_class->get_request_mode = lxpanel_get_request_mode;
+ #else
+     widget_class->size_request = lxpanel_size_request;
+ #endif

--- a/srcpkgs/lxpanel/template
+++ b/srcpkgs/lxpanel/template
@@ -1,7 +1,7 @@
 # Template file for 'lxpanel'
 pkgname=lxpanel
 version=0.10.1
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--enable-gtk3"
 hostmakedepends="pkg-config intltool"


### PR DESCRIPTION
The provided patch fixes panel width not taking size of the screen.

Fixes #41479.

#### Testing the changes
- I tested the changes in this PR: **YES**
