### PR TITLE
qt5-fsarchiver: update to 1.8.6pl1.

### DIFF
--- a/srcpkgs/qt5-fsarchiver/patches/attr.h.patch
+++ b/srcpkgs/qt5-fsarchiver/patches/attr.h.patch
@@ -1,0 +1,13 @@
+Index: qt5-fsarchiver-1.8.6pl1/src/oper_restore.c
+===================================================================
+--- qt5-fsarchiver-1.8.6pl1.orig/src/oper_restore.c
++++ qt5-fsarchiver-1.8.6pl1/src/oper_restore.c
+@@ -24,7 +24,7 @@
+ #include <assert.h>
+ #include <string.h>
+ #include <stdlib.h>
+-#include <attr/xattr.h>
++#include <sys/xattr.h>
+ #include <sys/time.h>
+ #include <sys/stat.h>
+ #include <gcrypt.h>

--- a/srcpkgs/qt5-fsarchiver/patches/cross.patch
+++ b/srcpkgs/qt5-fsarchiver/patches/cross.patch
@@ -1,6 +1,8 @@
---- a/qt5-fsarchiver.pro	2018-06-22 00:01:06.101404975 +0200
-+++ b/qt5-fsarchiver.pro	2018-06-22 00:01:45.933869386 +0200
-@@ -9,7 +9,7 @@
+Index: qt5-fsarchiver-1.8.6pl1/qt-fsarchiver.pro
+===================================================================
+--- qt5-fsarchiver-1.8.6pl1.orig/qt-fsarchiver.pro
++++ qt5-fsarchiver-1.8.6pl1/qt-fsarchiver.pro
+@@ -9,7 +9,7 @@ DEPENDPATH += . src translations src/ui
  QT += widgets gui core
  
  DEFINES +=  HAVE_CONFIG_H _REENTRANT _FILE_OFFSET_BITS=64 _LARGEFILE64_SOURCE _GNU_SOURCE HAVE_QT5

--- a/srcpkgs/qt5-fsarchiver/patches/fix-install-target.patch
+++ b/srcpkgs/qt5-fsarchiver/patches/fix-install-target.patch
@@ -1,20 +1,54 @@
---- a/qt5-fsarchiver.pro	2018-06-21 23:15:21.665117797 +0200
-+++ b/qt5-fsarchiver.pro	2018-06-21 23:15:36.159276907 +0200
-@@ -147,7 +147,7 @@
-            src/writebuf.c
- RESOURCES += src/icon.qrc
+Index: qt5-fsarchiver-1.8.6pl1/qt-fsarchiver.pro
+===================================================================
+--- qt5-fsarchiver-1.8.6pl1.orig/qt-fsarchiver.pro
++++ qt5-fsarchiver-1.8.6pl1/qt-fsarchiver.pro
+@@ -153,9 +153,9 @@ isEmpty(DOC_DIR) {
+   DOC_DIR = /usr/share/doc/qt-fsarchiver
+ }
  # install
 - target.path = /usr/sbin
 + target.path = /usr/bin
