### PR TITLE
PHP 8.[01] updates

### DIFF
--- a/srcpkgs/composer8.0/template
+++ b/srcpkgs/composer8.0/template
@@ -1,7 +1,7 @@
 # Template file for 'composer8.0'
 pkgname=composer8.0
-version=2.5.3
-revision=2
+version=2.5.4
+revision=1
 build_style=fetch
 depends="php8.0"
 short_desc="Dependency manager for PHP"
@@ -11,7 +11,7 @@ homepage="https://getcomposer.org/"
 changelog="https://raw.githubusercontent.com/composer/composer/main/CHANGELOG.md"
 distfiles="https://github.com/composer/composer/releases/download/${version}/composer.phar
  https://raw.githubusercontent.com/composer/composer/main/LICENSE"
-checksum="2e1061821951c6a5ece033a025d06296d4a1d056fee2f4bebd35815cf4b1b0f9
+checksum="91ce6cbf9463eae86ae9d5c21d42faa601a519f3fbb2b623a55ee24678079bd3
  7855ac293067aebe7e51afdd23b9dea54b8be24187dbecc9b9142581c37f596c"
 alternatives="composer:composer:/usr/bin/composer8.0"
 

--- a/srcpkgs/composer8.1/template
+++ b/srcpkgs/composer8.1/template
@@ -1,7 +1,7 @@
 # Template file for 'composer8.1'
 pkgname=composer8.1
-version=2.5.3
-revision=2
+version=2.5.4
+revision=1
 build_style=fetch
 depends="php8.1"
 short_desc="Dependency manager for PHP"
@@ -11,7 +11,7 @@ homepage="https://getcomposer.org/"
 changelog="https://raw.githubusercontent.com/composer/composer/main/CHANGELOG.md"
 distfiles="https://github.com/composer/composer/releases/download/${version}/composer.phar
  https://raw.githubusercontent.com/composer/composer/main/LICENSE"
-checksum="2e1061821951c6a5ece033a025d06296d4a1d056fee2f4bebd35815cf4b1b0f9
+checksum="91ce6cbf9463eae86ae9d5c21d42faa601a519f3fbb2b623a55ee24678079bd3
  7855ac293067aebe7e51afdd23b9dea54b8be24187dbecc9b9142581c37f596c"
 alternatives="composer:composer:/usr/bin/composer8.1"
 

--- a/srcpkgs/php8.0-igbinary/template
+++ b/srcpkgs/php8.0-igbinary/template
@@ -1,8 +1,7 @@
 # Template file for 'php8.0-igbinary'
 pkgname=php8.0-igbinary
-version=3.2.12
+version=3.2.14
 revision=1
-build_wrksrc=igbinary-$version
 build_style=gnu-configure
 configure_args="--with-php-config=/usr/bin/php-config8.0"
 hostmakedepends="autoconf php8.0-devel"
@@ -13,7 +12,7 @@ maintainer="Joel Beckmeyer <joel@beckmeyer.us>"
 license="BSD-3-Clause"
 homepage="https://github.com/igbinary/igbinary/"
 distfiles="https://pecl.php.net/get/igbinary-${version}.tgz"
