### PR TITLE
gscreenshot: update to 3.3.0.

### DIFF
--- a/srcpkgs/gscreenshot/template
+++ b/srcpkgs/gscreenshot/template
@@ -1,15 +1,20 @@
 # Template file for 'gscreenshot'
 pkgname=gscreenshot
-version=2.17.1
-revision=2
+version=3.3.0
+revision=1
 build_style=python3-module
-hostmakedepends="python3-setuptools gettext"
-depends="gtk+3 python3-setuptools python3-Pillow python3-gobject scrot"
-short_desc="GUI front-end for the scrot program"
+hostmakedepends="python3-setuptools gettext go-md2man"
+# refer to https://github.com/thenaterhood/gscreenshot#installation
+# for optional dependencies across system configurations
+depends="gtk+3 python3-setuptools python3-Pillow python3-gobject"
+checkdepends="${depends} python3-mock python3-pytest"
+short_desc="GUI for multiple screenshot backends including scrot, PIL, and grim"
 maintainer="Rui Flora <rui.flora@gmail.com>"
-license="GPL-2.0-or-later"
+license="GPL-2.0-only"
 homepage="https://github.com/thenaterhood/gscreenshot"
-distfiles="https://github.com/thenaterhood/gscreenshot/archive/v${version}.tar.gz"
-checksum=f0cdf81e9ab483e11c04ed27141ac37dd6f24415968bc5f4c874e7b17ca5958d
-# doesn't ship any tests
-make_check=no
+distfiles="https://github.com/thenaterhood/gscreenshot/archive/refs/tags/v${version}.tar.gz"
+checksum=f05e695676cda97483c6cdbebaba9a708b5791e544e977016a772325a1d37231
+
+do_check() {
+	(cd src && PYTHONPATH="$(cd build/lib* && pwd)" python3 -m pytest ../test)
+}


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture: **x86_64**

I think scrot shouldn't be a hard dependencny here since it has full [wayland compatibility](https://github.com/thenaterhood/gscreenshot#for-full-functionality-on-wayland-the-recommended-packages-are)