### PR TITLE
d2: update to 0.2.0.

### DIFF
--- a/srcpkgs/d2/template
+++ b/srcpkgs/d2/template
@@ -1,13 +1,13 @@
 # Template file for 'd2'
 pkgname=d2
-version=0.1.6
+version=0.2.0
 revision=1
 build_style=go
 go_import_path="oss.terrastruct.com/d2"
-go_package="oss.terrastruct.com/d2"
 short_desc="Modern diagram scripting language that turns text to diagrams"
 maintainer="Toyam Cox <Vaelatern@voidlinux.org>"
 license="MPL-2.0"
 homepage="https://d2lang.com/"
+changelog="https://d2lang.com/releases/intro/"
 distfiles="https://github.com/terrastruct/d2/archive/refs/tags/v${version}.tar.gz"
-checksum=3a45ef0e3bdf4ce6fc72fca6ed34c45c17a6ccd61e0b22adf658cf3abb2341cd
+checksum=15434cf2776b7e61da1b8142a221e2bc675881a53f864ecbe152f527903caf75


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture: **x86_64**

\cc @Vaelatern I removed the `go_package` variable since it defaults to `go_import_path` anyway (according to `Manual.md`)