### PR TITLE
chezmoi: update to 2.31.1.

### DIFF
--- a/srcpkgs/chezmoi/template
+++ b/srcpkgs/chezmoi/template
@@ -1,6 +1,6 @@
 # Template file for 'chezmoi'
 pkgname=chezmoi
-version=2.31.0
+version=2.31.1
 revision=1
 build_style=go
 go_import_path="github.com/twpayne/chezmoi/v2"
@@ -12,7 +12,7 @@ maintainer="classabbyamp <void@placeviolette.net>"
 license="MIT"
 homepage="https://chezmoi.io/"
 distfiles="https://github.com/twpayne/chezmoi/archive/v${version}.tar.gz"
-checksum=00e7e783172ec827f2f97dd0629d34c7e20ad949720609b406319ba75e2ccf35
+checksum=47ab2cf78a749a070f9b86b7518b8fe9cfb1dc46c31229f76ebdadad74abd235
 
 pre_build() {
 	local _date
@@ -20,6 +20,12 @@ pre_build() {
 		_date="$(date --utc --date "@$SOURCE_DATE_EPOCH" "+%Y-%m-%d")"
 		go_ldflags+=" -X main.date=${_date}"
 	fi
+}
+
+pre_check() {
+	# These tests fail with a "git: 'submodule' is not a git command."
+	# error because chroot-git does not include that subcommand.
+	rm pkg/cmd/testdata/scripts/{init,issue1213,issue2649,root,update}.txtar
 }
 
 do_check() {


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

@classabbyamp

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
