### PR TITLE
ImageMagick: update to 7.1.0.57.

### DIFF
--- a/srcpkgs/ImageMagick/template
+++ b/srcpkgs/ImageMagick/template
@@ -1,7 +1,7 @@
 # Template file for 'ImageMagick'
 pkgname=ImageMagick
-version=7.1.0.55
-revision=2
+version=7.1.0.57
+revision=1
 _upstream_version="${version/.${version##*.}/-${version##*.}}"
 build_style=gnu-configure
 configure_args="--disable-static --enable-opencl --with-modules --with-gslib
@@ -19,7 +19,7 @@ license="ImageMagick"
 homepage="https://www.imagemagick.org"
 changelog="https://raw.githubusercontent.com/ImageMagick/Website/main/ChangeLog.md"
 distfiles="https://github.com/ImageMagick/ImageMagick/archive/${_upstream_version}.tar.gz"
-checksum=77e1535448d6c7f951a8c9d10804246b76044b879adf5bf1f12c836ed9d4b5ec
+checksum=e0157354e0282d34968af6686830216b48d175b65720cd9650b4fae5af2f6251
 
 subpackages="libmagick libmagick-devel"
 


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

```
pkg          host         target        cross  result
ImageMagick  x86_64       x86_64        n      OK
ImageMagick  x86_64-musl  x86_64-musl   n      OK
ImageMagick  i686         i686          n      OK
ImageMagick  x86_64-musl  aarch64-musl  y      OK
ImageMagick  x86_64-musl  aarch64       y      OK
ImageMagick  x86_64-musl  armv7l-musl   y      OK
ImageMagick  x86_64-musl  armv7l        y      OK
ImageMagick  x86_64-musl  armv6l-musl   y      OK
ImageMagick  x86_64-musl  armv6l        y      OK
```