### PR TITLE
iputils: update to 20221126.

### DIFF
--- a/srcpkgs/iputils/template
+++ b/srcpkgs/iputils/template
@@ -1,9 +1,9 @@
 # Template file for 'iputils'
 pkgname=iputils
-version=20211215
-revision=2
+version=20221126
+revision=1
 build_style=meson
-configure_args="-DNO_SETCAP_OR_SUID=true -DUSE_IDN=false -DBUILD_NINFOD=false"
+configure_args="-DUSE_IDN=false"
 hostmakedepends="pkg-config docbook2x docbook-xsl-ns libcap-progs iproute2 gettext"
 makedepends="libcap-devel"
 depends="libcap-progs"
@@ -11,8 +11,9 @@ short_desc="Useful utilities for Linux networking (including ping)"
 maintainer="Enno Boland <gottox@voidlinux.org>"
 license="BSD-3-Clause, GPL-2.0-or-later"
 homepage="https://github.com/iputils/iputils"
-distfiles="https://github.com/iputils/iputils/archive/${version}.tar.gz"
-checksum=b6f67fc705490673ff4471d006221b4a2f1b1180b929d9fefd771352621ccedf
+changelog="https://raw.githubusercontent.com/iputils/iputils/master/CHANGES"
+distfiles="https://github.com/iputils/iputils/archive/refs/tags/${version}.tar.gz"
+checksum=745ea711fe06d5c57d470d21acce3c3ab866eb6afb69379a16c6d60b89bd4311
 
 alternatives="
  ping:ping:/usr/bin/${pkgname}-ping


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture: **x86_64**

Relevant changelog entries for the template and xpkgdiff changes:
> removed tools: ninfod, rdisc
> Meson build system: enable NO_SETCAP_OR_SUID by default