### PR TITLE
Gstreamer 1.22.2

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -1135,6 +1135,7 @@ libgstpbutils-1.0.so.0 gst-plugins-base1-1.0.0_1
 libgstriff-1.0.so.0 gst-plugins-base1-1.0.0_1
 libgstapp-1.0.so.0 gst-plugins-base1-1.0.0_1
 libgstallocators-1.0.so.0 gst-plugins-base1-1.1.1_1
+libgsttranscoder-1.0.so.0 gst-plugins-bad1-1.22.1_1
 libgstphotography-1.0.so.0 gst-plugins-bad1-1.18.3_2
 libgstsignalprocessor-1.0.so.0 gst-plugins-bad1-1.18.3_2
 libgstbasevideo-1.0.so.0 gst-plugins-bad1-1.18.3_2

--- a/srcpkgs/gst-libav/template
+++ b/srcpkgs/gst-libav/template
@@ -1,6 +1,6 @@
 # Template file for 'gst-libav'
 pkgname=gst-libav
-version=1.20.3
+version=1.22.2
 revision=1
 build_style=meson
 hostmakedepends="pkg-config yasm"
@@ -11,7 +11,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="LGPL-2.0-or-later"
 homepage="https://gstreamer.freedesktop.org"
 distfiles="${homepage}/src/${pkgname}/${pkgname}-${version}.tar.xz"
-checksum=3fedd10560fcdfaa1b6462cbf79a38c4e7b57d7f390359393fc0cef6dbf27dfe
+checksum=fcaaf9878fe8f3bc82317ef13a1558824cb68df1f8968c6797f556c5e33bcffd
 
 case "$XBPS_TARGET_MACHINE" in
 	*-musl) # Required by musl for M_SQRT1_2

--- a/srcpkgs/gst-omx/template
+++ b/srcpkgs/gst-omx/template
@@ -1,6 +1,6 @@
 # Template file for 'gst-omx'
 pkgname=gst-omx
-version=1.20.3
+version=1.22.2
 revision=1
 build_style=meson
 configure_args="-Dexamples=disabled -Dtarget=generic"
@@ -11,4 +11,4 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="LGPL-2.1-only"
 homepage="https://gstreamer.freedesktop.org"
 distfiles="${homepage}/src/${pkgname}/${pkgname}-${version}.tar.xz"
-checksum=8db48040bb41f09edf8d17ff6d16c54888d7777ba4501c2c69f0083350ea9a15
+checksum=1b0c57f2cc4ddeec5e7f0c436e502f06665c4e93c73261855b94e04fc94337b2

--- a/srcpkgs/gst-plugins-bad1/template
+++ b/srcpkgs/gst-plugins-bad1/template
@@ -1,7 +1,7 @@
 # Template file for 'gst-plugins-bad1'
 pkgname=gst-plugins-bad1
-version=1.20.3
-revision=3
+version=1.22.2
+revision=1
 build_helper="gir"
 build_style=meson
 configure_args="-Dpackage-origin=https://voidlinux.org -Ddoc=disabled
@@ -36,7 +36,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later, LGPL-2.1-or-later"
 homepage="https://gstreamer.freedesktop.org"
 distfiles="${homepage}/src/${pkgname/1/}/${pkgname/1/}-${version}.tar.xz"
-checksum=7a11c13b55dd1d2386dd902219e41cbfcdda8e1e0aa3e738186c95074b35da4f
+checksum=3d8faf1ce3402c8535ce3a8c4e1a6c960e4b5655dbda6b55943db9ac79022d0f
 
 build_options="gir gme wayland"
 build_options_default="gir wayland"

--- a/srcpkgs/gst-plugins-base1/template
+++ b/srcpkgs/gst-plugins-base1/template
@@ -1,6 +1,6 @@
 # Template file for 'gst-plugins-base1'
 pkgname=gst-plugins-base1
-version=1.20.3
+version=1.22.2
 revision=1
 build_style=meson
 build_helper="gir"
