### PR TITLE
perl-Moo: update to 2.005005.

### DIFF
--- a/srcpkgs/perl-Moo/template
+++ b/srcpkgs/perl-Moo/template
@@ -1,6 +1,6 @@
 # Template file for 'perl-Moo'
 pkgname=perl-Moo
-version=2.005004
+version=2.005005
 revision=1
 build_style=perl-module
 hostmakedepends="perl"
@@ -8,10 +8,9 @@ makedepends="perl perl-Class-Method-Modifiers perl-Devel-GlobalDestruction
  perl-Module-Runtime perl-Role-Tiny perl-Sub-Name perl-Sub-Quote perl-strictures
  perl-Class-XSAccessor"
 depends="$makedepends"
-checkdepends="perl-Test-Fatal"
 short_desc="Minimal Object Orientation support for Roles"
 maintainer="Zach Dykstra <dykstra.zachary@gmail.com>"
 license="Artistic-1.0-Perl, GPL-1.0-or-later"
 homepage="https://metacpan.org/release/Moo"
 distfiles="https://cpan.org/authors/id/H/HA/HAARG/Moo-${version}.tar.gz"
-checksum=e3030b80bd554a66f6b3c27fd53b1b5909d12af05c4c11ece9a58f8d1e478928
+checksum=fb5a2952649faed07373f220b78004a9c6aba387739133740c1770e9b1f4b108


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

Another mostly no-op upstream release - removing the dependency on `Test::Fatal` in checks.