### PR TITLE
iwgtk: fix dependencies

### DIFF
--- a/srcpkgs/iwgtk/template
+++ b/srcpkgs/iwgtk/template
@@ -1,11 +1,11 @@
 # Template file for 'iwgtk'
 pkgname=iwgtk
 version=0.9
-revision=1
+revision=2
 build_style=meson
 hostmakedepends="scdoc pkg-config gettext"
 makedepends="gtk4-devel qrencode-devel"
-depends="iwd"
+depends="iwd>=1.29"
 short_desc="Lightweight GTK frontend for iwd (WiFi)"
 maintainer="Subhaditya Nath <sn03.general@gmail.com>"
 license="GPL-3.0-or-later"


### PR DESCRIPTION
iwgtk 0.9 requires iwd>=1.29 as mentioned in the release notes here -  
https://github.com/J-Lentz/iwgtk/releases/tag/v0.9

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
@cinerea0 