### PR TITLE
squid: update to 5.7

### DIFF
--- a/srcpkgs/squid/template
+++ b/srcpkgs/squid/template
@@ -1,10 +1,9 @@
 # Template file for 'squid'
 pkgname=squid
-version=5.3
+version=5.7
 revision=1
 build_style=gnu-configure
 configure_args="
- --sbindir=/usr/bin
  --sysconfdir=/etc/squid
  --libexecdir=/usr/libexec/squid
  --datadir=/usr/share/squid
@@ -26,28 +25,18 @@ configure_args="
  --enable-icmp
  --enable-linux-netfilter
  --enable-ident-lookups
- --enable-useragent-log
  --enable-cache-digests
- --enable-referer-log
- --enable-arp-acl
  --enable-htcp
- --enable-carp
  --enable-epoll
  --with-large-files
- --enable-arp-acl
  --with-default-user=squid
  --enable-async-io
- --enable-truncate
  --enable-icap-client
  --enable-ssl-crtd
  --disable-arch-native
  --disable-strict-error-checking
  --enable-wccpv2
- --with-build-environment=default
- squid_cv_gnu_atomics=yes
- squid_opt_enable_large_files=yes
- BUILDCXX=${CXX_host}
- BUILDCXXFLAGS=-O2"
+ --with-build-environment=default"
 conf_files="/etc/squid/squid.conf
  /etc/squid/errorpage.css
  /etc/squid/cachemgr.conf
@@ -65,7 +54,7 @@ license="GPL-2.0-or-later"
 homepage="http://www.squid-cache.org/"
 changelog="http://www.squid-cache.org/Versions/v5/changesets/"
 distfiles="http://www.squid-cache.org/Versions/v5/squid-${version}.tar.xz"
-checksum=45178588df1311ded41ebadd632840c4d93a8d7f5f60e38e74acf2f1ae2f1715
+checksum=6b0753aaba4c9c4efd333e67124caecf7ad6cc2d38581f19d2f0321f5b7ecd81
 system_accounts="squid"
 # squid-conf-tests requires a squid user in the system
 make_check=no
@@ -75,6 +64,11 @@ if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
 	LDFLAGS+=" -latomic"
 fi
 
+pre_configure() {
+	export BUILDCXX="${CXX_host}"
+	export BUILDCXXFLAGS="-O2"
+}
+
 post_install() {
 	chmod u+s \
 		${DESTDIR}/usr/libexec/squid/basic_ncsa_auth \
@@ -82,7 +76,4 @@ post_install() {
 		${DESTDIR}/usr/libexec/squid/pinger
 	vsv squid
 	vinstall ${FILESDIR}/cron.daily 0744 etc/cron.daily squid
-
-	# CVE-2018-1000027
-	echo 'log_uses_indirect_client off' >> ${DESTDIR}/etc/squid/squid.conf
 }


### PR DESCRIPTION
- I tested the changes in this PR: no
- I built this PR locally for my native architecture, (x86_64-musl)

seems to build fine with openssl 3 #37681 