### PR TITLE
neovim: add buildoption to build with lua5.1

### DIFF
--- a/srcpkgs/libluv/template
+++ b/srcpkgs/libluv/template
@@ -4,18 +4,27 @@ version=1.43.0.0
 revision=1
 _distver="${version%.*}-${version##*.}"
 build_style=cmake
-configure_args="-DLUA_BUILD_TYPE=System -DBUILD_MODULE=OFF -DBUILD_SHARED_LIBS=ON"
-makedepends="libuv-devel LuaJIT-devel"
-depends="libuv LuaJIT"
+configure_args="-DLUA_BUILD_TYPE=System -DBUILD_MODULE=OFF -DBUILD_SHARED_LIBS=ON
+ -DWITH_LUA_ENGINE=$(vopt_if luajit LuaJIT Lua)"
+makedepends="libuv-devel $(vopt_if luajit LuaJIT-devel lua51-devel)"
+depends="libuv $(vopt_if luajit LuaJIT lua51)"
 short_desc="Bare libuv bindings for LuaJIT"
 maintainer="andry-dev <peketribal2@gmail.com>"
 license="Apache-2.0"
 homepage="https://github.com/luvit/luv"
 distfiles="https://github.com/luvit/luv/releases/download/${_distver}/luv-${_distver}.tar.gz
-			https://raw.githubusercontent.com/luvit/luv/${_distver}/libluv.pc.in"
+ https://raw.githubusercontent.com/luvit/luv/${_distver}/libluv.pc.in"
 checksum="567a6f3dcdcf8a9b54ddc57ffef89d1e950d72832b85ee81c8c83a9d4e0e9de2
  be2a4909c724e09a50de42b1caa3c82c1b1afee8b80abf20c6944f1df1c7fd0e"
 skip_extraction="libluv.pc.in"
+
+build_options=luajit
+
+case "$XBPS_TARGET_MACHINE" in
+	riscv64*) build_options_default="" ;;
+	*) build_options_default="luajit" ;;
+esac
+
 
 if [ "$CROSS_BUILD" -a "$XBPS_MACHINE" = "x86_64" ]; then
 	hostmakedepends+=" gcc-multilib"

--- a/srcpkgs/neovim/template
+++ b/srcpkgs/neovim/template
@@ -4,16 +4,24 @@ version=0.8.2
 revision=2
 build_style=cmake
 build_helper="qemu"
-configure_args="-DCOMPILE_LUA=OFF"
-hostmakedepends="pkg-config gettext gperf LuaJIT lua51-lpeg lua51-mpack"
+configure_args="-DCOMPILE_LUA=OFF -DPREFER_LUA=$(vopt_if luajit OFF ON)"
+hostmakedepends="pkg-config gettext gperf lua51-lpeg lua51-mpack lua51-BitOp
+ $(vopt_if luajit LuaJIT lua51)"
 makedepends="libtermkey-devel libuv-devel libvterm-devel msgpack-devel
- LuaJIT-devel libluv-devel tree-sitter-devel"
+ libluv-devel tree-sitter-devel $(vopt_if luajit LuaJIT-devel lua51-devel)"
 short_desc="Fork of Vim aiming to improve user experience, plugins and GUIs"
 maintainer="Marcin Puc <tranzystorek.io@protonmail.com>"
 license="Apache-2.0, Vim"
 homepage="https://neovim.io"
 distfiles="https://github.com/neovim/neovim/archive/refs/tags/v${version}.tar.gz"
 checksum=c516c8db73e1b12917a6b2e991b344d0914c057cef8266bce61a2100a28ffcc9
+
+build_options=luajit
+
+case "$XBPS_TARGET_MACHINE" in
+	riscv64*) build_options_default="" ;;
+	*) build_options_default="luajit" ;;
+esac
 
 alternatives="
  vi:vi:/usr/bin/nvim


### PR DESCRIPTION
- libluv: add buildoption to build with lua5.1
- neovim: add buildoption to build with lua5.1

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**|**briefly**|**NO**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
