### PR TITLE
bird: update to 2.0.12

### DIFF
--- a/srcpkgs/bird/template
+++ b/srcpkgs/bird/template
@@ -1,6 +1,6 @@
 # Template file for 'bird'
 pkgname=bird
-version=2.0.11
+version=2.0.12
 revision=1
 build_style=gnu-configure
 hostmakedepends="flex"
@@ -11,7 +11,7 @@ license="GPL-2.0-or-later"
 homepage="https://bird.network.cz"
 changelog="https://gitlab.nic.cz/labs/bird/-/raw/master/NEWS"
 distfiles="https://bird.network.cz/download/bird-${version}.tar.gz"
-checksum=60a7b83b67b9d089d2a745a11fddd12461f631abc7b645b6c085adf90b3f55d6
+checksum=3ec462a237d06d1f4455d6ec00a42f0b1686061fc988e5c89a841d01dd753b53
 
 conf_files="/etc/bird.conf"
 system_accounts="_bird"


### PR DESCRIPTION
Most notably, this contains a fix in the memory allocation for a bug that in some cases could lead to memory bloating. More information in https://gitlab.nic.cz/labs/bird/-/commit/973aa37e1e28a9c508fe09c008196f64cd3966fd

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures:
  - aarch64-musl
  - armv7l
  - armv6l-musl
  - x86_64-musl
