### PR TITLE
cross-vpkg-dummy: provide libthread_db.so.1 on glibc

### DIFF
--- a/common/travis/check-install.sh
+++ b/common/travis/check-install.sh
@@ -21,7 +21,8 @@ while read -r pkg; do
 				$ROOTDIR $ADDREPO \
 				-Sny \
 				"$subpkg" "$(xbps-uhelper getpkgname "$dep")"
-			if [ $? -eq 8 ]; then
+			ret="$?"
+			if [ "$ret" -eq 8 ] || [ "$ret" -eq 11 ]; then
 				/bin/echo -e "\x1b[31mFailed to install '$subpkg' and '$dep'\x1b[0m"
 				exit 1
 			fi

--- a/srcpkgs/cross-vpkg-dummy/template
+++ b/srcpkgs/cross-vpkg-dummy/template
@@ -1,15 +1,13 @@
 # Template file for 'cross-vpkg-dummy'
 pkgname=cross-vpkg-dummy
 version=0.39
-revision=3
+revision=4
 build_style=meta
+depends="base-files>=0.126"
 short_desc="Dummy meta-pkg for cross building packages with xbps-src"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="Public Domain"
 homepage="https://www.voidlinux.org/"
-
-depends="base-files>=0.126"
-
 provides="
 	kernel-libc-headers-9999_1
 	binutils-9999_1
@@ -62,6 +60,7 @@ shlib_provides="
 	libgnarl-12.so
 	libstdc++.so.6
 	libgfortran.so.5"
+repository=bootstrap
 
 if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
 	provides+=" musl-9999_1 musl-devel-9999_1"
@@ -75,5 +74,5 @@ else
 	shlib_provides+=" libanl.so.1 libnsl.so.1 libutil.so.1"
 	shlib_provides+=" ld-linux.so.2 ld-linux.so.3 ld-linux-x86-64.so.2"
 	shlib_provides+=" ld-linux-armhf.so.3 ld-linux-aarch64.so.1"
-	shlib_provides+=" ld64.so.2 ld.so.1"
+	shlib_provides+=" ld64.so.2 ld.so.1 libthread_db.so.1"
 fi


### PR DESCRIPTION
this should fix issues with openjdk11-jre in makedepends and "verify repository state" CI on cross:

```
openjdk11-jre-11.0.12+7_4: broken, unresolvable shlib `libthread_db.so.1'
Transaction aborted due to unresolved shlibs.
```

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

before:
```
[DEBUG] xbps_transaction_check_shlibs: checking for `libthread_db.so.1': not found
```
after:
```
[DEBUG] xbps_transaction_check_shlibs: checking for `libthread_db.so.1': provided by `cross-vpkg-dummy-0.39_4'
```

