### PR TITLE
python3-tempora: update to 5.2.1.

### DIFF
--- a/srcpkgs/python3-tempora/template
+++ b/srcpkgs/python3-tempora/template
@@ -1,17 +1,18 @@
 # Template file for 'python3-tempora'
 pkgname=python3-tempora
-version=5.0.1
-revision=2
+version=5.2.1
+revision=1
 build_style=python3-pep517
 hostmakedepends="python3-wheel python3-setuptools_scm"
-depends="python3-setuptools python3-pytz python3-jaraco.functools"
+depends="python3-pytz python3-jaraco.functools"
 checkdepends="python3-pytest python3-freezegun $depends"
 short_desc="Objects and routines pertaining to date and time (Python3)"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
 homepage="https://github.com/jaraco/tempora"
+changelog="https://raw.githubusercontent.com/jaraco/tempora/main/CHANGES.rst"
 distfiles="${PYPI_SITE}/t/tempora/tempora-${version}.tar.gz"
-checksum=cba0f197a64883bf3e73657efbc0324d5bf17179e7769b1385b4d75d26cd9127
+checksum=b7176486c5948a75201e8d0b21ef2c23ca808474060df47218c92295bdce5276
 alternatives="tempora:calc-prorate:/usr/bin/calc-prorate3"
 
 do_check() {


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture: **x86_64**