### PR TITLE
Signal-Desktop: update to 6.7.0.

### DIFF
--- a/srcpkgs/Signal-Desktop/template
+++ b/srcpkgs/Signal-Desktop/template
@@ -1,6 +1,6 @@
 # Template file for 'Signal-Desktop'
 pkgname=Signal-Desktop
-version=6.6.0
+version=6.7.0
 revision=1
 # Signal officially only supports x86_64 
 # x86_64-musl fails because of its dependency on 'node-gyp' which depends on a glibc specific extension
@@ -13,7 +13,7 @@ maintainer="akierig <anelki@fastmail.de>"
 license="AGPL-3.0-only"
 homepage="https://github.com/signalapp/Signal-Desktop"
 distfiles="https://github.com/signalapp/Signal-Desktop/archive/v${version}.tar.gz"
-checksum=1a799b9ba7e1a7645b2bc6bb946aa96afd52ba6f56e9341ffcbb504988f62597
+checksum=578be2af88704f022425c325b98d6bb4a84b22597a9c138655d5f1df3f1f57b7
 nostrip_files="signal-desktop"
 
 post_extract() {


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64 glibc
