### PR TITLE
R cran updates

### DIFF
--- a/srcpkgs/R-cran-RColorBrewer/template
+++ b/srcpkgs/R-cran-RColorBrewer/template
@@ -1,10 +1,11 @@
 # Template file for 'R-cran-RColorBrewer'
 pkgname=R-cran-RColorBrewer
-version=1.1r2
-revision=2
+version=1.1r3
+revision=1
 build_style=R-cran
 short_desc="ColorBrewer Palettes"
 maintainer="Florian Wagner <florian@wagner-flo.net>"
 license="Apache-2.0"
 homepage="https://cran.r-project.org/web/packages/RColorBrewer/"
-checksum=f3e9781e84e114b7a88eb099825936cc5ae7276bbba5af94d35adb1b3ea2ccdd
+checksum="4f42f5423c45688b39f492c7892d93f37b4541831c8ffb140364d2bd89031ac0
+ 4f42f5423c45688b39f492c7892d93f37b4541831c8ffb140364d2bd89031ac0"

--- a/srcpkgs/R-cran-RInside/template
+++ b/srcpkgs/R-cran-RInside/template
@@ -1,6 +1,6 @@
 # Template file for 'R-cran-RInside'
 pkgname=R-cran-RInside
-version=0.2.17
+version=0.2.18
 revision=1
 build_style=R-cran
 makedepends="R-cran-Rcpp"
@@ -8,5 +8,6 @@ short_desc="C++ classes to embed R in C++ (and C) applications"
 maintainer="Ben Jargowsky <benjar63@gmail.com>"
 license="GPL-2.0-or-later"
 homepage="https://CRAN.R-project.org/package=RInside"
-checksum=0be28c44ee34cba669a7264d2b99c289230645598ca78e21682559dc31824348
+checksum="805014f0f0a364633e0e3c59100665a089bc455dec80b24f04aaec96466cb736
+ 805014f0f0a364633e0e3c59100665a089bc455dec80b24f04aaec96466cb736"
 shlib_provides="libRInside.so"

--- a/srcpkgs/R-cran-Rcpp/template
+++ b/srcpkgs/R-cran-Rcpp/template
@@ -1,6 +1,6 @@
 # Template file for 'R-cran-Rcpp'
 pkgname=R-cran-Rcpp
-version=1.0.8
+version=1.0.10
 revision=1
 build_style=R-cran
 short_desc="Seamless R and C++ Integration"
@@ -8,5 +8,5 @@ maintainer="Florian Wagner <florian@wagner-flo.net>"
 license="GPL-2.0-or-later"
 homepage="http://www.rcpp.org/"
 changelog="https://raw.githubusercontent.com/RcppCore/Rcpp/master/ChangeLog"
-checksum="879f9296bc045ac4ed464578723bd37fcabbbdaa30aaaf070cf953e329f678ee
- 879f9296bc045ac4ed464578723bd37fcabbbdaa30aaaf070cf953e329f678ee"
+checksum="1e65e24a9981251ab5fc4f9fd65fe4eab4ba0255be3400a8c5abe20b62b5d546
+ 1e65e24a9981251ab5fc4f9fd65fe4eab4ba0255be3400a8c5abe20b62b5d546"

--- a/srcpkgs/R-cran-backports/template
+++ b/srcpkgs/R-cran-backports/template
@@ -1,10 +1,11 @@
 # Template file for 'R-cran-backports'
 pkgname=R-cran-backports
-version=1.2.1
+version=1.4.1
 revision=1
 build_style=R-cran
 short_desc="Reimplementations of Functions Introduced Since R-3.0.0"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-only, GPL-3.0-only"
 homepage="https://github.com/r-lib/backports"
-checksum=a2834bbd57e305e5d8010322f1906ea1789b3b5ba5eca77c5ff4248aceb7c2d5
+checksum="845c3c59fbb05e5a892c4231b955a0afdd331d82b7cc815bcff0672023242474
+ 845c3c59fbb05e5a892c4231b955a0afdd331d82b7cc815bcff0672023242474"

--- a/srcpkgs/R-cran-brio/template
+++ b/srcpkgs/R-cran-brio/template
@@ -1,0 +1,16 @@
+# Template file for 'R-cran-brio'
+pkgname=R-cran-brio
+version=1.1.3
+revision=1
+build_style=R-cran
+short_desc="Basic R Input Output"
+maintainer="Hervy Qurrotul Ainur Rozi <hervyqa@proton.me>"
+license="MIT"
+homepage="https://brio.r-lib.org/"
+changelog="https://raw.githubusercontent.com/r-lib/brio/main/NEWS.md"
+checksum="eaa89041856189bee545bf1c42c7920a0bb0f1f70bb477487c467ee3e8fedcc6
+ eaa89041856189bee545bf1c42c7920a0bb0f1f70bb477487c467ee3e8fedcc6"
+
+post_install() {
+	vlicense LICENSE
+}

--- a/srcpkgs/R-cran-callr/template
+++ b/srcpkgs/R-cran-callr/template
@@ -1,6 +1,6 @@
 # Template file for 'R-cran-callr'
 pkgname=R-cran-callr
-version=3.5.1
+version=3.7.3
 revision=1
 build_style=R-cran
 hostmakedepends="R-cran-processx R-cran-R6"
@@ -9,7 +9,8 @@ short_desc="Call R from R"
 maintainer="Luke Hannan <lukehannan@gmail.com>"
 license="MIT"
 homepage="https://github.com/r-lib/callr"
