### PR TITLE
mame: fix build

### DIFF
--- a/srcpkgs/mame/template
+++ b/srcpkgs/mame/template
@@ -5,7 +5,7 @@ revision=1
 hostmakedepends="pkg-config python3 qt5-host-tools tar xz which"
 makedepends="SDL2_ttf-devel fontconfig-devel glm libgomp-devel libjpeg-turbo-devel
  lua-devel libutf8proc-devel libuv-devel portaudio-devel portmidi-devel
- pugixml-devel rapidjson $(vopt_if qt 'qt5-devel')"
+ pugixml-devel libXinerama-devel rapidjson $(vopt_if qt 'qt5-devel')"
 depends="liberation-fonts-ttf"
 short_desc="Multiple Arcade Machine Emulator"
 maintainer="Orphaned <orphan@voidlinux.org>"


### PR DESCRIPTION
`libXinerama-devel` was the missing dependency (see https://vasilek.cz/logs/rebuild3/bad/mame.txt).

```
Compiling generated/mame/mame/drivlist.cpp...
Linking mame...
/usr/bin/ld: cannot find -lXinerama
collect2: error: ld returned 1 exit status
make[2]: *** [mame.make:269: ../../../../../mame] Error 1
make[1]: *** [Makefile:1144: mame] Error 2
make: *** [makefile:1387: linux_x64] Error 2
=> ERROR: mame-0229_1: do_build: 'make OVERRIDE_CC="$CC" OVERRIDE_CXX="$CXX" OVERRIDE_LD="$CXX" ${makejobs} ${_options}' exited with 2
=> ERROR:   in do_build() at srcpkgs/mame/template:94
```

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
