### PR TITLE
obs: update to 29.0.2

### DIFF
--- a/srcpkgs/obs/template
+++ b/srcpkgs/obs/template
@@ -1,17 +1,18 @@
 # Template file for 'obs'
 pkgname=obs
-version=28.1.2
-revision=2
+version=29.0.2
+revision=1
 archs="i686* x86_64* ppc64le* aarch64*"
 build_style=cmake
-configure_args="-DOBS_VERSION_OVERRIDE=${version} -DENABLE_BROWSER=OFF
- -DENABLE_JACK=ON -DENABLE_VST=OFF -DENABLE_AJA=OFF"
+configure_args="-DOBS_VERSION_OVERRIDE=${version} -DENABLE_JACK=ON
+ -DENABLE_VST=OFF -DENABLE_AJA=OFF"
 hostmakedepends="pkg-config swig python3-devel qt6-base-devel"
-makedepends="LuaJIT-devel fdk-aac-devel ffmpeg-devel glu-devel jack-devel
- libXcomposite-devel libcurl-devel pulseaudio-devel python3-devel
- speexdsp-devel v4l-utils-devel vlc-devel qt6-svg-devel x264-devel
- mbedtls-devel jansson-devel wayland-devel pipewire-devel libxkbcommon-devel
- pciutils-devel librist-devel srt-devel"
+makedepends="LuaJIT-devel fdk-aac-devel ffmpeg-devel glu-devel
+ jack-devel libXcomposite-devel libcurl-devel libva-devel
+ pulseaudio-devel python3-devel speexdsp-devel v4l-utils-devel
+ vlc-devel qt6-svg-devel x264-devel mbedtls-devel jansson-devel
+ wayland-devel pipewire-devel libxkbcommon-devel pciutils-devel
+ librist-devel srt-devel"
 depends="xset xdg-desktop-portal"
 short_desc="Open Broadcaster Software"
 maintainer="lemmi <lemmi@nerd2nerd.org>"
@@ -19,7 +20,7 @@ license="GPL-2.0-or-later"
 homepage="https://obsproject.com"
 changelog="https://github.com/obsproject/obs-studio/releases"
 distfiles="https://github.com/obsproject/obs-studio/archive/${version}.tar.gz"
-checksum=c51c72945867cd9862ba663b01cc8313153a0249dd3df0626e63fc5d82a84b39
+checksum=0e6260800b80c3fc9f67c4c3fb12ffae740ab1dd188e526a55e0fc8949168db2
 
 pre_configure() {
 	# it's not enough to use -DENABLE_BROWSER ...


### PR DESCRIPTION
Did a build and a quick check to see that it launched.  v29 pulls in libva, though this can likely be disabled if we really want.