### PR TITLE
gnunet: update to 0.19.3

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -2333,7 +2333,7 @@ libgnunettestbedlogger.so.0 gnunet-0.12.2_1
 libgnunettestbed.so.0 gnunet-0.12.2_1
 libgnunetatstesting.so.0 gnunet-0.12.2_1
 libgnunetnse.so.0 gnunet-0.12.2_1
-libgnunetdht.so.3 gnunet-0.12.2_1
+libgnunetdht.so.4 gnunet-0.19.3_1
 libgnunetfriends.so.0 gnunet-0.12.2_1
 libgnunetregexblock.so.1 gnunet-0.12.2_1
 libgnunetregex.so.3 gnunet-0.12.2_1
@@ -2353,7 +2353,7 @@ libgnunetsecretsharing.so.0 gnunet-0.12.2_1
 libnss_gns.so.2 gnunet-0.12.2_1
 libnss_gns4.so.2 gnunet-0.12.2_1
 libnss_gns6.so.2 gnunet-0.12.2_1
-libgnunetutil.so.13 gnunet-0.12.2_1
+libgnunetutil.so.15 gnunet-0.19.3_1
 libgnunetnt.so.0 gnunet-0.12.2_1
 libgnunetgnsrecord.so.0 gnunet-0.12.2_1
 libgnunethello.so.0 gnunet-0.12.2_1

--- a/srcpkgs/gnunet/template
+++ b/srcpkgs/gnunet/template
@@ -1,13 +1,14 @@
 # Template file for 'gnunet'
 pkgname=gnunet
-version=0.12.2
-revision=4
+version=0.19.3
+revision=1
 build_style=gnu-configure
 conf_files="/etc/gnunet/gnunet.conf"
 hostmakedepends="automake gettext gettext-devel libtool pkg-config tar texinfo"
 # XXX: curl-gnutls-devel
 makedepends="libidn-devel libltdl-devel libunistring-devel
  libmariadbclient-devel postgresql-libs-devel sqlite-devel zlib-devel
+ libsodium-devel
  $(vopt_if bluetooth libbluetooth-devel)
  $(vopt_if extractor libextractor-devel)
  $(vopt_if ifconfig inetutils-ifconfig)
@@ -25,7 +26,7 @@ maintainer="Anachron <gith@cron.world>"
 license="GPL-3.0-or-later"
 homepage="https://gnunet.org"
 distfiles="http://ftpmirror.gnu.org/gnunet/${pkgname}-${version}.tar.gz"
-checksum=ac288b047d1156fc5e739062b11242bad0487993631e79781aede620ddf18cd7
+checksum=82b7d5fe12d481387c37d2fbf032bb605c2e4d5976079a1947943243e5ba7a25
 
 build_options="bluetooth extractor iptables ifconfig jansson microhttpd opus gstreamer pulseaudio zbar"
 build_options_default="bluetooth extractor iptables ifconfig jansson microhttpd opus gstreamer pulseaudio zbar"


### PR DESCRIPTION
0.12.2 is not even available on the ftp server anymore, so I took the liberty to update it.

#### Testing the changes
- I tested the changes in this PR: **briefly** (I don't know much about GNUnet, but it builds and from a high-level look it runs, but I failed to test GNS functionality)

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc