### PR TITLE
python3: skip more tests

### DIFF
--- a/srcpkgs/python3/template
+++ b/srcpkgs/python3/template
@@ -73,23 +73,30 @@ do_configure() {
 }
 
 do_check() {
+	local _fail
+
 	# Tests ignored due to expected failures:
-	# test_chown_*: relies on sane group membership not found in xbps-src
-	# test_getspnam_exception: expects shadow passwd db unreadable by user
-	# test_find_library_with_*: expects functionality patched out for musl
-	# test_openssl_version: LibreSSL version and OpenSSL_version_num disagree
-	# test_shared_ciphers: SSL advertises unexpected ciphers
-	# test_freeze_simple_script: requires in-tree expat, which we removed
-	#
-	# Test ignored due to failures for unknown reasons:
-	# test_session*: anomalies in SSL session handling
-	# test_localtime_daylight_*_dst_true: overflow in datetime.time.mktime
-	local opts="-i test_chown_* -i test_getspnam_exception \
-		-i test_find_library_with_* -i test_openssl_version \
-		-i test_shared_ciphers -i test_session* \
-		-i test_localtime_daylight_*_dst_true \
-		-i test_freeze_simple_script"
-	make ${makejobs} EXTRATESTOPTS="${opts}" quicktest
+	_fail="test_chown_*" # relies on sane group membership not found in xbps-src
+	_fail="$_fail test_getspnam_exception" # expects shadow passwd db unreadable by user
+	_fail="$_fail test_find_library_with_*" # expects functionality patched out for musl
+	_fail="$_fail test_openssl_version" # LibreSSL version and OpenSSL_version_num disagree
+	_fail="$_fail test_shared_ciphers" # SSL advertises unexpected ciphers
+	_fail="$_fail test_freeze_simple_script" # requires in-tree expat, which we removed
+
+	# musl failures:
+	if [ "${XBPS_TARGET_LIBC}" = "musl" ]; then
+		_fail="$_fail test__locale test_c_locale_coercion test_locale test_os test_re"
+	fi
+
+	# Tests ignored due to failures for unknown reasons:
+	_fail="$_fail test_ctypes test_tools"
+	_fail="$_fail test_session*" # anomalies in SSL session handling
+	_fail="$_fail test_localtime_daylight_*_dst_true" # overflow in datetime.time.mktime
+
+	# aarch64 failure:
+	_fail="$_fail test_spwd"
+
+	make quicktest TESTOPTS="${makejobs} --exclude ${_fail}"
 }
 
 do_install() {


### PR DESCRIPTION
- I tested the changes in this PR: yes
- I built this PR locally for my native architecture, (x86_64-musl)

@ahesford These tests fail for me on musl with `XBPS_CHECK_PKGS=yes`.
is it ok to exclude them, so that I can look for new failures related to openssl3?