-checksum=b69cffdf054cc6e6b02893ff77cf440cec8c7a87d2dc00c1af183c212269581c
+checksum=6337147a4fb888072566674837bda9928ee06ee7f0114b4338b86c816232925d
 
 pre_configure() {
 	phpize8.0

--- a/srcpkgs/php8.0/template
+++ b/srcpkgs/php8.0/template
@@ -1,7 +1,7 @@
 # Template file for 'php8.0'
 pkgname=php8.0
-version=8.0.25
-revision=2
+version=8.0.28
+revision=1
 _php_version=8.0
 hostmakedepends="bison pkg-config apache-devel"
 makedepends="apache-devel enchant2-devel freetds-devel freetype-devel gdbm-devel
@@ -17,7 +17,7 @@ changelog="https://raw.githubusercontent.com/php/php-src/php-${version}/NEWS"
 # this is the source where the www.php.net code pulls the tarballs it serves
 # at https://www.php.net/distributions/
 distfiles="https://github.com/php/web-php-distributions/raw/master/php-${version}.tar.gz"
-checksum=349a2b5a01bfccbc9af8afdf183e57bed3349706a084f3c4694aa4c7ff7cb2e9
+checksum=7432184eae01e4e8e39f03f80e8ec0ca2c8bfebc56e9a7b983541ca8805df22f
 
 conf_files="/etc/php${_php_version}/php.ini"
 

--- a/srcpkgs/php8.1-igbinary/template
+++ b/srcpkgs/php8.1-igbinary/template
@@ -1,8 +1,7 @@
 # Template file for 'php8.1-igbinary'
 pkgname=php8.1-igbinary
-version=3.2.12
+version=3.2.14
 revision=1
-build_wrksrc=igbinary-$version
 build_style=gnu-configure
 configure_args="--with-php-config=/usr/bin/php-config8.1"
 hostmakedepends="autoconf php8.1-devel"
@@ -13,7 +12,7 @@ maintainer="Joel Beckmeyer <joel@beckmeyer.us>"
 license="BSD-3-Clause"
 homepage="https://github.com/igbinary/igbinary/"
 distfiles="https://pecl.php.net/get/igbinary-${version}.tgz"
-checksum=b69cffdf054cc6e6b02893ff77cf440cec8c7a87d2dc00c1af183c212269581c
+checksum=6337147a4fb888072566674837bda9928ee06ee7f0114b4338b86c816232925d
 
 pre_configure() {
 	phpize8.1

--- a/srcpkgs/php8.1/template
+++ b/srcpkgs/php8.1/template
@@ -1,7 +1,7 @@
 # Template file for 'php8.1'
 pkgname=php8.1
-version=8.1.12
-revision=2
+version=8.1.16
+revision=1
 _php_version=8.1
 hostmakedepends="bison pkg-config apache-devel"
 makedepends="apache-devel enchant2-devel freetds-devel freetype-devel gdbm-devel
@@ -17,7 +17,7 @@ changelog="https://raw.githubusercontent.com/php/php-src/php-${version}/NEWS"
 # this is the source where the www.php.net code pulls the tarballs it serves
 # at https://www.php.net/distributions/
 distfiles="https://github.com/php/web-php-distributions/raw/master/php-${version}.tar.gz"
-checksum=e0e7c823c9f9aa4c021f5e34ae1a7acafc2a9f3056ca60eb70a8af8f33da3fdf
+checksum=a929fb9ed3bc364a5dea4f64954e8aaaa3408b87df04d7c6f743a190f5594e84
 
 conf_files="/etc/php${_php_version}/php.ini"
 

--- a/srcpkgs/xdebug8.0/template
+++ b/srcpkgs/xdebug8.0/template
@@ -1,6 +1,6 @@
 # Template file for 'xdebug8.0'
 pkgname=xdebug8.0
-version=3.1.5
+version=3.2.0
 revision=1
 build_style=gnu-configure
 configure_args="--with-php-config=/usr/bin/php-config8.0"
@@ -12,7 +12,7 @@ license="PHP-3.0"
 homepage="http://xdebug.org"
 changelog="https://xdebug.org/updates"
 distfiles="http://xdebug.org/files/xdebug-${version}.tgz"
-checksum=55f6ef381245da079b2fc5ce1cfbcb7961197d0c0e04f9d977613cf9aa969a79
+checksum=7769b20eecdadf5fbe9f582512c10b394fb575b6f7a8c3a3a82db6883e0032b7
 
 pre_configure() {
 	phpize8.0

--- a/srcpkgs/xdebug8.1/template
+++ b/srcpkgs/xdebug8.1/template
@@ -1,6 +1,6 @@
 # Template file for 'xdebug8.1'
 pkgname=xdebug8.1
-version=3.1.5
+version=3.2.0
 revision=1
 build_style=gnu-configure
 configure_args="--with-php-config=/usr/bin/php-config8.1"
@@ -12,7 +12,7 @@ license="PHP-3.0"
 homepage="http://xdebug.org"
 changelog="https://xdebug.org/updates"
 distfiles="http://xdebug.org/files/xdebug-${version}.tgz"
-checksum=55f6ef381245da079b2fc5ce1cfbcb7961197d0c0e04f9d977613cf9aa969a79
+checksum=7769b20eecdadf5fbe9f582512c10b394fb575b6f7a8c3a3a82db6883e0032b7
 
 pre_configure() {
 	phpize8.1


### PR DESCRIPTION
- php8.0: update to 8.0.28.
- php8.1: update to 8.1.16.
- php8.0-igbinary: update to 3.2.14.
- php8.1-igbinary: update to 3.2.14.
- xdebug8.0: update to 3.2.0.
- xdebug8.1: update to 3.2.0.
- composer8.0: update to 2.5.4.
- composer8.1: update to 2.5.4.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
