### PR TITLE
xca: update to 2.4.0, patch for openssl3

### DIFF
--- a/srcpkgs/xca/patches/openssl3.patch
+++ b/srcpkgs/xca/patches/openssl3.patch
@@ -1,0 +1,238 @@
+From: https://git.alpinelinux.org/aports/plain/community/xca/openssl3.patch
+
+patch for openssl 3
+
+diff -Naurp xca-2.4.0.orig/lib/pkcs11.cpp xca-2.4.0.new/lib/pkcs11.cpp
+--- xca-2.4.0.orig/lib/pkcs11.cpp	2021-05-07 22:40:29.000000000 +0200
++++ xca-2.4.0.new/lib/pkcs11.cpp	2021-11-13 02:58:27.866824246 +0100
+@@ -840,8 +840,7 @@ EVP_PKEY *pkcs11::getPrivateKey(EVP_PKEY
+ 
+ 	switch (EVP_PKEY_type(keytype)) {
+ 	case EVP_PKEY_RSA:
+-		rsa = EVP_PKEY_get0_RSA(pub);
+-		rsa = RSAPublicKey_dup(rsa);
++		rsa = RSAPublicKey_dup(EVP_PKEY_get0_RSA(pub));
+ 		openssl_error();
+ 		if (!rsa_meth) {
+ #if OPENSSL_VERSION_NUMBER >= 0x1010000L
+@@ -865,8 +864,7 @@ EVP_PKEY *pkcs11::getPrivateKey(EVP_PKEY
+ 		EVP_PKEY_assign_RSA(evp, rsa);
+ 		break;
+ 	case EVP_PKEY_DSA:
+-		dsa = EVP_PKEY_get0_DSA(pub);
+-		dsa = DSAparams_dup(dsa);
++		dsa = DSAparams_dup(EVP_PKEY_get0_DSA(pub));
+ 		openssl_error();
+ 		if (!dsa_meth) {
+ #if OPENSSL_VERSION_NUMBER >= 0x10100000L
+@@ -889,8 +887,7 @@ EVP_PKEY *pkcs11::getPrivateKey(EVP_PKEY
+ 		break;
+ #if !defined(OPENSSL_NO_EC) && OPENSSL_VERSION_NUMBER >= 0x10100000L
+ 	case EVP_PKEY_EC:
+-		ec = EVP_PKEY_get0_EC_KEY(pub);
+-		ec = EC_KEY_dup(ec);
++		ec = EC_KEY_dup(EVP_PKEY_get0_EC_KEY(pub));
+ 		openssl_error();
+ 		if (!ec_key_meth) {
+ 			ec_key_meth = setup_ec_key_meth();
+diff -Naurp xca-2.4.0.orig/lib/pki_evp.cpp xca-2.4.0.new/lib/pki_evp.cpp
+--- xca-2.4.0.orig/lib/pki_evp.cpp	2021-05-07 22:40:29.000000000 +0200
++++ xca-2.4.0.new/lib/pki_evp.cpp	2021-11-13 03:00:39.279152488 +0100
+@@ -282,8 +282,8 @@ void pki_evp::fromPEMbyteArray(const QBy
+ static void search_ec_oid(EVP_PKEY *pkey)
+ {
+ #ifndef OPENSSL_NO_EC
+-	EC_KEY *ec;
+ 	EC_GROUP *builtin;
++	const EC_KEY *ec;
+ 	const EC_GROUP *ec_group;
+ 
+ 	int keytype = EVP_PKEY_id(pkey);
+@@ -498,7 +498,7 @@ void pki_evp::fload(const QString &fname
+ void pki_evp::fromData(const unsigned char *p, db_header_t *head)
+ {
+ 	int version, type, size;
+-	void *ptr = NULL;
++	const void *ptr = NULL;
+ 
+ 	if (key)
+ 		EVP_PKEY_free(key);
+@@ -518,8 +518,23 @@ void pki_evp::fromData(const unsigned ch
+ 	}
+ 	pki_openssl_error();
+ 
+-	if (key)
+-		ptr = EVP_PKEY_get0(key);
++	if (key) {
++		switch (EVP_PKEY_type(EVP_PKEY_id(key))) {
++		case EVP_PKEY_RSA:
++			ptr = EVP_PKEY_get0_RSA(key);
++			break;
++		case EVP_PKEY_DSA:
++			ptr = EVP_PKEY_get0_DSA(key);
++			break;
++#ifndef OPENSSL_NO_EX
++		case EVP_PKEY_EC:
++			ptr = EVP_PKEY_get0_EC_KEY(key);
++			break;
++#endif
++		default:
++			ptr = EVP_PKEY_get0(key);
++		}
++	}
+ 	if (!ptr)
+ 		throw errorEx(tr("Ignoring unsupported private key"));
+ 
+@@ -621,8 +636,8 @@ EVP_PKEY *pki_evp::legacyDecryptKey(QByt
+ 
+ 	pki_openssl_error();
+ 	if (EVP_PKEY_type(getKeyType()) == EVP_PKEY_RSA) {
+-		RSA *rsa = EVP_PKEY_get0_RSA(tmpkey);
+-		RSA_blinding_on(rsa, NULL);
++		const RSA *rsa = EVP_PKEY_get0_RSA(tmpkey);
++		RSA_blinding_on((RSA *) rsa, NULL);
+ 	}
+ 	myencKey.fill(0);
+ 	return tmpkey;
+@@ -930,7 +945,7 @@ bool pki_evp::verify_priv(EVP_PKEY *pkey
+ 		EVP_MD_CTX_free(ctx);
+ #endif
+ 	if (EVP_PKEY_id(pkey) == EVP_PKEY_RSA && EVP_PKEY_isPrivKey(pkey)) {
+-		RSA *rsa = EVP_PKEY_get0_RSA(pkey);
++		const RSA *rsa = EVP_PKEY_get0_RSA(pkey);
+ 		if (RSA_check_key(rsa) != 1)
+ 			verify = false;
+ 	}
+diff -Naurp xca-2.4.0.orig/lib/pki_key.cpp xca-2.4.0.new/lib/pki_key.cpp
+--- xca-2.4.0.orig/lib/pki_key.cpp	2021-05-07 22:40:29.000000000 +0200
++++ xca-2.4.0.new/lib/pki_key.cpp	2021-11-13 02:58:27.866824246 +0100
+@@ -197,7 +197,7 @@ QString pki_key::length() const
+ 
+ 	if (EVP_PKEY_id(key) == EVP_PKEY_DSA) {
+ 		const BIGNUM *p = NULL;
+-		DSA *dsa = EVP_PKEY_get0_DSA(key);
++		const DSA *dsa = EVP_PKEY_get0_DSA(key);
+ 		if (dsa)
+ 			DSA_get0_pqg(dsa, &p, NULL, NULL);
+ 		dsa_unset = p == NULL;
+@@ -299,7 +299,7 @@ QString pki_key::modulus() const
+ 	if (getKeyType() == EVP_PKEY_RSA) {
+ 		const BIGNUM *n = NULL;
+ 
+-		RSA *rsa = EVP_PKEY_get0_RSA(key);
++		const RSA *rsa = EVP_PKEY_get0_RSA(key);
+ 		RSA_get0_key(rsa, &n, NULL, NULL);
+ 		return BN2QString(n);
+ 	}
+@@ -310,7 +310,7 @@ QString pki_key::pubEx() const
+ {
+ 	if (getKeyType() == EVP_PKEY_RSA) {
+ 		const BIGNUM *e = NULL;
+-		RSA *rsa = EVP_PKEY_get0_RSA(key);
++		const RSA *rsa = EVP_PKEY_get0_RSA(key);
+ 		RSA_get0_key(rsa, NULL, &e, NULL);
+ 		return BN2QString(e);
+ 	}
+@@ -321,7 +321,7 @@ QString pki_key::subprime() const
+ {
+ 	if (getKeyType() == EVP_PKEY_DSA) {
+ 		const BIGNUM *q = NULL;
+-		DSA *dsa = EVP_PKEY_get0_DSA(key);
++		const DSA *dsa = EVP_PKEY_get0_DSA(key);
+ 		if (dsa)
+ 			DSA_get0_pqg(dsa, NULL, &q, NULL);
+ 		return BN2QString(q);
+@@ -333,7 +333,7 @@ QString pki_key::pubkey() const
+ {
+ 	if (getKeyType() == EVP_PKEY_DSA) {
+ 		const BIGNUM *pubkey = NULL;
+-		DSA *dsa = EVP_PKEY_get0_DSA(key);
++		const DSA *dsa = EVP_PKEY_get0_DSA(key);
+ 		if (dsa)
+ 			DSA_get0_key(dsa, &pubkey, NULL);
+ 		return BN2QString(pubkey);
+@@ -766,7 +766,7 @@ QByteArray pki_key::SSH2publicQByteArray
+ 		txt = "ssh-rsa";
+ 		ssh_key_QBA2data(txt, &data);
+ 		{
+-			RSA *rsa = EVP_PKEY_get0_RSA(key);
++			const RSA *rsa = EVP_PKEY_get0_RSA(key);
+ 			const BIGNUM *n, *e;
+ 			RSA_get0_key(rsa, &n, &e, NULL);
+ 			ssh_key_bn2data(e, &data);
+@@ -777,7 +777,7 @@ QByteArray pki_key::SSH2publicQByteArray
+ 		txt = "ssh-dss";
+ 		ssh_key_QBA2data(txt, &data);
+ 		{
+-			DSA *dsa = EVP_PKEY_get0_DSA(key);
++			const DSA *dsa = EVP_PKEY_get0_DSA(key);
+ 			const BIGNUM *p, *q, *g, *pubkey;
+ 			DSA_get0_pqg(dsa, &p, &q, &g);
+ 			DSA_get0_key(dsa, &pubkey, NULL);
+diff -Naurp xca-2.4.0.orig/lib/pki_scard.cpp xca-2.4.0.new/lib/pki_scard.cpp
+--- xca-2.4.0.orig/lib/pki_scard.cpp	2021-05-07 22:40:29.000000000 +0200
++++ xca-2.4.0.new/lib/pki_scard.cpp	2021-11-13 03:02:20.379174056 +0100
+@@ -293,10 +293,10 @@ void pki_scard::deleteFromToken()
+ pk11_attlist pki_scard::objectAttributesNoId(EVP_PKEY *pk, bool priv) const
+ {
+ 	QByteArray ba;
+-	RSA *rsa;
+-	DSA *dsa;
++	const RSA *rsa;
++	const DSA *dsa;
+ #ifndef OPENSSL_NO_EC
+-	EC_KEY *ec;
++	const EC_KEY *ec;
+ #endif
+ 	const BIGNUM *n = NULL;
+ 	const BIGNUM *e = NULL;
+@@ -401,10 +401,10 @@ int pki_scard::renameOnToken(const sloti
+ void pki_scard::store_token(const slotid &slot, EVP_PKEY *pkey)
+ {
+ 	QByteArray ba;
+-	RSA *rsa;
+-	DSA *dsa;
++	const RSA *rsa;
++	const DSA *dsa;
+ #ifndef OPENSSL_NO_EC
+-	EC_KEY *ec;
++	const EC_KEY *ec;
+ #endif
+ 	pk11_attlist pub_atts;
+ 	pk11_attlist priv_atts;
+@@ -691,7 +691,7 @@ pki_scard::~pki_scard()
+ void pki_scard::fromData(const unsigned char *p, db_header_t *head )
+ {
+ 	int version, size;
+-	void *ptr = NULL;
++	const void *ptr = NULL;
+ 
+ 	size = head->len - sizeof(db_header_t);
+         version = head->version;
+@@ -713,8 +713,23 @@ void pki_scard::fromData(const unsigned
+ 
+ 	d2i(ba);
+ 
+-	if (key)
+-		ptr = EVP_PKEY_get0(key);
++	if (key) {
++		switch (EVP_PKEY_type(EVP_PKEY_id(key))) {
++		case EVP_PKEY_RSA:
++			ptr = EVP_PKEY_get0_RSA(key);
++			break;
++		case EVP_PKEY_DSA:
++			ptr = EVP_PKEY_get0_DSA(key);
++			break;
++#ifndef OPENSSL_NO_EX
++		case EVP_PKEY_EC:
++			ptr = EVP_PKEY_get0_EC_KEY(key);
++			break;
++#endif
++		default:
++			ptr = EVP_PKEY_get0(key);
++		}
++	}
+ 
+ 	if (!ptr)
+ 		throw errorEx(tr("Ignoring unsupported token key"));
+

--- a/srcpkgs/xca/template
+++ b/srcpkgs/xca/template
@@ -1,17 +1,17 @@
 # Template file for 'xca'
 pkgname=xca
-version=2.1.2
-revision=4
+version=2.4.0
+revision=1
 build_style=gnu-configure
-hostmakedepends="pkg-config qt5-tools qt5-host-tools perl tar"
-makedepends="qt5-devel openssl-devel libltdl-devel"
+hostmakedepends="pkg-config qt5-host-tools"
+makedepends="qt5-devel qt5-tools-devel openssl-devel libltdl-devel"
 depends="qt5-plugin-sqlite"
 short_desc="X Certificate and Key Management"
 maintainer="Denis Revin <denis.revin@gmail.com>"
 license="BSD-3-Clause"
 homepage="https://hohnstaedt.de/xca"
 distfiles="https://github.com/chris2511/xca/releases/download/RELEASE.${version}/xca-${version}.tar.gz"
-checksum=fc845470a02b0b4534b46590be307f784662071fc412fdcad605c3bce901fe05
+checksum=66da8954fe9709ace965c6fcb1cfbb7b08ce75b7222988acb9e2b8b5fac7cf10
 
 pre_install() {
 	export destdir="${DESTDIR}"


### PR DESCRIPTION
- I tested the changes in this PR: no
- I built this PR locally for my native architecture, (x86_64-musl)

update and patch to build with openssl3 #37681 @dutsky 