### PR TITLE
common/xbps-src/shutils/chroot.sh: pass arguments to xbps-shell

### DIFF
--- a/common/xbps-src/shutils/chroot.sh
+++ b/common/xbps-src/shutils/chroot.sh
@@ -89,7 +89,7 @@ PATH=/void-packages:/usr/bin
 exec env -i -- SHELL=/bin/sh PATH="\$PATH" DISTCC_HOSTS="\$XBPS_DISTCC_HOSTS" DISTCC_DIR="/host/distcc" \
     ${XBPS_ARCH+XBPS_ARCH=$XBPS_ARCH} ${XBPS_CHECK_PKGS+XBPS_CHECK_PKGS=$XBPS_CHECK_PKGS} \
     CCACHE_DIR="/host/ccache" IN_CHROOT=1 LC_COLLATE=C LANG=en_US.UTF-8 TERM=linux HOME="/tmp" \
-    PS1="[\u@$XBPS_MASTERDIR \W]$ " /bin/bash +h
+    PS1="[\u@$XBPS_MASTERDIR \W]$ " /bin/bash +h "\$@"
 _EOF
 
     chmod 755 $XBPS_MASTERDIR/bin/xbps-shell

--- a/srcpkgs/perl-Net-OpenSSH/template
+++ b/srcpkgs/perl-Net-OpenSSH/template
@@ -1,6 +1,6 @@
 # Template file for 'perl-Net-OpenSSH'
 pkgname=perl-Net-OpenSSH
-version=0.82
+version=0.83
 revision=1
 build_style=perl-module
 hostmakedepends="perl"
@@ -10,7 +10,7 @@ checkdepends="procps-ng"
 short_desc="Net::OpenSSH - Perl SSH client package implemented on top of OpenSSH"
 maintainer="Leah Neukirchen <leah@vuxu.org>"
 license="Artistic-1.0-Perl, GPL-1.0-or-later"
-#changelog="http://cpansearch.perl.org/src/SALVA/Net-OpenSSH-${version}/Changes"
 homepage="https://metacpan.org/release/Net-OpenSSH"
+changelog="https://metacpan.org/dist/Net-OpenSSH/changes"
 distfiles="${CPAN_SITE}/Net/Net-OpenSSH-${version}.tar.gz"
-checksum=d41aa24dd53466753209f5a67c6392e6f3fa599709169342cbcc5f4871d97e83
+checksum=43d7d8672e9d4ecbd1ceb2a99e4143ca665f227d04720c43307e352f96060adf


### PR DESCRIPTION
Some software reads the shell from /etc/passwd and expects it to
implement standard flags like -c etc.