### PR TITLE
vsv: update to 2.0.0

### DIFF
--- a/srcpkgs/vsv/template
+++ b/srcpkgs/vsv/template
@@ -1,18 +1,18 @@
 # Template file for 'vsv'
 pkgname=vsv
-version=1.3.5
+version=2.0.0
 revision=1
-depends="bash psmisc"
+build_style=cargo
+depends="psmisc"
 short_desc="Manage and view runit services"
 maintainer="Dave Eddy <dave@daveeddy.com>"
 license="MIT"
 homepage="https://github.com/bahamas10/vsv"
 changelog="https://raw.githubusercontent.com/bahamas10/vsv/master/CHANGES.md"
 distfiles="https://github.com/bahamas10/vsv/archive/v${version}.tar.gz"
-checksum=d4b88a7d11189d6a9dd160a25025cbec8d27a88ea02a6826e0c010824b6bc943
+checksum=05c20d8e04ca37fdc47dde80a04a4709b54650748529456ebdddb4104fc805ec
 
-do_install() {
-	vbin vsv
+post_install() {
 	vman man/vsv.8
 	vlicense LICENSE
 }


### PR DESCRIPTION
`vsv` was rewritten from Bash to Rust so this template reflects that change - the user-facing CLI interface has not changed.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-2.36)
- I built this PR locally for these architectures:
  - armv6l (cross)

---

I built the package locally:

```
./xbps-src pkg vsv # exited successfully
./xbps-src -a armv6l pkg vsv # exited succkssefully
```

I tested to make sure the package looked sane (had the files i expected):

```
$ xbps-query --repository=hostdir/binpkgs -f vsv
/usr/bin/vsv
/usr/share/licenses/vsv/LICENSE
/usr/share/man/man8/vsv.8
```

I installed the package on my system to make sure 1. it ran 2. was a compiled binary and not a bash script.

```
$ sudo xbps-install --repository hostdir/binpkgs vsv
$ file /usr/bin/vsv
/usr/bin/vsv: ELF 64-bit LSB pie executable, x86-64, version 1 (SYSV), dynamically linked, interpreter /lib64/ld-linux-x86-64.so.2, BuildID[sha1]=351cfbeb98cf65b1d3c34e7296348b96384521d2, for GNU/Linux 3.2.0, stripped
$ vsv -V
vsv 2.0.0
```