### PR TITLE
kmymoney: Fix ineffective vsed

### DIFF
--- a/srcpkgs/kmymoney/template
+++ b/srcpkgs/kmymoney/template
@@ -23,7 +23,7 @@ checksum=3938b8078b7391ba32e12bb4239762fae134683a0c2ec1a75105c302ca3e5e3f
 
 post_extract() {
 	if [ "$CROSS_BUILD" ]; then
-		vsed /find_package\(Libical\)/d -i CMakeLists.txt
+		vsed /find_package\(LibIcal\)/d -i CMakeLists.txt
 	fi
 }
 


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

Addresses part of tracking issue #42441
- [x] kmymoney

#### Testing the changes
- I tested the changes in this PR: **NO**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
#### Local build testing
- I built this PR locally for my native architecture, x86\_64-glibc
- I built this PR locally for these architectures
  - x86\_64-musl
