### PR TITLE
python3-snakeoil: update to 0.10.5.

### DIFF
--- a/srcpkgs/python3-chroot/template
+++ b/srcpkgs/python3-chroot/template
@@ -1,17 +1,20 @@
 # Template file for 'python3-chroot'
 pkgname=python3-chroot
-version=0.10.1
-revision=3
+version=0.10.4
+revision=1
 build_style=python3-module
+# OSError: [Errno 16] Device or resource busy: '/proc'
+make_check_args="--deselect=tests/test_chroot.py::TestChroot::test_chroot"
 hostmakedepends="python3-setuptools python3-snakeoil"
 depends="python3-snakeoil"
+checkdepends="${depends} python3-pytest-xdist"
 short_desc="Python3 Library and CLI tool that simplify chroot handling"
 maintainer="Toyam Cox <Vaelatern@voidlinux.org>"
 license="BSD-3-Clause"
-homepage="https://github.com/pkgcore/pychroot"
-#changelog="https://github.com/pkgcore/pychroot/blob/master/NEWS.rst"
+homepage="https://pkgcore.github.io/pychroot/"
+changelog="https://raw.githubusercontent.com/pkgcore/pychroot/master/NEWS.rst"
 distfiles="${PYPI_SITE}/p/pychroot/pychroot-${version}.tar.gz"
-checksum=10b2d5195062d110df8e28bcdb1d79d1e8109fb77a226455ab2df6b40e7ff289
+checksum=bb06b9c5b811aba80acac0f214ff7e5c7814b17f899986cdcd3f914f31a39609
 conflicts="python-chroot>=0"
 
 post_install() {

--- a/srcpkgs/python3-snakeoil-devel
+++ b/srcpkgs/python3-snakeoil-devel
@@ -1,1 +1,0 @@
-python3-snakeoil

--- a/srcpkgs/python3-snakeoil/template
+++ b/srcpkgs/python3-snakeoil/template
@@ -1,38 +1,20 @@
 # Template file for 'python3-snakeoil'
 pkgname=python3-snakeoil
-version=0.8.8
-revision=4
-build_style=python3-module
-hostmakedepends="python3-setuptools python3-Cython"
-makedepends="python3-devel"
-depends="python3"
+version=0.10.5
+revision=1
+build_style=python3-pep517
+hostmakedepends="python3-flit_core"
+depends="python3-lazy-object-proxy"
+checkdepends="${depends} lbzip2 tar xz python3-pytest-xdist"
 short_desc="Python3 optimized versions of common python functionality"
 maintainer="Toyam Cox <Vaelatern@voidlinux.org>"
-license="BSD-3-Clause, GPL-2.0-only"
-homepage="https://github.com/pkgcore/snakeoil"
-# changelog="https://github.com/pkgcore/snakeoil/blob/master/NEWS.rst"
+license="BSD-3-Clause"
+homepage="https://pkgcore.github.io/snakeoil/"
+changelog="https://raw.githubusercontent.com/pkgcore/snakeoil/master/NEWS.rst"
 distfiles="${PYPI_SITE}/s/snakeoil/snakeoil-${version}.tar.gz"
-checksum=8381ed730cb4c127c2cb5f99ed8a148d3f2bc492de21f035aae8913f7a106d63
-
-post_extract() {
-	local _f
-	for _f in src/snakeoil/*.pyx; do
-		rm -f ${_f%.pyx}.c
-	done
-}
-
-pre_check() {
-	export PYTHONPATH=$(cd build/lib* && pwd)
-}
+checksum=fe502181818ff20c3fa6c7101f287fa323650b11d7265ac3fbcb6c53bd1feaaf
+make_check_pre="env PYTHONPATH=src"
 
 post_install() {
 	vlicense LICENSE
-}
-
-python3-snakeoil-devel_package() {
-	depends="python3-snakeoil>=${version}_${revision}"
-	short_desc+=" - development files"
-	pkg_install() {
-		vmove usr/include/python3*
-	}
 }

--- a/srcpkgs/removed-packages/template
+++ b/srcpkgs/removed-packages/template
@@ -455,6 +455,7 @@ replaces="
  python3-pyside-phonon<=5.15.0_2
  python3-pyside<=5.15.0_2
  python3-shiboken<=5.15.0_3
+ python3-snakeoil-devel<=0.8.8_4
  python3-txacme<=0.9.3_3
  qimageblitz<=0.0.6_4
  qt-designer-devel<=4.8.7_29


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture: **x86_64**

#### Rev dep checks
- [x] python3-chroot

snakeoil is a pure python package now, so no more c-extension/-devel-subpackage