### PR TITLE
dracut: fix broken network module, again

### DIFF
--- a/srcpkgs/dracut/patches/network-fix.patch
+++ b/srcpkgs/dracut/patches/network-fix.patch
@@ -1,0 +1,23 @@
+The `network` module tries to pick a default network backend based on the
+availability of executables used by those backends, but Void removes those that
+depend on systemd. This patch preserves the "use a given backend if it's
+included in the image" because modules that aren't installed should never be
+included, but replaces the default with network-legacy.
+
+--- a/modules.d/40network/module-setup.sh
++++ b/modules.d/40network/module-setup.sh
+@@ -17,13 +17,7 @@
+         done;
+ 
+         if [ -z "$network_handler" ]; then
+-            if find_binary wicked  &>/dev/null ; then
+-                network_handler="network-wicked"
+-            elif [[ -x $dracutsysrootdir/usr/libexec/nm-initrd-generator ]]; then
+-                network_handler="network-manager"
+-            else
+-                network_handler="network-legacy"
+-            fi
++            network_handler="network-legacy"
+         fi
+     echo "kernel-network-modules $network_handler"
+     return 0

--- a/srcpkgs/dracut/template
+++ b/srcpkgs/dracut/template
@@ -2,7 +2,7 @@
 pkgname=dracut
 reverts="056_1"
 version=053
-revision=6
+revision=7
 build_style=configure
 configure_args="--prefix=/usr --sysconfdir=/etc"
 conf_files="/etc/dracut.conf"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **by thought experiment**

@classabbyamp I know this is patch is undesirable from a long-term maintenance standpoint because the days of `network-legacy` are numbered. Upstream should really do something about dispatching to the right network backend on systemd-free systems, but for now, we can at least make things work. Please offer comments and let me know if this resolves issues relating to mklive.

@zdykstra If you are interested in attaching your name to this package, I'd be happy to add it here and know that somebody knowledgeable and invested will claim responsibility.