### PR TITLE
stunnel: update to 5.67

### DIFF
--- a/srcpkgs/stunnel/template
+++ b/srcpkgs/stunnel/template
@@ -1,6 +1,6 @@
 # Template file for 'stunnel'
 pkgname=stunnel
-version=5.66
+version=5.67
 revision=1
 build_style=gnu-configure
 configure_args="--enable-ipv6 --with-ssl=${XBPS_CROSS_BASE}/usr"
@@ -13,7 +13,7 @@ license="GPL-2.0-or-later"
 homepage="https://www.stunnel.org/"
 changelog="https://www.stunnel.org/NEWS.html"
 distfiles="https://www.stunnel.org/downloads/stunnel-${version}.tar.gz"
-checksum=558178704d1aa5f6883aac6cc5d6bbf2a5714c8a0d2e91da0392468cee9f579c
+checksum=3086939ee6407516c59b0ba3fbf555338f9d52f459bcab6337c0f00e91ea8456
 
 pre_check() {
 	# GitHub's CI doesn't support IPv6


### PR DESCRIPTION
- I tested the changes in this PR: no
- I built this PR locally for my native architecture, (x86_64-musl)

required to build with openssl3 #37681 