### PR TITLE
libXcursor: make -devel subpackage depend on libXrender-devel

### DIFF
--- a/srcpkgs/libXcursor/template
+++ b/srcpkgs/libXcursor/template
@@ -1,7 +1,7 @@
 # Template file for 'libXcursor'
 pkgname=libXcursor
 version=1.2.1
-revision=1
+revision=2
 build_style=gnu-configure
 hostmakedepends="pkg-config"
 makedepends="xorgproto libXfixes-devel libXrender-devel"
@@ -17,7 +17,7 @@ post_install() {
 }
 
 libXcursor-devel_package() {
-	depends="xorgproto libXfixes-devel ${sourcepkg}>=${version}_${revision}"
+	depends="${sourcepkg}>=${version}_${revision} ${makedepends}"
 	short_desc+=" - development files"
 	pkg_install() {
 		vmove usr/include


### PR DESCRIPTION
It's required as per `Requires.private` in `/usr/lib/pkgconfig/xcursor.pc` and e.g. the following seen during a project CMake configure:
```
-- Checking for module 'xcursor'
--   Package 'xrender', required by 'xcursor', not found
CMake Error at /usr/share/cmake-3.25/Modules/FindPkgConfig.cmake:607 (message):
  A required package was not found
Call Stack (most recent call first):
  /usr/share/cmake-3.25/Modules/FindPkgConfig.cmake:829 (_pkg_check_modules_internal)
  CMakeLists.txt:283 (pkg_check_modules)
```
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
