### PR TITLE
cryptsetup: update to 2.6.1.

### DIFF
--- a/srcpkgs/cryptsetup/template
+++ b/srcpkgs/cryptsetup/template
@@ -1,10 +1,10 @@
 # Template file for 'cryptsetup'
 pkgname=cryptsetup
-version=2.6.0
-revision=2
+version=2.6.1
+revision=1
 build_style=gnu-configure
-configure_args="--with-crypto_backend=openssl --enable-cryptsetup-reencrypt
- --disable-asciidoc --enable-libargon2 $(vopt_enable pwquality)"
+configure_args="--with-crypto_backend=openssl --disable-asciidoc
+ --enable-libargon2 $(vopt_enable pwquality)"
 make_check_args="-C tests"
 hostmakedepends="pkg-config"
 makedepends="device-mapper-devel json-c-devel openssl-devel popt-devel
@@ -16,7 +16,7 @@ license="GPL-2.0-or-later"
 homepage="https://gitlab.com/cryptsetup/cryptsetup"
 changelog="https://gitlab.com/cryptsetup/cryptsetup/raw/master/docs/v${version}-ReleaseNotes"
 distfiles="${KERNEL_SITE}/utils/cryptsetup/v${version%.*}/cryptsetup-${version}.tar.xz"
-checksum=44397ba76e75a9cde5b02177bc63cd7af428a785788e3a7067733e7761842735
+checksum=410ded65a1072ab9c8e41added37b9729c087fef4d2db02bb4ef529ad6da4693
 subpackages="libcryptsetup cryptsetup-devel"
 build_options="pwquality"
 desc_option_pwquality="Enable support for checking password quality via libpwquality"
@@ -27,7 +27,6 @@ post_patch() {
 	if [ "$XBPS_TARGET_LIBC" = musl ]; then
 		# Require losetup from util-linux, also failing when present
 		# TODO: 2 tests require lsblk
-		rm -f tests/compat-test
 		ln -f /bin/true tests/compat-test
 	fi
 }


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES** (booted into my FDE installation)

I'd appreciate anybody testing this PR.

ping @daniel-eys

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
