### PR TITLE
puzzles: update to 20230303.c0f715f.

### DIFF
--- a/srcpkgs/puzzles/template
+++ b/srcpkgs/puzzles/template
@@ -1,6 +1,6 @@
 # Template file for 'puzzles'
 pkgname=puzzles
-version=20230123.1f72a1a
+version=20230303.c0f715f
 revision=1
 build_style=cmake
 configure_args="-DNAME_PREFIX=puzzles-"
@@ -10,8 +10,8 @@ short_desc="Simon Tatham's Portable Puzzle Collection"
 maintainer="Leah Neukirchen <leah@vuxu.org>"
 license="MIT"
 homepage="https://www.chiark.greenend.org.uk/~sgtatham/puzzles/"
-distfiles="https://git.tartarus.org/?p=simon/puzzles.git;a=snapshot;h=1f72a1a2ecc89ba789a0b665a5e39da5febe27d2;sf=tgz>${pkgname}-${version#*.}.tgz"
-checksum=2a372deda982aff951bda19cb49dcf7fc56c14b63a7969763d95f1ebbc238906
+distfiles="https://git.tartarus.org/?p=simon/puzzles.git;a=snapshot;h=c0f715fbaca77fbb6e86de604098d82687bdea48;sf=tgz>${pkgname}-${version#*.}.tgz"
+checksum=dfd601d277f304cac5bb38a99dc478fe4e7ec2019951461c18f1516c64c7fd8b
 
 post_install() {
 	vlicense LICENCE LICENSE


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture: **x86_64**