### PR TITLE
got: update to 0.83

### DIFF
--- a/srcpkgs/got/template
+++ b/srcpkgs/got/template
@@ -1,6 +1,6 @@
 # Template file for 'got'
 pkgname=got
-version=0.79
+version=0.83
 revision=1
 build_style=gnu-configure
 hostmakedepends="byacc pkg-config"
@@ -11,7 +11,14 @@ license="ISC"
 homepage="https://gameoftrees.org"
 changelog="https://gameoftrees.org/releases/CHANGES"
 distfiles="https://gameoftrees.org/releases/portable/got-portable-${version}.tar.gz"
-checksum="78be1c0a905184ed1cb506468359faf87e4ee86851291b1670439c46bfb3d87c"
+checksum="90d854e8e47d21434f2fbd83f749e1ab65f9be6556ed8526a67abf10e52f1bff"
+nocross="the template subproject needs to be compiled and executed on the host but produces object files that are used by the cross build."
+
+post_extract() {
+	# XXX: doesn't correctly link to libbsd; will be fixed for the next release
+	(cd template && \
+		sed -i.orig 's,sys/queue.h,bsd/sys/queue.h,g' configure parse.[cy])
+}
 
 post_install() {
 	sed -n '/Copyright/,/PERFORMANCE/p' got/got.c > LICENSE


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (amd64-musl)

I had to disable cross-compiling.  since 0.79 there's a subproject `template` that is needed to generate some sources during build time.  it needs to be compiled and executed on the host.  However, as a byproduct of the build of `template`, some object files are left in places where they're then picked up by the regular build which thus fails at linking.  Will try to have it fixed for the next release.
