### PR TITLE
New package: qt-heif-image-plugin-0.3.3

### DIFF
--- a/srcpkgs/qt-heif-image-plugin/template
+++ b/srcpkgs/qt-heif-image-plugin/template
@@ -1,0 +1,13 @@
+# Template file for 'qt-heif-image-plugin'
+pkgname=qt-heif-image-plugin
+version=0.3.3
+revision=1
+build_style=cmake
+hostmakedepends="pkg-config qt5-host-tools qt5-qmake"
+makedepends="qt5-devel libheif-devel"
+short_desc="Qt image plugin for HEIF"
+maintainer="shtayerc <david.murko@mailbox.org>"
+license="LGPL-3.0-only"
+homepage="https://github.com/jakar/qt-heif-image-plugin"
+distfiles="https://github.com/jakar/qt-heif-image-plugin/archive/refs/tags/${version}.tar.gz"
+checksum=d84bb1cf91870b20358c373da667f803d2d246d3add27242632b39e3ca4c2d7c


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES** (Works with lximage-qt)

- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
