### PR TITLE
libgit2: remove git from hostmakedepends

### DIFF
--- a/srcpkgs/libgit2/template
+++ b/srcpkgs/libgit2/template
@@ -4,7 +4,7 @@ version=1.5.1
 revision=1
 build_style=cmake
 configure_args="-DENABLE_REPRODUCIBLE_BUILDS=ON -DUSE_SSH=ON"
-hostmakedepends="python3 git pkg-config"
+hostmakedepends="python3 pkg-config"
 makedepends="zlib-devel openssl-devel http-parser-devel libssh2-devel"
 short_desc="Git linkable library"
 maintainer="Orphaned <orphan@voidlinux.org>"


### PR DESCRIPTION
Fixes build cycle with cairo -> mesa -> rust -> libgit -> git -> gir -> cairo. git was added to hostmakedepends when the distfiles were obtained using git clone.

https://github.com/void-linux/void-packages/blob/237631485073e4883653b6a18e6fb141f1aa01d7/srcpkgs/libgit2/template

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

Fixes: https://github.com/void-linux/void-packages/issues/42378

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
