### PR TITLE
rsyslog: update to 8.2212.0.

### DIFF
--- a/srcpkgs/rsyslog/template
+++ b/srcpkgs/rsyslog/template
@@ -1,7 +1,7 @@
 # Template file for 'rsyslog'
 pkgname=rsyslog
-version=8.2204.1
-revision=2
+version=8.2212.0
+revision=1
 build_style=gnu-configure
 configure_args="--sbindir=/usr/bin --enable-gnutls --enable-mysql
  --enable-pgsql --enable-imdiag --enable-imfile --enable-mail --enable-imptcp
@@ -21,7 +21,7 @@ license="GPL-3.0-or-later, Apache-2.0"
 homepage="https://www.rsyslog.com"
 changelog="https://raw.githubusercontent.com/rsyslog/rsyslog/master/ChangeLog"
 distfiles="${homepage}/files/download/rsyslog/${pkgname}-${version}.tar.gz"
-checksum=a6d731e46ad3d64f6ad4b19bbf1bf56ca4760a44a24bb96823189dc2e71f7028
+checksum=53b59a872e3dc7384cdc149abe9744916776f7057d905f3df6722d2eb1b04f35
 conf_files="/etc/rsyslog.conf"
 make_dirs="/etc/rsyslog.d 0755 root root"
 lib32disabled=yes


### PR DESCRIPTION

#### Testing the changes
- I tested the changes in this PR: **YES**

Historically, the test suite hasn't played well with running in CI.

```
============================================================================                                                                 
Testsuite summary for rsyslog 8.2212.0                                                                                                       
============================================================================                                                                 
# TOTAL: 524                                                                                                                                 
# PASS:  508                                                                                                                                 
# SKIP:  16                                                                                                                                  
# XFAIL: 0                                                                                                                                   
# FAIL:  0                                                                                                                                   
# XPASS: 0                                                                                                                                   
# ERROR: 0 
```