### PR TITLE
[WIP] New package: rustfmt-1.5.1

### DIFF
--- a/srcpkgs/rustfmt/template
+++ b/srcpkgs/rustfmt/template
@@ -1,0 +1,15 @@
+# Template file for 'rustfmt'
+pkgname=rustfmt
+version=1.5.1
+revision=1
+build_style=cargo
+short_desc="Tool for formatting Rust code according to style guidelines"
+maintainer="astral <astral@astralchan.xyz>"
+license="MIT, Apache-2.0"
+homepage="https://github.com/rust-lang/rustfmt"
+distfiles="https://github.com/rust-lang/rustfmt/archive/refs/tags/v${version}.tar.gz"
+checksum=dc29a1c066fe4816e1400655c676d632335d667c3b0231ce344b2a7b02acc267
+
+post_install() {
+	vlicense LICENSE-MIT
+}


### PR DESCRIPTION
[ci skip]

#### Testing the changes
- I tested the changes in this PR: **NO**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

Currently failing:

```
   Compiling cargo_metadata v0.14.2
error[E0532]: expected unit struct, unit variant or constant, found tuple variant `ast::Extern::Implicit`
   --> src/utils.rs:141:9
    |
141 |         ast::Extern::Implicit => "C".to_owned(),
    |         ^^^^^^^^^^^^^^^^^^^^^
    |
help: use the tuple variant pattern syntax instead
    |
141 |         ast::Extern::Implicit(/* fields */) => "C".to_owned(),
    |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
help: consider importing this unit variant instead
    |
1   | use rustc_session::cstore::CrateDepKind::Implicit;
    |
help: if you import `Implicit`, refer to it directly
    |
141 -         ast::Extern::Implicit => "C".to_owned(),
141 +         Implicit => "C".to_owned(),
    |

error[E0554]: `#![feature]` may not be used on the stable release channel
 --> src/lib.rs:1:1
  |
1 | #![feature(rustc_private)]
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^

error[E0023]: this pattern has 1 field, but the corresponding tuple variant has 2 fields
   --> src/utils.rs:142:31
    |
142 |         ast::Extern::Explicit(abi) => abi.symbol_unescaped.to_string(),
    |                               ^^^ expected 2 fields, found 1
    |
help: use `_` to explicitly ignore each field
    |
142 |         ast::Extern::Explicit(abi, _) => abi.symbol_unescaped.to_string(),
    |                                  +++

error[E0023]: this pattern has 6 fields, but the corresponding tuple variant has 7 fields
   --> src/utils.rs:482:34
    |
482 |         | ast::ExprKind::Closure(_, _, _, _, ref expr, _)
    |                                  ^  ^  ^  ^  ^^^^^^^^  ^ expected 7 fields, found 6
    |
help: use `_` to explicitly ignore each field
    |
482 |         | ast::ExprKind::Closure(_, _, _, _, ref expr, _, _)
    |                                                         +++

error[E0023]: this pattern has 6 fields, but the corresponding tuple variant has 7 fields
   --> src/closures.rs:315:35
    |
315 |     if let ast::ExprKind::Closure(capture, ref is_async, movability, ref fn_decl, ref body, _) =
    |                                   ^^^^^^^  ^^^^^^^^^^^^  ^^^^^^^^^^  ^^^^^^^^^^^  ^^^^^^^^  ^ expected 7 fields, found 6
    |
help: use `_` to explicitly ignore each field
    |
315 |     if let ast::ExprKind::Closure(capture, ref is_async, movability, ref fn_decl, ref body, _, _) =
    |                                                                                              +++

error[E0023]: this pattern has 6 fields, but the corresponding tuple variant has 7 fields
   --> src/expr.rs:206:32
    |
