### PR TITLE
kde5: add qt5-tools

### DIFF
--- a/srcpkgs/kde5/template
+++ b/srcpkgs/kde5/template
@@ -1,7 +1,7 @@
 # Template file for 'kde5'
 pkgname=kde5
 version=5.26.0
-revision=1
+revision=2
 build_style=meta
 depends="bluedevil>=${version}
  breeze-gtk>=${version}
@@ -26,7 +26,8 @@ depends="bluedevil>=${version}
  plasma-thunderbolt>=${version}
  elogind
  upower
- udisks2"
+ udisks2
+ qt5-tools"
 short_desc="The KDE Plasma Desktop meta-package for Void Linux"
 maintainer="John <me@johnnynator.dev>"
 license="GPL-2, LGPL-2.1, FDL"


### PR DESCRIPTION
[ci skip]

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)

The kde environment relies on tools from `qt5-tools`. e.g. `/usr/lib/qt5/bin/qdbus`. As an example, the current meta package configuration will error when trying to change walpaper due to not having `qt5-tools`.