### PR TITLE
build-style/qmake: add support for Qt6

### DIFF
--- a/common/build-style/qmake.sh
+++ b/common/build-style/qmake.sh
@@ -4,13 +4,18 @@
 do_configure() {
 	local qmake
 	local qmake_args
+	local qt
 	if [ -x "/usr/lib/qt5/bin/qmake" ]; then
 		qmake="/usr/lib/qt5/bin/qmake"
+		qt="qt5"
+	elif [ -x "/usr/lib/qt6/bin/qmake" ]; then
+		qmake="/usr/lib/qt6/bin/qmake"
+		qt="qt6"
 	fi
 	if [ -z "${qmake}" ]; then
 		msg_error "${pkgver}: Could not find qmake - missing in hostmakedepends?\n"
 	fi
-	if [ "$CROSS_BUILD" ] && [ "$qmake" == "/usr/lib/qt5/bin/qmake" ]; then
+	if [ "$CROSS_BUILD" ]; then
 		case $XBPS_TARGET_MACHINE in
 			i686*) _qt_arch=i386;;
 			x86_64*) _qt_arch=x86_64;;
@@ -26,13 +31,13 @@ MAKEFILE_GENERATOR      = UNIX
 CONFIG                 += incremental no_qt_rpath
 QMAKE_INCREMENTAL_STYLE = sublib
 
-include(/usr/lib/qt5/mkspecs/common/linux.conf)
-include(/usr/lib/qt5/mkspecs/common/gcc-base-unix.conf)
-include(/usr/lib/qt5/mkspecs/common/g++-unix.conf)
+include(/usr/lib/${qt}/mkspecs/common/linux.conf)
+include(/usr/lib/${qt}/mkspecs/common/gcc-base-unix.conf)
+include(/usr/lib/${qt}/mkspecs/common/g++-unix.conf)
 
-QMAKE_TARGET_CONFIG     = ${XBPS_CROSS_BASE}/usr/lib/qt5/mkspecs/qconfig.pri
-QMAKE_TARGET_MODULE     = ${XBPS_CROSS_BASE}/usr/lib/qt5/mkspecs/qmodule.pri
-QMAKEMODULES            = ${XBPS_CROSS_BASE}/usr/lib/qt5/mkspecs/modules
+QMAKE_TARGET_CONFIG     = ${XBPS_CROSS_BASE}/usr/lib/${qt}/mkspecs/qconfig.pri
+QMAKE_TARGET_MODULE     = ${XBPS_CROSS_BASE}/usr/lib/${qt}/mkspecs/qmodule.pri
+QMAKEMODULES            = ${XBPS_CROSS_BASE}/usr/lib/${qt}/mkspecs/modules
 QMAKE_CC                = ${CC}
 QMAKE_CXX               = ${CXX}
 QMAKE_LINK              = ${CXX}
@@ -49,7 +54,7 @@ QMAKE_CXXFLAGS          = ${CXXFLAGS}
 QMAKE_LFLAGS            = ${LDFLAGS}
 load(qt_config)
 _EOF
-		echo "#include \"${XBPS_CROSS_BASE}/usr/lib/qt5/mkspecs/linux-g++/qplatformdefs.h\"" > "${wrksrc}/.target-spec/linux-g++/qplatformdefs.h"
+		echo "#include \"${XBPS_CROSS_BASE}/usr/lib/${qt}/mkspecs/linux-g++/qplatformdefs.h\"" > "${wrksrc}/.target-spec/linux-g++/qplatformdefs.h"
 
 		mkdir -p "${wrksrc}/.host-spec/linux-g++"
 		cat > "${wrksrc}/.host-spec/linux-g++/qmake.conf" <<_EOF
@@ -57,12 +62,12 @@ MAKEFILE_GENERATOR      = UNIX
 CONFIG                 += incremental no_qt_rpath
 QMAKE_INCREMENTAL_STYLE = sublib
 
-include(/usr/lib/qt5/mkspecs/common/linux.conf)
-include(/usr/lib/qt5/mkspecs/common/gcc-base-unix.conf)
-include(/usr/lib/qt5/mkspecs/common/g++-unix.conf)
+include(/usr/lib/${qt}/mkspecs/common/linux.conf)
+include(/usr/lib/${qt}/mkspecs/common/gcc-base-unix.conf)
+include(/usr/lib/${qt}/mkspecs/common/g++-unix.conf)
 
-QMAKE_TARGET_CONFIG     = ${XBPS_CROSS_BASE}/usr/lib/qt5/mkspecs/qconfig.pri
-QMAKE_TARGET_MODULE     = ${XBPS_CROSS_BASE}/usr/lib/qt5/mkspecs/qmodule.pri
+QMAKE_TARGET_CONFIG     = ${XBPS_CROSS_BASE}/usr/lib/${qt}/mkspecs/qconfig.pri
+QMAKE_TARGET_MODULE     = ${XBPS_CROSS_BASE}/usr/lib/${qt}/mkspecs/qmodule.pri
 QMAKE_CC                = ${CC_host}
 QMAKE_CXX               = ${CXX_host}
 QMAKE_LINK              = ${CXX_host}
