### PR TITLE
python3-ldap: update to 3.4.3

### DIFF
--- a/srcpkgs/python3-ldap/template
+++ b/srcpkgs/python3-ldap/template
@@ -1,10 +1,9 @@
 # Template file for 'python3-ldap'
 pkgname=python3-ldap
-_pkgname=python-ldap
-version=3.2.0
-revision=5
+version=3.4.3
+revision=1
 build_style=python3-module
-hostmakedepends="python3-setuptools"
+hostmakedepends="python3-setuptools python3-wheel python3-pyasn1-modules"
 makedepends="python3-devel libldap-devel"
 depends="python3-pyasn1-modules"
 checkdepends="openldap openldap-tools"
@@ -12,9 +11,5 @@ short_desc="Python3 modules for implementing LDAP clients"
 maintainer="Michael Aldridge <maldridge@voidlinux.org>"
 license="Python-2.0"
 homepage="https://www.python-ldap.org"
-distfiles="${PYPI_SITE}/p/${_pkgname}/${_pkgname}-${version}.tar.gz"
-checksum=7d1c4b15375a533564aad3d3deade789221e450052b21ebb9720fb822eccdb8e
-
-pre_build() {
-	sed -i "s:^libs = .*:libs = ldap_r lber sasl2 ssl crypto:" setup.cfg
-}
+distfiles="${PYPI_SITE}/p/python-ldap/python-ldap-${version}.tar.gz"
+checksum=ab26c519a0ef2a443a2a10391fa3c5cb52d7871323399db949ebfaa9f25ee2a0


### PR DESCRIPTION
Build was failing after revbump in #41948 
- remove unnecessary sed expression
- simplify distfile url

#### Testing the changes
- I tested the changes in this PR: test suite passes, I don't use this package directly

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for my native architecture, (x86_64-musl)
- I built this PR locally for these architectures:
  - aarch64-musl
  - armv7l
  - armv6l-musl
  - i686