### PR TITLE
mkinitcpio-nfs-utils: support NFSv4 roots

### DIFF
--- a/srcpkgs/mkinitcpio-nfs-utils/files/initcpio-hook-net
+++ b/srcpkgs/mkinitcpio-nfs-utils/files/initcpio-hook-net
@@ -84,7 +84,28 @@ nfs_mount_handler() {
         launch_interactive_shell
         msg "Trying to continue (this will most likely fail) ..."
     fi
-    nfsmount ${nfs_option:+-o ${nfs_option}} "${nfs_server}:${nfs_path}" "$1"
+
+    # nfsmount avoids problems with lockd for v2 and v3 but does not support v4;
+    # to support v4 roots, examine mount options for a v4 version spec and use
+    # the ordinary mount program. v4 doesn't need lockd for file locking anyway.
+    mount_cmd=
+    case "${nfs_option}" in
+        nfsvers=4*|*,nfsvers=4*|vers=4*|*,vers=4*)
+            command -v mount.nfs4 >/dev/null 2>&1 && mount_cmd="mount -t nfs4"
+            ;;
+    esac
+
+    # musl installations may not offer nfsmount, so fall back to mount.nfs
+    # when nfsmount does not exist. This probably requires a nolock mount.
+    if [ -z "${mount_cmd}" ]; then
+        if command -v nfsmount >/dev/null 2>&1; then
+            mount_cmd=nfsmount
+        else
+            mount_cmd="mount -t nfs"
+        fi
+    fi
+
+    ${mount_cmd} ${nfs_option:+-o ${nfs_option}} "${nfs_server}:${nfs_path}" "$1"
 }
 
 # vim: set ft=sh ts=4 sw=4 et:

--- a/srcpkgs/mkinitcpio-nfs-utils/files/initcpio-install-net
+++ b/srcpkgs/mkinitcpio-nfs-utils/files/initcpio-install-net
@@ -3,9 +3,20 @@
 build() {
     add_checked_modules '/drivers/net/'
     add_module nfsv3?
+    add_module nfsv4?
 
     add_binary "/usr/lib/initcpio/ipconfig" "/bin/ipconfig"
-    add_binary "/usr/lib/initcpio/nfsmount" "/bin/nfsmount"
+
+    # nfsmount helper might not be available on musl installations
+    if [ -e "/usr/lib/initcpio/nfsmount" ]; then
+        add_binary "/usr/lib/initcpio/nfsmount" "/bin/nfsmount"
+    else
+        add_binary "mount.nfs"
+    fi
+
+    if command -v mount.nfs4 >/dev/null 2>&1; then
+        add_binary "mount.nfs4"
+    fi
 
     add_runscript
 }

--- a/srcpkgs/mkinitcpio-nfs-utils/template
+++ b/srcpkgs/mkinitcpio-nfs-utils/template
@@ -1,7 +1,7 @@
 # Template file for 'mkinitcpio-nfs-utils'
 pkgname=mkinitcpio-nfs-utils
 version=0.3
-revision=3
+revision=4
 build_style=gnu-makefile
 depends="mkinitcpio"
 short_desc="Ipconfig and nfsmount tools for NFS root support in mkinitcpio"
@@ -11,26 +11,27 @@ homepage="http://www.archlinux.org/"
 distfiles="https://sources.archlinux.org/other/mkinitcpio/$pkgname-$version.tar.xz"
 checksum=d290d489844fae100ca7b848b8eef40078124ff373203086bacc07329d1e8939
 
-case "$XBPS_TARGET_MACHINE" in
-*-musl)
+if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
+	# musl doesn't set this
 	CFLAGS="-DSYS_NMLN=65"
-	# http://osxr.org/glibc/source/sysdeps/unix/sysv/linux/bits/utsname.h?v=glibc-2.15; fixes musl not having set this variable
-	;;
-esac
+fi
 
+post_patch() {
+	vsed -i '/CC.*-o/s/$/ $(LDFLAGS)/' */Makefile
 
-post_extract() {
-	sed -i '/CC.*-o/s/$/ $(LDFLAGS)/' */Makefile
+	# No RPC in musl for now
+	if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
+		vsed -i 's|PROGRAMS = ipconfig nfsmount|PROGRAMS = ipconfig|g' Makefile
+	fi
 }
-pre_configure() {
-	case "$XBPS_TARGET_MACHINE" in
-	*-musl)
-		sed -i 's|PROGRAMS = ipconfig nfsmount|PROGRAMS = ipconfig|g' Makefile
-		# No RPC in musl for now
-		;;
-	esac
-}
-post_install() {
+
+do_install() {
+	# Makefile installation is broken, just install the two executables directly
+	vinstall ipconfig/ipconfig 755 usr/lib/initcpio
+	if [ "$XBPS_TARGET_LIBC" != "musl" ]; then
+		vinstall nfsmount/nfsmount 755 usr/lib/initcpio
+	fi
+
 	vinstall ${FILESDIR}/initcpio-install-net 644 usr/lib/initcpio/install net
 	vinstall ${FILESDIR}/initcpio-hook-net 644 usr/lib/initcpio/hooks net
 }


### PR DESCRIPTION
The `net` hook for `mkinitcpio` shipped by this package uses a helper to do v2 or v3 mounts that support locking without the need for a local `lockd` in the initramfs. The helper does not support v4 mounts and v4 does not require a local `lockd`, so we can look for an NFS version requirement in the root spec and directly call `mount -t nfs4` instead of `nfsmount` to support v4 roots.

#### Testing the changes
- I tested the changes in this PR: **in progress**