### PR TITLE
glab: update to 1.26.0.

### DIFF
--- a/srcpkgs/glab/template
+++ b/srcpkgs/glab/template
@@ -1,6 +1,6 @@
 # Template file for 'glab'
 pkgname=glab
-version=1.25.3
+version=1.26.0
 revision=1
 build_style=go
 build_helper=qemu
@@ -12,7 +12,7 @@ maintainer="Enno Boland <gottox@voidlinux.org>"
 license="MIT"
 homepage="https://gitlab.com/gitlab-org/cli"
 distfiles="https://gitlab.com/gitlab-org/cli/-/archive/v$version/cli-v$version.tar.gz"
-checksum=4cc090b9ad7ee6608d70e3a7fb5ca91a505eff12cf967a944bd0581cb6a83972
+checksum=af1820a7872d53c7119a23317d6c80497374ac9529fc2ab1ea8b1ca033a9b4da
 
 post_install() {
 	for shell in bash fish zsh; do


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture: **x86_64**