### PR TITLE
fcitx: Remove obsolete vsed

### DIFF
--- a/srcpkgs/fcitx/template
+++ b/srcpkgs/fcitx/template
@@ -69,8 +69,6 @@ pre_configure() {
 	vsed -i -e 's;INCLUDE(${FCITX4_PREFIX}/share/cmake/fcitx;INCLUDE(${CMAKE_CURRENT_LIST_DIR};' \
 		cmake/FcitxConfig.cmake
 
-	vsed -i -e 's;enchant/enchant.h;enchant-2/enchant.h;' cmake/FindEnchant.cmake
-
 	if [ "$CROSS_BUILD" ]; then
 		# use host binaries
 		vsed -i -e 's;${PROJECT_BINARY_DIR}/tools/dev;/usr/lib/fcitx/libexec;' \


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

Addresses part of tracking issue #42441
- [x] fcitx

#### Testing the changes
- I tested the changes in this PR: **NO**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
#### Local build testing
- I built this PR locally for my native architecture, x86\_64-glibc
- I built this PR locally for these architectures
  - x86\_64-musl
