### PR TITLE
mandrel: update revdeps

### DIFF
--- a/srcpkgs/babashka/template
+++ b/srcpkgs/babashka/template
@@ -1,24 +1,24 @@
 # Template file for 'babashka'
 pkgname=babashka
-version=1.0.170
+version=1.2.174
 revision=1
 create_wrksrc=yes
 hostmakedepends="mandrel leiningen git"
 makedepends="zlib-devel"
-checkdepends="clojure curl"
+checkdepends="clojure curl tar"
 short_desc="Native, fast starting Clojure interpreter for scripting"
 maintainer="Leah Neukirchen <leah@vuxu.org>"
 license="EPL-1.0"
 homepage="https://babashka.org/"
-changelog="https://github.com/babashka/babashka/blob/master/CHANGELOG.md"
-_sci_commit=ee1df7aa95cb7279fd2040b0437ffb8415fbffa0
-_babashka_curl_commit=99e6d3ba7a7252284b43f9de7d91d3433ecfa8f0
+changelog="https://github.com/babashka/babashka/raw/master/CHANGELOG.md"
+_sci_commit=617bf809d1810b48cab24980864b85249c2a9d8b
+_babashka_curl_commit=e936acd40544eb637b6041c7e89454b21eb7ee34
 _babashka_nrepl_commit=ad763a78f1bc327a493ff0b650aa5408ecbf4819
 _depstar_commit=c419b8c82041855d55593c5b561fc7cea8234712
-_process_commit=8c98184222033c0af375b47dd3e13ba56ae8fe9f
+_process_commit=63bef86c76098366531ab973a79d04c51ae0856b
 _pods_commit=75c2216649bf5caf3ae41e7b8fc202e45b090ea9
-_deps_clj_commit=e9318a759628221c48b9259bc8885d4aee1d7262
-_fs_commit=8a8bfa618be6f0c1b21be0daafd1887e2a4f5c44
+_deps_clj_commit=b2356ff4b28e3b115479d2d3d6e4135bf20f9150
+_fs_commit=ceb8f7f48d4a1438a434ffc16238d5f1883bb4ac
 _babashka_core_commit=52a6037bd4b632bffffb04394fb4efd0cdab6b1e
 distfiles="https://github.com/babashka/babashka/archive/refs/tags/v${version}.tar.gz
  https://github.com/borkdude/sci/archive/${_sci_commit}.tar.gz
@@ -30,16 +30,19 @@ distfiles="https://github.com/babashka/babashka/archive/refs/tags/v${version}.ta
  https://github.com/borkdude/deps.clj/archive/${_deps_clj_commit}.tar.gz
  https://github.com/babashka/fs/archive/${_fs_commit}.tar.gz
  https://github.com/babashka/babashka.core/archive/${_babashka_core_commit}.tar.gz"
-checksum="b6e0984e8f8f0120ae6e0851c98e1649b3ca1d794e06bf3652351426490b95a5
- a29e0c23ea70b4b38c339faa47b9524c66e5a483489e05019364f1c1d86e746a
- bb0bccbdeb295b83f9b5b859a12634b28a6b1c68da7ab04d18f87dd8b7a69930
+checksum="6a1f6b045915e562354e55d78a67d81a1f9bf8857cc743c54640ec02d3d8be8d
+ 8ff28bf9148ae17719b4acffaaa6747bd768bfc148eac6f8691ef7dcbd37b1d0
+ 6e60865ae2d4522c3de55b3b1daed51b42bb9bb6095b1d2fbd3620facece3257
  c2a174c385d9728837c1432055669390de063a417fa7aacb36c9e826819f3e6a
  9d214a10a4f5e4f15b9c80354dae85689a40e941ec3417203354c0dc3ce9457b
- afa762485a8d92eb79c70a2467f67e05bd60189b8fce3ad9da25db57a8c00ac2
+ 6dc65d20df3996f51dab494a73bdc22b8befd0f0f1c223797c1307230669e9a9
  fd7d60d3b336c5c11f13a59f9524ef0b00e3755f3033e597cfc4c23f2c618fda
- 38f1eac7ec38374709972ea856acb6c684591bd36cfcfc44044874cdd12264ab
- 949f8da34f285f2385af569d6ed5bcc49851ec3774532f614bef63f5a496f787
+ efd247a5f1f9018900c239cdf3e39b24e114b1e483e987b1e629bf2984148e59
+ 8693d3d4cad5a6a198dbbcec2edc93d977711b1428235ff92e3c031495af0366
  bad285812bcc7de7e0dd905c5df99045d7f92d6e2e191fc2768c06adbaaeb709"
+
+# https://github.com/openjdk/jdk17u-dev/pull/783
+make_check=no # TODO: reenable after openjdk17>=17.0.6
 
 nocross="https://build.voidlinux.org/builders/aarch64_builder/builds/33769/steps/shell_3/logs/stdio"
 
@@ -55,7 +58,7 @@ post_extract() {
 }
 
 do_build() {
-	export GRAALVM_HOME=/usr/lib/jvm/mandrel11
+	export GRAALVM_HOME=/usr/lib/jvm/mandrel17
 	if [ "$XBPS_TARGET_LIBC" = musl ]; then
 		export BABASHKA_MUSL=true
 		export BABASHKA_STATIC=true  # mandrel workaround
@@ -67,6 +70,7 @@ do_build() {
 }
 
 do_check() {
+	export GRAALVM_HOME=/usr/lib/jvm/mandrel17
 	export BABASHKA_TEST_ENV=native
 	script/test
 	script/run_lib_tests

--- a/srcpkgs/jet/template
+++ b/srcpkgs/jet/template
@@ -1,6 +1,6 @@
 # Template file for 'jet'
 pkgname=jet
-version=0.1.1
+version=0.4.23
 revision=1
 hostmakedepends="mandrel leiningen"
 makedepends="zlib-devel"
@@ -8,13 +8,25 @@ short_desc="CLI to transform between JSON, EDN and Transit"
 maintainer="Leah Neukirchen <leah@vuxu.org>"
 license="EPL-1.0"
 homepage="https://github.com/borkdude/jet"
+changelog="https://raw.githubusercontent.com/borkdude/jet/master/CHANGELOG.md"
 distfiles="https://github.com/borkdude/jet/archive/refs/tags/v${version}.tar.gz"
-checksum=2085cd757607eebfdcc6107f507e362b88952f5cd7139127ba9c47708bbd91c4
+checksum=dae9367813eb28eed9807016947f286fe0825fddd3c596d9712d0c2a6c7596cf
 nocross="mandrel"
 
 do_build() {
-	export GRAALVM_HOME=/usr/lib/jvm/mandrel11
+	export GRAALVM_HOME=/usr/lib/jvm/mandrel17
+	if [ "$XBPS_TARGET_LIBC" = musl ]; then
+		export BABASHKA_MUSL=true
+		export BABASHKA_STATIC=true
+	fi
+
+	vsed -e "s/+native-image/+uberjar/" -i script/compile
 	script/compile
+}
+
+do_check() {
+	export JET_TEST_ENV=native
+	script/test
 }
 
 do_install() {


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture: **x86_64**

@leahneukirchen I updated mandrel [earlier](https://github.com/void-linux/void-packages/commit/9781d3805e4a0fb3eafcad404ca604a66697474a) and these are the packages that needed to be rebuilt. I had to disable babashka's tests temporarily till someone updates openjdk17 in the repos due to the linked issue in comment.