### PR TITLE
ubridge: rebuild with LINUX_RAW

### DIFF
--- a/srcpkgs/ubridge/template
+++ b/srcpkgs/ubridge/template
@@ -1,7 +1,7 @@
 # Template file for 'ubridge'
 pkgname=ubridge
 version=0.9.18
-revision=1
+revision=2
 build_style=gnu-makefile
 make_build_args="SYSTEM_INIPARSER=1"
 makedepends="libpcap-devel iniparser-devel"
@@ -9,8 +9,10 @@ short_desc="Bridge for UDP tunnels, Ethernet, TAP and VMnet interfaces"
 maintainer="Cameron Nemo <cam@nohom.org>"
 license="GPL-3.0-or-later"
 homepage="https://github.com/GNS3/ubridge"
-distfiles="${homepage}/archive/v${version}.tar.gz"
+distfiles="https://github.com/GNS3/ubridge/archive/v${version}.tar.gz"
 checksum=7481e0f4a11c151c698baf5fbd5e474236aa408ff7f9b503e13feb091fbc38e7
+
+CFLAGS="-DLINUX_RAW"
 
 do_install() {
 	vbin ubridge


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->
ubridge is not compiled with LINUX_RAW enabled so it cannot use `add_nio_linux_raw` to connect to network interfaces.
When ubridge is compiled with LINUX_RAW it works.

Below is the error I get in GNS3 when I use the current package of ubridge:
```
2023-01-25 09:17:20 ERROR route.py:221 Node error detected: UbridgeError
Traceback (most recent call last):
  File "/usr/lib/python3.11/site-packages/gns3server/compute/base_node.py", line 660, in _ubridge_send
    await self._ubridge_hypervisor.send(command)
  File "/usr/lib/python3.11/site-packages/gns3server/utils/asyncio/__init__.py", line 164, in wrapper
    return await f(oself, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/gns3server/ubridge/ubridge_hypervisor.py", line 259, in send
    raise UbridgeError(data[-1][4:])
gns3server.ubridge.ubridge_error.UbridgeError: Unknown command 'add_nio_linux_raw'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/lib/python3.11/site-packages/gns3server/web/route.py", line 200, in control_schema
    await func(request, response)
  File "/usr/lib/python3.11/site-packages/gns3server/handlers/api/compute/cloud_handler.py", line 147, in start
    await node.start()
  File "/usr/lib/python3.11/site-packages/gns3server/compute/builtin/nodes/cloud.py", line 232, in start
    raise e
  File "/usr/lib/python3.11/site-packages/gns3server/compute/builtin/nodes/cloud.py", line 229, in start
    await self._add_ubridge_connection(self._nios[port_number], port_number)
  File "/usr/lib/python3.11/site-packages/gns3server/compute/builtin/nodes/cloud.py", line 315, in _add_ubridge_connection
    await self._add_linux_ethernet(port_info, bridge_name)
  File "/usr/lib/python3.11/site-packages/gns3server/compute/builtin/nodes/cloud.py", line 357, in _add_linux_ethernet
    await self._ubridge_send('bridge add_nio_linux_raw {name} "{interface}"'.format(name=bridge_name, interface=interface))
  File "/usr/lib/python3.11/site-packages/gns3server/compute/base_node.py", line 662, in _ubridge_send
    raise UbridgeError("Error while sending command '{}': {}: {}".format(command, e, self._ubridge_hypervisor.read_stdout()))
gns3server.ubridge.ubridge_error.UbridgeError: Error while sending command 'bridge add_nio_linux_raw 15a9b700-ea53-446a-877a-b6cdd5decacd-2 "eth0"': Unknown command 'add_nio_linux_raw': uBridge version 0.9.18 running with libpcap version 1.10.3 (with TPACKET_V3)
```

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-GLIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64 (crossbuild)
