### PR TITLE
Waybar: Update to 0.9.17 & add libevdev-devel necessary for keyboard-module

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -4244,3 +4244,4 @@ libdate-tz.so.3 chrono-date-3.0.1_1
 libayatana-ido3-0.4.so.0 ayatana-ido-0.9.2_1
 libayatana-indicator3.so.7 libayatana-indicator-0.9.3_1
 libayatana-appindicator3.so.1 libayatana-appindicator-0.5.91_1
+libplayerctl.so.2 playerctl-2.4.1_1

--- a/common/shlibs
+++ b/common/shlibs
@@ -4245,3 +4245,4 @@ libayatana-ido3-0.4.so.0 ayatana-ido-0.9.2_1
 libayatana-indicator3.so.7 libayatana-indicator-0.9.3_1
 libayatana-appindicator3.so.1 libayatana-appindicator-0.5.91_1
 libplayerctl.so.2 playerctl-2.4.1_1
+libwireplumber-0.4.so.0 wireplumber-0.4.14_1

--- a/srcpkgs/Waybar/template
+++ b/srcpkgs/Waybar/template
@@ -9,12 +9,14 @@ configure_args="-Dgtk-layer-shell=enabled -Dlibudev=enabled -Dman-pages=enabled
  -Dpulseaudio=$(vopt_if pulseaudio enabled disabled)
  -Ddbusmenu-gtk=$(vopt_if dbusmenugtk enabled disabled)
  -Dmpd=$(vopt_if mpd enabled disabled)
- -Dsndio=$(vopt_if sndio enabled disabled)"
+ -Dsndio=$(vopt_if sndio enabled disabled)
+ -Dwireplumber=$(vopt_if pipewire enabled disabled)"
 hostmakedepends="cmake pkg-config glib-devel wayland-devel scdoc
  $(vopt_if dbusmenugtk gobject-introspection)"
 makedepends="libevdev-devel libinput-devel wayland-devel gtkmm-devel spdlog eudev-libudev-devel
  gtk-layer-shell-devel jsoncpp-devel libglib-devel libsigc++-devel fmt-devel chrono-date-devel
- playerctl-devel wireplumber-devel pipewire-devel
+ playerctl-devel
+ $(vopt_if pipewire 'wireplumber-devel pipewire-devel')
  $(vopt_if libnl libnl3-devel)
  $(vopt_if pulseaudio pulseaudio-devel)
  $(vopt_if dbusmenugtk libdbusmenu-gtk3-devel)
@@ -28,12 +30,13 @@ changelog="https://github.com/Alexays/Waybar/releases"
 distfiles="https://github.com/Alexays/Waybar/archive/refs/tags/${version}.tar.gz"
 checksum="da6f448be343a593ee092486fb4744502aa1e6ad85f4eccc3670d0b84a2a4266"
 
-build_options="libnl pulseaudio dbusmenugtk mpd sndio"
-build_options_default="libnl pulseaudio dbusmenugtk mpd sndio"
+build_options="libnl pulseaudio dbusmenugtk mpd sndio pipewire"
+build_options_default="libnl pulseaudio dbusmenugtk mpd sndio pipewire"
 
 desc_option_libnl="Enable libnl support for network related features"
 desc_option_dbusmenugtk="Enable support for tray"
 desc_option_mpd="Enable support for MPD"
+desc_option_pipewire="Enable support for pipewire related features"
 
 post_install() {
 	vlicense LICENSE

--- a/srcpkgs/Waybar/template
+++ b/srcpkgs/Waybar/template
@@ -1,10 +1,7 @@
 # Template file for 'Waybar'
 pkgname=Waybar
-version=0.9.16
+version=0.9.17
 revision=1
-_date_version=3.0.1
-_mesonbuild_date_ver=3.0.0-1
-build_wrksrc=Waybar-${version}
 build_style=meson
 configure_args="-Dgtk-layer-shell=enabled -Dlibudev=enabled -Dman-pages=enabled
  -Dsystemd=disabled -Drfkill=enabled
@@ -15,8 +12,9 @@ configure_args="-Dgtk-layer-shell=enabled -Dlibudev=enabled -Dman-pages=enabled
  -Dsndio=$(vopt_if sndio enabled disabled)"
 hostmakedepends="cmake pkg-config glib-devel wayland-devel scdoc
  $(vopt_if dbusmenugtk gobject-introspection)"
-makedepends="libinput-devel wayland-devel gtkmm-devel spdlog eudev-libudev-devel
- gtk-layer-shell-devel jsoncpp-devel libglib-devel libsigc++-devel fmt-devel
+makedepends="libevdev-devel libinput-devel wayland-devel gtkmm-devel spdlog eudev-libudev-devel
+ gtk-layer-shell-devel jsoncpp-devel libglib-devel libsigc++-devel fmt-devel chrono-date-devel
+ playerctl-devel wireplumber-devel pipewire-devel
  $(vopt_if libnl libnl3-devel)
  $(vopt_if pulseaudio pulseaudio-devel)
  $(vopt_if dbusmenugtk libdbusmenu-gtk3-devel)
@@ -27,13 +25,8 @@ maintainer="Érico Nogueira <ericonr@disroot.org>"
 license="MIT"
 homepage="https://github.com/Alexays/Waybar"
 changelog="https://github.com/Alexays/Waybar/releases"
-# date library URLs and checksums taken from subprojects/date.wrap
-distfiles="https://github.com/Alexays/Waybar/archive/refs/tags/${version}.tar.gz
- https://github.com/HowardHinnant/date/archive/refs/tags/v${_date_version}.tar.gz
- https://github.com/mesonbuild/hinnant-date/archive/refs/tags/${_mesonbuild_date_ver}.tar.gz"
-checksum="37ebd7b10e32e802afe9236ea9374fabb77b1abb2c203ca6173b27dc03128096
- 7a390f200f0ccd207e8cff6757e04817c1a0aec3e327b006b7eb451c57ee3538
- f2aa492b59893f69367228bf802cbb0a07c4d52fac2185dfd8ebb5d16295d893"
+distfiles="https://github.com/Alexays/Waybar/archive/refs/tags/${version}.tar.gz"
+checksum="da6f448be343a593ee092486fb4744502aa1e6ad85f4eccc3670d0b84a2a4266"
 
 build_options="libnl pulseaudio dbusmenugtk mpd sndio"
 build_options_default="libnl pulseaudio dbusmenugtk mpd sndio"
@@ -41,12 +34,6 @@ build_options_default="libnl pulseaudio dbusmenugtk mpd sndio"
 desc_option_libnl="Enable libnl support for network related features"
 desc_option_dbusmenugtk="Enable support for tray"
 desc_option_mpd="Enable support for MPD"
-
-post_extract() {
-	mv hinnant-date-${_mesonbuild_date_ver}/meson_options.txt date-${_date_version}/
-	mv hinnant-date-${_mesonbuild_date_ver}/meson.build date-${_date_version}/
-	mv date-${_date_version} Waybar-${version}/subprojects/
-}
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
The libevdev-devel dependency was missing, and was needed for the keyboard-state module to work.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)


