### PR TITLE
Bear: update to 3.1.0.

### DIFF
--- a/srcpkgs/Bear/template
+++ b/srcpkgs/Bear/template
@@ -1,6 +1,6 @@
 # Template file for 'Bear'
 pkgname=Bear
-version=3.0.21
+version=3.1.0
 revision=1
 build_style=cmake
 hostmakedepends="pkg-config protobuf protobuf-devel grpc"
@@ -10,9 +10,8 @@ short_desc="Tool that generates a compilation database for clang tooling"
 maintainer="John <me@johnnynator.dev>"
 license="GPL-3.0-or-later"
 homepage="https://github.com/rizsotto/Bear"
-distfiles="https://github.com/rizsotto/Bear/archive/${version}.tar.gz>${pkgname}-${version}.tar.gz"
-checksum=0c949a6a907bc61a1284661f8d9dab1788a62770c265f6142602669b6e5c389d
-conflicts="interception-tools>=0" # /usr/bin/intercept
+distfiles="https://github.com/rizsotto/Bear/archive/${version}.tar.gz"
+checksum=33c1f4663d94508f11cbd999dd5571359be7d15b0f473f7cfbea2c0b3190a891
 
 if [ -z "$XBPS_CHECK_PKGS" ]; then
 	configure_args="-DENABLE_FUNC_TESTS=OFF -DENABLE_UNIT_TESTS=OFF"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

made sure `/usr/bin/intercept` is no longer installed.

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
