### PR TITLE
nextcloud-client: update to 3.7.3

### DIFF
--- a/srcpkgs/nextcloud-client/patches/revert-mandatory-webengine.patch
+++ b/srcpkgs/nextcloud-client/patches/revert-mandatory-webengine.patch
@@ -1,0 +1,77 @@
+From 02dd76cdcec49e49b60f99a98dbe241007f548d1 Mon Sep 17 00:00:00 2001
+From: Rodrigo Oliveira <mdkcore@qtrnn.io>
+Date: Thu, 23 Feb 2023 12:56:27 -0300
+Subject: [PATCH] Revert "makes Qt WebEngine optional only on macOS"
+
+This reverts commit b81cdf177d3410db45e6f97eb3575ceddabb73dd.
+---
+ src/CMakeLists.txt | 53 ++--------------------------------------------
+ 1 file changed, 2 insertions(+), 51 deletions(-)
+
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index a4d06844a..cd3805799 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -4,57 +4,8 @@ endif()
+ 
+ include(ECMEnableSanitizers)
+ 
+-set(REQUIRED_QT_VERSION "5.15.0")
+-
+-find_package(Qt5Core ${REQUIRED_QT_VERSION} CONFIG QUIET)
+-set_package_properties(Qt5Core PROPERTIES
+-    DESCRIPTION "Qt5 Core component."
+-    TYPE REQUIRED
+-)
+-
+-find_package(Qt5Network ${REQUIRED_QT_VERSION} CONFIG QUIET)
+-set_package_properties(Qt5Network PROPERTIES
+-    DESCRIPTION "Qt5 Network component."
+-    TYPE REQUIRED
+-)
+-
+-find_package(Qt5Xml ${REQUIRED_QT_VERSION} CONFIG QUIET)
+-set_package_properties(Qt5Xml PROPERTIES
+-    DESCRIPTION "Qt5 Xml component."
+-    TYPE REQUIRED
+-)
+-
+-find_package(Qt5Concurrent ${REQUIRED_QT_VERSION} CONFIG QUIET)
+-set_package_properties(Qt5Concurrent PROPERTIES
+-    DESCRIPTION "Qt5 Concurrent component."
+-    TYPE REQUIRED
+-)
+-
+-find_package(Qt5WebEngineWidgets ${REQUIRED_QT_VERSION} CONFIG QUIET)
+-if(APPLE)
+-    set_package_properties(Qt5WebEngineWidgets PROPERTIES
+-        DESCRIPTION "Qt5 WebEngineWidgets component."
+-        TYPE RECOMMENDED
+-    )
+-else()
+-    set_package_properties(Qt5WebEngineWidgets PROPERTIES
+-        DESCRIPTION "Qt5 WebEngineWidgets component."
+-        TYPE REQUIRED
+-    )
+-endif()
+-
+-find_package(Qt5WebEngine ${REQUIRED_QT_VERSION} CONFIG QUIET)
+-if(APPLE)
+-    set_package_properties(Qt5WebEngine PROPERTIES
+-        DESCRIPTION "Qt5 WebEngine component."
+-        TYPE RECOMMENDED
+-    )
+-else()
+-    set_package_properties(Qt5WebEngine PROPERTIES
+-        DESCRIPTION "Qt5 WebEngine component."
+-        TYPE REQUIRED
+-    )
+-endif()
++find_package(Qt5 5.15 COMPONENTS Core Network Xml Concurrent REQUIRED)
++find_package(Qt5 5.15 COMPONENTS WebEngineWidgets WebEngine)
+ 
+ if(Qt5WebEngine_FOUND AND Qt5WebEngineWidgets_FOUND)
+   add_compile_definitions(WITH_WEBENGINE=1)
+-- 
+2.39.2
+

--- a/srcpkgs/nextcloud-client/template
+++ b/srcpkgs/nextcloud-client/template
@@ -1,13 +1,13 @@
 # Template file for 'nextcloud-client'
 pkgname=nextcloud-client
-version=3.6.6
+version=3.7.3
 revision=1
 build_style=cmake
 configure_args="-Wno-dev"
 hostmakedepends="pkg-config inkscape"
 makedepends="qt5-tools-devel qt5-declarative-devel qt5-webchannel-devel
  qt5-location-devel qtkeychain-qt5-devel sqlite-devel libcloudproviders-devel
- qt5-quickcontrols2-devel qt5-websockets-devel qt5-svg-devel
+ qt5-quickcontrols2-devel qt5-websockets-devel qt5-svg-devel karchive-devel
  $(vopt_if dolphin 'extra-cmake-modules kio-devel')
  $(vopt_if webengine 'qt5-webengine-devel')"
 depends="qt5-graphicaleffects"
@@ -19,7 +19,7 @@ license="GPL-2.0-or-later"
 homepage="https://nextcloud.com/clients/"
 changelog="https://github.com/nextcloud/desktop/releases"
 distfiles="https://github.com/nextcloud/desktop/archive/v${version}.tar.gz"
-checksum=04b3be9ab62eec7b81c971dc50c4e40666ee2d76c19cb72d9ad52e5a4d2edd47
+checksum=4c76a01fe3249a3b6cc8217a20dde1bb12b386ebc9af82e2623e12de2c86e808
 # https://github.com/void-linux/void-packages/pull/33358#discussion_r724518549
 make_check=ci-skip
 
@@ -76,7 +76,6 @@ nextcloud-client-dolphin_package() {
 	pkg_install() {
 		vmove usr/lib/libnextclouddolphinpluginhelper.so
 		vmove usr/lib/qt5
-		vmove usr/share/kservices5
 	}
 }
 


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **yes**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-lib)
- armv7l (crossbuild)
- i686-libc

Also:
- Add `karchive` as dependency: https://github.com/nextcloud/desktop/pull/4768
- Add patch to revert mandatory WebEngine dependency: https://github.com/nextcloud/desktop/pull/4875
