### PR TITLE
1password: update to 8.10.7.

### DIFF
--- a/srcpkgs/1password/INSTALL
+++ b/srcpkgs/1password/INSTALL
@@ -7,5 +7,11 @@ post)
 	chmod g+s opt/1Password/1Password-KeyringHelper
 	chown :_onepassword opt/1Password/1Password-BrowserSupport
 	chmod g+s opt/1Password/1Password-BrowserSupport
+	export POLICY_OWNERS
+	POLICY_OWNERS="$(cut -d: -f1,3 etc/passwd | grep -E ':[0-9]{4}$' | cut -d: -f1 | head -n 10 | sed 's/^/unix-user:/' | tr '\n' ' ')"
+	eval "cat <<EOF
+$(cat opt/1Password/com.1password.1Password.policy.tpl)
+EOF" > opt/1Password/com.1password.1Password.policy
+	install -Dm0644 opt/1Password/com.1password.1Password.policy -t usr/share/polkit-1/actions/
 	;;
 esac

--- a/srcpkgs/1password/files/EULA
+++ b/srcpkgs/1password/files/EULA
@@ -1,0 +1,1 @@
+The current version can be found at: https://1password.com/legal/terms-of-service/

--- a/srcpkgs/1password/template
+++ b/srcpkgs/1password/template
@@ -1,21 +1,34 @@
 # Template file for '1password'
 pkgname=1password
-version=8.4.1
+version=8.10.7
 revision=1
-archs="x86_64"
-hostmakedepends="w3m gnupg"
+archs="x86_64 aarch64"
+hostmakedepends="gnupg"
 short_desc="Password manager"
 maintainer="b-l-a-i-n-e <blaine.gilbreth@gmail.com>"
 license="custom:Proprietary"
 homepage="https://www.1password.com"
-distfiles="https://downloads.1password.com/linux/tar/stable/x86_64/1password-${version}.x64.tar.gz
- https://downloads.1password.com/linux/tar/stable/x86_64/1password-${version}.x64.tar.gz.sig"
-checksum="f5c2468127c363b3a3d2fa5857b6ff0979eeaf1485c1afb114b3929c1fc4a7df
- 0739424395377f56c9528c1169ef72d6a941e21f1bc9d728481bf5de8563bf01"
-_filename="1password-${version}.x64.tar.gz"
+
+case "${XBPS_TARGET_MACHINE}" in
+	aarch64)
+		_arch="arm64"
+		checksum="4e6a1ffa66b54893104525754f97e52de5df7ba5b56b6536998ce2f8caf1bc93
+ 31dd56227da961b346c5e00aebfe44b065cecb06314c144c3572033777d5c6d0"
+		;;
+
+	x86_64)
+		_arch="x64"
+		checksum="e4a300cecb683e636015e8e9db547c3dc76b994b645f7ab11d85f7ad5e49ab21
+ 572508224d18cceb7efe66ed2db3c52f2cfd7f572c7e107e9d7b8439340d17ac"
+		;;
+esac
+
+distfiles="https://downloads.1password.com/linux/tar/stable/${XBPS_TARGET_MACHINE}/1password-${version}.${_arch}.tar.gz
+ https://downloads.1password.com/linux/tar/stable/${XBPS_TARGET_MACHINE}/1password-${version}.${_arch}.tar.gz.sig"
+_filename="1password-${version}.${_arch}.tar.gz"
 _1passworddir="${_filename%.tar.*}"
-_license_checksum=b8f6ff9297488416f3d8063a151109ed5e8a2df6fa546856a4beaa715cbc0fda
 _gpg_key=3FEF9748469ADBE15DA7CA80AC2D62742012EA22
+_resources="opt/1Password/resources"
 system_groups="_onepassword"
 repository=nonfree
 restricted=yes
@@ -33,24 +46,28 @@ post_extract() {
 	then
 		msg_error "gpg verify failed\n"
 	fi
-
-	# verify EULA
-	$XBPS_FETCH_CMD -o eula https://1password.com/legal/terms-of-service/
-	cat eula |
-		w3m -dump -I utf-8 -T text/html |
-		sed -n '/Service Agreement for 1Password/,/We clarified what happens if we part ways./p' > EULA
-	filesum="$($XBPS_DIGEST_CMD EULA)"
-	if [ "$filesum" != "$_license_checksum" ]; then
-		msg_error "SHA256 mismatch for EULA:\n$filesum\n"
-	fi
 }
 
 do_install() {
 	vmkdir opt/1Password
-	vlicense EULA
-	rm -f EULA eula
+	vlicense ${FILESDIR}/EULA
 	vcopy "*" opt/1Password
-	vinstall com.1password.1Password.policy 644 usr/share/polkit-1/actions/
+
+	# Install the icons
+	for _s in 32 64 256 512; do
+		# Create xdg directory
+		vmkdir usr/share/icons/hicolor/${_s}x${_s}/apps
+
+		# Copy the 1Password icon
+		mv  ${DESTDIR}/${_resources}/icons/hicolor/${_s}x${_s}/apps/1password.png \
+		    ${DESTDIR}/usr/share/icons/hicolor/${_s}x${_s}/apps/1password.png
+	done
+
+	# Install the .desktop file
+	vmkdir usr/share/applications
+	mv ${DESTDIR}/${_resources}/1password.desktop \
+	   ${DESTDIR}/usr/share/applications/1password.desktop
+
 	vinstall resources/custom_allowed_browsers 644 usr/share/doc/1password/examples/
 	vbin "${FILESDIR}/1password"
 }


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally also for aarch64-glibc (cross-build)

#### Comments
- Added 1Password icons and 1password.desktop file to template
- Extended INSTALL post action to create and install custom policy file
- Added aarch64 as a supported architecture
- Revised the license handling as per commit 1527238