### PR TITLE
riff: update to 2.23.2.

### DIFF
--- a/srcpkgs/riff/template
+++ b/srcpkgs/riff/template
@@ -1,6 +1,6 @@
 # Template file for 'riff'
 pkgname=riff
-version=2.22.2
+version=2.23.2
 revision=1
 build_style=cargo
 short_desc="Diff filter highlighting which line parts have changed"
@@ -8,7 +8,7 @@ maintainer="0x5c <dev@0x5c.io>"
 license="MIT"
 homepage="https://github.com/walles/riff"
 distfiles="https://github.com/walles/riff/archive/refs/tags/${version}.tar.gz"
-checksum=7624e73d968d41133edc095b78ba49a19084933ff46f375864fed89fcf7c3e86
+checksum=fc39a75a6e09a3d94c6b2d8a3ad1f7aacae5a9e6da2f66f7b26dac55e82b62f3
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
This version has the fix for the [previous version's](https://github.com/void-linux/void-packages/pull/42868) race condition

Closes #42868

#### Testing the changes
- I tested the changes in this PR: **YES** 

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
