### PR TITLE
Update glslang and shaderc to the current version.

### DIFF
--- a/srcpkgs/glslang/patches/glslang-11.13.0-cmake_include_dirs.patch
+++ b/srcpkgs/glslang/patches/glslang-11.13.0-cmake_include_dirs.patch
@@ -1,0 +1,24 @@
+diff -ruN a/SPIRV/CMakeLists.txt b/SPIRV/CMakeLists.txt
+--- a/SPIRV/CMakeLists.txt	2022-12-06 23:34:33.000000000 +0100
++++ b/SPIRV/CMakeLists.txt	2022-12-16 12:15:03.231070779 +0100
+@@ -100,7 +100,7 @@
+     target_link_libraries(SPIRV PRIVATE MachineIndependent SPIRV-Tools-opt)
+     target_include_directories(SPIRV PUBLIC
+         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../External>
+-        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/External>)
++    )
+ else()
+     target_link_libraries(SPIRV PRIVATE MachineIndependent)
+ endif()
+diff -ruN a/StandAlone/CMakeLists.txt b/StandAlone/CMakeLists.txt
+--- a/StandAlone/CMakeLists.txt	2022-12-06 23:34:33.000000000 +0100
++++ b/StandAlone/CMakeLists.txt	2022-12-16 12:15:20.527812776 +0100
+@@ -83,7 +83,7 @@
+ target_link_libraries(glslangValidator ${LIBRARIES})
+ target_include_directories(glslangValidator PUBLIC
+     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../External>
+-    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/External>)
++)
+ 
+ if(ENABLE_OPT)
+     target_include_directories(glslangValidator

--- a/srcpkgs/glslang/template
+++ b/srcpkgs/glslang/template
@@ -1,17 +1,40 @@
 # Template file for 'glslang'
 # Libraries are unversioned, beware of ABI breakage (rebuild shaderc on updates)
 pkgname=glslang
-version=11.11.0
+version=11.13.0
 revision=1
 build_style=cmake
-configure_args="-DBUILD_SHARED_LIBS=ON"
 hostmakedepends="python3 bison"
 short_desc="Khronos reference front-end for GLSL, ESSL, and sample SPIR-V generator"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="BSD-3-Clause"
 homepage="https://github.com/KhronosGroup/glslang"
 distfiles="https://github.com/KhronosGroup/glslang/archive/${version}.tar.gz"
-checksum=26c216c3062512c018cbdd752224b8dad703b7e5bb90bf338ba2dbb5d4f11438
+checksum=592c98aeb03b3e81597ddaf83633c4e63068d14b18a766fd11033bad73127162
+
+do_build() {
+	# we need fat LTO objects to not break consumers during linking
+	CXXFLAGS+=" -ffat-lto-objects"
+	cmake \
+		-Bbuild-shared \
+		-GNinja \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DCMAKE_BUILD_TYPE=None \
+		-DBUILD_SHARED_LIBS=ON
+	ninja -Cbuild-shared
+	cmake \
+		-Bbuild-static \
+		-GNinja \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DCMAKE_BUILD_TYPE=None \
+		-DBUILD_SHARED_LIBS=OFF
+	ninja -Cbuild-static
+}
+
+do_install() {
+	DESTDIR="${DESTDIR}" ninja -C build-shared install
+	DESTDIR="${DESTDIR}" ninja -C build-static install
+}
 
 post_install() {
 	sed -n '2,32p' < glslang/GenericCodeGen/CodeGen.cpp > LICENSE
@@ -23,8 +46,8 @@ glslang-devel_package() {
 	short_desc+=" - development files"
 	pkg_install() {
 		vmove usr/include
-		vmove "usr/lib/*.a"
 		vmove usr/lib/libglslang.so
 		vmove usr/lib/cmake
+		vmove "usr/lib/*.a"
 	}
 }

--- a/srcpkgs/shaderc/template
+++ b/srcpkgs/shaderc/template
@@ -1,6 +1,6 @@
 # Template file for 'shaderc'
 pkgname=shaderc
-version=2022.2
+version=2023.1
 revision=1
 build_style=cmake
 configure_args="-DSHADERC_SKIP_TESTS=ON"
@@ -11,7 +11,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="Apache-2.0"
 homepage="https://github.com/google/shaderc"
 distfiles="https://github.com/google/shaderc/archive/v${version}.tar.gz"
-checksum=517d36937c406858164673db696dc1d9c7be7ef0960fbf2965bfef768f46b8c0
+checksum=8041c6874a085a0f357d7918855f9e39bbeff9313cbeacab28505aa233fc0da2
 
 CXXFLAGS="-I${XBPS_CROSS_BASE}/usr/include/glslang"
 LDFLAGS="-Wl,--no-undefined"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)

The update is also necessary for Godot 4 to be able to use the shared library instead of the
builtin glslang.