### PR TITLE
opustags: update to 1.8.0.

### DIFF
--- a/srcpkgs/opustags/template
+++ b/srcpkgs/opustags/template
@@ -1,6 +1,6 @@
 # Template file for 'opustags'
 pkgname=opustags
-version=1.6.0
+version=1.8.0
 revision=1
 build_style=cmake
 hostmakedepends="pkg-config"
@@ -9,8 +9,9 @@ short_desc="Ogg Opus tags editor"
 maintainer="tibequadorian <tibequadorian@posteo.de>"
 license="BSD-3-Clause"
 homepage="https://github.com/fmang/opustags"
+changelog="https://github.com/fmang/opustags/raw/master/CHANGELOG.md"
 distfiles="https://github.com/fmang/opustags/archive/${version}.tar.gz"
-checksum=0f82703a49b35d44503c53bb596129e89ec061fb1f6e82363f982d1e35377dce
+checksum=1cd4d07344ae85511851f4dc79afef0590757b3776133c5268cb100c367e714e
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
