### PR TITLE
SDL2_ttf: update to 2.20.1.

### DIFF
--- a/srcpkgs/SDL2_ttf/template
+++ b/srcpkgs/SDL2_ttf/template
@@ -1,6 +1,6 @@
 # Template file for 'SDL2_ttf'
 pkgname=SDL2_ttf
-version=2.20.0
+version=2.20.1
 revision=1
 build_style=gnu-configure
 configure_args="--disable-static"
@@ -10,8 +10,9 @@ short_desc="Use TrueType fonts in your SDL 2.x applications"
 maintainer="André Cerqueira <acerqueira021@gmail.com>"
 license="MIT"
 homepage="https://github.com/libsdl-org/SDL_ttf"
-distfiles="${homepage}/releases/download/release-${version}/${pkgname}-${version}.tar.gz"
-checksum=874680232b72839555a558b48d71666b562e280f379e673b6f0c7445ea3b9b8a
+changelog="https://github.com/libsdl-org/SDL_ttf/raw/SDL2/CHANGES.txt"
+distfiles="https://github.com/libsdl-org/SDL_ttf/releases/download/release-${version}/SDL2_ttf-${version}.tar.gz"
+checksum=78cdad51f3cc3ada6932b1bb6e914b33798ab970a1e817763f22ddbfd97d0c57
 
 post_install() {
 	vlicense LICENSE.txt


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**


#### Local build testing
```
SUMMARY
pkg       host         target        cross  result
SDL2_ttf  x86_64       x86_64        n      OK
SDL2_ttf  x86_64-musl  x86_64-musl   n      OK
SDL2_ttf  i686         i686          n      OK
SDL2_ttf  x86_64-musl  aarch64-musl  y      OK
SDL2_ttf  x86_64-musl  aarch64       y      OK
SDL2_ttf  x86_64-musl  armv7l-musl   y      OK
SDL2_ttf  x86_64-musl  armv7l        y      OK
SDL2_ttf  x86_64-musl  armv6l-musl   y      OK
SDL2_ttf  x86_64-musl  armv6l        y      OK
```