### PR TITLE
gscan2pdf: corrected a patch to make tesseract available

### DIFF
--- a/srcpkgs/gscan2pdf/patches/tesseract.patch
+++ b/srcpkgs/gscan2pdf/patches/tesseract.patch
@@ -13,13 +13,11 @@
      # we can use --list-langs and not bother with tessdata
      ( undef, my $out, my $err ) =
 -      Gscan2pdf::Document::exec_command( [ 'tesseract', '-v' ] );
--    if ( $err =~ /^tesseract[ ]([\d.]+)/xsm ) {
 +      Gscan2pdf::Document::exec_command( [ 'tesseract-ocr', '-v' ] );
-+    if ( $err =~ /^tesseract-ocr[ ]([\d.]+)/xsm ) {
+     if ( $err =~ /^tesseract[ ]([\d.]+)/xsm ) {
          $version = $1;
      }
--    elsif ( $out =~ /^tesseract[ ]([\d.]+)/xsm ) {
-+    elsif ( $out =~ /^tesseract-ocr[ ]([\d.]+)/xsm ) {
+     elsif ( $out =~ /^tesseract[ ]([\d.]+)/xsm ) {
          $version = $1;
      }
      if ( not $version )                 { return }

--- a/srcpkgs/gscan2pdf/template
+++ b/srcpkgs/gscan2pdf/template
@@ -1,7 +1,7 @@
-# Template file for 'gscan2pdf'.
+# Template file for 'gscan2pdf'
 pkgname=gscan2pdf
 version=2.13.2
-revision=1
+revision=2
 build_style=perl-module
 hostmakedepends="perl gettext"
 makedepends="ImageMagick djvulibre libmagick-perl perl-Config-General


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
#### Local build testing
- I built this PR locally for my native architecture, (x86_64-musl)
