### PR TITLE
redis: update to 7.0.8.

### DIFF
--- a/srcpkgs/redis/patches/use-system-jemalloc.patch
+++ b/srcpkgs/redis/patches/use-system-jemalloc.patch
@@ -8,7 +8,7 @@
 -	FINAL_CFLAGS+= -DUSE_JEMALLOC -I../deps/jemalloc/include
 -	FINAL_LIBS := ../deps/jemalloc/lib/libjemalloc.a $(FINAL_LIBS)
 +	FINAL_CFLAGS+= -DUSE_JEMALLOC -DJEMALLOC_NO_DEMANGLE
-+	FINAL_LIBS+= -ljemalloc -ldl
++	FINAL_LIBS+= -ljemalloc
  endif
  
  REDIS_CC=$(QUIET_CC)$(CC) $(FINAL_CFLAGS)

--- a/srcpkgs/redis/template
+++ b/srcpkgs/redis/template
@@ -1,16 +1,18 @@
 # Template file for 'redis'
 pkgname=redis
-version=7.0.5
+version=7.0.8
 revision=1
-makedepends="jemalloc-devel libatomic-devel"
+build_style=gnu-makefile
+make_build_args="V=1"
+make_check_target="test"
 checkdepends="pkg-config procps-ng tcl-devel which"
 short_desc="Advanced key-value store"
 maintainer="Enno Boland <gottox@voidlinux.org>"
 license="BSD-3-Clause"
 homepage="https://redis.io"
-changelog="https://raw.githubusercontent.com/antirez/redis/${version%.*}/00-RELEASENOTES"
-distfiles="http://download.redis.io/releases/${pkgname}-${version}.tar.gz"
-checksum=67054cc37b58c125df93bd78000261ec0ef4436a26b40f38262c780e56315cc3
+changelog="https://raw.githubusercontent.com/redis/redis/${version%.*}/00-RELEASENOTES"
+distfiles="http://download.redis.io/releases/redis-${version}.tar.gz"
+checksum=06a339e491306783dcf55b97f15a5dbcbdc01ccbde6dc23027c475cab735e914
 
 system_accounts="redis"
 redis_homedir="/var/lib/redis"
@@ -18,24 +20,26 @@ conf_files="/etc/redis/redis.conf"
 
 make_dirs="/var/lib/redis 0700 redis redis"
 
-do_configure() {
+if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
+	make_build_args+=" MALLOC=libc"
+else
+	makedepends+=" jemalloc-devel"
+	make_build_args+=" MALLOC=jemalloc"
+fi
+
+if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
+	makedepends+=" libatomic-devel"
+fi
+
+post_patch() {
 	vsed -i \
 		-e "s|^# bind 127.0.0.1|bind 127.0.0.1|" \
 		-e "s|^dir .*|dir ${redis_homedir}|" \
 		-e "s|^pidfile .*|pidfile /run/redis/redis.pid|" redis.conf
-	vsed -i -e "s|^FINAL_LIBS=.*|& -latomic|" src/Makefile
-}
 
-do_build() {
-	case "$XBPS_TARGET_MACHINE" in
-		*-musl) _malloc="none";;
-		*) _malloc="jemalloc";;
-	esac
-	make CC=$CC CFLAGS="$CFLAGS" LDFLAGS="$LDFLAGS" V=1 MALLOC=${_malloc} ${makejobs}
-}
-
-do_check() {
-	make test
+	if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
+		vsed -i -e "s|^FINAL_LIBS=.*|& -latomic|" src/Makefile
+	fi
 }
 
 do_install() {


### PR DESCRIPTION
The primary reason for updating this package is due to the following CVEs being found and fixed:

* [CVE-2022-35977](https://www.cvedetails.com/cve/CVE-2022-35977) (Integer overflow in the Redis SETRANGE and SORT/SORT_RO commands can drive Redis to OOM panic)

* [CVE-2023-22458](https://www.cvedetails.com/cve/CVE-2023-22458) (Integer overflow in the Redis HRANDFIELD and ZRANDMEMBER commands can lead to denial-of-service)

The rest is as follows:

* `jemalloc-devel` and `libatomic-devel` now are included conditionally.

* **antirez/redis** has been moved to **redis/redis88** (antirez stepped down in 2020 and handed over his work to his colleagues).

* `do_check` can be executed by setting `make_check_target` to `"test"`.

* `V=1` is retained in `make_build_args`; `MALLOC` is defined outside the removed `do_build` function.

* the `-ldl` flag in `use-system-jemalloc.patch` is no longer necessary since it is already defined in `src/Makefile`; see redis/redis@b7b9aa6d9bbed5a292f3e939bf0c5906bdf965ca

* `do_configure` is renamed to `post_patch` as its contents fit the latter's purpose.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
