### PR TITLE
python3-frozendict: update to 2.3.5.

### DIFF
--- a/srcpkgs/python3-frozendict/template
+++ b/srcpkgs/python3-frozendict/template
@@ -1,7 +1,7 @@
 # Template file for 'python3-frozendict'
 pkgname=python3-frozendict
-version=2.3.4
-revision=2
+version=2.3.5
+revision=1
 build_style=python3-module
 make_check_args="-k not(test_c_extension)"
 hostmakedepends="python3-setuptools"
@@ -13,12 +13,4 @@ maintainer="Joel Beckmeyer <joel@beckmeyer.us>"
 license="LGPL-3.0-only"
 homepage="https://github.com/Marco-Sulla/python-frozendict"
 distfiles="${PYPI_SITE}/f/frozendict/frozendict-${version}.tar.gz"
-checksum=15b4b18346259392b0d27598f240e9390fafbff882137a9c48a1e0104fb17f78
-
-do_build() {
-	python3 setup.py py build
-}
-
-do_install() {
-	python3 setup.py py install --prefix=/usr --root="${DESTDIR}"
-}
+checksum=65d7e3995c9174b77d7d80514d7062381750491e112bbeb44323368baa3e636a


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture: **x86_64**

This library does not build the C extension by default now so the workaround is unnecessary. I haven't removed the `makedepends` since a c extension for py3.11 is WIP upstream.