### PR TITLE
redis: restrict /etc/redis permissions

### DIFF
--- a/srcpkgs/redis/template
+++ b/srcpkgs/redis/template
@@ -1,7 +1,7 @@
 # Template file for 'redis'
 pkgname=redis
 version=7.0.8
-revision=1
+revision=2
 build_style=gnu-makefile
 make_build_args="V=1"
 make_check_target="test"
@@ -18,7 +18,9 @@ system_accounts="redis"
 redis_homedir="/var/lib/redis"
 conf_files="/etc/redis/redis.conf"
 
-make_dirs="/var/lib/redis 0700 redis redis"
+make_dirs="
+ /var/lib/redis 0700 redis redis
+ /etc/redis 0750 root redis"
 
 if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
 	make_build_args+=" MALLOC=libc"


### PR DESCRIPTION
It's not a good idea to have /etc/redis/redis.conf world-readable since it may contain sensitive informations like passwords.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
