### PR TITLE
devilutionX: switch to the -src tarball; drop gettext

### DIFF
--- a/srcpkgs/devilutionX/template
+++ b/srcpkgs/devilutionX/template
@@ -1,14 +1,10 @@
 # Template file for 'devilutionX'
 pkgname=devilutionX
 version=1.4.1
-revision=1
+revision=2
 build_style=cmake
-configure_args="-DVERSION_NUM=$version -DFETCHCONTENT_FULLY_DISCONNECTED=ON
- -DDISABLE_ZERO_TIER=ON -DDEVILUTIONX_SYSTEM_GOOGLETEST=ON
- -DDEVILUTIONX_SYSTEM_SDL2=ON -DDEVILUTIONX_SYSTEM_SDL_IMAGE=ON
- -DDEVILUTIONX_SYSTEM_LIBFMT=ON -DDEVILUTIONX_SYSTEM_BZIP2=ON
- -DDEVILUTIONX_SYSTEM_LIBSODIUM=ON"
-hostmakedepends="pkg-config gettext"
+configure_args="-DVERSION_NUM=$version -DDISABLE_ZERO_TIER=ON"
+hostmakedepends="pkg-config"
 makedepends="SDL2-devel SDL2_image-devel bzip2-devel libsodium-devel
  gtest-devel fmt-devel zlib-devel"
 short_desc="Diablo I engine for modern operating systems"
@@ -16,8 +12,8 @@ maintainer="MarcoAPC <marcoaureliopc@gmail.com>"
 license="Unlicense"
 homepage="https://github.com/diasurgical/devilutionX"
 changelog="https://raw.githubusercontent.com/diasurgical/devilutionX/master/docs/CHANGELOG.md"
-distfiles="https://github.com/diasurgical/devilutionX/releases/download/${version}/devilutionx-src-fully-vendored.tar.xz"
-checksum=80527c29cd1d369ce905be426b671350b400c9468b73ef8cfbe6a09a563aeac0
+distfiles="https://github.com/diasurgical/devilutionX/releases/download/${version}/devilutionx-src.tar.xz"
+checksum=f80a5414bb7b5a5ae9f6dbc69cec4ae080c29dd0a8a553cedd405d631011da9f
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
One of the upstream maintainers (glebm) suggested[^1] to use the `src` tarball instead of `src-fully-vendored`, which does not bundle libraries already available in the repository (SDL2, SDL2_image, libfmt, bzip2, libsodium, googletest) without the need to specify dedicated configure flags for them.

gettext is used for generating `libdevilutionX.mpq` but not required here because it is shipped in the tarball.

`-DFETCHCONTENT_FULLY_DISCONNECTED=ON` now is globally used in 48dabfa86779c1b32d40055ffc5747ba36332152 after the previous update for this package, so it is not needed here anymore.
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
[^1]: https://github.com/diasurgical/devilutionX/issues/5664#issuecomment-1383685675