### PR TITLE
discord: Update to 0.0.24

### DIFF
--- a/srcpkgs/discord/template
+++ b/srcpkgs/discord/template
@@ -1,6 +1,6 @@
 # Template file for 'discord'
 pkgname=discord
-version=0.0.23
+version=0.0.24
 revision=1
 archs="x86_64"
 depends="alsa-lib dbus-glib gtk+3 libnotify nss libXtst libcxx libatomic
@@ -10,7 +10,7 @@ maintainer="Ryan Conwell <ryanconwell@protonmail.com>"
 license="custom:Proprietary"
 homepage="https://discord.com"
 distfiles="https://dl.discordapp.net/apps/linux/${version}/discord-${version}.tar.gz"
-checksum=288c005901f2bf5a1148021e1d22fd297419d43c70b0f989820ab72aa79faa44
+checksum=486fb7e1fb74993aad83dac5888eb437a24838dcaa17c73c4a59d1727e5ae177
 repository=nonfree
 restricted=yes
 nopie=yes
@@ -36,7 +36,6 @@ do_install() {
 		libGLESv2.so \
 		chrome_100_percent.pak \
 		chrome_200_percent.pak \
-		chrome_crashpad_handler \
 		chrome-sandbox \
 		resources.pak \
 		swiftshader \


### PR DESCRIPTION
Updates Discord to 0.0.24. I removed the reference to chrome_crashpad_handler since it doesn't seem to exist, though given the discussion in #41609 I'm not sure what's up with that

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
