### PR TITLE
[RFC] common/environment/setup/install.sh: always add log service

### DIFF
--- a/Manual.md
+++ b/Manual.md
@@ -304,7 +304,7 @@ The following functions are defined by `xbps-src` and can be used on any templat
 	`$DESTDIR`. The optional 2nd argument can be used to change the
 	`file name`. See [license](#var_license) for when to use it.
 
-- *vsv()* `vsv <service>`
+- *vsv()* `vsv <service> [<facility>]`
 
 	Installs `service` from `${FILESDIR}` to /etc/sv. The service must
 	be a directory containing at least a run script. Note the `supervise`
@@ -312,6 +312,11 @@ The following functions are defined by `xbps-src` and can be used on any templat
 	is automatically made executable by this function.
 	For further information on how to create a new service directory see
 	[The corresponding section the FAQ](http://smarden.org/runit/faq.html#create).
+	A `log` sub-service will be automatically created if one does not exist in
+	`${FILESDIR}/$service`, containing `exec vlogger -t $service -p $facility`.
+	if a second argument is not specified, the `daemon` facility is used.
+	For more information about `vlogger` and available values for the facility,
+	see [vlogger(1)](https://man.voidlinux.org/vlogger.1).
 
 - *vsed()* `vsed -i <file> -e <regex>`
 

--- a/common/environment/setup/install.sh
+++ b/common/environment/setup/install.sh
@@ -19,11 +19,12 @@ done
 
 _vsv() {
 	local service="$1"
+	local facility="${2:-daemon}"
 	local LN_OPTS="-s"
 	local svdir="${PKGDESTDIR}/etc/sv/${service}"
 
-	if [ $# -lt 1 ]; then
-		msg_red "$pkgver: vsv: 1 argument expected: <service>\n"
+	if [ $# -lt 1 ] || [ $# -gt 2 ]; then
+		msg_red "$pkgver: vsv: up to 2 arguments expected: <service> [<log facility>]\n"
 		return 1
 	fi
 
@@ -34,17 +35,25 @@ _vsv() {
 	vmkdir etc/sv
 	vcopy "${FILESDIR}/$service" etc/sv
 	if [ ! -L $svdir/run ]; then
+		grep -Fq 'exec 2>&1' $svdir/run || msg_warn "$pkgver: vsv: service '$service' does not contain 'exec 2>&1' to log stderr\n"
 		chmod 755 $svdir/run
 	fi
 	if [ -e $svdir/finish ] && [ ! -L $svdir/finish ]; then
 		chmod 755 $svdir/finish
 	fi
 	ln ${LN_OPTS} /run/runit/supervise.${service} $svdir/supervise
-	if [ -d $svdir/log ]; then
-		ln ${LN_OPTS} /run/runit/supervise.${service}-log $svdir/log/supervise
-		if [ -e $svdir/log/run ] && [ ! -L $svdir/log/run ]; then
-			chmod 755 ${PKGDESTDIR}/etc/sv/${service}/log/run
-		fi
+	if [ -d $svdir/log ] || [ -L $svdir/log ]; then
+		msg_warn "$pkgver: vsv: overriding default log service\n"
+	else
+		mkdir $svdir/log
+		cat <<-EOF > $svdir/log/run
+		#!/bin/sh
+		exec vlogger -t $service -p $facility
+		EOF
+	fi
+	ln ${LN_OPTS} /run/runit/supervise.${service}-log $svdir/log/supervise
+	if [ -e $svdir/log/run ] && [ ! -L $svdir/log/run ]; then
+		chmod 755 ${PKGDESTDIR}/etc/sv/${service}/log/run
 	fi
 }
 

--- a/srcpkgs/3proxy/files/3proxy/run
+++ b/srcpkgs/3proxy/files/3proxy/run
@@ -1,2 +1,3 @@
 #!/bin/sh
+exec 2>&1
 exec 3proxy /etc/3proxy/3proxy.cfg

--- a/srcpkgs/Clightd/files/Clightd/log/run
+++ b/srcpkgs/Clightd/files/Clightd/log/run
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-exec /usr/bin/vlogger -t Clightd

--- a/srcpkgs/Clightd/files/Clightd/run
+++ b/srcpkgs/Clightd/files/Clightd/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 
 sv check dbus >/dev/null || exit 1
 exec /usr/libexec/clightd 2>&1

--- a/srcpkgs/EternalTerminal/files/etserver/run
+++ b/srcpkgs/EternalTerminal/files/etserver/run
@@ -1,2 +1,3 @@
 #!/bin/sh
+exec 2>&1
 exec chpst -u _eternal etserver

--- a/srcpkgs/FreeRADIUS/files/FreeRADIUS/run
+++ b/srcpkgs/FreeRADIUS/files/FreeRADIUS/run
@@ -1,2 +1,3 @@
 #!/bin/sh
+exec 2>&1
 exec chpst -u _freeradius:_freeradius radiusd -f

--- a/srcpkgs/GCP-Guest-Environment/files/GCP-Guest-Initialization/run
+++ b/srcpkgs/GCP-Guest-Environment/files/GCP-Guest-Initialization/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 
 # The Google services assert that the init is performing some
 # sequencing.  Since runit provides no such facility, we will block

--- a/srcpkgs/GCP-Guest-Environment/files/GCP-accounts/run
+++ b/srcpkgs/GCP-Guest-Environment/files/GCP-accounts/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 
 sv check GCP-Guest-Initialization >/dev/null || exit 1
 

--- a/srcpkgs/GCP-Guest-Environment/files/GCP-clock-skew/run
+++ b/srcpkgs/GCP-Guest-Environment/files/GCP-clock-skew/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 
 sv check GCP-Guest-Initialization >/dev/null || exit 1
 

--- a/srcpkgs/GCP-Guest-Environment/files/GCP-ip-forwarding/run
+++ b/srcpkgs/GCP-Guest-Environment/files/GCP-ip-forwarding/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 
 sv check GCP-Guest-Initialization >/dev/null || exit 1
 

--- a/srcpkgs/Gokapi/files/gokapi/log/run
+++ b/srcpkgs/Gokapi/files/gokapi/log/run
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-exec logger -t gokapi -p daemon.info

--- a/srcpkgs/Gokapi/files/gokapi/run
+++ b/srcpkgs/Gokapi/files/gokapi/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 
 [ -r ./conf ] && . ./conf
 

--- a/srcpkgs/NetAuth-ldap/files/netauth-ldap/log/run
+++ b/srcpkgs/NetAuth-ldap/files/netauth-ldap/log/run
@@ -1,4 +1,0 @@
-#!/bin/sh
-
-exec 2>&1
-exec vlogger -t netauth-ldap

--- a/srcpkgs/NetAuth-ldap/files/netauth-ldap/run
+++ b/srcpkgs/NetAuth-ldap/files/netauth-ldap/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 
 [ -r ./conf ] && . ./conf
 

--- a/srcpkgs/NetAuth/files/netauthd/log/run
+++ b/srcpkgs/NetAuth/files/netauthd/log/run
@@ -1,4 +1,0 @@
-#!/bin/sh
-
-exec 2>&1
-exec vlogger -t netauthd

--- a/srcpkgs/NetAuth/files/netauthd/run
+++ b/srcpkgs/NetAuth/files/netauthd/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 
 [ -r ./conf ] && . ./conf
 

--- a/srcpkgs/NetworkManager/files/NetworkManager/run
+++ b/srcpkgs/NetworkManager/files/NetworkManager/run
@@ -1,3 +1,4 @@
 #!/bin/sh
+exec 2>&1
 sv check dbus >/dev/null || exit 1
 exec NetworkManager -n > /dev/null 2>&1

--- a/srcpkgs/PopCorn/files/popcorn/log/run
+++ b/srcpkgs/PopCorn/files/popcorn/log/run
@@ -1,2 +1,0 @@
-#!/bin/sh
-exec vlogger -t popcorn

--- a/srcpkgs/PopCorn/files/pqueryd/run
+++ b/srcpkgs/PopCorn/files/pqueryd/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 
 [ -r ./conf ] && . ./conf
 

--- a/srcpkgs/PopCorn/files/statrepo/run
+++ b/srcpkgs/PopCorn/files/statrepo/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 
 [ -r ./conf ] && . ./conf
 

--- a/srcpkgs/Swapspace/files/swapspace/run
+++ b/srcpkgs/Swapspace/files/swapspace/run
@@ -1,2 +1,3 @@
 #!/bin/sh
+exec 2>&1
 exec swapspace

--- a/srcpkgs/TerraState/files/terrastate/log/run
+++ b/srcpkgs/TerraState/files/terrastate/log/run
@@ -1,4 +1,0 @@
-#!/bin/sh
-
-exec 2>&1
-exec vlogger -t terrastate

--- a/srcpkgs/acpid/files/acpid/run
+++ b/srcpkgs/acpid/files/acpid/run
@@ -1,3 +1,4 @@
 #!/bin/sh
+exec 2>&1
 [ -r conf ] && . ./conf
 exec acpid -f ${OPTS:=-l}

--- a/srcpkgs/activityrelay/files/activityrelay/log/run
+++ b/srcpkgs/activityrelay/files/activityrelay/log/run
@@ -1,1 +1,0 @@
-/usr/bin/vlogger

--- a/srcpkgs/alertmanager/files/alertmanager/run
+++ b/srcpkgs/alertmanager/files/alertmanager/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 
 # Add $ARGS for more arguments
 [ -f ./conf ] && . ./conf

--- a/srcpkgs/alfred/files/alfred/run
+++ b/srcpkgs/alfred/files/alfred/run
@@ -1,3 +1,4 @@
 #!/bin/sh
+exec 2>&1
 [ -r conf ] && . ./conf
 exec alfred ${OPTS:=-i "bat0" -b "bat0"}

--- a/srcpkgs/alfred/files/batadv-vis/run
+++ b/srcpkgs/alfred/files/batadv-vis/run
@@ -1,3 +1,4 @@
 #!/bin/sh
+exec 2>&1
 [ -r conf ] && . ./conf
 exec batadv-vis ${OPTS:=-si bat0}

--- a/srcpkgs/alsa-utils/files/alsa/run
+++ b/srcpkgs/alsa-utils/files/alsa/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 set -e
 alsactl restore
 exec chpst -b alsa pause

--- a/srcpkgs/android-tools/files/adb/run
+++ b/srcpkgs/android-tools/files/adb/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 set -e
 [ -r conf ] && . ./conf
 adb ${OPTS:=start-server -P5037}

--- a/srcpkgs/anope/files/anope/run
+++ b/srcpkgs/anope/files/anope/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 exec anopeservices \
     --confdir=/etc/anope \
     --dbdir=/var/lib/anope \

--- a/srcpkgs/apache-kafka/files/apache-kafka-zookeeper/log/run
+++ b/srcpkgs/apache-kafka/files/apache-kafka-zookeeper/log/run
@@ -1,2 +1,0 @@
-#!/bin/sh
-exec logger -t apache-kafka-zookeeper -p 'daemon.info'

--- a/srcpkgs/apache-kafka/files/apache-kafka-zookeeper/run
+++ b/srcpkgs/apache-kafka/files/apache-kafka-zookeeper/run
@@ -1,3 +1,4 @@
 #!/bin/sh
+exec 2>&1
 [ -r ./conf ] && . ./conf
 exec /usr/lib/kafka/bin/zookeeper-server-start.sh ${PROPERTIES_FILE:-/usr/lib/kafka/config/zookeeper.properties}

--- a/srcpkgs/apache-kafka/files/apache-kafka/log/run
+++ b/srcpkgs/apache-kafka/files/apache-kafka/log/run
@@ -1,2 +1,0 @@
-#!/bin/sh
-exec logger -t apache-kafka -p 'daemon.info'

--- a/srcpkgs/apache-kafka/files/apache-kafka/run
+++ b/srcpkgs/apache-kafka/files/apache-kafka/run
@@ -1,3 +1,4 @@
 #!/bin/sh
+exec 2>&1
 [ -r ./conf ] && . ./conf
 exec /usr/lib/kafka/bin/kafka-server-start.sh ${PROPERTIES_FILE:-/usr/lib/kafka/config/server.properties}

--- a/srcpkgs/apache-tomcat/files/apache-tomcat/run
+++ b/srcpkgs/apache-tomcat/files/apache-tomcat/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 
 
 export CATALINA_BASE=/usr/share/apache-tomcat

--- a/srcpkgs/apache/files/apache/run
+++ b/srcpkgs/apache/files/apache/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 
 set -e
 

--- a/srcpkgs/apcupsd/files/apcupsd/run
+++ b/srcpkgs/apcupsd/files/apcupsd/run
@@ -1,3 +1,4 @@
 #!/bin/sh
+exec 2>&1
 [ -r conf] && . ./conf
 exec apcupsd -b ${OPTS}

--- a/srcpkgs/ardor/files/ardor-tor/run
+++ b/srcpkgs/ardor/files/ardor-tor/run
@@ -1,2 +1,3 @@
 #!/bin/sh
+exec 2>&1
 exec ardor-tor > /dev/null

--- a/srcpkgs/ardor/files/ardor/run
+++ b/srcpkgs/ardor/files/ardor/run
@@ -1,2 +1,3 @@
 #!/bin/sh
+exec 2>&1
 exec ardor > /dev/null

--- a/srcpkgs/armagetronad/files/armagetronad-dedicated/run
+++ b/srcpkgs/armagetronad/files/armagetronad-dedicated/run
@@ -1,2 +1,3 @@
 #!/bin/sh
+exec 2>&1
 exec armagetronad-dedicated

--- a/srcpkgs/asus-kbd-backlight/files/asus-kbd/run
+++ b/srcpkgs/asus-kbd-backlight/files/asus-kbd/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 
 asus-kbd-backlight allowusers
 

--- a/srcpkgs/at/files/at/run
+++ b/srcpkgs/at/files/at/run
@@ -1,2 +1,3 @@
 #!/bin/sh
+exec 2>&1
 exec atd -f

--- a/srcpkgs/atop/files/atop/run
+++ b/srcpkgs/atop/files/atop/run
@@ -1,2 +1,3 @@
 #!/bin/sh
+exec 2>&1
 exec atop -a -w /var/log/atop/atop_$(date +%Y%m%d) 600

--- a/srcpkgs/audit/files/auditctl/run
+++ b/srcpkgs/audit/files/auditctl/run
@@ -1,4 +1,5 @@
 #!/bin/sh -e
+exec 2>&1
 
 test ! -r ./conf || . ./conf
 

--- a/srcpkgs/audit/files/auditd/run
+++ b/srcpkgs/audit/files/auditd/run
@@ -1,2 +1,3 @@
 #!/bin/sh
+exec 2>&1
 exec auditd -n

--- a/srcpkgs/autofs/files/autofs/log/run
+++ b/srcpkgs/autofs/files/autofs/log/run
@@ -1,2 +1,0 @@
-#!/bin/sh
-exec vlogger -p daemon.info -t autofs

--- a/srcpkgs/avahi/files/avahi-daemon/run
+++ b/srcpkgs/avahi/files/avahi-daemon/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 # if dbus is enabled wait for it.
 if [ -e /var/service/dbus ]; then
 	sv check dbus > /dev/null || exit 1

--- a/srcpkgs/bacula-common/files/bacula-dir/run
+++ b/srcpkgs/bacula-common/files/bacula-dir/run
@@ -1,3 +1,4 @@
 #!/bin/sh
+exec 2>&1
 [ ! -d /run/bacula ] && mkdir /run/bacula
 exec bacula-dir -f -c /etc/bacula/bacula-dir.conf

--- a/srcpkgs/bacula-common/files/bacula-fd/run
+++ b/srcpkgs/bacula-common/files/bacula-fd/run
@@ -1,3 +1,4 @@
 #!/bin/sh
+exec 2>&1
 [ ! -d /run/bacula ] && mkdir /run/bacula
 exec bacula-fd -f -c /etc/bacula/bacula-fd.conf

--- a/srcpkgs/bacula-common/files/bacula-sd/run
+++ b/srcpkgs/bacula-common/files/bacula-sd/run
@@ -1,3 +1,4 @@
 #!/bin/sh
+exec 2>&1
 [ ! -d /run/bacula ] && mkdir /run/bacula
 exec bacula-sd -f -c /etc/bacula/bacula-sd.conf

--- a/srcpkgs/barrier/files/barrierc/run
+++ b/srcpkgs/barrier/files/barrierc/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 [ -r ./conf ] && . ./conf
 [ -z $SERVER_ADDR ] && exit 0
 [ -z $SKIP_X11_TEST ] && ! ps -C Xorg >/dev/null 2>&1 && exit 0

--- a/srcpkgs/barrier/files/barriers/run
+++ b/srcpkgs/barrier/files/barriers/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 [ -r ./conf ] && . ./conf
 [ -z $SKIP_X11_TEST ] && ! ps -C Xorg >/dev/null 2>&1 && exit 0
 exec barriers --no-daemon ${OPTS:=--restart}

--- a/srcpkgs/beanstalkd/files/beanstalkd/log/run
+++ b/srcpkgs/beanstalkd/files/beanstalkd/log/run
@@ -1,2 +1,0 @@
-#!/bin/sh
-exec logger -t beanstalkd -p daemon.info

--- a/srcpkgs/beanstalkd/files/beanstalkd/run
+++ b/srcpkgs/beanstalkd/files/beanstalkd/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 # By default use persistent storage (binary log)
 [ -r conf ] && . ./conf
 exec chpst -u _beanstalkd:_beanstalkd beanstalkd ${OPTS:=-b /var/lib/beanstalkd} 2>&1

--- a/srcpkgs/beard/files/beard/run
+++ b/srcpkgs/beard/files/beard/run
@@ -1,3 +1,4 @@
 #!/bin/sh
+exec 2>&1
 [ -r ./conf ] && . ./conf
 exec beard -H ${BEARD_HIBERNATE:=/usr/bin/zzz} $OPTS

--- a/srcpkgs/bftpd/files/bftpd/run
+++ b/srcpkgs/bftpd/files/bftpd/run
@@ -1,2 +1,3 @@
 #!/bin/sh
+exec 2>&1
 exec bftpd -D 

--- a/srcpkgs/bind/files/named/log/run
+++ b/srcpkgs/bind/files/named/log/run
@@ -1,2 +1,0 @@
-#!/bin/sh
-exec vlogger -t named

--- a/srcpkgs/binfmt-support/files/binfmt-support/run
+++ b/srcpkgs/binfmt-support/files/binfmt-support/run
@@ -1,3 +1,4 @@
 #!/bin/sh
+exec 2>&1
 update-binfmts --enable
 exec chpst -b binfmt-support pause

--- a/srcpkgs/bird/files/bird/run
+++ b/srcpkgs/bird/files/bird/run
@@ -1,2 +1,3 @@
 #!/bin/sh
+exec 2>&1
 exec bird -f -u _bird -g _bird ${OPTS:=-c /etc/bird.conf}

--- a/srcpkgs/bird_exporter/files/bird_exporter/run
+++ b/srcpkgs/bird_exporter/files/bird_exporter/run
@@ -1,3 +1,4 @@
 #!/bin/sh
+exec 2>&1
 [ -r conf ] && . ./conf
 exec bird_exporter ${OPTS:=-bird.v2 -format.new}

--- a/srcpkgs/bitlbee/files/bitlbee/run
+++ b/srcpkgs/bitlbee/files/bitlbee/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 set -e
 install -d -m0755 -o bitlbee -g bitlbee /run/bitlbee
 [ -r conf ] && . ./conf

--- a/srcpkgs/blackbox_exporter/files/blackbox_exporter/run
+++ b/srcpkgs/blackbox_exporter/files/blackbox_exporter/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 
 # Add $ARGS for more arguments to blackbox_exporter
 # $CONF_FILE is the location of the configuration file.

--- a/srcpkgs/bluez-alsa/files/bluez-alsa/run
+++ b/srcpkgs/bluez-alsa/files/bluez-alsa/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 [ -r ./conf ] && . ./conf
 
 install -d -m0755 -o _bluez_alsa -g audio /run/bluealsa

--- a/srcpkgs/bluez/files/bluetooth-meshd/log/run
+++ b/srcpkgs/bluez/files/bluetooth-meshd/log/run
@@ -1,1 +1,0 @@
-/usr/bin/vlogger

--- a/srcpkgs/bluez/files/bluetoothd/log/run
+++ b/srcpkgs/bluez/files/bluetoothd/log/run
@@ -1,1 +1,0 @@
-/usr/bin/vlogger

--- a/srcpkgs/boinc/files/boinc/log/run
+++ b/srcpkgs/boinc/files/boinc/log/run
@@ -1,1 +1,0 @@
-/usr/bin/vlogger

--- a/srcpkgs/bolt/files/boltd/run
+++ b/srcpkgs/bolt/files/boltd/run
@@ -1,3 +1,4 @@
 #!/bin/sh
+exec 2>&1
 sv check dbus >/dev/null || exit 1
 exec /usr/libexec/boltd > /dev/null 2>&1

--- a/srcpkgs/brltty/files/brltty/run
+++ b/srcpkgs/brltty/files/brltty/run
@@ -1,3 +1,4 @@
 #!/bin/sh
+exec 2>&1
 mkdir -p /var/run/brltty || exit 1
 exec brltty -n

--- a/srcpkgs/bumblebee/files/bumblebeed/run
+++ b/srcpkgs/bumblebee/files/bumblebeed/run
@@ -1,2 +1,3 @@
 #!/bin/sh
+exec 2>&1
 exec bumblebeed --use-syslog

--- a/srcpkgs/burp2-server/files/burp2-server/run
+++ b/srcpkgs/burp2-server/files/burp2-server/run
@@ -1,2 +1,3 @@
 #!/bin/sh
+exec 2>&1
 exec burp -F -c /etc/burp/burp-server.conf

--- a/srcpkgs/busybox/files/busybox-klogd/run
+++ b/srcpkgs/busybox/files/busybox-klogd/run
@@ -1,2 +1,3 @@
 #!/bin/sh
+exec 2>&1
 exec busybox klogd -n

--- a/srcpkgs/busybox/files/busybox-ntpd/log/run
+++ b/srcpkgs/busybox/files/busybox-ntpd/log/run
@@ -1,2 +1,0 @@
-#!/bin/sh
-exec logger -t busybox-ntpd

--- a/srcpkgs/busybox/files/busybox-ntpd/run
+++ b/srcpkgs/busybox/files/busybox-ntpd/run
@@ -1,2 +1,3 @@
 #!/bin/sh
+exec 2>&1
 exec busybox ntpd -nN -p pool.ntp.org

--- a/srcpkgs/busybox/files/busybox-syslogd/run
+++ b/srcpkgs/busybox/files/busybox-syslogd/run
@@ -1,2 +1,3 @@
 #!/bin/sh
+exec 2>&1
 exec busybox syslogd -n

--- a/srcpkgs/cachefilesd/files/cachefilesd/run
+++ b/srcpkgs/cachefilesd/files/cachefilesd/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 [ -r conf ] && . ./conf
 modprobe cachefiles || exit 1
 exec cachefilesd -n ${OPTS:= -f /etc/cachefilesd.conf}

--- a/srcpkgs/caddy/files/caddy/log/run
+++ b/srcpkgs/caddy/files/caddy/log/run
@@ -1,1 +1,0 @@
-/usr/bin/vlogger

--- a/srcpkgs/caddy/files/caddy/run
+++ b/srcpkgs/caddy/files/caddy/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 
 [ -r ./conf ] && . ./conf
 

--- a/srcpkgs/canto-next/files/canto-daemon/run
+++ b/srcpkgs/canto-next/files/canto-daemon/run
@@ -1,2 +1,3 @@
 #!/bin/sh
+exec 2>&1
 exec canto-daemon

--- a/srcpkgs/chronograf/files/chronograf/run
+++ b/srcpkgs/chronograf/files/chronograf/run
@@ -1,3 +1,4 @@
 #!/bin/sh
+exec 2>&1
 
 exec chpst -u _chronograf:_chronograf chronograf --bolt-path=/var/lib/chronograf/chronograf-v1.db --canned-path=/usr/share/chronograf/canned

--- a/srcpkgs/chrony/files/chronyd/run
+++ b/srcpkgs/chrony/files/chronyd/run
@@ -1,3 +1,4 @@
 #!/bin/sh
+exec 2>&1
 install -d -m750 -o chrony -g chrony /var/run/chrony
 exec chronyd -n -u chrony

--- a/srcpkgs/ckb-next/files/ckb-next-daemon/log/run
+++ b/srcpkgs/ckb-next/files/ckb-next-daemon/log/run
@@ -1,2 +1,0 @@
-#!/bin/sh
-exec logger -t ckb-next-daemon -p daemon.notice

--- a/srcpkgs/ckb-next/files/ckb-next-daemon/run
+++ b/srcpkgs/ckb-next/files/ckb-next-daemon/run
@@ -1,2 +1,3 @@
 #!/bin/sh
+exec 2>&1
 exec /usr/bin/ckb-next-daemon 2>&1

--- a/srcpkgs/cntlm/files/cntlm/run
+++ b/srcpkgs/cntlm/files/cntlm/run
@@ -1,2 +1,3 @@
 #!/bin/sh
+exec 2>&1
 exec cntlm -f 2>&1

--- a/srcpkgs/collectd/files/collectd/run
+++ b/srcpkgs/collectd/files/collectd/run
@@ -1,2 +1,3 @@
 #!/bin/sh
+exec 2>&1
 exec collectd -f

--- a/srcpkgs/colord/files/colord/run
+++ b/srcpkgs/colord/files/colord/run
@@ -1,2 +1,3 @@
 #!/bin/sh
+exec 2>&1
 exec chpst -u colord /usr/libexec/colord 2>&1

--- a/srcpkgs/conduit/files/conduit/log/run
+++ b/srcpkgs/conduit/files/conduit/log/run
@@ -1,1 +1,0 @@
-/usr/bin/vlogger

--- a/srcpkgs/conduit/files/conduit/run
+++ b/srcpkgs/conduit/files/conduit/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 [ -r ./conf ] && . ./conf
 ulimit -n ${MAX_OPEN_FILES:-8192}
 export CONDUIT_CONFIG=${CONDUIT_CONFIG:-/etc/conduit/conduit.toml}

--- a/srcpkgs/connman/files/connmand/run
+++ b/srcpkgs/connman/files/connmand/run
@@ -1,3 +1,4 @@
 #!/bin/sh
+exec 2>&1
 [ -r conf ] && . ./conf
 exec connmand -n ${OPTS}

--- a/srcpkgs/containerd/files/containerd/run
+++ b/srcpkgs/containerd/files/containerd/run
@@ -1,3 +1,4 @@
 #!/bin/sh
+exec 2>&1
 env modeprobe overlay
 exec containerd

--- a/srcpkgs/coredns/files/coredns/log/run
+++ b/srcpkgs/coredns/files/coredns/log/run
@@ -1,3 +1,0 @@
-#!/bin/sh
-exec 2>&1
-exec vlogger -t coredns

--- a/srcpkgs/coturn/files/coturnserver/log/run
+++ b/srcpkgs/coturn/files/coturnserver/log/run
@@ -1,1 +1,0 @@
-/usr/bin/vlogger

--- a/srcpkgs/coturn/files/coturnserver/run
+++ b/srcpkgs/coturn/files/coturnserver/run
@@ -1,2 +1,3 @@
 #!/bin/sh
+exec 2>&1
 exec chpst -u _coturn:_coturn turnserver -c /etc/turnserver.conf

--- a/srcpkgs/criu/files/criu/run
+++ b/srcpkgs/criu/files/criu/run
@@ -1,3 +1,4 @@
 #!/bin/sh
+exec 2>&1
 [ -r conf ] && . ./conf
 exec criu service ${OPTS:=-o /var/log/criu-service.log}

--- a/srcpkgs/cronie/files/cronie/log/run
+++ b/srcpkgs/cronie/files/cronie/log/run
@@ -1,2 +1,0 @@
-#!/bin/sh
-exec vlogger -p cron.notice

--- a/srcpkgs/cronie/files/cronie/run
+++ b/srcpkgs/cronie/files/cronie/run
@@ -1,3 +1,4 @@
 #!/bin/sh
+exec 2>&1
 [ -r conf ] && . ./conf
 exec cronie-crond -n $OPTS 2>&1

--- a/srcpkgs/cronie/template
+++ b/srcpkgs/cronie/template
@@ -44,7 +44,7 @@ pre_configure() {
 }
 
 post_install() {
-	vsv cronie
+	vsv cronie cron
 	vinstall ${FILESDIR}/crond.pam 644 etc/pam.d crond
 
 	# Add /etc/cron.deny empty, to allow all users.

--- a/srcpkgs/cups-filters/files/cups-browsed/run
+++ b/srcpkgs/cups-filters/files/cups-browsed/run
@@ -1,2 +1,3 @@
 #!/bin/sh
+exec 2>&1
 exec cups-browsed

--- a/srcpkgs/cups/files/cupsd/run
+++ b/srcpkgs/cups/files/cupsd/run
@@ -1,2 +1,3 @@
 #!/bin/sh
+exec 2>&1
 exec cupsd -f

--- a/srcpkgs/darkhttpd/files/darkhttpd/run
+++ b/srcpkgs/darkhttpd/files/darkhttpd/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 [ -r conf ] && . ./conf
 : ${WWWDIR:=/srv/www/darkhttpd}
 exec darkhttpd "${WWWDIR}" --chroot --uid _darkhttpd --gid _darkhttpd $OPTS 2>&1 >>/var/log/darkhttpd/darkhttpd.log

--- a/srcpkgs/dbus-elogind/files/dbus/run
+++ b/srcpkgs/dbus-elogind/files/dbus/run
@@ -1,3 +1,4 @@
 #!/bin/sh
+exec 2>&1
 [ ! -d /run/dbus ] && install -m755 -g 22 -o 22 -d /run/dbus
 exec dbus-daemon --system --nofork --nopidfile

--- a/srcpkgs/dbus/files/dbus/run
+++ b/srcpkgs/dbus/files/dbus/run
@@ -1,3 +1,4 @@
 #!/bin/sh
+exec 2>&1
 [ ! -d /run/dbus ] && install -m755 -g 22 -o 22 -d /run/dbus
 exec dbus-daemon --system --nofork --nopidfile

--- a/srcpkgs/dcron/files/dcron/log/run
+++ b/srcpkgs/dcron/files/dcron/log/run
@@ -1,2 +1,0 @@
-#!/bin/sh
-exec logger -p cron.notice

--- a/srcpkgs/dcron/files/dcron/run
+++ b/srcpkgs/dcron/files/dcron/run
@@ -1,3 +1,4 @@
 #!/bin/sh
+exec 2>&1
 [ -r conf ] && . ./conf
 exec dcrond -f $OPTS 2>&1

--- a/srcpkgs/dcron/template
+++ b/srcpkgs/dcron/template
@@ -47,7 +47,7 @@ do_install() {
 	# crontab must be setuid for all users to work!
 	chmod 4755 ${DESTDIR}/usr/bin/crontab
 
-	vsv dcron
+	vsv dcron cron
 
 	# Fix conflicts with other packages
 	mv ${DESTDIR}/usr/bin/crond ${DESTDIR}/usr/bin/dcrond

--- a/srcpkgs/ddclient/files/ddclient/run
+++ b/srcpkgs/ddclient/files/ddclient/run
@@ -1,2 +1,3 @@
 #!/bin/sh
+exec 2>&1
 exec ddclient -foreground

--- a/srcpkgs/deluge/files/deluge-web/run
+++ b/srcpkgs/deluge/files/deluge-web/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 sv check deluged >/dev/null || exit 1
 HOME=/var/lib/deluge
 exec chpst -u deluge:deluge deluge-web -d 2>&1

--- a/srcpkgs/deluge/files/deluged/run
+++ b/srcpkgs/deluge/files/deluged/run
@@ -1,3 +1,4 @@
 #!/bin/sh
+exec 2>&1
 [ -r ./conf ] && . ./conf
 exec deluged -d -U deluge -g deluge -c /var/lib/deluge/.config/deluge ${OPTS} 2>&1

--- a/srcpkgs/dendrite/files/dendrite-monolith-server/log/run
+++ b/srcpkgs/dendrite/files/dendrite-monolith-server/log/run
@@ -1,1 +1,0 @@
-/usr/bin/vlogger

--- a/srcpkgs/dhcp/files/dhclient/log/run
+++ b/srcpkgs/dhcp/files/dhclient/log/run
@@ -1,1 +1,0 @@
-/usr/bin/vlogger

--- a/srcpkgs/dhcp/files/dhcpd4/log/run
+++ b/srcpkgs/dhcp/files/dhcpd4/log/run
@@ -1,1 +1,0 @@
-/usr/bin/vlogger

--- a/srcpkgs/dhcp/files/dhcpd6/log/run
+++ b/srcpkgs/dhcp/files/dhcpd6/log/run
@@ -1,1 +1,0 @@
-/usr/bin/vlogger

--- a/srcpkgs/dhcpcd/files/dhcpcd-eth0/run
+++ b/srcpkgs/dhcpcd/files/dhcpcd-eth0/run
@@ -1,3 +1,4 @@
 #!/bin/sh
+exec 2>&1
 [ -r conf ] && . ./conf
 exec dhcpcd -B eth0 $OPTS 1>&2

--- a/srcpkgs/dhcpcd/files/dhcpcd/run
+++ b/srcpkgs/dhcpcd/files/dhcpcd/run
@@ -1,3 +1,4 @@
 #!/bin/sh
+exec 2>&1
 [ -r conf ] && . ./conf
 exec dhcpcd -B ${OPTS:=-M} 1>&2

--- a/srcpkgs/dictd/files/dictd/run
+++ b/srcpkgs/dictd/files/dictd/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 [ -r conf ] && . ./conf
 exec 2>/dev/null
 exec chpst -u dictd:dictd dictd --debug nodetach ${OPTS:=--locale en_US.UTF-8 -s}

--- a/srcpkgs/diod/files/diod/run
+++ b/srcpkgs/diod/files/diod/run
@@ -1,3 +1,4 @@
 #!/bin/sh
+exec 2>&1
 
 exec diod -f 2>&1

--- a/srcpkgs/distcc/files/distccd/run
+++ b/srcpkgs/distcc/files/distccd/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 PROG="distccd"
 USER="nobody"
 OPTIONS="--no-detach"

--- a/srcpkgs/dkimproxy/files/dkimproxy_in/log/run
+++ b/srcpkgs/dkimproxy/files/dkimproxy_in/log/run
@@ -1,2 +1,0 @@
-#!/bin/sh
-exec logger -t dkimproxy_in -p mail.info

--- a/srcpkgs/dkimproxy/files/dkimproxy_in/run
+++ b/srcpkgs/dkimproxy/files/dkimproxy_in/run
@@ -1,2 +1,3 @@
 #!/bin/sh
+exec 2>&1
 exec chpst -u _dkim:_dkim dkimproxy.in --conf_file=/etc/dkimproxy_in.conf 2>&1

--- a/srcpkgs/dkimproxy/files/dkimproxy_out/log/run
+++ b/srcpkgs/dkimproxy/files/dkimproxy_out/log/run
@@ -1,2 +1,0 @@
-#!/bin/sh
-exec logger -t dkimproxy_out -p mail.info

--- a/srcpkgs/dkimproxy/files/dkimproxy_out/run
+++ b/srcpkgs/dkimproxy/files/dkimproxy_out/run
@@ -1,2 +1,3 @@
 #!/bin/sh
+exec 2>&1
 exec chpst -u _dkim:_dkim dkimproxy.out --conf_file=/etc/dkimproxy_out.conf 2>&1

--- a/srcpkgs/dkimproxy/template
+++ b/srcpkgs/dkimproxy/template
@@ -20,6 +20,6 @@ post_install() {
 	vsconf ${DESTDIR}/etc/dkimproxy_out.conf.example
 	mv ${DESTDIR}/etc/dkimproxy_in.conf.example ${DESTDIR}/etc/dkimproxy_in.conf
 	mv ${DESTDIR}/etc/dkimproxy_out.conf.example ${DESTDIR}/etc/dkimproxy_out.conf
-	vsv dkimproxy_in
-	vsv dkimproxy_out
+	vsv dkimproxy_in mail
+	vsv dkimproxy_out mail
 }

--- a/srcpkgs/dnscrypt-proxy/files/dnscrypt-proxy/log/run
+++ b/srcpkgs/dnscrypt-proxy/files/dnscrypt-proxy/log/run
@@ -1,2 +1,0 @@
-#!/bin/sh
-exec chpst -u dnscrypt_proxy:dnscrypt_proxy svlogd -t /var/log/dnscrypt-proxy

--- a/srcpkgs/dnscrypt-proxy/template
+++ b/srcpkgs/dnscrypt-proxy/template
@@ -1,7 +1,7 @@
 # Template file for 'dnscrypt-proxy'
 pkgname=dnscrypt-proxy
 version=2.1.4
-revision=1
+revision=2
 build_style=go
 go_import_path=github.com/dnscrypt/dnscrypt-proxy
 go_package="${go_import_path}/dnscrypt-proxy"

--- a/srcpkgs/dnsdist/files/dnsdist/run
+++ b/srcpkgs/dnsdist/files/dnsdist/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 [ -f ./conf ] && . ./conf
 MAX_OPEN_FILES=${MAX_OPEN_FILES:-2048}
 exec chpst -o $MAX_OPEN_FILES dnsdist --uid _dnsdist --gid _dnsdist --supervised --disable-syslog

--- a/srcpkgs/dnsmasq/files/dnsmasq/run
+++ b/srcpkgs/dnsmasq/files/dnsmasq/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 mkdir -p /var/lib/misc
 [ -r ./conf ] && . ./conf
 exec dnsmasq -k ${OPTS:---enable-dbus -u dnsmasq -g dnsmasq} 2>&1

--- a/srcpkgs/dotool/files/dotoold/log/run
+++ b/srcpkgs/dotool/files/dotoold/log/run
@@ -1,2 +1,0 @@
-#!/bin/sh
-exec vlogger -p daemon.info -t dotoold

--- a/srcpkgs/dovecot/files/dovecot/run
+++ b/srcpkgs/dovecot/files/dovecot/run
@@ -1,3 +1,4 @@
 #!/bin/sh
+exec 2>&1
 install -d -m 0755 -o root -g root /var/run/dovecot
 exec dovecot -F

--- a/srcpkgs/dq/files/dqcache/log/run
+++ b/srcpkgs/dq/files/dqcache/log/run
@@ -1,2 +1,0 @@
-#!/bin/sh
-exec chpst -u _dqcache svlogd -t /var/log/dqcache

--- a/srcpkgs/dq/files/dqcache/run
+++ b/srcpkgs/dq/files/dqcache/run
@@ -1,3 +1,4 @@
 #!/bin/sh
+exec 2>&1
 [ -r ./conf ] && . ./conf
 exec chpst -U _dqcache -e /etc/dqcache/env dqcache 2>&1

--- a/srcpkgs/dq/template
+++ b/srcpkgs/dq/template
@@ -1,7 +1,7 @@
 # Template file for 'dq'
 pkgname=dq
 version=0.0.20230101
-revision=1
+revision=2
 build_style=gnu-makefile
 make_dirs="
  /etc/dqcache/env 0755 root root

--- a/srcpkgs/drbd-utils/files/drbd/run
+++ b/srcpkgs/drbd-utils/files/drbd/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 set -e
 /usr/libexec/drbd start
 exec chpst -b drbd pause

--- a/srcpkgs/dropbear/files/dropbear/run
+++ b/srcpkgs/dropbear/files/dropbear/run
@@ -1,3 +1,4 @@
 #!/bin/sh
+exec 2>&1
 [ -r conf ] && . ./conf
 exec dropbear ${OPTS:=-F -R}

--- a/srcpkgs/duiadns/files/duiadns/log/run
+++ b/srcpkgs/duiadns/files/duiadns/log/run
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-exec vlogger -t duiadns

--- a/srcpkgs/duiadns/files/duiadns/run
+++ b/srcpkgs/duiadns/files/duiadns/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 
 [ -f ./conf ] && . ./conf
 

--- a/srcpkgs/earlyoom/files/earlyoom/log/run
+++ b/srcpkgs/earlyoom/files/earlyoom/log/run
@@ -1,2 +1,0 @@
-#!/bin/sh
-exec logger -t earlyoom

--- a/srcpkgs/earlyoom/files/earlyoom/run
+++ b/srcpkgs/earlyoom/files/earlyoom/run
@@ -1,3 +1,4 @@
 #!/bin/sh
+exec 2>&1
 [ -r conf ] && . ./conf
 exec earlyoom ${OPTS} 2>&1 >/dev/null

--- a/srcpkgs/edac-utils/files/edac/run
+++ b/srcpkgs/edac-utils/files/edac/run
@@ -1,3 +1,4 @@
 #!/bin/sh
+exec 2>&1
 edac-ctl --register-labels
 exec chpst -b edac pause

--- a/srcpkgs/elog/files/elogd/run
+++ b/srcpkgs/elog/files/elogd/run
@@ -1,2 +1,3 @@
 #!/bin/sh
+exec 2>&1
 exec chpst -u elog:elog /usr/bin/elogd -c /etc/elog/elogd.cfg

--- a/srcpkgs/elogind/files/elogind/run
+++ b/srcpkgs/elogind/files/elogind/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 # elogind doesn't work right if it starts before dbus
 sv check dbus >/dev/null || exit 1
 exec /usr/libexec/elogind/elogind.wrapper

--- a/srcpkgs/espeakup/files/espeakup/log/run
+++ b/srcpkgs/espeakup/files/espeakup/log/run
@@ -1,2 +1,0 @@
-#!/bin/sh
-exec logger -p daemon.debug -t espeakup

--- a/srcpkgs/etcd/files/etcd/run
+++ b/srcpkgs/etcd/files/etcd/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 
 export ETCD_DATA_DIR=/var/lib/etcd
 export ETCD_NAME=etcd

--- a/srcpkgs/eudev/files/udevd/run
+++ b/srcpkgs/eudev/files/udevd/run
@@ -1,3 +1,4 @@
 #!/bin/sh
+exec 2>&1
 udevadm control --exit
 exec udevd

--- a/srcpkgs/fah/files/FAHClient/run
+++ b/srcpkgs/fah/files/FAHClient/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 OPTS=--run-as=_fah
 set -e
 [ -r config ] && . config

--- a/srcpkgs/fail2ban/files/fail2ban/run
+++ b/srcpkgs/fail2ban/files/fail2ban/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 mkdir -p /var/run/fail2ban
 
 exec fail2ban-server -f

--- a/srcpkgs/fake-hwclock/files/fake-hwclock/run
+++ b/srcpkgs/fake-hwclock/files/fake-hwclock/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 exec 1>&2
 [ -r /etc/default/fake-hwclock ] && . /etc/default/fake-hwclock
 fake-hwclock load $FORCE || exit 1

--- a/srcpkgs/fastd/files/fastd/run
+++ b/srcpkgs/fastd/files/fastd/run
@@ -1,2 +1,3 @@
 #!/bin/sh
+exec 2>&1
 exec fastd --config /etc/fastd/fastd.conf

--- a/srcpkgs/fcron/files/fcron/run
+++ b/srcpkgs/fcron/files/fcron/run
@@ -1,2 +1,3 @@
 #!/bin/sh
+exec 2>&1
 exec fcron -f

--- a/srcpkgs/fiche/files/fiche/run
+++ b/srcpkgs/fiche/files/fiche/run
@@ -1,2 +1,3 @@
 #!/bin/sh
+exec 2>&1
 exec chpst -u _fiche:_fiche fiche -d yourdomain.com -o /var/tmp/fiche -l /var/log/fiche/log

--- a/srcpkgs/firehol/files/firehol/run
+++ b/srcpkgs/firehol/files/firehol/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 [ ! -e /etc/firehol/firehol.conf ] && exit 0
 firehol start || exit 1
 exec chpst -b firehol pause

--- a/srcpkgs/flannel/files/flannel/run
+++ b/srcpkgs/flannel/files/flannel/run
@@ -1,3 +1,4 @@
 #!/bin/sh
+exec 2>&1
 sv check etcd >/dev/null || exit 1
 exec flannel

--- a/srcpkgs/freeipmi/files/bmc-watchdog/run
+++ b/srcpkgs/freeipmi/files/bmc-watchdog/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 
 [ -f ./conf ] && . ./conf
 

--- a/srcpkgs/freeipmi/files/ipmidetectd/run
+++ b/srcpkgs/freeipmi/files/ipmidetectd/run
@@ -1,3 +1,4 @@
 #!/bin/sh
+exec 2>&1
 
 exec ipmidetectd -d

--- a/srcpkgs/freeipmi/files/ipmiseld/run
+++ b/srcpkgs/freeipmi/files/ipmiseld/run
@@ -1,2 +1,3 @@
 #!/bin/sh
+exec 2>&1
 exec ipmiseld --foreground

--- a/srcpkgs/frp/files/frpc/run
+++ b/srcpkgs/frp/files/frpc/run
@@ -1,2 +1,3 @@
 #!/bin/sh
+exec 2>&1
 exec /usr/bin/frpc -c /etc/frp/frpc.ini

--- a/srcpkgs/frp/files/frps/run
+++ b/srcpkgs/frp/files/frps/run
@@ -1,2 +1,3 @@
 #!/bin/sh
+exec 2>&1
 exec /usr/bin/frps -c /etc/frp/frps.ini

--- a/srcpkgs/frr/files/frr-generic/run
+++ b/srcpkgs/frr/files/frr-generic/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 
 daemon="$(basename "${PWD}")"
 

--- a/srcpkgs/fwknop/files/fwknopd/run
+++ b/srcpkgs/fwknop/files/fwknopd/run
@@ -1,2 +1,3 @@
 #!/bin/sh
+exec 2>&1
 exec fwknopd -f

--- a/srcpkgs/gdm/files/gdm/run
+++ b/srcpkgs/gdm/files/gdm/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 sv check dbus > /dev/null || exit 1
 [ ! -d /run/gdm ] && mkdir -m0711 -p /run/gdm && chown root:gdm /run/gdm
 exec gdm

--- a/srcpkgs/gemserv/files/gemserv/run
+++ b/srcpkgs/gemserv/files/gemserv/run
@@ -1,3 +1,4 @@
 #!/bin/sh
+exec 2>&1
 [ -r conf ] && . ./conf
 exec chpst -u _gemserv gemserv ${CONF:-/etc/gemserv.conf}

--- a/srcpkgs/geomyidae/files/geomyidae/run
+++ b/srcpkgs/geomyidae/files/geomyidae/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 [ -r ./conf ] && . ./conf
 
 user=_geomyidae

--- a/srcpkgs/gerbera/files/gerbera/log/run
+++ b/srcpkgs/gerbera/files/gerbera/log/run
@@ -1,1 +1,0 @@
-/usr/bin/vlogger

--- a/srcpkgs/gerbera/files/gerbera/run
+++ b/srcpkgs/gerbera/files/gerbera/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 
 if [ ! -d /var/lib/gerbera/.config ]; then
 	mkdir -p /var/lib/gerbera/.config/gerbera

--- a/srcpkgs/gitea/files/gitea/log/run
+++ b/srcpkgs/gitea/files/gitea/log/run
@@ -1,1 +1,0 @@
-/usr/bin/vlogger

--- a/srcpkgs/gitea/files/gitea/run
+++ b/srcpkgs/gitea/files/gitea/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 
 # USER and HOME are needed because gitea doesn't actually check the user it
 # runs as, but instead just grabs the variables from the variables.

--- a/srcpkgs/gitlab-runner/files/gitlab-runner/run
+++ b/srcpkgs/gitlab-runner/files/gitlab-runner/run
@@ -1,2 +1,3 @@
 #!/bin/sh
+exec 2>&1
 exec gitlab-runner run

--- a/srcpkgs/glibc/files/nscd/run
+++ b/srcpkgs/glibc/files/nscd/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 [ -r conf ] && . ./conf
 mkdir -p /var/run/nscd /var/db/nscd
 exec nscd -F ${OPTS} >/dev/null

--- a/srcpkgs/glider/files/glider/run
+++ b/srcpkgs/glider/files/glider/run
@@ -1,2 +1,3 @@
 #!/bin/sh
+exec 2>&1
 exec chpst -u nobody:nogroup glider -config /etc/glider/config

--- a/srcpkgs/glusterfs/files/glusterd/run
+++ b/srcpkgs/glusterfs/files/glusterd/run
@@ -1,2 +1,3 @@
 #!/bin/sh
+exec 2>&1
 exec glusterd -N 2>&1

--- a/srcpkgs/glusterfs/files/glusterfsd/run
+++ b/srcpkgs/glusterfs/files/glusterfsd/run
@@ -1,2 +1,3 @@
 #!/bin/sh
+exec 2>&1
 exec glusterfsd -N 2>&1

--- a/srcpkgs/gnunet/files/gnunet/run
+++ b/srcpkgs/gnunet/files/gnunet/run
@@ -1,2 +1,3 @@
 #!/bin/sh
+exec 2>&1
 /usr/lib/gnunet/libexec/gnunet-service-arm -c /etc/gnunet/gnunet.conf

--- a/srcpkgs/go-ipfs/files/ipfs/log/run
+++ b/srcpkgs/go-ipfs/files/ipfs/log/run
@@ -1,1 +1,0 @@
-/usr/bin/vlogger

--- a/srcpkgs/go-ipfs/files/ipfs/run
+++ b/srcpkgs/go-ipfs/files/ipfs/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 [ -r conf ] && . ./conf
 export IPFS_PATH=${IPFS_PATH:=/var/lib/ipfs}
 exec chpst -u _ipfs ipfs daemon ${OPTS:=--init --enable-gc --migrate} 2>&1

--- a/srcpkgs/goatcounter/files/goatcounter/log/run
+++ b/srcpkgs/goatcounter/files/goatcounter/log/run
@@ -1,2 +1,0 @@
-#!/bin/sh
-exec logger -p daemon.notice -t goatcounter

--- a/srcpkgs/goatcounter/files/goatcounter/run
+++ b/srcpkgs/goatcounter/files/goatcounter/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 
 [ -r ./conf ] && . ./conf
 

--- a/srcpkgs/gogs/files/gogs/run
+++ b/srcpkgs/gogs/files/gogs/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 export USER=gogs
 export HOME=/srv/gogs
 exec chpst -u gogs:gogs -P gogs web --config /etc/gogs.ini 2>&1

--- a/srcpkgs/gotify-server/files/gotify-server/log/run
+++ b/srcpkgs/gotify-server/files/gotify-server/log/run
@@ -1,1 +1,0 @@
-/usr/bin/vlogger

--- a/srcpkgs/gpm/files/gpm/run
+++ b/srcpkgs/gpm/files/gpm/run
@@ -1,3 +1,4 @@
 #!/bin/sh
+exec 2>&1
 exec 1>&2
 exec gpm -D -m /dev/input/mice -t imps2

--- a/srcpkgs/gpsd/files/gpsd/run
+++ b/srcpkgs/gpsd/files/gpsd/run
@@ -1,3 +1,4 @@
 #!/bin/sh
+exec 2>&1
 [ -r conf ] && . ./conf
 exec /usr/bin/gpsd -N -F /run/gpsd.sock $OPTS ${DEV:=/dev/gps0}

--- a/srcpkgs/grafana/files/grafana/log/run
+++ b/srcpkgs/grafana/files/grafana/log/run
@@ -1,2 +1,0 @@
-#!/bin/sh
-exec logger -p daemon.info -t grafana

--- a/srcpkgs/grafana/files/grafana/run
+++ b/srcpkgs/grafana/files/grafana/run
@@ -1,3 +1,4 @@
 #!/bin/sh
+exec 2>&1
 
 exec chpst -u _grafana:_grafana grafana-server -homepath /usr/share/grafana/ -config /etc/grafana/grafana.ini 2>&1

--- a/srcpkgs/grub-btrfs/files/grub-btrfs/log/run
+++ b/srcpkgs/grub-btrfs/files/grub-btrfs/log/run
@@ -1,2 +1,0 @@
-#!/bin/sh
-exec vlogger -t grub-btrfs

--- a/srcpkgs/h2o/files/h2o/run
+++ b/srcpkgs/h2o/files/h2o/run
@@ -1,2 +1,3 @@
 #!/bin/sh
+exec 2>&1
 exec h2o -c /etc/h2o.conf

--- a/srcpkgs/haproxy/files/haproxy/run
+++ b/srcpkgs/haproxy/files/haproxy/run
@@ -1,3 +1,4 @@
 #!/bin/sh
+exec 2>&1
 
 exec haproxy -W -f /etc/haproxy/haproxy.cfg

--- a/srcpkgs/haveged/files/haveged/run
+++ b/srcpkgs/haveged/files/haveged/run
@@ -1,3 +1,4 @@
 #!/bin/sh
+exec 2>&1
 exec 1>&2
 exec haveged -w 1024 -v 1 -F

--- a/srcpkgs/hddtemp/files/hddtemp/run
+++ b/srcpkgs/hddtemp/files/hddtemp/run
@@ -1,3 +1,4 @@
 #!/bin/sh
+exec 2>&1
 [ -r conf ] && . ./conf
 exec hddtemp -dF ${OPTS:=/dev/sda}

--- a/srcpkgs/hiawatha/files/hiawatha/run
+++ b/srcpkgs/hiawatha/files/hiawatha/run
@@ -1,2 +1,3 @@
 #!/bin/sh
+exec 2>&1
 exec hiawatha -d

--- a/srcpkgs/hitch/files/hitch/run
+++ b/srcpkgs/hitch/files/hitch/run
@@ -1,2 +1,3 @@
 #!/bin/sh
+exec 2>&1
 exec hitch -u _hitch --config=/etc/hitch.conf

--- a/srcpkgs/hostapd/files/hostapd/run
+++ b/srcpkgs/hostapd/files/hostapd/run
@@ -1,2 +1,3 @@
 #!/bin/sh
+exec 2>&1
 exec hostapd -s /etc/hostapd/hostapd.conf 2>&1

--- a/srcpkgs/i2pd/files/i2pd/log/run
+++ b/srcpkgs/i2pd/files/i2pd/log/run
@@ -1,1 +1,0 @@
-/usr/bin/vlogger

--- a/srcpkgs/i2pd/files/i2pd/run
+++ b/srcpkgs/i2pd/files/i2pd/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 [ -r conf ] && . ./conf
 ulimit -n ${MAX_OPEN_FILES:-16384}
 exec chpst -u _i2pd:_i2pd i2pd --service \

--- a/srcpkgs/i8kutils/files/i8kmon/run
+++ b/srcpkgs/i8kutils/files/i8kmon/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 
 if [ -r ./conf ]; then
 	. ./conf

--- a/srcpkgs/icinga2/files/icinga2/run
+++ b/srcpkgs/icinga2/files/icinga2/run
@@ -1,3 +1,4 @@
 #!/bin/sh
+exec 2>&1
 install -oicinga -gicinga -d /run/icinga2
 exec icinga2 daemon 2>&1

--- a/srcpkgs/iio-sensor-proxy/files/iio-sensor-proxy/run
+++ b/srcpkgs/iio-sensor-proxy/files/iio-sensor-proxy/run
@@ -1,2 +1,3 @@
 #!/bin/sh
+exec 2>&1
 exec /usr/libexec/iio-sensor-proxy

--- a/srcpkgs/inadyn/files/inadyn/run
+++ b/srcpkgs/inadyn/files/inadyn/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 [ -r ./conf ] && . ./conf
 [ ! -d /run/inadyn ] &&
 	mkdir -p /run/inadyn &&

--- a/srcpkgs/incron/files/incron/log/run
+++ b/srcpkgs/incron/files/incron/log/run
@@ -1,2 +1,0 @@
-#!/bin/sh
-exec logger -p cron.notice

--- a/srcpkgs/incron/files/incron/run
+++ b/srcpkgs/incron/files/incron/run
@@ -1,2 +1,3 @@
 #!/bin/sh
+exec 2>&1
 exec incrond -n

--- a/srcpkgs/influxdb/files/influxdb/log/run
+++ b/srcpkgs/influxdb/files/influxdb/log/run
@@ -1,2 +1,0 @@
-#!/bin/sh
-exec logger -p daemon.info -t influxdb

--- a/srcpkgs/influxdb/files/influxdb/run
+++ b/srcpkgs/influxdb/files/influxdb/run
@@ -1,3 +1,4 @@
 #!/bin/sh
+exec 2>&1
 
 exec chpst -u _influxdb:_influxdb influxd -config /etc/influxdb/influxdb.conf 2>&1

--- a/srcpkgs/inspircd/files/inspircd/run
+++ b/srcpkgs/inspircd/files/inspircd/run
@@ -1,3 +1,4 @@
 #!/bin/sh
+exec 2>&1
 exec chpst -u inspircd inspircd \
     --nofork --config /etc/inspircd/inspircd.conf

--- a/srcpkgs/iptables/files/ip6tables/run
+++ b/srcpkgs/iptables/files/ip6tables/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 [ ! -e /etc/iptables/ip6tables.rules ] && exit 0
 ip6tables-restore -w 3 /etc/iptables/ip6tables.rules || exit 1
 exec chpst -b ip6tables pause

--- a/srcpkgs/iptables/files/iptables/run
+++ b/srcpkgs/iptables/files/iptables/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 [ ! -e /etc/iptables/iptables.rules ] && exit 0
 iptables-restore -w 3 /etc/iptables/iptables.rules || exit 1
 exec chpst -b iptables pause

--- a/srcpkgs/ipvsadm/files/ipvsadm/run
+++ b/srcpkgs/ipvsadm/files/ipvsadm/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 : ${CONF_FILE:=/etc/ipvsadm.conf}
 [ -r conf ] && . ./conf
 [ -s $CONF_FILE ] || exit 0

--- a/srcpkgs/irqbalance/files/irqbalance/run
+++ b/srcpkgs/irqbalance/files/irqbalance/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 [ -r conf ] && . ./conf
 install -d -m0755 /run/irqbalance
 exec irqbalance -f $OPTS

--- a/srcpkgs/iwd/files/ead/log/run
+++ b/srcpkgs/iwd/files/ead/log/run
@@ -1,2 +1,0 @@
-#!/bin/sh
-exec vlogger -p daemon.info -t ead

--- a/srcpkgs/iwd/files/ead/run
+++ b/srcpkgs/iwd/files/ead/run
@@ -1,3 +1,4 @@
 #!/bin/sh
+exec 2>&1
 [ -r ./conf ] && . conf
 exec /usr/libexec/ead ${OPTS} 2>&1

--- a/srcpkgs/iwd/files/iwd/log/run
+++ b/srcpkgs/iwd/files/iwd/log/run
@@ -1,2 +1,0 @@
-#!/bin/sh
-exec vlogger -p daemon.info -t iwd

--- a/srcpkgs/iwd/files/iwd/run
+++ b/srcpkgs/iwd/files/iwd/run
@@ -1,3 +1,4 @@
 #!/bin/sh
+exec 2>&1
 [ -r ./conf ] && . ./conf
 exec /usr/libexec/iwd ${OPTS} 2>&1

--- a/srcpkgs/jenkins/files/jenkins/run
+++ b/srcpkgs/jenkins/files/jenkins/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 . /etc/profile
 [ -r conf ] && . ./conf
 

--- a/srcpkgs/kapacitor/files/kapacitor/run
+++ b/srcpkgs/kapacitor/files/kapacitor/run
@@ -1,2 +1,3 @@
 #!/bin/sh
+exec 2>&1
 exec chpst -u _kapacitor:_kapacitor kapacitord --config /etc/kapacitor/kapacitor.conf 2>&1

--- a/srcpkgs/kea/files/kea-dhcp-ddns/run
+++ b/srcpkgs/kea/files/kea-dhcp-ddns/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 [ -r conf ] && . ./conf
 mkdir -p /run/kea
 exec kea-dhcp-ddns ${OPTS:=-c /etc/kea/kea.conf}

--- a/srcpkgs/kea/files/kea-dhcp4/run
+++ b/srcpkgs/kea/files/kea-dhcp4/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 [ -r conf ] && . ./conf
 [ -n "$WAIT_IFACE" ] && [ -z "$(ip -f inet address show "$WAIT_IFACE")" ] && exit 1
 mkdir -p /run/kea

--- a/srcpkgs/kea/files/kea-dhcp6/run
+++ b/srcpkgs/kea/files/kea-dhcp6/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 [ -r conf ] && . ./conf
 [ -n "$WAIT_IFACE" ] && [ -z "$(ip -f inet6 address show "$WAIT_IFACE")" ] && exit 1
 mkdir -p /run/kea

--- a/srcpkgs/keepalived/files/keepalived/run
+++ b/srcpkgs/keepalived/files/keepalived/run
@@ -1,2 +1,3 @@
 #!/bin/sh
+exec 2>&1
 exec keepalived --dont-fork

--- a/srcpkgs/keyd/files/keyd/run
+++ b/srcpkgs/keyd/files/keyd/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 
 # Sometimes when starting the keyd service, the keyboard can become unresponsive.
 # This is the result of keyd starting when the early udevd process is still running but

--- a/srcpkgs/knot-resolver/files/kresd/run
+++ b/srcpkgs/knot-resolver/files/kresd/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 [ -r ./conf ] && . ./conf
 install -d -m0755 -o _knot_resolver -g _knot_resolver /run/knot-resolver
 exec kresd ${OPTS:--f 1}

--- a/srcpkgs/knot/files/knotd/run
+++ b/srcpkgs/knot/files/knotd/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 [ -r ./conf ] && . ./conf
 install -d -m0755 -o _knot -g _knot /run/knot
 exec knotd ${OPTS}

--- a/srcpkgs/kubernetes/files/kube-apiserver/run
+++ b/srcpkgs/kubernetes/files/kube-apiserver/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 [ -r /etc/kubernetes/config ] && . /etc/kubernetes/config
 [ -r /etc/kubernetes/apiserver ] && . /etc/kubernetes/apiserver
 exec chpst -u kube:kube kube-apiserver \

--- a/srcpkgs/kubernetes/files/kube-controller-manager/run
+++ b/srcpkgs/kubernetes/files/kube-controller-manager/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 [ -r /etc/kubernetes/config ] && . /etc/kubernetes/config
 [ -r /etc/kubernetes/controller-manager ] && . /etc/kubernetes/controller-manager
 exec chpst -u kube:kube kube-controller-manager \

--- a/srcpkgs/kubernetes/files/kube-proxy/run
+++ b/srcpkgs/kubernetes/files/kube-proxy/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 [ -r /etc/kubernetes/config ] && . /etc/kubernetes/config
 [ -r /etc/kubernetes/proxy ] && . /etc/kubernetes/proxy
 exec kube-proxy \

--- a/srcpkgs/kubernetes/files/kube-scheduler/run
+++ b/srcpkgs/kubernetes/files/kube-scheduler/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 [ -r /etc/kubernetes/config ] && . /etc/kubernetes/config
 [ -r /etc/kubernetes/scheduler ] && . /etc/kubernetes/scheduler
 exec chpst -u kube:kube kube-scheduler \

--- a/srcpkgs/kubernetes/files/kubelet/run
+++ b/srcpkgs/kubernetes/files/kubelet/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 [ -r /etc/kubernetes/config ] && . /etc/kubernetes/config
 [ -r /etc/kubernetes/kubelet ] && . /etc/kubernetes/kubelet
 exec kubelet $OPTS 2>/dev/null

--- a/srcpkgs/laptop-mode/files/laptop-mode/run
+++ b/srcpkgs/laptop-mode/files/laptop-mode/run
@@ -1,3 +1,4 @@
 #!/bin/sh
+exec 2>&1
 laptop_mode init auto
 exec chpst -b laptop-mode pause

--- a/srcpkgs/ldm/files/ldm/run
+++ b/srcpkgs/ldm/files/ldm/run
@@ -1,3 +1,4 @@
 #!/bin/sh
+exec 2>&1
 [ -s conf ] && . ./conf
 exec ldm ${OPTS:=-u nobody}

--- a/srcpkgs/libcgroup/files/cgred/run
+++ b/srcpkgs/libcgroup/files/cgred/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 # Default logs to syslog with facility DAEMON
 # man cgrulesengd for options list and descriptions.
 [ -r conf ] && . ./conf

--- a/srcpkgs/libratbag/files/ratbagd/run
+++ b/srcpkgs/libratbag/files/ratbagd/run
@@ -1,3 +1,4 @@
 #!/bin/sh
+exec 2>&1
 sv check dbus >/dev/null || exit 1
 exec ratbagd

--- a/srcpkgs/libvirt/files/libvirt-generic/log/run
+++ b/srcpkgs/libvirt/files/libvirt-generic/log/run
@@ -1,7 +1,0 @@
-#!/bin/sh
-
-# Take daemon name from parent of the log subservice
-daemon="${PWD%/*}"
-daemon="${daemon##*/}"
-
-exec logger -t "$daemon" -p daemon.info

--- a/srcpkgs/libvirt/files/libvirt-generic/run
+++ b/srcpkgs/libvirt/files/libvirt-generic/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 
 sv check dbus >/dev/null || exit 1
 

--- a/srcpkgs/libvirt/files/libvirtd/log/run
+++ b/srcpkgs/libvirt/files/libvirtd/log/run
@@ -1,1 +1,0 @@
-../../libvirt-generic/log/run

--- a/srcpkgs/libvirt/files/virtinterfaced/log/run
+++ b/srcpkgs/libvirt/files/virtinterfaced/log/run
@@ -1,1 +1,0 @@
-../../libvirt-generic/log/run

--- a/srcpkgs/libvirt/files/virtlockd/log/run
+++ b/srcpkgs/libvirt/files/virtlockd/log/run
@@ -1,1 +1,0 @@
-../../libvirt-generic/log/run

--- a/srcpkgs/libvirt/files/virtlogd/log/run
+++ b/srcpkgs/libvirt/files/virtlogd/log/run
@@ -1,1 +1,0 @@
-../../libvirt-generic/log/run

--- a/srcpkgs/libvirt/files/virtlxcd/log/run
+++ b/srcpkgs/libvirt/files/virtlxcd/log/run
@@ -1,1 +1,0 @@
-../../libvirt-generic/log/run

--- a/srcpkgs/libvirt/files/virtnetworkd/log/run
+++ b/srcpkgs/libvirt/files/virtnetworkd/log/run
@@ -1,1 +1,0 @@
-../../libvirt-generic/log/run

--- a/srcpkgs/libvirt/files/virtnodedevd/log/run
+++ b/srcpkgs/libvirt/files/virtnodedevd/log/run
@@ -1,1 +1,0 @@
-../../libvirt-generic/log/run

--- a/srcpkgs/libvirt/files/virtnwfilterd/log/run
+++ b/srcpkgs/libvirt/files/virtnwfilterd/log/run
@@ -1,1 +1,0 @@
-../../libvirt-generic/log/run

--- a/srcpkgs/libvirt/files/virtproxyd/log/run
+++ b/srcpkgs/libvirt/files/virtproxyd/log/run
@@ -1,1 +1,0 @@
-../../libvirt-generic/log/run

--- a/srcpkgs/libvirt/files/virtqemud/log/run
+++ b/srcpkgs/libvirt/files/virtqemud/log/run
@@ -1,1 +1,0 @@
-../../libvirt-generic/log/run

--- a/srcpkgs/libvirt/files/virtsecretd/log/run
+++ b/srcpkgs/libvirt/files/virtsecretd/log/run
@@ -1,1 +1,0 @@
-../../libvirt-generic/log/run

--- a/srcpkgs/libvirt/files/virtstoraged/log/run
+++ b/srcpkgs/libvirt/files/virtstoraged/log/run
@@ -1,1 +1,0 @@
-../../libvirt-generic/log/run

--- a/srcpkgs/libvirt/files/virtvboxd/log/run
+++ b/srcpkgs/libvirt/files/virtvboxd/log/run
@@ -1,1 +1,0 @@
-../../libvirt-generic/log/run

--- a/srcpkgs/libvirt/files/virtxend/log/run
+++ b/srcpkgs/libvirt/files/virtxend/log/run
@@ -1,1 +1,0 @@
-../../libvirt-generic/log/run

--- a/srcpkgs/lightdm/files/lightdm/run
+++ b/srcpkgs/lightdm/files/lightdm/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 sv check dbus >/dev/null || exit 1
 install -d -m0711 -olightdm -glightdm /run/lightdm
 [ -f ./conf ] && . ./conf

--- a/srcpkgs/lighttpd/files/lighttpd/run
+++ b/srcpkgs/lighttpd/files/lighttpd/run
@@ -1,2 +1,3 @@
 #!/bin/sh
+exec 2>&1
 exec lighttpd-angel -D -f /etc/lighttpd/lighttpd.conf

--- a/srcpkgs/linux-tools/files/freefall/run
+++ b/srcpkgs/linux-tools/files/freefall/run
@@ -1,3 +1,4 @@
 #!/bin/sh
+exec 2>&1
 [ -r conf ] && . ./conf
 exec freefall ${OPTS:=/dev/sda}

--- a/srcpkgs/linux-tools/files/usbipd/run
+++ b/srcpkgs/linux-tools/files/usbipd/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 modprobe -q usbip-host || exit 1
 modprobe -q vhci-hcd || exit 1
 exec usbipd

--- a/srcpkgs/lldpd/files/lldpd/log/run
+++ b/srcpkgs/lldpd/files/lldpd/log/run
@@ -1,1 +1,0 @@
-/usr/bin/vlogger

--- a/srcpkgs/lldpd/files/lldpd/run
+++ b/srcpkgs/lldpd/files/lldpd/run
@@ -1,3 +1,4 @@
 #!/bin/sh
+exec 2>&1
 [ -r conf ] && . ./conf
 exec lldpd ${OPTS:- -d} 2>&1

--- a/srcpkgs/lm_sensors/files/fancontrol/run
+++ b/srcpkgs/lm_sensors/files/fancontrol/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 [ -r conf ] && . conf
 [ ! -r ${CONF_FILE:-/etc/fancontrol} ] && exit 1
 exec /usr/bin/fancontrol ${CONF_FILE:-/etc/fancontrol}

--- a/srcpkgs/lsyncd/files/lsyncd/log/run
+++ b/srcpkgs/lsyncd/files/lsyncd/log/run
@@ -1,2 +1,0 @@
-#!/bin/sh
-exec logger -t lsyncd -p 'daemon.info'

--- a/srcpkgs/lsyncd/files/lsyncd/run
+++ b/srcpkgs/lsyncd/files/lsyncd/run
@@ -1,3 +1,4 @@
 #!/bin/sh
+exec 2>&1
 [ -r ./conf ] && . ./conf
 exec lsyncd -nodaemon "${CONF_FILE:-/etc/lsyncd/lsyncd.conf.lua}"

--- a/srcpkgs/lvm2/files/dmeventd/run
+++ b/srcpkgs/lvm2/files/dmeventd/run
@@ -1,2 +1,3 @@
 #!/bin/sh
+exec 2>&1
 exec dmeventd -f

--- a/srcpkgs/lvm2/files/lvmetad/run
+++ b/srcpkgs/lvm2/files/lvmetad/run
@@ -1,2 +1,3 @@
 #!/bin/sh
+exec 2>&1
 exec lvmetad -f

--- a/srcpkgs/lxc/files/lxc-autostart/run
+++ b/srcpkgs/lxc/files/lxc-autostart/run
@@ -1,3 +1,4 @@
 #!/bin/sh
+exec 2>&1
 lxc-autostart || exit 1
 exec chpst -b lxc-autostart pause

--- a/srcpkgs/lxcfs/files/lxcfs/run
+++ b/srcpkgs/lxcfs/files/lxcfs/run
@@ -1,2 +1,3 @@
 #!/bin/sh
+exec 2>&1
 exec lxcfs -f /var/lib/lxcfs

--- a/srcpkgs/lxd-lts/files/lxd/run
+++ b/srcpkgs/lxd-lts/files/lxd/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 _systemd_cgrp="/sys/fs/cgroup/systemd"
 if [ ! -d ${_systemd_cgrp} ]; then
 	mkdir ${_systemd_cgrp}

--- a/srcpkgs/lxd/files/lxd/log/run
+++ b/srcpkgs/lxd/files/lxd/log/run
@@ -1,2 +1,0 @@
-#!/bin/sh
-exec vlogger -t lxd

--- a/srcpkgs/lxd/files/lxd/run
+++ b/srcpkgs/lxd/files/lxd/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 _systemd_cgrp="/sys/fs/cgroup/systemd"
 if [ ! -d ${_systemd_cgrp} ]; then
 	mkdir ${_systemd_cgrp}

--- a/srcpkgs/lxdm/files/lxdm/run
+++ b/srcpkgs/lxdm/files/lxdm/run
@@ -1,2 +1,3 @@
 #!/bin/sh
+exec 2>&1
 exec lxdm

--- a/srcpkgs/mDNSResponder/files/dnsextd/run
+++ b/srcpkgs/mDNSResponder/files/dnsextd/run
@@ -1,2 +1,3 @@
 #!/bin/sh
+exec 2>&1
 exec dnsextd -d

--- a/srcpkgs/mDNSResponder/files/mdnsd/run
+++ b/srcpkgs/mDNSResponder/files/mdnsd/run
@@ -1,2 +1,3 @@
 #!/bin/sh
+exec 2>&1
 exec mdnsd -debug

--- a/srcpkgs/mariadb/files/mysqld/log/run
+++ b/srcpkgs/mariadb/files/mysqld/log/run
@@ -1,2 +1,0 @@
-#!/bin/sh
-exec logger -p daemon.notice

--- a/srcpkgs/mariadb/files/mysqld/run
+++ b/srcpkgs/mariadb/files/mysqld/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 [ ! -d /run/mysqld ] && mkdir -p /run/mysqld
 chown mysql:mysql /run/mysqld
 exec chpst -u mysql:mysql mysqld --user=mysql 2>&1

--- a/srcpkgs/mcelog/files/mcelog/run
+++ b/srcpkgs/mcelog/files/mcelog/run
@@ -1,2 +1,3 @@
 #!/bin/sh
+exec 2>&1
 exec mcelog --daemon --foreground --syslog

--- a/srcpkgs/mdadm/files/mdadm/run
+++ b/srcpkgs/mdadm/files/mdadm/run
@@ -1,3 +1,4 @@
 #!/bin/sh
+exec 2>&1
 # --syslog makes it run in every case, yet forwards to mail address if given.
 exec mdadm --monitor --scan --syslog

--- a/srcpkgs/metalog/files/metalog/run
+++ b/srcpkgs/metalog/files/metalog/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 exec 1>&2
 [ -r conf ] && . ./conf
 exec metalog ${OPTS=-v}

--- a/srcpkgs/minidlna/files/minidlnad/log/run
+++ b/srcpkgs/minidlna/files/minidlnad/log/run
@@ -1,1 +1,0 @@
-/usr/bin/vlogger

--- a/srcpkgs/minidlna/files/minidlnad/run
+++ b/srcpkgs/minidlna/files/minidlnad/run
@@ -1,3 +1,4 @@
 #!/bin/sh
+exec 2>&1
 [ -r conf ] && . ./conf
 exec minidlnad -S ${OPTS} 2>&1

--- a/srcpkgs/miniflux/files/miniflux/log/run
+++ b/srcpkgs/miniflux/files/miniflux/log/run
@@ -1,1 +1,0 @@
-/usr/bin/vlogger

--- a/srcpkgs/minio/files/minio/log/run
+++ b/srcpkgs/minio/files/minio/log/run
@@ -1,2 +1,0 @@
-#!/bin/sh
-exec logger -p daemon.notice

--- a/srcpkgs/minio/files/minio/run
+++ b/srcpkgs/minio/files/minio/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 . /etc/default/minio
 : ${MINIO_VOLUMES:="/var/lib/minio/data/"}
 exec chpst -u _minio:_minio minio -C /etc/minio/ server "$MINIO_VOLUMES"

--- a/srcpkgs/mit-krb5/files/kadmind/run
+++ b/srcpkgs/mit-krb5/files/kadmind/run
@@ -1,2 +1,3 @@
 #!/bin/sh
+exec 2>&1
 exec kadmind -nofork

--- a/srcpkgs/mit-krb5/files/krb5kdc/run
+++ b/srcpkgs/mit-krb5/files/krb5kdc/run
@@ -1,2 +1,3 @@
 #!/bin/sh
+exec 2>&1
 exec krb5kdc -n

--- a/srcpkgs/moby/files/docker/log/run
+++ b/srcpkgs/moby/files/docker/log/run
@@ -1,1 +1,0 @@
-/usr/bin/vlogger

--- a/srcpkgs/moby/files/docker/run
+++ b/srcpkgs/moby/files/docker/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 [ -r conf ] && . ./conf
 modprobe -q loop || exit 1
 mountpoint -q /sys/fs/cgroup/systemd || {

--- a/srcpkgs/monero/files/monerod/log/run
+++ b/srcpkgs/monero/files/monerod/log/run
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-exec logger -p daemon.notice -t monerod

--- a/srcpkgs/monero/files/monerod/run
+++ b/srcpkgs/monero/files/monerod/run
@@ -1,2 +1,3 @@
 #!/bin/sh
+exec 2>&1
 exec chpst -u monero:monero /usr/bin/monerod --non-interactive --config-file /etc/monerod.conf

--- a/srcpkgs/monit/files/monit/run
+++ b/srcpkgs/monit/files/monit/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 if [ -f /etc/monit/monitrc ]; then
 	CONF="-c /etc/monit/monitrc"
 fi

--- a/srcpkgs/monkey/files/monkey/run
+++ b/srcpkgs/monkey/files/monkey/run
@@ -1,2 +1,3 @@
 #!/bin/sh
+exec 2>&1
 exec monkey

--- a/srcpkgs/moosefs/files/mfschunkserver/run
+++ b/srcpkgs/moosefs/files/mfschunkserver/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 [ -e conf ] && . ./conf
 : ${CONF_FILE:=/etc/mfs/mfschunkserver.cfg}
 [ -e ${CONF_FILE} ] || exit 1

--- a/srcpkgs/moosefs/files/mfsmaster/run
+++ b/srcpkgs/moosefs/files/mfsmaster/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 [ -e conf ] && . ./conf
 : ${CONF_FILE:=/etc/mfs/mfsmaster.cfg}
 [ -e ${CONF_FILE} ] || exit 1

--- a/srcpkgs/moosefs/files/mfsmetalogger/run
+++ b/srcpkgs/moosefs/files/mfsmetalogger/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 [ -e conf ] && . ./conf
 : ${CONF_FILE:=/etc/mfs/mfsmetalogger.cfg}
 [ -e ${CONF_FILE} ] || exit 1

--- a/srcpkgs/mopidy/files/mopidy/run
+++ b/srcpkgs/mopidy/files/mopidy/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 exec chpst -u mopidy:audio \
 	mopidy --config /etc/mopidy/mopidy.conf \
 	>/dev/null 2>&1

--- a/srcpkgs/mosquitto/files/mosquitto/run
+++ b/srcpkgs/mosquitto/files/mosquitto/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 
 cd /var/lib/mosquitto
 exec chpst -u _mosquitto:_mosquitto mosquitto -c /etc/mosquitto/mosquitto.conf

--- a/srcpkgs/mouseemu/files/mouseemu/run
+++ b/srcpkgs/mouseemu/files/mouseemu/run
@@ -1,3 +1,4 @@
 #!/bin/sh
+exec 2>&1
 [ -r conf ] && . ./conf
 exec mouseemu -nofork $MID_CLICK $RIGHT_CLICK $SCROLL $TYPING_BLOCK

--- a/srcpkgs/mpDris2/files/mpDris2/run
+++ b/srcpkgs/mpDris2/files/mpDris2/run
@@ -1,2 +1,3 @@
 #!/bin/sh
+exec 2>&1
 exec mpDris2

--- a/srcpkgs/mpd/files/mpd/run
+++ b/srcpkgs/mpd/files/mpd/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 [ -r conf ] && . ./conf
 install -d -m 0755 -o mpd -g mpd /run/mpd
 exec mpd --no-daemon ${OPTS:-}

--- a/srcpkgs/mpdscribble/files/mpdscribble/run
+++ b/srcpkgs/mpdscribble/files/mpdscribble/run
@@ -1,2 +1,3 @@
 #!/bin/sh
+exec 2>&1
 exec mpdscribble --no-daemon

--- a/srcpkgs/mumble/files/mumble-server/log/run
+++ b/srcpkgs/mumble/files/mumble-server/log/run
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-exec logger -p daemon.notice -t murmur

--- a/srcpkgs/munge/files/munge/run
+++ b/srcpkgs/munge/files/munge/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 if [ ! -d /var/run/munge ]; then
     mkdir -m0755 -p /var/run/munge
 fi

--- a/srcpkgs/musl-nscd/files/nscd/run
+++ b/srcpkgs/musl-nscd/files/nscd/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 [ -r conf ] && . ./conf
 mkdir -p /var/run/nscd /var/db/nscd
 exec nscd -F ${OPTS} >/dev/null

--- a/srcpkgs/nbd/files/nbd/run
+++ b/srcpkgs/nbd/files/nbd/run
@@ -1,2 +1,3 @@
 #!/bin/sh
+exec 2>&1
 exec nbd-server -d 2>&1

--- a/srcpkgs/ndhc/files/ndhc/log/run
+++ b/srcpkgs/ndhc/files/ndhc/log/run
@@ -1,2 +1,0 @@
-#!/bin/sh
-exec logger -t ndhc

--- a/srcpkgs/ndhc/files/ndhc/run
+++ b/srcpkgs/ndhc/files/ndhc/run
@@ -1,3 +1,4 @@
 #!/bin/sh
+exec 2>&1
 [ -r conf ] && . ./conf
 exec ndhc -R /etc/resolv.conf -u ndhc -U ndhc -D ndhc -C /var/lib/ndhc/jail -s /var/lib/ndhc/state ${OPTS:=-i eth0} 2>&1

--- a/srcpkgs/ndppd/files/ndppd/log/run
+++ b/srcpkgs/ndppd/files/ndppd/log/run
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-exec logger -t ndppd

--- a/srcpkgs/ndppd/files/ndppd/run
+++ b/srcpkgs/ndppd/files/ndppd/run
@@ -1,3 +1,4 @@
 #!/bin/sh
+exec 2>&1
 
 exec ndppd -v

--- a/srcpkgs/neard/files/neard/log/run
+++ b/srcpkgs/neard/files/neard/log/run
@@ -1,1 +1,0 @@
-/usr/bin/vlogger

--- a/srcpkgs/neard/files/neard/run
+++ b/srcpkgs/neard/files/neard/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 sv check dbus >/dev/null || exit 1
 [ -r conf ] && . ./conf
 exec /usr/libexec/nfc/neard --nodaemon ${OPTS}

--- a/srcpkgs/neard/files/seeld/log/run
+++ b/srcpkgs/neard/files/seeld/log/run
@@ -1,1 +1,0 @@
-/usr/bin/vlogger

--- a/srcpkgs/neard/files/seeld/run
+++ b/srcpkgs/neard/files/seeld/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 sv check dbus >/dev/null || exit 1
 [ -r conf ] && . ./conf
 exec /usr/libexec/nfc/seeld --nodaemon ${OPTS}

--- a/srcpkgs/nebula/files/nebula/log/run
+++ b/srcpkgs/nebula/files/nebula/log/run
@@ -1,2 +1,0 @@
-#!/bin/sh
-exec logger --tag nebula --priority daemon.info

--- a/srcpkgs/net-snmp/files/snmpd/log/run
+++ b/srcpkgs/net-snmp/files/snmpd/log/run
@@ -1,1 +1,0 @@
-/usr/bin/vlogger

--- a/srcpkgs/net-snmp/files/snmpd/run
+++ b/srcpkgs/net-snmp/files/snmpd/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 
 [ -r ./conf ] && . ./conf
 exec snmpd -f -Lo $OPTS

--- a/srcpkgs/netdata/files/netdata/run
+++ b/srcpkgs/netdata/files/netdata/run
@@ -1,2 +1,3 @@
 #!/bin/sh
+exec 2>&1
 exec chpst -u _netdata:_netdata netdata -D

--- a/srcpkgs/network-ups-tools/files/upsd/run
+++ b/srcpkgs/network-ups-tools/files/upsd/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 # Network UPS Tools - information server
 # upsd will run in the foreground and prints information on stdout
 install -d -m 0770 -o nut -g nut /run/ups

--- a/srcpkgs/network-ups-tools/files/upsdrvctl/run
+++ b/srcpkgs/network-ups-tools/files/upsdrvctl/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 # Network UPS Tools - driver controller
 install -d -m 0770 -o nut -g nut /run/ups
 upsdrvctl -D start

--- a/srcpkgs/network-ups-tools/files/upsmon/run
+++ b/srcpkgs/network-ups-tools/files/upsmon/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 # Network UPS Tools - monitor and shutdown controller
 # upsmon will run in the foreground and prints information on stdout
 exec upsmon -D

--- a/srcpkgs/nfs-utils/files/nfs-server/run
+++ b/srcpkgs/nfs-utils/files/nfs-server/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 
 # Make sure the statd service is running.
 sv check statd >/dev/null || exit 1

--- a/srcpkgs/nfs-utils/files/rpcblkmapd/run
+++ b/srcpkgs/nfs-utils/files/rpcblkmapd/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 
 # Make sure the portmap service is running.
 sv check rpcbind >/dev/null || exit 1

--- a/srcpkgs/nfs-utils/files/rpcgssd/run
+++ b/srcpkgs/nfs-utils/files/rpcgssd/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 
 # Make sure the portmap service is running.
 sv check rpcbind >/dev/null || exit 1

--- a/srcpkgs/nfs-utils/files/rpcidmapd/run
+++ b/srcpkgs/nfs-utils/files/rpcidmapd/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 
 # Make sure the portmap service is running.
 sv check rpcbind >/dev/null || exit 1

--- a/srcpkgs/nfs-utils/files/rpcsvcgssd/run
+++ b/srcpkgs/nfs-utils/files/rpcsvcgssd/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 
 # Make sure the portmap service is running.
 sv check rpcbind >/dev/null || exit 1

--- a/srcpkgs/nfs-utils/files/statd/run
+++ b/srcpkgs/nfs-utils/files/statd/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 
 # Make sure the portmap service is running.
 sv check rpcbind >/dev/null || exit 1

--- a/srcpkgs/nftables/files/nftables/run
+++ b/srcpkgs/nftables/files/nftables/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 [ ! -r /etc/nftables.conf ] && exit 0
 nft -f /etc/nftables.conf
 exec chpst -b nftables pause

--- a/srcpkgs/ngetty/files/ngetty/run
+++ b/srcpkgs/ngetty/files/ngetty/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 export TERM=linux
 [ -r conf ] && . ./conf
 exec ngetty ${OPTS:=tty1 tty2 tty3 tty4 tty5 tty6}

--- a/srcpkgs/nginx/files/nginx/run
+++ b/srcpkgs/nginx/files/nginx/run
@@ -1,2 +1,3 @@
 #!/bin/sh
+exec 2>&1
 exec nginx -g 'daemon off;'

--- a/srcpkgs/ngircd/files/ngircd/run
+++ b/srcpkgs/ngircd/files/ngircd/run
@@ -1,2 +1,3 @@
 #!/bin/sh
+exec 2>&1
 exec ngircd -n

--- a/srcpkgs/nix/files/nix-daemon/run
+++ b/srcpkgs/nix/files/nix-daemon/run
@@ -1,2 +1,3 @@
 #!/bin/sh
+exec 2>&1
 exec nix-daemon

--- a/srcpkgs/node_exporter/files/node_exporter/log/run
+++ b/srcpkgs/node_exporter/files/node_exporter/log/run
@@ -1,2 +1,0 @@
-#!/bin/sh
-exec vlogger -p daemon.info -t node_exporter

--- a/srcpkgs/node_exporter/files/node_exporter/run
+++ b/srcpkgs/node_exporter/files/node_exporter/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 
 # Add $ARGS for more arguments to node_exporter
 [ -f ./conf ] && . ./conf

--- a/srcpkgs/nodm/files/nodm/run
+++ b/srcpkgs/nodm/files/nodm/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 [ -r conf ] && . ./conf
 export NODM_USER NODM_X_OPTIONS NODM_MIN_SESSION_TIME NODM_XSESSION
 exec nodm 1>&2

--- a/srcpkgs/noip2/files/noip2/run
+++ b/srcpkgs/noip2/files/noip2/run
@@ -1,2 +1,3 @@
 #!/bin/sh
+exec 2>&1
 exec noip2 -f

--- a/srcpkgs/nrpe/files/nrpe/run
+++ b/srcpkgs/nrpe/files/nrpe/run
@@ -1,2 +1,3 @@
 #!/bin/sh
+exec 2>&1
 exec nrpe --no-forking --config=/etc/nagios/nrpe.cfg 2>&1

--- a/srcpkgs/nsd/files/nsd/run
+++ b/srcpkgs/nsd/files/nsd/run
@@ -1,3 +1,4 @@
 #!/bin/sh
+exec 2>&1
 install -d -m 0755 -o nsd -g nsd /run/nsd
 exec nsd -d 2>/dev/null

--- a/srcpkgs/nss-pam-ldapd/files/nslcd/run
+++ b/srcpkgs/nss-pam-ldapd/files/nslcd/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 mkdir -p /var/run/nslcd
 chown nslcd:nslcd /var/run/nslcd
 exec chpst -u nslcd:nslcd nslcd -n

--- a/srcpkgs/ntp/files/isc-ntpd/run
+++ b/srcpkgs/ntp/files/isc-ntpd/run
@@ -1,2 +1,3 @@
 #!/bin/sh
+exec 2>&1
 exec isc-ntpd -g -u ntpd:ntpd -n >/dev/null 2>&1

--- a/srcpkgs/nullmailer/files/nullmailer/run
+++ b/srcpkgs/nullmailer/files/nullmailer/run
@@ -1,2 +1,3 @@
 #!/bin/sh
+exec 2>&1
 exec chpst -u _nullmail nullmailer-send 2>&1

--- a/srcpkgs/nvidia/files/nvidia-powerd/run
+++ b/srcpkgs/nvidia/files/nvidia-powerd/run
@@ -1,3 +1,4 @@
 #!/bin/sh
+exec 2>&1
 
 exec /usr/bin/nvidia-powerd

--- a/srcpkgs/nxt/files/nxt-tor/run
+++ b/srcpkgs/nxt/files/nxt-tor/run
@@ -1,3 +1,4 @@
 #!/bin/sh
+exec 2>&1
 sv check tor >/dev/null || exit 1
 exec nxt-tor > /dev/null

--- a/srcpkgs/nxt/files/nxt/run
+++ b/srcpkgs/nxt/files/nxt/run
@@ -1,2 +1,3 @@
 #!/bin/sh
+exec 2>&1
 exec nxt > /dev/null

--- a/srcpkgs/odroid-u2-base/files/odroid-led/run
+++ b/srcpkgs/odroid-u2-base/files/odroid-led/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 set -e
 odroid-led
 exec chpst -b odroid-led pause

--- a/srcpkgs/ofono/files/ofonod/run
+++ b/srcpkgs/ofono/files/ofonod/run
@@ -1,2 +1,3 @@
 #!/bin/sh
+exec 2>&1
 exec ofonod -n

--- a/srcpkgs/oidentd/files/oidentd/run
+++ b/srcpkgs/oidentd/files/oidentd/run
@@ -1,3 +1,4 @@
 #!/bin/sh
+exec 2>&1
 [ -r conf ] && . ./conf
 exec oidentd -i ${OPTS:=-u nobody -g nogroup}

--- a/srcpkgs/olsrd/files/olsrd/run
+++ b/srcpkgs/olsrd/files/olsrd/run
@@ -1,2 +1,3 @@
 #!/bin/sh
+exec 2>&1
 exec olsrd -nofork -f /etc/olsrd.conf

--- a/srcpkgs/open-vm-tools/files/vmtoolsd/run
+++ b/srcpkgs/open-vm-tools/files/vmtoolsd/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 
 set -e
 

--- a/srcpkgs/open-vm-tools/files/vmware-vmblock-fuse/run
+++ b/srcpkgs/open-vm-tools/files/vmware-vmblock-fuse/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 
 set -e
 

--- a/srcpkgs/opendkim/files/opendkim/run
+++ b/srcpkgs/opendkim/files/opendkim/run
@@ -1,3 +1,4 @@
 #!/bin/sh
+exec 2>&1
 [ -r ./conf ] && . ./conf
 exec opendkim -f ${OPTS}

--- a/srcpkgs/openntpd/files/openntpd/log/run
+++ b/srcpkgs/openntpd/files/openntpd/log/run
@@ -1,2 +1,0 @@
-#!/bin/sh
-exec logger -t openntpd -p daemon.notice

--- a/srcpkgs/openntpd/files/openntpd/run
+++ b/srcpkgs/openntpd/files/openntpd/run
@@ -1,3 +1,4 @@
 #!/bin/sh
+exec 2>&1
 [ -r conf ] && . ./conf
 exec openntpd -d ${OPTS} 2>&1

--- a/srcpkgs/openrgb/files/openrgb/log/run
+++ b/srcpkgs/openrgb/files/openrgb/log/run
@@ -1,2 +1,0 @@
-#!/bin/sh
-exec logger -t openrgb -p daemon.info

--- a/srcpkgs/openrgb/files/openrgb/run
+++ b/srcpkgs/openrgb/files/openrgb/run
@@ -1,2 +1,3 @@
 #!/bin/sh
+exec 2>&1
 exec openrgb --server 2>&1

--- a/srcpkgs/opensmtpd/files/opensmtpd/run
+++ b/srcpkgs/opensmtpd/files/opensmtpd/run
@@ -1,2 +1,3 @@
 #!/bin/sh
+exec 2>&1
 exec smtpd -F 2>&1

--- a/srcpkgs/openssh/files/sshd/run
+++ b/srcpkgs/openssh/files/sshd/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 ssh-keygen -A >/dev/null 2>&1 # Will generate host keys if they don't already exist
 [ -r conf ] && . ./conf
 exec /usr/bin/sshd -D $OPTS

--- a/srcpkgs/openvswitch/files/ovs-vswitchd/run
+++ b/srcpkgs/openvswitch/files/ovs-vswitchd/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 modprobe -q openvswitch || exit 1
 sv check ovsdb-server >/dev/null || exit 1
 install -d /run/openvswitch

--- a/srcpkgs/openvswitch/files/ovsdb-server/run
+++ b/srcpkgs/openvswitch/files/ovsdb-server/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 if [ ! -f /etc/openvswitch/conf.db ]; then
     install -d /etc/openvswitch
     ovsdb-tool create /etc/openvswitch/conf.db /usr/share/openvswitch/vswitch.ovsschema || exit 1

--- a/srcpkgs/oragono/files/oragono/log/run
+++ b/srcpkgs/oragono/files/oragono/log/run
@@ -1,2 +1,0 @@
-#!/bin/sh
-exec vlogger -t oragono

--- a/srcpkgs/parpd/files/parpd/run
+++ b/srcpkgs/parpd/files/parpd/run
@@ -1,3 +1,4 @@
 #!/bin/sh
+exec 2>&1
 [ -r conf ] && . ./conf
 exec parpd ${OPTS:=-fl} 1>&2

--- a/srcpkgs/parprouted/files/parprouted/run
+++ b/srcpkgs/parprouted/files/parprouted/run
@@ -1,3 +1,4 @@
 #!/bin/sh
+exec 2>&1
 [ -r ./conf ] && . ./conf
 exec parprouted ${OPTS}

--- a/srcpkgs/pbbuttonsd/files/pbbuttonsd/run
+++ b/srcpkgs/pbbuttonsd/files/pbbuttonsd/run
@@ -1,3 +1,4 @@
 #!/bin/sh
+exec 2>&1
 [ -r conf ] && . ./conf
 exec pbbuttonsd --configfile=${CONF:=/etc/pbbuttonsd.cnf} ${OPTS}

--- a/srcpkgs/pcsclite/files/pcscd/run
+++ b/srcpkgs/pcsclite/files/pcscd/run
@@ -1,2 +1,3 @@
 #!/bin/sh
+exec 2>&1
 exec pcscd -f

--- a/srcpkgs/pd-mapper/files/pd-mapper/run
+++ b/srcpkgs/pd-mapper/files/pd-mapper/run
@@ -1,3 +1,4 @@
 #!/bin/sh
+exec 2>&1
 [ -r conf ] && . ./conf
 exec pd-mapper $OPTS

--- a/srcpkgs/php/files/php-fpm/run
+++ b/srcpkgs/php/files/php-fpm/run
@@ -1,3 +1,4 @@
 #!/bin/sh
+exec 2>&1
 
 exec php-fpm --nodaemonize

--- a/srcpkgs/php8.0/files/php-fpm8.0/run
+++ b/srcpkgs/php8.0/files/php-fpm8.0/run
@@ -1,3 +1,4 @@
 #!/bin/sh
+exec 2>&1
 [ -r conf ] && . ./conf
 exec php-fpm8.0 --nodaemonize ${OPTS}

--- a/srcpkgs/php8.1/files/php-fpm8.1/run
+++ b/srcpkgs/php8.1/files/php-fpm8.1/run
@@ -1,3 +1,4 @@
 #!/bin/sh
+exec 2>&1
 [ -r conf ] && . ./conf
 exec php-fpm8.1 --nodaemonize ${OPTS}

--- a/srcpkgs/pipewire/files/pipewire-pulse/run
+++ b/srcpkgs/pipewire/files/pipewire-pulse/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 # this service is experimental and most setups should start pipewire as a user,
 # for further information, please refer to the handbook
 ! [ -d /run/pulse ] && install -m 755 -g _pipewire -o _pipewire -d /run/pulse

--- a/srcpkgs/pipewire/files/pipewire/run
+++ b/srcpkgs/pipewire/files/pipewire/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 # this service is experimental and most setups should start pipewire as a user,
 # for further information, please refer to the handbook
 ! [ -d /run/pipewire ] && install -m 755 -g _pipewire -o _pipewire -d /run/pipewire

--- a/srcpkgs/podman/files/podman-docker/run
+++ b/srcpkgs/podman/files/podman-docker/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 
 ln -sf /run/podman/podman.sock /run/docker.sock
 exec chpst -b podman-docker pause

--- a/srcpkgs/podman/files/podman/log/run
+++ b/srcpkgs/podman/files/podman/log/run
@@ -1,1 +1,0 @@
-/usr/bin/vlogger

--- a/srcpkgs/podman/files/podman/run
+++ b/srcpkgs/podman/files/podman/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 
 [ -r ./conf ] && . ./conf
 exec podman --log-level info system service ${OPTS:---time=0} 2>&1

--- a/srcpkgs/polipo/files/polipo/run
+++ b/srcpkgs/polipo/files/polipo/run
@@ -1,2 +1,3 @@
 #!/bin/sh
+exec 2>&1
 exec chpst -u nobody polipo

--- a/srcpkgs/polkit/files/polkitd/run
+++ b/srcpkgs/polkit/files/polkitd/run
@@ -1,2 +1,3 @@
 #!/bin/sh
+exec 2>&1
 exec /usr/lib/polkit-1/polkitd --no-debug

--- a/srcpkgs/postfix/files/postfix/run
+++ b/srcpkgs/postfix/files/postfix/run
@@ -1,3 +1,4 @@
 #!/bin/sh
+exec 2>&1
 postfix check || exit 1
 exec /usr/libexec/postfix/master -d

--- a/srcpkgs/postgresql14/files/postgresql14/log/run
+++ b/srcpkgs/postgresql14/files/postgresql14/log/run
@@ -1,2 +1,0 @@
-#!/bin/sh
-exec logger -p daemon.info -t postgres@VERSION@

--- a/srcpkgs/postgresql14/files/postgresql14/run
+++ b/srcpkgs/postgresql14/files/postgresql14/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 . /etc/psql@VERSION@/default/postgresql
 : ${PGDATA:="$PGROOT/data"}
 

--- a/srcpkgs/postgresql15/files/postgresql15/log/run
+++ b/srcpkgs/postgresql15/files/postgresql15/log/run
@@ -1,2 +1,0 @@
-#!/bin/sh
-exec logger -p daemon.info -t postgres@VERSION@

--- a/srcpkgs/postgresql15/files/postgresql15/run
+++ b/srcpkgs/postgresql15/files/postgresql15/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 . /etc/psql@VERSION@/default/postgresql
 : ${PGDATA:="$PGROOT/data"}
 

--- a/srcpkgs/power-profiles-daemon/files/power-profiles-daemon/run
+++ b/srcpkgs/power-profiles-daemon/files/power-profiles-daemon/run
@@ -1,2 +1,3 @@
 #!/bin/sh
+exec 2>&1
 exec /usr/libexec/power-profiles-daemon

--- a/srcpkgs/preload/files/preload/log/run
+++ b/srcpkgs/preload/files/preload/log/run
@@ -1,2 +1,0 @@
-#!/bin/sh
-exec svlogd -t /var/log/preload

--- a/srcpkgs/preload/template
+++ b/srcpkgs/preload/template
@@ -1,13 +1,13 @@
 # Template file for 'preload'
 pkgname=preload
 version=0.6.4
-revision=10
+revision=11
 build_style=gnu-configure
 hostmakedepends="pkg-config"
 makedepends="libglib-devel"
 short_desc="Adaptive readahead daemon"
 maintainer="bougyman <bougyman@voidlinux.org>"
-license="GPL-2"
+license="GPL-2.0-or-later"
 homepage="http://sourceforge.net/projects/preload"
 distfiles="${SOURCEFORGE_SITE}/${pkgname}/${pkgname}-${version}.tar.gz"
 checksum=d0a558e83cb29a51d9d96736ef39f4b4e55e43a589ad1aec594a048ca22f816b

--- a/srcpkgs/privoxy/files/privoxy/log/run
+++ b/srcpkgs/privoxy/files/privoxy/log/run
@@ -1,2 +1,0 @@
-#!/bin/sh
-exec vlogger -t privoxy

--- a/srcpkgs/privoxy/files/privoxy/run
+++ b/srcpkgs/privoxy/files/privoxy/run
@@ -1,2 +1,3 @@
 #!/bin/sh
+exec 2>&1
 exec chpst -u privoxy:privoxy privoxy --no-daemon /etc/privoxy/config 2>&1

--- a/srcpkgs/prometheus/files/prometheus/log/run
+++ b/srcpkgs/prometheus/files/prometheus/log/run
@@ -1,2 +1,0 @@
-#!/bin/sh
-exec logger -p daemon.info -t prometheus

--- a/srcpkgs/prometheus/files/prometheus/run
+++ b/srcpkgs/prometheus/files/prometheus/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 
 [ -f ./conf ] && . ./conf
 

--- a/srcpkgs/prosody/files/prosody/run
+++ b/srcpkgs/prosody/files/prosody/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 mkdir -p /run/prosody
 chown prosody:prosody /run/prosody
 exec chpst -u prosody:prosody prosody

--- a/srcpkgs/pulseaudio/files/pulseaudio/run
+++ b/srcpkgs/pulseaudio/files/pulseaudio/run
@@ -1,2 +1,3 @@
 #!/bin/sh
+exec 2>&1
 exec pulseaudio --system

--- a/srcpkgs/qemu/files/qemu-ga/run
+++ b/srcpkgs/qemu/files/qemu-ga/run
@@ -1,3 +1,4 @@
 #!/bin/sh
+exec 2>&1
 [ -r conf ] && . ./conf
 exec qemu-ga ${OPTS}

--- a/srcpkgs/qrtr-ns/files/qrtr-ns/log/run
+++ b/srcpkgs/qrtr-ns/files/qrtr-ns/log/run
@@ -1,1 +1,0 @@
-/usr/bin/vlogger

--- a/srcpkgs/qrtr-ns/files/qrtr-ns/run
+++ b/srcpkgs/qrtr-ns/files/qrtr-ns/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 [ -r conf ] && . ./conf
 : ${OPTS:=-f 1}
 exec qrtr-ns $OPTS

--- a/srcpkgs/quassel/files/quasselcore/run
+++ b/srcpkgs/quassel/files/quasselcore/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 [ -r conf ] && . ./conf
 exec chpst -u quassel quasselcore \
 	${OPTS:=--require-ssl --configdir=/var/lib/quassel --logfile=/var/log/quassel/quasselcore.log}

--- a/srcpkgs/radeon-profile-daemon/files/radeon-profile-daemon/run
+++ b/srcpkgs/radeon-profile-daemon/files/radeon-profile-daemon/run
@@ -1,2 +1,3 @@
 #!/bin/sh
+exec 2>&1
 exec radeon-profile-daemon

--- a/srcpkgs/radicale/files/radicale/log/run
+++ b/srcpkgs/radicale/files/radicale/log/run
@@ -1,2 +1,0 @@
-#!/bin/sh
-exec svlogd /var/log/radicale

--- a/srcpkgs/radicale/template
+++ b/srcpkgs/radicale/template
@@ -1,7 +1,7 @@
 # Template file for 'radicale'
 pkgname=radicale
 version=3.1.8
-revision=2
+revision=3
 build_style=python3-module
 hostmakedepends="python3-setuptools"
 depends="python3-vobject python3-dateutil python3-passlib python3-bcrypt

--- a/srcpkgs/radvd/files/radvd/run
+++ b/srcpkgs/radvd/files/radvd/run
@@ -1,2 +1,3 @@
 #!/bin/sh
+exec 2>&1
 exec radvd --nodaemon --logmethod=syslog

--- a/srcpkgs/redis/files/redis/run
+++ b/srcpkgs/redis/files/redis/run
@@ -1,3 +1,4 @@
 #!/bin/sh
+exec 2>&1
 install -d -m0750 -o redis -g redis /run/redis
 exec chpst -u redis:redis redis-server /etc/redis/redis.conf > /dev/null

--- a/srcpkgs/rest-server/files/rest-server/run
+++ b/srcpkgs/rest-server/files/rest-server/run
@@ -1,3 +1,4 @@
 #!/bin/sh
+exec 2>&1
 . /etc/default/rest-server
 exec chpst -u _restserver:_restserver rest-server --path $DATA_DIRECTORY $OPTIONS

--- a/srcpkgs/rmilter/files/rmilter/run
+++ b/srcpkgs/rmilter/files/rmilter/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 [ -r conf ] && . ./conf
 : ${RMILTERUSER:=rmilter}
 : ${RMILTERGROUP:=rmilter}

--- a/srcpkgs/rmtfs/files/rmtfs/run
+++ b/srcpkgs/rmtfs/files/rmtfs/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 [ -r conf ] && . ./conf
 : ${OPTS:=-r -P -s}
 exec rmtfs $OPTS

--- a/srcpkgs/rng-tools/files/rngd/run
+++ b/srcpkgs/rng-tools/files/rngd/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 RNGD_OPTS=""
 [ -r conf ] && . ./conf
 

--- a/srcpkgs/routinator/files/routinator/log/run
+++ b/srcpkgs/routinator/files/routinator/log/run
@@ -1,1 +1,0 @@
-/usr/bin/vlogger

--- a/srcpkgs/routinator/files/routinator/run
+++ b/srcpkgs/routinator/files/routinator/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 [ -r conf ] && . ./conf
 
 exec routinator --config ${CONF_FILE:-/etc/routinator/routinator.conf} server --user=_routinator --group=_routinator $OPTS 2>&1

--- a/srcpkgs/rpcbind/files/rpcbind/run
+++ b/srcpkgs/rpcbind/files/rpcbind/run
@@ -1,2 +1,3 @@
 #!/bin/sh
+exec 2>&1
 exec rpcbind -f

--- a/srcpkgs/rspamd/files/rspamd/run
+++ b/srcpkgs/rspamd/files/rspamd/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 [ -r conf ] && . ./conf
 : ${RSPAMDUSER:=rspamd}
 : ${RSPAMDGROUP:=rspamd}

--- a/srcpkgs/rsync/files/rsyncd/run
+++ b/srcpkgs/rsync/files/rsyncd/run
@@ -1,3 +1,4 @@
 #!/bin/sh
+exec 2>&1
 [ ! -e /etc/rsyncd.conf ] && exit 1
 exec rsync --daemon --no-detach

--- a/srcpkgs/rsyslog/files/rsyslogd/run
+++ b/srcpkgs/rsyslog/files/rsyslogd/run
@@ -1,2 +1,3 @@
 #!/bin/sh
+exec 2>&1
 exec rsyslogd -n

--- a/srcpkgs/rtkit/files/rtkit/run
+++ b/srcpkgs/rtkit/files/rtkit/run
@@ -1,2 +1,3 @@
 #!/bin/sh
+exec 2>&1
 exec /usr/libexec/rtkit-daemon

--- a/srcpkgs/salt/files/salt-api/run
+++ b/srcpkgs/salt/files/salt-api/run
@@ -1,2 +1,3 @@
 #!/bin/sh
+exec 2>&1
 exec salt-api

--- a/srcpkgs/salt/files/salt-master/run
+++ b/srcpkgs/salt/files/salt-master/run
@@ -1,2 +1,3 @@
 #!/bin/sh
+exec 2>&1
 exec salt-master

--- a/srcpkgs/salt/files/salt-minion/run
+++ b/srcpkgs/salt/files/salt-minion/run
@@ -1,2 +1,3 @@
 #!/bin/sh
+exec 2>&1
 exec salt-minion

--- a/srcpkgs/salt/files/salt-syndic/run
+++ b/srcpkgs/salt/files/salt-syndic/run
@@ -1,2 +1,3 @@
 #!/bin/sh
+exec 2>&1
 exec salt-syndic

--- a/srcpkgs/samba/files/ctdbd/log/run
+++ b/srcpkgs/samba/files/ctdbd/log/run
@@ -1,2 +1,0 @@
-#!/bin/sh
-exec logger -p daemon.notice -t ctdbd

--- a/srcpkgs/samba/files/ctdbd/run
+++ b/srcpkgs/samba/files/ctdbd/run
@@ -1,2 +1,3 @@
 #!/bin/sh
+exec 2>&1
 exec ctdbd -i

--- a/srcpkgs/samba/files/nmbd/log/run
+++ b/srcpkgs/samba/files/nmbd/log/run
@@ -1,2 +1,0 @@
-#!/bin/sh
-exec logger -p daemon.notice -t nmbd

--- a/srcpkgs/samba/files/smbd/log/run
+++ b/srcpkgs/samba/files/smbd/log/run
@@ -1,2 +1,0 @@
-#!/bin/sh
-exec logger -p daemon.notice -t smbd

--- a/srcpkgs/sane/files/saned/run
+++ b/srcpkgs/sane/files/saned/run
@@ -1,3 +1,4 @@
 #!/bin/sh
+exec 2>&1
 [ -r ./conf ] && . ./conf
 exec saned -l -u _saned ${OPTS}

--- a/srcpkgs/scron/files/scron/run
+++ b/srcpkgs/scron/files/scron/run
@@ -1,2 +1,3 @@
 #!/bin/sh
+exec 2>&1
 exec scrond -n 2>&1

--- a/srcpkgs/sddm/files/sddm/run
+++ b/srcpkgs/sddm/files/sddm/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 set -e
 sv check dbus >/dev/null || exit 1
 

--- a/srcpkgs/seatd/files/seatd/run
+++ b/srcpkgs/seatd/files/seatd/run
@@ -1,2 +1,3 @@
 #!/bin/sh
+exec 2>&1
 exec /usr/bin/seatd -g _seatd

--- a/srcpkgs/sftpgo/files/sftpgo/run
+++ b/srcpkgs/sftpgo/files/sftpgo/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 
 export SFTPGO_HTTPD__TEMPLATES_PATH=/usr/share/sftpgo/templates
 export SFTPGO_HTTPD__STATIC_FILES_PATH=/usr/share/sftpgo/static

--- a/srcpkgs/shadowsocks-libev/files/shadowsocks-libev-client/run
+++ b/srcpkgs/shadowsocks-libev/files/shadowsocks-libev-client/run
@@ -1,2 +1,3 @@
 #!/bin/sh
+exec 2>&1
 exec chpst -u shadowsocks:shadowsocks ss-local -c /etc/shadowsocks-libev/config.json 1>/dev/null

--- a/srcpkgs/shadowsocks-libev/files/shadowsocks-libev-server/run
+++ b/srcpkgs/shadowsocks-libev/files/shadowsocks-libev-server/run
@@ -1,2 +1,3 @@
 #!/bin/sh
+exec 2>&1
 exec chpst -u shadowsocks:shadowsocks ss-server -c /etc/shadowsocks-libev/config.json 1>/dev/null

--- a/srcpkgs/shinit/files/shinit/run
+++ b/srcpkgs/shinit/files/shinit/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 
 export SHINIT_USER=void
 

--- a/srcpkgs/shiori/files/shiori/run
+++ b/srcpkgs/shiori/files/shiori/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 
 [ -r ./conf ] && . ./conf
 exec chpst -u _shiori shiori serve ${OPTS="--address 127.0.0.1 --port 8080"}

--- a/srcpkgs/shorewall/files/shorewall/run
+++ b/srcpkgs/shorewall/files/shorewall/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 set -e
 shorewall start
 exec chpst -b shorewall pause

--- a/srcpkgs/shorewall/files/shorewall6/run
+++ b/srcpkgs/shorewall/files/shorewall6/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 set -e
 shorewall6 start
 exec chpst -b shorewall6 pause

--- a/srcpkgs/sklogw/files/sklogw/log/run
+++ b/srcpkgs/sklogw/files/sklogw/log/run
@@ -1,5 +1,0 @@
-#!/usr/bin/sh
-
-#log script
-[ -d /var/log/sklogw ] || mkdir -p /var/log/sklogw
-exec svlogd -ttt /var/log/sklogw

--- a/srcpkgs/slim/files/slim/run
+++ b/srcpkgs/slim/files/slim/run
@@ -1,2 +1,3 @@
 #!/bin/sh
+exec 2>&1
 exec slim -nodaemon

--- a/srcpkgs/smartmontools/files/smartd/run
+++ b/srcpkgs/smartmontools/files/smartd/run
@@ -1,2 +1,3 @@
 #!/bin/sh
+exec 2>&1
 exec smartd -n

--- a/srcpkgs/smcroute/files/smcrouted/run
+++ b/srcpkgs/smcroute/files/smcrouted/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 
 [ -r conf ] && . ./conf
 

--- a/srcpkgs/snapcast/files/snapclient/log/run
+++ b/srcpkgs/snapcast/files/snapclient/log/run
@@ -1,2 +1,0 @@
-#!/bin/sh
-exec vlogger -t snapclient

--- a/srcpkgs/snapcast/files/snapclient/run
+++ b/srcpkgs/snapcast/files/snapclient/run
@@ -1,3 +1,4 @@
 #!/bin/sh
+exec 2>&1
 [ -r conf ] && . ./conf
 exec chpst -u _snapclient:audio snapclient ${OPTS} 2>&1

--- a/srcpkgs/snapcast/files/snapserver/log/run
+++ b/srcpkgs/snapcast/files/snapserver/log/run
@@ -1,2 +1,0 @@
-#!/bin/sh
-exec vlogger -t snapserver

--- a/srcpkgs/snapcast/files/snapserver/run
+++ b/srcpkgs/snapcast/files/snapserver/run
@@ -1,3 +1,4 @@
 #!/bin/sh
+exec 2>&1
 [ -r conf ] && . ./conf
 exec chpst -u _snapserver snapserver ${OPTS} 2>&1

--- a/srcpkgs/snapper/files/snapperd/run
+++ b/srcpkgs/snapper/files/snapperd/run
@@ -1,2 +1,3 @@
 #!/bin/sh
+exec 2>&1
 exec snapperd

--- a/srcpkgs/sndio/files/sndiod/log/run
+++ b/srcpkgs/sndio/files/sndiod/log/run
@@ -1,2 +1,0 @@
-#!/bin/sh
-exec logger -t sndiod

--- a/srcpkgs/sndio/files/sndiod/run
+++ b/srcpkgs/sndio/files/sndiod/run
@@ -1,3 +1,4 @@
 #!/bin/sh
+exec 2>&1
 [ -r conf ] && . ./conf
 exec sndiod ${OPTS} -d 2>&1

--- a/srcpkgs/socklog-ucspi/files/socklog-ucspi-tcp/log/run
+++ b/srcpkgs/socklog-ucspi/files/socklog-ucspi-tcp/log/run
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-exec vlogger -p daemon -t socklog-ucspi-tcp

--- a/srcpkgs/socklog-ucspi/files/socklog-ucspi-tcp/run
+++ b/srcpkgs/socklog-ucspi/files/socklog-ucspi-tcp/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 
 [ -r conf ] && . ./conf
 

--- a/srcpkgs/soju/files/soju/log/run
+++ b/srcpkgs/soju/files/soju/log/run
@@ -1,2 +1,0 @@
-#!/bin/sh
-exec vlogger -t soju -p daemon

--- a/srcpkgs/spamassassin/files/spamd/run
+++ b/srcpkgs/spamassassin/files/spamd/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 [ -r conf ] && . ./conf
 [ -d /var/lib/spamassassin ] || sa-update
 exec spamd ${OPTS}

--- a/srcpkgs/spampd/files/spampd/run
+++ b/srcpkgs/spampd/files/spampd/run
@@ -1,3 +1,4 @@
 #!/bin/sh
+exec 2>&1
 [ -r conf ] && . ./conf
 exec spampd --nodetach ${OPTS:=--host=127.0.0.1:10025 --relayhost=127.0.0.1:10026 --a --rh --u=_spampd --g=_spampd --maxsize=512}

--- a/srcpkgs/spice-vdagent/files/spice-vdagentd/run
+++ b/srcpkgs/spice-vdagent/files/spice-vdagentd/run
@@ -1,3 +1,4 @@
 #!/bin/sh
+exec 2>&1
 mkdir -p /var/run/spice-vdagentd
 exec /usr/bin/spice-vdagentd -x 

--- a/srcpkgs/spreed-webrtc/files/spreed-webrtc-server/log/run
+++ b/srcpkgs/spreed-webrtc/files/spreed-webrtc-server/log/run
@@ -1,2 +1,0 @@
-#!/bin/sh
-exec logger -t spreed-webrtc-server -p daemon.notice

--- a/srcpkgs/spreed-webrtc/files/spreed-webrtc-server/run
+++ b/srcpkgs/spreed-webrtc/files/spreed-webrtc-server/run
@@ -1,2 +1,3 @@
 #!/bin/sh
+exec 2>&1
 exec chpst -u _spreed_webrtc:_spreed_webrtc spreed-webrtc-server -c /etc/spreed/webrtc.conf

--- a/srcpkgs/sqmail/files/qmail-send/log/run
+++ b/srcpkgs/sqmail/files/qmail-send/log/run
@@ -1,2 +1,0 @@
-#!/bin/sh
-exec vlogger -p mail.notice -t qmail-send

--- a/srcpkgs/sqmail/files/qmail-send/run
+++ b/srcpkgs/sqmail/files/qmail-send/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 if [ -f /var/qmail/control/defaultdelivery ]; then
 	defaultdelivery=$(cat /var/qmail/control/defaultdelivery)
 else

--- a/srcpkgs/sqmail/files/qmail-smtpd/log/run
+++ b/srcpkgs/sqmail/files/qmail-smtpd/log/run
@@ -1,2 +1,0 @@
-#!/bin/sh
-exec vlogger -p mail.notice -t qmail-smtpd

--- a/srcpkgs/sqmail/files/qmail-smtpd/run
+++ b/srcpkgs/sqmail/files/qmail-smtpd/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 QMAILU=$(id -u _qmaild)
 QMAILG=$(id -g _qmaild)
 HOSTNAME=$(hostname)

--- a/srcpkgs/sqmail/files/qmail-smtpsd/log/run
+++ b/srcpkgs/sqmail/files/qmail-smtpsd/log/run
@@ -1,2 +1,0 @@
-#!/bin/sh
-exec vlogger -p mail.notice -t qmail-smtpsd

--- a/srcpkgs/sqmail/files/qmail-smtpsd/run
+++ b/srcpkgs/sqmail/files/qmail-smtpsd/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 QMAILU=$(id -u _qmaild)
 QMAILG=$(id -g _qmaild)
 HOSTNAME=$(hostname)

--- a/srcpkgs/sqmail/files/qmail-smtpsub/log/run
+++ b/srcpkgs/sqmail/files/qmail-smtpsub/log/run
@@ -1,2 +1,0 @@
-#!/bin/sh
-exec vlogger -p mail.notice -t qmail-smtpsub

--- a/srcpkgs/sqmail/files/qmail-smtpsub/run
+++ b/srcpkgs/sqmail/files/qmail-smtpsub/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 QMAILU=$(id -u _qmaild)
 QMAILG=$(id -g _qmaild)
 HOSTNAME=$(hostname)

--- a/srcpkgs/sqmail/template
+++ b/srcpkgs/sqmail/template
@@ -117,10 +117,10 @@ do_install() {
 	done
 	rm ${DESTDIR}/usr/bin/hostname
 	rm ${DESTDIR}/usr/share/man/man8/hostname.8
-	vsv qmail-send
-	vsv qmail-smtpd
-	vsv qmail-smtpsd
-	vsv qmail-smtpsub
+	vsv qmail-send mail
+	vsv qmail-smtpd mail
+	vsv qmail-smtpsd mail
+	vsv qmail-smtpsub mail
 	vlicense ../doc/LICENSE
 	mv ${DESTDIR}/usr/bin/maildirmake ${DESTDIR}/usr/bin/maildirmake.sqmail
 	mv ${DESTDIR}/usr/share/man/man1/maildirmake.1 ${DESTDIR}/usr/share/man/man1/maildirmake.sqmail.1

--- a/srcpkgs/squid/files/squid/run
+++ b/srcpkgs/squid/files/squid/run
@@ -1,4 +1,5 @@
 #!/bin/sh -e
+exec 2>&1
 install -o squid -g squid -m 0755 -d /var/run/squid
 squid -N -s -z
 exec squid -N -s

--- a/srcpkgs/sshguard/files/sshguard-socklog/run
+++ b/srcpkgs/sshguard/files/sshguard-socklog/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 
 # Defaults that mabe be overridden (or erased entirely) by configuration
 LOGFILE="${LOGFILE:-/var/log/socklog/secure/current}"

--- a/srcpkgs/ssl_exporter/files/ssl_exporter/run
+++ b/srcpkgs/ssl_exporter/files/ssl_exporter/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 
 [ -r ./conf ] && . ./conf
 exec chpst -u nobody ssl_exporter $OPTS

--- a/srcpkgs/sslh/files/sslh/run
+++ b/srcpkgs/sslh/files/sslh/run
@@ -1,2 +1,3 @@
 #!/bin/sh
+exec 2>&1
 exec sslh -f -u nobody -F/etc/sslh.cfg

--- a/srcpkgs/sssd/files/sssd/run
+++ b/srcpkgs/sssd/files/sssd/run
@@ -1,2 +1,3 @@
 #!/bin/sh
+exec 2>&1
 exec sssd -i

--- a/srcpkgs/strongswan/files/strongswan/run
+++ b/srcpkgs/strongswan/files/strongswan/run
@@ -1,2 +1,3 @@
 #!/bin/sh
+exec 2>&1
 exec ipsec start --nofork

--- a/srcpkgs/stubby/files/stubby/log/run
+++ b/srcpkgs/stubby/files/stubby/log/run
@@ -1,2 +1,0 @@
-#!/bin/sh
-exec logger -t stubby -p daemon.notice

--- a/srcpkgs/stubby/files/stubby/run
+++ b/srcpkgs/stubby/files/stubby/run
@@ -1,2 +1,3 @@
 #!/bin/sh
+exec 2>&1
 exec chpst -u _stubby:_stubby /usr/bin/stubby 2>&1

--- a/srcpkgs/subversion/files/svnserve/run
+++ b/srcpkgs/subversion/files/svnserve/run
@@ -1,3 +1,4 @@
 #!/bin/sh
+exec 2>&1
 [ -r conf ] && . ./conf
 exec svnserve -d --foreground $OPTS

--- a/srcpkgs/sv-netmount/files/netmount/run
+++ b/srcpkgs/sv-netmount/files/netmount/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 # Load user defined variables
 [ -r conf ] && . ./conf
 

--- a/srcpkgs/synapse/files/synapse/run
+++ b/srcpkgs/synapse/files/synapse/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 [ -r ./conf ] && . ./conf
 cd /var/lib/synapse
 exec chpst -u synapse:synapse synapse_homeserver -c ${CONFIG_FILE:-/etc/synapse/homeserver.yaml}

--- a/srcpkgs/syncthing/files/discosrv/log/run
+++ b/srcpkgs/syncthing/files/discosrv/log/run
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-exec svlogd /var/log/discosrv

--- a/srcpkgs/syncthing/files/relaysrv/log/run
+++ b/srcpkgs/syncthing/files/relaysrv/log/run
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-exec svlogd /var/log/relaysrv

--- a/srcpkgs/syncthing/template
+++ b/srcpkgs/syncthing/template
@@ -1,7 +1,7 @@
 # Template file for 'syncthing'
 pkgname=syncthing
 version=1.23.1
-revision=1
+revision=2
 build_style=go
 go_import_path="github.com/syncthing/syncthing"
 go_package="

--- a/srcpkgs/synergy/files/synergyc/run
+++ b/srcpkgs/synergy/files/synergyc/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 [ -r ./conf ] && . ./conf
 [ -z $SERVER_ADDR ] && exit 0
 [ -z $SKIP_X11_TEST ] && ! ps -C Xorg >/dev/null 2>&1 && exit 0

--- a/srcpkgs/synergy/files/synergys/run
+++ b/srcpkgs/synergy/files/synergys/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 [ -r ./conf ] && . ./conf
 [ -z $SKIP_X11_TEST ] && ! ps -C Xorg >/dev/null 2>&1 && exit 0
 exec synergys --no-daemon ${OPTS:=--restart}

--- a/srcpkgs/tailscale/files/tailscaled/log/run
+++ b/srcpkgs/tailscale/files/tailscaled/log/run
@@ -1,4 +1,0 @@
-#!/bin/sh
-
-exec 2>&1
-exec logger -t tailscaled -p daemon.info

--- a/srcpkgs/telegraf/files/telegraf/run
+++ b/srcpkgs/telegraf/files/telegraf/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 [ -r ./conf ] && . ./conf
 
 exec chpst -u _telegraf:_telegraf telegraf "$TELEGRAF_CONF_LINE" "$TELEGRAF_CONFDIR_LINE" 2>&1

--- a/srcpkgs/tftp-hpa/files/tftpd-hpa/run
+++ b/srcpkgs/tftp-hpa/files/tftpd-hpa/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 
 [ -r conf ] && . ./conf
 

--- a/srcpkgs/thermald/files/thermald/log/run
+++ b/srcpkgs/thermald/files/thermald/log/run
@@ -1,1 +1,0 @@
-/usr/bin/vlogger

--- a/srcpkgs/thermald/files/thermald/run
+++ b/srcpkgs/thermald/files/thermald/run
@@ -1,3 +1,4 @@
 #!/bin/sh
+exec 2>&1
 sv check dbus >/dev/null || exit 1
 exec thermald --no-daemon --dbus-enable 2>&1

--- a/srcpkgs/thttpd/files/thttpd/run
+++ b/srcpkgs/thttpd/files/thttpd/run
@@ -1,2 +1,3 @@
 #!/bin/sh
+exec 2>&1
 exec thttpd -D

--- a/srcpkgs/tinc/files/tincd/run
+++ b/srcpkgs/tinc/files/tincd/run
@@ -1,2 +1,3 @@
 #!/bin/sh
+exec 2>&1
 exec tincd -D

--- a/srcpkgs/tinyproxy/files/tinyproxy/run
+++ b/srcpkgs/tinyproxy/files/tinyproxy/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 [ -r conf ] && . ./conf
 install -d -m 0755 -o _tinyproxy -g _tinyproxy /run/tinyproxy
 exec chpst -1 tinyproxy -d $OPTS

--- a/srcpkgs/tinyssh/files/tinysshd/run
+++ b/srcpkgs/tinyssh/files/tinysshd/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 [ -r ./conf ] && . ./conf
 # Override OPTS in conf.  Suggested:
 # OPTS='-x sftp=/usr/libexec/sftp-server -l -v'

--- a/srcpkgs/tlp/files/tlp/run
+++ b/srcpkgs/tlp/files/tlp/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 exec 1>&2
 tlp init start || exit 1
 exec chpst -b tlp pause

--- a/srcpkgs/tor/files/tor/run
+++ b/srcpkgs/tor/files/tor/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 [ -r conf ] && . ./conf
 ulimit -n ${MAX_OPEN_FILES:-65536}
 exec tor ${OPTS:=--quiet} --runasdaemon 0 2>&1

--- a/srcpkgs/touchegg/files/touchegg/run
+++ b/srcpkgs/touchegg/files/touchegg/run
@@ -1,2 +1,3 @@
 #!/bin/sh
+exec 2>&1
 exec chpst -u _touchegg:input touchegg --daemon

--- a/srcpkgs/toxcore/files/tox-bootstrapd/run
+++ b/srcpkgs/toxcore/files/tox-bootstrapd/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 
 [ -r ./conf ] && . ./conf
 exec chpst -u _tox_bootstrapd tox-bootstrapd --foreground ${OPTS:-"--config=/etc/tox-bootstrapd.conf"}

--- a/srcpkgs/tqftpserv/files/tqftpserv/log/run
+++ b/srcpkgs/tqftpserv/files/tqftpserv/log/run
@@ -1,1 +1,0 @@
-/usr/bin/vlogger

--- a/srcpkgs/transmission/files/transmission-daemon/run
+++ b/srcpkgs/transmission/files/transmission-daemon/run
@@ -1,2 +1,3 @@
 #!/bin/sh
+exec 2>&1
 exec chpst -u transmission:transmission transmission-daemon -f --log-error

--- a/srcpkgs/trousers/files/tcsd/log/run
+++ b/srcpkgs/trousers/files/tcsd/log/run
@@ -1,2 +1,0 @@
-#!/bin/sh
-exec logger -p daemon.info -t tcsd 

--- a/srcpkgs/twoftpd/files/twoftpd-anon/run
+++ b/srcpkgs/twoftpd/files/twoftpd-anon/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 UID=$(id -u ftp)
 GID=$(id -g ftp)
 echo $UID > ./env/UID

--- a/srcpkgs/ufw/files/ufw/run
+++ b/srcpkgs/ufw/files/ufw/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 set -e
 /usr/lib/ufw/ufw-init start quiet
 exec chpst -b ufw pause

--- a/srcpkgs/ulogd/files/ulogd/run
+++ b/srcpkgs/ulogd/files/ulogd/run
@@ -1,2 +1,3 @@
 #!/bin/sh
+exec 2>&1
 exec ulogd -u _ulogd

--- a/srcpkgs/umurmur/files/umurmurd/log/run
+++ b/srcpkgs/umurmur/files/umurmurd/log/run
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-exec logger -p daemon.notice -t umurmurd

--- a/srcpkgs/unbound/files/unbound/run
+++ b/srcpkgs/unbound/files/unbound/run
@@ -1,2 +1,3 @@
 #!/bin/sh
+exec 2>&1
 exec unbound -dp

--- a/srcpkgs/up_rewrite/files/up_rewrite/log/run
+++ b/srcpkgs/up_rewrite/files/up_rewrite/log/run
@@ -1,1 +1,0 @@
-/usr/bin/vlogger

--- a/srcpkgs/upmpdcli/files/upmpdcli/log/run
+++ b/srcpkgs/upmpdcli/files/upmpdcli/log/run
@@ -1,2 +1,0 @@
-#!/bin/sh
-exec vlogger -t upmpdcli

--- a/srcpkgs/upmpdcli/files/upmpdcli/run
+++ b/srcpkgs/upmpdcli/files/upmpdcli/run
@@ -1,3 +1,4 @@
 #!/bin/sh
+exec 2>&1
 [ -r conf ] && . ./conf
 exec chpst -u _upmpdcli upmpdcli ${OPTS:- -c /etc/upmpdcli.conf} 2>&1

--- a/srcpkgs/uptimed/files/uptimed/run
+++ b/srcpkgs/uptimed/files/uptimed/run
@@ -1,3 +1,4 @@
 #!/bin/sh
+exec 2>&1
 [ -r conf ] && . ./conf
 exec uptimed -f $OPTS

--- a/srcpkgs/usbguard/files/usbguard/run
+++ b/srcpkgs/usbguard/files/usbguard/run
@@ -1,2 +1,3 @@
 #!/bin/sh
+exec 2>&1
 exec usbguard-daemon

--- a/srcpkgs/usbmuxd/files/usbmuxd/run
+++ b/srcpkgs/usbmuxd/files/usbmuxd/run
@@ -1,2 +1,3 @@
 #!/bin/sh
+exec 2>&1
 exec usbmuxd -f -u

--- a/srcpkgs/util-linux/files/uuidd/run
+++ b/srcpkgs/util-linux/files/uuidd/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 [ ! -d /run/uuidd ] && mkdir -p /run/uuidd
 chown _uuidd:_uuidd /run/uuidd
 exec chpst -u _uuidd:_uuidd uuidd -F -P

--- a/srcpkgs/v2ray/files/v2ray/run
+++ b/srcpkgs/v2ray/files/v2ray/run
@@ -1,3 +1,4 @@
 #!/bin/sh
+exec 2>&1
 
 exec chpst -u _v2ray v2ray run -config=/etc/v2ray/config.json 2>&1

--- a/srcpkgs/varnish/files/varnishd/log/run
+++ b/srcpkgs/varnish/files/varnishd/log/run
@@ -1,2 +1,0 @@
-#!/bin/sh
-exec logger -t varnishd -p daemon.info

--- a/srcpkgs/varnish/files/varnishd/run
+++ b/srcpkgs/varnish/files/varnishd/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 
 # Default options
 VARNISH_ADDR=0.0.0.0:80

--- a/srcpkgs/vault/files/vault/run
+++ b/srcpkgs/vault/files/vault/run
@@ -1,3 +1,4 @@
 #!/bin/sh
+exec 2>&1
 
 exec chpst -u _vault vault server -config=/etc/vault/

--- a/srcpkgs/vaultwarden/files/vaultwarden/log/run
+++ b/srcpkgs/vaultwarden/files/vaultwarden/log/run
@@ -1,1 +1,0 @@
-/usr/bin/vlogger

--- a/srcpkgs/vaultwarden/files/vaultwarden/run
+++ b/srcpkgs/vaultwarden/files/vaultwarden/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 [ -r ./conf ] && . ./conf
 ENV_FILE=${ENV_FILE:-/etc/vaultwarden.conf}
 export ENV_FILE

--- a/srcpkgs/virtualbox-ose/files/vboxservice/run
+++ b/srcpkgs/virtualbox-ose/files/vboxservice/run
@@ -1,3 +1,4 @@
 #!/bin/sh
+exec 2>&1
 # Note: requires dbus service
 exec VBoxService -f

--- a/srcpkgs/virtualbox-ose/files/vboxwebsrv/run
+++ b/srcpkgs/virtualbox-ose/files/vboxwebsrv/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 sv check vboxservice >/dev/null || exit 1
 sv check dbus >/dev/null || exit 1
 exec vboxwebsrv

--- a/srcpkgs/vnstat/files/vnstatd/log/run
+++ b/srcpkgs/vnstat/files/vnstatd/log/run
@@ -1,1 +1,0 @@
-/usr/bin/vlogger

--- a/srcpkgs/vnstat/files/vnstatd/run
+++ b/srcpkgs/vnstat/files/vnstatd/run
@@ -1,2 +1,3 @@
 #!/bin/sh
+exec 2>&1
 exec vnstatd -n

--- a/srcpkgs/vpnd/files/vpnd/run
+++ b/srcpkgs/vpnd/files/vpnd/run
@@ -1,2 +1,3 @@
 #!/bin/sh
+exec 2>&1
 exec /usr/bin/vpnd

--- a/srcpkgs/vsftpd/files/vsftpd-ipv6/run
+++ b/srcpkgs/vsftpd/files/vsftpd-ipv6/run
@@ -1,3 +1,4 @@
 #!/bin/sh
+exec 2>&1
 [ -r conf ] && . ./conf
 exec vsftpd -obackground=no -olisten=no -olisten_ipv6=yes ${OPTS} 

--- a/srcpkgs/vsftpd/files/vsftpd/run
+++ b/srcpkgs/vsftpd/files/vsftpd/run
@@ -1,3 +1,4 @@
 #!/bin/sh
+exec 2>&1
 [ -r conf ] && . ./conf
 exec vsftpd -obackground=no ${OPTS} 

--- a/srcpkgs/watchdog/files/watchdog/run
+++ b/srcpkgs/watchdog/files/watchdog/run
@@ -1,3 +1,4 @@
 #!/bin/sh
+exec 2>&1
 [ -r conf ] && . ./conf
 exec watchdog -F ${OPTS}

--- a/srcpkgs/waydroid/files/waydroid-container/log/run
+++ b/srcpkgs/waydroid/files/waydroid-container/log/run
@@ -1,1 +1,0 @@
-/usr/bin/vlogger

--- a/srcpkgs/waydroid/files/waydroid-container/run
+++ b/srcpkgs/waydroid/files/waydroid-container/run
@@ -1,2 +1,3 @@
 #!/bin/sh
+exec 2>&1
 exec waydroid -w container start

--- a/srcpkgs/webhook/files/webhook/log/run
+++ b/srcpkgs/webhook/files/webhook/log/run
@@ -1,2 +1,0 @@
-#!/bin/sh
-exec vlogger -p daemon.info -t webhook

--- a/srcpkgs/wesnoth/files/wesnothd/run
+++ b/srcpkgs/wesnoth/files/wesnothd/run
@@ -1,3 +1,4 @@
 #!/bin/sh
+exec 2>&1
 mkdir -m0700 -p /run/wesnoth
 exec wesnothd

--- a/srcpkgs/wicd/files/wicd/run
+++ b/srcpkgs/wicd/files/wicd/run
@@ -1,3 +1,4 @@
 #!/bin/sh
+exec 2>&1
 sv check dbus >/dev/null || exit 1
 exec chpst -1 wicd --no-daemon

--- a/srcpkgs/wireguard-tools/files/wireguard/run
+++ b/srcpkgs/wireguard-tools/files/wireguard/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 set -e
 
 for conf in /etc/wireguard/*.conf; do

--- a/srcpkgs/wireplumber/files/wireplumber/log/run
+++ b/srcpkgs/wireplumber/files/wireplumber/log/run
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-exec logger -t wireplumber -p daemon.info

--- a/srcpkgs/wireproxy/files/wireproxy/run
+++ b/srcpkgs/wireproxy/files/wireproxy/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 
 [ -r ./conf ] && . ./conf
 

--- a/srcpkgs/x2goserver/files/x2gocleansessions/log/run
+++ b/srcpkgs/x2goserver/files/x2gocleansessions/log/run
@@ -1,2 +1,0 @@
-#!/bin/sh
-exec logger -p daemon.info -t x2gocleansessions

--- a/srcpkgs/x2goserver/files/x2gocleansessions/run
+++ b/srcpkgs/x2goserver/files/x2gocleansessions/run
@@ -1,2 +1,3 @@
 #!/bin/sh
+exec 2>&1
 exec /usr/bin/x2gocleansessions --nofork

--- a/srcpkgs/xdm/files/xdm/run
+++ b/srcpkgs/xdm/files/xdm/run
@@ -1,2 +1,3 @@
 #!/bin/sh
+exec 2>&1
 exec xdm -error /dev/stdout -nodaemon 2>&1

--- a/srcpkgs/xen/files/xen/run
+++ b/srcpkgs/xen/files/xen/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 sv check xenconsoled >/dev/null || exit 1
 xenstore-write "/local/domain/0/domid" 0 || exit 1
 xenstore-write "/local/domain/0/name" "Domain-0" || exit 1

--- a/srcpkgs/xen/files/xenconsoled/run
+++ b/srcpkgs/xen/files/xenconsoled/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 sv check xenstored >/dev/null || exit 1
 mkdir -p /var/log/xen/console
 exec xenconsoled -i --log=all

--- a/srcpkgs/xen/files/xenstored/run
+++ b/srcpkgs/xen/files/xenstored/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 [ ! -d /run/xen ] && mkdir -p /run/xen
 modprobe -q xen-evtchn xen-gnttalloc || exit 1
 mountpoint -q /proc/xen || mount -t xenfs xenfs /proc/xen

--- a/srcpkgs/xinetd/files/xinetd/run
+++ b/srcpkgs/xinetd/files/xinetd/run
@@ -1,2 +1,3 @@
 #!/bin/sh
+exec 2>&1
 exec xinetd -dontfork -syslog daemon

--- a/srcpkgs/xl2tpd/files/xl2tpd/run
+++ b/srcpkgs/xl2tpd/files/xl2tpd/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 [ -r conf ] && . ./conf
 [ -d /var/run/xl2tpd ] || mkdir /var/run/xl2tpd
 exec xl2tpd -D ${OPTS:=-c /etc/xl2tpd/xl2tpd.conf}

--- a/srcpkgs/yggdrasil/files/yggdrasil/log/run
+++ b/srcpkgs/yggdrasil/files/yggdrasil/log/run
@@ -1,1 +1,0 @@
-/usr/bin/vlogger

--- a/srcpkgs/yggdrasil/files/yggdrasil/run
+++ b/srcpkgs/yggdrasil/files/yggdrasil/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 modprobe tun
 caps='-all,+NET_ADMIN,+NET_RAW'
 drop_caps="setpriv --inh-caps $caps --bounding-set $caps"

--- a/srcpkgs/zabbix/files/zabbix-agent/run
+++ b/srcpkgs/zabbix/files/zabbix-agent/run
@@ -1,3 +1,4 @@
 #!/bin/sh
+exec 2>&1
 install -d -m0750 -o _zabbix_agent -g _zabbix_agent /run/zabbix-agentd
 chpst -u _zabbix_agent:_zabbix_agent zabbix_agentd -f -c /etc/zabbix_agentd.conf

--- a/srcpkgs/zabbix/files/zabbix-proxy/run
+++ b/srcpkgs/zabbix/files/zabbix-proxy/run
@@ -1,3 +1,4 @@
 #!/bin/sh
+exec 2>&1
 install -d -m0750 -o _zabbix_proxy -g _zabbix_proxy /run/zabbix-proxy
 chpst -u _zabbix_proxy:_zabbix_proxy zabbix_proxy -f -c /etc/zabbix_proxy.conf

--- a/srcpkgs/zabbix/files/zabbix-server/run
+++ b/srcpkgs/zabbix/files/zabbix-server/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 sv start mysqld >/dev/null || exit 1
 
 install -d -m0750 -o _zabbix_server -g _zabbix_server /run/zabbix-server

--- a/srcpkgs/zeek/files/bro/run
+++ b/srcpkgs/zeek/files/bro/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 
 BROLOGDIR="/var/log/bro"
 

--- a/srcpkgs/zeek/files/zeek/run
+++ b/srcpkgs/zeek/files/zeek/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 
 ZEEKLOGDIR="/var/log/zeek"
 

--- a/srcpkgs/zfs/files/zed/run
+++ b/srcpkgs/zfs/files/zed/run
@@ -1,3 +1,4 @@
 #!/bin/sh
+exec 2>&1
 [ -r conf ] && . conf
 exec zed -F $OPTS

--- a/srcpkgs/znc/files/znc/log/run
+++ b/srcpkgs/znc/files/znc/log/run
@@ -1,1 +1,0 @@
-/usr/bin/vlogger

--- a/srcpkgs/znc/files/znc/run
+++ b/srcpkgs/znc/files/znc/run
@@ -1,2 +1,3 @@
 #!/bin/sh
+exec 2>&1
 exec chpst -u znc:znc znc -f -n 2>&1

--- a/srcpkgs/zrepl/files/zrepl/run
+++ b/srcpkgs/zrepl/files/zrepl/run
@@ -1,3 +1,4 @@
 #!/bin/sh
+exec 2>&1
 install -d -m0700 /var/run/zrepl
 exec zrepl --config /etc/zrepl/zrepl.yml daemon


### PR DESCRIPTION
- common/environment/setup/install.sh: always add log service
    - overridable by having a log service at `$pkgname/files/$service/log`
    - uses a sane default run script with the service name set as tag and daemon facility
    - warns if stderr is not redirected in the main service
    - example of warnings:
```
=> soju-0.5.2_1: running post_install ...
=> WARNING: soju-0.5.2_1: vsv: service 'soju' does not contain 'exec 2>&1' to log stderr
=> WARNING: soju-0.5.2_1: vsv: overriding default log service
```
- Manual.md: document vsv log autocreation
- *: remove log dir en-masse

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

### TODO
- [x] go through all removed log services and see if any need overrides
    - candidates at a glance: cronie, dcron, dkimproxy, dnscrypt-proxy, dq, postgres13/14, sqmail
- [x] add/fix redirection to main run file of all services

### Questions
- ~~Should there be a possible second vlogger argument that sets the facility? This would remove the need for overrides for the few services that set cron/mail as facility~~
    - added this for ease-of-use

[ci skip]