### PR TITLE
New package: hurl-3.0.0

### DIFF
--- a/srcpkgs/hurl/template
+++ b/srcpkgs/hurl/template
@@ -1,0 +1,27 @@
+# Template file for 'hurl'
+pkgname=hurl
+version=3.0.0
+revision=1
+build_style=cargo
+make_check_args="-- --skip=runner::hurl_file::run --skip=http::tests::libcurl"
+hostmakedepends="pkg-config"
+makedepends="openssl-devel libcurl-devel libxml2-devel"
+short_desc="CLI to run HTTP requests defined in a simple plain text format"
+maintainer="icp <pangolin@vivaldi.net>"
+license="Apache-2.0"
+homepage="https://hurl.dev"
+changelog="https://raw.githubusercontent.com/Orange-OpenSource/hurl/master/CHANGELOG.md"
+distfiles="https://github.com/Orange-OpenSource/hurl/archive/refs/tags/${version}.tar.gz"
+checksum=7ad9a1043129edb4850727c085a83010b916b3515c2af5afddd0809c1e2bd85c
+
+if [[ "$XBPS_WORDSIZE" -eq 32 ]]; then
+	make_check=no # https://github.com/Orange-OpenSource/hurl/issues/1220
+fi
+
+do_install() {
+	vbin target/${RUST_TARGET}/release/hurl
+	vbin target/${RUST_TARGET}/release/hurlfmt
+
+	vman docs/manual/hurl.1
+	vman docs/manual/hurlfmt.1
+}


### PR DESCRIPTION
#### Description
[Hurl](https://hurl.dev) is a CLI tool that runs HTTP requests defined in a simple plain text format. It can chain requests, capture values and evaluate queries on headers and body response. It can be used for both fetching data and testing HTTP sessions.

#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

#### Local build testing
- I built this PR locally for my native architecture: **x86_64**