### PR TITLE
caddy: update to 2.6.3.

### DIFF
--- a/srcpkgs/caddy/template
+++ b/srcpkgs/caddy/template
@@ -1,7 +1,7 @@
 # Template file for 'caddy'
 pkgname=caddy
-version=2.6.2
-revision=2
+version=2.6.3
+revision=1
 build_style=go
 go_import_path=github.com/caddyserver/caddy/v2
 go_package="${go_import_path}/cmd/caddy"
@@ -11,7 +11,7 @@ maintainer="Dominic Monroe <monroef4@googlemail.com>"
 license="Apache-2.0"
 homepage="https://caddyserver.com"
 distfiles="https://github.com/caddyserver/caddy/archive/v${version}.tar.gz"
-checksum=563d027a78919f859188fb894ae5f3669508a3430db347aa726cd73c19fb7038
+checksum=86d6bb9b90fb21b223dc570eb2ccc8cf917750d70fb0d9c4a86d3ec6c13c712c
 
 system_accounts="caddy"
 caddy_homedir="/var/lib/caddy"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->
fixes build with go 1.20

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
