### PR TITLE
tox: update to 3.28.0, orphan.

### DIFF
--- a/srcpkgs/python3-pytest/template
+++ b/srcpkgs/python3-pytest/template
@@ -1,11 +1,11 @@
 # Template file for 'python3-pytest'
 pkgname=python3-pytest
-version=7.1.3
+version=7.2.1
 revision=1
 build_style=python3-module
 _common_deps="python3-attrs python3-iniconfig python3-py python3-pluggy"
 hostmakedepends="python3-setuptools_scm python3-wheel python3-Sphinx ${_common_deps}"
-depends="python3-packaging python3-tomli ${_common_deps}"
+depends="python3-packaging ${_common_deps}"
 checkdepends="$depends python3-argcomplete python3-hypothesis python3-mock
  python3-nose python3-requests python3-parsing python3-xmlschema"
 short_desc="Simple powerful testing with Python 3"
@@ -14,7 +14,7 @@ license="MIT"
 homepage="https://docs.pytest.org/en/latest/"
 changelog="https://docs.pytest.org/en/latest/changelog.html"
 distfiles="${PYPI_SITE}/p/pytest/pytest-${version}.tar.gz"
-checksum=4f365fec2dff9c1162f834d9f18af1ba13062db0c708bf7b946f8a5c76180c39
+checksum=d45e0952f3727241918b8fd0f376f5ff6b301cc0777c6f9a556935c92d8a7d42
 alternatives="
  pytest:pytest:/usr/bin/pytest3
  pytest:py.test:/usr/bin/py.test3"

--- a/srcpkgs/tox/template
+++ b/srcpkgs/tox/template
@@ -1,25 +1,26 @@
 # Template file for 'tox'
 pkgname=tox
-version=3.25.1
-revision=2
+version=3.28.0
+revision=1
 build_style=python3-module
 hostmakedepends="python3-setuptools_scm"
 depends="python3-filelock python3-packaging
- python3-pluggy python3-pytest python3-toml python3-virtualenv"
+ python3-pluggy python3-pytest python3-virtualenv"
 checkdepends="${depends} python3-pip python3-pytest-mock
  python3-flaky python3-pathlib2 python3-freezegun"
 short_desc="Generic virtualenv management and test command line tool"
-maintainer="Piotr Wójcik <chocimier@tlen.pl>"
+maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
-homepage="https://tox.readthedocs.io/en/latest/"
-changelog="https://tox.readthedocs.io/en/latest/changelog.html"
+homepage="https://tox.wiki/en/legacy/"
+changelog="https://tox.wiki/en/legacy/changelog.html"
 distfiles="${PYPI_SITE}/t/tox/tox-${version}.tar.gz"
-checksum=c138327815f53bc6da4fe56baec5f25f00622ae69ef3fe4e1e385720e22486f9
+checksum=d0d28f3fe6d6d7195c27f8b054c3e99d5451952b54abdae673b71609a581f640
 
 do_check() {
 	# Skipped tests fail to find module or rely on missing entrypoint script
 	PYTHONPATH=src python3 -m pytest \
 		-k "not test_parallel \
+			and not test_provision_race \
 			and not test_tox_console_script \
 			and not test_tox_quickstart_script \
 			and not test_provision_cli_args_ignore \


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

Tox was packaged for do_check, but it runs in virtualenv, thus not useful.
Maybe it could be made work with [sitepackages](https://tox.wiki/en/latest/config.html#sitepackages).

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
