### PR TITLE
common/build-style/python3-pep517.sh: unpack wheels for testing

### DIFF
--- a/srcpkgs/fava/template
+++ b/srcpkgs/fava/template
@@ -3,7 +3,6 @@ pkgname=fava
 version=1.23.1
 revision=1
 build_style=python3-pep517
-make_check_args="--deselect tests/test_cli.py::test_cli"
 hostmakedepends="python3-setuptools_scm python3-wheel"
 depends="python3-Babel python3-Cheroot python3-Flask-Babel python3-Flask
  python3-Jinja2 beancount python3-click python3-markdown2 python3-ply

--- a/srcpkgs/hatch/template
+++ b/srcpkgs/hatch/template
@@ -5,10 +5,8 @@ revision=2
 build_style=python3-pep517
 # ignore backend tests, because updating hatchling when there is no new hatch
 # version yet breaks these in hatch.
-make_check_args="--deselect tests/cli/test_root.py::TestFreshInstallation::test_config_file_creation_verbose
- --deselect tests/cli/run/test_run.py::test_scripts_no_environment
- --ignore tests/backend
- --ignore backend/tests"
+make_check_args="--ignore tests/backend
+ --deselect tests/cli/run/test_run.py::test_scripts_no_environment"
 _deps="python3-click hatchling python3-httpx python3-hyperlink python3-keyring
  python3-packaging python3-pexpect python3-platformdirs python3-pyperclip
  python3-rich python3-shellingham python3-tomli-w python3-tomlkit

--- a/srcpkgs/python3-adblock/template
+++ b/srcpkgs/python3-adblock/template
@@ -33,11 +33,6 @@ do_build() {
 	mv adblock-${version}-*.whl dist/adblock-${version}-py3-none-any.whl
 }
 
