### PR TITLE
New package: MangoHud-nvidia-0.6.9

### DIFF
--- a/srcpkgs/MangoHud-nvidia/files/musl.patch
+++ b/srcpkgs/MangoHud-nvidia/files/musl.patch
@@ -1,0 +1,30 @@
+--- a/src/meson.build	2023-04-17 23:31:55.000000000 +0100
++++ b/src/meson.build	2023-04-27 06:21:59.187169515 +0100
+@@ -3,10 +3,10 @@
+ # Needs prefix for configure_file()
+ if get_option('append_libdir_mangohud')
+   libdir_mangohud = join_paths(get_option('prefix'), get_option('libdir'), 'mangohud')
+-  ld_libdir_mangohud = get_option('prefix') + '/\$LIB/mangohud/'
++  ld_libdir_mangohud = join_paths(get_option('prefix') ,get_option('libdir'), 'mangohud')
+ else
+   libdir_mangohud = join_paths(get_option('prefix'), get_option('libdir'))
+-  ld_libdir_mangohud = get_option('prefix') + '/\$LIB/'
++  ld_libdir_mangohud = join_paths(get_option('prefix') ,get_option('libdir'))
+ endif
+ 
+ conf_data = configuration_data()
+--- a/bin/mangohud.in	2023-04-17 23:31:55.000000000 +0100
++++ b/bin/mangohud.in	2023-04-27 06:30:23.169862796 +0100
+@@ -8,11 +8,11 @@
+ 	exit 1
+ fi
+ 
+-MANGOHUD_LIB_NAME="@ld_libdir_mangohud@libMangoHud.so"
++MANGOHUD_LIB_NAME="@ld_libdir_mangohud@/libMangoHud.so"
+ 
+ if [ "$1" = "--dlsym" ]; then
+ 	MANGOHUD_DLSYM=1
+-	MANGOHUD_LIB_NAME="@ld_libdir_mangohud@libMangoHud_dlsym.so:${MANGOHUD_LIB_NAME}"
++	MANGOHUD_LIB_NAME="@ld_libdir_mangohud@/libMangoHud_dlsym.so:${MANGOHUD_LIB_NAME}"
+ 	shift
+ fi

--- a/srcpkgs/MangoHud-nvidia/template
+++ b/srcpkgs/MangoHud-nvidia/template
@@ -1,0 +1,84 @@
+# Template file for 'MangoHud-nvidia'
+pkgname=MangoHud-nvidia
+version=0.6.9
+revision=1
+build_style=meson
+configure_args="-Dwith_xnvctrl=disabled -Dwith_nvml=enabled -Duse_system_spdlog=enabled"
+hostmakedepends="python3-Mako glslang pkg-config"
+makedepends="libglvnd-devel dbus-devel vulkan-loader spdlog"
+short_desc="Vulkan and OpenGL overlay for monitoring FPS, temperatures and more"
+maintainer="gmbeard <gmbeard@googlemail.com>"
+license="MIT,custom:NVIDIA"
+homepage="https://github.com/flightlessmango/MangoHud"
+distfiles="https://github.com/flightlessmango/MangoHud/releases/download/v${version}-1/MangoHud-v${version}-1-Source.tar.xz"
+checksum=30d9336b60cbc7fdc2a1ba86ec62b9fb7f2986a2b0f6196ca347f5c13e583c6d
+conflicts=MangoHud
+repository=nonfree
+
+post_patch() {
+	if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
+		patch -Np1 -i ${FILESDIR}/musl.patch
+	fi
+}
+
+# Ensure that each eligible architecture ships its multilib layer files.
+# This allows us to not have to ship these files in the current *-32bit packages
+_generate_counterpart_vulkan_layer() {
+
+	local arch=${XBPS_TARGET_MACHINE%-*}
+	local oarch
+	local olibdir="/usr/lib32/"
+
+	if [ "${XBPS_TARGET_WORDSIZE}" = "32" ]; then
+		olibdir="/usr/lib64/"
+	fi
+
+	# Deduce the current and counterpart archs based on meson's cpu_family,
+	# which is what the build uses to name the layer files...
+	# (https://mesonbuild.com/Reference-tables.html#cpu-families)
+	case "${arch}" in
+		aarch64)
+			oarch="arm"
+			;;
+		armv[67]l)
+			arch="arm"
+			oarch="aarch64"
+			;;
+		x86_64)
+			oarch="x86"
+			;;
+		i686)
+			arch="x86"
+			oarch="x86_64"
+			;;
+		ppc64*)
+			arch="ppc64"
+			oarch="ppc"
+			;;
+		ppc|ppcle)
+			arch="ppc"
+			oarch="ppc64"
+			;;
+		*) ;; # no counterparts
+	esac
+
+	if [ -n "${oarch}" ]; then
+		local layer="${DESTDIR}/usr/share/vulkan/implicit_layer.d/MangoHud.${arch}.json"
+
+		sed "s#/usr/lib${XBPS_TARGET_WORDSIZE}/#${olibdir}#g" \
+			"${layer}" > "${layer/.${arch}/.${oarch}}"
+	fi
+}
+
+post_install() {
+	_generate_counterpart_vulkan_layer
+
+	# Extract the NVIDIA license from the nvml.h header
+	head -n $( \
+		awk '/NVML API Reference/{ print NR-1; exit }' ${wrksrc}/include/nvml.h \
+		) ${wrksrc}/include/nvml.h \
+		| sed 's;^\([/ ]\?\)\*/\?;;g' >${wrksrc}/LICENSE-NVIDIA
+
+	vlicense LICENSE
+	vlicense LICENSE-NVIDIA
+}


### PR DESCRIPTION
### Description
This packages MangoHud with the necessary build config to enable nVidia GPU stats. Because of the non-free license of the nVidia headers used in the source distribution, I've made the assumption that this must be treated in the same way as the `nvidia*` packages (i.e `nonfree`), hence the separate package.

This is essentially a straight clone of the existing MangoHud package, but uses a non-DFSG upstream.
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
#### Local build testing
- I built this PR locally for my native architecture, x86\_64-glibc
- I built this PR locally for these architectures:
  - x86\_64-musl
