### PR TITLE
loki: update to 2.7.3, fix build with go 1.20

### DIFF
--- a/srcpkgs/loki/patches/go1.20.patch
+++ b/srcpkgs/loki/patches/go1.20.patch
@@ -1,0 +1,96 @@
+--- a/go.mod
++++ b/go.mod
+@@ -272,7 +272,7 @@ require (
+ 	go.uber.org/multierr v1.8.0 // indirect
+ 	go.uber.org/zap v1.21.0 // indirect
+ 	go4.org/intern v0.0.0-20211027215823-ae77deb06f29 // indirect
+-	go4.org/unsafe/assume-no-moving-gc v0.0.0-20220617031537-928513b29760 // indirect
++	go4.org/unsafe/assume-no-moving-gc v0.0.0-20230209150437-ee73d164e760 // indirect
+ 	golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4 // indirect
+ 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 // indirect
+ 	golang.org/x/tools v0.1.12 // indirect
+--- a/go.sum
++++ b/go.sum
+@@ -1449,8 +1449,8 @@ go.uber.org/zap v1.21.0/go.mod h1:wjWOCqI0f2ZZrJF/UufIOkiC8ii6tm1iqIsLo76RfJw=
+ go4.org/intern v0.0.0-20211027215823-ae77deb06f29 h1:UXLjNohABv4S58tHmeuIZDO6e3mHpW2Dx33gaNt03LE=
+ go4.org/intern v0.0.0-20211027215823-ae77deb06f29/go.mod h1:cS2ma+47FKrLPdXFpr7CuxiTW3eyJbWew4qx0qtQWDA=
+ go4.org/unsafe/assume-no-moving-gc v0.0.0-20211027215541-db492cf91b37/go.mod h1:FftLjUGFEDu5k8lt0ddY+HcrH/qU/0qk+H8j9/nTl3E=
+-go4.org/unsafe/assume-no-moving-gc v0.0.0-20220617031537-928513b29760 h1:FyBZqvoA/jbNzuAWLQE2kG820zMAkcilx6BMjGbL/E4=
+-go4.org/unsafe/assume-no-moving-gc v0.0.0-20220617031537-928513b29760/go.mod h1:FftLjUGFEDu5k8lt0ddY+HcrH/qU/0qk+H8j9/nTl3E=
++go4.org/unsafe/assume-no-moving-gc v0.0.0-20230209150437-ee73d164e760 h1:gH0IO5GDYAcawu+ThKrvAofVTgJjYaoOZ5rrC4pS2Xw=
++go4.org/unsafe/assume-no-moving-gc v0.0.0-20230209150437-ee73d164e760/go.mod h1:FftLjUGFEDu5k8lt0ddY+HcrH/qU/0qk+H8j9/nTl3E=
+ golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
+ golang.org/x/crypto v0.0.0-20181029021203-45a5f77698d3/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
+ golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+--- a/operator/go.mod
++++ b/operator/go.mod
+@@ -145,7 +145,7 @@ require (
+ 	go.uber.org/multierr v1.7.0 // indirect
+ 	go.uber.org/zap v1.21.0 // indirect
+ 	go4.org/intern v0.0.0-20211027215823-ae77deb06f29 // indirect
+-	go4.org/unsafe/assume-no-moving-gc v0.0.0-20220617031537-928513b29760 // indirect
++	go4.org/unsafe/assume-no-moving-gc v0.0.0-20230209150437-ee73d164e760 // indirect
+ 	golang.org/x/crypto v0.0.0-20220315160706-3147a52a75dd // indirect
+ 	golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4 // indirect
+ 	golang.org/x/net v0.0.0-20220722155237-a158d28d115b // indirect
+--- a/vendor/go4.org/unsafe/assume-no-moving-gc/assume-no-moving-gc.go
++++ b/vendor/go4.org/unsafe/assume-no-moving-gc/assume-no-moving-gc.go
+@@ -4,7 +4,11 @@
+ 
+ // Package go4.org/unsafe/assume-no-moving-gc exists so you can depend
+ // on it from unsafe code that wants to declare that it assumes that
+-// the Go runtime does not using a moving garbage colllector.
++// the Go runtime does not using a moving garbage colllector. Specifically,
++// it asserts that the caller is playing stupid games with the addresses
++// of heap-allocated values. It says nothing about values that Go's escape
++// analysis keeps on the stack. Ensuring things aren't stack-allocated
++// is the caller's responsibility.
+ //
+ // This package is then updated for new Go versions when that
+ // is still the case and explodes at runtime with a failure
+@@ -16,6 +20,14 @@
+ //
+ // There is no API.
+ //
++// It is intentional that this package will break code that's not updated
++// regularly to double check its assumptions about the world and new Go
++// versions. If you play stupid games with unsafe pointers, the stupid prize
++// is this maintenance cost. (The alternative would be memory corruption if
++// some unmaintained, unsafe library were built with a future version of Go
++// that worked very differently than when the unsafe library was built.)
++// Ideally you shouldn't write unsafe code, though.
++//
+ // The GitHub repo is at https://github.com/go4org/unsafe-assume-no-moving-gc
+ package assume_no_moving_gc
+ 
+--- a/vendor/go4.org/unsafe/assume-no-moving-gc/untested.go
++++ b/vendor/go4.org/unsafe/assume-no-moving-gc/untested.go
+@@ -2,8 +2,8 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-//go:build go1.20
+-// +build go1.20
++//go:build go1.21
++// +build go1.21
+ 
+ package assume_no_moving_gc
+ 
+@@ -22,5 +22,5 @@ func init() {
+ 	if os.Getenv(env) == v {
+ 		return
+ 	}
+-	panic("Something in this program imports go4.org/unsafe/assume-no-moving-gc to declare that it assumes a non-moving garbage collector, but your version of go4.org/unsafe/assume-no-moving-gc hasn't been updated to assert that it's safe against the " + v + " runtime. If you want to risk it, run with environment variable " + env + "=" + v + " set. Notably, if " + v + " adds a moving garbage collector, this program is unsafe to use.")
++	panic("Something in this program imports go4.org/unsafe/assume-no-moving-gc to declare that it assumes a non-moving garbage collector, but your version of go4.org/unsafe/assume-no-moving-gc hasn't been updated to assert that it's safe against the " + v + " runtime. If you want to risk it, run with environment variable " + env + "=\"" + v + "\" set. Notably, if " + v + " adds a moving garbage collector, this program is unsafe to use.")
+ }
+--- a/vendor/modules.txt
++++ b/vendor/modules.txt
+@@ -1256,7 +1256,7 @@ go.uber.org/zap/zapgrpc
+ # go4.org/intern v0.0.0-20211027215823-ae77deb06f29
+ ## explicit; go 1.13
+ go4.org/intern
+-# go4.org/unsafe/assume-no-moving-gc v0.0.0-20220617031537-928513b29760
++# go4.org/unsafe/assume-no-moving-gc v0.0.0-20230209150437-ee73d164e760
+ ## explicit; go 1.11
+ go4.org/unsafe/assume-no-moving-gc
+ # golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa

--- a/srcpkgs/loki/template
+++ b/srcpkgs/loki/template
@@ -1,6 +1,6 @@
 # Template file for 'loki'
 pkgname=loki
-version=2.4.1
+version=2.7.3
 revision=1
 build_style=go
 go_import_path="github.com/grafana/loki"
@@ -12,4 +12,4 @@ maintainer="Michael Aldridge <maldridge@voidlinux.org>"
 license="Apache-2.0"
 homepage="https://grafana.com/oss/loki/"
 distfiles="https://github.com/grafana/loki/archive/v$version.tar.gz"
-checksum=a26c22941b406b8c42e55091c23798301181df74063aaaf0f678acffc66d8c27
+checksum=07b7030576abf4ef63febf4dcddf95ff935aab6d9ab4fc0404322794d94bf3ee


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **NO** (I only tested the build and that it no longer fails to run when built with go 1.20)

@the-maldridge 
<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
