### PR TITLE
clamav: update to 0.103.8.

### DIFF
--- a/srcpkgs/clamav/template
+++ b/srcpkgs/clamav/template
@@ -1,7 +1,7 @@
 # Template file for 'clamav'
 pkgname=clamav
-version=0.103.4
-revision=3
+version=0.103.8
+revision=1
 build_style=gnu-configure
 # XXX: system llvm is too new (< 3.7 required)
 # Shipped llvm does not build with gcc>=6
@@ -19,7 +19,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-only"
 homepage="https://www.clamav.net/"
 distfiles="https://www.clamav.net/downloads/production/clamav-${version}.tar.gz"
-checksum=def0ad15500fa6aff81d8e68b9f83aa75ee5b607a01335c1d26dbcc959932f85
+checksum=6f49da6ee927936de13d359e559d3944248e3a257d40b80b6c99ebe6fe8c8c3f
 _clamav_homedir="/var/lib/_${pkgname}"
 _clamav_descr="ClamAV user"
 system_accounts="_clamav"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl (crossbuild)
  - armv7l (crossbuild)
  - armv6l-musl (crossbuild)

This release contains very important fixes for some critical CVEs.
Here is the information: https://blog.clamav.net/

We should merge this PR ASAP.