### PR TITLE
SPIRV-Headers: update to 1.3.236.0.

### DIFF
--- a/srcpkgs/SPIRV-Headers/template
+++ b/srcpkgs/SPIRV-Headers/template
@@ -1,7 +1,7 @@
 # Template file for 'SPIRV-Headers'
 pkgname=SPIRV-Headers
 reverts="1.5.4.raytracing.fixed_1 1.5.3_2 1.5.3_1 1.5.1_1 1.4.1_1"
-version=1.3.231.1
+version=1.3.236.0
 revision=1
 build_style=cmake
 short_desc="Machine-readable files for the SPIR-V Registry"
@@ -9,7 +9,7 @@ maintainer="tibequadorian <tibequadorian@posteo.de>"
 license="MIT"
 homepage="https://github.com/KhronosGroup/SPIRV-Headers"
 distfiles="https://github.com/KhronosGroup/SPIRV-Headers/archive/sdk-${version}.tar.gz"
-checksum=fc340700b005e9a2adc98475b5afbbabd1bc931f789a2afd02d54ebc22522af3
+checksum=4d74c685fdd74469eba7c224dd671a0cb27df45fc9aa43cdd90e53bd4f2b2b78
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **NO**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)

