### PR TITLE
cups-filters shall be a dependency.

### DIFF
--- a/srcpkgs/cups/template
+++ b/srcpkgs/cups/template
@@ -8,7 +8,7 @@ hostmakedepends="gnutls-devel pkg-config
  $(vopt_if avahi avahi-libs-devel)"
 makedepends="acl-devel gnutls-devel libpaper-devel libusb-devel pam-devel
  zlib-devel $(vopt_if avahi avahi-libs-devel) $(vopt_if gssapi mit-krb5-devel)"
-depends="xdg-utils"
+depends="xdg-utils cups-filters"
 short_desc="Common Unix Printing System"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="Apache-2.0"


### PR DESCRIPTION
Without cups-filters, one may encounter problems such that one cannot print anything through cups. See for example [1], although it was reported on FreeBSD, the same issue happened to me using Void Liunx.

[1] https://forums.freebsd.org/threads/printer-doesnt-work-after-upgrading-cups.45738/

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**|**briefly**|**NO**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
