### PR TITLE
plasma 5.27

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -2522,7 +2522,8 @@ libosgUtil.so.161 osg-3.6.5_1
 libosgVolume.so.161 osg-3.6.5_1
 libosgGA.so.161 osg-3.6.5_1
 libosgPresentation.so.161 osg-3.6.5_1
-libKF5Screen.so.7 libkscreen-5.7.5_1
+libKF5Screen.so.8 libkscreen-5.26.90_1
+libKF5ScreenDpms.so.8 libkscreen-5.26.90_1
 libdbusmenu-qt5.so.2 libdbusmenu-qt5-0.9.3.0_1
 libKF5Solid.so.5 libksolid-5.15.0_2
 libfreeimage.so.3 freeimage-3.17.0_1

--- a/common/shlibs
+++ b/common/shlibs
@@ -954,7 +954,7 @@ libsuil-0.so.0 suil-0.6.4_1
 libmcpp.so.0 libmcpp-2.7.2_1
 libjitterentropy.so.3 jitterentropy-3.0.0_1
 libkdecorations2.so.5 kdecoration-5.8.4_1
-libkdecorations2private.so.9 kdecoration-5.23.0_1
+libkdecorations2private.so.10 kdecoration-5.26.90_1
 libGlacier2.so.37 libIce-3.7.5_2
 libGlacier2CryptPermissionsVerifier.so.37 libIce-3.7.5_2
 libIce.so.37 libIce-3.7.5_2

--- a/srcpkgs/bluedevil/template
+++ b/srcpkgs/bluedevil/template
@@ -1,6 +1,6 @@
 # Template file for 'bluedevil'
 pkgname=bluedevil
-version=5.26.3.1
+version=5.27.0
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF -DKF5_HOST_TOOLING=/usr/lib/cmake"
@@ -13,5 +13,5 @@ short_desc="KDE Bluetooth integration"
 maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later, LGPL-2.1-or-later"
 homepage="https://invent.kde.org/plasma/bluedevil"
-distfiles="${KDE_SITE}/plasma/${version%.*}/${pkgname}-${version}.tar.xz"
-checksum=709fcf35c849d56e84fa686f8cbec940b735f9fa0c78c54cd8a6bfe6d7540e92
+distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
+checksum=9e521661fc0c7212e91a3ea56c99ff5c52d46a18f7d02d6a47b3d5858ca15472

--- a/srcpkgs/breeze-gtk/template
+++ b/srcpkgs/breeze-gtk/template
@@ -1,6 +1,6 @@
 # Template file for 'breeze-gtk'
 pkgname=breeze-gtk
-version=5.26.3
+version=5.27.0
 revision=1
 build_style=cmake
 hostmakedepends="extra-cmake-modules sassc python3 python3-cairo qt5-devel"
@@ -10,4 +10,4 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/plasma/breeze-gtk"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=4a3a3b40bcdc0110e51ed394ae1bd4ce1adf68ae2d28a3a4aa19803de73c3f63
+checksum=aa62672ad56071437ad6e192f61ba7443119ff52b75da3a98822a27bd609edaa

--- a/srcpkgs/breeze/template
+++ b/srcpkgs/breeze/template
@@ -1,6 +1,6 @@
 # Template file for 'breeze'
 pkgname=breeze
-version=5.26.3.1
+version=5.27.0
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF"
@@ -13,8 +13,8 @@ short_desc="Breeze visual style for the Plasma Desktop"
 maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later"
 homepage="https://invent.kde.org/plasma/breeze"
-distfiles="${KDE_SITE}/plasma/${version%.*}/${pkgname}-${version}.tar.xz"
-checksum=fcafba03194fb81e075e2a3ea7fd006a8f91f898169e1f39fdc3d92801ae4568
+distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
+checksum=8a5c57a4ea5d48a3f80a9eb06b7d7b27ed51bf1a765d9ea982e9eae626a0c83c
 
 if [ "$CROSS_BUILD" ]; then
 	configure_args+=" -DKF5_HOST_TOOLING=/usr/lib/cmake"

--- a/srcpkgs/kactivitymanagerd/template
+++ b/srcpkgs/kactivitymanagerd/template
@@ -1,7 +1,7 @@
 # Template file for 'kactivitymanagerd'
 pkgname=kactivitymanagerd
-version=5.26.3
-revision=2
+version=5.27.0
+revision=1
 build_style=cmake
 build_helper="qemu"
 configure_args="-DBUILD_TESTING=OFF"
@@ -13,4 +13,4 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later"
 homepage="https://invent.kde.org/plasma/kactivitymanagerd"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=2c6f5200c46008f4ae2002ebd1a696a45eb43ecf8d3a08e10de4a00a755966f3
+checksum=560fb9be7077031e9d28644b728b4aacfa6b98be100e6367cbc3d0a7098d680a

--- a/srcpkgs/kde-cli-tools/template
+++ b/srcpkgs/kde-cli-tools/template
@@ -1,7 +1,7 @@
 # Template file for 'kde-cli-tools'
 pkgname=kde-cli-tools
-version=5.26.3
-revision=2
+version=5.27.0
+revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF -DKF5_HOST_TOOLING=/usr/lib/cmake"
 hostmakedepends="extra-cmake-modules gettext pkg-config kcmutils-devel
@@ -14,7 +14,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later, GPL-2.0-or-later"
 homepage="https://invent.kde.org/plasma/kde-cli-tools"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=fbbfcb5e4d9fac5b4e2df1b4d2af4adb0de83630e2fb0369098d30366de2e640
