### PR TITLE
set null IFS in v* commands

### DIFF
--- a/common/environment/setup/install.sh
+++ b/common/environment/setup/install.sh
@@ -9,7 +9,7 @@ unalias -a
 # disable wildcards helper
 _noglob_helper() {
        set +f
-       "$@"
+       IFS= "$@"
 }
 
 # Apply _noglob to v* commands


### PR DESCRIPTION
without this, if `<pattern>` arguments contain whitespace, word splitting causes the argument to be split unexpectedly.

for example:
    `vcopy 'Spacey Folder/*.ttf' usr/share/TTF/`

calls something equivalent to
    `cp "Spacey" "Folder/*.ttf" usr/share/TTF/`

which of course fails.

i couldn't find a way to escape word splitting from outside, aside from setting `IFS`.
i'm not at all confident this won't break anything else in install.sh, but if it doesn't, i think it would be nice to preserve the expectation that `<pattern>` arguments are just pure globs.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**