### PR TITLE
xcb-util-keysyms: update to 0.4.1;adopt.

### DIFF
--- a/srcpkgs/xcb-util-keysyms/template
+++ b/srcpkgs/xcb-util-keysyms/template
@@ -1,21 +1,20 @@
 # Template file for 'xcb-util-keysyms'
 pkgname=xcb-util-keysyms
-version=0.4.0
-revision=4
+version=0.4.1
+revision=1
 build_style=gnu-configure
 configure_args="--disable-static"
 hostmakedepends="pkg-config"
 makedepends="libxcb-devel xcb-util-devel"
 short_desc="Utility libraries for XCB - key constants and keycode conversion"
-maintainer="Orphaned <orphan@voidlinux.org>"
+maintainer="André Cerqueira <acerqueira021@gmail.com>"
 license="X11"
-homepage="https://xcb.freedesktop.org"
-distfiles="https://xcb.freedesktop.org/dist/xcb-util-keysyms-${version}.tar.bz2"
-checksum=0ef8490ff1dede52b7de533158547f8b454b241aa3e4dcca369507f66f216dd9
+homepage="https://gitlab.freedesktop.org/xorg/lib/libxcb-keysyms"
+distfiles="https://xcb.freedesktop.org/dist/xcb-util-keysyms-${version}.tar.xz"
+checksum=7c260a5294412aed429df1da2f8afd3bd07b7cba3fec772fba15a613a6d5c638
 
 post_install() {
-	head -n30 keysyms/keysyms.c > LICENSE
-	vlicense LICENSE
+	vlicense COPYING LICENSE
 }
 
 xcb-util-keysyms-devel_package() {


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
```
SUMMARY
pkg:xcb-util-keysyms host:x86_64 target:x86_64 cross:n result:OK
pkg:xcb-util-keysyms host:x86_64-musl target:x86_64-musl cross:n result:OK
pkg:xcb-util-keysyms host:i686 target:i686 cross:n result:OK
pkg:xcb-util-keysyms host:x86_64 target:aarch64-musl cross:y result:OK
pkg:xcb-util-keysyms host:x86_64 target:aarch64 cross:y result:OK
pkg:xcb-util-keysyms host:x86_64 target:armv7l-musl cross:y result:OK
pkg:xcb-util-keysyms host:x86_64 target:armv7l cross:y result:OK
pkg:xcb-util-keysyms host:x86_64 target:armv6l-musl cross:y result:OK
pkg:xcb-util-keysyms host:x86_64 target:armv6l cross:y result:OK
```