### PR TITLE
nextcloud-client: update to 3.6.6

### DIFF
--- a/srcpkgs/nextcloud-client/template
+++ b/srcpkgs/nextcloud-client/template
@@ -1,6 +1,6 @@
 # Template file for 'nextcloud-client'
 pkgname=nextcloud-client
-version=3.6.4
+version=3.6.6
 revision=1
 build_style=cmake
 configure_args="-Wno-dev"
@@ -19,7 +19,7 @@ license="GPL-2.0-or-later"
 homepage="https://nextcloud.com/clients/"
 changelog="https://github.com/nextcloud/desktop/releases"
 distfiles="https://github.com/nextcloud/desktop/archive/v${version}.tar.gz"
-checksum=684969ad119c9a9879f2a040a13bf57eb9b9f8d5db1060d6be3d0e9a7e26e5cb
+checksum=04b3be9ab62eec7b81c971dc50c4e40666ee2d76c19cb72d9ad52e5a4d2edd47
 # https://github.com/void-linux/void-packages/pull/33358#discussion_r724518549
 make_check=ci-skip
 


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-libc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - armv7l (crossbuild)
  - i686-libc