### PR TITLE
kdenlive: add missing dependencies

### DIFF
--- a/srcpkgs/kdenlive/template
+++ b/srcpkgs/kdenlive/template
@@ -1,7 +1,7 @@
 # Template file for 'kdenlive'
 pkgname=kdenlive
 version=22.12.1
-revision=1
+revision=2
 build_style=cmake
 hostmakedepends="
  extra-cmake-modules kconfig kcoreaddons kdoctools pkg-config python3
@@ -10,7 +10,8 @@ makedepends="
  kdeclarative-devel kfilemetadata5-devel knewstuff-devel knotifyconfig-devel
  kplotting-devel mlt7-devel qt5-multimedia-devel qt5-webkit-devel purpose-devel
  v4l-utils-devel ksolid-devel qt5-quickcontrols2-devel qt5-networkauth-devel"
-depends="breeze-icons dvdauthor ffmpeg frei0r-plugins kinit qt5-quickcontrols"
+depends="breeze-icons dvdauthor ffmpeg frei0r-plugins kirigami2 udisks2 kinit
+ qt5-quickcontrols"
 checkdepends="$depends"
 short_desc="Non-linear video editor"
 maintainer="Orphaned <orphan@voidlinux.org>"


### PR DESCRIPTION
Fixes:
file:///usr/lib/qt5/qml/org/kde/newstuff/Action.qml:40:1: module "org.kde.kirigami" is not installed

kf.solid.backends.udisks2: Failed enumerating UDisks2 objects: "org.freedesktop.DBus.Error.ServiceUnknown"

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