+checksum=15113efa066d1d04516828f5a187f3a03bc348c890714900e5655bc7fbeaacf0
 
 post_install() {
 	ln -sf ../libexec/kf5/kdesu ${DESTDIR}/usr/bin

--- a/srcpkgs/kde-gtk-config5/template
+++ b/srcpkgs/kde-gtk-config5/template
@@ -1,7 +1,7 @@
 # Template file for 'kde-gtk-config5'
 pkgname=kde-gtk-config5
-version=5.26.3
-revision=2
+version=5.27.0
+revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF"
 hostmakedepends="extra-cmake-modules pkg-config qt5-qmake qt5-host-tools
@@ -14,7 +14,7 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later, LGPL-2.1-or-later"
 homepage="https://invent.kde.org/plasma/kde-gtk-config"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname%5}-${version}.tar.xz"
-checksum=275aacf7e2cfdbae7317795176b208235aeb99b1539780f3d25b082192c371ba
+checksum=6fea6257599821296f88bfa7850d7de3e473b95df6033b5d96c9c8fbaeed18ae
 
 if [ "$CROSS_BUILD" ]; then
 	hostmakedepends+=" kcoreaddons"

--- a/srcpkgs/kdecoration/template
+++ b/srcpkgs/kdecoration/template
@@ -1,6 +1,6 @@
 # Template file for 'kdecoration'
 pkgname=kdecoration
-version=5.26.3
+version=5.27.0
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF"
@@ -12,7 +12,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/plasma/kdecoration"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=918b449136478233fc5219487df7ffaafc2b6ae1bd0cd74eab0d790caec3ec59
+checksum=4ec94df56f2e6c98486d0328e2ee080255a806336915c42f7ab260befd4c7c13
 
 kdecoration-devel_package() {
 	short_desc+=" - development"

--- a/srcpkgs/kdeplasma-addons5/template
+++ b/srcpkgs/kdeplasma-addons5/template
@@ -1,6 +1,6 @@
 # Template file for 'kdeplasma-addons5'
 pkgname=kdeplasma-addons5
-version=5.26.3
+version=5.27.0
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF -DKF5_HOST_TOOLING=/usr/lib/cmake"
@@ -13,4 +13,4 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later, LGPL-2.1-or-later"
 homepage="https://invent.kde.org/plasma/kdeplasma-addons"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname%5}-${version}.tar.xz"
-checksum=c41d787eb6381447e836ad126e2d924aaa393be57146ac7565a80b791248478e
+checksum=4398b77251bd2b95f8a9b5c55bf16ff7e852162f4081fc8b0fbab91bd508d9a6

--- a/srcpkgs/kgamma5/template
+++ b/srcpkgs/kgamma5/template
@@ -1,6 +1,6 @@
 # Template file for 'kgamma5'
 pkgname=kgamma5
-version=5.26.3
+version=5.27.0
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF"
@@ -13,4 +13,4 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later"
 homepage="https://invent.kde.org/plasma/kgamma5"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=876caa4a787c943428000122745e247683cc46e56a09ed130836224f63c65e5e
+checksum=85375a2a3aee1ba89aaa656c28747f9d0988ec98aa8ecce84056dca61cbfceb7

--- a/srcpkgs/khotkeys/template
+++ b/srcpkgs/khotkeys/template
@@ -1,6 +1,6 @@
 # Template file for 'khotkeys'
 pkgname=khotkeys
-version=5.26.3
+version=5.27.0
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF"
@@ -12,7 +12,7 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-only, LGPL-2.0-or-later"
 homepage="https://invent.kde.org/plasma/khotkeys"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=7500019385813b6a243b472d18e9a6855dce655f91f357d8ce5b7c87cb70955f
+checksum=3fde86d65902a32d63a4fde33ab5082c648ee6c203e36132ed4199194239def7
 
 if [ "$CROSS_BUILD" ]; then
 	configure_args+=" -DDESKTOPTOJSON_EXECUTABLE=/usr/bin/desktoptojson"

--- a/srcpkgs/kinfocenter/template
+++ b/srcpkgs/kinfocenter/template
@@ -1,7 +1,7 @@
 # Template file for 'kinfocenter'
 pkgname=kinfocenter
-version=5.26.3
-revision=2
+version=5.27.0
+revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF -DKF5_HOST_TOOLING=/usr/lib/cmake"
 hostmakedepends="extra-cmake-modules gettext pkg-config qt5-host-tools qt5-qmake
@@ -16,4 +16,4 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later, LGPL-2.1-or-later, GFDL-1.2-only"
 homepage="https://invent.kde.org/plasma/kinfocenter"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=c558ea3f092ce722a39b0511ea24a212ce7a7c6a722a701f74796e9f2c19ac3a
+checksum=74fb006288b81aee4f1ec25644c1b3d44858b50655dd649dc7bef52f4125304d

--- a/srcpkgs/kmenuedit/template
+++ b/srcpkgs/kmenuedit/template
@@ -1,6 +1,6 @@
 # Template file for 'kmenuedit'
 pkgname=kmenuedit
-version=5.26.3
+version=5.27.0
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF"
@@ -13,4 +13,4 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later"
 homepage="https://invent.kde.org/plasma/kmenuedit"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=7c073853dc2cf97fd09c5b8939365777068a4671432f8cf84312ba145dd6572d
+checksum=c24440dcffa63bc9d75fb29fdc7d8f00ee2abbcf76abe43b04595167bcbc65c9

