### PR TITLE
cargo-outdated: update to 0.11.2.

### DIFF
--- a/srcpkgs/cargo-outdated/template
+++ b/srcpkgs/cargo-outdated/template
@@ -1,7 +1,7 @@
 # Template file for 'cargo-outdated'
 pkgname=cargo-outdated
-version=0.11.1
-revision=2
+version=0.11.2
+revision=1
 build_style=cargo
 hostmakedepends="pkg-config zlib-devel"
 makedepends="libcurl-devel libgit2-devel openssl-devel"
@@ -11,7 +11,7 @@ license="MIT"
 homepage="https://github.com/kbknapp/cargo-outdated"
 changelog="https://raw.githubusercontent.com/kbknapp/cargo-outdated/master/CHANGELOG.md"
 distfiles="https://github.com/kbknapp/cargo-outdated/archive/refs/tags/v${version}.tar.gz"
-checksum=2d80f0243d70a3563c48644dd3567519c32a733fb5d20f1161fd5d9f8e6e9146
+checksum=7e82d1507594d86cb1c2007d58e329a9780a22bdb0f38d5e71d2692a7f1727d9
 
 post_install() {
 	vlicense LICENSE-MIT


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture: **x86_64**