### PR TITLE
pjproject: update to 2.13

### DIFF
--- a/srcpkgs/pjproject/template
+++ b/srcpkgs/pjproject/template
@@ -2,9 +2,8 @@
 # no-third-party.patch comes from Alpine,
 # and this template is heavily based on Alpine's APKBUILD.
 pkgname=pjproject
-version=2.8
-revision=5
-disable_parallel_build=yes
+version=2.13
+revision=1
 build_style=gnu-configure
 configure_args="--enable-shared \
 	--enable-libsamplerate \
@@ -17,13 +16,14 @@ configure_args="--enable-shared \
 # webrtc-audio-processing, but it doesn't have what I need.  Using the
 # bundled versions would also pollute build with libyuv and libwebrtc (yuck).
 makedepends="openssl-devel alsa-lib-devel libgsm-devel speex-devel speexdsp-devel
-	libsrtp-devel libsamplerate-devel"
+ libsrtp-devel libsamplerate-devel"
 short_desc="Open source SIP and media stack"
 maintainer="Christopher Brannon <chris@the-brannons.com>"
 license="GPL-2.0-or-later"
-homepage="http://www.pjsip.org/pjsua.htm"
-distfiles="http://www.pjsip.org/release/${version}/${pkgname}-${version}.tar.bz2"
-checksum=503d0bd7f9f13dc1492ac9b71b761b1089851fbb608b9a13996edc3c42006f79
+homepage="https://www.pjsip.org/"
+distfiles="https://github.com/pjsip/pjproject/archive/refs/tags/${version}.tar.gz"
+checksum=4178bb9f586299111463fc16ea04e461adca4a73e646f8ddef61ea53dafa92d9
+disable_parallel_build=yes
 
 pre_configure() {
 	export LD="${CC}"


### PR DESCRIPTION
- I tested the changes in this PR: no
- I built this PR locally for my native architecture, (x86_64-musl)

required to build with openssl3 #37681 