### PR TITLE
seahorse: allow building with GnuPG-2.4.x

### DIFF
--- a/srcpkgs/seahorse/patches/allow-building-with-gpg-2.4.patch
+++ b/srcpkgs/seahorse/patches/allow-building-with-gpg-2.4.patch
@@ -1,0 +1,25 @@
+From 9260c74779be3d7a378db0671af862ffa3573d42 Mon Sep 17 00:00:00 2001
+From: Xi Ruoyao <xry111@xry111.site>
+Date: Wed, 21 Dec 2022 20:58:26 +0800
+Subject: [PATCH] Allow building with GnuPG-2.4.x
+
+---
+ meson.build | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/meson.build b/meson.build
+index e29b5322..23d0b54f 100644
+--- a/meson.build
++++ b/meson.build
+@@ -26,7 +26,7 @@ endif
+ # Dependencies
+ min_glib_version = '2.66'
+ min_gcr_version = '3.38'
+-accepted_gpg_versions = [ '2.2.0', '2.3.0' ]
++accepted_gpg_versions = [ '2.2.0', '2.3.0', '2.4.0' ]
+ gpg_check_version = find_program('build-aux' / 'gpg_check_version.py')
+ 
+ glib_deps = [
+-- 
+2.39.1
+


### PR DESCRIPTION
This patch is taken from upstream but is not in any released version yet

- I tested the changes in this PR: see #41948