### PR TITLE
FreeRADIUS: update to 3.0.26

### DIFF
--- a/srcpkgs/FreeRADIUS/template
+++ b/srcpkgs/FreeRADIUS/template
@@ -1,6 +1,6 @@
 # Template file for 'FreeRADIUS'
 pkgname=FreeRADIUS
-version=3.0.23
+version=3.0.26
 revision=1
 build_style=gnu-configure
 makedepends="talloc-devel openssl-devel mit-krb5-devel pam-devel \
@@ -10,7 +10,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-only"
 homepage="http://freeradius.org"
 distfiles="https://github.com/FreeRADIUS/freeradius-server/archive/release_${version//./_}.tar.gz"
-checksum=6192b6a8d141545dc54c00c1a7af7f502f990418d780dcae76074163070dbb86
+checksum=6aea98d6126035e7ccca483d8b3faea447030169639807017ec98985b78fb2ca
 nocross=yes # Not supported by upstream
 system_accounts="_freeradius"
 make_dirs="/etc/raddb 0750 _freeradius _freeradius"


### PR DESCRIPTION
- I tested the changes in this PR: no
- I built this PR locally for my native architecture, (x86_64-musl)

this now builds with openssl3, unlike before #37681 