### PR TITLE
New package: lswt-1.0.4

### DIFF
--- a/srcpkgs/lswt/template
+++ b/srcpkgs/lswt/template
@@ -1,0 +1,13 @@
+# Template file for 'lswt'
+pkgname=lswt
+version=1.0.4
+revision=1
+build_style=gnu-makefile
+hostmakedepends="wayland-devel"
+makedepends="wayland-devel"
+short_desc="List Wayland toplevels"
+maintainer="icp <pangolin@vivaldi.net>"
+license="GPL-3.0-only"
+homepage="https://git.sr.ht/~leon_plickat/lswt"
+distfiles="https://git.sr.ht/~leon_plickat/lswt/archive/v${version}.tar.gz"
+checksum=a1a422d996e9dbfa2d07daf5588ede280157ab0d0cc7e918d7c16999f4e14b5f


### PR DESCRIPTION
#### Description
`lswt` will list all toplevels advertised by a Wayland server using the `foreign-toplevel-management-unstable-v1` protocol extension.

#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

#### Local build testing
- I built this PR locally for my native architecture: **x86_64**

Closes https://github.com/void-linux/void-packages/issues/42057