### PR TITLE
sane: fix PDF-producing eSCL scanners failing with `Invalid argument`

### DIFF
--- a/srcpkgs/sane/template
+++ b/srcpkgs/sane/template
@@ -2,15 +2,16 @@
 pkgname=sane
 _gitlab_release_hash=110fc43336d0fb5e514f1fdc7360dd87
 version=1.2.1
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--disable-locking --enable-ipv6 --enable-pthread
  --with-usb --docdir=/usr/share/doc/sane ac_cv_func_mmap_fixed_mapped=yes
- $(vopt_with snmp)"
+ $(vopt_with snmp) $(vopt_with poppler poppler-glib)"
 hostmakedepends="pkg-config python3"
 makedepends="libjpeg-turbo-devel tiff-devel libgphoto2-devel v4l-utils-devel
  libusb-devel openssl-devel libxml2-devel libpng-devel
- $(vopt_if snmp net-snmp-devel) $(vopt_if avahi 'avahi-libs-devel libcurl-devel')"
+ $(vopt_if snmp net-snmp-devel) $(vopt_if avahi 'avahi-libs-devel libcurl-devel')
+ $(vopt_if poppler 'cairo-devel poppler-glib-devel')"
 depends="$(vopt_if snmp net-snmp)"
 conf_files="/etc/sane.d/*.conf"
 short_desc="Scanner Access Now Easy"
@@ -26,11 +27,15 @@ noshlibprovides="avoid false detection of device drivers"
 system_accounts="_saned"
 _saned_groups="lp,scanner"
 
-build_options="avahi snmp"
-build_options_default="avahi"
+build_options="avahi snmp poppler"
+build_options_default="avahi poppler"
+desc_option_poppler="build with poppler (support for PDF-producing scanners, e.g. Epson eSCL)"
 
 if [ "$XBPS_TARGET_WORDSIZE" = "32" ]; then
 	make_check=no # tests broken on 32bit.  https://gitlab.com/sane-project/backends/-/issues/157
+fi
+if [ "$build_option_poppler" ]; then
+	make_check=no # tests broken when poppler enabled due to bundled minigtest
 fi
 
 post_build() {


### PR DESCRIPTION
eSCL-speaking scanners that produce PDF-formatted output scan properly, but completion is only met with `sane_start: Invalid argument` expressed in various forms depending on front-end.

This is due to SANE being built without PDF support, provided by poppler-glib; this commit enables that as a default-on option, fixing support for those scanners.

#### Testing the changes
- I tested the changes in this PR: **YES** (using an EPSON XP-325)
