### PR TITLE
rankwidth: remove dependency on igraph

### DIFF
--- a/srcpkgs/rankwidth/template
+++ b/srcpkgs/rankwidth/template
@@ -1,10 +1,10 @@
 # Template file for 'rankwidth'
 pkgname=rankwidth
 version=0.9
-revision=2
+revision=3
 build_style=gnu-configure
-hostmakedepends="pkg-config"
-makedepends="igraph-devel"
+# don't depend on igraph, we don't ship the binary anyway
+configure_args="--disable-executable"
 short_desc="Calculates rank-width and rank-decompositions"
 maintainer="Gonzalo Tornaría <tornaria@cmat.edu.uy>"
 license="GPL-2.0-or-later"
@@ -21,7 +21,7 @@ post_install() {
 }
 
 rankwidth-devel_package() {
-	depends="${makedepends} ${sourcepkg}>=${version}_${revision}"
+	depends="${sourcepkg}>=${version}_${revision}"
 	short_desc+=" - development files"
 	pkg_install() {
 		vmove usr/include


### PR DESCRIPTION
It turns out that rankwidth only depends on igraph for the binary, but we don't ship the binary anyway (for sagemath we only need the library).

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
