### PR TITLE
vdirsyncer: update to 0.19.1

### DIFF
--- a/srcpkgs/vdirsyncer/template
+++ b/srcpkgs/vdirsyncer/template
@@ -1,23 +1,21 @@
 # Template file for 'vdirsyncer'
 pkgname=vdirsyncer
-version=0.19.0
+version=0.19.1
 revision=1
 build_style=python3-module
 hostmakedepends="python3-setuptools_scm"
 depends="python3-atomicwrites python3-click python3-click-log python3-requests
  python3-requests-toolbelt python3-aiohttp python3-aiostream"
 checkdepends="python3-pytest-xdist python3-pytest-asyncio python3-trustme
- python3-aioresponses python3-pytest-httpserver python3-hypothesis $depends"
+ python3-aioresponses python3-pytest-httpserver python3-hypothesis
+ python3-pytest-cov $depends"
 short_desc="Synchronize calendars and addressbooks"
 maintainer="Andrew J. Hesford <ajh@sideband.org>"
 license="BSD-3-Clause"
 homepage="https://vdirsyncer.pimutils.org/"
+changelog="https://github.com/pimutils/vdirsyncer/raw/main/CHANGELOG.rst"
 distfiles="${PYPI_SITE}/v/vdirsyncer/vdirsyncer-${version}.tar.gz"
-checksum=8e1e8403a08659e5a4e7fa3e9caaa2e2dce2bf1f98d923029049a34db75a2525
-
-pre_check() {
-	vsed -e 's/^addopts/noaddopts/' -i setup.cfg
-}
+checksum=aa76c7725aa5a711f6374bc5cd83be78aae68c74829635a9ed073cd4c09f03ae
 
 post_install() {
 	vsconf config.example


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures:
  - x86_64-musl (crossbuild)
  - aarch64 (crossbuild)
  - armv7l (crossbuild)
