### PR TITLE
chroot-grep: patch out problematic warnings in egrep and fgrep.

### DIFF
--- a/srcpkgs/chroot-grep/patches/efgrep-remove-warning.patch
+++ b/srcpkgs/chroot-grep/patches/efgrep-remove-warning.patch
@@ -1,0 +1,10 @@
+since 3.8, egrep and fgrep print a warning which can cause many issues with
+programs not expecting this behaviour
+
+--- a/src/egrep.sh
++++ b/src/egrep.sh
+@@ -1,4 +1,3 @@
+ #!@SHELL@
+ cmd=${0##*/}
+-echo "$cmd: warning: $cmd is obsolescent; using @grep@ @option@" >&2
+ exec @grep@ @option@ "$@"

--- a/srcpkgs/chroot-grep/template
+++ b/srcpkgs/chroot-grep/template
@@ -1,7 +1,7 @@
 # Template file for 'chroot-grep'
 pkgname=chroot-grep
 version=3.8
-revision=1
+revision=2
 bootstrap=yes
 build_style=gnu-configure
 configure_args="--disable-perl-regexp --disable-nls ac_cv_path_GREP=grep"


### PR DESCRIPTION
This mirrors the changes from grep in https://github.com/void-linux/void-packages/commit/ef5ffe4d696b31041c272be92e912fb454c075ac into chroot-grep.