### PR TITLE
gitea: update to 1.18.5

### DIFF
--- a/srcpkgs/gitea/template
+++ b/srcpkgs/gitea/template
@@ -1,6 +1,6 @@
 # Template file for 'gitea'
 pkgname=gitea
-version=1.18.3
+version=1.18.5
 revision=1
 build_style=go
 go_import_path=code.gitea.io/gitea
@@ -31,7 +31,7 @@ license="MIT"
 homepage="https://gitea.io"
 changelog="https://raw.githubusercontent.com/go-gitea/gitea/main/CHANGELOG.md"
 distfiles="https://dl.gitea.io/gitea/${version}/gitea-src-${version}.tar.gz"
-checksum=8ea8e96c381c9b066873fa2f81bbab15e7ad6bd98024e9b3ef2aef994280c115
+checksum=3863e7e1f92761fce6b808ba08bf26fc8878b9136b6950e6a419b6d2a4f794a9
 
 system_accounts="_gitea"
 _gitea_homedir="/var/lib/gitea"


### PR DESCRIPTION
Tagging the maintainer @fosslinux
It's just a version bump

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)
- I built this PR locally for these architectures:
  - x86_64-musl
