### PR TITLE
openjdk17: static-libs subpackage

### DIFF
--- a/srcpkgs/mandrel/template
+++ b/srcpkgs/mandrel/template
@@ -1,11 +1,10 @@
 # Template file for 'mandrel'
 pkgname=mandrel
-version=22.1.0.0
+version=22.3.1.0
 revision=1
-_java_ver=11
-_mx_ver=6.1.2
+_java_ver=17
+_mx_ver=6.16.0
 archs="aarch64* x86_64*"  # upstream supported archs
-create_wrksrc=yes
 hostmakedepends="openjdk${_java_ver} openjdk${_java_ver}-jmods
  openjdk${_java_ver}-src openjdk${_java_ver}-static-libs python3"
 makedepends="zlib-devel"
@@ -16,9 +15,9 @@ homepage="https://github.com/graalvm/mandrel"
 distfiles="https://github.com/graalvm/mandrel-packaging/archive/refs/tags/mandrel-${version}-Final.tar.gz>packaging-${version}.tar.gz
  https://github.com/graalvm/mandrel/archive/refs/tags/mandrel-${version}-Final.tar.gz
  https://github.com/graalvm/mx/archive/refs/tags/${_mx_ver}.tar.gz"
-checksum="a93ef67c75c52ff90faba95236100c4f702df2de87593b9bb00da3a2cbec3a23
- 8cf3aefe5f9aa7869ddaf02376be5febc20831461ce524c912f3f22fbf922863
- ae7a7d2a195666e32126f51dad5b55abbc204a13e89582172cc461a29ae84205"
+checksum="dd37f4a8f628b8909228f489e12363427df9d0f95d1afedad39a2443b22a806d
+ bfe15128e8ffb5fd108ee20477e5ee1572c63405d6d0b93d905185356128dcec
+ aeec921e0669c72575dd9af54b5d5413d744dac590c82db46ae2bf60c4dfeb1b"
 shlib_provides="libawt.so libawt_xawt.so libjava.so libjli.so libjvm.so libjawt.so"
 nocross=yes
 
@@ -32,6 +31,7 @@ post_patch() {
 
 do_build() {
 	cd mandrel-packaging-*
+	export PATH=/usr/libexec/chroot-git:$PATH
 	export JAVA_HOME=/usr/lib/jvm/openjdk${_java_ver}
 	$JAVA_HOME/bin/java -ea build.java \
 		--mx-home $PWD/../mx-* \

--- a/srcpkgs/openjdk11/template
+++ b/srcpkgs/openjdk11/template
@@ -36,8 +36,8 @@ short_desc="OpenJDK Java Development Kit (version ${_java_ver})"
 maintainer="Kyle Nusbaum <knusbaum+void@sdf.org>"
 license="GPL-2.0-only WITH Classpath-exception-2.0"
 homepage="http://openjdk.java.net/"
-distfiles="https://hg.openjdk.java.net/jdk-updates/jdk${_java_ver}u/archive/jdk-${version}.tar.gz"
-checksum=06ad7b39625374c30a8d8be9e7e18f37663ba6fe44c2a66aa7b7987b140d069a
+distfiles="https://github.com/openjdk/jdk${_java_ver}u/archive/jdk-${version}.tar.gz"
+checksum=9a37c9641b45f5c51fe19c1ccae141daeb5dcdbd59fa2f56e7dea7bf09484bec
 provides="java-environment-${version}_1"
 
 # Build is still parallel, but don't use -jN.
@@ -212,7 +212,6 @@ openjdk11-src_package() {
 }
 
 openjdk11-static-libs_package() {
-	notstrip=yes
 	short_desc+=" - static libs"
 	pkg_install() {
 		vmkdir $_jdk_home

--- a/srcpkgs/openjdk11/update
+++ b/srcpkgs/openjdk11/update
@@ -1,2 +1,1 @@
-site="http://hg.openjdk.java.net/jdk-updates/jdk11u/tags"
-pattern='jdk-\K11\.[\d.+]+'
+pattern='jdk-\K11\.[\d.+]+(?=\.)'

--- a/srcpkgs/openjdk17-static-libs
+++ b/srcpkgs/openjdk17-static-libs
@@ -1,0 +1,1 @@
+openjdk17

--- a/srcpkgs/openjdk17/template
+++ b/srcpkgs/openjdk17/template
@@ -1,7 +1,7 @@
 # Template file for 'openjdk17'
 pkgname=openjdk17
 version=17.0.5+7
-revision=1
+revision=2
 _gtest_ver=1.8.1
 _java_ver="${version%%.*}"
 _jdk_update="${version#*+}"
@@ -30,7 +30,7 @@ configure_args="--disable-warnings-as-errors
  --with-vendor-url=https://voidlinux.org/
  --with-vendor-bug-url=https://github.com/void-linux/void-packages/issues
  --with-vendor-vm-bug-url=https://github.com/void-linux/void-packages/issues"
-make_build_args="images $(vopt_if docs docs)"
+make_build_args="images static-libs-image $(vopt_if docs docs)"
 make_install_args="INSTALL_PREFIX=\"${DESTDIR}/usr/lib\""
 make_check_target="test-hotspot-gtest"
 hostmakedepends="pkg-config automake autoconf cpio tar unzip zip ca-certificates
@@ -159,6 +159,7 @@ do_configure() {
 post_install() {
 	rm -rf ${DESTDIR}/usr/lib/bin
 	mv ${DESTDIR}/usr/lib/jvm/openjdk-${_base_version} ${DESTDIR}/$_jdk_home
+	vcopy build/*-release/images/static-libs/lib $_jdk_home
 	vmkdir $_jdk_home/lib/security
 	make-ca -g -f --destdir "${PWD}/ca" -k "${DESTDIR}/$_jdk_home/bin/keytool"
 	mv ./ca/etc/pki/tls/java/cacerts ${DESTDIR}/$_jdk_home/lib/security/
@@ -166,7 +167,7 @@ post_install() {
 	rm -rf ./ca
 }
 
-subpackages="openjdk17-src openjdk17-jre openjdk17-doc openjdk17-jmods"
+subpackages="openjdk17-static-libs openjdk17-src openjdk17-jre openjdk17-doc openjdk17-jmods"
 
 openjdk17-jre_package() {
 	shlib_provides="libawt.so libawt_xawt.so libjava.so libjli.so libjvm.so libjawt.so"
@@ -216,6 +217,13 @@ openjdk17-src_package() {
 	short_desc+=" - source code"
 	pkg_install() {
 		vmove "$_jdk_home/lib/src.zip"
+	}
+}
+
+openjdk17-static-libs_package() {
+	short_desc+=" - static libs"
+	pkg_install() {
+		vmove "$_jdk_home/lib/*.a"
 	}
 }
 


### PR DESCRIPTION
- openjdk11: remove useless nostrep from -static-libs
- openjdk17: static libs subpackage

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **NO**

