### PR TITLE
New package: bash-language-server-4.9.1

### DIFF
--- a/srcpkgs/bash-language-server/template
+++ b/srcpkgs/bash-language-server/template
@@ -1,0 +1,36 @@
+# Template file for 'bash-language-server'
+pkgname=bash-language-server
+version=4.9.1
+revision=1
+hostmakedepends="jq yarn"
+depends="nodejs"
+short_desc="Bash language server"
+maintainer="sirkhancision <jsantiago12tone@gmail.com>"
+license="MIT"
+homepage="https://github.com/bash-lsp/bash-language-server"
+distfiles="https://github.com/bash-lsp/bash-language-server/archive/refs/tags/server-${version}.tar.gz"
+checksum=eef93c1167394fb01fc300c5b8c326fd9362dd3118a1e075549342e24e9d6e5c
+
+do_build() {
+	yarn
+	yarn run compile
+}
+
+do_install() {
+	TARGET_PATH="usr/lib/${pkgname}"
+	cd server
+
+	cp package.json{,.bak}
+	read -ra _devDependencies < <(jq -r '.devDependencies | keys | join(" ")' package.json)
+	yarn remove --frozen-lockfile "${_devDependencies[@]}"
+	mv package.json{.bak,}
+
+	vmkdir ${TARGET_PATH}
+	vcopy * ${TARGET_PATH}
+
+	vmkdir usr/bin
+	ln -sf /${TARGET_PATH}/out/cli.js ${DESTDIR}/usr/bin/${pkgname}
+	chmod 0755 ${DESTDIR}/${TARGET_PATH}/out/cli.js
+
+	vlicense ../LICENSE
+}


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures:
  - i686
  - x86_64-musl
  - aarch64
