### PR TITLE
perl-Regexp-Grammars: update to 1.058.

### DIFF
--- a/srcpkgs/perl-Regexp-Grammars/template
+++ b/srcpkgs/perl-Regexp-Grammars/template
@@ -1,7 +1,7 @@
 # Template file for 'perl-Regexp-Grammars'
 pkgname=perl-Regexp-Grammars
-version=1.057
-revision=2
+version=1.058
+revision=1
 build_style=perl-module
 hostmakedepends="perl"
 makedepends="perl"
@@ -11,4 +11,4 @@ maintainer="Zach Dykstra <dykstra.zachary@gmail.com>"
 license="Artistic-1.0-Perl, GPL-1.0-or-later"
 homepage="https://metacpan.org/release/Regexp-Grammars"
 distfiles="${CPAN_SITE}/Regexp/${pkgname/perl-/}-${version}.tar.gz"
-checksum=af53c19818461cd701aeb57c49dffdb463edc4bf8f658d9ea4e6d534ac177041
+checksum=ea88d58e251674fae39b49f4d3b5342eaccb8fcb55856cd304aa1a5ff3d41c92


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

Another mostly no-op upstream change. Is ... is Perl dying?