### PR TITLE
rmapi: update to 0.0.25

### DIFF
--- a/srcpkgs/rmapi/template
+++ b/srcpkgs/rmapi/template
@@ -1,6 +1,6 @@
 # Template file for 'rmapi'
 pkgname=rmapi
-version=0.0.22.1
+version=0.0.25
 revision=1
 build_style=go
 go_import_path=github.com/juruen/rmapi
@@ -9,4 +9,4 @@ maintainer="Patrick Pichler <mail@patrickpichler.dev>"
 license="GPL-3.0-or-later"
 homepage="https://github.com/juruen/rmapi"
 distfiles="https://github.com/juruen/rmapi/archive/v${version}.tar.gz"
-checksum=880dae291267ae19ed524e4342fb86a935cfe9d20be99cf02086b50e179f6978
+checksum=f8ae984941e6e4755ee8b156f9876fa7f1cde084bca02bd83ced6afcc886bc33


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, `x86_64-glibc`
