### PR TITLE
dracut: patch dracut-network

### DIFF
--- a/srcpkgs/dracut/patches/network.patch
+++ b/srcpkgs/dracut/patches/network.patch
@@ -1,0 +1,32 @@
+From 209812fe905ab8a66e0c131a1173dd46ee7c4cc7 Mon Sep 17 00:00:00 2001
+From: Laszlo Gombos <laszlo.gombos@gmail.com>
+Date: Wed, 18 Jan 2023 20:50:27 +0000
+Subject: [PATCH] meta module should check if module exists
+
+Bug: https://github.com/dracutdevs/dracut/issues/1756
+---
+ modules.d/40network/module-setup.sh | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/modules.d/40network/module-setup.sh b/modules.d/40network/module-setup.sh
+index d30f496..a69978c 100755
+--- a/modules.d/40network/module-setup.sh
++++ b/modules.d/40network/module-setup.sh
+@@ -17,11 +17,11 @@ depends() {
+         done;
+ 
+         if [ -z "$network_handler" ]; then
+-            if find_binary wicked  &>/dev/null ; then
++            if [[ -d "$dracutbasedir"/modules.d/35network-wicked ]] && find_binary wicked  &>/dev/null ; then
+                 network_handler="network-wicked"
+-            elif [[ -x $dracutsysrootdir/usr/libexec/nm-initrd-generator ]]; then
++            elif [[ -d "$dracutbasedir"/modules.d/35connman ]] && [[ -x $dracutsysrootdir/usr/libexec/nm-initrd-generator ]]; then
+                 network_handler="network-manager"
+-            else
++            elif [[ -d "$dracutbasedir"/modules.d/35network-legacy ]]; then
+                 network_handler="network-legacy"
+             fi
+         fi
+-- 
+2.34.1
+

--- a/srcpkgs/dracut/template
+++ b/srcpkgs/dracut/template
@@ -2,7 +2,7 @@
 pkgname=dracut
 reverts="056_1"
 version=053
-revision=6
+revision=7
 build_style=configure
 configure_args="--prefix=/usr --sysconfdir=/etc"
 conf_files="/etc/dracut.conf"


### PR DESCRIPTION
only network-legacy is supported by dracut-network.

Sadly https://github.com/void-linux/void-packages/pull/41031 introduced a regression, so until this PR lands, the regression is in place. Apologies . 

#### Testing the changes
- I tested the changes in this PR: **briefly**

Upstream Dracut discussion - https://github.com/dracutdevs/dracut/issues/1756
Gentoo discussion - https://github.com/gentoo/gentoo/pull/28777

CC @classabbyamp
