### PR TITLE
nvidia after 455.x no longer require modesetting driver

### DIFF
--- a/srcpkgs/nvidia/files/nvidia-drm-outputclass.conf
+++ b/srcpkgs/nvidia/files/nvidia-drm-outputclass.conf
@@ -4,12 +4,6 @@ Section "ServerLayout"
 EndSection
 
 Section "OutputClass"
-    Identifier "intel"
-    MatchDriver "i915"
-    Driver "modesetting"
-EndSection
-
-Section "OutputClass"
     Identifier "nvidia"
     MatchDriver "nvidia-drm"
     Driver "nvidia"

--- a/srcpkgs/nvidia/template
+++ b/srcpkgs/nvidia/template
@@ -4,7 +4,7 @@ _desc="NVIDIA drivers for linux"
 
 pkgname=nvidia
 version=525.89.02
-revision=1
+revision=2
 maintainer="Andrew Benson <abenson+void@gmail.com>"
 license="custom:NVIDIA Proprietary"
 homepage="https://www.nvidia.com/en-us/drivers/unix/"

--- a/srcpkgs/nvidia470/files/nvidia-drm-outputclass.conf
+++ b/srcpkgs/nvidia470/files/nvidia-drm-outputclass.conf
@@ -4,12 +4,6 @@ Section "ServerLayout"
 EndSection
 
 Section "OutputClass"
-    Identifier "intel"
-    MatchDriver "i915"
-    Driver "modesetting"
-EndSection
-
-Section "OutputClass"
     Identifier "nvidia"
     MatchDriver "nvidia-drm"
     Driver "nvidia"

--- a/srcpkgs/nvidia470/template
+++ b/srcpkgs/nvidia470/template
@@ -4,7 +4,7 @@ _desc="NVIDIA drivers (GKxxx “Kepler”)"
 
 pkgname=nvidia470
 version=470.161.03
-revision=3
+revision=4
 maintainer="Andrew Benson <abenson+void@gmail.com>"
 license="custom:NVIDIA Proprietary"
 homepage="https://www.nvidia.com/en-us/drivers/unix/"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64

This can always be set if someone prefers that, but I've had some strange artifacts with the modesetting driver.  I'm testing now to see if that's fixed by switching back to the Intel DDX.