-pre_check() {
-	# Tests require the compiled extension
-	cp target/${RUST_TARGET}/release/libadblock.so adblock/adblock.so
-}
-
 post_install() {
 	vlicense LICENSE-MIT
 	chmod 755 ${DESTDIR}/${py3_sitelib}/adblock/*.so

--- a/srcpkgs/python3-bcrypt/template
+++ b/srcpkgs/python3-bcrypt/template
@@ -14,7 +14,3 @@ homepage="https://github.com/pyca/bcrypt"
 changelog="https://github.com/pyca/bcrypt/blob/main/README.rst#changelog"
 distfiles="${PYPI_SITE}/b/bcrypt/bcrypt-${version}.tar.gz"
 checksum=433c410c2177057705da2a9f2cd01dd157493b2a7ac14c8593a16b3dab6b6bfb
-
-do_check() {
-	PYTHONPATH="$(cd build/lib* && pwd)" pytest
-}

--- a/srcpkgs/python3-jsonschema/template
+++ b/srcpkgs/python3-jsonschema/template
@@ -3,6 +3,7 @@ pkgname=python3-jsonschema
 version=4.17.3
 revision=1
 build_style=python3-pep517
+make_check_args="--deselect jsonschema/tests/test_jsonschema_test_suite.py::test_suite_bug"
 hostmakedepends="hatchling hatch-vcs"
 depends="python3-attrs python3-pyrsistent"
 checkdepends="${depends} python3-pytest python3-pip"
@@ -13,16 +14,6 @@ homepage="https://github.com/Julian/jsonschema"
 changelog="https://raw.githubusercontent.com/Julian/jsonschema/master/CHANGELOG.rst"
 distfiles="${PYPI_SITE}/j/jsonschema/jsonschema-${version}.tar.gz"
 checksum=0f864437ab8b6076ba6707453ef8f98a6a0d512a80e93f8abdb676f737ecb60d
-
-do_check() {
-	rm -rf *.dist-info tmp # remove artifacts from previous unsuccessful check run
-	mkdir tmp
-	bsdtar xf dist/jsonschema-$version-py3-none-any.whl -C tmp
-	rm tmp/jsonschema/tests -rf
-	mv tmp/*.dist-info .
-	PYTHONPATH=. pytest --deselect jsonschema/tests/test_jsonschema_test_suite.py::test_suite_bug
-	rm -rf *.dist-info tmp
-}
 
 pre_build() {
 	export SETUPTOOLS_SCM_PRETEND_VERSION="${version}"

--- a/srcpkgs/python3-pytest-httpserver/template
+++ b/srcpkgs/python3-pytest-httpserver/template
@@ -14,14 +14,6 @@ changelog="https://raw.githubusercontent.com/csernazs/pytest-httpserver/master/C
 distfiles="https://github.com/csernazs/pytest-httpserver/archive/refs/tags/${version}.tar.gz"
 checksum=932843df9fa584e6a664b2e7a21dec4ddf9507c235a78853f21e00b111352395
 
-do_check() {
-	rm -rf tmp # remove artifacts from previous unsuccessful check run
-	mkdir tmp
-	bsdtar xf dist/pytest_httpserver-$version-py3-none-any.whl -C tmp
-	PYTHONPATH=tmp pytest tests
-	rm -rf tmp
-}
-
 post_install() {
 	vlicense LICENSE
 }

--- a/srcpkgs/python3-pytest-isort/template
+++ b/srcpkgs/python3-pytest-isort/template
@@ -11,10 +11,8 @@ maintainer="Jan Christian Grünhage <jan.christian@gruenhage.xyz>"
 license="MIT"
 homepage="https://github.com/stephrdev/pytest-isort"
 changelog="https://github.com/stephrdev/pytest-isort/raw/master/CHANGELOG.rst"
-distfiles="${PYPI_SITE}/p/pytest_isort/pytest_isort-${version}.tar.gz"
-checksum=067801dc5e54a474330d074d521c815948ff6d5cf0ed3b9d057b78216851186c
-# cba for now
-make_check=no
+distfiles="https://github.com/stephrdev/pytest-isort/archive/refs/tags/${version}.tar.gz"
+checksum=c6994dd442e2fe50f2667d6fa6e14a5800192966b628cc31107c8f96c36a514b
 
 post_install() {
 	vlicense LICENSE.rst

--- a/srcpkgs/python3-quart/template
+++ b/srcpkgs/python3-quart/template
@@ -7,7 +7,7 @@ make_install_target="dist/quart-${version}-*-*-*.whl"
 hostmakedepends="python3-poetry-core"
 depends="python3-aiofiles python3-hypercorn python3-click python3-MarkupSafe
  python3-blinker python3-itsdangerous python3-Jinja2 python3-Werkzeug"
-checkdepends="python3-pytest-asyncio python3-hypothesis python3-mock python3-dotenv unzip $depends"
+checkdepends="python3-pytest-asyncio python3-hypothesis python3-mock python3-dotenv $depends"
 short_desc="Python asyncio ASGI web framework with Flask API"
 maintainer="Andrew J. Hesford <ajh@sideband.org>"
 license="MIT"
@@ -16,14 +16,8 @@ changelog="https://raw.githubusercontent.com/pallets/quart/main/CHANGES.rst"
 distfiles="https://github.com/pallets/quart/archive/refs/tags/${version}.tar.gz"
 checksum=68ce4e6f786d5bf4a6056569e07e7055e1dfbb7136a531a18087345d8ba34c5c
 
-do_check() {
-	# Tests require dist-info on the package, which is only in the wheel.
-	# Pip can install the wheel in the build tree, but unzip is less evil.
-	mkdir -p test
-	unzip ${make_install_target} -d test
-
+pre_check() {
 	vsed -e '/addopts/d' -i pyproject.toml
-	PYTHONPATH=test python3 -m pytest
 }
 
 post_install() {


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

Python packages built with pep517 system occasionally require accessing distinfo files and/or entry points provided by the package for tests to run. Since these assets are packed inside the wheel generated in `do_build`, the target wheel is unpacked in `do_check` first so that the said artifacts are accessible during test runs.

Initially I unpacked the wheel during `do_build` with the `do_install` only copying the unarchived files (similar to the zig build style). That required patching pep517 templates with explicit `do_build` but no explicit `do_install`. There were only four such cases and it worked fine for me locally but maybe that was too big of a change so submitting this version for now instead.

The later commits are for demonstration purpose and not intended for merging. Those templates (and hopefully all others) still work fine as is.