### PR TITLE
qt5: Remove ineffective vseds

### DIFF
--- a/srcpkgs/qt5/template
+++ b/srcpkgs/qt5/template
@@ -3,9 +3,9 @@
 # revbump libqtxdg after bumping patch version
 pkgname=qt5
 version=5.15.7+20221119
+revision=3
 # commit f8c9fb304bc3e53b3aa07f962cd74e9160decccc
 # base repo: https://invent.kde.org/qt/qt/qt5
-revision=3
 build_style=meta
 hostmakedepends="cmake clang flex perl glib-devel pkg-config
  python re2c ruby which"
@@ -31,7 +31,7 @@ homepage="https://qt.io/"
 # can be marked with the export-ignore attribute
 distfiles="https://void.johnnynator.dev/distfiles/qt5-${version}.tar.gz"
 checksum=9d57af471c78029a362276b7c99108ea009f511bb9ba6ff6cb884f6ddd255e9f
-python_version=2 #unverified
+python_version=2
 replaces="qt5-doc<5.6.0 qt5-quick1<5.6.0 qt5-quick1-devel<5.6.0 qt5-webkit<5.6.0 qt5-webkit-devel<5.6.0
  qt5-enginio<5.7.1 qt5-enginio-devel<5.7.1 qt5-plugin-gtk<5.7.1 qt5-canvas3d<5.13.0"
 lib32mode=full
@@ -52,18 +52,6 @@ if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
 fi
 
 _cleanup_wrksrc_leak() {
-	if [ -d "${PKGDESTDIR}/usr/lib/cmake" ]; then
-		# Replace references to ${wrksrc} in cmake files
-		vsed -i ${PKGDESTDIR}/usr/lib/cmake/*/*.cmake \
-			-e "s;${wrksrc}/host;/usr/lib/qt5;g" \
-			-e "s;devices/void-${XBPS_CROSS_TRIPLET}-g++;linux-g++;g"
-	fi
-	if [ -d "${PKGDESTDIR}/usr/lib/pkgconfig" ]; then
-		# Replace references to ${wrksrc} in pkgconfig files
-		vsed -i ${PKGDESTDIR}/usr/lib/pkgconfig/*.pc \
-			-e "s;${wrksrc}/host;/usr/lib/qt5;g" \
-			-e "s;devices/void-${XBPS_CROSS_TRIPLET}-g++;linux-g++;g"
-	fi
 	# Remove QMAKE_PRL_BUILD_DIR from hint files for static libraries
 	# and replace references to ${wrksrc}
 	find ${PKGDESTDIR} -iname "*.prl" -exec sed -i "{}" \
@@ -1131,9 +1119,6 @@ qt5-qmake_package() {
 		vmove usr/lib/qt5/mkspecs
 		vmove usr/bin/qmake-qt5
 
-		# Change -isystem to -I to avoid "#include_next <stdlib.h>" errors
-		vsed -i ${PKGDESTDIR}/usr/lib/qt5/mkspecs/common/gcc-base.conf \
-			-e '/^QMAKE_CFLAGS_ISYSTEM/s;-isystem;-I;'
 		find ${PKGDESTDIR} -iname "*.prl" -exec sed -i "{}" \
 			-e 's%/usr/lib/lib\([^[:space:]]*\)\.[sa][o]*%-l\1%g' \;
 		find ${PKGDESTDIR} -iname "*.pri" -exec sed -i "{}" \


### PR DESCRIPTION
[ci skip]

<!-- Uncomment relevant sections and delete options which are not applicable -->

Addresses part of tracking issue #42441

- [x] qt5

#### Testing the changes
- I tested the changes in this PR: **NO**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
#### Local build testing
- I built this PR locally for my native architecture, x86\_64-glibc
