### PR TITLE
wayclip: update to 0.4.1.

### DIFF
--- a/srcpkgs/wayclip/template
+++ b/srcpkgs/wayclip/template
@@ -1,6 +1,6 @@
 # Template file for 'wayclip'
 pkgname=wayclip
-version=0.3
+version=0.4.1
 revision=1
 build_style=gnu-makefile
 hostmakedepends="wayland-devel"
@@ -10,8 +10,10 @@ maintainer="Jan Christian Grünhage <jan.christian@gruenhage.xyz>"
 license="ISC"
 homepage="https://git.sr.ht/~noocsharp/wayclip"
 distfiles="https://git.sr.ht/~noocsharp/wayclip/archive/${version}.tar.gz"
-checksum=f3131b459bfb6354d9cf1ad129946205035aa79aa29953f5e21c6b62878eb977
+checksum=c4fa53618b0869595957e146cb1cfb32309dcbec3ad354ff8e3b075f4219cba8
 
 post_install() {
 	vlicense LICENSE
+	vman waycopy.1
+	vman waypaste.1
 }


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<del>but it's broken. `waycopy` works, `waypaste` does not</del> problem was resolved in 0.4.1.

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
