### PR TITLE
kicad: update to 7.0.1

### DIFF
--- a/srcpkgs/kicad-doc/template
+++ b/srcpkgs/kicad-doc/template
@@ -1,13 +1,13 @@
 # Template file for 'kicad-doc'
 pkgname=kicad-doc
-version=7.0.0
+version=7.0.1
 revision=1
 short_desc="KiCad documentation"
 maintainer="Érico Nogueira <ericonr@disroot.org>"
 license="GPL-3.0-or-later, CC-BY-3.0"
 homepage="http://kicad.org"
 distfiles="https://kicad-downloads.s3.cern.ch/docs/kicad-doc-${version}.tar.gz"
-checksum=04cad356fd19b46e70eaa6e3365d94c326e4237d80c09394208fd4662e756465
+checksum=05dd54cc3cc9dd60e60deb67c4bd7d877f41f3cdba3423f006e713e4a79f9868
 
 if [ "$XBPS_WORDSIZE" != "$XBPS_TARGET_WORDSIZE" ]; then
 	broken="kicad not available"

--- a/srcpkgs/kicad-footprints/template
+++ b/srcpkgs/kicad-footprints/template
@@ -1,6 +1,6 @@
 # Template file for 'kicad-footprints'
 pkgname=kicad-footprints
-version=7.0.0
+version=7.0.1
 revision=1
 build_style=cmake
 depends="kicad"
@@ -9,4 +9,4 @@ maintainer="Urs Schulz <voidpkgs@ursschulz.de>"
 license="CC-BY-SA-4.0"
 homepage="http://kicad.org"
 distfiles="https://gitlab.com/kicad/libraries/kicad-footprints/-/archive/${version}/kicad-footprints-${version}.tar.gz"
-checksum=c10550c6b621d8e5f7e84d3d1443eae3900c80a86982b05326adc0e3d61768c7
+checksum=b45e84e3af07704bd9c61736faa3c65e2ff3d3907d6d67c2b446b9b26bcb023e

--- a/srcpkgs/kicad-library/template
+++ b/srcpkgs/kicad-library/template
@@ -1,6 +1,6 @@
 # Template file for 'kicad-library'
 pkgname=kicad-library
-version=7.0.0
+version=7.0.1
 revision=1
 build_style=meta
 depends="kicad-footprints>=${version} kicad-packages3D>=${version}

--- a/srcpkgs/kicad-packages3D/template
+++ b/srcpkgs/kicad-packages3D/template
@@ -1,6 +1,6 @@
 # Template file for 'kicad-packages3D'
 pkgname=kicad-packages3D
-version=7.0.0
+version=7.0.1
 revision=1
 build_style=cmake
 depends="kicad"
@@ -9,4 +9,4 @@ maintainer="Urs Schulz <voidpkgs@ursschulz.de>"
 license="CC-BY-SA-4.0"
 homepage="http://kicad.org"
 distfiles="https://gitlab.com/kicad/libraries/kicad-packages3D/-/archive/${version}/kicad-packages3D-${version}.tar.gz"
-checksum=2a11bb29f55e6c3b719174dddef649bee414c1ffa36f82ee9c09f184bbded90e
+checksum=9eb07aaf686468e20b042b6ca0b63789f20d08ba5130c63ce8e60e3d56960908

--- a/srcpkgs/kicad-symbols/template
+++ b/srcpkgs/kicad-symbols/template
@@ -1,6 +1,6 @@
 # Template file for 'kicad-symbols'
 pkgname=kicad-symbols
-version=7.0.0
+version=7.0.1
 revision=1
 build_style=cmake
 depends="kicad"
@@ -9,4 +9,4 @@ maintainer="Urs Schulz <voidpkgs@ursschulz.de>"
 license="CC-BY-SA-4.0"
 homepage="http://kicad.org"
 distfiles="https://gitlab.com/kicad/libraries/kicad-symbols/-/archive/${version}/kicad-symbols-${version}.tar.gz"
-checksum=0f04db7a5965436b754f43a3ebb02d055223f306a1c56a90973216eac227dbc8
+checksum=b5020fd9c8548ec2714d513100dd8dc0a94835aa575eeb6d31826889ad69b370

--- a/srcpkgs/kicad-templates/template
+++ b/srcpkgs/kicad-templates/template
@@ -1,6 +1,6 @@
 # Template file for 'kicad-templates'
 pkgname=kicad-templates
-version=7.0.0
+version=7.0.1
 revision=1
 build_style=cmake
 depends="kicad"
@@ -9,4 +9,4 @@ maintainer="Urs Schulz <voidpkgs@ursschulz.de>"
 license="CC-BY-SA-4.0"
 homepage="http://kicad.org"
 distfiles="https://gitlab.com/kicad/libraries/kicad-templates/-/archive/${version}/kicad-templates-${version}.tar.gz"
-checksum=26c611621f452effdb748975ab88227fedf455cfa6dce40b298a01bbd60a63e2
+checksum=91dea880d4832dcb9481bf9584026aa7588aa9667bbfe269d0deb0af95f9e08d

--- a/srcpkgs/kicad/template
+++ b/srcpkgs/kicad/template
@@ -1,6 +1,6 @@
 # Template file for 'kicad'
 pkgname=kicad
-version=7.0.0
+version=7.0.1
 revision=1
 build_style=cmake
 build_helper=cmake-wxWidgets-gtk3
@@ -18,7 +18,7 @@ maintainer="Érico Nogueira <ericonr@disroot.org>"
 license="GPL-3.0-or-later"
 homepage="http://kicad.org"
 distfiles="https://gitlab.com/kicad/code/kicad/-/archive/${version}/kicad-${version}.tar.gz"
-checksum=a992234a06d18e45dbec847624e7966b3850c5f1e44474007e8fe7c6c24d3fbc
+checksum=7c160857e7042f2a3b0570887b2413a6412f58202c54748bcfa0f7a015c3ba65
 python_version=3
 replaces="kicad-i18n>=0"
 # one test appears to be flaky


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, (x64-glibc)

Just a version bump following the 7.0.1 bug-fix release from last week. Opened and exported some projects, works just fine afaics. 