### PR TITLE
python3-gobject: update to 3.44.0.

### DIFF
--- a/srcpkgs/python3-gobject/template
+++ b/srcpkgs/python3-gobject/template
@@ -1,20 +1,21 @@
 # Template file for 'python3-gobject'
 pkgname=python3-gobject
-version=3.42.2
-revision=2
+version=3.44.0
+revision=1
 build_style=meson
 build_helper="gir"
 configure_args="-Dpython=python${py3_ver}"
-hostmakedepends="pkg-config python3 python3-MarkupSafe"
+hostmakedepends="pkg-config python3-setuptools"
 makedepends="libglib-devel python3-cairo-devel python3-devel"
 depends="gir-freedesktop python3-cairo"
-checkdepends="python3-pytest gtk+3 xvfb-run"
+checkdepends="python3-pytest pango python3-cairo gtk+3 xvfb-run"
 short_desc="Python3 bindings for GObject"
 maintainer="Enno Boland <gottox@voidlinux.org>"
 license="LGPL-2.1-or-later"
 homepage="https://pygobject.readthedocs.io/"
+changelog="https://pygobject.readthedocs.io/en/latest/changelog.html"
 distfiles="${GNOME_SITE}/pygobject/${version%.*}/pygobject-${version}.tar.xz"
-checksum=ade8695e2a7073849dd0316d31d8728e15e1e0bc71d9ff6d1c09e86be52bc957
+checksum=f6863d6a3b70d9ace4c36a9901d39e42c8801d11309ca2a8b3459d1c24e34b7f
 make_check_pre="xvfb-run"
 
 python3-gobject-devel_package() {


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture: **x86_64**

Built and used Solaar from this PR. Also built meld & xapps which went fine.