### PR TITLE
gnome-software: update to 43.3.

### DIFF
--- a/srcpkgs/flatpak/template
+++ b/srcpkgs/flatpak/template
@@ -1,10 +1,11 @@
 # Template file for 'flatpak'
 pkgname=flatpak
 version=1.15.1
-revision=1
+revision=2
 build_style=gnu-configure
 build_helper="gir"
 configure_args="
+ --with-curl
  --with-system-bubblewrap
  --with-system-dbus-proxy
  --with-system-helper-user=_flatpak
@@ -15,7 +16,7 @@ hostmakedepends="bubblewrap gettext glib-devel libxslt pkg-config bison
  python3-parsing xmlto docbook-xml docbook-xsl xdg-dbus-proxy"
 makedepends="AppStream-devel libarchive-devel gpgme-devel json-glib-devel
  libcap-devel libostree-devel libseccomp-devel polkit-devel dconf-devel
- fuse3-devel libsoup-devel libcurl-devel gdk-pixbuf-devel"
+ fuse3-devel libcurl-devel libxml2-devel gdk-pixbuf-devel"
 depends="bubblewrap gnupg>=2 xdg-dbus-proxy"
 checkdepends="attr-progs bubblewrap dbus gnupg socat which xdg-dbus-proxy"
 short_desc="Application sandboxing and distribution framework"

--- a/srcpkgs/gnome-software/template
+++ b/srcpkgs/gnome-software/template
@@ -1,6 +1,6 @@
 # Template file for 'gnome-software'
 pkgname=gnome-software
-version=43.2
+version=43.3
 revision=1
 build_style=meson
 configure_args="-Dpackagekit=false -Dfwupd=false
@@ -8,7 +8,7 @@ configure_args="-Dpackagekit=false -Dfwupd=false
  -Dhardcoded_foss_webapps=false -Dhardcoded_proprietary_webapps=false"
 hostmakedepends="pkg-config tar glib-devel gettext libxslt docbook-xsl
  $(vopt_if gtk_doc gtk-doc) AppStream"
-makedepends="AppStream-devel libxmlb-devel gnome-online-accounts-devel
+makedepends="AppStream-devel libxmlb-devel
  json-glib-devel gtk4-devel libadwaita-devel gsettings-desktop-schemas-devel
  gspell-devel polkit-devel flatpak-devel libgudev-devel libsoup3-devel"
 checkdepends="dbus"
@@ -17,7 +17,7 @@ maintainer="Michal Vasilek <michal@vasilek.cz>"
 license="GPL-3.0-or-later"
 homepage="https://gitlab.gnome.org/GNOME/gnome-software"
 distfiles="https://gitlab.gnome.org/GNOME/gnome-software/-/archive/${version}/gnome-software-${version}.tar.gz"
-checksum=5d93c568d5106a1183ee80fab573961cb0617af10e685314822aca5bedfd789d
+checksum=9fbdf888ec61cd6f261dbf9e94939a5ff95ba43993ef58946b02b4f92866819c
 make_check=no # FIXME
 
 build_options="gtk_doc"

--- a/srcpkgs/libostree/template
+++ b/srcpkgs/libostree/template
@@ -1,17 +1,18 @@
 # Template file for 'libostree'
 pkgname=libostree
 version=2022.7
-revision=1
+revision=2
 build_style=gnu-configure
 build_helper="gir"
 configure_args="
  --with-builtin-grub2-mkconfig
  --with-ed25519-libsodium
  --with-openssl
+ --with-curl
  $(vopt_enable gir introspection)"
 hostmakedepends="bison docbook-xsl glib-devel libxslt pkg-config"
 makedepends="e2fsprogs-devel fuse-devel glib-devel gpgme-devel libarchive-devel
- libsoup-devel libsodium-devel $(vopt_if gir 'gobject-introspection')"
+ libcurl-devel libsoup-devel libsodium-devel $(vopt_if gir 'gobject-introspection')"
 checkdepends="attr-progs cpio elfutils gnupg python3-yaml tar which xz"
 short_desc="Operating system and container binary deployment and upgrades"
 maintainer="Duncaen <duncaen@voidlinux.org>"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

Also fixes a gnome-software crash related to libsoup2

(note: libostree still depends on libsoup2 even with `--with-curl`, but that should be fine https://github.com/ostreedev/ostree/blob/1fb9404612f3d98d329f0129ecbc6c8225823679/configure.ac#L137)

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
