### PR TITLE
wpa_supplicant: add CONFIG_EXT_PASSWORD_FILE=y

### DIFF
--- a/srcpkgs/wpa_supplicant/files/config
+++ b/srcpkgs/wpa_supplicant/files/config
@@ -531,7 +531,7 @@ CONFIG_WIFI_DISPLAY=y
 # External password backend for testing purposes (developer use)
 #CONFIG_EXT_PASSWORD_TEST=y
 # File-based backend to read passwords from an external file.
-#CONFIG_EXT_PASSWORD_FILE=y
+CONFIG_EXT_PASSWORD_FILE=y
 
 # Enable Fast Session Transfer (FST)
 #CONFIG_FST=y

--- a/srcpkgs/wpa_supplicant/template
+++ b/srcpkgs/wpa_supplicant/template
@@ -1,7 +1,7 @@
 # Template file for 'wpa_supplicant'
 pkgname=wpa_supplicant
 version=2.10
-revision=1
+revision=2
 build_wrksrc="$pkgname"
 short_desc="WPA/WPA2/IEEE 802.1X Supplicant"
 maintainer="Enno Boland <gottox@voidlinux.org>"


### PR DESCRIPTION
- I tested the changes in this PR: yes
- I built this PR locally for my native architecture, (x86_64-musl)

This allows to use an external file to store passwords.