### PR TITLE
e2fsprogs: update to 1.47.0, add fuse-devel to makedepends, split fus…

### DIFF
--- a/srcpkgs/e2fsprogs/template
+++ b/srcpkgs/e2fsprogs/template
@@ -1,6 +1,6 @@
 # Template file for 'e2fsprogs'
 pkgname=e2fsprogs
-version=1.46.5
+version=1.47.0
 revision=1
 build_style=gnu-configure
 configure_args="--enable-elf-shlibs --disable-fsck
@@ -10,14 +10,14 @@ configure_args="--enable-elf-shlibs --disable-fsck
  --sbindir=/usr/bin --libdir=/usr/lib e2fsprogs_cv_struct_st_flags=no"
 make_install_args="install-libs"
 hostmakedepends="texinfo pkg-config"
-makedepends="libuuid-devel libblkid-devel"
+makedepends="libuuid-devel libblkid-devel fuse-devel"
 checkdepends="perl tar"
 short_desc="Ext2/3/4 Filesystem Utilities"
 maintainer="Enno Boland <gottox@voidlinux.org>"
 license="GPL-2.0-or-later, LGPL-2.1-or-later"
 homepage="http://e2fsprogs.sourceforge.net/"
 distfiles="${KERNEL_SITE}/kernel/people/tytso/e2fsprogs/v${version}/e2fsprogs-${version}.tar.xz"
-checksum=2f16c9176704cf645dc69d5b15ff704ae722d665df38b2ed3cfc249757d8d81e
+checksum=144af53f2bbd921cef6f8bea88bb9faddca865da3fbc657cc9b4d2001097d5db
 conf_files="/etc/mke2fs.conf /etc/e2scrub.conf"
 
 do_check() {
@@ -55,9 +55,18 @@ e2fsprogs-devel_package() {
 		vmove "usr/share/info/libext2fs.info*"
 	}
 }
+
 e2fsprogs-libs_package() {
 	short_desc+=" - shared libraries"
 	pkg_install() {
 		vmove "usr/lib/*.so.*"
+	}
+}
+
+fuse2fs_package() {
+	short_desc+=" - driver for FUSE"
+	pkg_install() {
+		vmove usr/bin/fuse2fs
+		vmove usr/share/man/man1/fuse2fs.1
 	}
 }

--- a/srcpkgs/fuse2fs
+++ b/srcpkgs/fuse2fs
@@ -1,0 +1,1 @@
+e2fsprogs

--- a/srcpkgs/grub/patches/xx-e2fsprogs-1.patch
+++ b/srcpkgs/grub/patches/xx-e2fsprogs-1.patch
@@ -1,0 +1,62 @@
+Patch-Source: https://git.savannah.gnu.org/cgit/grub.git/commit/?id=7fd5feff97c4b1f446f8fcf6d37aca0c64e7c763
+useful because e2fsprogs 1.47 defaults to this enabled, and grub won't touch it
+--
+From 7fd5feff97c4b1f446f8fcf6d37aca0c64e7c763 Mon Sep 17 00:00:00 2001
+From: Javier Martinez Canillas <javierm@redhat.com>
+Date: Fri, 11 Jun 2021 21:36:16 +0200
+Subject: fs/ext2: Ignore checksum seed incompat feature
+
+This incompat feature is used to denote that the filesystem stored its
+metadata checksum seed in the superblock. This is used to allow tune2fs
+changing the UUID on a mounted metdata_csum filesystem without having
+to rewrite all the disk metadata. However, the GRUB doesn't use the
+metadata checksum at all. So, it can just ignore this feature if it
+is enabled. This is consistent with the GRUB filesystem code in general
+which just does a best effort to access the filesystem's data.
+
+The checksum seed incompat feature has to be removed from the ignore
+list if the support for metadata checksum verification is added to the
+GRUB ext2 driver later.
+
+Suggested-by: Eric Sandeen <esandeen@redhat.com>
+Suggested-by: Lukas Czerner <lczerner@redhat.com>
+Signed-off-by: Javier Martinez Canillas <javierm@redhat.com>
+Reviewed-by: Lukas Czerner <lczerner@redhat.com>
+Reviewed-by: Daniel Kiper <daniel.kiper@oracle.com>
+---
+ grub-core/fs/ext2.c | 10 ++++++++--
+ 1 file changed, 8 insertions(+), 2 deletions(-)
+
+diff --git a/grub-core/fs/ext2.c b/grub-core/fs/ext2.c
+index e7dd78e..4953a15 100644
+--- a/grub-core/fs/ext2.c
++++ b/grub-core/fs/ext2.c
+@@ -103,6 +103,7 @@ GRUB_MOD_LICENSE ("GPLv3+");
+ #define EXT4_FEATURE_INCOMPAT_64BIT		0x0080
+ #define EXT4_FEATURE_INCOMPAT_MMP		0x0100
+ #define EXT4_FEATURE_INCOMPAT_FLEX_BG		0x0200
++#define EXT4_FEATURE_INCOMPAT_CSUM_SEED		0x2000
+ #define EXT4_FEATURE_INCOMPAT_ENCRYPT          0x10000
+ 
+ /* The set of back-incompatible features this driver DOES support. Add (OR)
+@@ -123,10 +124,15 @@ GRUB_MOD_LICENSE ("GPLv3+");
+  * mmp:            Not really back-incompatible - was added as such to
+  *                 avoid multiple read-write mounts. Safe to ignore for this
+  *                 RO driver.
++ * checksum seed:  Not really back-incompatible - was added to allow tools
++ *                 such as tune2fs to change the UUID on a mounted metadata
++ *                 checksummed filesystem. Safe to ignore for now since the
++ *                 driver doesn't support checksum verification. However, it
++ *                 has to be removed from this list if the support is added later.
+  */
+ #define EXT2_DRIVER_IGNORED_INCOMPAT ( EXT3_FEATURE_INCOMPAT_RECOVER \
+-				     | EXT4_FEATURE_INCOMPAT_MMP)
+-
++				     | EXT4_FEATURE_INCOMPAT_MMP \
++				     | EXT4_FEATURE_INCOMPAT_CSUM_SEED)
+ 
+ #define EXT3_JOURNAL_MAGIC_NUMBER	0xc03b3998U
+ 
+-- 
+cgit v1.1
+

