### PR TITLE
ipmiutil: update to 3.1.8

### DIFF
--- a/srcpkgs/ipmiutil/template
+++ b/srcpkgs/ipmiutil/template
@@ -1,7 +1,7 @@
 # Template file for 'ipmiutil'
 pkgname=ipmiutil
-version=3.1.3
-revision=4
+version=3.1.8
+revision=1
 archs="i686* x86_64* ppc*"
 build_style=gnu-configure
 configure_args="--disable-systemd --libdir=/usr/lib"
@@ -12,8 +12,9 @@ license="BSD-2-Clause, BSD-3-Clause"
 #changelog="http://ipmiutil.sourceforge.net/docs/ChangeLog"
 homepage="http://ipmiutil.sourceforge.net"
 distfiles="${SOURCEFORGE_SITE}/project/${pkgname}/${pkgname}-${version}.tar.gz"
-checksum=b80303b6f05cbe48e728dd925fef201e9604a90cd3fc9c8af113367e8d6dbe57
+checksum=b14357b9723e38a19c24df2771cff63d5f15f8682cd8a5b47235044b767b1888
 disable_parallel_build=yes
+conflicts="renameutils"
 
 post_install() {
 	vlicense COPYING


### PR DESCRIPTION
- I tested the changes in this PR: **NO**
- I built this PR locally for my native architecture, (x86_64-musl)

Update so it builds with openssl3 #37681 @Vaelatern 