### PR TITLE
libwacom: update to 2.5.0, adopt. 

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -1043,7 +1043,7 @@ libgck-2.so.0.0.0 gcr4-4.0.0_1
 libgcr-4.so.0.0.0 gcr4-4.0.0_1
 libcld2.so cld2-0.0.1.20150821_1
 libcld2_full.so cld2-full-0.0.1.20150821_1
-libwacom.so.2 libwacom-0.3_1
+libwacom.so.9 libwacom-2.6.0_1
 libfarstream-0.2.so.5 farstream-0.2.7_1
 libass.so.9 libass-0.13.6_1
 libcryptui.so.0 libcryptui-3.4.0_1

--- a/srcpkgs/budgie-control-center/template
+++ b/srcpkgs/budgie-control-center/template
@@ -1,7 +1,7 @@
 # Template file for 'budgie-control-center'
 pkgname=budgie-control-center
 version=1.1.1
-revision=2
+revision=3
 build_style=meson
 hostmakedepends="glib-devel gsettings-desktop-schemas-devel gettext pkg-config
  polkit python3 libxml2"

--- a/srcpkgs/cinnamon-control-center/template
+++ b/srcpkgs/cinnamon-control-center/template
@@ -1,7 +1,7 @@
 # Template file for 'cinnamon-control-center'
 pkgname=cinnamon-control-center
 version=5.4.7
-revision=1
+revision=2
 build_style=meson
 build_helper=gir
 hostmakedepends="gettext-devel glib-devel

--- a/srcpkgs/gnome-control-center/template
+++ b/srcpkgs/gnome-control-center/template
@@ -1,7 +1,7 @@
 # Template file for 'gnome-control-center'
 pkgname=gnome-control-center
 version=43.2
-revision=1
+revision=2
 build_style=meson
 build_helper="gir"
 hostmakedepends="glib-devel gsettings-desktop-schemas-devel gettext pkg-config

--- a/srcpkgs/gnome-settings-daemon/template
+++ b/srcpkgs/gnome-settings-daemon/template
@@ -1,7 +1,7 @@
 # Template file for 'gnome-settings-daemon'
 pkgname=gnome-settings-daemon
 version=43.0
-revision=1
+revision=2
 build_style=meson
 configure_args="-Dsystemd=false"
 hostmakedepends="cmake docbook-xsl gettext glib-devel libglib-devel libxslt

--- a/srcpkgs/kcm-wacomtablet/template
+++ b/srcpkgs/kcm-wacomtablet/template
@@ -1,12 +1,13 @@
 # Template file for 'kcm-wacomtablet'
 pkgname=kcm-wacomtablet
 version=3.2.0
-revision=2
+revision=3
 build_style=cmake
+configure_args="-DBUILD_TESTING=OFF"
 hostmakedepends="pkg-config gettext extra-cmake-modules qt5-qmake qt5-host-tools
- kdoctools kcoreaddons"
+ kdoctools kcoreaddons kpackage"
 makedepends="qt5-devel qt5-x11extras-devel qt5-declarative-devel
- plasma-workspace-devel libwacom-devel xf86-input-wacom-devel"
+ plasma-workspace-devel libwacom-devel xf86-input-wacom-devel libinput-devel"
 depends="xf86-input-wacom"
 short_desc="GUI for the Wacom Linux Drivers"
 maintainer="Piraty <mail@piraty.dev>"
@@ -14,3 +15,4 @@ license="GPL-2.0-or-later"
 homepage="https://invent.kde.org/system/wacomtablet"
 distfiles="${KDE_SITE}/wacomtablet/${version}/wacomtablet-${version}.tar.xz"
 checksum=c80ce63a41f6fcbb50ac4c2130ed2f8273c4b744e62e33d4b714bf83e8e5f7a4
+make_check=no # FIXME

--- a/srcpkgs/libinput/template
+++ b/srcpkgs/libinput/template
@@ -1,7 +1,7 @@
 # Template file for 'libinput'
 pkgname=libinput
 version=1.22.0
-revision=1
+revision=2
 build_style=meson
 configure_args="-Db_ndebug=false -Ddebug-gui=false"
 hostmakedepends="pkg-config"

--- a/srcpkgs/libwacom/template
+++ b/srcpkgs/libwacom/template
@@ -1,6 +1,6 @@
 # Template file for 'libwacom'
 pkgname=libwacom
-version=1.12
+version=2.6.0
 revision=1
 build_style=meson
 build_helper="qemu"
@@ -9,12 +9,12 @@ hostmakedepends="pkg-config"
 makedepends="libgudev-devel libxml2-devel"
 checkdepends="python3-pytest python3-libevdev python3-pyudev"
 short_desc="Library to identify wacom tablets"
-maintainer="Orphaned <orphan@voidlinux.org>"
+maintainer="Mohammed Anas <triallax@tutanota.com>"
 license="MIT"
 homepage="https://github.com/linuxwacom/libwacom"
 changelog="https://raw.githubusercontent.com/linuxwacom/libwacom/master/NEWS"
-distfiles="https://github.com/linuxwacom/libwacom/releases/download/${pkgname}-${version}/${pkgname}-${version}.tar.bz2"
-checksum=290450d604f78bbd956eddb69f79f8d56f8ed1a5ccbb5e88e22fa84fa2fceb4f
+distfiles="https://github.com/linuxwacom/libwacom/releases/download/libwacom-${version}/libwacom-${version}.tar.xz"
+checksum=2376cca99475235b75053a2cfbc7ed40fd8763d5a516941a664870ff1f3aa98f
 
 if [ -z "${XBPS_CHECK_PKGS}" ]; then
 	configure_args+=" -Dtests=disabled"

--- a/srcpkgs/muffin/template
+++ b/srcpkgs/muffin/template
@@ -1,7 +1,7 @@
 # Template file for 'muffin'
 pkgname=muffin
 version=5.4.5
-revision=1
+revision=2
 build_style=meson
 build_helper=gir
 # -Dtests requires -Dwayland, which is explicitly disabled

--- a/srcpkgs/mutter/template
+++ b/srcpkgs/mutter/template
@@ -1,7 +1,7 @@
 # Template file for 'mutter'
 pkgname=mutter
 version=43.2
-revision=1
+revision=2
 build_helper="gir"
 build_style=meson
 configure_args="-Degl_device=true -Dudev=true -Dnative_backend=true


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly** (tested with my Wacom Intuos Pro)

I checked locally and the `kcm-wacomtablet` test failures are present without this PR's changes, so it's an unrelated issue.

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
