### PR TITLE
haproxy: fix default configuration

### DIFF
--- a/srcpkgs/haproxy/files/haproxy.cfg
+++ b/srcpkgs/haproxy/files/haproxy.cfg
@@ -2,7 +2,7 @@ global
   chroot /var/lib/haproxy
   user haproxy
   group haproxy
-  stats socket /var/run/haproxy.sock mode 0600 level admin expose-fd listeners process 1/1
+  stats socket /var/run/haproxy.sock mode 0600 level admin expose-fd listeners thread 1
 
 defaults
   mode http

--- a/srcpkgs/haproxy/template
+++ b/srcpkgs/haproxy/template
@@ -1,7 +1,7 @@
 # Template file for 'haproxy'
 pkgname=haproxy
 version=2.6.9
-revision=1
+revision=2
 build_style=gnu-makefile
 make_install_args="SBINDIR=${DESTDIR}/usr/bin DOCDIR=${DESTDIR}/usr/share/doc/${pkgname}"
 hostmakedepends="lua53-devel"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

I missed updating the default configuration file when a configuration verb was retired in 2.6.x. 