### PR TITLE
dnsmasq: enable dnssec build option by default

### DIFF
--- a/srcpkgs/dnsmasq/template
+++ b/srcpkgs/dnsmasq/template
@@ -16,6 +16,7 @@ system_accounts="dnsmasq"
 dnsmasq_homedir="/var/chroot"
 
 build_options="dnssec"
+build_options_default="dnssec"
 desc_option_dnssec="Enable DNSSEC support via nettle"
 
 do_build() {
@@ -31,6 +32,8 @@ do_install() {
 	make PREFIX=/usr BINDIR=/usr/bin DESTDIR=${DESTDIR} install
 
 	vsv dnsmasq
+	vsconf dnsmasq.conf.example dnsmasq.conf
 	vconf dnsmasq.conf.example dnsmasq.conf
 	vinstall ${FILESDIR}/dbus.conf 644 etc/dbus-1/system.d
+	vinstall trust-anchors.conf 644 usr/share/dnsmasq
 }


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-musl

#### Notes
I uncommented these lines in `/etc/dnsmasq.conf`;
```
conf-file=/usr/share/dnsmasq/trust-anchors.conf
dnssec
```

Logs show it worked:
```
DNSSEC validation enabled
configured with trust anchor for <root> keytag 20326
```