### PR TITLE
gsoap: update to 2.8.124

### DIFF
--- a/srcpkgs/gsoap/patches/libtool.patch
+++ b/srcpkgs/gsoap/patches/libtool.patch
@@ -1,0 +1,137 @@
+From: https://src.fedoraproject.org/rpms/gsoap/blob/master/f/gsoap-libtool.patch
+
+diff -ur gsoap-2.8.orig/configure.ac gsoap-2.8/configure.ac
+--- gsoap-2.8.orig/configure.ac	2019-01-14 18:17:20.000000000 +0100
++++ gsoap-2.8/configure.ac	2019-01-17 15:48:00.000982088 +0100
+@@ -16,8 +16,7 @@
+ AM_PROG_LEX
+ AC_PROG_YACC
+ AC_PROG_CPP
+-AC_PROG_RANLIB
+-#AM_PROG_LIBTOOL
++AM_PROG_LIBTOOL
+ AC_PROG_LN_S
+ AC_PROG_AWK
+ AC_PROG_INSTALL
+@@ -295,15 +294,15 @@
+     WSDL2H_EXTRA_LIBS="${WSDL2H_EXTRA_LIBS} -lgnutls -lgcrypt -lgpg-error -lz"
+     SAMPLE_INCLUDES=
+     SAMPLE_SSL_LIBS="-lgnutls -lgcrypt -lgpg-error -lz"
+-    WSDL2H_SOAP_CPP_LIB="libgsoapssl++.a"
++    WSDL2H_SOAP_CPP_LIB="libgsoapssl++.la"
+   else
+     AC_MSG_RESULT(no)
+     WSDL2H_EXTRA_FLAGS="-DWITH_OPENSSL -DWITH_GZIP"
+     # compile with wsdl2h when OPENSSL is available
+-    WSDL2H_EXTRA_LIBS="${WSDL2H_EXTRA_LIBS} -lssl -lcrypto -lz"
++    WSDL2H_EXTRA_LIBS="${WSDL2H_EXTRA_LIBS} -lcrypto"
+     SAMPLE_INCLUDES=
+     SAMPLE_SSL_LIBS="-lssl -lcrypto -lz"
+-    WSDL2H_SOAP_CPP_LIB="libgsoapssl++.a"
++    WSDL2H_SOAP_CPP_LIB="libgsoapssl++.la"
+   fi
+   if test -n "$ZLIB"; then
+     WSDL2H_EXTRA_FLAGS="-I${ZLIB}/include ${WSDL2H_EXTRA_FLAGS}"
+@@ -322,7 +321,7 @@
+   WSDL2H_EXTRA_FLAGS=
+   SAMPLE_SSL_LIBS=
+   SAMPLE_INCLUDES=
+-  WSDL2H_SOAP_CPP_LIB="libgsoap++.a"
++  WSDL2H_SOAP_CPP_LIB="libgsoap++.la"
+ fi
+ AM_CONDITIONAL(WITH_OPENSSL, test "x$with_openssl" = "xyes" -a "x$with_gnutls" != "xyes")
+ AC_SUBST(WITH_OPENSSL)
+diff -ur gsoap-2.8.orig/gsoap/Makefile.am gsoap-2.8/gsoap/Makefile.am
+--- gsoap-2.8.orig/gsoap/Makefile.am	2019-01-14 18:17:21.000000000 +0100
++++ gsoap-2.8/gsoap/Makefile.am	2019-01-17 15:58:13.041317567 +0100
+@@ -34,20 +34,30 @@
+ dom_cpp.cpp: dom.cpp
+ 	$(LN_S) -f $(top_srcdir)/gsoap/dom.cpp dom_cpp.cpp
+ 
+-lib_LIBRARIES = libgsoap.a libgsoap++.a libgsoapck.a libgsoapck++.a libgsoapssl.a libgsoapssl++.a
++lib_LTLIBRARIES = libgsoap.la libgsoap++.la libgsoapck.la libgsoapck++.la libgsoapssl.la libgsoapssl++.la
+ 
+-libgsoap_a_SOURCES = stdsoap2.c dom.c
+-libgsoap_a_CFLAGS = $(SOAPCPP2_DEBUG) $(SOAPCPP2_NONAMESPACES) $(SOAPCPP2_NO_C_LOCALE) $(SOAPCPP2_IPV6) $(SOAPCPP2_IPV6_V6ONLY) -D$(platform)
+-libgsoap___a_SOURCES = stdsoap2_cpp.cpp dom_cpp.cpp
+-libgsoap___a_CXXFLAGS = $(SOAPCPP2_DEBUG) $(SOAPCPP2_NONAMESPACES) $(SOAPCPP2_NO_C_LOCALE) $(SOAPCPP2_IPV6) $(SOAPCPP2_IPV6_V6ONLY) -D$(platform)
+-libgsoapck_a_SOURCES = stdsoap2_ck.c dom.c
+-libgsoapck_a_CFLAGS = $(SOAPCPP2_DEBUG) $(SOAPCPP2_NONAMESPACES) $(SOAPCPP2_NO_C_LOCALE) $(SOAPCPP2_IPV6) $(SOAPCPP2_IPV6_V6ONLY) -D$(platform) -DWITH_COOKIES
+-libgsoapck___a_SOURCES = stdsoap2_ck_cpp.cpp dom_cpp.cpp
+-libgsoapck___a_CXXFLAGS = $(SOAPCPP2_DEBUG) $(SOAPCPP2_NONAMESPACES) $(SOAPCPP2_NO_C_LOCALE) $(SOAPCPP2_IPV6) $(SOAPCPP2_IPV6_V6ONLY) -D$(platform) -DWITH_COOKIES
+-libgsoapssl_a_SOURCES = stdsoap2_ssl.c dom.c
+-libgsoapssl_a_CFLAGS = $(SOAPCPP2_DEBUG) $(SOAPCPP2_NONAMESPACES) $(SOAPCPP2_NO_C_LOCALE) $(SOAPCPP2_IPV6) $(SOAPCPP2_IPV6_V6ONLY) -D$(platform) $(WSDL2H_EXTRA_FLAGS) -DWITH_DOM -DWITH_COOKIES
+-libgsoapssl___a_SOURCES = stdsoap2_ssl_cpp.cpp dom_cpp.cpp
+-libgsoapssl___a_CXXFLAGS = $(SOAPCPP2_DEBUG) $(SOAPCPP2_NONAMESPACES) $(SOAPCPP2_NO_C_LOCALE) $(SOAPCPP2_IPV6) $(SOAPCPP2_IPV6_V6ONLY) -D$(platform) $(WSDL2H_EXTRA_FLAGS) -DWITH_DOM -DWITH_COOKIES
++SOVERSION = $(shell grep 'define VERSION' $(srcdir)/src/soapcpp2.h | cut -d '"' -f 2)
++
++libgsoap_la_SOURCES = stdsoap2.c dom.c
++libgsoap_la_CFLAGS = $(SOAPCPP2_DEBUG) $(SOAPCPP2_NONAMESPACES) $(SOAPCPP2_NO_C_LOCALE) $(SOAPCPP2_IPV6) $(SOAPCPP2_IPV6_V6ONLY) -D$(platform)
++libgsoap_la_LDFLAGS = -release $(SOVERSION)
++libgsoap___la_SOURCES = stdsoap2_cpp.cpp dom_cpp.cpp
++libgsoap___la_CXXFLAGS = $(SOAPCPP2_DEBUG) $(SOAPCPP2_NONAMESPACES) $(SOAPCPP2_NO_C_LOCALE) $(SOAPCPP2_IPV6) $(SOAPCPP2_IPV6_V6ONLY) -D$(platform)
++libgsoap___la_LDFLAGS = -release $(SOVERSION)
++libgsoapck_la_SOURCES = stdsoap2_ck.c dom.c
++libgsoapck_la_CFLAGS = $(SOAPCPP2_DEBUG) $(SOAPCPP2_NONAMESPACES) $(SOAPCPP2_NO_C_LOCALE) $(SOAPCPP2_IPV6) $(SOAPCPP2_IPV6_V6ONLY) -D$(platform) -DWITH_COOKIES
++libgsoapck_la_LDFLAGS = -release $(SOVERSION)
++libgsoapck___la_SOURCES = stdsoap2_ck_cpp.cpp dom_cpp.cpp
++libgsoapck___la_CXXFLAGS = $(SOAPCPP2_DEBUG) $(SOAPCPP2_NONAMESPACES) $(SOAPCPP2_NO_C_LOCALE) $(SOAPCPP2_IPV6) $(SOAPCPP2_IPV6_V6ONLY) -D$(platform) -DWITH_COOKIES
++libgsoapck___la_LDFLAGS = -release $(SOVERSION)
++libgsoapssl_la_SOURCES = stdsoap2_ssl.c dom.c
++libgsoapssl_la_CFLAGS = $(SOAPCPP2_DEBUG) $(SOAPCPP2_NONAMESPACES) $(SOAPCPP2_NO_C_LOCALE) $(SOAPCPP2_IPV6) $(SOAPCPP2_IPV6_V6ONLY) -D$(platform) $(WSDL2H_EXTRA_FLAGS) -DWITH_DOM -DWITH_COOKIES
++libgsoapssl_la_LDFLAGS = -release $(SOVERSION)
++libgsoapssl_la_LIBADD = -lssl -lcrypto -lz
++libgsoapssl___la_SOURCES = stdsoap2_ssl_cpp.cpp dom_cpp.cpp
++libgsoapssl___la_CXXFLAGS = $(SOAPCPP2_DEBUG) $(SOAPCPP2_NONAMESPACES) $(SOAPCPP2_NO_C_LOCALE) $(SOAPCPP2_IPV6) $(SOAPCPP2_IPV6_V6ONLY) -D$(platform) $(WSDL2H_EXTRA_FLAGS) -DWITH_DOM -DWITH_COOKIES
++libgsoapssl___la_LDFLAGS = -release $(SOVERSION)
++libgsoapssl___la_LIBADD = -lssl -lcrypto -lz
+ 
+ BUILT_SOURCES = stdsoap2_cpp.cpp dom_cpp.cpp stdsoap2_ck.c stdsoap2_ck_cpp.cpp stdsoap2_ssl.c stdsoap2_ssl_cpp.cpp
+ 
+diff -ur gsoap-2.8.orig/gsoap/samples/autotest/Makefile.am gsoap-2.8/gsoap/samples/autotest/Makefile.am
+--- gsoap-2.8.orig/gsoap/samples/autotest/Makefile.am	2019-01-14 18:17:22.000000000 +0100
++++ gsoap-2.8/gsoap/samples/autotest/Makefile.am	2019-01-17 15:48:00.008982002 +0100
+@@ -14,7 +14,7 @@
+ WSDLINPUT=$(top_srcdir)/gsoap/samples/autotest/examples.wsdl
+ SOAPHEADER=$(top_srcdir)/gsoap/samples/autotest/examples.h
+ SOAP_CPP_SRC=soapC.cpp soapServer.cpp
+-SOAP_CPP_LIB=$(top_builddir)/gsoap/libgsoap++.a
++SOAP_CPP_LIB=$(top_builddir)/gsoap/libgsoap++.la
+ 
+ $(SOAP_CPP_SRC) : $(WSDLINPUT)
+ 	$(WSDL) $(WSDL_FLAGS) $(WSDLINPUT)
+diff -ur gsoap-2.8.orig/gsoap/samples/databinding/Makefile.am gsoap-2.8/gsoap/samples/databinding/Makefile.am
+--- gsoap-2.8.orig/gsoap/samples/databinding/Makefile.am	2019-01-14 18:17:22.000000000 +0100
++++ gsoap-2.8/gsoap/samples/databinding/Makefile.am	2019-01-17 15:48:00.008982002 +0100
+@@ -14,7 +14,7 @@
+ WSDLINPUT=$(top_srcdir)/gsoap/samples/databinding/address.xsd
+ SOAPHEADER=$(top_srcdir)/gsoap/samples/databinding/address.h
+ SOAP_CPP_SRC=addressC.cpp
+-SOAP_CPP_LIB=$(top_builddir)/gsoap/libgsoap++.a
++SOAP_CPP_LIB=$(top_builddir)/gsoap/libgsoap++.la
+ 
+ $(SOAP_CPP_SRC) : $(WSDLINPUT)
+ 	$(WSDL) $(WSDL_FLAGS) $(WSDLINPUT)
+diff -ur gsoap-2.8.orig/gsoap/samples/Makefile.defines gsoap-2.8/gsoap/samples/Makefile.defines
+--- gsoap-2.8.orig/gsoap/samples/Makefile.defines	2019-01-14 18:17:22.000000000 +0100
++++ gsoap-2.8/gsoap/samples/Makefile.defines	2019-01-17 15:48:00.008982002 +0100
+@@ -13,13 +13,13 @@
+ SOAP_C_CORE=soapC.c
+ SOAP_C_CLIENT=soapClient.c $(SOAP_C_CORE)
+ SOAP_C_SERVER=soapServer.c $(SOAP_C_CORE)
+-SOAP_C_LIB=$(top_builddir)/gsoap/libgsoap.a
+-SOAP_C_LIB_CK=$(top_builddir)/gsoap/libgsoapck.a
+-SOAP_C_LIB_SSL=$(top_builddir)/gsoap/libgsoapssl.a
++SOAP_C_LIB=$(top_builddir)/gsoap/libgsoap.la
++SOAP_C_LIB_CK=$(top_builddir)/gsoap/libgsoapck.la
++SOAP_C_LIB_SSL=$(top_builddir)/gsoap/libgsoapssl.la
+ 
+ SOAP_CPP_CORE=soapC.cpp
+ SOAP_CPP_CLIENT=soapClient.cpp $(SOAP_CPP_CORE)
+ SOAP_CPP_SERVER=soapServer.cpp $(SOAP_CPP_CORE)
+-SOAP_CPP_LIB=$(top_builddir)/gsoap/libgsoap++.a
+-SOAP_CPP_LIB_CK=$(top_builddir)/gsoap/libgsoapck++.a
+-SOAP_CPP_LIB_SSL=$(top_builddir)/gsoap/libgsoapssl++.a
++SOAP_CPP_LIB=$(top_builddir)/gsoap/libgsoap++.la
++SOAP_CPP_LIB_CK=$(top_builddir)/gsoap/libgsoapck++.la
++SOAP_CPP_LIB_SSL=$(top_builddir)/gsoap/libgsoapssl++.la

