### PR TITLE
common/travis/xpkgdiff.sh: fix on cross build

### DIFF
--- a/common/travis/xpkgdiff.sh
+++ b/common/travis/xpkgdiff.sh
@@ -2,7 +2,7 @@
 #
 # xpkgdiff.sh
 
-export XBPS_DISTDIR=/hostrepo XBPS_HOSTDIR="$HOME/hostdir"
+export XBPS_TARGET_ARCH="$2" XBPS_DISTDIR=/hostrepo XBPS_HOSTDIR="$HOME/hostdir"
 export DIFF='diff --unified=0 --report-identical-files --suppress-common-lines
  --color=always --label REPO --label BUILT'
 ARGS="-a $2 -R https://repo-ci.voidlinux.org/current"


### PR DESCRIPTION
xbps-query in this script needs a target architecture specified

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: 
  - https://github.com/void-linux/void-packages/actions/runs/3940693091/jobs/6742126472#step:9:9
  - https://github.com/Chocimier/void-packages-org/actions/runs/3943107347/jobs/6747551877#step:9:9

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
