### PR TITLE
LGOGDownloader: fix coredump with curl >= 7.87.0

### DIFF
--- a/srcpkgs/LGOGDownloader/patches/Fix-coredump-with-new-curl.patch
+++ b/srcpkgs/LGOGDownloader/patches/Fix-coredump-with-new-curl.patch
@@ -1,0 +1,43 @@
+Force destruction of downloader before curl_global_cleanup
+See: https://github.com/Sude-/lgogdownloader/commit/6ce6aeb1dc06f8af1508c5ce6ee71775b8d188b3
+Index: LGOGDownloader-3.9/main.cpp
+===================================================================
+--- LGOGDownloader-3.9.orig/main.cpp
++++ LGOGDownloader-3.9/main.cpp
+@@ -607,9 +607,10 @@ int main(int argc, char *argv[])
+         std::cerr << std::endl;
+     }
+ 
++    int res = 0;
+     // Init curl globally
+     curl_global_init(CURL_GLOBAL_ALL);
+-
++    {
+     Downloader downloader;
+ 
+     int iLoginTries = 0;
+@@ -733,12 +734,10 @@ int main(int argc, char *argv[])
+     bool bInitOK = downloader.init();
+     if (!bInitOK)
+     {
+-        curl_global_cleanup();
+-        return 1;
++        res = 1;
++        goto end;
+     }
+ 
+-    int res = 0;
+-
+     if (Globals::globalConfig.bShowWishlist)
+         downloader.showWishlist();
+     else if (Globals::globalConfig.bUpdateCache)
+@@ -801,7 +800,8 @@ int main(int argc, char *argv[])
+     // Orphan check was called at the same time as download. Perform it after download has finished
+     if (!Globals::globalConfig.sOrphanRegex.empty() && Globals::globalConfig.bDownload)
+         downloader.checkOrphans();
+-
++    }
++end:
+     curl_global_cleanup();
+ 
+     return res;

--- a/srcpkgs/LGOGDownloader/template
+++ b/srcpkgs/LGOGDownloader/template
@@ -1,11 +1,14 @@
 # Template file for 'LGOGDownloader'
 pkgname=LGOGDownloader
 version=3.9
-revision=3
+revision=4
 build_style=cmake
+configure_args="$(vopt_bool qt USE_QT_GUI)"
 hostmakedepends="pkg-config"
 makedepends="htmlcxx-devel tinyxml2-devel libcurl-devel rhash-devel
- jsoncpp-devel boost-devel openssl-devel zlib-devel"
+ jsoncpp-devel boost-devel openssl-devel zlib-devel
+ $(vopt_if qt "qt5-webengine-devel qt5-declarative-devel
+ qt5-webchannel-devel qt5-location-devel")"
 short_desc="Open source downloader for GOG.com games that uses the GOG.com API"
 maintainer="RunningDroid <runningdroid@zoho.com>"
 license="WTFPL"
@@ -13,7 +16,13 @@ homepage="https://github.com/Sude-/lgogdownloader"
 distfiles="https://github.com/Sude-/lgogdownloader/archive/v${version}.tar.gz"
 checksum=4ab9fe89b47bde7744d5100663c7822de74bb161e2790baddede8146056430b1
 
+build_options="qt"
+desc_option_qt="Include QT WebEngine to support solving captchas"
 
 if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
 	makedepends+=" libatomic-devel"
+fi
+
+if [ -z "$CROSS_BUILD" ]; then
+	hostmakedepends+=" help2man"
 fi


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

I also added `help2man` as a hostmakedep for native builds and an option to build with a `qt5-webengine` dep for solving  captchas, but the `qt5-webengine` dep isn't enabled by default because I don't know how common it is to get a captcha from GOG.

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
