### PR TITLE
httpry: Remove obsolete vsed

### DIFF
--- a/srcpkgs/httpry/template
+++ b/srcpkgs/httpry/template
@@ -12,8 +12,7 @@ distfiles="https://github.com/jbittel/${pkgname}/archive/${pkgname}-${version}.t
 checksum=b3bcbec3fc6b72342022e940de184729d9cdecb30aa754a2c994073447468cf0
 
 post_extract() {
-	vsed -i -e'/^CC /d' \
-		-e 's/^CCFLAGS .*/CCFLAGS=$(CFLAGS) $(LDFLAGS)/' Makefile
+	vsed -i -e 's/^CCFLAGS .*/CCFLAGS=$(CFLAGS) $(LDFLAGS)/' Makefile
 }
 
 do_install() {


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

Addresses part of tracking issue #42441
- [x] httpry

#### Testing the changes
- I tested the changes in this PR: **NO**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
#### Local build testing
- I built this PR locally for my native architecture, x86\_64-glibc
- I built this PR locally for these architectures
  - x86\_64-musl
