### PR TITLE
Signal-Desktop: update to 6.9.0.

### DIFF
--- a/srcpkgs/Signal-Desktop/template
+++ b/srcpkgs/Signal-Desktop/template
@@ -1,6 +1,6 @@
 # Template file for 'Signal-Desktop'
 pkgname=Signal-Desktop
-version=6.8.0
+version=6.9.0
 revision=1
 # Signal officially only supports x86_64 
 # x86_64-musl fails because of its dependency on 'node-gyp' which depends on a glibc specific extension
@@ -13,7 +13,7 @@ maintainer="akierig <anelki@fastmail.de>"
 license="AGPL-3.0-only"
 homepage="https://github.com/signalapp/Signal-Desktop"
 distfiles="https://github.com/signalapp/Signal-Desktop/archive/v${version}.tar.gz"
-checksum=0f216192e73f5481682ac683ccc05e134c3f0a386e058944467008f3b24af53c
+checksum=5cf68e2e33c86d1dc53bf9f9c510c2d7871061eecb59d10d6968d46315560185
 nostrip_files="signal-desktop"
 
 post_extract() {


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64