### PR TITLE
ffuf: updated checksum and fixed import path

### DIFF
--- a/srcpkgs/ffuf/template
+++ b/srcpkgs/ffuf/template
@@ -1,15 +1,15 @@
 # Template file for 'ffuf'
 pkgname=ffuf
 version=2.0.0
-revision=1
+revision=2
 build_style=go
-go_import_path="github.com/ffuf/ffuf"
+go_import_path="github.com/ffuf/ffuf/v2@latest"
 short_desc="Fast web fuzzer"
 maintainer="Andrew Benson <abenson+void@gmail.com>"
 license="MIT"
 homepage="https://github.com/ffuf/ffuf"
 distfiles="${homepage}/archive/v${version}.tar.gz"
-checksum=bc27b19ed78b31862b1922a3adb66839cdf58c9b799a715c206709a73e2583d0
+checksum=80b42fe3dda8b24e10bade7b18651d402d1acf5031baedd0b344985721f3d8cd
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures:
  - aarch64-musl (cross)
  - armv7l (cross)
  - armv6l-musl (cross)
  - x86_64-musl (cross)

---

- **Briefly** means I ran `$ ffuf` and it didn't produce any stderr
- Fixes tracked package `ffuf` in #39072