-  icon.files = src/images/harddrive1.png
-  icon.path = /usr/share/app-install/icons
-  autostart.files = starter/gnome-qt5-fsarchiver.desktop
-@@ -158,7 +158,7 @@
-  autostart2.path = /usr/share/applications
-  doc.files = doc
-  doc.path = /usr/share/doc/qt5-fsarchiver/doc
-- smbfind.files = src/sbin
-+ smbfind.files = src/bin
-  smbfind.path = /usr
- TRANSLATIONS += translations/qt5-fsarchiver_ar.ts \
-                 translations/qt5-fsarchiver_ca.ts \
+  target1.files = src/sbin/qt-fsarchiver.sh
+- target1.path = /usr/sbin
++ target1.path = /usr/bin
+  icon.files = src/images/qt-fsarchiver.png
+  icon.path = /usr/share/pixmaps
+  autostart.files = starter/qt-fsarchiver.desktop
+Index: qt5-fsarchiver-1.8.6pl1/src/mainWindow.cpp
+===================================================================
+--- qt5-fsarchiver-1.8.6pl1.orig/src/mainWindow.cpp
++++ qt5-fsarchiver-1.8.6pl1/src/mainWindow.cpp
+@@ -315,10 +315,10 @@ MWindow::MWindow()
+       }
+    j = 0; 
+    // qt-fsarchiver-terminal entfernen
+-   QFile file1("/usr/sbin/qt-fsarchiver-terminal");
++   QFile file1("/usr/bin/qt-fsarchiver-terminal");
+    if (file1.exists()) 
+       {
+-      befehl = "rm /usr/sbin/qt-fsarchiver-terminal";
++      befehl = "rm /usr/bin/qt-fsarchiver-terminal";
+       if(system (befehl.toLatin1().data()))
+          befehl = "";
+       }
+Index: qt5-fsarchiver-1.8.6pl1/src/sbin/qt-fsarchiver.sh
+===================================================================
+--- qt5-fsarchiver-1.8.6pl1.orig/src/sbin/qt-fsarchiver.sh
++++ qt5-fsarchiver-1.8.6pl1/src/sbin/qt-fsarchiver.sh
+@@ -1,2 +1,2 @@
+ #!/bin/bash
+-pkexec env DISPLAY=$DISPLAY XAUTHORITY=$XAUTHORITY '/usr/sbin/qt-fsarchiver' 
++pkexec env DISPLAY=$DISPLAY XAUTHORITY=$XAUTHORITY /usr/bin/qt-fsarchiver
+Index: qt5-fsarchiver-1.8.6pl1/starter/qt-fsarchiver.desktop
+===================================================================
+--- qt5-fsarchiver-1.8.6pl1.orig/starter/qt-fsarchiver.desktop
++++ qt5-fsarchiver-1.8.6pl1/starter/qt-fsarchiver.desktop
+@@ -2,7 +2,7 @@
+ Name=qt-fsarchiver
+ Name[de_DE]=qt-fsarchiver
+ Comment=Qt GUI for fsarchiver
+-Exec=/usr/sbin/qt-fsarchiver.sh
++Exec=/usr/bin/qt-fsarchiver.sh
+ Icon=qt-fsarchiver
+ Terminal=false
+ Type=Application

--- a/srcpkgs/qt5-fsarchiver/patches/musl.patch
+++ b/srcpkgs/qt5-fsarchiver/patches/musl.patch
@@ -1,5 +1,7 @@
---- a/src/common.c	2018-06-21 23:29:12.238999543 +0200
-+++ b/src/common.c	2018-06-21 23:30:28.347795214 +0200
+Index: qt5-fsarchiver-1.8.6pl1/src/common.c
+===================================================================
+--- qt5-fsarchiver-1.8.6pl1.orig/src/common.c
++++ qt5-fsarchiver-1.8.6pl1/src/common.c
 @@ -34,7 +34,7 @@
  #include <time.h>
  #include <limits.h>
@@ -9,7 +11,7 @@
  #include <execinfo.h>
  #endif
  
-@@ -567,7 +567,7 @@
+@@ -567,7 +567,7 @@ u64 stats_errcount(cstats stats)
  
  int format_stacktrace(char *buffer, int bufsize)
  {

--- a/srcpkgs/qt5-fsarchiver/template
+++ b/srcpkgs/qt5-fsarchiver/template
@@ -1,8 +1,7 @@
 # Template file for 'qt5-fsarchiver'
 pkgname=qt5-fsarchiver
-version=0.8.5
-revision=2
-_realversion=0.8.5-1
+version=1.8.6pl1
+revision=1
 build_style=qmake
 hostmakedepends="qt5-qmake qt5-host-tools"
 makedepends="qt5-devel liblz4-devel liblzma-devel lzo-devel libzstd-devel
@@ -12,16 +11,5 @@ short_desc="Program to save/restore partitions, folders and MBR/GPT"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-only"
 homepage="https://sourceforge.net/projects/qt4-fsarchiver"
-distfiles="${SOURCEFORGE_SITE}/qt4-fsarchiver/${pkgname}-${_realversion}.tar.gz"
-checksum=b32e02c9e1fc8038482752f5620d88b103b700ed29314bd55dcf6486f5c6f175
-
-CFLAGS="-fcommon"
-
-pre_configure() {
-	if [ "$CROSS_BUILD" ]; then
-		CXXFLAGS+=" -I${XBPS_CROSS_BASE}/usr/include/qt5"
-		for i in ${XBPS_CROSS_BASE}/usr/include/qt5/*; do
-			CXXFLAGS+=" -I$i"
-		done
-	fi
-}
+distfiles="${SOURCEFORGE_SITE}/qt-fsarchiver/qt-fsarchiver-${version/pl/-}.tar.gz"
+checksum=0f05efb520cdb8431788dc3dc127174f4b04845c0d778525a4110cf829229ae7


### PR DESCRIPTION
https://archive.is/eAian

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **NO**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
