### PR TITLE
go-mtpfs: depend on fuse

### DIFF
--- a/srcpkgs/go-mtpfs/template
+++ b/srcpkgs/go-mtpfs/template
@@ -1,11 +1,12 @@
 # Template file for 'go-mtpfs'
 pkgname=go-mtpfs
 version=1.0.0
-revision=1
+revision=2
 build_style=go
 go_import_path=github.com/hanwen/go-mtpfs
 hostmakedepends="pkg-config"
 makedepends="libusb-devel"
+depends="fuse"
 short_desc="Mount MTP devices over FUSE"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="BSD-3-Clause"


### PR DESCRIPTION
Uses fusermount from the 'fuse' package to mount MTP devices.

Closes #41731. 
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
