### PR TITLE
python3-spotipy: update to 2.22.1.

### DIFF
--- a/srcpkgs/python3-spotipy/template
+++ b/srcpkgs/python3-spotipy/template
@@ -1,6 +1,6 @@
 # Template file for 'python3-spotipy'
 pkgname=python3-spotipy
-version=2.22.0
+version=2.22.1
 revision=1
 build_style=python3-module
 hostmakedepends="pkg-config python3-setuptools"
@@ -12,7 +12,7 @@ license="MIT"
 homepage="https://github.com/plamere/spotipy"
 changelog="https://raw.githubusercontent.com/spotipy-dev/spotipy/master/CHANGELOG.md"
 distfiles="https://github.com/plamere/spotipy/archive/${version}.tar.gz"
-checksum=d5cc2672f249d339ba2054d4a0228a1670bc43fd9942f0e7c62fbe99e16f97e2
+checksum=f82ddd9d1a0da7d782cd70bc0fdc5943118958f6c93d8b9feedcff676ff2b419
 make_check=no # Requires Spotify API Key
 
 post_install() {


### PR DESCRIPTION
Fixes [CVE-2023-23608](https://github.com/spotipy-dev/spotipy/security/advisories/GHSA-q764-g6fm-555v)

#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-musl)