### PR TITLE
xcb-util-renderutil: update to 0.3.10;adopt.

### DIFF
--- a/srcpkgs/xcb-util-renderutil/template
+++ b/srcpkgs/xcb-util-renderutil/template
@@ -1,17 +1,17 @@
 # Template file for 'xcb-util-renderutil'
 pkgname=xcb-util-renderutil
-version=0.3.9
-revision=3
+version=0.3.10
+revision=1
 build_style=gnu-configure
 configure_args="--disable-static"
 hostmakedepends="pkg-config"
 makedepends="libxcb-devel xcb-util-devel"
 short_desc="Utility libraries for XCB - Render extension convenience functions"
-maintainer="Orphaned <orphan@voidlinux.org>"
+maintainer="André Cerqueira <acerqueira021@gmail.com>"
 license="X11, MIT"
-homepage="https://xcb.freedesktop.org"
-distfiles="https://xcb.freedesktop.org/dist/xcb-util-renderutil-${version}.tar.bz2"
-checksum=c6e97e48fb1286d6394dddb1c1732f00227c70bd1bedb7d1acabefdd340bea5b
+homepage="https://gitlab.freedesktop.org/xorg/lib/libxcb-render-util"
+distfiles="https://xcb.freedesktop.org/dist/xcb-util-renderutil-${version}.tar.xz"
+checksum=3e15d4f0e22d8ddbfbb9f5d77db43eacd7a304029bf25a6166cc63caa96d04ba
 
 post_install() {
 	vlicense COPYING LICENSE


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
```
SUMMARY
pkg:xcb-util-renderutil host:x86_64 target:x86_64 cross:n result:OK
pkg:xcb-util-renderutil host:x86_64-musl target:x86_64-musl cross:n result:OK
pkg:xcb-util-renderutil host:i686 target:i686 cross:n result:OK
pkg:xcb-util-renderutil host:x86_64 target:aarch64-musl cross:y result:OK
pkg:xcb-util-renderutil host:x86_64 target:aarch64 cross:y result:OK
pkg:xcb-util-renderutil host:x86_64 target:armv7l-musl cross:y result:OK
pkg:xcb-util-renderutil host:x86_64 target:armv7l cross:y result:OK
pkg:xcb-util-renderutil host:x86_64 target:armv6l-musl cross:y result:OK
pkg:xcb-util-renderutil host:x86_64 target:armv6l cross:y result:OK
```
