### PR TITLE
LanguageTool: discontinue packaging like Arch

### DIFF
--- a/srcpkgs/LanguageTool/files/languagetool-cli.sh
+++ b/srcpkgs/LanguageTool/files/languagetool-cli.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec "$JAVA_HOME/bin/java" -jar "/usr/share/java/languagetool/languagetool-commandline.jar" "$@"

--- a/srcpkgs/LanguageTool/files/languagetool-gui.sh
+++ b/srcpkgs/LanguageTool/files/languagetool-gui.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec "$JAVA_HOME/bin/java" -jar "/usr/share/java/languagetool/languagetool.jar" "$@"

--- a/srcpkgs/LanguageTool/files/languagetool-http.sh
+++ b/srcpkgs/LanguageTool/files/languagetool-http.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec "$JAVA_HOME/bin/java" -cp "/usr/share/java/languagetool/languagetool-server.jar" "org.languagetool.server.HTTPServer" "$@"

--- a/srcpkgs/LanguageTool/files/languagetool-https.sh
+++ b/srcpkgs/LanguageTool/files/languagetool-https.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec "$JAVA_HOME/bin/java" -jar "/usr/share/java/languagetool/languagetool-server.jar" "$@"

--- a/srcpkgs/LanguageTool/template
+++ b/srcpkgs/LanguageTool/template
@@ -1,24 +1,20 @@
 # Template file for 'LanguageTool'
 pkgname=LanguageTool
 version=5.8
-revision=1
+revision=2
 depends="virtual?java-environment"
-short_desc="Checks your writing in more than 20 languages"
+short_desc="Checks your writing in many languages"
 maintainer="Stacy Harper <contact@stacyhaper.net>"
 license="LGPL-2.1-or-later"
 homepage="https://www.languagetool.org/"
-distfiles="https://www.languagetool.org/download/LanguageTool-${version}.zip
- https://raw.githubusercontent.com/archlinux/svntogit-community/packages/languagetool/trunk/languagetool.sh"
-checksum="20913a50eb4568fdc727066eee8aab833f52b626710fc9e0213c3f1098bfdee3
- 009c0a65a978ad11ac097edd4be64688a2c80281b201495eff9ab667c5b0f0fe"
-skip_extraction="languagetool.sh"
+distfiles="https://www.languagetool.org/download/LanguageTool-${version}.zip"
+checksum="20913a50eb4568fdc727066eee8aab833f52b626710fc9e0213c3f1098bfdee3"
 
 do_install() {
-	vmkdir usr/bin
-	vmkdir usr/share/java/languagetool
-	vcopy "*.jar" /usr/share/java/languagetool
-	vcopy "libs/*.jar" /usr/share/java/languagetool
-	rm -rf *.jar libs
-	vcopy "$wrksrc" /usr/share/languagetool/
-	vbin ${XBPS_SRCDISTDIR}/${pkgname}-${version}/languagetool.sh languagetool
+	vmkdir usr/share/java/
+	vcopy "$wrksrc" /usr/share/java/languagetool
+	vbin ${FILESDIR}/languagetool-gui.sh languagetool
+	vbin ${FILESDIR}/languagetool-http.sh languagetool-http
+	vbin ${FILESDIR}/languagetool-https.sh languagetool-https
+	vbin ${FILESDIR}/languagetool-cli.sh languagetool-cli
 }


### PR DESCRIPTION
Template of LanguageTool followed Arch's [Java Package Guidelines](https://wiki.archlinux.org/title/Java_Package_Guidelines) and put files in several places. Arch's [bin wrapper](https://github.com/archlinux/svntogit-community/blob/master/languagetool/trunk/languagetool.sh) "fixed" all issues by defining (many) class paths. This approach fails if other tools try to start the jars directly without doing those "fixes" (see #42372).

Use four very simple binary script wrappers tracked in our git instead.

Install LanguageTool in one single directory.
This change makes LanguageTool behave like upstream and easier to configure and use in other applications like TeXstudio. Fixes #42372 "LanguageTool does not start with TeXstudio"

####Possible points of interests
- /usr/bin/languagetool starts the gui variant because that seems to be the version when upstream says to start the standalone version.
- languagetool-cli : -cmd or -command-line instead of -cli?
- languagetool-http(s): -server is ambigious and -server-http(s) too long
- commit message is too wordy but I am not sure which parts to throw away


<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly** (issue use case, "--help", checked and corrected commit message using languagetool-cli)

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-libc)