### PR TITLE
New packages: netavark-1.6.0, aardvark-dns-1.6.0

### DIFF
--- a/srcpkgs/aardvark-dns/template
+++ b/srcpkgs/aardvark-dns/template
@@ -1,0 +1,17 @@
+# Template file for 'aardvark-dns'
+pkgname=aardvark-dns
+version=1.6.0
+revision=1
+build_style=cargo
+short_desc="Authoritative dns server for A/AAAA container records"
+maintainer="Daniel Eyßer <daniel.eysser@gmail.com>"
+license="Apache-2.0"
+homepage="https://github.com/containers/aardvark-dns"
+changelog="https://raw.githubusercontent.com/containers/aardvark-dns/main/RELEASE_NOTES.md"
+distfiles="https://github.com/containers/aardvark-dns/archive/refs/tags/v${version}.tar.gz"
+checksum=f3a2ff2d7baf07d8bf2785b6f1c9618db8aa188bd738b7f5cf1b0a31848232f5
+
+post_install() {
+	vmkdir usr/libexec/podman
+	ln -sf ../../bin/aardvark-dns "${DESTDIR}/usr/libexec/podman"
+}

--- a/srcpkgs/netavark/template
+++ b/srcpkgs/netavark/template
@@ -1,0 +1,23 @@
+# Template file for 'netavark'
+pkgname=netavark
+version=1.6.0
+revision=1
+build_style=cargo
+hostmakedepends="mandown protobuf"
+short_desc="Container network stack"
+maintainer="Daniel Eyßer <daniel.eysser@gmail.com>"
+license="Apache-2.0"
+homepage="https://github.com/containers/netavark"
+changelog="https://raw.githubusercontent.com/containers/netavark/main/RELEASE_NOTES.md"
+distfiles="https://github.com/containers/netavark/archive/refs/tags/v${version}.tar.gz"
+checksum=3bec9e9b0f3f8f857370900010fb2125ead462d43998ad8f43e4387a5b06f9d6
+# needs unshare which cannot be used in CI
+make_check=ci-skip
+
+post_install() {
+	vmkdir usr/libexec/podman
+	ln -sf ../../bin/netavark "${DESTDIR}/usr/libexec/podman"
+	ln -sf ../../bin/netavark-dhcp-proxy-client "${DESTDIR}/usr/libexec/podman"
+	mandown docs/netavark.1.md > netavark.1
+	vman netavark.1
+}


### PR DESCRIPTION
podman 4.0's new network stack.
Some more information if anybody is interested: https://www.redhat.com/sysadmin/podman-new-network-stack

https://github.com/containers/netavark
https://github.com/containers/aardvark-dns

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
