### PR TITLE
lagrange: update to 1.15.2.

### DIFF
--- a/srcpkgs/lagrange/template
+++ b/srcpkgs/lagrange/template
@@ -1,6 +1,6 @@
 # Template file for 'lagrange'
 pkgname=lagrange
-version=1.14.2
+version=1.15.2
 revision=1
 build_style=cmake
 configure_args="-DTFDN_ENABLE_SSE41=NO"
@@ -13,7 +13,7 @@ license="BSD-2-Clause"
 homepage="https://gmi.skyjake.fi/lagrange/"
 changelog="https://git.skyjake.fi/skyjake/lagrange/raw/branch/dev/res/about/version.gmi"
 distfiles="https://git.skyjake.fi/skyjake/lagrange/releases/download/v$version/lagrange-$version.tar.gz"
-checksum=51b05ef7fd730d77ed9571c76a1772067fcfeeb900cbe8e66ec19c6fdfe58c64
+checksum=73b42a7b719793933a38fb7c7728dfac166b055b4dabc53259fc32c47856edf5
 
 post_install() {
 	vlicense LICENSE.md


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
