### PR TITLE
dracut: remove ifcfg dracut module

### DIFF
--- a/srcpkgs/dracut/template
+++ b/srcpkgs/dracut/template
@@ -1,7 +1,7 @@
 # Template file for 'dracut'
 pkgname=dracut
 version=059
-revision=2
+revision=3
 build_style=configure
 configure_args="--prefix=/usr --sysconfdir=/etc"
 conf_files="/etc/dracut.conf"
@@ -52,7 +52,7 @@ post_install() {
 
 	# systemd dependent additional dracut modules
 	for f in 06rngd 06dbus-broker 06dbus-daemon 09dbus \
-		35network-manager 35network-wicked 80lvmmerge \
+		35connman 35network-manager 35network-wicked 80lvmmerge \
 		99memstrack 99squash; do
 		rm -r ${DESTDIR}/usr/lib/dracut/modules.d/${f}
 	done
@@ -64,6 +64,9 @@ post_install() {
 		rm -r ${DESTDIR}/usr/lib/dracut/modules.d/${f}
 	done
 
+	# ifcfg network-scripts dependent (RHEL-derived)
+	rm -r ${DESTDIR}/usr/lib/dracut/modules.d/45ifcfg
+
 	rm ${DESTDIR}/usr/share/man/man8/*.service.*
 	rm -r ${DESTDIR}/usr/lib/kernel
 }
@@ -72,8 +75,9 @@ dracut-network_package() {
 	depends="dhclient ${sourcepkg}-${version}_${revision}"
 	short_desc+=" - network modules"
 	pkg_install() {
-		for f in 35network-legacy 40network 90livenet \
-			95fcoe 95iscsi 95nbd 95nfs; do
+		for f in 35network-legacy 40network 45url-lib \
+			90kernel-network-modules 90qemu-net 90livenet \
+			95cifs 95fcoe 95fcoe-uefi 95iscsi 95nbd 95nfs 95ssh-client; do
 			vmove usr/lib/dracut/modules.d/${f}
 		done
 	}


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **NO**

Follow-up to https://github.com/void-linux/void-packages/pull/41716#issuecomment-1451141356

Other changes:
 - remove connman as it depends on systemd
 - move more network dependent modules to dracut-network package
 
 CC @zdykstra @classabbyamp 
