### PR TITLE
New package: font-terminus-ttf-4.49.2

### DIFF
--- a/srcpkgs/font-terminus-ttf/template
+++ b/srcpkgs/font-terminus-ttf/template
@@ -1,0 +1,21 @@
+# Template file for 'font-terminus-ttf'
+pkgname=font-terminus-ttf
+version=4.49.2
+revision=1
+hostmakedepends="unzip"
+depends="font-util"
+short_desc="TTF version of the terminus monospaced bitmap font"
+maintainer="Milan Toth <milgra@milgra.com>"
+license="OFL-1.1"
+homepage="https://files.ax86.net/terminus-ttf"
+distfiles="https://files.ax86.net/terminus-ttf/files/${version}/terminus-ttf-${version}.zip"
+checksum=523bb09ec554514bedecd4d068b9d89b3bf124189542b82ab221c972d3d54664
+font_dirs="/usr/share/fonts/TTF"
+
+do_install() {
+	vmkdir usr/share/fonts/TTF
+	vinstall "TerminusTTF-${version}.ttf" 644 usr/share/fonts/TTF/
+	vinstall "TerminusTTF-Bold-${version}.ttf" 644 usr/share/fonts/TTF/
+	vinstall "TerminusTTF-Italic-${version}.ttf" 644 usr/share/fonts/TTF/
+	vinstall "TerminusTTF-Bold Italic-${version}.ttf" 644 usr/share/fonts/TTF/
+}


### PR DESCRIPTION
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)

If you need terminus font in a different size than the bitmap version provides or your app doesn't support bitmap fonts then the TTF version can come handy. It is also the default font for all my applications ( https://github.com/milgra/sov, https://github.com/milgra/wcp, https://github.com/milgra/mmfm, https://github.com/milgra/vmp ) so it would be nice to have it in the source packages collection.