### PR TITLE
docker-buildx: update to 0.10.3.

### DIFF
--- a/srcpkgs/docker-buildx/template
+++ b/srcpkgs/docker-buildx/template
@@ -1,6 +1,6 @@
 # Template file for 'docker-buildx'
 pkgname=docker-buildx
-version=0.9.1
+version=0.10.3
 revision=1
 build_style=go
 go_import_path="github.com/docker/buildx/cmd/buildx"
@@ -11,7 +11,7 @@ maintainer="Gabriel Sanches <gabriel@gsr.dev>"
 license="Apache-2.0"
 homepage="https://docs.docker.com/buildx/working-with-buildx/"
 distfiles="https://github.com/docker/buildx/archive/refs/tags/v${version}.tar.gz"
-checksum=22b0d2acfffaaa4a52d13cd6fa78608e9c817c3d1bdfbaf2e274242325bb293d
+checksum=e21ce4b222cfcc5fe981a1ee51fca1f7c7d59de0f1911ae3f64f6d9a969695a3
 
 post_install() {
 	vmkdir usr/libexec/docker/cli-plugins


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, glibc, x86_64

