### PR TITLE
New package: obs-plugin-browser-bin-29.0.2

### DIFF
--- a/srcpkgs/obs-plugin-browser-bin/template
+++ b/srcpkgs/obs-plugin-browser-bin/template
@@ -1,0 +1,25 @@
+# Template file for 'obs-plugin-browser-bin'
+pkgname=obs-plugin-browser-bin
+version=29.0.2 # This is actually the version of obs to extract the plugin from
+revision=1
+archs="x86_64"
+short_desc="CEF-based OBS Studio browser plugin"
+maintainer="Michael Aldridge <maldridge@voidlinux.org>"
+license="GPL-2.0-only"
+homepage="https://obsproject.com/kb/browser-source"
+distfiles="https://launchpad.net/~obsproject/+archive/ubuntu/obs-studio/+files/obs-studio_29.0.2-0obsproject1~kinetic_amd64.deb"
+checksum=1fcc84fa3c917c8bb60c8d70c1b0961ceeb4db6b8f09483611b9b1e015b268c4
+
+do_install() {
+	vinstall lib/x86_64-linux-gnu/obs-plugins/obs-browser.so 0644 usr/lib/obs-plugins/
+	vinstall lib/x86_64-linux-gnu/obs-plugins/libcef.so 0644 usr/lib/obs-plugins/
+	vinstall lib/x86_64-linux-gnu/obs-plugins/icudtl.dat 0644 usr/lib/obs-plugins/
+	vinstall lib/x86_64-linux-gnu/obs-plugins/v8_context_snapshot.bin 0644 usr/lib/obs-plugins/
+	vinstall lib/x86_64-linux-gnu/obs-plugins/resources.pak 0644 usr/lib/obs-plugins/
+	vinstall lib/x86_64-linux-gnu/obs-plugins/vk_swiftshader_icd.json 0644 usr/lib/obs-plugins/
+	vinstall lib/x86_64-linux-gnu/obs-plugins/libvk_swiftshader.so 0644 usr/lib/obs-plugins/
+	vinstall lib/x86_64-linux-gnu/obs-plugins/chrome-sandbox 0644 usr/lib/obs-plugins/
+	vinstall lib/x86_64-linux-gnu/obs-plugins/chrome_100_percent.pak 0644 usr/lib/obs-plugins/
+	vinstall lib/x86_64-linux-gnu/obs-plugins/chrome_200_percent.pak 0644 usr/lib/obs-plugins/
+	vinstall lib/x86_64-linux-gnu/obs-plugins/obs-browser-page 0755 usr/lib/obs-plugins/
+}


### PR DESCRIPTION
I'm not sure this is a good idea.  It works, but its doing the same kind of stuff we do to make the google chrome package work.  It should probably work then as a result, but I suspect its pretty fragile.  I stuck GPL-2.0-ONLY on it which is the correct license for the source, but since this includes a full embedded chromium I suspect that isn't quite right.  Advice is appreciated.