### PR TITLE
swirc: update to 3.4.0.

### DIFF
--- a/srcpkgs/swirc/template
+++ b/srcpkgs/swirc/template
@@ -1,6 +1,6 @@
 # Template file for 'swirc'
 pkgname=swirc
-version=3.3.9
+version=3.4.0
 revision=1
 build_style=configure
 configure_args="$(vopt_with notify libnotify)"
@@ -8,16 +8,16 @@ make_build_args="PREFIX=/usr"
 make_check_args="PREFIX=/usr"
 make_install_args="PREFIX=/usr"
 hostmakedepends="gettext-devel-tools pkg-config which"
-makedepends="gettext-devel libcurl-devel libidn-devel ncurses-devel openssl-devel
- $(vopt_if notify libnotify-devel)"
+makedepends="gettext-devel hunspell-devel libcurl-devel libidn-devel
+ ncurses-devel openssl-devel $(vopt_if notify libnotify-devel)"
 checkdepends="cmocka-devel"
 short_desc="Curses ICB and IRC client"
 maintainer="Markus Uhlin <markus.uhlin@bredband.net>"
 license="BSD-3-Clause, ISC, MIT"
 homepage="https://www.nifty-networks.net/swirc"
 changelog="https://raw.githubusercontent.com/uhlin/swirc/master/CHANGELOG.md"
-distfiles="https://www.nifty-networks.net/swirc/releases/${pkgname}-${version}.tgz"
-checksum=4326dcf521d2a0ca3c55ed289fea0c0d1a289dcc158c80f4aee207ff2085ab37
+distfiles="https://www.nifty-networks.net/swirc/releases/swirc-${version}.tgz"
+checksum=3142273db2568a9dd812abf87112edb01fdcac6b4ee7e61ebb5fc96f60a95a18
 
 build_options="notify"
 build_options_default="notify"


### PR DESCRIPTION
Swirc 3.4.0 out

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, **x86_64-musl**
- I built this PR locally for these architectures:
  - armv6l-musl **cross**
