### PR TITLE
python3-poetry-core: update to 1.5.0.

### DIFF
--- a/srcpkgs/python3-poetry-core/template
+++ b/srcpkgs/python3-poetry-core/template
@@ -1,20 +1,19 @@
 # Template file for 'python3-poetry-core'
 pkgname=python3-poetry-core
-version=1.3.1
-revision=2
+version=1.5.0
+revision=1
 build_style="python3-pep517"
-make_check_args="--deselect tests/masonry/builders/test_sdist.py::test_default_with_excluded_data
- --deselect tests/masonry/builders/test_wheel.py::test_default_src_with_excluded_data"
 depends="python3"
-checkdepends="python3-devel python3-virtualenv python3-pyrsistent python3-pytest-mock git"
+checkdepends="python3-devel python3-setuptools python3-virtualenv python3-pyrsistent
+ python3-pytest-mock"
 short_desc="Poetry PEP 517 Build Backend & Core Utilities"
 maintainer="Kye Shi <shi.kye@gmail.com>"
 license="MIT"
 homepage="https://github.com/python-poetry/poetry-core"
 changelog="https://raw.githubusercontent.com/python-poetry/poetry-core/main/CHANGELOG.md"
 distfiles="https://github.com/python-poetry/poetry-core/archive/refs/tags/${version}.tar.gz"
-checksum=8da8ce8f2e861527f660d7205a77095279d462b44d1d11bcf9e8ce74d96219ee
-make_check_pre="env PYTHONPATH=src"
+checksum=c186b6212224fddae1de8ad7c5e660f40f295cf42559550523f15e72c562f5a8
+make_check_pre="env PYTHONPATH=src PATH=/usr/libexec/chroot-git:${PATH}"
 
 pre_check() {
 	rm -r tests/integration


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture: **x86_64**

#### Rev dep checks
- [x] python3-msoffcrypto-tool
- [x] python3-WeasyPrint
- [x] python3-pytest-isort
- [x] python3-cssselect2
- [x] python3-Pyphen
- [x] python3-pydyf
- [x] python3-pytest-httpserver
- [x] python3-tinycss2
- [x] python3-matrix-nio
- [x] python3-quart
- [x] python3-aiofiles
- [x] python3-hypercorn
- [x] python3-pytzdata (unrelated test failures from before)
- [x] rofi-rbw
- [x] python3-httpx
- [x] synapse
- [x] python3-unpaddedbase64
- [x] jrnl
- [x] python3-pendulum (unrelated test failures from before)

Only real blocker was synapse, which has been resolved [upstream](https://github.com/matrix-org/synapse/commit/64a631879c8be583efe47ca48e39f6cdf6115645) and merged [here](https://github.com/void-linux/void-packages/commit/404663e7968ec3e7c4ce67771639aebac0cf822d).