### PR TITLE
Signal-Desktop: update to 6.10.1.

### DIFF
--- a/srcpkgs/Signal-Desktop/template
+++ b/srcpkgs/Signal-Desktop/template
@@ -1,6 +1,6 @@
 # Template file for 'Signal-Desktop'
 pkgname=Signal-Desktop
-version=6.10.0
+version=6.10.1
 revision=1
 # Signal officially only supports x86_64 
 # x86_64-musl fails because of its dependency on 'node-gyp' which depends on a glibc specific extension
@@ -13,7 +13,7 @@ maintainer="akierig <anelki@fastmail.de>"
 license="AGPL-3.0-only"
 homepage="https://github.com/signalapp/Signal-Desktop"
 distfiles="https://github.com/signalapp/Signal-Desktop/archive/v${version}.tar.gz"
-checksum=aec9001aa11f3a96807b67678996796b43140d0b51cf58db0a6aa011c72e5a28
+checksum=5a5ea57b3053fdd9a68a6209e0e99db4282c08478c099ee8a5235c5272cc782d
 nostrip_files="signal-desktop"
 
 post_extract() {


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64