### PR TITLE
timidity: build on musl without broken alsa audio

### DIFF
--- a/srcpkgs/timidity/template
+++ b/srcpkgs/timidity/template
@@ -1,12 +1,10 @@
 # Template file for 'timidity'
 pkgname=timidity
 version=2.15.0
-revision=1
+revision=2
 build_style=gnu-configure
-configure_args="--with-default-path=/etc/timidity
- --enable-audio=alsa,oss,ao,vorbis,flac --enable-server
- --enable-alsaseq=yes --enable-network
- --enable-gtk --enable-ncurses"
+configure_args="--with-default-path=/etc/timidity --enable-server
+ --enable-alsaseq=yes --enable-network --enable-gtk --enable-ncurses"
 hostmakedepends="pkg-config"
 makedepends="alsa-lib-devel libvorbis-devel libao-devel libflac-devel
  libX11-devel gtk+-devel ncurses-devel"
@@ -17,9 +15,12 @@ homepage="http://timidity.sourceforge.net"
 distfiles="${SOURCEFORGE_SITE}/timidity/TiMidity++-${version}.tar.xz"
 checksum=9eaf4fadb0e19eb8e35cd4ac16142d604c589e43d0e8798237333697e6381d39
 
-case "$XBPS_TARGET_MACHINE" in
-	*-musl) broken="uses alsa's pcm_old.h, which depends on symbol versioning to work";;
-esac
+# disable alsa audio on musl since it uses pcm_old.h, which depends on symbol versioning to work
+if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
+	configure_args+=" --enable-audio=oss,ao,vorbis,flac"
+else
+	configure_args+=" --enable-audio=alsa,oss,ao,vorbis,flac"
+fi
 
 if [ "$CROSS_BUILD" ]; then
 	# check for va_copy runs test program; assume no for target


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
#### Local build testing
- I built this PR locally for my native architecture, (x86_64-musl)
