### PR TITLE
obs: depend on v4l2loopback for virtual camera support

### DIFF
--- a/srcpkgs/obs/template
+++ b/srcpkgs/obs/template
@@ -1,7 +1,7 @@
 # Template file for 'obs'
 pkgname=obs
 version=29.0.2
-revision=1
+revision=2
 archs="i686* x86_64* ppc64le* aarch64*"
 build_style=cmake
 configure_args="-DOBS_VERSION_OVERRIDE=${version} -DENABLE_JACK=ON
@@ -13,7 +13,7 @@ makedepends="LuaJIT-devel fdk-aac-devel ffmpeg-devel glu-devel
  vlc-devel qt6-svg-devel x264-devel mbedtls-devel jansson-devel
  wayland-devel pipewire-devel libxkbcommon-devel pciutils-devel
  librist-devel srt-devel"
-depends="xset xdg-desktop-portal"
+depends="xset xdg-desktop-portal v4l2loopback"
 short_desc="Open Broadcaster Software"
 maintainer="lemmi <lemmi@nerd2nerd.org>"
 license="GPL-2.0-or-later"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

This dependency enables virtual camera support