### PR TITLE
kore: ignore certain warnings (openssl3)

### DIFF
--- a/srcpkgs/kore/template
+++ b/srcpkgs/kore/template
@@ -1,7 +1,7 @@
 # Template file for 'kore'
 pkgname=kore
 version=4.2.3
-revision=2
+revision=3
 # arch specific seccomp stuff
 archs="x86_64* aarch64* ppc64*"
 build_style=gnu-makefile
@@ -16,6 +16,8 @@ homepage="https://kore.io"
 distfiles="https://kore.io/releases/kore-${version}.tar.gz"
 checksum=f9a9727af97441ae87ff9250e374b9fe3a32a3348b25cb50bd2b7de5ec7f5d82
 disable_parallel_build=yes
+# openssl3 fix
+CFLAGS+=" -Wno-deprecated-declarations -Wno-discarded-qualifiers"
 
 export TARGET_PLATFORM=${XBPS_TARGET_MACHINE}
 


### PR DESCRIPTION
- I tested the changes in this PR: no
- I built this PR locally for my native architecture, (x86_64-musl)

@Hoshpak Added flags to build with openssl3, see #37681 