### PR TITLE
cadaver: update to 0.24

### DIFF
--- a/srcpkgs/cadaver/template
+++ b/srcpkgs/cadaver/template
@@ -1,16 +1,16 @@
 # Template file for 'cadaver'
 pkgname=cadaver
-version=0.23.3
-revision=5
+version=0.24
+revision=1
 build_style=gnu-configure
 configure_args="--with-ssl=gnutls"
-hostmakedepends="pkg-config"
+hostmakedepends="pkg-config neon-devel"
 makedepends="readline-devel gnutls-devel neon-devel"
 short_desc="Command-line WebDAV client for Unix"
 maintainer="Leah Neukirchen <leah@vuxu.org>"
 license="GPL-2.0-or-later"
-homepage="http://www.webdav.org/cadaver"
-distfiles="${DEBIAN_SITE}/main/c/cadaver/${pkgname}_${version}.orig.tar.gz"
-checksum=fd4ce68a3230ba459a92bcb747fc6afa91e46d803c1d5ffe964b661793c13fca
+homepage="https://notroj.github.io/cadaver/"
+distfiles="https://notroj.github.io/cadaver/cadaver-${version}.tar.gz"
+checksum=46cff2f3ebd32cd32836812ca47bcc75353fc2be757f093da88c0dd8f10fd5f6
 
 CFLAGS="-DHAVE_LOCALE_H"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures:
  - x86_64-musl
  - aarch64 (crossbuild)
  - armv7l (crossbuild)

#### Notes
 - The homepage has moved
 - `distfiles` now also points to the new homepage