### PR TITLE
swirc: update to 3.4.3.

### DIFF
--- a/srcpkgs/swirc/template
+++ b/srcpkgs/swirc/template
@@ -1,6 +1,6 @@
 # Template file for 'swirc'
 pkgname=swirc
-version=3.4.2
+version=3.4.3
 revision=1
 build_style=configure
 configure_args="$(vopt_with notify libnotify)"
@@ -17,7 +17,7 @@ license="BSD-3-Clause, ISC, MIT"
 homepage="https://www.nifty-networks.net/swirc"
 changelog="https://raw.githubusercontent.com/uhlin/swirc/master/CHANGELOG.md"
 distfiles="https://www.nifty-networks.net/swirc/releases/swirc-${version}.tgz"
-checksum=cdfe4d7d5879b40791f759fe94a95dc6b310c54a1c685790fc8d2447ba2fdc97
+checksum=008caf24eedeeeaad85c0f48ee74178545c1467eb55aac5b902fda38d78179c2
 
 build_options="notify"
 build_options_default="notify"


### PR DESCRIPTION
Today I released Swirc 3.4.3 which comes with code improvements and new translations.
No new bugs were fixed/found.

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, **x86_64-musl**
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - armv6l-musl **cross**
