### PR TITLE
android-tools: update to 34.0.0.

### DIFF
--- a/srcpkgs/android-tools/template
+++ b/srcpkgs/android-tools/template
@@ -1,6 +1,6 @@
 # Template file for 'android-tools'
 pkgname=android-tools
-version=33.0.3p2
+version=34.0.0
 revision=1
 archs="armv* aarch64* x86_64* i686* ppc64le*"
 build_style=cmake
@@ -11,9 +11,9 @@ depends="python3"
 short_desc="Android platform tools (adb and fastboot)"
 maintainer="John <me@johnnynator.dev>"
 license="Apache-2.0, ISC, GPL-2.0-only, MIT"
-homepage="http://developer.android.com/tools/help/adb.html"
+homepage="https://developer.android.com/tools/help/adb.html"
 distfiles="https://github.com/nmeum/android-tools/releases/download/${version}/android-tools-${version}.tar.xz"
-checksum=6bf6b52d7389e79fc92b63cc206451ee42fc4f7da769d76922193e98d75f5604
+checksum=f88ec5686937f7fb2f689c3b0506123f2399276a14673164b0f95454a4c7b97a
 
 if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
 	makedepends+=" libatomic-devel"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

@Johnnynator

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
