### PR TITLE
kdevelop: update to 22.12.2, update kdevelop-pg-qt and re-enable kdevelop-python

### DIFF
--- a/srcpkgs/kdevelop-pg-qt/template
+++ b/srcpkgs/kdevelop-pg-qt/template
@@ -1,6 +1,6 @@
 # Template file for 'kdevelop-pg-qt'
 pkgname=kdevelop-pg-qt
-version=2.2.1
+version=2.2.2
 revision=1
 build_style=cmake
 hostmakedepends="extra-cmake-modules qt5-qmake qt5-host-tools bison flex"
@@ -10,4 +10,4 @@ maintainer="yopito <pierre.bourgin@free.fr>"
 license="LGPL-2.0-or-later"
 homepage="https://techbase.kde.org/Development/KDevelop-PG-Qt_Introduction"
 distfiles="$KDE_SITE/kdevelop-pg-qt/${version}/src/kdevelop-pg-qt-${version}.tar.xz"
-checksum=c13931788ac9dc02188cdd9c6e71e164ae81b4568b048748652bbf6fa4a9c62b
+checksum=3d56604c479f8f04ae32a523ee91f3078c717117d0deb39e973e22494cbb65f1

--- a/srcpkgs/kdevelop-php/template
+++ b/srcpkgs/kdevelop-php/template
@@ -1,6 +1,6 @@
 # Template file for 'kdevelop-php'
 pkgname=kdevelop-php
-version=22.12.1
+version=22.12.2
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF"
@@ -15,4 +15,4 @@ license="GPL-2.0-or-later, LGPL-2.0-or-later"
 homepage="https://www.kdevelop.org/"
 changelog="https://kde.org/announcements/changelogs/gear/${version}/#kdev-php"
 distfiles="${KDE_SITE}/release-service/${version}/src/kdev-php-${version}.tar.xz"
-checksum=00f6b91e73d7c6900e4c4975bf174cb72e03c55f6bc72884e92947c2d22aca4a
+checksum=0df5bdebfffe72cc4ae5bc842418ac30908fbaa4ae5c8762a9c4ad361c3e42b7

--- a/srcpkgs/kdevelop-python/patches/musl-headers-for-python3-devel.patch
+++ b/srcpkgs/kdevelop-python/patches/musl-headers-for-python3-devel.patch
@@ -1,0 +1,10 @@
+--- a/parser/python_header.h
++++ b/parser/python_header.h
+@@ -13,6 +13,7 @@
+ 
+ #include <language/duchain/duchainlock.h>
+ 
++#include <sys/types.h> /* define ssize_t with musl libc */
+ #include "pyport.h"
+ #ifndef _WIN32
+ #include "pyconfig.h"

--- a/srcpkgs/kdevelop-python/template
+++ b/srcpkgs/kdevelop-python/template
@@ -1,7 +1,7 @@
 # Template file for 'kdevelop-python'
 pkgname=kdevelop-python
-version=5.6.2
-revision=2
+version=22.12.2
+revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF"
 pycompile_dirs="usr/share/kdevpythonsupport"
@@ -14,10 +14,10 @@ short_desc="Python 3 language and Django project support for KDevelop"
 maintainer="yopito <pierre.bourgin@free.fr>"
 license="LGPL-2.0-or-later, GPL-2.0-or-later"
 homepage="https://www.kdevelop.org/"
-distfiles="${KDE_SITE}/kdevelop/${version}/src/kdev-python-${version}.tar.xz"
-checksum=20f9b771b961262ded986a4f32b8d259ad9f7bc48bb29eac0a5d5853be1d917f
+changelog="https://kde.org/announcements/changelogs/gear/${version}/#kdev-python"
+distfiles="${KDE_SITE}/release-service/${version}/src/kdev-python-${version}.tar.xz"
+checksum=2521f2f2a7174dfb2bf1d962c460d40addc3bb486e9823c2b2707ced33456430
 python_version=3
-broken="relies on parser headers removed in python 3.10, no upstream fix yet"
 
 post_install() {
 	# don't install this python2 script: generates documentation_files, useless at runtime

--- a/srcpkgs/kdevelop/template
+++ b/srcpkgs/kdevelop/template
@@ -1,6 +1,6 @@
 # Template file for 'kdevelop'
 pkgname=kdevelop
-version=22.12.1
+version=22.12.2
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF"
@@ -19,7 +19,7 @@ license="GPL-2.0-or-later, LGPL-2.1-or-later"
 homepage="https://www.kdevelop.org/"
 changelog="https://kde.org/announcements/changelogs/gear/${version}/#kdevelop"
 distfiles="${KDE_SITE}/release-service/${version}/src/kdevelop-${version}.tar.xz"
-checksum=f330bbd2209e88b4340af0ef84d5f9c6e37b91ccdc06ad83ab58eaa854939062
+checksum=57f85e5eb1be0ae71d3440304c985fff2be03aab02de367535568ccef7c25ec9
 
 build_options="webengine"
 desc_option_webengine="Use Qt5 WebEngine for documentation"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture: **x86_64-musl**
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
  - [x] aarch64

