### PR TITLE
gtk4: update to 4.10.1.

### DIFF
--- a/srcpkgs/gtk4/template
+++ b/srcpkgs/gtk4/template
@@ -1,6 +1,6 @@
 # Template file for 'gtk4'
 pkgname=gtk4
-version=4.8.3
+version=4.10.1
 revision=1
 build_style=meson
 build_helper="gir"
@@ -32,7 +32,7 @@ homepage="https://www.gtk.org/"
 #changelog="https://gitlab.gnome.org/GNOME/gtk/-/raw/main/NEWS"
 changelog="https://gitlab.gnome.org/GNOME/gtk/-/raw/gtk-4-8/NEWS"
 distfiles="${GNOME_SITE}/gtk/${version%.*}/gtk-${version}.tar.xz"
-checksum=b362f968d085b4d3d9340d4d38c706377ded9d5374e694a2b6b7e6292e3cba74
+checksum=e8fcac04bc7715b9da667c911a5ee8f262e200d1d6a50adf23645ca8cfcd0311
 
 # Package build options
 build_options="broadway cloudproviders colord cups gir vulkan wayland x11 tracker"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

Fixes annoying listveiw scroll bug that causes nautilus to constantly snap to the bottom of a page if the list is too long.

https://gitlab.gnome.org/GNOME/gtk/-/issues/2971

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
