### PR TITLE
netpgp: add cflag to build with openssl3

### DIFF
--- a/srcpkgs/netpgp/template
+++ b/srcpkgs/netpgp/template
@@ -1,7 +1,7 @@
 # Template file for 'netpgp'
 pkgname=netpgp
 version=20140220
-revision=20
+revision=21
 build_style=gnu-configure
 hostmakedepends="automake libtool pkg-config"
 makedepends="zlib-devel bzip2-devel openssl-devel"
@@ -14,7 +14,7 @@ checksum=fbe403f037376a40afd19bc8a1786b55b67cf8092a723ef36a61d99260b66dbf
 
 CFLAGS="-Wno-error=unused-but-set-variable -Wno-error=cpp -Wno-format-truncation \
  -Wno-stringop-truncation -Wno-stringop-overflow -Wno-error=format-overflow \
- -Wno-array-parameter"
+ -Wno-array-parameter -Wno-deprecated-declarations"
 
 pre_configure() {
 	autoreconf -fi


### PR DESCRIPTION
- I tested the changes in this PR: no
- I built this PR locally for my native architecture, (x86_64-musl)
#37681 