### PR TITLE
devilutionX: update to 1.4.1.

### DIFF
--- a/srcpkgs/devilutionX/template
+++ b/srcpkgs/devilutionX/template
@@ -1,16 +1,23 @@
 # Template file for 'devilutionX'
 pkgname=devilutionX
-version=1.2.1
+version=1.4.1
 revision=1
 build_style=cmake
-configure_args="-DVERSION_NUM=$version -DBINARY_RELEASE=ON -DTTF_FONT_PATH=\"/usr/share/fonts/truetype/CharisSILB.ttf\""
-makedepends="SDL2-devel SDL2_ttf-devel SDL2_mixer-devel libsodium-devel"
+configure_args="-DVERSION_NUM=$version -DFETCHCONTENT_FULLY_DISCONNECTED=ON
+ -DDISABLE_ZERO_TIER=ON -DDEVILUTIONX_SYSTEM_GOOGLETEST=ON
+ -DDEVILUTIONX_SYSTEM_SDL2=ON -DDEVILUTIONX_SYSTEM_SDL_IMAGE=ON
+ -DDEVILUTIONX_SYSTEM_LIBFMT=ON -DDEVILUTIONX_SYSTEM_BZIP2=ON
+ -DDEVILUTIONX_SYSTEM_LIBSODIUM=ON"
+hostmakedepends="pkg-config gettext"
+makedepends="SDL2-devel SDL2_image-devel bzip2-devel libsodium-devel
+ gtest-devel fmt-devel zlib-devel"
 short_desc="Diablo I engine for modern operating systems"
 maintainer="MarcoAPC <marcoaureliopc@gmail.com>"
 license="Unlicense"
 homepage="https://github.com/diasurgical/devilutionX"
-distfiles="https://github.com/diasurgical/devilutionX/archive/${version}.tar.gz"
-checksum=002dcbd4d4a5bdf8db1a3ec01139e5bfbed46d6a1caa32b17c9f2df161ad3521
+changelog="https://raw.githubusercontent.com/diasurgical/devilutionX/master/docs/CHANGELOG.md"
+distfiles="https://github.com/diasurgical/devilutionX/releases/download/${version}/devilutionx-src-fully-vendored.tar.xz"
+checksum=80527c29cd1d369ce905be426b671350b400c9468b73ef8cfbe6a09a563aeac0
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-musl
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl (cross)
  - armv6l-musl (cross)

#### About mpqtool

Apparently upstream needs some tool to pack assets into one file.

If such a tool is not used within CMake, `do_install()` will not install the binary, icons, etc to `$DESTDIR`.

Pull request #39184 had encountered this behaviour and placed needed files manually as a result.

Packaging `smpq` is a little too much, hence `mpqtool` is used with little patching to address all issues listed above.