### PR TITLE
python3-markdown-it: update to 2.2.0 [unbreak python3-rich]

### DIFF
--- a/srcpkgs/python3-markdown-it/template
+++ b/srcpkgs/python3-markdown-it/template
@@ -1,6 +1,6 @@
 # Template file for 'python3-markdown-it'
 pkgname=python3-markdown-it
-version=2.1.0
+version=2.2.0
 revision=1
 build_style=python3-pep517
 make_install_target="dist/markdown_it_py-${version}-*-*-*.whl"
@@ -12,7 +12,7 @@ license="MIT"
 homepage="https://github.com/executablebooks/markdown-it-py"
 changelog="https://raw.githubusercontent.com/executablebooks/markdown-it-py/master/CHANGELOG.md"
 distfiles="${PYPI_SITE}/m/markdown-it-py/markdown-it-py-${version}.tar.gz"
-checksum=cf7e59fed14b5ae17c0006eff14a2d9a00ed5f3a846148153899a0224e2c07da
+checksum=7c9a5e412688bc771c67432cbfebcdd686c93ce6484913dccf06cb5a0bea35a1
 # Tests not shipped in PYPI tarball
 make_check=no
 


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture: **x86_64**

python3-rich-13.3.2 needs this version of markdown-it-py
https://github.com/Textualize/rich/blob/v13.3.2/pyproject.toml#L33