--- a/srcpkgs/grub/patches/xx-e2fsprogs-2.patch
+++ b/srcpkgs/grub/patches/xx-e2fsprogs-2.patch
@@ -1,0 +1,60 @@
+Patch-Source: https://git.savannah.gnu.org/cgit/grub.git/patch/?id=2e9fa73a040462b81bfbfe56c0bc7ad2d30b446b
+useful to support the large_dir ext4 feature
+--
+From 2e9fa73a040462b81bfbfe56c0bc7ad2d30b446b Mon Sep 17 00:00:00 2001
+From: Theodore Ts'o <tytso@mit.edu>
+Date: Tue, 30 Aug 2022 22:41:59 -0400
+Subject: fs/ext2: Ignore the large_dir incompat feature
+
+Recently, ext4 added the large_dir feature, which adds support for
+a 3 level htree directory support.
+
+The GRUB supports existing file systems with htree directories by
+ignoring their existence, and since the index nodes for the hash tree
+look like deleted directory entries (by design), the GRUB can simply do
+a brute force O(n) linear search of directories. The same is true for
+3 level deep htrees indicated by large_dir feature flag.
+
+Hence, it is safe for the GRUB to ignore the large_dir incompat feature.
+
+Fixes: https://savannah.gnu.org/bugs/?61606
+
+Signed-off-by: Theodore Ts'o <tytso@mit.edu>
+Reviewed-by: Daniel Kiper <daniel.kiper@oracle.com>
+---
+ grub-core/fs/ext2.c | 10 +++++++++-
+ 1 file changed, 9 insertions(+), 1 deletion(-)
+
+diff --git a/grub-core/fs/ext2.c b/grub-core/fs/ext2.c
+index 0989e26..e1cc5e6 100644
+--- a/grub-core/fs/ext2.c
++++ b/grub-core/fs/ext2.c
+@@ -104,6 +104,7 @@ GRUB_MOD_LICENSE ("GPLv3+");
+ #define EXT4_FEATURE_INCOMPAT_MMP		0x0100
+ #define EXT4_FEATURE_INCOMPAT_FLEX_BG		0x0200
+ #define EXT4_FEATURE_INCOMPAT_CSUM_SEED		0x2000
++#define EXT4_FEATURE_INCOMPAT_LARGEDIR		0x4000 /* >2GB or 3 level htree */
+ #define EXT4_FEATURE_INCOMPAT_ENCRYPT          0x10000
+ 
+ /* The set of back-incompatible features this driver DOES support. Add (OR)
+@@ -129,10 +130,17 @@ GRUB_MOD_LICENSE ("GPLv3+");
+  *                 checksummed filesystem. Safe to ignore for now since the
+  *                 driver doesn't support checksum verification. However, it
+  *                 has to be removed from this list if the support is added later.
++ * large_dir:      Not back-incompatible given that the GRUB ext2 driver does
++ *                 not implement EXT2_FEATURE_COMPAT_DIR_INDEX. If the GRUB
++ *                 eventually supports the htree feature (aka dir_index)
++ *                 it should support 3 level htrees and then move
++ *                 EXT4_FEATURE_INCOMPAT_LARGEDIR to
++ *                 EXT2_DRIVER_SUPPORTED_INCOMPAT.
+  */
+ #define EXT2_DRIVER_IGNORED_INCOMPAT ( EXT3_FEATURE_INCOMPAT_RECOVER \
+ 				     | EXT4_FEATURE_INCOMPAT_MMP \
+-				     | EXT4_FEATURE_INCOMPAT_CSUM_SEED)
++				     | EXT4_FEATURE_INCOMPAT_CSUM_SEED \
++				     | EXT4_FEATURE_INCOMPAT_LARGEDIR)
+ 
+ #define EXT3_JOURNAL_MAGIC_NUMBER	0xc03b3998U
+ 
+-- 
+cgit v1.1

--- a/srcpkgs/grub/template
+++ b/srcpkgs/grub/template
@@ -1,7 +1,7 @@
 # Template file for 'grub'
 pkgname=grub
 version=2.06
-revision=2
+revision=3
 hostmakedepends="python3 pkg-config flex freetype-devel font-unifont-bdf help2man
  automake gettext-devel-tools"
 makedepends="libusb-compat-devel ncurses-devel freetype-devel


### PR DESCRIPTION
…e2fs subpkg

- I tested the changes in this PR: no
- I built this PR locally for my native architecture, (x86_64-musl)

fixes https://github.com/void-linux/void-packages/issues/42150 @Gottox @danjenson