### PR TITLE
ldns: Removes ineffective vsed

### DIFF
--- a/srcpkgs/ldns/template
+++ b/srcpkgs/ldns/template
@@ -16,7 +16,6 @@ distfiles="http://www.nlnetlabs.nl/downloads/${pkgname}/${pkgname}-${version}.ta
 checksum=c3f72dd1036b2907e3a56e6acf9dfb2e551256b3c1bbd9787942deeeb70e7860
 
 post_install() {
-	vsed -i -e "s|\(-specs=.*hardened-ld\)||g" -e "s|\(-specs=.*hardened-cc1\)||g" ${DESTDIR}/usr/bin/ldns-config
 	vlicense LICENSE
 }
 


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

Addresses part of tracking issue #42441

- [x] ldns

#### Testing the changes
- I tested the changes in this PR: **NO**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
#### Local build testing
- I built this PR locally for my native architecture, x86\_64-glibc
- I built this PR locally for these architectures:
  - x86\_64-musl
