### PR TITLE
kicad: update to 7.0.0

### DIFF
--- a/srcpkgs/kicad-doc/template
+++ b/srcpkgs/kicad-doc/template
@@ -1,13 +1,13 @@
 # Template file for 'kicad-doc'
 pkgname=kicad-doc
-version=6.0.7
+version=7.0.0
 revision=1
 short_desc="KiCad documentation"
 maintainer="Érico Nogueira <ericonr@disroot.org>"
 license="GPL-3.0-or-later, CC-BY-3.0"
 homepage="http://kicad.org"
-distfiles="https://kicad-downloads.s3.cern.ch/docs/${pkgname}-${version}.tar.gz"
-checksum=470b741e55f80c828d6fe607b503d9e9d27081bf871ec52092d0ba7e1a0c9b2c
+distfiles="https://kicad-downloads.s3.cern.ch/docs/kicad-doc-${version}.tar.gz"
+checksum=04cad356fd19b46e70eaa6e3365d94c326e4237d80c09394208fd4662e756465
 
 if [ "$XBPS_WORDSIZE" != "$XBPS_TARGET_WORDSIZE" ]; then
 	broken="kicad not available"

--- a/srcpkgs/kicad-footprints/template
+++ b/srcpkgs/kicad-footprints/template
@@ -1,6 +1,6 @@
 # Template file for 'kicad-footprints'
 pkgname=kicad-footprints
-version=6.0.7
+version=7.0.0
 revision=1
 build_style=cmake
 depends="kicad"
@@ -8,5 +8,5 @@ short_desc="Kicad footprint libraries"
 maintainer="Urs Schulz <voidpkgs@ursschulz.de>"
 license="CC-BY-SA-4.0"
 homepage="http://kicad.org"
-distfiles="https://gitlab.com/kicad/libraries/${pkgname}/-/archive/${version}/${pkgname}-${version}.tar.gz"
-checksum=3dabfa018597c181e9ca1add4c78d50d5bf38500c1c665510bb37e0ea7b5ba7e
+distfiles="https://gitlab.com/kicad/libraries/kicad-footprints/-/archive/${version}/kicad-footprints-${version}.tar.gz"
+checksum=c10550c6b621d8e5f7e84d3d1443eae3900c80a86982b05326adc0e3d61768c7

--- a/srcpkgs/kicad-library/template
+++ b/srcpkgs/kicad-library/template
@@ -1,6 +1,6 @@
 # Template file for 'kicad-library'
 pkgname=kicad-library
-version=6.0.7
+version=7.0.0
 revision=1
 build_style=meta
 depends="kicad-footprints>=${version} kicad-packages3D>=${version}

--- a/srcpkgs/kicad-packages3D/template
+++ b/srcpkgs/kicad-packages3D/template
@@ -1,6 +1,6 @@
 # Template file for 'kicad-packages3D'
 pkgname=kicad-packages3D
-version=6.0.7
+version=7.0.0
 revision=1
 build_style=cmake
 depends="kicad"
@@ -8,5 +8,5 @@ short_desc="Kicad 3D model libraries"
 maintainer="Urs Schulz <voidpkgs@ursschulz.de>"
 license="CC-BY-SA-4.0"
 homepage="http://kicad.org"
-distfiles="https://gitlab.com/kicad/libraries/${pkgname}/-/archive/${version}/${pkgname}-${version}.tar.gz"
-checksum=e8d008f743330c4b46e8d2ad518ad554653a2c5b3866f59a865ec4334e68b3aa
+distfiles="https://gitlab.com/kicad/libraries/kicad-packages3D/-/archive/${version}/kicad-packages3D-${version}.tar.gz"
+checksum=2a11bb29f55e6c3b719174dddef649bee414c1ffa36f82ee9c09f184bbded90e

--- a/srcpkgs/kicad-symbols/template
+++ b/srcpkgs/kicad-symbols/template
@@ -1,6 +1,6 @@
 # Template file for 'kicad-symbols'
 pkgname=kicad-symbols
-version=6.0.7
+version=7.0.0
 revision=1
 build_style=cmake
 depends="kicad"
@@ -8,5 +8,5 @@ short_desc="Kicad symbol libraries"
 maintainer="Urs Schulz <voidpkgs@ursschulz.de>"
 license="CC-BY-SA-4.0"
 homepage="http://kicad.org"
