### PR TITLE
power-profiles-daemon: add dependency for powerprofilesctl

### DIFF
--- a/srcpkgs/power-profiles-daemon/template
+++ b/srcpkgs/power-profiles-daemon/template
@@ -1,11 +1,12 @@
 # Template file for 'power-profiles-daemon'
 pkgname=power-profiles-daemon
 version=0.12
-revision=1
+revision=2
 build_style=meson
 configure_args="-Dsystemdsystemunitdir=/usr/lib/systemd/system/"
 hostmakedepends="pkg-config glib-devel"
 makedepends="libglib-devel libgudev-devel upower0-devel polkit-devel"
+depends="python3-gobject"
 checkdepends="python3-dbusmock umockdev-devel"
 short_desc="Makes power profiles handling available over D-Bus"
 maintainer="oreo639 <oreo6391@gmail.com>"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
