### PR TITLE
New package: sov-0.92b

### DIFF
--- a/srcpkgs/sov/template
+++ b/srcpkgs/sov/template
@@ -1,0 +1,14 @@
+# Template file for 'sov'
+pkgname=sov
+version=0.92b
+revision=1
+build_style=meson
+hostmakedepends="pkg-config wayland-devel"
+makedepends="wayland-devel wayland-protocols freetype-devel libglvnd-devel libpng-devel libxkbcommon-devel liberation-fonts-ttf"
+short_desc="Overlay that shows schemas for all workspaces in sway wm"
+maintainer="Milan Toth <milgra@milgra.com>"
+license="GPL-3.0-or-later"
+homepage="https://github.com/milgra/sov"
+changelog="https://github.com/milgra/sov/releases"
+distfiles="https://github.com/milgra/sov/archive/${version}.tar.gz"
+checksum=ca7b4653af481b026a4bcc99e5954f9abff3fdbfe368c0f9b4fa6cbd33fcfa9d


### PR DESCRIPTION
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)

[sov](https://www.github.com/milgra/sov) is an overlay that shows schemas for all workspaces to make navigation in sway wm easier.