### PR TITLE
autofs: Remove obsolete vseds

### DIFF
--- a/srcpkgs/autofs/template
+++ b/srcpkgs/autofs/template
@@ -22,8 +22,7 @@ if [ -z "$CROSS_BUILD" ] && [ "$XBPS_TARGET_LIBC" != "musl" ]; then
 fi
 
 pre_configure() {
-	vsed -i 's,nfs/nfs.h,linux/nfs.h,g' */*.[ch]
-	vsed -i 's,__S_IEXEC,S_IXUSR,g' */*.[ch]
+	vsed -e 's,__S_IEXEC,S_IXUSR,g' -i daemon/lookup.c -i modules/lookup_multi.c
 }
 
 pre_build() {


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

Addresses part of tracking issue #42441
- [x] autofs

#### Testing the changes
- I tested the changes in this PR: **NO**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
#### Local build testing
- I built this PR locally for my native architecture, x86\_64-glibc
