### PR TITLE
haproxy: update to 2.6.9.

### DIFF
--- a/srcpkgs/haproxy/template
+++ b/srcpkgs/haproxy/template
@@ -1,19 +1,19 @@
 # Template file for 'haproxy'
 pkgname=haproxy
-version=2.4.20
+version=2.6.9
 revision=1
 build_style=gnu-makefile
 make_install_args="SBINDIR=${DESTDIR}/usr/bin DOCDIR=${DESTDIR}/usr/share/doc/${pkgname}"
 hostmakedepends="lua53-devel"
-makedepends="libatomic-devel openssl-devel lua53-devel pcre-devel"
+makedepends="libatomic-devel openssl-devel lua53-devel pcre2-devel"
 checkdepends="curl varnish"
 short_desc="Reliable, high performance TCP/HTTP load balancer"
 maintainer="Zach Dykstra <dykstra.zachary@gmail.com>"
 license="GPL-2.0-or-later, LGPL-2.1-or-later"
 homepage="https://www.haproxy.org"
-changelog="https://www.haproxy.org/download/2.4/src/CHANGELOG"
+changelog="https://www.haproxy.org/download/${version%.*}/src/CHANGELOG"
 distfiles="https://www.haproxy.org/download/${version%.*}/src/haproxy-${version}.tar.gz"
-checksum=415c62d2159941a17c443941aa85e7353047d79f3b72a0e7062473f7e753cacc
+checksum=f01a1c5f465dc1b5cd175d0b28b98beb4dfe82b5b5b63ddcc68d1df433641701
 
 haproxy_homedir="/var/lib/${pkgname}"
 make_dirs="$haproxy_homedir 0750 ${pkgname} ${pkgname}"
@@ -28,7 +28,7 @@ do_build() {
 		atomic="-latomic"
 	fi
 	make ${makejobs} CC="$CC" DEBUG_CFLAGS="${CFLAGS}" LDFLAGS="${LDFLAGS}" EXTRA= \
-		TARGET=$target USE_PCRE=1 USE_PCRE_JIT=1 USE_ZLIB=1 \
+		TARGET=$target USE_PCRE2=1 USE_PCRE2_JIT=1 USE_ZLIB=1 \
 		USE_OPENSSL=1 USE_LIBCRYPT=1 USE_GETADDRINFO=1 USE_LUA=1 \
 		USE_PROMEX=1 ADDLIB="$atomic"
 }

--- a/srcpkgs/haproxy/update
+++ b/srcpkgs/haproxy/update
@@ -1,0 +1,2 @@
+# 2.6 is the current LTS
+ignore="2\.[!6].*"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl

HAProxy 2.6 is the latest LTS release with some nice improvements over the 2.4 series. Until another LTS hits, it's reasonable to lock the package to 2.6.x.
