### PR TITLE
moe: update to 1.13

### DIFF
--- a/srcpkgs/moe/template
+++ b/srcpkgs/moe/template
@@ -1,10 +1,10 @@
 # Template file for 'moe'
 pkgname=moe
-version=1.12
+version=1.13
 revision=1
 build_style=configure
 configure_args="--prefix=/usr --sysconfdir=/etc"
-conf_files="/etc/moerc"
+conf_files="/etc/moe.conf"
 hostmakedepends="lzip"
 makedepends="ncurses-devel"
 short_desc="Powerful and user-friendly text editor"
@@ -12,7 +12,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="https://www.gnu.org/software/moe/"
 distfiles="${GNU_SITE}/${pkgname}/${pkgname}-${version}.tar.lz"
-checksum=8a885f2be426f8e04ad39c96012bd860954085a23744f2451663168826d7a1e8
+checksum=43a557bc512f89d6c718e5f41029cfe3a055682620eb8dbece6302f34a26146b
 
 pre_configure() {
 	# remove hardcoded values


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, x86_64
- I crossbuilded this PR locally for these architectures:
  - armv7l
  - armv6l-musl
  - aarch64-musl

#### Notes

From `NEWS` : 

> The moe configuration file 'moerc' has been renamed to 'moe.conf'.
Moe now looks for the configuration file in $XDG_CONFIG_HOME/moe.conf
instead of $HOME/.moerc. (XDG_CONFIG_HOME defaults to $HOME/.config).

From `Changelog` :
> * moerc: Rename to moe.conf. Search for it in $XDG_CONFIG_HOME.

So I modified `conf_files`.