### PR TITLE
epson-inkjet-printer-escpr: update to 1.7.25, adopt.

### DIFF
--- a/srcpkgs/epson-inkjet-printer-escpr/template
+++ b/srcpkgs/epson-inkjet-printer-escpr/template
@@ -1,14 +1,14 @@
 # Template file for 'epson-inkjet-printer-escpr'
 pkgname=epson-inkjet-printer-escpr
-version=1.7.22
+version=1.7.25
 revision=1
 build_style=gnu-configure
 configure_args="--disable-static --with-cupsppddir=/usr/share/ppd --with-cupsfilterdir=/usr/lib/cups/filter"
 makedepends="cups-devel"
 depends="cups-filters"
 short_desc="Epson Inkjet Printer Driver (ESC/P-R)"
-maintainer="Justin Berthault <justin.berthault@zaclys.net>"
+maintainer="Mohammed Anas <triallax@tutanota.com>"
 license="GPL-2.0-or-later"
-homepage="http://download.ebz.epson.net/dsc/search/01/search/?OSC=LX"
-distfiles="https://download3.ebz.epson.net/dsc/f/03/00/13/96/55/c6fced63098ae1ba104f11f572794fd558ffca29/${pkgname}-${version}-1lsb3.2.tar.gz"
-checksum=0b2fefa7fd077b6fdf778cb53a8c60bf999a396ef88145182c5c4a08f34c652c
+homepage="https://download.ebz.epson.net/dsc/search/01/search/?OSC=LX&productName=B700"
+distfiles="https://download3.ebz.epson.net/dsc/f/03/00/14/34/76/47198c0bab357b96ec59490973c492c5d6059604/epson-inkjet-printer-escpr-${version}-1lsb3.2.tar.gz"
+checksum=d5e30b58dc6152df6b63fcbc7315506d155002b4b11342e7e6699c49e7bb5b69


### PR DESCRIPTION

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

Maintainer hasn't committed to this package since they adopted it in January 2020 (e7d4687296a973a9290db2af228b9b874d175e7b).

ping @Bridouz

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
