### PR TITLE
libcotp: update to 1.2.8

### DIFF
--- a/srcpkgs/libcotp/template
+++ b/srcpkgs/libcotp/template
@@ -1,6 +1,6 @@
 # Template file for 'libcotp'
 pkgname=libcotp
-version=1.2.7
+version=1.2.8
 revision=1
 build_style=cmake
 hostmakedepends="pkg-config"
@@ -10,7 +10,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="Apache-2.0"
 homepage="https://github.com/paolostivanin/libcotp"
 distfiles="https://github.com/paolostivanin/libcotp/archive/v${version}.tar.gz"
-checksum=35b9bdb94dd80a95433db0c78d0d0fe98039a20bbd29105383fea5c6fedb51ac
+checksum=78dab6a2ee08e73f1d052dcb7c1ad069cc37fdf600f3f660d8e6299e11218f0b
 
 libcotp-devel_package() {
 	depends="libcotp-${version}_${revision}"


### PR DESCRIPTION
Fixes regression introduced in libcotp 1.2.7: https://github.com/paolostivanin/libcotp/issues/33

#### Testing the changes
- I tested the changes in this PR: **YES**
