### PR TITLE
libnfnetlink: update to 1.0.2.

### DIFF
--- a/srcpkgs/libnfnetlink/template
+++ b/srcpkgs/libnfnetlink/template
@@ -1,20 +1,14 @@
 # Template file for 'libnfnetlink'
 pkgname=libnfnetlink
-version=1.0.1
-revision=4
+version=1.0.2
+revision=1
 build_style=gnu-configure
 short_desc="Low-level library for netfilter kernel/userspace communication"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-only"
 homepage="http://www.netfilter.org/projects/libnfnetlink/index.html"
-distfiles="http://www.netfilter.org/projects/${pkgname}/files/${pkgname}-${version}.tar.bz2"
-checksum=f270e19de9127642d2a11589ef2ec97ef90a649a74f56cf9a96306b04817b51a
-
-pre_configure() {
-	sed -e "/#include <linux\/netlink.h>/i #include <stdint.h>" \
-		-i ${wrksrc}/include/libnfnetlink/libnfnetlink.h
-	find ${wrksrc} -type f -exec sed -e "s;u_int;uint;g" -i "{}" \;
-}
+distfiles="http://www.netfilter.org/projects/libnfnetlink/files/libnfnetlink-${version}.tar.bz2"
+checksum=b064c7c3d426efb4786e60a8e6859b82ee2f2c5e49ffeea640cfe4fe33cbc376
 
 libnfnetlink-devel_package() {
 	depends="${sourcepkg}>=${version}_${revision}"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
```
SUMMARY
pkg:libnfnetlink host:x86_64 target:x86_64 cross:n result:OK
pkg:libnfnetlink host:x86_64-musl target:x86_64-musl cross:n result:OK
pkg:libnfnetlink host:i686 target:i686 cross:n result:OK
pkg:libnfnetlink host:x86_64 target:aarch64-musl cross:y result:OK
pkg:libnfnetlink host:x86_64 target:aarch64 cross:y result:OK
pkg:libnfnetlink host:x86_64 target:armv7l-musl cross:y result:OK
pkg:libnfnetlink host:x86_64 target:armv7l cross:y result:OK
pkg:libnfnetlink host:x86_64 target:armv6l-musl cross:y result:OK
pkg:libnfnetlink host:x86_64 target:armv6l cross:y result:OK
```
