### PR TITLE
freeciv: Use proper URLs

### DIFF
--- a/srcpkgs/freeciv/template
+++ b/srcpkgs/freeciv/template
@@ -10,12 +10,14 @@ makedepends="SDL2_gfx-devel SDL2_image-devel SDL2_mixer-devel SDL2_ttf-devel
 short_desc="Free and Open Source empire-building strategy game - server/data"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later"
-homepage="http://freeciv.org/"
-changelog="https://freeciv.fandom.com/wiki/NEWS-${version}"
+homepage="https://www.freeciv.org/"
+changelog="https://www.freeciv.org/wiki/NEWS-${version}"
 distfiles="${SOURCEFORGE_SITE}/${pkgname}/${pkgname}-${version}.tar.xz"
 checksum=13215adc96be9f2894d5f3a12c78b8ebb9ae06ecdab25fe6bb1794f6e6d2b61b
 nopie_files="/usr/bin/freeciv-ruledit"
 
+# TODO: gtk3 should be replaced by better supported gtk3.22 in any
+#       distribution that has gtk+-3.22 or gtk+-3.24 available.
 _clients="gtk3,sdl2"
 subpackages="freeciv-gtk2 freeciv-gtk3 freeciv-sdl freeciv-xaw"
 if [ -z "$CROSS_BUILD" ]; then


### PR DESCRIPTION
- https instead of http
- Use canonical freeciv wiki URL

Also add a TODO -comment about the need to switch from mostly deprecated gtk3-client to gtk3.22-client.

Signed-off-by: Marko Lindqvist <cazfi74@gmail.com>

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**|**briefly**|**NO**

NO: I don't have void-linux installation do to any testing, but the change does not touch any functionality.