### PR TITLE
libnitrokey: update to 3.8.

### DIFF
--- a/srcpkgs/libnitrokey/template
+++ b/srcpkgs/libnitrokey/template
@@ -1,16 +1,16 @@
 # Template file for 'libnitrokey'
 pkgname=libnitrokey
-version=3.5
+version=3.8
 revision=1
 build_style=cmake
 hostmakedepends="pkg-config"
 makedepends="hidapi-devel"
 short_desc="Communicate with Nitrokey devices in a clean and easy manner"
 maintainer="Julio Galvan <juliogalvan@protonmail.com>"
-license="LGPL-3.0"
+license="LGPL-3.0-only"
 homepage="https://github.com/Nitrokey/libnitrokey"
-distfiles="${homepage}/archive/v${version}.tar.gz"
-checksum=d836f2f20c5b24088542da445893ef0a04834dca7dd8eef020e793de0601bb5a
+distfiles="https://github.com/Nitrokey/libnitrokey/releases/download/v${version}/libnitrokey-v${version}.tar.gz"
+checksum=3b7ebcfc47b2c45313bc5f17842f0160cbaf87f41d2621af18c5b56837e393a1
 
 libnitrokey-devel_package() {
 	short_desc+=" - development files"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64
- I built this PR locally for these architectures (if supported. mark crossbuilds):

  - armv6l
