### PR TITLE
New package: passt-2023.03.09.7c7625d

### DIFF
--- a/srcpkgs/passt/template
+++ b/srcpkgs/passt/template
@@ -1,0 +1,19 @@
+# Template file for 'passt'
+pkgname=passt
+version=2023.03.21.1ee2f7c
+revision=1
+# upstream uses YYYY_MM_DD.COMMIT
+_version=${version/./_}
+_version=${_version/./_}
+build_style=gnu-makefile
+short_desc="Plug A Simple Socket Transport"
+maintainer="lemmi <lemmi@nerd2nerd.org>"
+license="AGPL-3.0-or-later, BSD-3-Clause"
+homepage="https://passt.top"
+distfiles="https://passt.top/passt/snapshot/passt-${_version}.tar.xz"
+checksum=46ae6bd4b03ba0982938f51fbfbf8c0f11ac0c23e4a04c41211f03e0aa564952
+
+post_install() {
+	vlicense LICENSES/AGPL-3.0-or-later.txt
+	vlicense LICENSES/BSD-3-Clause.txt
+}

--- a/srcpkgs/passt/update
+++ b/srcpkgs/passt/update
@@ -1,0 +1,2 @@
+site="https://passt.top/passt"
+pattern='passt-\K[\d._abcdef]+(?=.tar.xz)'


### PR DESCRIPTION
[podman-v4.4.0](https://github.com/containers/podman/releases/tag/v4.4.0) added support for [pasta](https://passt.top/passt/about/) with <https://github.com/containers/podman/pull/16141>. It's interesting for proper IPv6 forwarding with rootless containers.

There is an [open issue](https://bugs.passt.top/show_bug.cgi?id=4) for `musl` support.

#### Testing the changes
- I tested the changes in this PR: **briefly**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**
