### PR TITLE
New package: claws-mail-theme-basicsvg-0.6.4.

### DIFF
--- a/.github/workflows/trigger.yaml
+++ b/.github/workflows/trigger.yaml
@@ -1,0 +1,18 @@
+name: Trigger repository build
+
+on:
+  push:
+    branches:
+      - wagnerflo
+
+jobs:
+  trigger:
+    name: Trigger
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.PAT }}
+          repository: wagnerflo/void-repository
+          event-type: Push to wagnerflo/void-packages

--- a/srcpkgs/bupstash/template
+++ b/srcpkgs/bupstash/template
@@ -1,0 +1,18 @@
+# Template file for 'bupstash'
+pkgname=bupstash
+version=0.12.0
+revision=1
+archs="~i686*"
+build_style=cargo
+hostmakedepends="pkg-config"
+makedepends="libsodium-devel"
+short_desc="Easy and efficient encrypted backups"
+maintainer="Florian Wagner <florian@wagner-flo.de>"
+license="MIT"
+homepage="https://bupstash.io"
+distfiles="https://github.com/andrewchambers/bupstash/archive/refs/tags/v${version}.tar.gz"
+checksum=a2ce4eeb2caa881a778e823cc70d39c2adb0b301f737c55e44a4dd0fbd6a4265
+
+post_install() {
+	vlicense LICENSE
+}

--- a/srcpkgs/claws-mail-theme-basicsvg/template
+++ b/srcpkgs/claws-mail-theme-basicsvg/template
@@ -1,0 +1,17 @@
+# Template file for 'claws-mail-theme-basicsvg'
+pkgname=claws-mail-theme-basicsvg
+version=0.6.4
+revision=1
+depends="claws-mail"
+short_desc="Basic SVG icons theme for Claws Mail"
+maintainer="Florian Wagner <florian@wagner-flo.de>"
+license="GPL-2.0-only"
+homepage="http://rame.altervista.org/cmbasicsvg/"
+distfiles="http://rame.altervista.org/dl.php?fp=cmbasicsvg/BasicSVG-${version}.tar.gz"
+checksum=6136910b431bc39496557d9cf5786607c4c95473e8d9eac2d3f8d91f0a0dee3b
+create_wrksrc=yes
+
+do_install() {
+	vmkdir usr/share/claws-mail/themes
+	vcopy "${wrksrc}/BasicSVG" usr/share/claws-mail/themes
+}


### PR DESCRIPTION
#### New package
Yes, it's a theme but might be of interest anyways: Claws-mail comes with a internal theme of raster icons and will not scale these, resulting in very tiny icons on Hi-DPI displays. This theme brings SVG replacements that will scale.

#### Local build testing
This package contains only architecture independent files.