### PR TITLE
New package: hg-evolve-11.0.1

### DIFF
--- a/srcpkgs/hg-evolve/template
+++ b/srcpkgs/hg-evolve/template
@@ -1,0 +1,32 @@
+# Template file for 'hg-evolve'
+pkgname=hg-evolve
+version=11.0.1
+revision=1
+_hg_version=6.3.2 # sync with mercurial version in repo"
+build_style=python3-module
+build_wrksrc="hg-evolve-${version}"
+hostmakedepends="python3-setuptools"
+depends="mercurial"
+checkdepends="mercurial unzip"
+short_desc="Mercurial extension for faster and safer mutable history"
+maintainer="icp <pangolin@vivaldi.net>"
+license="GPL-2.0-or-later"
+homepage="https://www.mercurial-scm.org/doc/evolution/"
+changelog="https://www.mercurial-scm.org/repo/evolve/file/tip/CHANGELOG"
+distfiles="${PYPI_SITE}/h/hg-evolve/hg-evolve-${version}.tar.gz
+ https://www.mercurial-scm.org/release/mercurial-${_hg_version}.tar.gz"
+checksum="82ea42df9a4b40e2604a65e2069f8ac6a5ae317de22925fdc4352d11a07fc054
+ cfe6eeb5dd893ab32c0b79c1531aac420773e0fc837a35db3d4d92703df45a98"
+
+do_check() {
+	_skips="check-compat-strings check-sdist version-install"
+	for skip in $_skips; do rm "tests/test-${skip}.t"; done
+
+	python3 ${wrksrc}/mercurial-${_hg_version}/tests/run-tests.py \
+		${makejobs} --with-hg=/usr/bin/hg tests
+}
+
+post_install() {
+	# resolve conflict against mercurial
+	rm ${DESTDIR}/${py3_sitelib}/hgext3rd/__init__.py
+}


### PR DESCRIPTION
#### Description
[evolve](https://www.mercurial-scm.org/wiki/EvolveExtension) is a Mercurial extension for faster and safer mutable history. It implements the [changeset evolution](https://www.mercurial-scm.org/doc/evolution/#changeset-evolution) concept for Mercurial.

#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

#### Local build testing
- I built this PR locally for my native architecture: **x86_64**

This version of evolve finally ships the stabilized (v1.0.0) version of the [topics extension](https://www.mercurial-scm.org/doc/evolution/tutorials/topic-tutorial.html).