### PR TITLE
python3-shapely: update to 2.0.1.

### DIFF
--- a/srcpkgs/python3-shapely/template
+++ b/srcpkgs/python3-shapely/template
@@ -1,29 +1,34 @@
 # Template file for 'python3-shapely'
 pkgname=python3-shapely
-version=1.8.5.post1
+version=2.0.1
 revision=1
 build_style=python3-module
 build_helper=numpy
-make_check_target=tests
 hostmakedepends="python3-setuptools python3-Cython geos"
 makedepends="python3-devel python3-numpy geos-devel"
 depends="python3"
-checkdepends="python3-pytest"
+checkdepends="python3-pytest-xdist"
 short_desc="Library for manipulation and analysis of geometric objects for Python3"
 maintainer="Karl Nilsson <karl.robert.nilsson@gmail.com>"
 license="BSD-3-Clause"
 homepage="https://github.com/shapely/shapely"
 distfiles="https://github.com/shapely/shapely/archive/${version}.tar.gz"
-checksum=51badb76fa13ce1d4d6e5b2cbfef2b6af0ddae56a4449b84c3f3e6f404c6b43c
+checksum=6250e79ca299222a239ce44df613d228f1216c5cc31351217bf377b03d7be4e0
 
 pre_configure() {
 	if [ "$CROSS_BUILD" ]; then
-		sed "
-			/^prefix=/s,=.*,=$XBPS_CROSS_BASE/usr,
-			s,echo [\$]{prefix}$,echo /usr,
-		" $XBPS_CROSS_BASE/usr/bin/geos-config >$XBPS_WRAPPERDIR/geos-config
-		chmod +x $XBPS_WRAPPERDIR/geos-config
+		local _wrapper="${XBPS_WRAPPERDIR}/geos-config"
+
+		sed -e 's,echo [$]{prefix}$,echo /usr,' \
+			-e "/^prefix=/s,=.*,=\"${XBPS_CROSS_BASE}/usr\"," \
+			"${XBPS_CROSS_BASE}/usr/bin/geos-config" > "${_wrapper}"
+		chmod +x "${_wrapper}"
 	fi
+}
+
+do_check() {
+	cd build/lib*
+	PYTHONPATH="${PWD}" python3 -m pytest -n "${XBPS_MAKEJOBS}" shapely/tests
 }
 
 post_install() {


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **pending**

@karl-nilsson This update embodies a major refactor of the `shapely` package, but the API used by `python3-trimesh` and `Uranium` does not seem to have changed. However, I can't meaningfully test those packages.