### PR TITLE
freerdp: update to 2.10.0.

### DIFF
--- a/srcpkgs/freerdp/template
+++ b/srcpkgs/freerdp/template
@@ -1,6 +1,6 @@
 # Template file for 'freerdp'
 pkgname=freerdp
-version=2.9.0
+version=2.10.0
 revision=1
 build_style=cmake
 configure_args="-DWITH_ALSA=ON -DWITH_CUPS=OFF -DWITH_FFMPEG=ON
@@ -18,9 +18,9 @@ short_desc="Free RDP (Remote Desktop Protocol) client"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="Apache-2.0"
 homepage="https://www.freerdp.com/"
-changelog="https://raw.githubusercontent.com/FreeRDP/FreeRDP/stable-2.0/ChangeLog"
+changelog="https://raw.githubusercontent.com/FreeRDP/FreeRDP/2.10.0/ChangeLog"
 distfiles="https://github.com/FreeRDP/FreeRDP/archive/${version}.tar.gz"
-checksum=ab8de7e962bdc3c34956160de2de8ed28423d39a78452b7686b72c94b1953b27
+checksum=88fa59f8e8338d5cb2490d159480564562a5624f3a3572c89fa3070b9626835c
 CFLAGS="-Wno-dev"
 
 case "$XBPS_TARGET_MACHINE" in


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **NO**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (all crossbuilds):
  - aarch64-*
  - armv7l-*
  - armv6l-*
  - x86_64-musl
  - i686-glibc