--- a/srcpkgs/kpipewire/template
+++ b/srcpkgs/kpipewire/template
@@ -1,6 +1,6 @@
 # Template file for 'kpipewire'
 pkgname=kpipewire
-version=5.26.3
+version=5.27.0
 revision=1
 build_style=cmake
 hostmakedepends="extra-cmake-modules plasma-wayland-protocols gettext
@@ -13,7 +13,7 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-3.0-or-later"
 homepage="https://invent.kde.org/plasma/kpipewire"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=b4a865a38c8e2b281df4fe1405880fae4ed1ecba3229454b8af8a34dbecd7ca4
+checksum=0018fee05e03e2eb5c0ed2a6417d20a5ae2e33216fd2745fb77f15014c881756
 
 kpipewire-devel_package() {
 	depends="${sourcepkg}>=${version}_${revision}"

--- a/srcpkgs/kscreen/template
+++ b/srcpkgs/kscreen/template
@@ -1,7 +1,7 @@
 # Template file for 'kscreen'
 pkgname=kscreen
-version=5.26.3
-revision=2
+version=5.27.0
+revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF -DKF5_HOST_TOOLING=/usr/lib/cmake"
 hostmakedepends="extra-cmake-modules qt5-devel qt5-qmake
@@ -14,4 +14,4 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later, LGPL-2.1-or-later"
 homepage="https://invent.kde.org/plasma/kscreen"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=5a2fa3c74d891fd7355673d28cafc5127277eeca11a2351c5774ee228273ac15
+checksum=fc85b5e1f0a9e365ba4ac4bd1d36a86e24c743aa85a8ba1cee649a4905046f10

--- a/srcpkgs/kscreenlocker/template
+++ b/srcpkgs/kscreenlocker/template
@@ -1,20 +1,20 @@
 # Template file for 'kscreenlocker'
 pkgname=kscreenlocker
-version=5.26.3
-revision=2
+version=5.27.0
+revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF -DKF5_HOST_TOOLING=/usr/lib/cmake"
 hostmakedepends="extra-cmake-modules pkg-config kcoreaddons-devel
  qt5-qmake wayland-devel qt5-host-tools gettext kcmutils-devel"
 makedepends="kdeclarative-devel kidletime-devel kcmutils-devel
  libSM-devel kwayland-devel libXi-devel pam-devel libXcursor-devel
- layer-shell-qt-devel"
+ layer-shell-qt-devel libkscreen-devel"
 short_desc="KDE Library and components for secure lock screen architecture"
 maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later"
 homepage="https://invent.kde.org/plasma/kscreenlocker"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=ce38d13e1075a5f8a318d802d83dc75e5b1dfee1c5b640be39af1ed57d334569
+checksum=397690ed31738549d3aaf1dd026a5fbd50feddd97566ad121532db6920a67c77
 
 kscreenlocker-devel_package() {
 	short_desc+=" - development"

--- a/srcpkgs/ksshaskpass/template
+++ b/srcpkgs/ksshaskpass/template
@@ -1,6 +1,6 @@
 # Template file for 'ksshaskpass'
 pkgname=ksshaskpass
-version=5.26.3
+version=5.27.0
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF"
@@ -12,5 +12,5 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later"
 homepage="https://invent.kde.org/plasma/ksshaskpass"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=91970e960b33cc6c54ffd8294904374b7e98c07edc26126e2aa453e32d677c16
+checksum=7afd805c4ef26701624bb4613c3b333e12ccd861c572a1f3dddbfe7d88a3a5dc
 alternatives="ssh-askpass:/usr/libexec/ssh-askpass:/usr/bin/ksshaskpass"

--- a/srcpkgs/ksystemstats/template
+++ b/srcpkgs/ksystemstats/template
@@ -1,6 +1,6 @@
 # Template file for 'ksystemstats'
 pkgname=ksystemstats
-version=5.26.3
+version=5.27.0
 revision=1
 build_style=cmake
 hostmakedepends="extra-cmake-modules qt5-qmake gettext
@@ -12,4 +12,4 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-only OR GPL-3.0-only, LGPL-2.1-only OR LGPL-3-only"
 homepage="https://invent.kde.org/plasma/ksystemstats"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=428985af05a782a4e464d5db1bddc6072c88b50e64829f62d6735236ba168246
+checksum=b1e4d435aca21927ce8fd4ab721275eeb69d27d30b81f41516bbbf31304b5ded

--- a/srcpkgs/kwallet-pam/template
+++ b/srcpkgs/kwallet-pam/template
@@ -1,7 +1,7 @@
 # Template file for 'kwallet-pam'
 pkgname=kwallet-pam
-version=5.26.3
-revision=2
+version=5.27.0
+revision=1
 build_style=cmake
 hostmakedepends="qt5-qmake qt5-host-tools extra-cmake-modules"
 makedepends="libgcrypt-devel pam-devel kwallet-devel"
@@ -11,4 +11,4 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/plasma/kwallet-pam"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=85221ede6b0fc5489223971030c2701e62bcd0fcf1d3236858cd73a91beb0a0e
+checksum=87ef659e79f66d0bda87cac00ac17c00afda120340b04e56ccb8b36eac8d944f

--- a/srcpkgs/kwayland-integration/template
+++ b/srcpkgs/kwayland-integration/template
@@ -1,6 +1,6 @@
 # Template file for 'kwayland-integration'
 pkgname=kwayland-integration
-version=5.26.3
+version=5.27.0
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF"
@@ -13,4 +13,4 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/plasma/kwayland-integration"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=e571d13d1e8473188c780784bab35ede12a8ddaf483d85afaf6c2700c2eec643
+checksum=1b3bff453176d37fedd3ddb7bb69c978fc42c48f6324737d94b9aa644311b42a

--- a/srcpkgs/kwin/template
+++ b/srcpkgs/kwin/template
@@ -1,7 +1,7 @@
 # Template file for 'kwin'
 pkgname=kwin
-version=5.26.3
-revision=2
+version=5.27.0
+revision=1
 build_style=cmake
 build_helper=qemu
 configure_args="-DBUILD_TESTING=OFF -DFORCE_CROSSCOMPILED_TOOLS=ON
@@ -22,7 +22,7 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later"
 homepage="https://invent.kde.org/plasma/kwin"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=c1985f5796fc7fa559d93554e1ba23f57f4aeb213cbe470b516184da802c0a14
+checksum=2cf12150d18b4509fefc528eb3d63be8010ea20b46e9897703211a3d87aa39bc
 replaces="kwayland-server>=0"
 
 kwin-devel_package() {

--- a/srcpkgs/kwrited/template
+++ b/srcpkgs/kwrited/template
@@ -1,6 +1,6 @@
 # Template file for 'kwrited'
 pkgname=kwrited
-version=5.26.3
+version=5.27.0
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF"
@@ -11,4 +11,4 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later"
 homepage="https://invent.kde.org/plasma/kwrited"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=b275c1e78f4690ed49a552fee737e15f1669a60b5072fccbdc427c9172b8f64b
+checksum=a359699b50857e1b14926fa246d7e408eac8f14f4bc39498bbe983d6d284dd95

--- a/srcpkgs/layer-shell-qt/template
+++ b/srcpkgs/layer-shell-qt/template
@@ -1,6 +1,6 @@
 # Template file for 'layer-shell-qt'
 pkgname=layer-shell-qt
-version=5.26.3
+version=5.27.0
 revision=1
 build_style=cmake
 confiugre_args="-DWaylandScanner_EXECUTABLE=/usr/bin/wayland-scanner"
@@ -13,7 +13,7 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-3.0-or-later"
 homepage="https://invent.kde.org/plasma/layer-shell-qt"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=02c3a0cf6351e97cda49d39712c698ed35444345c386d3c820f6880f4edca481
+checksum=9c0d4737929a80c97c4084a13391ee2ff94ea5bfa1f82f1a11ce0fbedcb943ff
 
 layer-shell-qt-devel_package() {
 	depends="${sourcepkg}>=${version}_${revision}"

--- a/srcpkgs/libkscreen/template
+++ b/srcpkgs/libkscreen/template
@@ -1,7 +1,7 @@
 # Template file for 'libkscreen'
 pkgname=libkscreen
-version=5.26.3
-revision=2
+version=5.27.0
+revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF"
 hostmakedepends="pkg-config extra-cmake-modules qt5-host-tools qt5-x11extras-devel
@@ -13,7 +13,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/plasma/libkscreen"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=eec38e5e4ada818ddbd364cb1066691b87dba7bb8b7e9c067633438f2051d7d9
+checksum=50605ae2c1a2d36a24293c87010f94cc39437d20325e5479b722b8e71e926299
 
 libkscreen-devel_package() {
 	short_desc+=" - development"

--- a/srcpkgs/libksysguard/template
+++ b/srcpkgs/libksysguard/template
@@ -1,7 +1,7 @@
 # Template file for 'libksysguard'
 pkgname=libksysguard
-version=5.26.3
-revision=2
+version=5.27.0
+revision=1
 build_style=cmake
 hostmakedepends="extra-cmake-modules gettext kauth qt5-host-tools qt5-qmake
  kpackage"
@@ -13,7 +13,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/plasma/libksysguard"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=c940eedc468a1862728bea329ba5172b1f19eaa1ac2382c533061b4b237b76d1
+checksum=652d37197c05c43d3033c67153d482a238cac97351054d4c82e67e3745719a06
 
 build_options="webengine"
 

--- a/srcpkgs/lxqt-config/patches/libkscreen-527.patch
+++ b/srcpkgs/lxqt-config/patches/libkscreen-527.patch
@@ -1,0 +1,80 @@
+From 6add4e4f0040693e7c4242fbae48c9d32007686c Mon Sep 17 00:00:00 2001
+From: Mamoru TASAKA <mtasaka@fedoraproject.org>
+Date: Fri, 3 Feb 2023 08:11:04 +0900
+Subject: [PATCH] lxqt-config-monitor: add more header file inclusion for
+ libkscreen 5.26.90 (#915)
+
+With https://github.com/KDE/libkscreen/commit/94f330959b0eda775418aef7faee80ce69144e63 ,
+`#include <KScreen/Output>` no longer includes "mode.h" implicitly.
+So in lxqt-config-monitor, files using `class KScreen::Mode` should include
+`#include <KScreen/Mode>` explicitly.
+
+Related: #903 .
+---
+ lxqt-config-monitor/kscreenutils.cpp          | 1 +
+ lxqt-config-monitor/loadsettings.cpp          | 1 +
+ lxqt-config-monitor/monitorpicture.cpp        | 1 +
+ lxqt-config-monitor/monitorsettingsdialog.cpp | 1 +
+ lxqt-config-monitor/monitorwidget.cpp         | 1 +
+ 5 files changed, 5 insertions(+)
+
+diff --git a/lxqt-config-monitor/kscreenutils.cpp b/lxqt-config-monitor/kscreenutils.cpp
+index 9515e789..be2634d7 100644
+--- a/lxqt-config-monitor/kscreenutils.cpp
++++ b/lxqt-config-monitor/kscreenutils.cpp
+@@ -2,6 +2,7 @@
+ #include "timeoutdialog.h"
+ 
+ #include <KScreen/Output>
++#include <KScreen/Mode>
+ #include <KScreen/Config>
+ #include <KScreen/GetConfigOperation>
+ #include <KScreen/SetConfigOperation>
+diff --git a/lxqt-config-monitor/loadsettings.cpp b/lxqt-config-monitor/loadsettings.cpp
+index 0c7bd73c..4e9331ba 100644
+--- a/lxqt-config-monitor/loadsettings.cpp
++++ b/lxqt-config-monitor/loadsettings.cpp
+@@ -23,6 +23,7 @@
+ #include "kscreenutils.h"
+ #include <KScreen/Output>
+ #include <KScreen/Config>
++#include <KScreen/Mode>
+ #include <KScreen/GetConfigOperation>
+ #include <KScreen/SetConfigOperation>
+ #include <LXQt/Settings>
+diff --git a/lxqt-config-monitor/monitorpicture.cpp b/lxqt-config-monitor/monitorpicture.cpp
+index 0d06ab82..4cb14894 100644
+--- a/lxqt-config-monitor/monitorpicture.cpp
++++ b/lxqt-config-monitor/monitorpicture.cpp
+@@ -24,6 +24,7 @@
+ #include <QDebug>
+ #include <QVector2D>
+ #include <QRectF>
++#include <KScreen/Mode>
+ #include <QScrollBar>
+ 
+ #include "configure.h"
+diff --git a/lxqt-config-monitor/monitorsettingsdialog.cpp b/lxqt-config-monitor/monitorsettingsdialog.cpp
+index 6172019f..bfd8c1dd 100644
+--- a/lxqt-config-monitor/monitorsettingsdialog.cpp
++++ b/lxqt-config-monitor/monitorsettingsdialog.cpp
+@@ -28,6 +28,7 @@
+ #include "kscreenutils.h"
+ 
+ #include <KScreen/Output>
++#include <KScreen/Mode>
+ #include <QJsonObject>
+ #include <QJsonArray>
+ #include <LXQt/Settings>
+diff --git a/lxqt-config-monitor/monitorwidget.cpp b/lxqt-config-monitor/monitorwidget.cpp
+index e0fcf0a8..41883c25 100644
+--- a/lxqt-config-monitor/monitorwidget.cpp
++++ b/lxqt-config-monitor/monitorwidget.cpp
+@@ -22,6 +22,7 @@
+ #include <QComboBox>
+ #include <QStringBuilder>
+ #include <QDialogButtonBox>
++#include <KScreen/Mode>
+ #include <KScreen/EDID>
+ 
+ #include <algorithm>

--- a/srcpkgs/lxqt-config/template
+++ b/srcpkgs/lxqt-config/template
@@ -1,8 +1,9 @@
 # Template file for 'lxqt-config'
 pkgname=lxqt-config
 version=1.2.0
-revision=1
+revision=2
 build_style=cmake
+configure_args="-DCMAKE_CXX_STANDARD=17"
 hostmakedepends="pkg-config lxqt-build-tools qt5-qmake qt5-host-tools perl"
 makedepends="liblxqt-devel libXcursor-devel libkscreen-devel
  xf86-input-libinput-devel libqtxdg-devel"

--- a/srcpkgs/milou/template
+++ b/srcpkgs/milou/template
@@ -1,6 +1,6 @@
 # Template file for 'milou'
 pkgname=milou
-version=5.26.3
+version=5.27.0
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF"
@@ -12,7 +12,7 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later, LPGL-2.1-or-later"
 homepage="https://invent.kde.org/plasma/milou"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=81cca7b3b9fa27b5cc178c0a68a0f5d213c9f21531242cb782630071f85e928b
+checksum=7ddd4a8fce239c62b03ea8963ee1139b17a35d1aa29725995f1fdfccceb045ff
 
 if [ "$CROSS_BUILD" ]; then
 	hostmakedepends+=" kpackage-devel kconfig-devel kcoreaddons-devel plasma-framework"

--- a/srcpkgs/oxygen/template
+++ b/srcpkgs/oxygen/template
@@ -1,6 +1,6 @@
 # Template file for 'oxygen'
 pkgname=oxygen
-version=5.26.3
+version=5.27.0
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF"
@@ -13,4 +13,4 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later, GPL-2.0-or-later"
 homepage="https://invent.kde.org/plasma/oxygen"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=90b525e9af293a300a16079c90f513d6b7fddb07f81a8c8bbec93b2540a99fc1
+checksum=200f1bcf4ed7439f8ddb98375ba45a248115ff2c1bdd6d26f9e217a6460d8d6e

--- a/srcpkgs/plasma-browser-integration/template
+++ b/srcpkgs/plasma-browser-integration/template
@@ -1,6 +1,6 @@
 # Template file for 'plasma-browser-integration'
 pkgname=plasma-browser-integration
-version=5.26.3
+version=5.27.0
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF
@@ -14,4 +14,4 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-3.0-or-later"
 homepage="https://invent.kde.org/plasma/plasma-browser-integration"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=f51ffe0b49769eeb58248a96978ac5c677a9c2cf3b3e36ca499299ff9ba18daf
+checksum=f1cc9fc7656346720f833c857da9e9ebc580de209f755dbc3aea5e380fb18e04

--- a/srcpkgs/plasma-desktop/template
+++ b/srcpkgs/plasma-desktop/template
@@ -1,7 +1,7 @@
 # Template file for 'plasma-desktop'
 pkgname=plasma-desktop
-version=5.26.3
-revision=2
+version=5.27.0
+revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF
  -DKF5_HOST_TOOLING=/usr/lib/cmake"
@@ -19,6 +19,6 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later, LGPL-2.0-or-later, LGPL-2.1-or-later, GFDL-1.2-or-later"
 homepage="https://invent.kde.org/plasma/plasma-desktop"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=6174c23419d425ef1e73c6c81f0536458d685e3ec23cac66d8212d3ef3095cd3
+checksum=1880308ee3d4ff9ea20827d51b2b1a0339556e1d258cb49481ca4fd91451a234
 replaces="user-manager>=0"
 python_version=3

--- a/srcpkgs/plasma-disks/template
+++ b/srcpkgs/plasma-disks/template
@@ -1,7 +1,7 @@
 # Template file for 'plasma-disks'
 pkgname=plasma-disks
-version=5.26.3
-revision=2
+version=5.27.0
+revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF"
 hostmakedepends="extra-cmake-modules qt5-qmake qt5-host-tools
@@ -13,4 +13,4 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later"
 homepage="https://invent.kde.org/plasma/plasma-disks"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=f5d58bc4f766019bfd6700fd200ceaad49d07152b02df7430bcd6e729c854b3e
+checksum=8bc2c4ed3e36c4419ad1af877ab8ad07d829cd8758bf7be48a009e1b4082f0d4

--- a/srcpkgs/plasma-firewall/template
+++ b/srcpkgs/plasma-firewall/template
@@ -1,7 +1,7 @@
 # Template file for 'plasma-firewall'
 pkgname=plasma-firewall
-version=5.26.3
-revision=2
+version=5.27.0
+revision=1
 build_style=cmake
 configure_args="-DKF5_HOST_TOOLING=/usr/lib/cmake"
 hostmakedepends="extra-cmake-modules qt5-qmake qt5-host-tools
@@ -12,4 +12,4 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-only OR GPL-3.0-only"
 homepage="https://invent.kde.org/network/plasma-firewall"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=9dcf0d2cb56ddca9beaf6bc17edd88316831558c2b51af61c17a092b761d4265
+checksum=024ece9371843958b5ec9aa6ccce05221c20eb86335272c039138b1aa3c40a0a

--- a/srcpkgs/plasma-integration/template
+++ b/srcpkgs/plasma-integration/template
@@ -1,6 +1,6 @@
 # Template file for 'plasma-integration'
 pkgname=plasma-integration
-version=5.26.3
+version=5.27.0
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF"
@@ -14,4 +14,4 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.0-or-later"
 homepage="https://invent.kde.org/plasma/plasma-integration"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=c70723dd22a7e8ffc7f70066bc01a9033a0c0f2d728e60a97c9deb9b3834daed
+checksum=3cb091a677bfbfacbdffdd1a2c0e76afded539db3a48b2d5358236face8b4655

--- a/srcpkgs/plasma-nm/template
+++ b/srcpkgs/plasma-nm/template
@@ -1,6 +1,6 @@
 # Template file for 'plasma-nm'
 pkgname=plasma-nm
-version=5.26.3
+version=5.27.0
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF -DKF5_HOST_TOOLING=/usr/lib/cmake"
@@ -16,4 +16,4 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/plasma/plasma-nm"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=ccfbe391c0205cd28187a34a0548992e31c8cf5b069543ef38b50d5fa8a541e0
+checksum=8e34e66e81a4ac3ac8e2fb65cd9d294f4735f3a4aaf0f22841fef2690fc7fb5c

--- a/srcpkgs/plasma-pa/template
+++ b/srcpkgs/plasma-pa/template
@@ -1,6 +1,6 @@
 # Template file for 'plasma-pa'
 pkgname=plasma-pa
-version=5.26.3
+version=5.27.0
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF -DKF5_HOST_TOOLING=/usr/lib/cmake"
@@ -15,4 +15,4 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/plasma/plasma-pa"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=33a2e7654e776353b0aa74c88c672d7b3cfcf1d10a2ed4b9511886d8d6920807
+checksum=74f2f0ba643667a67888ff2cd7acde86b9143746e2375d04483e79941d93767c

--- a/srcpkgs/plasma-sdk/template
+++ b/srcpkgs/plasma-sdk/template
@@ -1,6 +1,6 @@
 # Template file for 'plasma-sdk'
 pkgname=plasma-sdk
-version=5.26.3
+version=5.27.0
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF"
@@ -13,7 +13,7 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later, LGPL-2.1-or-later"
 homepage="https://invent.kde.org/plasma/plasma-sdk"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=2e905821ac1da77f72af4687280e5d6293f941267bca6b3ec3cc26763165e168
+checksum=3f9610e5f161609f35ab7398b28ba16953b68c11ceeebdbe06de177038bb0b3b
 
 if [ "$CROSS_BUILD" ]; then
 	hostmakedepends+=" kpackage-devel kconfig-devel kcoreaddons-devel plasma-framework"

--- a/srcpkgs/plasma-systemmonitor/template
+++ b/srcpkgs/plasma-systemmonitor/template
@@ -1,6 +1,6 @@
 # Template file for 'plasma-systemmonitor'
 pkgname=plasma-systemmonitor
-version=5.26.3
+version=5.27.0
 revision=1
 build_style=cmake
 hostmakedepends="extra-cmake-modules gettext qt5-host-tools qt5-qmake
@@ -12,4 +12,4 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-only OR GPL-3.0-only, LGPL-2.1-only OR LGPL-3.0-only"
 homepage="https://invent.kde.org/plasma/plasma-systemmonitor"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=9fbf2889d1f991a4984e19f0db7083831533463b9a0bcc886e830d04b2fcbb85
+checksum=5d5fd3a9268d095b38a6f73c88b8a4e33509f4f43a6796dd3dac4fcf37f6328d

--- a/srcpkgs/plasma-thunderbolt/template
+++ b/srcpkgs/plasma-thunderbolt/template
@@ -1,6 +1,6 @@
 # Template file for 'plasma-thunderbolt'
 pkgname=plasma-thunderbolt
-version=5.26.3
+version=5.27.0
 revision=1
 build_style=cmake
 configure_args="-DKF5_HOST_TOOLING=/usr/lib/cmake"
@@ -13,7 +13,7 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-3.0-or-later"
 homepage="https://invent.kde.org/plasma/plasma-thunderbolt"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=cf58570ce0caa18cc06fb07840ead5e55e1cc9d28a77bae34c0fc1d989080bf0
+checksum=43b12410905f4d7c4f2678160f1ee6ba4a7bd159a095cf70df6a2b2ab7897d14
 
 do_check() {
 	: # Requires running dbus and bolt services

--- a/srcpkgs/plasma-vault/template
+++ b/srcpkgs/plasma-vault/template
@@ -1,6 +1,6 @@
 # Template file for 'plasma-vault'
 pkgname=plasma-vault
-version=5.26.3
+version=5.27.0
 revision=1
 build_style=cmake
 configure_args=" -DKF5_HOST_TOOLING=/usr/lib/cmake
@@ -14,4 +14,4 @@ maintainer="Giuseppe Fierro <gspe@ae-design.ws>"
 license="GPL-2.0-or-later, LGPL-2.0-or-later, LGPL-2.1-or-later"
 homepage="https://github.com/KDE/plasma-vault"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=ae425285f5c03ec6ddde22b6b116bd56918cf2b472f506dde76ba37fac94b426
+checksum=e88a2790d75dfc3696bae731e017a7258c4e5831fc96a32b77b9ecbbbd4cb544

--- a/srcpkgs/plasma-wayland-protocols/template
+++ b/srcpkgs/plasma-wayland-protocols/template
@@ -1,6 +1,6 @@
 # Template file for 'plasma-wayland-protocols'
 pkgname=plasma-wayland-protocols
-version=1.9.0
+version=1.10.0
 revision=1
 build_style=cmake
 hostmakedepends="extra-cmake-modules"
@@ -9,7 +9,7 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-3.0-or-later"
 homepage="https://invent.kde.org/libraries/plasma-wayland-protocols"
 distfiles="${KDE_SITE}/${pkgname}/${pkgname}-${version}.tar.xz"
-checksum=a4275b9a854716fa5ed9c2ba2d697df2b0749fc45a28ad965e68d0aa36c5d4c8
+checksum=31948867c9a04613e6de0d23adfcbc5acecddef0b39f986b345ec6c1972736fe
 
 post_install() {
 	vsed -e '/NOT CMAKE_SIZEOF_VOID_P STREQUAL/,+5d' \

--- a/srcpkgs/plasma-workspace-wallpapers/template
+++ b/srcpkgs/plasma-workspace-wallpapers/template
@@ -1,6 +1,6 @@
 # Template file for 'plasma-workspace-wallpapers'
 pkgname=plasma-workspace-wallpapers
-version=5.26.3
+version=5.27.0
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF"
@@ -10,4 +10,4 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later"
 homepage="https://invent.kde.org/plasma/plasma-workspace-wallpapers"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=61345372a5513c197703ec798db44cf80854ce3ef3a56dd58baf109491753ce3
+checksum=dfcacabb0f3dd6373dc2c67c50382f249444f04b927212fd01c98ab7ec0bdfdf

--- a/srcpkgs/plasma-workspace/template
+++ b/srcpkgs/plasma-workspace/template
@@ -1,7 +1,7 @@
 # Template file for 'plasma-workspace'
 pkgname=plasma-workspace
-version=5.26.3
-revision=2
+version=5.27.0
+revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF
  -DWaylandScanner_EXECUTABLE=/usr/bin/wayland-scanner
@@ -23,7 +23,7 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later, GFDL-1.2-or-later, LGPL-2.1-or-later"
 homepage="https://invent.kde.org/plasma/plasma-workspace"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=0a2c1e98e3e540822db833a6f8d0a35a174d327e56a81756b3baf0d8ba35c953
+checksum=01244ed2df75960192cf810a263410a7b2c9b34c3c237b14429d028ba10b073b
 
 build_options="pipewire"
 build_options_default="pipewire"

--- a/srcpkgs/polkit-kde-agent/template
+++ b/srcpkgs/polkit-kde-agent/template
@@ -1,7 +1,7 @@
 # Template file for 'polkit-kde-agent'
 pkgname=polkit-kde-agent
-version=5.26.3
-revision=2
+version=5.27.0
+revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF"
 hostmakedepends="extra-cmake-modules qt5-qmake qt5-host-tools gettext kcoreaddons"
@@ -12,4 +12,4 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later"
 homepage="https://commits.kde.org/polkit-kde-agent"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-1-${version}.tar.xz"
-checksum=2f98b07ce9e44dc2883ab4b490e68b5f0f4694fae514dbf696383e1c9af4a671
+checksum=415f6fb58f5c934e07179dc94a7954508fdbf31f398527a0de98e6c451de3056

--- a/srcpkgs/powerdevil/template
+++ b/srcpkgs/powerdevil/template
@@ -1,7 +1,7 @@
 # Template file for 'powerdevil'
 pkgname=powerdevil
-version=5.26.3
-revision=2
+version=5.27.0
+revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF -DKF5_HOST_TOOLING=/usr/lib/cmake"
 hostmakedepends="extra-cmake-modules pkg-config kdoctools kauth-devel
@@ -13,4 +13,4 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later"
 homepage="https://invent.kde.org/plasma/powerdevil"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=bb8c3e2a3cb2e5fd140de6807e250794abf9075d43091e03da0a91c39ecf2005
+checksum=2f27b4fabe84e6cad22dfd49aabf075c166c7a4a475e92099d3f98d3f517b73d

--- a/srcpkgs/sddm-kcm/template
+++ b/srcpkgs/sddm-kcm/template
@@ -1,7 +1,7 @@
 # Template file for 'sddm-kcm'
 pkgname=sddm-kcm
-version=5.26.3
-revision=2
+version=5.27.0
+revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF -DKF5_HOST_TOOLING=/usr/lib/cmake"
 hostmakedepends="extra-cmake-modules pkg-config qt5-devel qt5-qmake
@@ -14,4 +14,4 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later"
 homepage="https://invent.kde.org/plasma/sddm-kcm"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=2a76a5ac4c9f24cf143b10cefce9d68334502ade89ef571b0f53520534e6d3f5
+checksum=d706c7a2578203f66e7c3732a74b029fdc48f054ca7f2f97003d53b2bd2cabcd

--- a/srcpkgs/systemsettings/template
+++ b/srcpkgs/systemsettings/template
@@ -1,6 +1,6 @@
 # Template file for 'systemsettings'
 pkgname=systemsettings
-version=5.26.3
+version=5.27.0
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF"
@@ -14,4 +14,4 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later, GFDL-1.2-only"
 homepage="https://invent.kde.org/plasma/systemsettings"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=c3e361531bf619797ed5a246ad0b64650a3d9306acae85cf7a874c7b10e098b2
+checksum=2715bfa6df9810dee9961bb626cc0d644e96e1b81b9213af3fadb09467d8ba6a

--- a/srcpkgs/xdg-desktop-portal-kde/template
+++ b/srcpkgs/xdg-desktop-portal-kde/template
@@ -1,7 +1,7 @@
 # Template file for 'xdg-desktop-portal-kde'
 pkgname=xdg-desktop-portal-kde
-version=5.26.3
-revision=2
+version=5.27.0
+revision=1
 build_style=cmake
 configure_args="-DWaylandScanner_EXECUTABLE=/usr/bin/wayland-scanner"
 hostmakedepends="extra-cmake-modules qt5-qmake qt5-host-tools kcoreaddons gettext
@@ -13,4 +13,4 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-3.0-or-later"
 homepage="https://phabricator.kde.org/source/xdg-desktop-portal-kde/"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=57def236877f336c867ee7b3f57437416e84dfe0b9dd1c3ed3de6b5fd01ca7d3
+checksum=70d50c45d87a7b993d637d374bd953c41dde29ed57b85c401de69e7d08d72e19


### PR DESCRIPTION
- bluedevil: update to 5.27.0
- breeze-gtk: update to 5.27.0
- breeze: update to 5.27.0
- kactivitymanagerd: update to 5.27.0
- kde-cli-tools: update to 5.27.0
- kde-gtk-config5: update to 5.27.0
- kdecoration: update to 5.27.0
- kdeplasma-addons5: update to 5.27.0
- kgamma5: update to 5.27.0
- khotkeys: update to 5.27.0
- kinfocenter: update to 5.27.0
- kmenuedit: update to 5.27.0
- kpipewire: update to 5.27.0
- kscreen: update to 5.27.0
- kscreenlocker: update to 5.27.0
- ksshaskpass: update to 5.27.0
- ksystemstats: update to 5.27.0
- kwallet-pam: update to 5.27.0
- kwayland-integration: update to 5.27.0
- kwin: update to 5.27.0
- kwrited: update to 5.27.0
- layer-shell-qt: update to 5.27.0
- libkscreen: update to 5.27.0
- libksysguard: update to 5.27.0
- milou: update to 5.27.0
- oxygen: update to 5.27.0
- plasma-browser-integration: update to 5.27.0
- plasma-desktop: update to 5.27.0
- plasma-disks: update to 5.27.0
- plasma-firewall: update to 5.27.0
- plasma-integration: update to 5.27.0
- plasma-nm: update to 5.27.0
- plasma-pa: update to 5.27.0
- plasma-sdk: update to 5.27.0
- plasma-systemmonitor: update to 5.27.0
- plasma-thunderbolt: update to 5.27.0
- plasma-vault: update to 5.27.0
- plasma-workspace-wallpapers: update to 5.27.0
- plasma-workspace: update to 5.27.0
- polkit-kde-agent: update to 5.27.0
- powerdevil: update to 5.27.0
- sddm-kcm: update to 5.27.0
- systemsettings: update to 5.27.0
- xdg-desktop-portal-kde: update to 5.27.0
- plasma-wayland-protocols: update to 1.10.0.
- lxqt-config: rebuild against libkscreen-5.27.0

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**|**briefly**|**NO**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
