### PR TITLE
monitoring-plugins: update to 2.3.2

### DIFF
--- a/srcpkgs/monitoring-plugins/template
+++ b/srcpkgs/monitoring-plugins/template
@@ -1,6 +1,6 @@
 # Template file for 'monitoring-plugins'
 pkgname=monitoring-plugins
-version=2.3.1
+version=2.3.2
 revision=1
 build_style=gnu-configure
 configure_args="--libexecdir=/usr/lib/monitoring-plugins"
@@ -15,7 +15,7 @@ license="GPL-3.0-or-later"
 homepage="https://www.monitoring-plugins.org/"
 changelog="https://www.monitoring-plugins.org/news/index.html"
 distfiles="${homepage}/download/${pkgname}-${version}.tar.gz"
-checksum=f56eb84871983fd719247249e3532228b37e2efaae657a3979bd14ac1f84a35b
+checksum=8d9405baf113a9f25e4fb961d56f9f231da02e3ada0f41dbb0fa4654534f717b
 
 do_configure() {
 	./configure ${configure_args} --with-ping-command='/usr/bin/iputils-ping -n -U -w %d -c %d %s' --with-ping6-command='/usr/bin/iputils-ping6 -n -U -w %d -c %d %s'


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures:
  - aarch64-musl
  - armv7l
  - armv6l-musl
  - x86_64-musl