--- a/srcpkgs/gsoap/patches/musl.patch
+++ b/srcpkgs/gsoap/patches/musl.patch
@@ -1,0 +1,48 @@
+adapted from: https://git.alpinelinux.org/aports/tree/community/gsoap/musl-fixes.patch
+with help from paper42
+
+--- a/gsoap/stdsoap2.c
++++ b/gsoap/stdsoap2.c
+@@ -5125,7 +5125,7 @@
+     hostent = NULL;
+     soap->errnum = h_errno;
+   }
+-#elif (!defined(_GNU_SOURCE) || (!(~_GNU_SOURCE+1) && !defined(_POSIX_C_SOURCE) && !defined(_XOPEN_SOURCE)) || _POSIX_C_SOURCE >= 200112L || _XOPEN_SOURCE >= 600 || defined(__ANDROID__) || defined(FREEBSD) || defined(__FreeBSD__)) && !defined(SUN_OS) && defined(HAVE_GETHOSTBYNAME_R)
++#elif defined(LINUX) && defined(HAVE_GETHOSTBYNAME_R)
+   while ((r = gethostbyname_r(addr, hostent, tmpbuf, tmplen, &hostent, &soap->errnum)) < 0)
+   {
+     if (tmpbuf != soap->tmpbuf)
+--- a/gsoap/stdsoap2.cpp
++++ b/gsoap/stdsoap2.cpp
+@@ -5092,7 +5092,7 @@
+ {
+ #if (defined(_AIX43) || defined(TRU64) || defined(HP_UX)) && defined(HAVE_GETHOSTBYNAME_R)
+   struct hostent_data ht_data;
+-#elif (!defined(_GNU_SOURCE) || (!(~_GNU_SOURCE+1) && !defined(_POSIX_C_SOURCE) && !defined(_XOPEN_SOURCE)) || _POSIX_C_SOURCE >= 200112L || _XOPEN_SOURCE >= 600 || defined(__ANDROID__) || defined(FREEBSD) || defined(__FreeBSD__)) && defined(HAVE_GETHOSTBYNAME_R)
++#elif defined(LINUX) && defined(HAVE_GETHOSTBYNAME_R)
+   int r;
+   char *tmpbuf = soap->tmpbuf;
+   size_t tmplen = sizeof(soap->tmpbuf);
+@@ -5125,7 +5125,7 @@
+     hostent = NULL;
+     soap->errnum = h_errno;
+   }
+-#elif (!defined(_GNU_SOURCE) || (!(~_GNU_SOURCE+1) && !defined(_POSIX_C_SOURCE) && !defined(_XOPEN_SOURCE)) || _POSIX_C_SOURCE >= 200112L || _XOPEN_SOURCE >= 600 || defined(__ANDROID__) || defined(FREEBSD) || defined(__FreeBSD__)) && !defined(SUN_OS) && defined(HAVE_GETHOSTBYNAME_R)
++#elif defined(LINUX) && defined(HAVE_GETHOSTBYNAME_R)
+   while ((r = gethostbyname_r(addr, hostent, tmpbuf, tmplen, &hostent, &soap->errnum)) < 0)
+   {
+     if (tmpbuf != soap->tmpbuf)
+--- a/gsoap/stdsoap2.cpp
++++ b/gsoap/stdsoap2.cpp
+@@ -22618,9 +22618,9 @@
+   {
+ #ifndef WIN32
+ # ifdef HAVE_STRERROR_R
+-#  if !defined(_GNU_SOURCE) || (!(~_GNU_SOURCE+1) && ((!defined(_POSIX_C_SOURCE) && !defined(_XOPEN_SOURCE)) || (_POSIX_C_SOURCE >= 200112L || _XOPEN_SOURCE >= 600)))
++# ifndef __GLIBC__
+     err = strerror_r(err, soap->msgbuf, sizeof(soap->msgbuf)); /* XSI-compliant */
+     if (err != 0)
+       soap_strcpy(soap->msgbuf, sizeof(soap->msgbuf), "unknown error");
+ #  else
+     return strerror_r(err, soap->msgbuf, sizeof(soap->msgbuf)); /* GNU-specific */
+ #  endif

--- a/srcpkgs/gsoap/template
+++ b/srcpkgs/gsoap/template
@@ -1,34 +1,33 @@
 # Template file for 'gsoap'
 pkgname=gsoap
-version=2.8.91
-revision=3
+version=2.8.124
+revision=1
 build_style=gnu-configure
 configure_args="--enable-ipv6"
-hostmakedepends="unzip flex autoconf"
+hostmakedepends="unzip flex autoconf automake libtool"
 makedepends="openssl-devel zlib-devel"
 short_desc="Toolkit for SOAP and REST Web Services and XML-Based Applications"
 maintainer="Enno Boland <gottox@voidlinux.org>"
-license="gSOAP-1.3b, GPL-2.0-only"
-homepage="http://www.cs.fsu.edu/~engelen/soap.html"
+license="GPL-2.0-only"
+homepage="https://www.genivia.com/dev.html"
 distfiles="${SOURCEFORGE_SITE}/gsoap2/gsoap_${version}.zip"
-checksum=2ca21b5ab2b40d899566c559f71a1d51ed7eac3f00160ab78060027a3ee6488f
+checksum=4b798780989338f665ef8e171bbcc422a271004d62d5852666d5eeca33a6a636
 disable_parallel_build=yes
-
 CFLAGS="-fcommon"
 
 if [ "$CROSS_BUILD" ]; then
 	hostmakedepends+=" gsoap"
 fi
 
+pre_configure() {
+	autoreconf -fi
+}
+
 pre_build() {
 	if [ "$CROSS_BUILD" ]; then
 		# run host 'soapcpp2'
 		sed -i 's|^\(SOAP = \).*|\1soapcpp2|' gsoap/wsdl/Makefile
 	fi
-}
-
-post_install() {
-	vlicense license.pdf
 }
 
 gsoap-devel_package() {


### PR DESCRIPTION
The current version has no available tarball, so I'm unable to test it with openssl3.
@Gottox @motorto 

- I tested the changes in this PR: **NO**
- I built this PR locally for my native architecture, (x86_64-musl)