### PR TITLE
eggdrop: Remove useless vsed

### DIFF
--- a/srcpkgs/eggdrop/template
+++ b/srcpkgs/eggdrop/template
@@ -33,6 +33,9 @@ do_install() {
 	for _asset in language scripts help; do
 		vmkdir "${_share}/${_asset}/"
 		vcopy "ed_staging/${_asset}/*" "${_share}/${_asset}"
+	done
+
+	for _asset in scripts help; do
 		vsed -e "s|${_asset}/|/${_share}/&|" -i eggdrop.conf
 	done
 


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

Addresses part of tracking issue #42441
- [x] eggdrop

#### Testing the changes
- I tested the changes in this PR: **briefly**

Running the binary both before and after this change gives the following error:

    $ eggdrop
    LANG: No lang files found for section core.

    Eggdrop v1.9.4 (C) 1997 Robey Pointer (C) 2010-2022 Eggheads
    --- Loading eggdrop v1.9.4 (Sat Mar 18 2023)
    * MSG534

I don't use *eggdrop* so I'm not sure how to test this further. Happy to take advice on this and retest if needed.

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
#### Local build testing
- I built this PR locally for my native architecture, x86\_64-glibc
