### PR TITLE
libpeas: update to 1.36.0.

### DIFF
--- a/srcpkgs/libpeas/template
+++ b/srcpkgs/libpeas/template
@@ -1,7 +1,7 @@
 # Template file for 'libpeas'
 pkgname=libpeas
-version=1.34.0
-revision=2
+version=1.36.0
+revision=1
 build_style=meson
 build_helper="gir"
 configure_args="-Ddemos=false -Dvapi=true"
@@ -16,7 +16,7 @@ license="LGPL-2.1-or-later"
 homepage="https://wiki.gnome.org/Projects/Libpeas"
 changelog="https://gitlab.gnome.org/GNOME/libpeas/-/raw/master/NEWS"
 distfiles="${GNOME_SITE}/libpeas/${version%.*}/libpeas-${version}.tar.xz"
-checksum=4305f715dab4b5ad3e8007daec316625e7065a94e63e25ef55eb1efb964a7bf0
+checksum=297cb9c2cccd8e8617623d1a3e8415b4530b8e5a893e3527bbfd1edd13237b4c
 make_check_pre="xvfb-run"
 
 libpeas-devel_package() {


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
