### PR TITLE
xorg-server: update to 21.1.7.

### DIFF
--- a/srcpkgs/xorg-server/template
+++ b/srcpkgs/xorg-server/template
@@ -1,6 +1,6 @@
 # Template file for 'xorg-server'
 pkgname=xorg-server
-version=21.1.6
+version=21.1.7
 revision=1
 build_style=meson
 configure_args="-Dipv6=true -Dxorg=true -Dxnest=true -Dxephyr=true
@@ -24,7 +24,7 @@ maintainer="Leah Neukirchen <leah@vuxu.org>"
 license="MIT, BSD-3-Clause"
 homepage="https://xorg.freedesktop.org"
 distfiles="${XORG_SITE}/xserver/${pkgname}-${version}.tar.xz"
-checksum=1eb86ed674d042b6c8b1f9135e59395cbbca35ed551b122f73a7d8bb3bb22484
+checksum=d9c60b2dd0ec52326ca6ab20db0e490b1ff4f566f59ca742d6532e92795877bb
 lib32disabled=yes
 provides="xserver-abi-extension-10_1 xserver-abi-input-24_1
  xserver-abi-video-25_1 xf86-video-modesetting-1_1"


### PR DESCRIPTION
@leahneukirchen 

CVE-2023-0494 is resolved for xserver in 21.1.7. It's a use-after-free vulnerability. 

[Announcement](https://marc.info/?l=freedesktop-xorg&m=167573014011487&w=2) 
[Commit](https://gitlab.freedesktop.org/xorg/xserver/-/commit/0ba6d8c37071131a49790243cdac55392ecf71ec)

(Side note: xwayland also needs a bump to 22.1.8 for the same reason, but I recognize that someone other than you maintains it)

#### Testing the changes
- I tested the changes in this PR: YES. 
- Brief runtime testing on x86_64. 
- Cross-compiled for armv6l.