206 |         ast::ExprKind::Closure(capture, ref is_async, movability, ref fn_decl, ref body, _) => {
    |                                ^^^^^^^  ^^^^^^^^^^^^  ^^^^^^^^^^  ^^^^^^^^^^^  ^^^^^^^^  ^ expected 7 fields, found 6
    |
help: use `_` to explicitly ignore each field
    |
206 |         ast::ExprKind::Closure(capture, ref is_async, movability, ref fn_decl, ref body, _, _) => {
    |                                                                                           +++

error[E0277]: the size for values of type `str` cannot be known at compilation time
   --> src/expr.rs:401:20
    |
401 |         .and_then(|expr_str| {
    |                    ^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `str`
help: function arguments must have a statically known size, borrowed types always have a known size
    |
401 |         .and_then(|&expr_str| {
    |                    +

error[E0061]: this function takes 2 arguments but 1 argument was supplied
   --> src/items.rs:151:17
    |
151 |                 ast::Extern::from_abi(fm.abi),
    |                 ^^^^^^^^^^^^^^^^^^^^^-------- an argument of type `Span` is missing
    |
note: associated function defined here
help: provide the argument
    |
151 |                 ast::Extern::from_abi(fm.abi, /* Span */),
    |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

error[E0023]: this pattern has 1 field, but the corresponding tuple variant has 2 fields
   --> src/macros.rs:685:26
    |
685 |         TokenTree::Token(ref t) => t.clone(),
    |                          ^^^^^ expected 2 fields, found 1
    |
help: use `_` to explicitly ignore each field
    |
685 |         TokenTree::Token(ref t, _) => t.clone(),
    |                               +++

error[E0023]: this pattern has 1 field, but the corresponding tuple variant has 2 fields
   --> src/macros.rs:740:35
    |
740 |               Some(TokenTree::Token(Token {
    |  ___________________________________^
741 | |                 kind: TokenKind::Ident(name, _),
742 | |                 ..
743 | |             })) => {
    | |_____________^ expected 2 fields, found 1
    |
help: use `_` to explicitly ignore each field
    |
743 |             }, _)) => {
    |              +++

error[E0023]: this pattern has 1 field, but the corresponding tuple variant has 2 fields
   --> src/macros.rs:780:34
    |
780 |                   TokenTree::Token(Token {
    |  __________________________________^
781 | |                     kind: TokenKind::BinOp(BinOpToken::Plus),
782 | |                     ..
783 | |                 })
    | |_________________^ expected 2 fields, found 1
    |
help: use `_` to explicitly ignore each field
    |
783 |                 }, _)
    |                  +++

error[E0023]: this pattern has 1 field, but the corresponding tuple variant has 2 fields
   --> src/macros.rs:784:36
    |
784 |                   | TokenTree::Token(Token {
    |  ____________________________________^
785 | |                     kind: TokenKind::Question,
786 | |                     ..
787 | |                 })
    | |_________________^ expected 2 fields, found 1
    |
help: use `_` to explicitly ignore each field
    |
787 |                 }, _)
    |                  +++

error[E0023]: this pattern has 1 field, but the corresponding tuple variant has 2 fields
   --> src/macros.rs:788:36
    |
788 |                   | TokenTree::Token(Token {
    |  ____________________________________^
789 | |                     kind: TokenKind::BinOp(BinOpToken::Star),
790 | |                     ..
791 | |                 }) => {
    | |_________________^ expected 2 fields, found 1
    |
help: use `_` to explicitly ignore each field
    |
791 |                 }, _) => {
    |                  +++

error[E0023]: this pattern has 1 field, but the corresponding tuple variant has 2 fields
   --> src/macros.rs:794:34
    |
794 |                 TokenTree::Token(ref t) => {
    |                                  ^^^^^ expected 2 fields, found 1
    |
help: use `_` to explicitly ignore each field
    |
794 |                 TokenTree::Token(ref t, _) => {
    |                                       +++

error[E0023]: this pattern has 1 field, but the corresponding tuple variant has 2 fields
   --> src/macros.rs:862:34
    |
862 |                   TokenTree::Token(Token {
    |  __________________________________^
863 | |                     kind: TokenKind::Dollar,
864 | |                     span,
865 | |                 }) => {
    | |_________________^ expected 2 fields, found 1
    |
help: use `_` to explicitly ignore each field
    |
865 |                 }, _) => {
    |                  +++

error[E0023]: this pattern has 1 field, but the corresponding tuple variant has 2 fields
   --> src/macros.rs:878:34
    |
878 |                   TokenTree::Token(Token {
    |  __________________________________^
879 | |                     kind: TokenKind::Colon,
880 | |                     ..
881 | |                 }) if self.is_meta_var => {
    | |_________________^ expected 2 fields, found 1
    |
help: use `_` to explicitly ignore each field
    |
881 |                 }, _) if self.is_meta_var => {
    |                  +++

error[E0023]: this pattern has 1 field, but the corresponding tuple variant has 2 fields
   --> src/macros.rs:884:34
    |
884 |                 TokenTree::Token(ref t) => self.update_buffer(t),
    |                                  ^^^^^ expected 2 fields, found 1
    |
help: use `_` to explicitly ignore each field
    |
884 |                 TokenTree::Token(ref t, _) => self.update_buffer(t),
    |                                       +++

error[E0308]: mismatched types
    --> src/macros.rs:1126:42
     |
1126 |         let args = TokenStream::new(vec![(tok, Spacing::Joint)]);
     |                                          ^^^^^^^^^^^^^^^^^^^^^ expected enum `TokenTree`, found tuple
     |
     = note: expected enum `TokenTree`
               found tuple `(TokenTree, Spacing)`

error[E0023]: this pattern has 1 field, but the corresponding tuple variant has 2 fields
    --> src/macros.rs:1128:30
     |
1128 |               TokenTree::Token(Token {
     |  ______________________________^
1129 | |                 kind: TokenKind::FatArrow,
1130 | |                 ..
1131 | |             }) => {}
     | |_____________^ expected 2 fields, found 1
     |
help: use `_` to explicitly ignore each field
     |
1131 |             }, _) => {}
     |              +++

error[E0023]: this pattern has 1 field, but the corresponding tuple variant has 2 fields
    --> src/macros.rs:1150:38
     |
1150 |           if let Some(TokenTree::Token(Token {
     |  ______________________________________^
1151 | |             kind: TokenKind::Semi,
1152 | |             span,
1153 | |         })) = self.toks.look_ahead(0)
     | |_________^ expected 2 fields, found 1
     |
help: use `_` to explicitly ignore each field
     |
1153 |         }, _)) = self.toks.look_ahead(0)
     |          +++

Some errors have detailed explanations: E0023, E0061, E0277, E0308, E0532, E0554.
For more information about an error, try `rustc --explain E0023`.
error: could not compile `rustfmt-nightly` due to 20 previous errors
warning: build failed, waiting for other jobs to finish...
=> ERROR: rustfmt-1.5.1_1: do_build: '${make_cmd} build --release --target ${RUST_TARGET} ${configure_args}' exited with 101
=> ERROR:   in do_build() at common/build-style/cargo.sh:8
```