### PR TITLE
New package: font-inter-3.19

### DIFF
--- a/srcpkgs/font-inter/template
+++ b/srcpkgs/font-inter/template
@@ -1,0 +1,19 @@
+# Template file for 'font-inter'
+pkgname=font-inter
+version=3.19
+revision=1
+depends="font-util"
+short_desc="Variable typeface carefully crafted & designed for computer screens"
+maintainer="Robin Lundgren <linkert@onan.in>"
+license="OFL-1.1"
+homepage="https://rsms.me/inter/"
+distfiles="https://github.com/rsms/inter/releases/download/v${version}/Inter-${version}.zip"
+checksum=150ab6230d1762a57bebf35dfc04d606ff91598a31d785f7f100356ecdcc0032
+
+font_dirs="/usr/share/fonts/OTF/inter"
+
+do_install() {
+	vmkdir usr/share/fonts/OTF/inter
+	vcopy *Desktop/*.otf usr/share/fonts/OTF/inter
+	vlicense LICENSE.txt LICENSE.md
+}


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES?**

If one would like to reduce some of the absolute pinnacle of screen specific typeface into "aesthetics", well that's under appreciating something like Inter. An absolute beast of a typeface within the space it exists. Anyone should be able to enjoy the detail and work that's gone into this typeface. Check out the website, it provides far more justice and detail as to why it exists, it's goals and strengths than I'm able to provide here.

I'd like it to be merged because:

- The insane quality this typeface offers. I'm gonna use it for GTK applications, for PDF exports through pandoc texlive stuff and whatnot.
- It's actively developed. Some of us do care about typography and want to receive updates in a modern, convenient manner just as with any other software on our systems. Like Iosevka which is in the repos — love seeing it in my updates, always checkout the changes, fixes and features it brings.
- It might add some new glyphs? — haven't done a diff. Maybe, for instance the insert key symbol, that's one I rarely see [⎀](https://rsms.me/inter/glyphs/?g=insertionsymbol) along with other modifier keys in a cohesive way
- I have been a Void Linux user since 2019  — want to start nice and easy with the role as a package maintainer :)

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
