### PR TITLE
zrepl: update to 0.6.0.

### DIFF
--- a/srcpkgs/zrepl/template
+++ b/srcpkgs/zrepl/template
@@ -1,6 +1,6 @@
 # Template file for 'zrepl'
 pkgname=zrepl
-version=0.5.0
+version=0.6.0
 revision=1
 build_style=go
 go_import_path=github.com/zrepl/zrepl
@@ -11,7 +11,7 @@ maintainer="Frans Bergman <frans@tankernn.eu>"
 license="MIT"
 homepage="https://github.com/zrepl/zrepl"
 distfiles="${homepage}/archive/v${version}.tar.gz"
-checksum=4acfde9e7a09eca2de3de5c7d2987907ae446b345b69133e4b3c58a99c294465
+checksum=0bf1dcf634a43af81cd9a0d7b9ae65f63a5938c35d3e6cd804177c8db52929f4
 
 conf_files="/etc/zrepl/*"
 


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

It should be noted that the 0.6 version replication is not interoperable with 0.5 counterpart. 

#### Testing the changes
- I tested the changes in this PR: **YES**

- Tested on my configuration with snapshoting and replication to FreeBSD server.

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)

