### PR TITLE
spotify-tui: fix build, patch for openssl3

### DIFF
--- a/srcpkgs/spotify-tui/patches/openssl3.patch
+++ b/srcpkgs/spotify-tui/patches/openssl3.patch
@@ -1,0 +1,614 @@
+From: https://git.alpinelinux.org/aports/plain/testing/spotify-tui/openssl3.patch
+
+diff --git a/Cargo.lock b/Cargo.lock
+index fa129f0..7ddbd81 100644
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -133,9 +133,9 @@ checksum = "b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7"
+ 
+ [[package]]
+ name = "base64"
+-version = "0.12.3"
++version = "0.13.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
++checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
+ 
+ [[package]]
+ name = "bitflags"
+@@ -287,32 +287,16 @@ version = "0.1.5"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
+ 
+-[[package]]
+-name = "core-foundation"
+-version = "0.7.0"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "57d24c7a13c43e870e37c1556b74555437870a04514f7685f5b354e090567171"
+-dependencies = [
+- "core-foundation-sys 0.7.0",
+- "libc",
+-]
+-
+ [[package]]
+ name = "core-foundation"
+ version = "0.9.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "0a89e2ae426ea83155dccf10c0fa6b1463ef6d5fcb44cee0b224a408fa640a62"
+ dependencies = [
+- "core-foundation-sys 0.8.2",
++ "core-foundation-sys",
+  "libc",
+ ]
+ 
+-[[package]]
+-name = "core-foundation-sys"
+-version = "0.7.0"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "b3a71ab494c0b5b860bdc8407ae08978052417070c2ced38573a9157ad75b8ac"
+-
+ [[package]]
+ name = "core-foundation-sys"
+ version = "0.8.2"
+@@ -326,7 +310,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "52a67c4378cf203eace8fb6567847eb641fd6ff933c1145a115c6ee820ebb978"
+ dependencies = [
+  "bitflags",
+- "core-foundation 0.9.1",
++ "core-foundation",
+  "foreign-types",
+  "libc",
+ ]
+@@ -537,9 +521,9 @@ version = "0.1.8"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
+ dependencies = [
+- "proc-macro2 1.0.24",
++ "proc-macro2 1.0.43",
+  "quote 1.0.7",
+- "syn 1.0.60",
++ "syn 1.0.99",
+  "synstructure",
+ ]
+ 
+@@ -564,6 +548,16 @@ version = "0.1.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+ 
++[[package]]
++name = "form_urlencoded"
++version = "1.0.1"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
++dependencies = [
++ "matches",
++ "percent-encoding 2.1.0",
++]
++
+ [[package]]
+ name = "fuchsia-cprng"
+ version = "0.1.1"
+@@ -641,9 +635,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "d0b5a30a4328ab5473878237c447333c093297bded83a4983d10f4deea240d39"
+ dependencies = [
+  "proc-macro-hack",
+- "proc-macro2 1.0.24",
++ "proc-macro2 1.0.43",
+  "quote 1.0.7",
+- "syn 1.0.60",
++ "syn 1.0.99",
+ ]
+ 
+ [[package]]
+@@ -764,7 +758,7 @@ checksum = "28d569972648b2c512421b5f2a405ad6ac9666547189d0c5477a3f200f3e02f9"
+ dependencies = [
+  "bytes 0.5.6",
+  "fnv",
+- "itoa",
++ "itoa 0.4.6",
+ ]
+ 
+ [[package]]
+@@ -806,7 +800,7 @@ dependencies = [
+  "http",
+  "http-body",
+  "httparse",
+- "itoa",
++ "itoa 0.4.6",
+  "pin-project",
+  "socket2",
+  "time",
+@@ -901,6 +895,12 @@ dependencies = [
+  "libc",
+ ]
+ 
++[[package]]
++name = "ipnet"
++version = "2.5.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "879d54834c8c76457ef4293a689b2a8c59b076067ad77b15efafbb05f92a592b"
++
+ [[package]]
+ name = "itertools"
+ version = "0.8.2"
+@@ -916,6 +916,12 @@ version = "0.4.6"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "dc6f3ad7b9d11a0c00842ff8de1b60ee58661048eb8049ed33c73594f359d7e6"
+ 
++[[package]]
++name = "itoa"
++version = "1.0.3"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "6c8af84674fe1f223a982c933a0ee1086ac4d4052aa0fb8060c12c6ad838e754"
++
+ [[package]]
+ name = "jpeg-decoder"
+ version = "0.1.20"
+@@ -927,9 +933,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "js-sys"
+-version = "0.3.42"
++version = "0.3.59"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "52732a3d3ad72c58ad2dc70624f9c17b46ecd0943b9a4f1ee37c4c18c5d983e2"
++checksum = "258451ab10b34f8af53416d1fdab72c22e805f0c92a1136d59470ec0b11138b2"
+ dependencies = [
+  "wasm-bindgen",
+ ]
+@@ -952,9 +958,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+ 
+ [[package]]
+ name = "libc"
+-version = "0.2.82"
++version = "0.2.127"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "89203f3fba0a3795506acaad8ebce3c80c0af93f994d5a1d7a0b1eeb23271929"
++checksum = "505e71a4706fa491e9b1b55f51b95d4037d0821ee40131190475f692b35b009b"
+ 
+ [[package]]
+ name = "linked-hash-map"
+@@ -1116,9 +1122,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "native-tls"
+-version = "0.2.4"
++version = "0.2.10"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "2b0d88c06fe90d5ee94048ba40409ef1d9315d86f6f38c2efdaad4fb50c58b2d"
++checksum = "fd7e2f3618557f980e0b17e8856252eee3c97fa12c54dff0ca290fb6266ca4a9"
+ dependencies = [
+  "lazy_static",
+  "libc",
+@@ -1252,24 +1258,36 @@ checksum = "a9a7ab5d64814df0fe4a4b5ead45ed6c5f181ee3ff04ba344313a6c80446c5d4"
+ 
+ [[package]]
+ name = "once_cell"
+-version = "1.4.0"
++version = "1.13.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "0b631f7e854af39a1739f401cf34a8a013dfe09eac4fa4dba91e9768bd28168d"
++checksum = "18a6dbe30758c9f83eb00cbea4ac95966305f5a7772f3f42ebfc7fc7eddbd8e1"
+ 
+ [[package]]
+ name = "openssl"
+-version = "0.10.30"
++version = "0.10.41"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "8d575eff3665419f9b83678ff2815858ad9d11567e082f5ac1814baba4e2bcb4"
++checksum = "618febf65336490dfcf20b73f885f5651a0c89c64c2d4a8c3662585a70bf5bd0"
+ dependencies = [
+  "bitflags",
+- "cfg-if 0.1.10",
++ "cfg-if 1.0.0",
+  "foreign-types",
+- "lazy_static",
+  "libc",
++ "once_cell",
++ "openssl-macros",
+  "openssl-sys",
+ ]
+ 
++[[package]]
++name = "openssl-macros"
++version = "0.1.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "b501e44f11665960c7e7fcf062c7d96a14ade4aa98116c004b2e37b5be7d736c"
++dependencies = [
++ "proc-macro2 1.0.43",
++ "quote 1.0.7",
++ "syn 1.0.99",
++]
++
+ [[package]]
+ name = "openssl-probe"
+ version = "0.1.2"
+@@ -1278,9 +1296,9 @@ checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
+ 
+ [[package]]
+ name = "openssl-sys"
+-version = "0.9.58"
++version = "0.9.75"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "a842db4709b604f0fe5d1170ae3565899be2ad3d9cbc72dedc789ac0511f78de"
++checksum = "e5f9bd0c2710541a3cda73d6f9ac4f1b240de4ae261065d309dbe73d9dceb42f"
+ dependencies = [
+  "autocfg 1.0.0",
+  "cc",
+@@ -1329,22 +1347,22 @@ checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
+ 
+ [[package]]
+ name = "pin-project"
+-version = "0.4.22"
++version = "0.4.30"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "12e3a6cdbfe94a5e4572812a0201f8c0ed98c1c452c7b8563ce2276988ef9c17"
++checksum = "3ef0f924a5ee7ea9cbcea77529dba45f8a9ba9f622419fe3386ca581a3ae9d5a"
+ dependencies = [
+  "pin-project-internal",
+ ]
+ 
+ [[package]]
+ name = "pin-project-internal"
+-version = "0.4.22"
++version = "0.4.30"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "6a0ffd45cf79d88737d7cc85bfd5d2894bee1139b356e616fe85dc389c61aaf7"
++checksum = "851c8d0ce9bebe43790dedfc86614c23494ac9f423dd618d3a61fc693eafe61e"
+ dependencies = [
+- "proc-macro2 1.0.24",
++ "proc-macro2 1.0.43",
+  "quote 1.0.7",
+- "syn 1.0.60",
++ "syn 1.0.99",
+ ]
+ 
+ [[package]]
+@@ -1353,6 +1371,12 @@ version = "0.1.7"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "282adbf10f2698a7a77f8e983a74b2d18176c19a7fd32a45446139ae7b02b715"
+ 
++[[package]]
++name = "pin-project-lite"
++version = "0.2.9"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
++
+ [[package]]
+ name = "pin-utils"
+ version = "0.1.0"
+@@ -1406,11 +1430,11 @@ dependencies = [
+ 
+ [[package]]
+ name = "proc-macro2"
+-version = "1.0.24"
++version = "1.0.43"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "1e0704ee1a7e00d7bb417d0770ea303c1bccbabf0ef1667dae92b5967f5f8a71"
++checksum = "0a2ca2c61bc9f3d74d2886294ab7b9853abd9c1ad903a3ac7815c58989bb7bab"
+ dependencies = [
+- "unicode-xid 0.2.1",
++ "unicode-ident",
+ ]
+ 
+ [[package]]
+@@ -1434,7 +1458,7 @@ version = "1.0.7"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "aa563d17ecb180e500da1cfd2b028310ac758de548efdd203e18f283af693f37"
+ dependencies = [
+- "proc-macro2 1.0.24",
++ "proc-macro2 1.0.43",
+ ]
+ 
+ [[package]]
+@@ -1685,11 +1709,11 @@ dependencies = [
+ 
+ [[package]]
+ name = "reqwest"
+-version = "0.10.6"
++version = "0.10.10"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "3b82c9238b305f26f53443e3a4bc8528d64b8d0bee408ec949eb7bf5635ec680"
++checksum = "0718f81a8e14c4dbb3b34cf23dc6aaf9ab8a0dfec160c534b3dbca1aaa21f47c"
+ dependencies = [
+- "base64 0.12.3",
++ "base64 0.13.0",
+  "bytes 0.5.6",
+  "encoding_rs",
+  "futures-core",
+@@ -1698,6 +1722,7 @@ dependencies = [
+  "http-body",
+  "hyper",
+  "hyper-tls",
++ "ipnet",
+  "js-sys",
+  "lazy_static",
+  "log",
+@@ -1705,14 +1730,14 @@ dependencies = [
+  "mime_guess",
+  "native-tls",
+  "percent-encoding 2.1.0",
+- "pin-project-lite",
++ "pin-project-lite 0.2.9",
+  "serde",
+  "serde_json",
+  "serde_urlencoded",
+  "tokio",
+  "tokio-socks",
+  "tokio-tls",
+- "url 2.1.1",
++ "url 2.2.2",
+  "wasm-bindgen",
+  "wasm-bindgen-futures",
+  "web-sys",
+@@ -1793,24 +1818,24 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+ 
+ [[package]]
+ name = "security-framework"
+-version = "0.4.4"
++version = "2.3.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "64808902d7d99f78eaddd2b4e2509713babc3dc3c85ad6f4c447680f3c01e535"
++checksum = "23a2ac85147a3a11d77ecf1bc7166ec0b92febfa4461c37944e180f319ece467"
+ dependencies = [
+  "bitflags",
+- "core-foundation 0.7.0",
+- "core-foundation-sys 0.7.0",
++ "core-foundation",
++ "core-foundation-sys",
+  "libc",
+  "security-framework-sys",
+ ]
+ 
+ [[package]]
+ name = "security-framework-sys"
+-version = "0.4.3"
++version = "2.4.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "17bf11d99252f512695eb468de5516e5cf75455521e69dfe343f3b74e4748405"
++checksum = "a9dd14d83160b528b7bfd66439110573efcfbe281b17fc2ca9f39f550d619c7e"
+ dependencies = [
+- "core-foundation-sys 0.7.0",
++ "core-foundation-sys",
+  "libc",
+ ]
+ 
+@@ -1829,9 +1854,9 @@ version = "1.0.128"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "13af2fbb8b60a8950d6c72a56d2095c28870367cc8e10c55e9745bac4995a2c4"
+ dependencies = [
+- "proc-macro2 1.0.24",
++ "proc-macro2 1.0.43",
+  "quote 1.0.7",
+- "syn 1.0.60",
++ "syn 1.0.99",
+ ]
+ 
+ [[package]]
+@@ -1840,21 +1865,21 @@ version = "1.0.64"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "799e97dc9fdae36a5c8b8f2cae9ce2ee9fdce2058c57a93e6099d919fd982f79"
+ dependencies = [
+- "itoa",
++ "itoa 0.4.6",
+  "ryu",
+  "serde",
+ ]
+ 
+ [[package]]
+ name = "serde_urlencoded"
+-version = "0.6.1"
++version = "0.7.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "9ec5d77e2d4c73717816afac02670d5c4f534ea95ed430442cad02e7a6e32c97"
++checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+ dependencies = [
+- "dtoa",
+- "itoa",
++ "form_urlencoded",
++ "itoa 1.0.3",
++ "ryu",
+  "serde",
+- "url 2.1.1",
+ ]
+ 
+ [[package]]
+@@ -1974,13 +1999,13 @@ dependencies = [
+ 
+ [[package]]
+ name = "syn"
+-version = "1.0.60"
++version = "1.0.99"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "c700597eca8a5a762beb35753ef6b94df201c81cca676604f547495a0d7f0081"
++checksum = "58dbef6ec655055e20b86b15a8cc6d439cca19b667537ac6a1369572d151ab13"
+ dependencies = [
+- "proc-macro2 1.0.24",
++ "proc-macro2 1.0.43",
+  "quote 1.0.7",
+- "unicode-xid 0.2.1",
++ "unicode-ident",
+ ]
+ 
+ [[package]]
+@@ -1989,9 +2014,9 @@ version = "0.12.4"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "b834f2d66f734cb897113e34aaff2f1ab4719ca946f9a7358dba8f8064148701"
+ dependencies = [
+- "proc-macro2 1.0.24",
++ "proc-macro2 1.0.43",
+  "quote 1.0.7",
+- "syn 1.0.60",
++ "syn 1.0.99",
+  "unicode-xid 0.2.1",
+ ]
+ 
+@@ -2042,9 +2067,9 @@ version = "1.0.20"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "bd80fc12f73063ac132ac92aceea36734f04a1d93c1240c6944e23a3b8841793"
+ dependencies = [
+- "proc-macro2 1.0.24",
++ "proc-macro2 1.0.43",
+  "quote 1.0.7",
+- "syn 1.0.60",
++ "syn 1.0.99",
+ ]
+ 
+ [[package]]
+@@ -2100,7 +2125,7 @@ dependencies = [
+  "mio-named-pipes",
+  "mio-uds",
+  "num_cpus",
+- "pin-project-lite",
++ "pin-project-lite 0.1.7",
+  "signal-hook-registry",
+  "slab",
+  "tokio-macros",
+@@ -2113,16 +2138,16 @@ version = "0.2.6"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "e44da00bfc73a25f814cd8d7e57a68a5c31b74b3152a0a1d1f590c97ed06265a"
+ dependencies = [
+- "proc-macro2 1.0.24",
++ "proc-macro2 1.0.43",
+  "quote 1.0.7",
+- "syn 1.0.60",
++ "syn 1.0.99",
+ ]
+ 
+ [[package]]
+ name = "tokio-socks"
+-version = "0.2.2"
++version = "0.3.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "1997788a0e25e09300e44680ba1ef9d44d6f634a883641f80109e8b59c928daf"
++checksum = "d611fd5d241872372d52a0a3d309c52d0b95a6a67671a6c8f7ab2c4a37fb2539"
+ dependencies = [
+  "bytes 0.4.12",
+  "either",
+@@ -2151,7 +2176,7 @@ dependencies = [
+  "futures-core",
+  "futures-sink",
+  "log",
+- "pin-project-lite",
++ "pin-project-lite 0.1.7",
+  "tokio",
+ ]
+ 
+@@ -2218,6 +2243,12 @@ dependencies = [
+  "matches",
+ ]
+ 
++[[package]]
++name = "unicode-ident"
++version = "1.0.3"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "c4f5b37a154999a8f3f98cc23a628d850e154479cd94decf3414696e12e31aaf"
++
+ [[package]]
+ name = "unicode-normalization"
+ version = "0.1.13"
+@@ -2264,10 +2295,11 @@ dependencies = [
+ 
+ [[package]]
+ name = "url"
+-version = "2.1.1"
++version = "2.2.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "829d4a8476c35c9bf0bbce5a3b23f4106f79728039b726d292bb93bc106787cb"
++checksum = "a507c383b2d33b5fc35d1861e77e6b383d158b2da5e14fe51b83dfedf6fd578c"
+ dependencies = [
++ "form_urlencoded",
+  "idna 0.2.0",
+  "matches",
+  "percent-encoding 2.1.0",
+@@ -2315,11 +2347,11 @@ checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
+ 
+ [[package]]
+ name = "wasm-bindgen"
+-version = "0.2.65"
++version = "0.2.82"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "f3edbcc9536ab7eababcc6d2374a0b7bfe13a2b6d562c5e07f370456b1a8f33d"
++checksum = "fc7652e3f6c4706c8d9cd54832c4a4ccb9b5336e2c3bd154d5cccfbf1c1f5f7d"
+ dependencies = [
+- "cfg-if 0.1.10",
++ "cfg-if 1.0.0",
+  "serde",
+  "serde_json",
+  "wasm-bindgen-macro",
+@@ -2327,26 +2359,26 @@ dependencies = [
+ 
+ [[package]]
+ name = "wasm-bindgen-backend"
+-version = "0.2.65"
++version = "0.2.82"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "89ed2fb8c84bfad20ea66b26a3743f3e7ba8735a69fe7d95118c33ec8fc1244d"
++checksum = "662cd44805586bd52971b9586b1df85cdbbd9112e4ef4d8f41559c334dc6ac3f"
+ dependencies = [
+  "bumpalo",
+- "lazy_static",
+  "log",
+- "proc-macro2 1.0.24",
++ "once_cell",
++ "proc-macro2 1.0.43",
+  "quote 1.0.7",
+- "syn 1.0.60",
++ "syn 1.0.99",
+  "wasm-bindgen-shared",
+ ]
+ 
+ [[package]]
+ name = "wasm-bindgen-futures"
+-version = "0.4.15"
++version = "0.4.32"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "41ad6e4e8b2b7f8c90b6e09a9b590ea15cb0d1dbe28502b5a405cd95d1981671"
++checksum = "fa76fb221a1f8acddf5b54ace85912606980ad661ac7a503b4570ffd3a624dad"
+ dependencies = [
+- "cfg-if 0.1.10",
++ "cfg-if 1.0.0",
+  "js-sys",
+  "wasm-bindgen",
+  "web-sys",
+@@ -2354,9 +2386,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "wasm-bindgen-macro"
+-version = "0.2.65"
++version = "0.2.82"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "eb071268b031a64d92fc6cf691715ca5a40950694d8f683c5bb43db7c730929e"
++checksum = "b260f13d3012071dfb1512849c033b1925038373aea48ced3012c09df952c602"
+ dependencies = [
+  "quote 1.0.7",
+  "wasm-bindgen-macro-support",
+@@ -2364,22 +2396,22 @@ dependencies = [
+ 
+ [[package]]
+ name = "wasm-bindgen-macro-support"
+-version = "0.2.65"
++version = "0.2.82"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "cf592c807080719d1ff2f245a687cbadb3ed28b2077ed7084b47aba8b691f2c6"
++checksum = "5be8e654bdd9b79216c2929ab90721aa82faf65c48cdf08bdc4e7f51357b80da"
+ dependencies = [
+- "proc-macro2 1.0.24",
++ "proc-macro2 1.0.43",
+  "quote 1.0.7",
+- "syn 1.0.60",
++ "syn 1.0.99",
+  "wasm-bindgen-backend",
+  "wasm-bindgen-shared",
+ ]
+ 
+ [[package]]
+ name = "wasm-bindgen-shared"
+-version = "0.2.65"
++version = "0.2.82"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "72b6c0220ded549d63860c78c38f3bcc558d1ca3f4efa74942c536ddbbb55e87"
++checksum = "6598dd0bd3c7d51095ff6531a5b23e02acdc81804e30d8f07afb77b7215a140a"
+ 
+ [[package]]
+ name = "web-sys"

--- a/srcpkgs/spotify-tui/template
+++ b/srcpkgs/spotify-tui/template
@@ -1,7 +1,7 @@
 # Template file for 'spotify-tui'
 pkgname=spotify-tui
 version=0.25.0
-revision=1
+revision=2
 build_style=cargo
 hostmakedepends="pkg-config python3"
 makedepends="openssl-devel python3-devel libxcb-devel"
@@ -17,6 +17,7 @@ pre_build() {
 	cargo update --package num-traits:0.2.12 --precise 0.2.15
 	cargo update --package num-integer:0.1.43 --precise 0.1.45
 	cargo update --package autocfg:1.0.0 --precise 1.1.0
+	cargo update --package socket2:0.3.12 --precise 0.3.19
 }
 
 post_install() {


### PR DESCRIPTION
- I tested the changes in this PR: **NO**
- I built this PR locally for my native architecture, (x86_64-musl)

see https://github.com/Rigellute/spotify-tui/issues/1025
#37681 @abenson 