### PR TITLE
faketime: update to 0.9.10

### DIFF
--- a/srcpkgs/faketime/template
+++ b/srcpkgs/faketime/template
@@ -1,13 +1,14 @@
 # Template file for 'faketime'
 pkgname=faketime
-version=0.9.9
+version=0.9.10
 revision=1
 build_style=gnu-makefile
 short_desc="Modifies the system time for a single application"
 maintainer="Enno Boland <gottox@voidlinux.org>"
 license="GPL-2.0-only"
 homepage="https://github.com/wolfcw/libfaketime"
-distfiles="https://github.com/wolfcw/libfaketime/archive/v$version.tar.gz"
-checksum=57d0181150361c0a9b5c8eef05b11392f6134ada2c2d998e92e63daed639647c
+changelog="https://raw.githubusercontent.com/wolfcw/libfaketime/master/NEWS"
+distfiles="https://github.com/wolfcw/libfaketime/archive/v${version}.tar.gz"
+checksum=729ad33b9c750a50d9c68e97b90499680a74afd1568d859c574c0fe56fe7947f
 CFLAGS='-fPIC -DPREFIX=\"/usr\" -DLIBDIRNAME=\"/lib/faketime\"'
 LDFLAGS='-lpthread'


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

---

By *briefly*, I mean the checks for `rsyslog`, the only package that depends on this, continue to pass with this update.