-distfiles="https://gitlab.com/kicad/libraries/${pkgname}/-/archive/${version}/${pkgname}-${version}.tar.gz"
-checksum=03a888a516e3899cbc7dada1127e9c0309c0f7a8d995aa0dd9c7aa7f6f3a9d7f
+distfiles="https://gitlab.com/kicad/libraries/kicad-symbols/-/archive/${version}/kicad-symbols-${version}.tar.gz"
+checksum=0f04db7a5965436b754f43a3ebb02d055223f306a1c56a90973216eac227dbc8

--- a/srcpkgs/kicad-templates/template
+++ b/srcpkgs/kicad-templates/template
@@ -1,6 +1,6 @@
 # Template file for 'kicad-templates'
 pkgname=kicad-templates
-version=6.0.7
+version=7.0.0
 revision=1
 build_style=cmake
 depends="kicad"
@@ -8,5 +8,5 @@ short_desc="Kicad templates"
 maintainer="Urs Schulz <voidpkgs@ursschulz.de>"
 license="CC-BY-SA-4.0"
 homepage="http://kicad.org"
-distfiles="https://gitlab.com/kicad/libraries/${pkgname}/-/archive/${version}/${pkgname}-${version}.tar.gz"
-checksum=1da05f4067b16c4b8be8e172cc73ddc5ce05977f384dd7e531f23c7fdc69da8a
+distfiles="https://gitlab.com/kicad/libraries/kicad-templates/-/archive/${version}/kicad-templates-${version}.tar.gz"
+checksum=26c611621f452effdb748975ab88227fedf455cfa6dce40b298a01bbd60a63e2

--- a/srcpkgs/kicad/patches/disable-warnings.patch
+++ b/srcpkgs/kicad/patches/disable-warnings.patch
@@ -1,5 +1,5 @@
---- a/CMakeModules/Warnings.cmake
-+++ b/CMakeModules/Warnings.cmake
+--- a/cmake/Warnings.cmake
++++ b/cmake/Warnings.cmake
 @@ -38,13 +38,6 @@
      set( WARN_FLAGS_CXX "-Wall" )
  

--- a/srcpkgs/kicad/template
+++ b/srcpkgs/kicad/template
@@ -1,7 +1,7 @@
 # Template file for 'kicad'
 pkgname=kicad
-version=6.0.7
-revision=2
+version=7.0.0
+revision=1
 build_style=cmake
 build_helper=cmake-wxWidgets-gtk3
 configure_args="-DKICAD_SCRIPTING_WXPYTHON=ON
@@ -10,17 +10,20 @@ configure_args="-DKICAD_SCRIPTING_WXPYTHON=ON
  -DKICAD_USE_OCC=$(vopt_if occt ON OFF) -DKICAD_SPICE=$(vopt_if spice ON OFF)"
 hostmakedepends="pkg-config swig wxWidgets-gtk3-devel python3 tar gettext"
 makedepends="wxWidgets-gtk3-devel wxPython4 python3-devel glew-devel cairo-devel
- boost-devel libcurl-devel glm libgomp-devel libfreeglut-devel gtk+3-devel
+ boost-devel libcurl-devel glm libgomp-devel libfreeglut-devel gtk+3-devel unixodbc-devel
  $(vopt_if occt occt-devel) $(vopt_if spice ngspice-devel)"
 depends="wxPython4"
 short_desc="Electronic schematic and PCB design software"
 maintainer="Érico Nogueira <ericonr@disroot.org>"
 license="GPL-3.0-or-later"
 homepage="http://kicad.org"
-distfiles="https://gitlab.com/kicad/code/${pkgname}/-/archive/${version}/kicad-${version}.tar.gz"
-checksum=a72e88b15f360d76ea7427923a5073db5e34b5f8cfc4be389cfc24b12a71e7f9
+distfiles="https://gitlab.com/kicad/code/kicad/-/archive/${version}/kicad-${version}.tar.gz"
+checksum=a992234a06d18e45dbec847624e7966b3850c5f1e44474007e8fe7c6c24d3fbc
 python_version=3
 replaces="kicad-i18n>=0"
+# one test appears to be flaky
+# https://gitlab.com/kicad/code/kicad/-/blob/7.0.0/qa/unittests/eeschema/test_netlist_exporter_spice.h#L195-197
+make_check=ci-skip
 
 build_options="spice occt"
 build_options_default="spice occt"


### PR DESCRIPTION

#### Testing the changes
- I tested the changes in this PR: **YES**

 Opened up some projects and exported gerbers without issues. 

- I built this PR locally for my native architecture, (x86_64-glibc)

I am seeing a lot of warnings in the build, mostly coming from the comes-with-kicad pybind11. Since there is already a patch for the Warnings.cmake file, this could be silenced further, but i am not sure if this wanted. 

New dependency on unixodbc, i hope i put it in the right places. 