@@ -22,7 +22,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later, LGPL-2.0-or-later"
 homepage="https://gstreamer.freedesktop.org"
 distfiles="${homepage}/src/${pkgname/1/}/${pkgname/1/}-${version}.tar.xz"
-checksum=7e30b3dd81a70380ff7554f998471d6996ff76bbe6fc5447096f851e24473c9f
+checksum=eb65120c4ee79b7a153c3c1972d5c0158c2151877cc51ec7725bba5749679d49
 
 build_options="cdparanoia gir sndio wayland"
 build_options_default="cdparanoia gir wayland"

--- a/srcpkgs/gst-plugins-good1/template
+++ b/srcpkgs/gst-plugins-good1/template
@@ -1,6 +1,6 @@
 # Template file for 'gst-plugins-good1'
 pkgname=gst-plugins-good1
-version=1.20.3
+version=1.22.2
 revision=1
 build_style=meson
 configure_args="-Ddv=disabled -Ddv1394=disabled -Dshout2=disabled -Dqt5=enabled
@@ -22,7 +22,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="LGPL-2.1-or-later"
 homepage="https://gstreamer.freedesktop.org"
 distfiles="${homepage}/src/${pkgname/1/}/${pkgname/1/}-${version}.tar.xz"
-checksum=f8f3c206bf5cdabc00953920b47b3575af0ef15e9f871c0b6966f6d0aa5868b7
+checksum=7c8cc59425f2b232f60ca7d13e56edd615da4f711e73dd01a7cffa46e6bc0cdd
 
 build_options="gtk3 wayland"
 build_options_default="gtk3 wayland"

--- a/srcpkgs/gst-plugins-ugly1/template
+++ b/srcpkgs/gst-plugins-ugly1/template
@@ -1,6 +1,6 @@
 # Template file for 'gst-plugins-ugly1'
 pkgname=gst-plugins-ugly1
-version=1.20.3
+version=1.22.2
 revision=1
 build_style=meson
 configure_args="-Damrnb=disabled -Damrwbdec=disabled -Dsidplay=disabled"
@@ -15,4 +15,4 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="LGPL-2.1-or-later"
 homepage="https://gstreamer.freedesktop.org"
 distfiles="${homepage}/src/${pkgname/1/}/${pkgname/1/}-${version}.tar.xz"
-checksum=8caa20789a09c304b49cf563d33cca9421b1875b84fcc187e4a385fa01d6aefd
+checksum=8f30f44db0bd063709bf6fbe55138e3a98af0abcb61c360f35582bbe10e80691

--- a/srcpkgs/gst-rtsp-server/template
+++ b/srcpkgs/gst-rtsp-server/template
@@ -1,7 +1,7 @@
 # Template file for 'gst-rtsp-server'
 pkgname=gst-rtsp-server
-version=1.20.3
-revision=2
+version=1.22.2
+revision=1
 build_style=meson
 hostmakedepends="pkg-config python3"
 makedepends="glib-devel gst-plugins-bad1-devel gobject-introspection
@@ -10,5 +10,5 @@ short_desc="GStreamer multimedia graph framework - rtsp server"
 maintainer="1is7ac3 <isaac.qa13@gmail.com>"
 license="LGPL-2.1-or-later"
 homepage="https://gstreamer.freedesktop.org"
-distfiles="https://gstreamer.freedesktop.org/src/gst-rtsp-server/gst-rtsp-server-${version}.tar.xz"
-checksum=ee402718be9b127f0e5e66ca4c1b4f42e4926ec93ba307b7ccca5dc6cc9794ca
+distfiles="${homepage}/src/${pkgname}/${pkgname}-${version}.tar.xz"
+checksum=2be4aecfb88710100ea7115ed0216403e8094344ebf146094271b8d4d73828bf

--- a/srcpkgs/gst1-editing-services/template
+++ b/srcpkgs/gst1-editing-services/template
@@ -1,6 +1,6 @@
 # Template file for 'gst1-editing-services'
 pkgname=gst1-editing-services
-version=1.20.3
+version=1.22.2
 revision=1
 build_style=meson
 build_helper="gir"
