### PR TITLE
etckeeper: update to 1.18.21, support xbps, run tests

### DIFF
--- a/srcpkgs/etckeeper/template
+++ b/srcpkgs/etckeeper/template
@@ -1,23 +1,31 @@
 # Template file for 'etckeeper'
 pkgname=etckeeper
-version=1.18.14
-revision=2
+version=1.18.21
+revision=1
 build_style=gnu-makefile
 conf_files="/etc/etckeeper/etckeeper.conf"
+make_check_target=test
 hostmakedepends="perl"
 depends="git perl"
+checkdepends="bats git"
 short_desc="Tools to store /etc in a git, mercurial, or darcs repository"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="https://etckeeper.branchable.com"
 distfiles="https://git.joeyh.name/index.cgi/etckeeper.git/snapshot/${pkgname}-${version}.tar.gz"
-checksum=15924673fa3f15e4b172f9f0111a442ed3f0ee99dcf9ad3c5107736ffb8c1089
+checksum=a87c5e9c847c29f761da933c1cd907779545c7ddf92fb75de8ef692b90fc9e5d
+make_check=ci-skip # due to not detecting chroot
 
 pre_install() {
 	sed -ni '/systemddir/!p' Makefile
 	sed -ni '/apt.conf/!p' Makefile
+	sed -i 's|^PYTHON=python$|PYTHON=/bin/false|' Makefile
+	sed -i -e "/^LOWLEVEL_PACKAGE_MANAGER/c LOWLEVEL_PACKAGE_MANAGER=xbps" etckeeper.conf
+	sed -i -e "/^HIGHLEVEL_PACKAGE_MANAGER/c HIGHLEVEL_PACKAGE_MANAGER=xbps" etckeeper.conf
 }
 
 post_install() {
 	vdoc doc/README.mdwn
+	rm -rf lib/systemd
+	rm -rf etc/apt
 }


### PR DESCRIPTION
- I tested the changes in this PR: yes
- I built this PR locally for my native architecture, (`x86_64-musl`)

A couple of tests fail, likely due to `fakeroot` or similar.