### PR TITLE
gdk-pixbuf: update to 2.42.10.

### DIFF
--- a/srcpkgs/gdk-pixbuf/patches/largejpeg-oom-test.patch
+++ b/srcpkgs/gdk-pixbuf/patches/largejpeg-oom-test.patch
@@ -1,0 +1,14 @@
+--- a/tests/pixbuf-jpeg.c
++++ b/tests/pixbuf-jpeg.c
+@@ -196,10 +196,7 @@ test_jpeg_fbfbfbfb (void)
+   g_assert_no_error (error);
+ 
+   gdk_pixbuf_loader_close (loader, &error);
+-  g_assert_error (error, GDK_PIXBUF_ERROR, GDK_PIXBUF_ERROR_CORRUPT_IMAGE);
+-
+-  pixbuf = gdk_pixbuf_loader_get_pixbuf (loader);
+-  g_assert_nonnull (pixbuf);
++  g_assert_error (error, GDK_PIXBUF_ERROR, GDK_PIXBUF_ERROR_INSUFFICIENT_MEMORY);
+ 
+   g_object_unref (loader);
+   g_free (contents);

--- a/srcpkgs/gdk-pixbuf/template
+++ b/srcpkgs/gdk-pixbuf/template
@@ -1,13 +1,13 @@
 # Template file for 'gdk-pixbuf'
 pkgname=gdk-pixbuf
-version=2.42.6
+version=2.42.10
 revision=1
 build_style=meson
 build_helper="gir"
-configure_args="-Dintrospection=$(vopt_if gir enabled disabled) -Dpng=true
- -Dinstalled_tests=false"
-hostmakedepends="gettext-devel glib-devel pkg-config libxslt docbook-xsl"
-makedepends="libglib-devel libpng-devel tiff-devel
+configure_args="-Dintrospection=$(vopt_if gir enabled disabled) -Dpng=enabled
+ -Djpeg=enabled -Dtiff=enabled -Dinstalled_tests=false"
+hostmakedepends="gettext-devel glib-devel pkg-config python3-docutils"
+makedepends="libglib-devel libpng-devel tiff-devel libjpeg-turbo-devel
  shared-mime-info"
 depends="shared-mime-info"
 short_desc="Image loading library for The GTK+ toolkit (v2)"
@@ -15,7 +15,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="LGPL-2.1-or-later"
 homepage="https://wiki.gnome.org/Projects/GdkPixbuf"
 distfiles="${GNOME_SITE}/${pkgname}/${version%.*}/${pkgname}-${version}.tar.xz"
-checksum=c4a6b75b7ed8f58ca48da830b9fa00ed96d668d3ab4b1f723dcf902f78bde77f
+checksum=ee9b6c75d13ba096907a2e3c6b27b61bcd17f5c7ebeab5a5b439d2f2e39fe44b
 
 # Package build options
 build_options="gir"

--- a/srcpkgs/libjpeg-turbo/template
+++ b/srcpkgs/libjpeg-turbo/template
@@ -1,6 +1,6 @@
 # Template file for 'libjpeg-turbo'
 pkgname=libjpeg-turbo
-version=2.1.4
+version=2.1.5.1
 revision=1
 build_style=cmake
 configure_args="-DWITH_JPEG8=1 -DCMAKE_INSTALL_LIBDIR=/usr/lib"
@@ -11,7 +11,7 @@ license="IJG, BSD-3-Clause, Zlib"
 homepage="https://libjpeg-turbo.org/"
 changelog="https://raw.githubusercontent.com/libjpeg-turbo/libjpeg-turbo/main/ChangeLog.md"
 distfiles="${SOURCEFORGE_SITE}/libjpeg-turbo/libjpeg-turbo-${version}.tar.gz"
-checksum=d3ed26a1131a13686dfca4935e520eb7c90ae76fbc45d98bb50a8dc86230342b
+checksum=2fdc3feb6e9deb17adec9bafa3321419aa19f8f4e5dea7bf8486844ca22207bf
 
 provides="jpeg-8_1"
 replaces="jpeg>=0"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
