### PR TITLE
i2pd: restrict /etc/i2pd permissions

### DIFF
--- a/srcpkgs/i2pd/template
+++ b/srcpkgs/i2pd/template
@@ -1,7 +1,7 @@
 # Template file for 'i2pd'
 pkgname=i2pd
 version=2.46.0
-revision=1
+revision=2
 build_style=gnu-makefile
 make_build_args="USE_UPNP=yes"
 makedepends="zlib-devel boost-devel openssl-devel miniupnpc-devel
@@ -19,7 +19,9 @@ conf_files="
  /etc/i2pd/tunnels.conf"
 system_accounts="_i2pd"
 _i2pd_homedir="/var/lib/i2pd"
-make_dirs="/var/lib/i2pd 0700 _i2pd _i2pd"
+make_dirs="
+ /var/lib/i2pd 0700 _i2pd _i2pd
+ /etc/i2pd 0750 root _i2pd"
 
 case "${XBPS_TARGET_MACHINE}" in
 	x86_64*) ;;


### PR DESCRIPTION
It's not a good idea to have /etc/i2pd/*.conf world-readable since it may contain sensitive information

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
