### PR TITLE
perl-Params-ValidationCompiler: update to 0.31

### DIFF
--- a/srcpkgs/perl-Params-ValidationCompiler/template
+++ b/srcpkgs/perl-Params-ValidationCompiler/template
@@ -1,16 +1,17 @@
-# Template build file for 'perl-Params-ValidationCompiler'.
+# Template file for 'perl-Params-ValidationCompiler'
 pkgname=perl-Params-ValidationCompiler
-version=0.30
-revision=2
+version=0.31
+revision=1
 build_style=perl-module
 hostmakedepends="perl"
 makedepends="perl perl-Eval-Closure perl-Exception-Class"
 depends="${makedepends}"
-checkdepends="perl-Specio perl-Test2-Suite perl-Test-Without-Module
- perl-Test2-Plugin-NoWarnings perl-Term-Table"
+checkdepends="perl-Class-XSAccessor perl-Specio perl-Test2-Suite
+ perl-Test-Without-Module perl-Test2-Plugin-NoWarnings perl-Term-Table
+ perl-Type-Tiny"
 short_desc="Build an optimized subroutine parameter validator once, use it forever"
 maintainer="newbluemoon <blaumolch@mailbox.org>"
-homepage="https://metacpan.org/release/Params-ValidationCompiler"
 license="Artistic-2.0"
-distfiles="${CPAN_SITE}/Params/${pkgname/perl-/}-$version.tar.gz"
-checksum=dc5bee23383be42765073db284bed9fbd819d4705ad649c20b644452090d16cb
+homepage="https://metacpan.org/release/Params-ValidationCompiler"
+distfiles="${CPAN_SITE}/Params/Params-ValidationCompiler-$version.tar.gz"
+checksum=7b6497173f1b6adb29f5d51d8cf9ec36d2f1219412b4b2410e9d77a901e84a6d


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES** (only change is that it checks for Class::XSAccessor 1.17+, we’re at 1.19)
<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - armv7l-musl

