### PR TITLE
python3-ipython: update to 8.11.0.

### DIFF
--- a/srcpkgs/python3-ipython/template
+++ b/srcpkgs/python3-ipython/template
@@ -1,6 +1,6 @@
 # Template file for 'python3-ipython'
 pkgname=python3-ipython
-version=8.10.0
+version=8.11.0
 revision=1
 build_style=python3-module
 hostmakedepends="python3-setuptools"
@@ -14,8 +14,9 @@ short_desc="Enhanced interactive Python3 shell"
 maintainer="Andrew J. Hesford <ajh@sideband.org>"
 license="BSD-3-Clause"
 homepage="https://ipython.org/"
+changelog="https://github.com/ipython/ipython/raw/main/docs/source/whatsnew/version8.rst"
 distfiles="${PYPI_SITE}/i/ipython/ipython-${version}.tar.gz"
-checksum=b13a1d6c1f5818bd388db53b7107d17454129a70de2b87481d555daede5eb49e
+checksum=735cede4099dbc903ee540307b9171fbfef4aa75cfcacc5a273b2cda2f02be04
 conflicts="python-ipython<=5.8.0_2"
 
 do_check() {

--- a/srcpkgs/python3-prompt_toolkit/template
+++ b/srcpkgs/python3-prompt_toolkit/template
@@ -1,6 +1,6 @@
 # Template file for 'python3-prompt_toolkit'
 pkgname=python3-prompt_toolkit
-version=3.0.37
+version=3.0.38
 revision=1
 build_style=python3-module
 hostmakedepends="python3-setuptools"
@@ -12,7 +12,7 @@ license="BSD-3-Clause"
 homepage="https://github.com/prompt-toolkit/python-prompt-toolkit"
 changelog="https://raw.githubusercontent.com/prompt-toolkit/python-prompt-toolkit/master/CHANGELOG"
 distfiles="${PYPI_SITE}/p/prompt_toolkit/prompt_toolkit-${version}.tar.gz"
-checksum=d5d73d4b5eb1a92ba884a88962b157f49b71e06c4348b417dd622b25cdd3800b
+checksum=23ac5d50538a9a38c8bde05fecb47d0b403ecd0662857a86f886f798563d5b9b
 conflicts="python3-prompt_toolkit2<=2.0.9_4"
 
 post_install() {

--- a/srcpkgs/python3-traitlets/template
+++ b/srcpkgs/python3-traitlets/template
@@ -1,6 +1,6 @@
 # Template file for 'python3-traitlets'
 pkgname=python3-traitlets
-version=5.5.0
+version=5.9.0
 revision=1
 build_style=python3-pep517
 hostmakedepends="python3-flit_core hatchling"
@@ -10,12 +10,9 @@ short_desc="Configuration system for Python applications"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="BSD-3-Clause"
 homepage="https://github.com/ipython/traitlets"
+changelog="https://github.com/ipython/traitlets/raw/main/CHANGELOG.md"
 distfiles="${PYPI_SITE}/t/traitlets/traitlets-${version}.tar.gz"
-checksum=b122f9ff2f2f6c1709dab289a05555be011c87828e911c0cf4074b85cb780a79
-
-do_check() {
-	pytest
-}
+checksum=f6cde21a9c68cf756af02035f72d5a723bf607e862e7be33ece505abf4a3bad9
 
 post_install() {
 	vlicense COPYING.md LICENSE


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

Also updates prompt_toolkit and traitlets (the former is necessary: resolves a test failure in the new ipython)

#### Testing the changes
- I tested the changes in this PR: **briefly**

I'm running sagemath with this update, everything seems ok. A couple doctests fail in sagemath due to a new warning, harmless ( see https://github.com/sagemath/sage/pull/35235).

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
