### PR TITLE
iwd: update to 2.2.

### DIFF
--- a/srcpkgs/iwd/template
+++ b/srcpkgs/iwd/template
@@ -1,6 +1,6 @@
 # Template file for 'iwd'
 pkgname=iwd
-version=2.0
+version=2.2
 revision=1
 build_style=gnu-configure
 configure_args="--disable-systemd-service --enable-pie
@@ -15,7 +15,7 @@ license="LGPL-2.1-or-later"
 homepage="https://iwd.wiki.kernel.org/"
 changelog="https://git.kernel.org/pub/scm/network/wireless/iwd.git/plain/ChangeLog"
 distfiles="${KERNEL_SITE}/network/wireless/${pkgname}-${version}.tar.xz"
-checksum=5a0bfbc567092476d60a8f9700f68a273e39fd46e7177ce2d69bbc74255a930c
+checksum=dfeada6d1680221fb128dc6be50fc2d6b40e314b98458acbd696418f8da5c570
 make_dirs="/var/lib/iwd 0600 root root
  /var/lib/ead 0600 root root
  /etc/iwd 755 root root"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture: **x86_64**

I have used the new version for 2+ days; didn't seem to have any issues with wifi.