### PR TITLE
xcb-util: update to 0.4.1;adopt.

### DIFF
--- a/srcpkgs/xcb-util/template
+++ b/srcpkgs/xcb-util/template
@@ -1,17 +1,17 @@
 # Template file for 'xcb-util'
 pkgname=xcb-util
-version=0.4.0
-revision=3
+version=0.4.1
+revision=1
 build_style=gnu-configure
 configure_args="--disable-static"
 hostmakedepends="pkg-config gperf"
 makedepends="libxcb-devel"
 short_desc="XCB utilities library"
-maintainer="Orphaned <orphan@voidlinux.org>"
+maintainer="André Cerqueira <acerqueira021@gmail.com>"
 license="X11"
-homepage="https://xcb.freedesktop.org"
-distfiles="https://xcb.freedesktop.org/dist/$pkgname-$version.tar.bz2"
-checksum=46e49469cb3b594af1d33176cd7565def2be3fa8be4371d62271fabb5eae50e9
+homepage="https://gitlab.freedesktop.org/xorg/lib/libxcb-util"
+distfiles="https://xorg.freedesktop.org/archive/individual/lib/xcb-util-${version}.tar.xz"
+checksum=5abe3bbbd8e54f0fa3ec945291b7e8fa8cfd3cccc43718f8758430f94126e512
 
 post_install() {
 	vlicense COPYING LICENSE


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**, x86_64-glibc

#### Local build testing
```
SUMMARY
pkg:xcb-util host:x86_64 target:x86_64 cross:n result:OK
pkg:xcb-util host:x86_64-musl target:x86_64-musl cross:n result:OK
pkg:xcb-util host:i686 target:i686 cross:n result:OK
pkg:xcb-util host:x86_64 target:aarch64-musl cross:y result:OK
pkg:xcb-util host:x86_64 target:aarch64 cross:y result:OK
pkg:xcb-util host:x86_64 target:armv7l-musl cross:y result:OK
pkg:xcb-util host:x86_64 target:armv7l cross:y result:OK
pkg:xcb-util host:x86_64 target:armv6l-musl cross:y result:OK
pkg:xcb-util host:x86_64 target:armv6l cross:y result:OK
```