@@ -79,29 +84,30 @@ QMAKE_CXXFLAGS          = ${CXXFLAGS_host}
 QMAKE_LFLAGS            = ${LDFLAGS_host}
 load(qt_config)
 _EOF
-echo '#include "/usr/lib/qt5/mkspecs/linux-g++/qplatformdefs.h"' > "${wrksrc}/.host-spec/linux-g++/qplatformdefs.h"
+echo '#include "/usr/lib/${qt}/mkspecs/linux-g++/qplatformdefs.h"' > "${wrksrc}/.host-spec/linux-g++/qplatformdefs.h"
 		cat > "${wrksrc}/qt.conf" <<_EOF
 [Paths]
 Sysroot=${XBPS_CROSS_BASE}
 Prefix=/usr
-ArchData=${XBPS_CROSS_BASE}/usr/lib/qt5
-Data=${XBPS_CROSS_BASE}/usr/share/qt5
-Documentation=${XBPS_CROSS_BASE}/usr/share/doc/qt5
-Headers=${XBPS_CROSS_BASE}/usr/include/qt5
+ArchData=${XBPS_CROSS_BASE}/usr/lib/${qt}
+Data=${XBPS_CROSS_BASE}/usr/share/${qt}
+Documentation=${XBPS_CROSS_BASE}/usr/share/doc/${qt}
+Headers=${XBPS_CROSS_BASE}/usr/include/${qt}
 Libraries=${XBPS_CROSS_BASE}/usr/lib
-LibraryExecutables=/usr/lib/qt5/libexec
-Binaries=/usr/lib/qt5/bin
+LibraryExecutables=/usr/lib/${qt}/libexec
+Binaries=/usr/lib/${qt}/bin
 Tests=${XBPS_CROSS_BASE}/usr/tests
-Plugins=/usr/lib/qt5/plugins
-Imports=${XBPS_CROSS_BASE}/usr/lib/qt5/imports
-Qml2Imports=${XBPS_CROSS_BASE}/usr/lib/qt5/qml
-Translations=${XBPS_CROSS_BASE}/usr/share/qt5/translations
+Plugins=/usr/lib/${qt}/plugins
+Imports=${XBPS_CROSS_BASE}/usr/lib/${qt}/imports
+Qml2Imports=${XBPS_CROSS_BASE}/usr/lib/${qt}/qml
+Translations=${XBPS_CROSS_BASE}/usr/share/${qt}/translations
 Settings=${XBPS_CROSS_BASE}/etc/xdg
-Examples=${XBPS_CROSS_BASE}/usr/share/qt5/examples
+Examples=${XBPS_CROSS_BASE}/usr/share/${qt}/examples
 HostPrefix=/usr
-HostData=/usr/lib/qt5
-HostBinaries=/usr/lib/qt5/bin
+HostData=/usr/lib/${qt}
+HostBinaries=/usr/lib/${qt}/bin
 HostLibraries=/usr/lib
+HostLibraryExecutables=/usr/lib/${qt}/libexec
 Spec=${wrksrc}/.host-spec/linux-g++
 TargetSpec=${wrksrc}/.target-spec/linux-g++
 _EOF


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->
There's no `qt6-doc` package (compared to `qt5-doc`) or `qt6-examples` subpackage (compared to `qt5-examples`) but those could just be ignored I suppose

~~There's a big problem: cross-compiling any Qt6 `qmake` package quickly results in something like `make: *** No rule to make target '/usr/libexec/moc', needed by '.moc/main.moc'.  Stop.`~~

~~Native builds still work as expected however already. For a testing tree see [my `qt6-qmake-demo` tree](https://github.com/JamiKettunen/void-packages/commits/qt6-qmake-demo) and try e.g. `./xbps-src pkg qt6-qpa-hwcomposer-plugin` vs `./xbps-src pkg -a aarch64 qt6-qpa-hwcomposer-plugin` on a glibc masterdir.~~

~~As per https://forum.qt.io/topic/137300/qtpaths-return-incorrect-path `ln -s /usr/lib/qt6/libexec/moc /usr/libexec/moc` would probably work as a really ugly hack, but is there someone around (perhaps @Johnnynator?) who knows how this could be fixed properly, and maybe even upstream? Here's a few other places where the same error can be seen:~~
- ~~https://community.nxp.com/t5/i-MX-Processors/Imx8mp-cmake-creat-qt6-project-with-an-error-usr-libexec-moc-no/m-p/1567183~~
- ~~https://gobolinux.discourse.group/t/system-index-libexec-is-empty-issue/101~~

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
