### PR TITLE
qutebrowser: update to 2.5.4, adopt

### DIFF
--- a/srcpkgs/qutebrowser/template
+++ b/srcpkgs/qutebrowser/template
@@ -1,18 +1,18 @@
 # Template file for 'qutebrowser'
 pkgname=qutebrowser
-version=2.5.2
-revision=2
+version=2.5.4
+revision=1
 build_style=python3-module
 hostmakedepends="python3-setuptools asciidoc"
 depends="python3-PyQt5-quick python3-Jinja2 python3-yaml
  python3-PyQt5-opengl python3-PyQt5-sql qt5-plugin-sqlite"
 short_desc="Keyboard-focused browser with a minimal GUI"
-maintainer="Orphaned <orphan@voidlinux.org>"
+maintainer="Daniel Eyßer <daniel.eysser@gmail.com>"
 license="GPL-3.0-or-later"
 homepage="https://qutebrowser.org/"
 changelog="https://raw.githubusercontent.com/qutebrowser/qutebrowser/master/doc/changelog.asciidoc"
 distfiles="https://github.com/qutebrowser/qutebrowser/releases/download/v${version}/qutebrowser-${version}.tar.gz"
-checksum=a9bfce14ddc403de0deb2eedf983c231ce003e0759995ec7ef4ea34e4974e908
+checksum=a460b2202527e42a670c26d225d9fa6417d092cc1f16f3a95e7bc95dd89c1ab1
 nostrip=yes
 # testing requires unpackaged plugins:
 # pytest-bdd, pytest-benchmark, pytest-instafail, pytest-rerunfailures


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
