### PR TITLE
borg: update to 1.2.3.

### DIFF
--- a/srcpkgs/borg/template
+++ b/srcpkgs/borg/template
@@ -1,36 +1,27 @@
 # Template file for 'borg'
 pkgname=borg
-version=1.2.2
-revision=3
+version=1.2.3
+revision=1
 build_style=python3-module
-make_check_args="-k not((benchmark)or(test_readonly_check)or(test_readonly_diff)or(test_readonly_export_tar)or(test_readonly_extract)or(test_readonly_info)or(test_readonly_list))"
+make_check_args="-k not((benchmark)or(readonly))"
 make_check_target="build/lib.*/borg/testsuite"
-hostmakedepends="python3-dateutil python3-pip python3-pkgconfig
- python3-setuptools python3-wheel"
-makedepends="python3-devel openssl-devel acl-devel liblz4-devel libzstd-devel"
-depends="python3-llfuse python3-msgpack python3-packaging python3-argon2"
-# llfuse is purposefully not included in checkdepends since the tests using it
-# don't work in chroot
-checkdepends="python3-pytest ${depends/python3-llfuse/}"
+hostmakedepends="python3-setuptools_scm python3-pkgconfig python3-Cython"
+makedepends="python3-devel openssl-devel acl-devel liblz4-devel
+ libzstd-devel xxHash-devel"
+depends="python3-msgpack python3-packaging python3-pyfuse3"
+checkdepends="tar python3-msgpack python3-dateutil python3-pytest-xdist"
 short_desc="Deduplicating backup program with compression and encryption"
 maintainer="Leah Neukirchen <leah@vuxu.org>"
 license="BSD-3-Clause"
-homepage="https://borgbackup.github.io/"
+homepage="https://www.borgbackup.org"
 changelog="https://borgbackup.readthedocs.io/en/stable/changes.html#changelog"
 distfiles="${PYPI_SITE}/b/borgbackup/borgbackup-${version}.tar.gz"
-checksum=d730687443f1beb602b1d72bae36318f6f9654818fcdc50458540ec579e57260
+checksum=e32418f8633c96fa9681352a56eb63b98e294203472c114a5242709d36966785
 
 export BORG_OPENSSL_PREFIX="${XBPS_CROSS_BASE}/usr"
 export BORG_LIBLZ4_PREFIX="${XBPS_CROSS_BASE}/usr"
 export BORG_LIBZSTD_PREFIX="${XBPS_CROSS_BASE}/usr"
-
-pre_build() {
-	vsed -i setup.py \
-		-e '/setup_requires=/d' \
-		-e '/use_scm_version=/,+3d' \
-		-e "/name=/ a\
-		version='${version}',"
-}
+export BORG_LIBXXHASH_PREFIX="${XBPS_CROSS_BASE}/usr"
 
 post_install() {
 	vlicense LICENSE

--- a/srcpkgs/borg/update
+++ b/srcpkgs/borg/update
@@ -1,3 +1,2 @@
-site='https://github.com/borgbackup/borg/releases'
-pattern='borgbackup-\K[\d.rcab]+\d'
+pkgname=borgbackup
 ignore='*rc* *b* *a*'

--- a/srcpkgs/python3-pyfuse3/template
+++ b/srcpkgs/python3-pyfuse3/template
@@ -1,0 +1,16 @@
+# Template file for 'python3-pyfuse3'
+pkgname=python3-pyfuse3
+version=3.2.2
+revision=1
+build_style=python3-module
+hostmakedepends="pkg-config python3-setuptools"
+makedepends="fuse3-devel python3-devel"
+depends="python3-trio"
+checkdepends="${depends} which python3-pytest" # pytest-trio
+short_desc="Python3 bindings for libfuse3 with async I/O support"
+maintainer="icp <pangolin@vivaldi.net>"
+license="LGPL-2.0-or-later"
+homepage="https://pypi.org/project/pyfuse3/"
+changelog="https://raw.githubusercontent.com/libfuse/pyfuse3/master/Changes.rst"
+distfiles="${PYPI_SITE}/p/pyfuse3/pyfuse3-${version}.tar.gz"
+checksum=aa4080913e6148bff1365d4aaacdc96767b87a1e178031fd9caeb5f0b9fc8cec


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture: **x86_64**

cc: @leahneukirchen 

Notes on the changes:
* use setuptools_scm for versioning instead of the manual hack
* switch to pyfuse3 from unmaintained llfuse as [recommended](https://github.com/borgbackup/borg/blob/1.2.3/setup.py#L77-L79)
* enable compiling the [hashindex extension](https://github.com/borgbackup/borg/blob/1.2.3/setup.py#L214)
* fix update file which was reporting NO VERSION