### PR TITLE
android-udev-rules: update to 20230303, adopt.

### DIFF
--- a/srcpkgs/android-udev-rules/template
+++ b/srcpkgs/android-udev-rules/template
@@ -1,13 +1,13 @@
 # Template file for 'android-udev-rules'
 pkgname=android-udev-rules
-version=20230104
+version=20230303
 revision=1
 short_desc="Android udev rules list aimed to be the most comprehensive on the net"
-maintainer="Rien Maertens <rien.maertens@posteo.be>"
+maintainer="Mohammed Anas <triallax@tutanota.com>"
 license="GPL-3.0-or-later"
 homepage="https://github.com/M0Rf30/android-udev-rules"
 distfiles="https://github.com/M0Rf30/android-udev-rules/archive/${version}.tar.gz"
-checksum=d6220afcb6c7b51bd73e01b5260445fe3f072bd3bbdea919955a070a759ad1f7
+checksum=be0ef595f1ff1262696ac63fa2fc16998da02c170b49be461cfc712cd4317a9f
 system_groups="adbusers"
 
 do_install() {


### PR DESCRIPTION
Maintainer did not touch package since June 2020, so adopting it.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
