### PR TITLE
git-crypt: update to 0.7.0, add CXXFLAG for openssl3

### DIFF
--- a/srcpkgs/git-crypt/template
+++ b/srcpkgs/git-crypt/template
@@ -1,7 +1,7 @@
 # Template file for 'git-crypt'
 pkgname=git-crypt
-version=0.6.0
-revision=8
+version=0.7.0
+revision=1
 build_style=gnu-makefile
 make_use_env=yes
 make_build_args="ENABLE_MAN=yes"
@@ -13,7 +13,11 @@ maintainer="Andy Cobaugh <andrewcobaugh@gmail.com>"
 license="GPL-3.0-or-later"
 homepage="https://www.agwa.name/projects/git-crypt/"
 distfiles="https://github.com/AGWA/git-crypt/archive/${version}.tar.gz"
-checksum=777c0c7aadbbc758b69aff1339ca61697011ef7b92f1d1ee9518a8ee7702bb78
+checksum=2210a89588169ae9a54988c7fdd9717333f0c6053ff704d335631a387bd3bcff
+
+do_build() {
+	make CXXFLAGS="$CXXFLAGS -DOPENSSL_API_COMPAT=0x30000000L"
+}
 
 post_install() {
 	vdoc README


### PR DESCRIPTION
- I tested the changes in this PR: no
- I built this PR locally for my native architecture, (x86_64-musl)

required to build with openssl3 #37681 
