### PR TITLE
imv: configure with -Db_ndebug=false

### DIFF
--- a/srcpkgs/imv/template
+++ b/srcpkgs/imv/template
@@ -1,8 +1,12 @@
 # Template file for 'imv'
 pkgname=imv
 version=4.4.0
-revision=1
+revision=2
 build_style=meson
+# don't define NDEBUG since assert(3) is used to detect error conditions
+# (e.g.: https://git.sr.ht/~exec64/imv/tree/v4.4.0/item/src/x11_window.c#L109
+# and https://git.sr.ht/~exec64/imv/tree/v4.4.0/item/src/wl_window.c#L673)
+configure_args="-Db_ndebug=false"
 hostmakedepends="asciidoc pkg-config cmake"
 makedepends="cmocka-devel freeimage-devel glu-devel librsvg-devel libheif-devel libxkbcommon-devel
  pango-devel wayland-devel inih-devel"


### PR DESCRIPTION
`WAYLAND_DISPLAY= imv-wayland` and `DISPLAY= imv-x11` segfault because assertions are used to check for errors in these cases and we build with `-Db_ndebug=true` by default.

By looking at the commit history, I see that similar problems occurred in the past for other meson projects.
Meson, unlike cmake, doesn't define NDEBUG by default for release build types, so it's possible that many meson projects rely on assertions being always enabled. I don't believe it's safe to have `-Db_ndebug=true` in our build style.

#### Testing the changes
- I tested the changes in this PR: **YES**