### PR TITLE
libwebsockets: update to 4.3.2, revbump or upgrade dependencies

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -2255,7 +2255,7 @@ libcvm-v2client.so.1 cvm-0.97_1
 libudns.so.0 udns-0.4_1
 libcriu.so.2 criu-3.13_2
 libcompel.so.1 criu-3.13_2
-libwebsockets.so.15 libwebsockets-3.2.2_5
+libwebsockets.so.19 libwebsockets-4.3.2_1
 libnfc.so.6 libnfc-1.8.0_1
 libfuzzy.so.2 libfuzzy-2.12_1
 libSDL_gfx.so.15 SDL_gfx-2.0.25_2

--- a/srcpkgs/kismet/template
+++ b/srcpkgs/kismet/template
@@ -1,7 +1,7 @@
 # Template file for 'kismet'
 pkgname=kismet
 version=2022.08.R1
-revision=1
+revision=2
 _realver="${version//./-}"
 build_style=gnu-configure
 configure_args="--disable-python-tools"
@@ -14,7 +14,7 @@ depends="libcap-progs"
 short_desc="Wireless network detector, sniffer, and intrusion detection system"
 maintainer="Leah Neukirchen <leah@vuxu.org>"
 license="GPL-2.0-or-later"
-homepage="http://www.kismetwireless.net/"
+homepage="https://www.kismetwireless.net/"
 distfiles="http://www.kismetwireless.net/code/${pkgname}-${_realver}.tar.xz"
 checksum=2149cceac5526508653f4d02dcf7a694e3da3dc000a2372a1ee4bf9988279781
 system_groups="kismet"

--- a/srcpkgs/libwebsockets/template
+++ b/srcpkgs/libwebsockets/template
@@ -1,20 +1,22 @@
 # Template file for 'libwebsockets'
 pkgname=libwebsockets
-version=3.2.2
-revision=5
+version=4.3.2
+revision=1
 build_style=cmake
 configure_args="-DLWS_WITH_LIBEV=ON -DLWS_WITH_LIBUV=ON -DLWS_WITH_HTTP2=ON
- -DLWS_IPV6=ON -DLWS_HAVE_LIBCAP=ON"
+ -DLWS_IPV6=ON -DLWS_HAVE_LIBCAP=ON -DLWS_WITH_EVLIB_PLUGINS=OFF"
 makedepends="libcap-devel libev-devel libuv-devel openssl-devel zlib-devel"
 short_desc="Lightweight client and server websocket library"
 maintainer="Enno Boland <gottox@voidlinux.org>"
-license="LGPL-2.1-only"
+license="MIT"
 homepage="https://libwebsockets.org"
-changelog="https://raw.githubusercontent.com/warmcat/libwebsockets/v3.0-stable/changelog"
+changelog="https://raw.githubusercontent.com/warmcat/libwebsockets/main/changelog"
 distfiles="https://github.com/warmcat/libwebsockets/archive/v${version}.tar.gz"
-checksum=166d6e17cab64bfc10c2a71799c298284540a1fa63f6ea3de5caccb34502243c
+checksum=6a85a1bccf25acc7e8e5383e4934c9b32a102880d1e4c37c70b27ae2a42406e1
 
-CFLAGS="-Wno-error"
+post_install() {
+	vlicense LICENSE
+}
 
 libwebsockets-devel_package() {
 	depends="libwebsockets>=${version}_${revision} libcap-devel libev-devel openssl-devel libuv-devel"

--- a/srcpkgs/mosquitto/template
+++ b/srcpkgs/mosquitto/template
@@ -1,6 +1,6 @@
 # Template file for 'mosquitto'
 pkgname=mosquitto
-version=2.0.9
+version=2.0.15
 revision=1
 build_style=gnu-makefile
 make_build_args="WITH_WEBSOCKETS=yes WITH_BUNDLED_DEPS=no"
@@ -14,7 +14,8 @@ maintainer="Lukas Braun <koomi@hackerspace-bamberg.de>"
 license="EPL-1.0, BSD-3-Clause-Attribution"
 homepage="https://mosquitto.org"
 distfiles="${homepage}/files/source/${pkgname}-${version}.tar.gz"
-checksum=1b8553ef64a1cf5e4f4cfbe098330ae612adccd3d37f35b2db6f6fab501b01d4
+checksum=4735b1d32e3f91c7a8896741d88a3022e89730a1ee897946decfa0df27039ac6
+# testing too long ?
 make_check="ci-skip"
 
 system_accounts="_mosquitto"

--- a/srcpkgs/ttyd/template
+++ b/srcpkgs/ttyd/template
@@ -1,6 +1,6 @@
 # Template file for 'ttyd'
 pkgname=ttyd
-version=1.7.2
+version=1.7.3
 revision=1
 build_style=cmake
 hostmakedepends="pkg-config xxd"
@@ -11,7 +11,7 @@ maintainer="Toyam Cox <Vaelatern@voidlinux.org>"
 license="MIT"
 homepage="https://tsl0922.github.io/ttyd/"
 distfiles="https://github.com/tsl0922/ttyd/archive/${version}.tar.gz"
-checksum=edc44cd5319c0c9d0858081496cae36fc5c54ee7722e0a547dde39537dfb63de
+checksum=c9cf5eece52d27c5d728000f11315d36cb400c6948d1964a34a7eae74b454099
 
 if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
 	makedepends+=" musl-legacy-compat"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC) : **x86_64-musl**
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [] aarch64-musl
  - [] armv7l
  - [] armv6l-musl
  - [x] aarch64

