### PR TITLE
[WIP] new package: libudev-zero

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -222,6 +222,7 @@ libgirepository-everything-1.0.so libgirepository-1.30_1
 libgirepository-1.0.so.1 libgirepository-1.30_1
 libudev.so.0 libudev0-shim-1_1
 libudev.so.1 eudev-libudev-1.6_1
+libudev.so.1 libudev-zero-1.0.1_1
 libgudev-1.0.so.0 libgudev-230_1
 libumockdev.so.0 libumockdev-0.17.6_1
 libext2fs.so.2 e2fsprogs-libs-1.41.5_1

--- a/srcpkgs/libudev-zero-devel
+++ b/srcpkgs/libudev-zero-devel
@@ -1,0 +1,1 @@
+libudev-zero/

--- a/srcpkgs/libudev-zero-helper
+++ b/srcpkgs/libudev-zero-helper
@@ -1,0 +1,1 @@
+libudev-zero/

--- a/srcpkgs/libudev-zero/template
+++ b/srcpkgs/libudev-zero/template
@@ -1,0 +1,45 @@
+# Template file for 'libudev-zero'
+pkgname=libudev-zero
+version=1.0.3
+revision=1
+_UDEV_VERSION=251
+_eudev_version=3.2.14_1
+build_style=gnu-makefile
+short_desc="Daemonless replacement for libudev"
+maintainer="dkwo <npiazza@disroot.org>"
+license="ISC"
+homepage="https://github.com/illiliti/libudev-zero"
+distfiles="https://github.com/illiliti/libudev-zero/archive/refs/tags/${version}.tar.gz"
+checksum=0bd89b657d62d019598e6c7ed726ff8fed80e8ba092a83b484d66afb80b77da5
+make_check=no # no tests
+provides="libudev-${_UDEV_VERSION}_${revision} eudev-libudev-${_eudev_version}"
+replaces="eudev-libudev>=0"
+
+post_build() {
+	"$CC" $LDFLAGS $CFLAGS $CPPFLAGS -o libudev-zero-helper contrib/helper.c
+}
+
+post_install() {
+	vlicense LICENSE
+}
+
+libudev-zero-devel_package() {
+	provides="libudev-devel-${_UDEV_VERSION}_${revision} eudev-libudev-devel-${_eudev_version}"
+	replaces="eudev-libudev-devel>=0"
+	depends="libudev-zero>=${version}_${revision}"
+	short_desc+=" - development files"
+	pkg_install() {
+		vmove usr/include
+		vmove usr/lib/pkgconfig
+		vmove "usr/lib/*.a"
+		vmove "usr/lib/*.so"
+	}
+}
+
+libudev-zero-helper_package() {
+	depends="libudev-zero>=${version}_${revision}"
+	short_desc+=" - helper"
+	pkg_install() {
+		vinstall libudev-zero-helper 755 usr/libexec
+	}
+}


### PR DESCRIPTION
https://github.com/illiliti/libudev-zero

- user must provide own alternative udevd (e.g. mdevd), and edit runit stage 1 script accordingly (see e.g. void-linux/void-runit#106 )
- I tested the changes in this PR: initram and init scripts, rebuilt some libraries with it
- I built this PR locally for my native architecture, (x86_64-musl)