### PR TITLE
mk-configure: Remove ineffective vsed

### DIFF
--- a/srcpkgs/mk-configure/template
+++ b/srcpkgs/mk-configure/template
@@ -29,7 +29,6 @@ post_extract() {
 	rm -r examples/*lex*
 	rm -r tests/test_subprj_dash
 	rm -r tests/test_mkc_vs_*
-	vsed -i -e 's/-Wabi//g' mk/mkc_imp.platform.sys.mk
 }
 pre_build() {
 	${make_cmd} all-scripts PROG.awk=/usr/bin/awk PREFIX=/usr


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

Addresses part of tracking issue #42441

- [x] mk-configure

#### Testing the changes
- I tested the changes in this PR: **NO**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
#### Local build testing
- I built this PR locally for my native architecture, x86\_64-glibc
- I built this PR locally for these architectures:
  - x86\_64-musl