@@ -12,7 +12,7 @@ maintainer="Toyam Cox <Vaelatern@gmail.com>"
 license="LGPL-2.0-or-later"
 homepage="https://gstreamer.freedesktop.org"
 distfiles="${homepage}/src/${pkgname/gst1/gst}/${pkgname/gst1/gst}-${version}.tar.xz"
-checksum=5fd896de69fbe24421eb6b0ff8d2f8b4c3cba3f3025ceacd302172f39a8abaa2
+checksum=453b1464fc3857de269a7cb0ebd966afe02171d97bef672a0b8a0a6d43e0cebf
 
 do_check() {
 	: # Tests fail in older versions as well

--- a/srcpkgs/gst1-python3/template
+++ b/srcpkgs/gst1-python3/template
@@ -1,7 +1,7 @@
 # Template file for 'gst1-python3'
 pkgname=gst1-python3
-version=1.20.3
-revision=2
+version=1.22.2
+revision=1
 build_style=meson
 hostmakedepends="pkg-config python3"
 makedepends="libglib-devel python3-devel python3-gobject-devel gst-plugins-base1-devel"
@@ -11,4 +11,4 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="LGPL-2.1-or-later"
 homepage="https://gstreamer.freedesktop.org"
 distfiles="${homepage}/src/gst-python/gst-python-${version}.tar.xz"
-checksum=db348120eae955b8cc4de3560a7ea06e36d6e1ddbaa99a7ad96b59846601cfdc
+checksum=bef2b3d82ce4be46b775b1bb56305c1003ee01b535a53a82f9fe8924972153ad

--- a/srcpkgs/gstreamer-vaapi/template
+++ b/srcpkgs/gstreamer-vaapi/template
@@ -1,6 +1,6 @@
 # Template file for 'gstreamer-vaapi'
 pkgname=gstreamer-vaapi
-version=1.20.3
+version=1.22.2
 revision=1
 build_style=meson
 hostmakedepends="pkg-config"
@@ -11,7 +11,7 @@ license="LGPL-2.1-or-later"
 homepage="https://gstreamer.freedesktop.org"
 changelog="https://raw.githubusercontent.com/GStreamer/gstreamer-vaapi/master/ChangeLog"
 distfiles="${homepage}/src/gstreamer-vaapi/gstreamer-vaapi-${version}.tar.xz"
-checksum=6ee99eb316abdde9ad37002915bd8c3867918f6fdc74b7cf2ac4c1ae0d690b45
+checksum=d2e642f9745f97d9f73a7f5085e7659a9a31fe209b774e6e45dae041b435df06
 
 pre_check() {
 	# Seems to need certain hardware to pass

--- a/srcpkgs/gstreamer1/template
+++ b/srcpkgs/gstreamer1/template
@@ -1,6 +1,6 @@
 # Template file for 'gstreamer1'
 pkgname=gstreamer1
-version=1.20.3
+version=1.22.2
 revision=1
 build_style=meson
 build_helper="gir"
@@ -16,7 +16,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="LGPL-2.0-or-later"
 homepage="https://gstreamer.freedesktop.org"
 distfiles="${homepage}/src/gstreamer/gstreamer-${version}.tar.xz"
-checksum=607daf64bbbd5fb18af9d17e21c0d22c4d702fffe83b23cb22d1b1af2ca23a2a
+checksum=b2afe73603921c608ba48969dbb7d743776744bfe5d8059ece241137b7f88e21
 
 pre_check() {
 	# gst_gstdatetime is known to fail according to LFS


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES** **partially**

not installed:

- gst-omx
- gst-rtsp-server
- gst1-editing-services
- gst1-python3


#### Local build testing
- I built this PR locally for my native architecture **x86_64**


#### Comments

Change distfiles to vars for rtsp like the other packages.


#### Questions

I see `shlibs` has some libgst* links to 1.0 versions and then what I assume are leftover 1.18.3_2 versions? should those be removed? I don't see anything like a 1.xx on my box, only 2023 and 1.0s. It's a relatively new build and gst* is getting bumped from 1.20.3.