### PR TITLE
miniserve: update to 0.23.0

### DIFF
--- a/srcpkgs/miniserve/template
+++ b/srcpkgs/miniserve/template
@@ -1,9 +1,13 @@
 # Template file for 'miniserve'
 pkgname=miniserve
-version=0.22.0
+version=0.23.0
 revision=1
 build_style=cargo
 build_helper=qemu
+# these tests fail to create a tempdir
+make_check_args="--
+ --skip qrcode_hidden_in_tty_when_disabled
+ --skip qrcode_shown_in_tty_when_enabled"
 checkdepends="curl"
 short_desc="CLI tool to serve files and dirs over HTTP"
 maintainer="Enno Boland <gottox@voidlinux.org>"
@@ -11,7 +15,7 @@ license="MIT"
 homepage="https://github.com/svenstaro/miniserve"
 changelog="https://raw.githubusercontent.com/svenstaro/miniserve/master/CHANGELOG.md"
 distfiles="https://github.com/svenstaro/miniserve/archive/refs/tags/v${version}.tar.gz"
-checksum=325f6cde391c468000b1bdcc8455ec2c6950b3c930029187671c536507b185ba
+checksum=46e076f35cd8919a566d595b7fef05ce9c5c223a66bea6ee6dd3092c42697bd1
 make_check=ci-skip  # port binding succeeds locally but fails in CI
 
 case "$XBPS_TARGET_MACHINE" in


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
