### PR TITLE
bpftrace: the man pages does not clash any more

### DIFF
--- a/srcpkgs/bpftrace/template
+++ b/srcpkgs/bpftrace/template
@@ -1,7 +1,7 @@
 # Template file for 'bpftrace'
 pkgname=bpftrace
 version=0.17.0
-revision=1
+revision=2
 archs="x86_64* aarch64* ppc64*"
 build_style=cmake
 configure_args="-DUSE_SYSTEM_BPF_BCC=ON -DBUILD_TESTING=OFF" # needs root to run
@@ -16,8 +16,3 @@ checksum=ccc853205b081fd7e4270016065ccc04764286644bf8e0eee9bd7f344cad63e5
 nostrip=yes  # needs to read own symbol table
 
 CXXFLAGS="-isystem ${XBPS_CROSS_BASE}/usr/include/bcc/compat"
-
-post_install() {
-	# clashes with bcc-tools
-	rm -rf ${DESTDIR}/usr/share/man
-}


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

The man pages for bpftrace does not clash with bcc-tools man pages any more.

Tagging the maintainer @leahneukirchen

#### Testing the changes
- I tested the changes in this PR: **YES**

- Validation of the built package man pages against bcc-tools:

```
❯ xbps-query -f bpftrace | grep man8 | grep -v '\.bt\.'
/usr/share/man/man8/bpftrace.8
❯ xbps-query -f bcc-tools | grep man8 | grep 'bpftrace'
❯ xbps-query -f bpftrace | grep man8 | grep '\.bt\.'
/usr/share/man/man8/bashreadline.bt.8
/usr/share/man/man8/biolatency.bt.8
/usr/share/man/man8/biosnoop.bt.8
/usr/share/man/man8/biostacks.bt.8
/usr/share/man/man8/bitesize.bt.8
/usr/share/man/man8/capable.bt.8
/usr/share/man/man8/cpuwalk.bt.8
/usr/share/man/man8/dcsnoop.bt.8
/usr/share/man/man8/execsnoop.bt.8
/usr/share/man/man8/gethostlatency.bt.8
/usr/share/man/man8/killsnoop.bt.8
/usr/share/man/man8/loads.bt.8
/usr/share/man/man8/mdflush.bt.8
/usr/share/man/man8/naptime.bt.8
/usr/share/man/man8/oomkill.bt.8
/usr/share/man/man8/opensnoop.bt.8
/usr/share/man/man8/pidpersec.bt.8
/usr/share/man/man8/runqlat.bt.8
/usr/share/man/man8/runqlen.bt.8
/usr/share/man/man8/setuids.bt.8
/usr/share/man/man8/ssllatency.bt.8
/usr/share/man/man8/sslsnoop.bt.8
/usr/share/man/man8/statsnoop.bt.8
/usr/share/man/man8/swapin.bt.8
/usr/share/man/man8/syncsnoop.bt.8
/usr/share/man/man8/syscount.bt.8
/usr/share/man/man8/tcpaccept.bt.8
/usr/share/man/man8/tcpconnect.bt.8
/usr/share/man/man8/tcpdrop.bt.8
/usr/share/man/man8/tcplife.bt.8
/usr/share/man/man8/tcpretrans.bt.8
/usr/share/man/man8/tcpsynbl.bt.8
/usr/share/man/man8/threadsnoop.bt.8
/usr/share/man/man8/undump.bt.8
/usr/share/man/man8/vfscount.bt.8
/usr/share/man/man8/vfsstat.bt.8
/usr/share/man/man8/writeback.bt.8
/usr/share/man/man8/xfsdist.bt.8
❯ xbps-query -f bcc-tools | grep man8 | grep '\.bt\.'
❯ 
```
- bcc-tools can be cleanly installed alongside bpftrace

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
