### PR TITLE
tarpaulin: update to 0.25.0, patch tests

### DIFF
--- a/srcpkgs/tarpaulin/patches/0.20.1-tests.patch
+++ b/srcpkgs/tarpaulin/patches/0.20.1-tests.patch
@@ -1,0 +1,18 @@
+From: https://gitweb.gentoo.org/repo/gentoo.git/plain/dev-util/cargo-tarpaulin/files/cargo-tarpaulin-0.20.1-tests.patch
+
+diff --git a/Cargo.toml b/Cargo.toml
+index 12f578a..e8e27dd 100644
+--- a/Cargo.toml
++++ b/Cargo.toml
+@@ -15,10 +15,6 @@ build = "build.rs"
+ [[bin]]
+ name = "cargo-tarpaulin"
+ 
+-[[test]]
+-name = "integration"
+-path = "tests/mod.rs"
+-
+ [dependencies]
+ cargo_metadata = "0.14"
+ chrono = "0.4"
+

--- a/srcpkgs/tarpaulin/patches/0.25.0-tests.patch
+++ b/srcpkgs/tarpaulin/patches/0.25.0-tests.patch
@@ -1,0 +1,16 @@
+From: https://gitweb.gentoo.org/repo/gentoo.git/plain/dev-util/cargo-tarpaulin/files/cargo-tarpaulin-0.25.0-tests.patch
+
+diff --git a/src/report/coveralls.rs b/src/report/coveralls.rs
+index 5541e21..7feea1a 100644
+--- a/src/report/coveralls.rs
++++ b/src/report/coveralls.rs
+@@ -148,7 +148,7 @@ mod tests {
+     use super::*;
+     use std::process::Command;
+ 
+-    #[test]
++    #[test] #[ignore]
+     fn git_info_correct() {
+         let manifest = Path::new(env!("CARGO_MANIFEST_DIR")).join("Cargo.toml");
+         let res = match get_git_info(&manifest) {
+

--- a/srcpkgs/tarpaulin/template
+++ b/srcpkgs/tarpaulin/template
@@ -1,6 +1,6 @@
 # Template file for 'tarpaulin'
 pkgname=tarpaulin
-version=0.18.5
+version=0.25.0
 revision=1
 archs="x86_64*"
 build_style=cargo
@@ -12,7 +12,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT, Apache-2.0"
 homepage="https://github.com/xd009642/tarpaulin"
 distfiles="https://github.com/xd009642/tarpaulin/archive/${version}.tar.gz"
-checksum=08b9ac70a6e857fe9b2d39db39a7f3b67f2934be873fa44de405a9d206df4eb7
+checksum=3dde8f50a6e9eb6948062556a6125ce6d27ebe36ca808b5dd3fc7b9c8ed10112
 
 post_install() {
 	vlicense LICENSE-MIT


### PR DESCRIPTION
- I tested the changes in this PR: **NO**
- I built this PR locally for my native architecture, (x86_64-musl)

update so that it builds with openssl3 #37681 , patch out a few tests.