### PR TITLE
gotify-cli, up_rewrite: orphan; gotify-server: update to 2.2.3, orphan.

### DIFF
--- a/srcpkgs/gotify-cli/template
+++ b/srcpkgs/gotify-cli/template
@@ -7,7 +7,7 @@ go_import_path="github.com/gotify/cli/v2"
 go_ldflags="-X main.Version=${version} -X main.BuildDate=${SOURCE_DATE_EPOCH}
  -X main.Mode=prod"
 short_desc="Command line interface for pushing messages to a Gotify server"
-maintainer="Joel Beckmeyer <joel@beckmeyer.us>"
+maintainer="Michal Vasilek <michal@vasilek.cz>"
 license="MIT"
 homepage="https://gotify.net"
 distfiles="https://github.com/gotify/cli/archive/v${version}.tar.gz"

--- a/srcpkgs/gotify-server/template
+++ b/srcpkgs/gotify-server/template
@@ -1,6 +1,6 @@
 # Template file for 'gotify-server'
 pkgname=gotify-server
-version=2.2.2
+version=2.2.3
 revision=1
 build_style=go
 go_import_path="github.com/gotify/server/v2"
@@ -8,11 +8,11 @@ go_ldflags="-extldflags=-fuse-ld=bfd -X main.Version=${version}
  -X main.BuildDate=${SOURCE_DATE_EPOCH} -X main.Mode=prod"
 hostmakedepends="yarn packr2"
 short_desc="Simple server for sending and receiving messages"
-maintainer="Joel Beckmeyer <joel@beckmeyer.us>"
+maintainer="Michal Vasilek <michal@vasilek.cz>"
 license="MIT"
 homepage="https://gotify.net"
 distfiles="https://github.com/gotify/server/archive/v${version}.tar.gz"
-checksum=20549d2e30fcec71c19954818aa44d60547d53f2c804817895f8f36d02ee2dff
+checksum=bb84d1153e6c40b192d037b017b54aed7b57e708ccab1e9687ace7a5ca493b94
 conf_files="/etc/gotify/config.yml"
 
 system_accounts="_gotify"

--- a/srcpkgs/up_rewrite/template
+++ b/srcpkgs/up_rewrite/template
@@ -6,7 +6,7 @@ build_style=go
 go_import_path="github.com/karmanyaahm/up_rewrite"
 go_ldflags="-X $go_import_path/config.Version=$version"
 short_desc="Rewrite Proxy for UnifiedPush written in Go"
-maintainer="Joel Beckmeyer <joel@beckmeyer.us>"
+maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
 homepage="https://unifiedpush.org"
 distfiles="https://github.com/UnifiedPush/common-proxies/archive/v${version}.tar.gz"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->

UnifiedPush [killed their fork of gotify-android with UnifiedPush support](https://github.com/UnifiedPush/gotify-android/#deprecated), so I have no use for this anymore. Reccomend ntfy as a similar alternative, currently in a PR here: https://github.com/void-linux/void-packages/pull/41427

EDIT: and [since ntfy has a built-in Matrix Push Gateway](https://docs.ntfy.sh/publish/?h=matrix#matrix-gateway), I no longer need up_rewrite either.