### PR TITLE
WoeUSB: make some room for uefi image.

### DIFF
--- a/srcpkgs/WoeUSB/patches/0001-Make-some-room-for-uefi-img.patch
+++ b/srcpkgs/WoeUSB/patches/0001-Make-some-room-for-uefi-img.patch
@@ -1,0 +1,34 @@
+From aa1299fdbc92a2723016568735a07ebc5bc85914 Mon Sep 17 00:00:00 2001
+From: sinetek <pitwuu@gmail.com>
+Date: Sun, 15 Jan 2023 19:21:18 +0100
+Subject: [PATCH] Make some room for uefi img
+
+---
+ src/woeusb | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/woeusb b/src/woeusb
+index 8cb292c..f9986c4 100755
+--- a/src/woeusb
++++ b/src/woeusb
+@@ -1093,7 +1093,7 @@ create_target_partition(){
+ 				primary \
+ 				"${parted_mkpart_fs_type}" \
+ 				4MiB \
+-				-- -1025s # Leave 512KiB==1024sector in traditional 512bytes/sector disk, disks with sector with more than 512bytes only result in partition size greater than 512KiB and is intentionally let-it-be.
++				-- -2049s # Leave 512KiB==1024sector in traditional 512bytes/sector disk, disks with sector with more than 512bytes only result in partition size greater than 512KiB and is intentionally let-it-be.
+ 				# FIXME: Leave exact 512KiB in all circumstances is better, but the algorithm to do so is quite brainkilling.
+ 			;;
+ 		*)
+@@ -1149,7 +1149,7 @@ create_uefi_ntfs_support_partition(){
+ 		primary \
+ 		fat16 \
+ 		--  \
+-		-1024s \
++		-2048s \
+ 		-1s
+ 
+ 	return "$?"
+-- 
+2.39.0
+

--- a/srcpkgs/WoeUSB/template
+++ b/srcpkgs/WoeUSB/template
@@ -1,7 +1,7 @@
 # Template file for 'WoeUSB'
 pkgname=WoeUSB
 version=3.3.1
-revision=3
+revision=4
 build_style=gnu-configure
 configure_args="--with-wx-config=wx-config-gtk3"
 hostmakedepends="automake gettext libtool"


### PR DESCRIPTION
Add a patch for WoeUSB. Version of the program stays the same.
The patch is required because one of the files that is used, downloaded from a github repository at runtime, has doubled in size, and so a small change in the code is needed to accommodate this boot file.

#### Testing the changes
- I tested the changes in this PR: YES

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc

