### PR TITLE
hostapd: support WPA3 (CONFIG_SAE flag)

### DIFF
--- a/srcpkgs/hostapd/files/config
+++ b/srcpkgs/hostapd/files/config
@@ -100,3 +100,6 @@ CONFIG_ACS=y
 
 # Support debug logging to syslog
 CONFIG_DEBUG_SYSLOG=y
+
+# Simultaneous Authentication of Equals (SAE), WPA3-Personal
+CONFIG_SAE=y

--- a/srcpkgs/hostapd/template
+++ b/srcpkgs/hostapd/template
@@ -1,7 +1,7 @@
 # Template file for 'hostapd'
 pkgname=hostapd
 version=2.10
-revision=1
+revision=2
 build_wrksrc="$pkgname"
 conf_files="/etc/hostapd/hostapd.conf"
 hostmakedepends="pkg-config"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-musl

#### Notes
I just sanity-checked by running locally, these are the salient parts of my `hostapd.conf`:
```
driver=nl80211
auth_algs=1
wpa=2
extended_key_id=1
wpa_key_mgmt=SAE
wpa_pairwise=CCMP
ieee80211w=2
```