-checksum=ce338c648cc9ab501168a55f93e68fc81e31dc5ec881e908b5b4a9d6f5bd8696
+checksum="567bfedf073a1d4c5785f0553341608a214938110567b9a6495ff20ebb2fd04e
+ 567bfedf073a1d4c5785f0553341608a214938110567b9a6495ff20ebb2fd04e"
 
 post_install() {
 	vlicense LICENSE

--- a/srcpkgs/R-cran-cli/template
+++ b/srcpkgs/R-cran-cli/template
@@ -1,6 +1,6 @@
 # Template file for 'R-cran-cli'
 pkgname=R-cran-cli
-version=3.4.1
+version=3.6.0
 revision=1
 build_style=R-cran
 makedepends="R-cran-assertthat R-cran-glue"
@@ -9,8 +9,8 @@ short_desc="Helpers for Developing Command Line Interfaces"
 maintainer="Cameron Nemo <cam@nohom.org>"
 license="MIT"
 homepage="https://github.com/r-lib/cli/"
-checksum="1c585efbfd8b8685c66fac34bcb60f28c351691bb4b9931df214e6e47fd9744e
- 1c585efbfd8b8685c66fac34bcb60f28c351691bb4b9931df214e6e47fd9744e"
+checksum="b6078131803043d53d4e670aa3a0506f614e0b40fda8e0102afd48a6188ab896
+ b6078131803043d53d4e670aa3a0506f614e0b40fda8e0102afd48a6188ab896"
 
 post_install() {
 	vlicense LICENSE

--- a/srcpkgs/R-cran-colorspace/template
+++ b/srcpkgs/R-cran-colorspace/template
@@ -1,14 +1,14 @@
 # Template file for 'R-cran-colorspace'
 pkgname=R-cran-colorspace
-version=2.0r3
+version=2.1r0
 revision=1
 build_style=R-cran
 short_desc="Color Space Manipulation"
 maintainer="Cameron Nemo <cam@nohom.org>"
 license="BSD-3-Clause"
 homepage="http://www.hclwizard.org/r-colorspace/"
-checksum="e75681cc4dd6e4b70303fd96a6d4597065dc6bffcaa4ae4244b73ff19016857f
- e75681cc4dd6e4b70303fd96a6d4597065dc6bffcaa4ae4244b73ff19016857f"
+checksum="04078abb6b54119c90dc7085d62916bf292ccb163e213f9ea70567d1be82614c
+ 04078abb6b54119c90dc7085d62916bf292ccb163e213f9ea70567d1be82614c"
 
 post_install() {
 	vlicense LICENSE

--- a/srcpkgs/R-cran-data.table/template
+++ b/srcpkgs/R-cran-data.table/template
@@ -1,6 +1,6 @@
 # Template file for 'R-cran-data.table'
 pkgname=R-cran-data.table
-version=1.14.0
+version=1.14.8
 revision=1
 build_style=R-cran
 makedepends="libgomp-devel pkg-config zlib-devel"
@@ -8,4 +8,5 @@ short_desc="Extension of 'data.frame'"
 maintainer="Florian Wagner <florian@wagner-flo.net>"
 license="MPL-2.0"
 homepage="https://github.com/Rdatatable/data.table/wiki"
-checksum=13f1de244e7fa90fadfb0be964db5ffb324ca024d5f136feb4578b5daedaeb4d
+checksum="14b2ce5367df9c9bb58f373555066f5dcb629c156149b5565de36d69557139fd
+ 14b2ce5367df9c9bb58f373555066f5dcb629c156149b5565de36d69557139fd"

--- a/srcpkgs/R-cran-desc/template
+++ b/srcpkgs/R-cran-desc/template
@@ -1,15 +1,17 @@
 # Template file for 'R-cran-desc'
 pkgname=R-cran-desc
-version=1.2.0
-revision=2
+version=1.4.2
+revision=1
 build_style=R-cran
-hostmakedepends="R-cran-assertthat R-cran-crayon R-cran-R6 R-cran-rprojroot"
-depends="R-cran-assertthat R-cran-crayon R-cran-R6 R-cran-rprojroot"
+hostmakedepends="R-cran-assertthat R-cran-cli R-cran-crayon R-cran-R6
+ R-cran-rprojroot"
+depends="R-cran-assertthat R-cran-cli R-cran-crayon R-cran-R6 R-cran-rprojroot"
 short_desc="Manipulate DESCRIPTION Files"
 maintainer="Luke Hannan <lukehannan@gmail.com>"
 license="MIT"
 homepage="https://github.com/r-lib/desc"
-checksum=e66fb5d4fc7974bc558abcdc107a1f258c9177a29dcfcf9164bc6b33dd08dae8
+checksum="758acf14be478c09ba7e84ade3a7ce512becf35d44e5e6a997b932065f2a227c
+ 758acf14be478c09ba7e84ade3a7ce512becf35d44e5e6a997b932065f2a227c"
 
 post_install() {
 	vlicense LICENSE

--- a/srcpkgs/R-cran-diffobj/template
+++ b/srcpkgs/R-cran-diffobj/template
@@ -1,0 +1,14 @@
+# Template file for 'R-cran-diffobj'
+pkgname=R-cran-diffobj
+version=0.3.5
+revision=1
+build_style=R-cran
+makedepends="R-cran-crayon"
+depends="R-cran-crayon"
+short_desc="Diffs for R Objects"
+maintainer="Hervy Qurrotul Ainur Rozi <hervyqa@proton.me>"
+license="GPL-2.0-or-later"
+homepage="https://github.com/brodieG/diffobj"
+changelog="https://raw.githubusercontent.com/brodieG/diffobj/master/NEWS.md"
+checksum="d860a79b1d4c9e369282d7391b539fe89228954854a65ba47181407c53e3cf60
+ d860a79b1d4c9e369282d7391b539fe89228954854a65ba47181407c53e3cf60"

--- a/srcpkgs/R-cran-digest/template
+++ b/srcpkgs/R-cran-digest/template
@@ -1,6 +1,6 @@
 # Template file for 'R-cran-digest'
 pkgname=R-cran-digest
-version=0.6.29
+version=0.6.31
 revision=1
 build_style=R-cran
 short_desc="Create Compact Hash Digests of R Objects"
@@ -8,5 +8,5 @@ maintainer="Cameron Nemo <cam@nohom.org>"
 license="GPL-2.0-or-later"
 homepage="http://dirk.eddelbuettel.com/code/digest.html"
 changelog="https://github.com/eddelbuettel/digest/raw/master/ChangeLog"
-checksum="792c1f14a4c8047745152f5e45ce7351978af8d770c29d2ea39c7acd5d619cd9
- 792c1f14a4c8047745152f5e45ce7351978af8d770c29d2ea39c7acd5d619cd9"
+checksum="5a284f490eaca6750f695f00a584cfca3f180ca1046ac1107202141149d431b9
+ 5a284f490eaca6750f695f00a584cfca3f180ca1046ac1107202141149d431b9"

--- a/srcpkgs/R-cran-dplyr/template
+++ b/srcpkgs/R-cran-dplyr/template
@@ -1,6 +1,6 @@
 # Template file for 'R-cran-dplyr'
 pkgname=R-cran-dplyr
-version=1.0.10
+version=1.1.0
 revision=1
 build_style=R-cran
 makedepends="R-cran-ellipsis R-cran-generics R-cran-glue R-cran-lifecycle
@@ -13,8 +13,8 @@ short_desc="Grammar of Data Manipulation for R"
 maintainer="Cameron Nemo <cam@nohom.org>"
 license="MIT"
 homepage="https://dplyr.tidyverse.org/"
-checksum="3ab639f627b4e439052df18f193f0ccab223225a4ae2ff8c18aba4f9807e0f2b
- 3ab639f627b4e439052df18f193f0ccab223225a4ae2ff8c18aba4f9807e0f2b"
+checksum="8cb0535e49dd40b3054046735738f1e48507ac9a56b015d16ebcb54593b84ed7
+ 8cb0535e49dd40b3054046735738f1e48507ac9a56b015d16ebcb54593b84ed7"
 
 post_install() {
 	vlicense LICENSE

--- a/srcpkgs/R-cran-evaluate/template
+++ b/srcpkgs/R-cran-evaluate/template
@@ -1,13 +1,14 @@
 # Template file for 'R-cran-evaluate'
 pkgname=R-cran-evaluate
-version=0.14
-revision=2
+version=0.20
+revision=1
 build_style=R-cran
 short_desc="Parsing and Evaluation Tools that Provide More Details than the Default"
 maintainer="luhann <lukehannan@gmail.com>"
 license="MIT"
 homepage="https://github.com/r-lib/evaluate"
-checksum=a8c88bdbe4e60046d95ddf7e181ee15a6f41cdf92127c9678f6f3d328a3c5e28
+checksum="35f5d9e85603600b58960923d591c5ca1115153febba7c612867d8b5598afff0
+ 35f5d9e85603600b58960923d591c5ca1115153febba7c612867d8b5598afff0"
 
 post_install() {
 	vlicense LICENSE

--- a/srcpkgs/R-cran-fansi/template
+++ b/srcpkgs/R-cran-fansi/template
@@ -1,11 +1,11 @@
 # Template file for 'R-cran-fansi'
 pkgname=R-cran-fansi
-version=1.0.3
+version=1.0.4
 revision=1
 build_style=R-cran
 short_desc="ANSI Control Sequence Aware String Functions"
 maintainer="Cameron Nemo <cam@nohom.org>"
 license="GPL-2.0-or-later"
 homepage="https://cran.r-project.org/web/packages/fansi/index.html"
-checksum="86a7b83d8c9d28baebbde310cd0b459d0950a9c7ff1a6276ce5858f6a89bc06a
- 86a7b83d8c9d28baebbde310cd0b459d0950a9c7ff1a6276ce5858f6a89bc06a"
+checksum="3163214e6c40922bbb495229259ed8ce1bebd98b77098a6936d234e43da9c49f
+ 3163214e6c40922bbb495229259ed8ce1bebd98b77098a6936d234e43da9c49f"

--- a/srcpkgs/R-cran-fs/template
+++ b/srcpkgs/R-cran-fs/template
@@ -1,0 +1,16 @@
+# Template file for 'R-cran-fs'
+pkgname=R-cran-fs
+version=1.6.1
+revision=1
+build_style=R-cran
+short_desc="Cross-Platform File System Operations Based on libuv"
+maintainer="Hervy Qurrotul Ainur Rozi <hervyqa@proton.me>"
+license="MIT"
+homepage="https://fs.r-lib.org/"
+changelog="https://raw.githubusercontent.com/r-lib/fs/main/NEWS.md"
+checksum="faf1e421a2c270c60c0a30c74e1a48faad45b339163716102d77d64d23d76732
+ faf1e421a2c270c60c0a30c74e1a48faad45b339163716102d77d64d23d76732"
+
+post_install() {
+	vlicense LICENSE
+}

--- a/srcpkgs/R-cran-ggplot2/template
+++ b/srcpkgs/R-cran-ggplot2/template
@@ -1,6 +1,6 @@
 # Template file for 'R-cran-ggplot2'
 pkgname=R-cran-ggplot2
-version=3.3.6
+version=3.4.1
 revision=1
 build_style=R-cran
 makedepends="R-cran-digest R-cran-glue R-cran-gtable R-cran-isoband
@@ -11,5 +11,5 @@ short_desc="Create Elegant Data Visualisations Using the Grammar of Graphics"
 maintainer="Florian Wagner <florian@wagner-flo.net>"
 license="GPL-2.0-only"
 homepage="https://ggplot2.tidyverse.org/"
-checksum="bfcb4eb92a0fcd3fab713aca4bb25e916e05914f2540271a45522ad7e43943a9
- bfcb4eb92a0fcd3fab713aca4bb25e916e05914f2540271a45522ad7e43943a9"
+checksum="041bc333f90d6026702c8bd5140a1c8ddd270b15742badf8ca5c53f0e02c6d84
+ 041bc333f90d6026702c8bd5140a1c8ddd270b15742badf8ca5c53f0e02c6d84"

--- a/srcpkgs/R-cran-gtable/template
+++ b/srcpkgs/R-cran-gtable/template
@@ -1,10 +1,11 @@
 # Template file for 'R-cran-gtable'
 pkgname=R-cran-gtable
-version=0.3.0
-revision=2
+version=0.3.1
+revision=1
 build_style=R-cran
 short_desc="Arrange 'Grobs' in Tables"
 maintainer="Florian Wagner <florian@wagner-flo.net>"
 license="GPL-2.0-only"
 homepage="https://cran.r-project.org/web/packages/gtable/"
-checksum=fd386cc4610b1cc7627dac34dba8367f7efe114b968503027fb2e1265c67d6d3
+checksum="8bd62c5722d5188914d667cabab12991c555f657f4f5ce7b547571ae3aec7cb5
+ 8bd62c5722d5188914d667cabab12991c555f657f4f5ce7b547571ae3aec7cb5"

--- a/srcpkgs/R-cran-isoband/template
+++ b/srcpkgs/R-cran-isoband/template
@@ -1,14 +1,14 @@
 # Template file for 'R-cran-isoband'
 pkgname=R-cran-isoband
-version=0.2.5
+version=0.2.7
 revision=1
 build_style=R-cran
 short_desc="Generate Isolines and Isobands from Regularly Spaced Elevation Grids"
 maintainer="Luke Hannan <lukehannan@gmail.com>"
 license="MIT"
 homepage="https://github.com/wilkelab/isoband"
-checksum="46f53fa066f0966f02cb2bf050190c0d5e950dab2cdf565feb63fc092c886ba5
- 46f53fa066f0966f02cb2bf050190c0d5e950dab2cdf565feb63fc092c886ba5"
+checksum="7693223343b45b86de2b5b638ff148f0dafa6d7b1237e822c5272902f79cdf61
+ 7693223343b45b86de2b5b638ff148f0dafa6d7b1237e822c5272902f79cdf61"
 
 post_install() {
 	vlicense LICENSE

--- a/srcpkgs/R-cran-jsonlite/template
+++ b/srcpkgs/R-cran-jsonlite/template
@@ -1,0 +1,16 @@
+# Template file for 'R-cran-jsonlite'
+pkgname=R-cran-jsonlite
+version=1.8.4
+revision=1
+build_style=R-cran
+short_desc="Simple and Robust JSON Parser and Generator for R"
+maintainer="Hervy Qurrotul Ainur Rozi <hervyqa@proton.me>"
+license="MIT"
+homepage="https://github.com/jeroen/jsonlite"
+changelog="https://raw.githubusercontent.com/jeroen/jsonlite/master/NEWS"
+checksum="79eaabe042226b0918aa828cc63d54fee8be67ae7c67f5e0d3010f468efb1278
+ 79eaabe042226b0918aa828cc63d54fee8be67ae7c67f5e0d3010f468efb1278"
+
+post_install() {
+	vlicense LICENSE
+}

--- a/srcpkgs/R-cran-lubridate/template
+++ b/srcpkgs/R-cran-lubridate/template
@@ -1,14 +1,14 @@
 # Template file for 'R-cran-lubridate'
 pkgname=R-cran-lubridate
-version=1.7.9
-revision=3
+version=1.9.2
+revision=1
 build_style=R-cran
-makedepends="R-cran-generics R-cran-Rcpp"
-depends="R-cran-generics R-cran-Rcpp>=0.12.13"
+makedepends="R-cran-generics R-cran-Rcpp R-cran-timechange"
+depends="R-cran-generics R-cran-Rcpp>=0.12.13 R-cran-timechange"
 short_desc="Make Dealing with Dates a Little Easier"
 maintainer="Florian Wagner <florian@wagner-flo.net>"
 license="GPL-2.0-or-later"
 homepage="https://github.com/tidyverse/lubridate"
 changelog="https://raw.githubusercontent.com/tidyverse/lubridate/main/NEWS.md"
-distfiles="https://src.fedoraproject.org/repo/pkgs/R-lubridate/lubridate_${version}.tar.gz/sha512/344cb68f9943f9cec50a191fa7d6527d5f5c5dbb6d967f5d90088bda8d2997fbfe3e729d06afa95cfdb634dbf396c1c7b0a60338bd417f34741e30f60087daec/lubridate_${version}.tar.gz"
-checksum=cbf95ee07323f3912a98f3cfdae04258d7ce1edb259787f284e2be3cddfed272
+checksum="8976431a4affe989261cbaa5e09cd44bb42a3b16eed59a42c1698da34c6544a7
+ 8976431a4affe989261cbaa5e09cd44bb42a3b16eed59a42c1698da34c6544a7"

--- a/srcpkgs/R-cran-nloptr/template
+++ b/srcpkgs/R-cran-nloptr/template
@@ -1,12 +1,13 @@
 # Template file for 'R-cran-nloptr'
 pkgname=R-cran-nloptr
-version=1.2.2.2
-revision=2
+version=2.0.3
+revision=1
 build_style=R-cran
-hostmakedepends="pkg-config"
-makedepends="nlopt-devel"
+hostmakedepends="pkg-config R-cran-testthat"
+makedepends="nlopt-devel openblas-devel"
 short_desc="R interface to NLopt"
-maintainer="Orphaned <orphan@voidlinux.org>"
+maintainer="Hervy Qurrotul Ainur Rozi <hervyqa@proton.me>"
 license="LGPL-3.0-only"
-homepage="https://cran.r-project.org/package=nloptr"
-checksum=e80ea9619ac18f4bfe44812198b40b9ae5c0ddf3f9cc91778f9ccc82168d1372
+homepage="https://astamm.github.io/nloptr/index.html"
+checksum="7b26ac1246fd1bd890817b0c3a145456c11aec98458b8518de863650b99616d7
+ 7b26ac1246fd1bd890817b0c3a145456c11aec98458b8518de863650b99616d7"

--- a/srcpkgs/R-cran-pkgbuild/template
+++ b/srcpkgs/R-cran-pkgbuild/template
@@ -1,7 +1,7 @@
 # Template file for 'R-cran-pkgbuild'
 pkgname=R-cran-pkgbuild
-version=1.1.0
-revision=2
+version=1.4.0
+revision=1
 build_style=R-cran
 hostmakedepends="R-cran-callr R-cran-cli R-cran-crayon R-cran-desc
  R-cran-prettyunits R-cran-R6 R-cran-rprojroot R-cran-withr"
@@ -11,4 +11,5 @@ short_desc="Find Tools Needed to Build R Packages"
 maintainer="Luke Hannan <lukehannan@gmail.com>"
 license="GPL-3.0-only"
 homepage="https://github.com/r-lib/pkgbuild"
-checksum=b39bfb7661fc53f88962e2380fa9ded2e323c6ad43ac6b582195c749b0ccabbd
+checksum="357f3c40c99650eaa8a715991ff1355a553acb165f217ed204712f698ba55ed6
+ 357f3c40c99650eaa8a715991ff1355a553acb165f217ed204712f698ba55ed6"

--- a/srcpkgs/R-cran-pkgload/template
+++ b/srcpkgs/R-cran-pkgload/template
@@ -1,14 +1,15 @@
 # Template file for 'R-cran-pkgload'
 pkgname=R-cran-pkgload
-version=1.1.0
-revision=2
+version=1.3.2
+revision=1
 build_style=R-cran
-hostmakedepends="R-cran-cli R-cran-crayon R-cran-desc R-cran-pkgbuild
+hostmakedepends="R-cran-cli R-cran-crayon R-cran-desc R-cran-fs R-cran-pkgbuild
  R-cran-rlang R-cran-rprojroot R-cran-rstudioapi R-cran-withr"
-depends="R-cran-cli R-cran-crayon R-cran-desc R-cran-pkgbuild
+depends="R-cran-cli R-cran-crayon R-cran-desc R-cran-fs R-cran-pkgbuild
  R-cran-rlang R-cran-rprojroot R-cran-rstudioapi R-cran-withr"
 short_desc="Simulate Package Installation and Attach"
 maintainer="Luke Hannan <lukehannan@gmail.com>"
 license="GPL-3.0-only"
 homepage="https://github.com/r-lib/pkgload"
-checksum=189d460dbba2b35fa15dd59ce832df252dfa654a5acee0c9a8471b4d70477b0d
+checksum="35d19a032bfeeefcab92d76a768b4a420c2ede0920badaf48cca878592b46b2f
+ 35d19a032bfeeefcab92d76a768b4a420c2ede0920badaf48cca878592b46b2f"

--- a/srcpkgs/R-cran-plyr/template
+++ b/srcpkgs/R-cran-plyr/template
@@ -1,7 +1,7 @@
 # Template file for 'R-cran-plyr'
 pkgname=R-cran-plyr
-version=1.8.6
-revision=3
+version=1.8.8
+revision=1
 build_style=R-cran
 makedepends="R-cran-Rcpp"
 depends="R-cran-Rcpp>=0.11.0"
@@ -9,7 +9,8 @@ short_desc="Tools for Splitting, Applying and Combining Data"
 maintainer="Florian Wagner <florian@wagner-flo.net>"
 license="MIT"
 homepage="http://had.co.nz/plyr/"
-checksum=ea55d26f155443e9774769531daa5d4c20a0697bb53abd832e891b126c935287
+checksum="a73211b4bbe13e4e5e764966a8dd90172c1cc311938dd464d142e1c7a701070c
+ a73211b4bbe13e4e5e764966a8dd90172c1cc311938dd464d142e1c7a701070c"
 
 post_install() {
 	vlicense LICENSE

--- a/srcpkgs/R-cran-processx/template
+++ b/srcpkgs/R-cran-processx/template
@@ -1,6 +1,6 @@
 # Template file for 'R-cran-processx'
 pkgname=R-cran-processx
-version=3.4.4
+version=3.8.0
 revision=1
 build_style=R-cran
 hostmakedepends="R-cran-ps R-cran-R6"
@@ -9,7 +9,8 @@ short_desc="Execute and Control System Processes"
 maintainer="Luke Hannan <lukehannan@gmail.com>"
 license="MIT"
 homepage="https://github.com/r-lib/processx"
-checksum=aaa40f10a6670eeb451e038bc0eb7c16f263dacb797f76d965b9fc75dda7482b
+checksum="9270d9d26c4314151062801a5c1fc57556b4fcb41dbf3558cb5bd230b18ffb0b
+ 9270d9d26c4314151062801a5c1fc57556b4fcb41dbf3558cb5bd230b18ffb0b"
 
 post_install() {
 	vlicense LICENSE

--- a/srcpkgs/R-cran-ps/template
+++ b/srcpkgs/R-cran-ps/template
@@ -1,13 +1,14 @@
 # Template file for 'R-cran-ps'
 pkgname=R-cran-ps
-version=1.4.0
+version=1.7.2
 revision=1
 build_style=R-cran
 short_desc="List, Query, Manipulate System Processes"
 maintainer="Luke Hannan <lukehannan@gmail.com>"
 license="MIT"
 homepage="https://github.com/r-lib/ps"
-checksum=5f79ae4489090e07abbea892049ec0db900d31955237b388664289e6dc00da7a
+checksum="9225ebdedb5c1b245bb38b01ce88084c0fc7eafcff6c4fda2e299003ace6b21a
+ 9225ebdedb5c1b245bb38b01ce88084c0fc7eafcff6c4fda2e299003ace6b21a"
 
 post_install() {
 	vlicense LICENSE

--- a/srcpkgs/R-cran-purrr/template
+++ b/srcpkgs/R-cran-purrr/template
@@ -1,13 +1,15 @@
 # Template file for 'R-cran-purrr'
 pkgname=R-cran-purrr
-version=0.3.5
+version=1.0.1
 revision=1
 build_style=R-cran
-makedepends="R-cran-magrittr R-cran-rlang"
-depends="R-cran-magrittr>=1.5 R-cran-rlang>=0.3.1"
+makedepends="R-cran-cli R-cran-lifecycle R-cran-magrittr R-cran-rlang
+ R-cran-vctrs"
+depends="R-cran-cli R-cran-lifecycle R-cran-magrittr R-cran-rlang
+ R-cran-vctrs"
 short_desc="Backend for selecting functions of the tidyverse"
 maintainer="Cameron Nemo <cam@nohom.org>"
 license="GPL-3.0-or-later"
 homepage="https://purrr.tidyverse.org/"
-checksum="a2386cd7e78a043cb9c14703023fff15ab1c879bf648816879d2c0c4a554fcef
- a2386cd7e78a043cb9c14703023fff15ab1c879bf648816879d2c0c4a554fcef"
+checksum="0a7911be3539355a4c40d136f2602befcaaad5a3f7222078500bfb969a6f2ba2
+ 0a7911be3539355a4c40d136f2602befcaaad5a3f7222078500bfb969a6f2ba2"

--- a/srcpkgs/R-cran-rematch2/template
+++ b/srcpkgs/R-cran-rematch2/template
@@ -1,0 +1,18 @@
+# Template file for 'R-cran-rematch2'
+pkgname=R-cran-rematch2
+version=2.1.2
+revision=1
+build_style=R-cran
+makedepends="R-cran-tibble"
+depends="R-cran-tibble"
+short_desc="Tidy Output from Regular Expression Matching"
+maintainer="Hervy Qurrotul Ainur Rozi <hervyqa@proton.me>"
+license="MIT"
+homepage="https://github.com/r-lib/rematch2"
+changelog="https://raw.githubusercontent.com/r-lib/rematch2/main/NEWS.md"
+checksum="fe9cbfe99dd7731a0a2a310900d999f80e7486775b67f3f8f388c30737faf7bb
+ fe9cbfe99dd7731a0a2a310900d999f80e7486775b67f3f8f388c30737faf7bb"
+
+post_install() {
+	vlicense LICENSE
+}

--- a/srcpkgs/R-cran-rprojroot/template
+++ b/srcpkgs/R-cran-rprojroot/template
@@ -1,10 +1,11 @@
 # Template file for 'R-cran-rprojroot'
 pkgname=R-cran-rprojroot
-version=2.0.2
+version=2.0.3
 revision=1
 build_style=R-cran
 short_desc="Finding Files in Project Subdirectories"
 maintainer="Luke Hannan <lukehannan@gmail.com>"
 license="GPL-3.0-only"
-homepage="https://github.com/r-lib/rprojroot"
-checksum=5fa161f0d4ac3b7a99dc6aa2d832251001dc92e93c828593a51fe90afd019e1f
+homepage="https://rprojroot.r-lib.org/"
+checksum="50604247470e910cecfe9b76df754bf96a0d701f81b732f7aa9c90a20d30f897
+ 50604247470e910cecfe9b76df754bf96a0d701f81b732f7aa9c90a20d30f897"

--- a/srcpkgs/R-cran-rstudioapi/template
+++ b/srcpkgs/R-cran-rstudioapi/template
@@ -1,13 +1,14 @@
 # Template file for 'R-cran-rstudioapi'
 pkgname=R-cran-rstudioapi
-version=0.13
+version=0.14
 revision=1
 build_style=R-cran
 short_desc="Safely Access the RStudio API"
 maintainer="Luke Hannan <lukehannan@gmail.com>"
 license="MIT"
 homepage="https://github.com/rstudio/rstudioapi"
-checksum=aac35bbdcb4a8e8caba943bc8a2b98120e8940b80cd1020224bb1a26ff776d8b
+checksum="469d0987b1ad728a96c363a422fba712a5cebc8b11a5f7e953b4a671044dafc4
+ 469d0987b1ad728a96c363a422fba712a5cebc8b11a5f7e953b4a671044dafc4"
 
 post_install() {
 	vlicense LICENSE

--- a/srcpkgs/R-cran-scales/template
+++ b/srcpkgs/R-cran-scales/template
@@ -1,7 +1,7 @@
 # Template file for 'R-cran-scales'
 pkgname=R-cran-scales
-version=1.1.1
-revision=2
+version=1.2.1
+revision=1
 build_style=R-cran
 makedepends="R-cran-RColorBrewer R-cran-farver
  R-cran-munsell R-cran-labeling R-cran-R6
@@ -13,7 +13,8 @@ short_desc="Scale Functions for Visualization"
 maintainer="Florian Wagner <florian@wagner-flo.net>"
 license="MIT"
 homepage="https://github.com/hadley/scales"
-checksum=40b2b66522f1f314a20fd09426011b0cdc9d16b23ee2e765fe1930292dd03705
+checksum="59453e6dbdafee93dfb101e4d86048a62a12898134259d3ef02d65aeec57ed08
+ 59453e6dbdafee93dfb101e4d86048a62a12898134259d3ef02d65aeec57ed08"
 
 post_install() {
 	vlicense LICENSE

--- a/srcpkgs/R-cran-stringi/template
+++ b/srcpkgs/R-cran-stringi/template
@@ -1,14 +1,15 @@
 # Template file for 'R-cran-stringi'
 pkgname=R-cran-stringi
-version=1.7.3
-revision=3
+version=1.7.8
+revision=1
 build_style=R-cran
 makedepends="pkg-config icu-devel"
 short_desc="Character String Processing Facilities"
 maintainer="Florian Wagner <florian@wagner-flo.net>"
 license="BSD-3-Clause"
 homepage="http://gagolewski.com/software/stringi/"
-checksum=d98632f1d7dc22e0a190315ee3c435146894e18ef586adbeb80ad526673b1f56
+checksum="538918b1cd6ed1d8a2dd5ab146ba800a088e99f93c52dcd82615b6e127478b1c
+ 538918b1cd6ed1d8a2dd5ab146ba800a088e99f93c52dcd82615b6e127478b1c"
 
 post_install() {
 	vlicense LICENSE

--- a/srcpkgs/R-cran-stringr/template
+++ b/srcpkgs/R-cran-stringr/template
@@ -1,12 +1,15 @@
 # Template file for 'R-cran-stringr'
 pkgname=R-cran-stringr
-version=1.4.0
-revision=2
+version=1.5.0
+revision=1
 build_style=R-cran
-makedepends="R-cran-stringi R-cran-magrittr R-cran-glue"
-depends="R-cran-stringi>=1.1.7 R-cran-magrittr R-cran-glue>=1.2.0"
+makedepends="R-cran-cli R-cran-glue R-cran-lifecycle R-cran-rlang
+ R-cran-stringi R-cran-magrittr R-cran-vctrs"
+depends="R-cran-glue>=1.6.1 R-cran-lifecycle>=1.0.3 R-cran-stringi>=1.5.3
+ R-cran-magrittr R-cran-vctrs"
 short_desc="Simple, Consistent Wrappers for Common String Operations"
 maintainer="Florian Wagner <florian@wagner-flo.net>"
 license="GPL-2.0-or-later"
 homepage="https://stringr.tidyverse.org"
-checksum=87604d2d3a9ad8fd68444ce0865b59e2ffbdb548a38d6634796bbd83eeb931dd
+checksum="52b159d7700a139111b4caf939e7c9c6ab3e01185181400d70a74c552826633a
+ 52b159d7700a139111b4caf939e7c9c6ab3e01185181400d70a74c552826633a"

--- a/srcpkgs/R-cran-svglite/template
+++ b/srcpkgs/R-cran-svglite/template
@@ -1,6 +1,6 @@
 # Template file for 'R-cran-svglite'
 pkgname=R-cran-svglite
-version=2.1.0
+version=2.1.1
 revision=1
 build_style=R-cran
 makedepends="R-cran-systemfonts R-cran-cpp11 libpng-devel"
@@ -9,5 +9,5 @@ short_desc="Lightweight svg graphics device for R"
 maintainer="Cameron Nemo <cam@nohom.org>"
 license="GPL-2.0-or-later"
 homepage="https://svglite.r-lib.org"
-checksum="ad40f590c7e80ae83001a3826b6e8394ba733446ed51fd55faeda974ab839c9b
- ad40f590c7e80ae83001a3826b6e8394ba733446ed51fd55faeda974ab839c9b"
+checksum="48700169eec1b05dbee9e2bae000aa84c544617b018cb3ac431a128cfd8dac56
+ 48700169eec1b05dbee9e2bae000aa84c544617b018cb3ac431a128cfd8dac56"

--- a/srcpkgs/R-cran-testthat/template
+++ b/srcpkgs/R-cran-testthat/template
@@ -1,19 +1,22 @@
 # Template file for 'R-cran-testthat'
 pkgname=R-cran-testthat
-version=2.3.2
-revision=2
+version=3.1.6
+revision=1
 build_style=R-cran
-hostmakedepends="R-cran-cli R-cran-crayon R-cran-digest R-cran-ellipsis
- R-cran-evaluate R-cran-magrittr R-cran-pkgload R-cran-praise R-cran-R6
- R-cran-rlang R-cran-withr"
-depends="R-cran-cli R-cran-crayon R-cran-digest R-cran-ellipsis
- R-cran-evaluate R-cran-magrittr R-cran-pkgload R-cran-praise R-cran-R6
- R-cran-rlang R-cran-withr"
+hostmakedepends="R-cran-brio R-cran-callr R-cran-cli R-cran-desc R-cran-digest
+ R-cran-ellipsis R-cran-evaluate R-cran-jsonlite R-cran-lifecycle
+ R-cran-magrittr R-cran-pkgload R-cran-praise R-cran-processx
+ R-cran-ps R-cran-R6 R-cran-rlang R-cran-waldo R-cran-withr"
+depends="R-cran-brio R-cran-callr R-cran-cli R-cran-desc R-cran-digest
+ R-cran-ellipsis R-cran-evaluate R-cran-jsonlite R-cran-lifecycle
+ R-cran-magrittr R-cran-pkgload R-cran-praise R-cran-processx
+ R-cran-ps R-cran-R6 R-cran-rlang R-cran-waldo R-cran-withr"
 short_desc="Unit Testing for R"
 maintainer="Luke Hannan <lukehannan@gmail.com>"
 license="MIT"
 homepage="http://testthat.r-lib.org"
-checksum=1a268d8df07f7cd8d282d03bb96ac2d96a24a95c9aa52f4cca5138a09dd8e06c
+checksum="a7cb8c416475c182c4faaa32c3a12fc5d8ead77196d3c9811a3d39b3f994cdae
+ a7cb8c416475c182c4faaa32c3a12fc5d8ead77196d3c9811a3d39b3f994cdae"
 
 post_install() {
 	vlicense LICENSE

--- a/srcpkgs/R-cran-tibble/template
+++ b/srcpkgs/R-cran-tibble/template
@@ -1,6 +1,6 @@
 # Template file for 'R-cran-tibble'
 pkgname=R-cran-tibble
-version=3.1.8
+version=3.2.0
 revision=1
 build_style=R-cran
 makedepends="R-cran-ellipsis
@@ -13,8 +13,8 @@ short_desc="Simple Data Frames"
 maintainer="Cameron Nemo <cam@nohom.org>"
 license="MIT"
 homepage="http://tibble.tidyverse.org/"
-checksum="acf30e075d18d2f61de53ca20a13c502bb32abb8083089b0bb9172a0cb5cedea
- acf30e075d18d2f61de53ca20a13c502bb32abb8083089b0bb9172a0cb5cedea"
+checksum="8f2ff14bca39e342f36d026776351f21b7627fe0f20f009b7a9e0a69a166298a
+ 8f2ff14bca39e342f36d026776351f21b7627fe0f20f009b7a9e0a69a166298a"
 
 post_install() {
 	vlicense LICENSE

--- a/srcpkgs/R-cran-timechange/template
+++ b/srcpkgs/R-cran-timechange/template
@@ -1,0 +1,14 @@
+# Template file for 'R-cran-timechange'
+pkgname=R-cran-timechange
+version=0.2.0
+revision=1
+build_style=R-cran
+makedepends="R-cran-cpp11"
+depends="R-cran-cpp11"
+short_desc="Efficient Manipulation of Date-Times"
+maintainer="Hervy Qurrotul Ainur Rozi <hervyqa@proton.me>"
+license="GPL-3.0-or-later"
+homepage="https://github.com/vspinu/timechange"
+changelog="https://raw.githubusercontent.com/vspinu/timechange/main/NEWS.md"
+checksum="3d602008052123daef94a5c3f5154c5461b4ec0432ab70c37273d7ddd252f7f1
+ 3d602008052123daef94a5c3f5154c5461b4ec0432ab70c37273d7ddd252f7f1"

--- a/srcpkgs/R-cran-utf8/template
+++ b/srcpkgs/R-cran-utf8/template
@@ -1,11 +1,11 @@
 # Template file for 'R-cran-utf8'
 pkgname=R-cran-utf8
-version=1.2.2
+version=1.2.3
 revision=1
 build_style=R-cran
 short_desc="Unicode Text Processing"
 maintainer="Cameron Nemo <cam@nohom.org>"
 license="Apache-2.0"
 homepage="https://github.com/patperry/r-utf8/"
-checksum="a71aee87d43a9bcf29249c7a5a2e9ca1d2a836e8d5ee3a264d3062f25378d8f4
- a71aee87d43a9bcf29249c7a5a2e9ca1d2a836e8d5ee3a264d3062f25378d8f4"
+checksum="c0a88686591f4ad43b52917d0964e9df4c62d8858fe25135a1bf357dfcbd6347
+ c0a88686591f4ad43b52917d0964e9df4c62d8858fe25135a1bf357dfcbd6347"

--- a/srcpkgs/R-cran-vctrs/template
+++ b/srcpkgs/R-cran-vctrs/template
@@ -1,13 +1,15 @@
 # Template file for 'R-cran-vctrs'
 pkgname=R-cran-vctrs
-version=0.4.2
+version=0.5.2
 revision=1
 build_style=R-cran
-makedepends="R-cran-ellipsis R-cran-digest R-cran-glue R-cran-rlang R-cran-cli"
-depends="R-cran-ellipsis R-cran-digest R-cran-glue R-cran-rlang R-cran-cli"
+makedepends="R-cran-ellipsis R-cran-digest R-cran-glue R-cran-lifecycle
+ R-cran-rlang R-cran-cli"
+depends="R-cran-ellipsis R-cran-digest R-cran-glue R-cran-lifecycle
+ R-cran-rlang R-cran-cli"
 short_desc="Vector Helpers"
 maintainer="Cameron Nemo <cam@nohom.org>"
 license="GPL-3.0-only"
 homepage="https://github.com/r-lib/vctrs"
-checksum="5414d1d6977163b4e85efa40d6facdd98089d6ffd460daaba729d4200942d815
- 5414d1d6977163b4e85efa40d6facdd98089d6ffd460daaba729d4200942d815"
+checksum="76bf10243b9b31e23f56ffdaa1677a01767699e2098487f86bd42cb801d8c047
+ 76bf10243b9b31e23f56ffdaa1677a01767699e2098487f86bd42cb801d8c047"

--- a/srcpkgs/R-cran-waldo/template
+++ b/srcpkgs/R-cran-waldo/template
@@ -1,0 +1,20 @@
+# Template file for 'R-cran-waldo'
+pkgname=R-cran-waldo
+version=0.4.0
+revision=1
+build_style=R-cran
+makedepends="R-cran-cli R-cran-diffobj R-cran-fansi R-cran-glue R-cran-rematch2
+R-cran-rlang R-cran-tibble"
+depends="R-cran-cli R-cran-diffobj R-cran-fansi R-cran-glue R-cran-rematch2
+R-cran-rlang R-cran-tibble"
+short_desc="Find Differences Between R Objects"
+maintainer="Hervy Qurrotul Ainur Rozi <hervyqa@proton.me>"
+license="MIT"
+homepage="https://waldo.r-lib.org/"
+changelog="https://raw.githubusercontent.com/r-lib/waldo/main/NEWS.md"
+checksum="57ee89eec9bcbba58cf8fa29c8e097f038768c30833eaf812682826333127eaa
+ 57ee89eec9bcbba58cf8fa29c8e097f038768c30833eaf812682826333127eaa"
+
+post_install() {
+	vlicense LICENSE
+}

--- a/srcpkgs/R-cran-zoo/template
+++ b/srcpkgs/R-cran-zoo/template
@@ -1,10 +1,11 @@
 # Template file for 'R-cran-zoo'
 pkgname=R-cran-zoo
-version=1.8r8
-revision=2
+version=1.8r11
+revision=1
 build_style=R-cran
 short_desc="S3 Infrastructure for Regular and Irregular Time Series"
 maintainer="Florian Wagner <florian@wagner-flo.net>"
 license="GPL-2.0-only, GPL-3.0-only"
 homepage="http://zoo.r-forge.r-project.org/"
-checksum=4e8cc4065047ba12e103b9664f3b607c770673096e9c2b694fad2b2ec3203ce7
+checksum="848e50f875afe06f13422e32160082b0725159a8be98234ef358480e57029ca5
+ 848e50f875afe06f13422e32160082b0725159a8be98234ef358480e57029ca5"


### PR DESCRIPTION
* R-cran-zoo: update to 1.8r11
* R-cran-utf8: update to 1.2.3
* R-cran-svglite: update to 2.1.1
* R-cran-stringr: update to 1.5.0
* R-cran-stringi: update to 1.7.8
* R-cran-purrr: update to 1.0.1
* R-cran-plyr: update to 1.8.8
* R-cran-nloptr: update to 2.0.3, adopt
* R-cran-testthat: update to 3.1.6
* New package: R-cran-waldo-0.4.0
* New package: R-cran-rematch2-2.1.2
* New package: R-cran-diffobj-0.3.5
* R-cran-pkgload: update to 1.3.2
* R-cran-rstudioapi: update to 0.14
* R-cran-pkgbuild: update to 1.4.0
* New package: R-cran-fs-1.6.1
* New package: R-cran-jsonlite-1.8.4
* New package: R-cran-brio-1.1.3
* R-cran-lubridate: update to 1.9.2
* New package: R-cran-timechange-0.2.0
* R-cran-ggplot2: update to 3.4.1
* R-cran-scales: update to 1.2.1
* R-cran-isoband: update to 0.2.7
* R-cran-gtable: update to 0.3.1
* R-cran-evaluate: update to 0.20
* R-cran-dplyr: update to 1.1.0
* R-cran-tibble: update to 3.2.0
* R-cran-vctrs: update to 0.5.2
* R-cran-fansi: update to 1.0.4
* R-cran-digest: update to 0.6.31
* R-cran-desc: update to 1.4.2
* R-cran-rprojroot: update to 2.0.3
* R-cran-data.table: update to 1.14.8
* R-cran-colorspace: update to 2.1.r0
* R-cran-cli: update to 3.6.0
* R-cran-callr: update to 3.7.3
* R-cran-processx: update to 3.8.0
* R-cran-ps: update to 1.7.2
* R-cran-backports: update to 1.4.1
* R-cran-RInside: update to 0.2.18
* R-cran-Rcpp: update to 1.0.10
* R-cran-RColorBrewer: update to 1.8r11

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)

![Screenshot_20230312_003613](https://user-images.githubusercontent.com/45872139/224503310-51e33d5c-4695-465a-9e03-bec9f4d27037.png)
