### PR TITLE
libpcap: update to 1.10.3.

### DIFF
--- a/srcpkgs/libpcap/template
+++ b/srcpkgs/libpcap/template
@@ -1,6 +1,6 @@
 # Template file for 'libpcap'
 pkgname=libpcap
-version=1.10.1
+version=1.10.3
 revision=1
 build_style=gnu-configure
 configure_args="--enable-ipv6 --with-libnl --with-pcap=linux
@@ -14,7 +14,7 @@ license="BSD-3-Clause"
 homepage="https://www.tcpdump.org/"
 changelog="https://www.tcpdump.org/libpcap-changes.txt"
 distfiles="https://www.tcpdump.org/release/${pkgname}-${version}.tar.gz"
-checksum=ed285f4accaf05344f90975757b3dbfe772ba41d1c401c2648b7fa45b711bdd4
+checksum=2a8885c403516cf7b0933ed4b14d6caa30e02052489ebd414dc75ac52e7559e6
 
 build_options="bluetooth dbus usb"
 build_options_default="usb"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **NO**


#### Local build testing
SUMMARY
pkg:libpcap host:x86_64 target:x86_64 cross:n result:OK
pkg:libpcap host:x86_64-musl target:x86_64-musl cross:n result:OK
pkg:libpcap host:i686 target:i686 cross:n result:OK
pkg:libpcap host:x86_64 target:aarch64-musl cross:y result:OK
pkg:libpcap host:x86_64 target:aarch64 cross:y result:OK
pkg:libpcap host:x86_64 target:armv7l-musl cross:y result:OK
pkg:libpcap host:x86_64 target:armv7l cross:y result:OK
pkg:libpcap host:x86_64 target:armv6l-musl cross:y result:OK
pkg:libpcap host:x86_64 target:armv6l cross:y result:OK

