### PR TITLE
New package: lua54-luasocket-3.1.0

### DIFF
--- a/srcpkgs/lua54-luasocket/template
+++ b/srcpkgs/lua54-luasocket/template
@@ -1,0 +1,25 @@
+# Template file for 'lua54-luasocket'
+pkgname=lua54-luasocket
+version=3.1.0
+revision=1
+build_style=gnu-makefile
+makedepends="lua54-devel"
+depends="lua54"
+short_desc="Network support for the Lua language"
+maintainer="Orphaned <orphan@voidlinux.org>"
+license="MIT"
+homepage="https://lunarmodules.github.io/luasocket/"
+distfiles="https://github.com/lunarmodules/luasocket/archive/v${version}/luasocket-${version}.tar.gz"
+checksum=bf033aeb9e62bcaa8d007df68c119c966418e8c9ef7e4f2d7e96bddeca9cca6e
+
+do_build() {
+	make CC=$CC LD=$CC LUAV=5.4 LUAINC=${XBPS_CROSS_BASE}/usr/include/lua5.4/ ${makejobs}
+}
+
+do_install() {
+	make LUAV=5.4 prefix=/usr DESTDIR=${DESTDIR} ${makejobs} install
+}
+
+post_install() {
+	vlicense LICENSE
+}

--- a/srcpkgs/lua54-luasocket/update
+++ b/srcpkgs/lua54-luasocket/update
@@ -1,0 +1,3 @@
+site="https://github.com/diegonehab/luasocket/tags"
+pattern='archive/v\K[\d\w-.]+(?=\.tar\.gz)'
+ignore="*rc*"


### PR DESCRIPTION
This is derived from lua51-luasocket but without the transitional package luasocket, and from the new upstream (hence the different version).

This version is required to update the prosody package to use lua54 instead of the now-deprecated lua51.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, x86_64-musl
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - ppc