### PR TITLE
fatsort: update to 1.6.5.640.

### DIFF
--- a/srcpkgs/fatsort/template
+++ b/srcpkgs/fatsort/template
@@ -1,6 +1,6 @@
 # Template file for 'fatsort'
 pkgname=fatsort
-version=1.6.4.625
+version=1.6.5.640
 revision=1
 build_style=gnu-makefile
 make_check_target=tests
@@ -10,8 +10,9 @@ short_desc="Utility that sorts FAT12, FAT16, FAT32 and exFAT partitions"
 maintainer="tibequadorian <tibequadorian@posteo.de>"
 license="GPL-2.0-or-later"
 homepage="https://fatsort.sourceforge.io/"
+changelog="https://fatsort.sourceforge.io/CHANGES.html"
 distfiles="${SOURCEFORGE_SITE}/project/fatsort/fatsort-${version}.tar.xz"
-checksum=9a6f89a0640bb782d82ff23a780c9f0aec3dfbe4682c0a8eda157e0810642ead
+checksum=630ece56d9eb3a55524af0aec3aade7854360eba949172a6cfb4768cb8fbe42e
 
 if [ "$XBPS_TARGET_LIBC" = musl ]; then
 	broken="most tests are failed"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
