### PR TITLE
fltk: Remove obsolete vsed

### DIFF
--- a/srcpkgs/fltk/template
+++ b/srcpkgs/fltk/template
@@ -18,12 +18,6 @@ pre_build() {
 	vsed -i '/DIRS =/s,test,,' Makefile
 }
 
-post_build() {
-	vsed -i fltk-config \
-		-e's;-specs=/void-packages/common/environment/configure/gccspecs/hardened-cc1 ;;' \
-		-e's;-specs=/void-packages/common/environment/configure/gccspecs/hardened-ld ;;'
-}
-
 post_install() {
 	rm -rf ${DESTDIR}/usr/share/man/cat[13]
 	vlicense COPYING


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

Addresses part of tracking issue #42441
- [x] fltk

#### Testing the changes
- I tested the changes in this PR: **NO**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
#### Local build testing
- I built this PR locally for my native architecture, x86\_64-glibc
- I built this PR locally for these architectures
  - x86\_64-musl