### PR TITLE
Signal-Desktop: update to 6.6.0.

### DIFF
--- a/srcpkgs/Signal-Desktop/template
+++ b/srcpkgs/Signal-Desktop/template
@@ -1,8 +1,8 @@
 # Template file for 'Signal-Desktop'
 pkgname=Signal-Desktop
-version=6.5.1
+version=6.6.0
 revision=1
-# Signal officially only supports x86_64 (also due to Electron)
+# Signal officially only supports x86_64 
 # x86_64-musl fails because of its dependency on 'node-gyp' which depends on a glibc specific extension
 # armv7hf/arm64: https://github.com/signalapp/Signal-Desktop/issues/3410
 archs="x86_64"
@@ -13,7 +13,7 @@ maintainer="akierig <anelki@fastmail.de>"
 license="AGPL-3.0-only"
 homepage="https://github.com/signalapp/Signal-Desktop"
 distfiles="https://github.com/signalapp/Signal-Desktop/archive/v${version}.tar.gz"
-checksum=553902fc571a0965538b6ade8e0bdd4056540c91165f49b5e7b826e0545302d8
+checksum=1a799b9ba7e1a7645b2bc6bb946aa96afd52ba6f56e9341ffcbb504988f62597
 nostrip_files="signal-desktop"
 
 post_extract() {


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64
