### PR TITLE
libiberty-devel: update to 20230104

### DIFF
--- a/srcpkgs/libiberty-devel/template
+++ b/srcpkgs/libiberty-devel/template
@@ -1,6 +1,6 @@
 # Template file for 'libiberty-devel'
 pkgname=libiberty-devel
-version=20220713
+version=20230104
 revision=1
 build_wrksrc=libiberty
 build_style=gnu-configure
@@ -10,7 +10,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-3.0-or-later"
 homepage="http://gcc.gnu.org/"
 distfiles="http://deb.debian.org/debian/pool/main/libi/libiberty/libiberty_${version}.orig.tar.xz"
-checksum=b59050f48c8a0f9c9e6fba5d17c7a4f11d1329de0c0dca7331b767a6d2bbe8d9
+checksum=f0c873589b983a2e82287d1beea3b230959803121ede290154d44008984013ef
 conflicts="binutils-devel<=2.35.1_3"
 
 CFLAGS="-fPIC"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl
  - i686
  - i686-musl
  - aarch64
  - aarch64-musl
  - armv7l
  - armv7l-musl
  - armv6l
  - armv6l-musl
  - ppc64le


Current version doesn't available anymore. Source was here https://deb.debian.org/debian/pool/main/libi/libiberty/ . 
I worked on `qbittorrent` package update. And without this library it can't built for `i686-musl` platform.
