### PR TITLE
libinput: update to 1.22.1.

### DIFF
--- a/srcpkgs/libinput/template
+++ b/srcpkgs/libinput/template
@@ -1,7 +1,7 @@
 # Template file for 'libinput'
 pkgname=libinput
-version=1.22.0
-revision=2
+version=1.22.1
+revision=1
 build_style=meson
 configure_args="-Db_ndebug=false -Ddebug-gui=false"
 hostmakedepends="pkg-config"
@@ -11,8 +11,9 @@ short_desc="Provides handling input devices in Wayland compositors and X"
 maintainer="Michal Vasilek <michal@vasilek.cz>"
 license="MIT"
 homepage="https://www.freedesktop.org/wiki/Software/libinput"
+changelog="https://gitlab.freedesktop.org/libinput/libinput/-/releases"
 distfiles="https://gitlab.freedesktop.org/libinput/libinput/-/archive/${version}/libinput-${version}.tar.gz"
-checksum=ebbe5a966cf2a12f59666adbfb505cafca58635b96239bbcdf04a09dc4cd0d7b
+checksum=45d9e03c16c3c343b7537aa7f744ae9339b1a0dae446ecbe6f5ed9d49be11e87
 
 if [ "$XBPS_CHECK_PKGS" ]; then
 	configure_args+=" -Dtests=true"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

@paper42

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
