### PR TITLE
dracut: backport fix for live images on linux 5.19+

### DIFF
--- a/srcpkgs/dracut/patches/isoscan-udev-trigger.patch
+++ b/srcpkgs/dracut/patches/isoscan-udev-trigger.patch
@@ -1,0 +1,25 @@
+This upstream accepted patch fixes a bug where the live images don't work when
+booted from grub loopback (void-linux/void-mklive#294).
+
+From d880d62f5f81d7ec69555f5deb60694fdb693c01 Mon Sep 17 00:00:00 2001
+From: 0x5c <dev@0x5c.io>
+Date: Thu, 9 Feb 2023 05:26:30 -0500
+Subject: [PATCH] fix: make iso-scan trigger udev events
+
+Fixes #2183
+---
+ modules.d/90dmsquash-live/iso-scan.sh | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/modules.d/90dmsquash-live/iso-scan.sh b/modules.d/90dmsquash-live/iso-scan.sh
+index 886d23033..fa06b33cd 100755
+--- a/modules.d/90dmsquash-live/iso-scan.sh
++++ b/modules.d/90dmsquash-live/iso-scan.sh
+@@ -22,6 +22,7 @@ do_iso_scan() {
+         mount -t auto -o ro "$dev" "/run/initramfs/isoscan" || continue
+         if [ -f "/run/initramfs/isoscan/$isofile" ]; then
+             losetup -f "/run/initramfs/isoscan/$isofile"
++            udevadm trigger --action=add > /dev/null 2>&1
+             ln -s "$dev" /run/initramfs/isoscandev
+             rm -f -- "$job"
+             exit 0

--- a/srcpkgs/dracut/template
+++ b/srcpkgs/dracut/template
@@ -1,7 +1,7 @@
 # Template file for 'dracut'
 pkgname=dracut
 version=059
-revision=1
+revision=2
 build_style=configure
 configure_args="--prefix=/usr --sysconfdir=/etc"
 conf_files="/etc/dracut.conf"


### PR DESCRIPTION
This fixes a bug in the live images when booted from grub as loopback (https://github.com/void-linux/void-mklive/issues/294).

https://github.com/dracutdevs/dracut/issues/2183
https://github.com/dracutdevs/dracut/pull/2196

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
