### PR TITLE
nextcloud-client: fix kwallet desktop file

### DIFF
--- a/srcpkgs/nextcloud-client/template
+++ b/srcpkgs/nextcloud-client/template
@@ -1,10 +1,10 @@
 # Template file for 'nextcloud-client'
 pkgname=nextcloud-client
 version=3.6.6
-revision=1
+revision=2
 build_style=cmake
 configure_args="-Wno-dev"
-hostmakedepends="pkg-config inkscape"
+hostmakedepends="pkg-config inkscape qt5-qmake qt5-host-tools qt5-tools"
 makedepends="qt5-tools-devel qt5-declarative-devel qt5-webchannel-devel
  qt5-location-devel qtkeychain-qt5-devel sqlite-devel libcloudproviders-devel
  qt5-quickcontrols2-devel qt5-websockets-devel qt5-svg-devel
@@ -35,7 +35,6 @@ if [ "$XBPS_TARGET_ENDIAN" = "le" ]; then
 fi
 
 if [ "$CROSS_BUILD" ]; then
-	hostmakedepends+=" qt5-qmake qt5-host-tools qt5-tools"
 	# provides desktoptojson
 	hostmakedepends+=" $(vopt_if dolphin 'kcoreaddons')"
 fi
@@ -53,19 +52,23 @@ if [ "$XBPS_CHECK_PKGS" ]; then
 	esac
 fi
 
+post_install() {
+	vsed -i -e 's,^Exec=.*,Exec=/usr/bin/nextcloud.kwallet,' \
+	     -e 's,\(^Name=.*\),\1 - use kwallet,' \
+	     -e 's,\(^Comment=.*\),\1 - use kwallet credential storage,' \
+	     -e '/^# Translations/,$d' \
+	     build/src/gui/com.nextcloud.desktopclient.nextcloud.desktop
+	vinstall build/src/gui/com.nextcloud.desktopclient.nextcloud.desktop \
+		644 usr/share/applications/ \
+		nextcloud-kwallet.desktop
+}
+
 nextcloud-client-kwallet_package() {
 	short_desc+=" - kwallet credential backend"
 	depends="nextcloud-client>=${version}_${revision} kwallet"
 	pkg_install() {
 		vbin ${FILESDIR}/kwallet/nextcloud.kwallet
-		vmkdir usr/share/applications
-		cp build/src/gui/com.nextcloud.desktopclient.nextcloud.desktop \
-		   ${DESTDIR}/usr/share/applications/nextcloud-kwallet.desktop
-		vsed -i -e 's,^Exec=.*,Exec=/usr/bin/nextcloud.kwallet,' \
-		     -e 's,\(^Name=.*\),\1 - use kwallet,' \
-		     -e 's,\(^Comment=.*\),\1 - use kwallet credential storage,' \
-		     -e '/^# Translations/,$d' \
-		     ${DESTDIR}/usr/share/applications/nextcloud-kwallet.desktop
+		vmove usr/share/applications/nextcloud-kwallet.desktop
 		vdoc ${FILESDIR}/kwallet/README.voidlinux
 	}
 }


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->
nextcloud-client had a problem where installing nextcloud-client would also install the "Nextcloud Desktop - use kwallet" desktop file. But it wouldn't work because the executable it pointed to didn't exist. As far as I could tell, the issue was a `${DESTDIR}` instead of `${PKGDESTDIR}.` Also changed a `cp` to a `vcopy,` which seems preferred in the codebase.

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, x86_64 glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - armv7l (successful)
  - x86_64 musl failed "unable to find argp.h" like in #39467 and upstream https://github.com/nextcloud/desktop/issues/3200


