### PR TITLE
sbsigntool: patch for openss3, add CFLAG

### DIFF
--- a/srcpkgs/sbsigntool/patches/f12484869c9590682ac3253d583bf59b890bb826.patch
+++ b/srcpkgs/sbsigntool/patches/f12484869c9590682ac3253d583bf59b890bb826.patch
@@ -1,0 +1,60 @@
+From f12484869c9590682ac3253d583bf59b890bb826 Mon Sep 17 00:00:00 2001
+From: dann frazier <dann.frazier@canonical.com>
+Date: Wed, 12 Aug 2020 15:27:08 -0600
+Subject: sbkeysync: Don't ignore errors from insert_new_keys()
+
+If insert_new_keys() fails, say due to a full variable store, we currently
+still exit(0). This can make it difficult to know something is wrong.
+For example, Debian and Ubuntu implement a secureboot-db systemd service
+to update the DB and DBX, which calls:
+
+ ExecStart=/usr/bin/sbkeysync --no-default-keystores --keystore /usr/share/secureboot/updates --verbose
+
+But although this seemed to succeed on my system, looking at the logs shows
+a different story:
+
+Inserting key update /usr/share/secureboot/updates/dbx/dbxupdate_x64.bin into dbx
+Error writing key update: Invalid argument
+Error syncing keystore file /usr/share/secureboot/updates/dbx/dbxupdate_x64.bin
+
+Signed-off-by: dann frazier <dann.frazier@canonical.com>
+Signed-off-by: James Bottomley <James.Bottomley@HansenPartnership.com>
+---
+ src/sbkeysync.c | 8 +++++---
+ 1 file changed, 5 insertions(+), 3 deletions(-)
+
+diff --git a/src/sbkeysync.c b/src/sbkeysync.c
+index e51f177..7748990 100644
+--- a/src/sbkeysync.c
++++ b/src/sbkeysync.c
+@@ -889,10 +889,12 @@ int main(int argc, char **argv)
+ {
+ 	bool use_default_keystore_dirs;
+ 	struct sync_context *ctx;
++	int rc;
+ 
+ 	use_default_keystore_dirs = true;
+ 	ctx = talloc_zero(NULL, struct sync_context);
+ 	list_head_init(&ctx->new_keys);
++	rc = EXIT_SUCCESS;
+ 
+ 	for (;;) {
+ 		int idx, c;
+@@ -985,10 +987,10 @@ int main(int argc, char **argv)
+ 	if (ctx->verbose)
+ 		print_new_keys(ctx);
+ 
+-	if (!ctx->dry_run)
+-		insert_new_keys(ctx);
++	if (!ctx->dry_run && insert_new_keys(ctx))
++		rc = EXIT_FAILURE;
+ 
+ 	talloc_free(ctx);
+ 
+-	return EXIT_SUCCESS;
++	return rc;
+ }
+-- 
+cgit 1.2.3-1.el7
+
+

--- a/srcpkgs/sbsigntool/patches/openssl3.patch
+++ b/srcpkgs/sbsigntool/patches/openssl3.patch
@@ -1,0 +1,35 @@
+Subject: [PATCH] Fix openssl-3.0 issue involving ASN1 xxx_it
+From: Jeremi Piotrowski <jeremi.piotrowski@microsoft.com>
+Origin: https://groups.io/g/sbsigntools/message/54
+
+Use ASN1_ITEM_rptr() instead of taking the address of IDC_PEID_it.
+
+openssl-3.0 changed the type of TYPE_it from `const ASN1_ITEM TYPE_it` to
+`const ASN1_ITEM *TYPE_it(void)`. This was previously hidden behind
+OPENSSL_EXPORT_VAR_AS_FUNCTION but in 3.0 only the function version is
+available. This change should have been transparent to the application, but
+only if the `ASN1_ITEM_rptr()` macro is used.
+
+This change passes `make check` with both openssl 1.1 and 3.0.
+
+Signed-off-by: Jeremi Piotrowski <jpiotrowski@microsoft.com>
+---
+ src/idc.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/idc.c b/src/idc.c
+index 6d87bd4..0a82218 100644
+--- a/src/idc.c
++++ b/src/idc.c
+@@ -189,7 +189,7 @@ int IDC_set(PKCS7 *p7, PKCS7_SIGNER_INFO *si, struct image *image)
+ 
+ 	idc->data->type = OBJ_nid2obj(peid_nid);
+ 	idc->data->value = ASN1_TYPE_new();
+-	type_set_sequence(image, idc->data->value, peid, &IDC_PEID_it);
++	type_set_sequence(image, idc->data->value, peid, ASN1_ITEM_rptr(IDC_PEID));
+ 
+         idc->digest->alg->parameter = ASN1_TYPE_new();
+         idc->digest->alg->algorithm = OBJ_nid2obj(NID_sha256);
+-- 
+2.25.1
+

--- a/srcpkgs/sbsigntool/template
+++ b/srcpkgs/sbsigntool/template
@@ -1,7 +1,7 @@
 # Template file for 'sbsigntool'
 pkgname=sbsigntool
 version=0.9.4
-revision=4
+revision=5
 archs="x86_64* i686* aarch64* arm*"
 build_style=gnu-configure
 hostmakedepends="autoconf automake pkg-config help2man"
@@ -20,6 +20,8 @@ checksum="eddb7d21263ee2b07be8f0ed93b6ba021c3f943964730b2d86f44736fa1924d5
  1dc1e1de5f2dda50dbd2e6a83355fe7ae38ca0f79daeb404026421af70606653"
 skip_extraction="sbsigntool_0.9.2.orig.tar.gz"
 conf_files="/etc/default/sbsigntool-kernel-hook"
+# openssl3 fix
+CFLAGS+=" -Wno-error=deprecated-declarations"
 
 post_extract() {
 	bsdtar -xzf $XBPS_SRCDISTDIR/$pkgname-$version/sbsigntool_0.9.2.orig.tar.gz


### PR DESCRIPTION
- I tested the changes in this PR: **NO**
- I built this PR locally for my native architecture, (x86_64-musl)

needed to build with openssl3 #37681 