### PR TITLE
xfce4-session: fix use after free

### DIFF
--- a/srcpkgs/xfce4-session/patches/911f5b8101dec6a6d28f7601768588a2f0fd4aaf.patch
+++ b/srcpkgs/xfce4-session/patches/911f5b8101dec6a6d28f7601768588a2f0fd4aaf.patch
@@ -1,0 +1,194 @@
+From 911f5b8101dec6a6d28f7601768588a2f0fd4aaf Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Ga=C3=ABl=20Bonithon?= <gael@xfce.org>
+Date: Tue, 14 Mar 2023 13:56:19 +0100
+Subject: [PATCH] Fix Xfconf memory management
+
+* Each xfconf_init() should match an xfconf_shutdown()
+* Xfconf already manages a singleton channel, no need to duplicate that
+
+(cherry picked from commit 87ec0e7e8a3f18e776da899098698f0acf0b1fd9)
+---
+ libxfsm/xfsm-util.c                      | 10 ----------
+ libxfsm/xfsm-util.h                      |  3 +--
+ settings/main.c                          |  1 +
+ settings/xfce4-session-settings-common.h |  2 --
+ xfce4-session/main.c                     |  6 +++---
+ xfce4-session/xfsm-consolekit.c          |  2 +-
+ xfce4-session/xfsm-logout-dialog.c       |  4 ++--
+ xfce4-session/xfsm-shutdown-fallback.c   |  2 +-
+ xfce4-session/xfsm-systemd.c             |  2 +-
+ 9 files changed, 10 insertions(+), 22 deletions(-)
+
+diff --git a/libxfsm/xfsm-util.c b/libxfsm/xfsm-util.c
+index 69ba01f1..9f84ffb2 100644
+--- a/libxfsm/xfsm-util.c
++++ b/libxfsm/xfsm-util.c
+@@ -155,16 +155,6 @@ xfsm_strv_equal (gchar **a, gchar **b)
+ }
+ 
+ 
+-XfconfChannel*
+-xfsm_open_config (void)
+-{
+-  static XfconfChannel *channel = NULL;
+-
+-  if (G_UNLIKELY (channel == NULL))
+-    channel = xfconf_channel_get ("xfce4-session");
+-  return channel;
+-}
+-
+ gchar*
+ xfsm_gdk_display_get_fullname (GdkDisplay *display)
+ {
+diff --git a/libxfsm/xfsm-util.h b/libxfsm/xfsm-util.h
+index c68e0f2d..0893a7b7 100644
+--- a/libxfsm/xfsm-util.h
++++ b/libxfsm/xfsm-util.h
+@@ -32,6 +32,7 @@
+ G_BEGIN_DECLS;
+ 
+ #define DEFAULT_SESSION_NAME "Default"
++#define SETTINGS_CHANNEL "xfce4-session"
+ 
+ typedef struct _XfsmSessionInfo  XfsmSessionInfo;
+ 
+@@ -68,8 +69,6 @@ void           xfsm_place_trash_window               (GtkWindow *window,
+ gboolean       xfsm_strv_equal                       (gchar **a,
+                                                       gchar **b);
+ 
+-XfconfChannel *xfsm_open_config                      (void);
+-
+ gchar         *xfsm_gdk_display_get_fullname         (GdkDisplay *display);
+ 
+ cairo_surface_t *xfsm_load_session_preview           (const gchar *name,
+diff --git a/settings/main.c b/settings/main.c
+index 55d65da2..53470c34 100644
+--- a/settings/main.c
++++ b/settings/main.c
+@@ -248,6 +248,7 @@ main(int argc,
+     }
+ 
+     g_object_unref(builder);
++    xfconf_shutdown ();
+ 
+     return EXIT_SUCCESS;
+ }
+diff --git a/settings/xfce4-session-settings-common.h b/settings/xfce4-session-settings-common.h
+index 3c1a11db..c372925c 100644
+--- a/settings/xfce4-session-settings-common.h
++++ b/settings/xfce4-session-settings-common.h
+@@ -19,8 +19,6 @@
+ #ifndef __XFCE4_SESSION_SETTINGS_COMMON_H__
+ #define __XFCE4_SESSION_SETTINGS_COMMON_H__
+ 
+-#define  SETTINGS_CHANNEL  "xfce4-session"
+-
+ void session_editor_init(GtkBuilder *builder);
+ 
+ #endif
+diff --git a/xfce4-session/main.c b/xfce4-session/main.c
+index d98500c1..ab63b1ad 100644
+--- a/xfce4-session/main.c
++++ b/xfce4-session/main.c
+@@ -171,7 +171,7 @@ bus_acquired (GDBusConnection *connection,
+ 
+   setup_environment ();
+ 
+-  channel = xfsm_open_config ();
++  channel = xfconf_channel_get (SETTINGS_CHANNEL);
+ 
+   dpy = gdk_display_get_default ();
+   init_display (*manager, dpy, opt_disable_tcp);
+@@ -244,12 +244,10 @@ name_lost (GDBusConnection *connection,
+ 
+   g_object_unref (shutdown_helper);
+   g_object_unref (*manager);
+-  g_object_unref (channel);
+   g_clear_error (&error);
+ 
+   shutdown_helper = NULL;
+   *manager = NULL;
+-  channel = NULL;
+ 
+   gtk_main_quit ();
+ }
+@@ -353,6 +351,7 @@ main (int argc, char **argv)
+     {
+       xfce_dialog_show_error (NULL, error, _("Unable to contact settings server"));
+       g_error_free (error);
++      return EXIT_FAILURE;
+     }
+ 
+   /* Process all pending events prior to start DBUS */
+@@ -369,6 +368,7 @@ main (int argc, char **argv)
+   gtk_main ();
+ 
+   xfsm_startup_shutdown ();
++  xfconf_shutdown ();
+ 
+   return EXIT_SUCCESS;
+ }
+diff --git a/xfce4-session/xfsm-consolekit.c b/xfce4-session/xfsm-consolekit.c
+index 022dfbe4..b79b3abd 100644
+--- a/xfce4-session/xfsm-consolekit.c
++++ b/xfce4-session/xfsm-consolekit.c
+@@ -393,7 +393,7 @@ lock_screen (XfsmConsolekit  *consolekit,
+   XfconfChannel *channel;
+   gboolean       ret = TRUE;
+ 
+-  channel = xfsm_open_config ();
++  channel = xfconf_channel_get (SETTINGS_CHANNEL);
+   if (xfconf_channel_get_bool (channel, "/shutdown/LockScreen", FALSE))
+       ret = xfce_screensaver_lock (consolekit->screensaver);
+ 
+diff --git a/xfce4-session/xfsm-logout-dialog.c b/xfce4-session/xfsm-logout-dialog.c
+index e48571fb..89bac76d 100644
+--- a/xfce4-session/xfsm-logout-dialog.c
++++ b/xfce4-session/xfsm-logout-dialog.c
+@@ -174,7 +174,7 @@ xfsm_logout_dialog_init (XfsmLogoutDialog *dialog)
+   g_object_unref (provider);
+ 
+   /* load xfconf settings */
+-  channel = xfsm_open_config ();
++  channel = xfconf_channel_get (SETTINGS_CHANNEL);
+   if (xfsm_shutdown_can_save_session (dialog->shutdown))
+     save_session = xfconf_channel_get_bool (channel, "/general/SaveOnExit", TRUE);
+ 
+@@ -750,7 +750,7 @@ xfsm_logout_dialog (const gchar      *session_name,
+   GdkPixbuf        *screenshot = NULL;
+   XfsmFadeout      *fadeout = NULL;
+   XfsmLogoutDialog *xfsm_dialog;
+-  XfconfChannel    *channel = xfsm_open_config ();
++  XfconfChannel    *channel = xfconf_channel_get (SETTINGS_CHANNEL);
+   gboolean          autosave;
+   XfsmShutdown     *shutdown;
+   GdkDevice        *device;
+diff --git a/xfce4-session/xfsm-shutdown-fallback.c b/xfce4-session/xfsm-shutdown-fallback.c
+index 01818ec2..d0f209d8 100644
+--- a/xfce4-session/xfsm-shutdown-fallback.c
++++ b/xfce4-session/xfsm-shutdown-fallback.c
+@@ -336,7 +336,7 @@ lock_screen (GError **error)
+   XfceScreensaver *saver;
+   gboolean       ret = TRUE;
+ 
+-  channel = xfsm_open_config ();
++  channel = xfconf_channel_get (SETTINGS_CHANNEL);
+   saver = xfce_screensaver_new ();
+   if (xfconf_channel_get_bool (channel, "/shutdown/LockScreen", FALSE))
+       ret = xfce_screensaver_lock (saver);
+diff --git a/xfce4-session/xfsm-systemd.c b/xfce4-session/xfsm-systemd.c
+index 5b9c8239..5d0ac3ae 100644
+--- a/xfce4-session/xfsm-systemd.c
++++ b/xfce4-session/xfsm-systemd.c
+@@ -116,7 +116,7 @@ xfsm_systemd_lock_screen (XfsmSystemd  *systemd,
+   XfconfChannel *channel;
+   gboolean       ret = TRUE;
+ 
+-  channel = xfsm_open_config ();
++  channel = xfconf_channel_get (SETTINGS_CHANNEL);
+   if (xfconf_channel_get_bool (channel, "/shutdown/LockScreen", FALSE))
+       ret = xfce_screensaver_lock (systemd->screensaver);
+ 
+-- 
+GitLab
+

--- a/srcpkgs/xfce4-session/patches/cff23d0fadd502f7db9230f9ebbc02c00853f825.patch
+++ b/srcpkgs/xfce4-session/patches/cff23d0fadd502f7db9230f9ebbc02c00853f825.patch
@@ -1,0 +1,62 @@
+From cff23d0fadd502f7db9230f9ebbc02c00853f825 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Ga=C3=ABl=20Bonithon?= <gael@xfce.org>
+Date: Wed, 15 Mar 2023 11:16:17 +0100
+Subject: [PATCH] manager: Fix GQueue memory management
+
+Other iterations over the queue don't seem to be a problem:
+g_queue_remove() is only called in xfsm_manager_close_connection(),
+which only really causes problems in one place.
+
+Fixes: #166
+(cherry picked from commit 321ca64377eb8ddf5572f260e78f119c9e87dd8b)
+---
+ xfce4-session/xfsm-manager.c | 11 +++++++++--
+ 1 file changed, 9 insertions(+), 2 deletions(-)
+
+diff --git a/xfce4-session/xfsm-manager.c b/xfce4-session/xfsm-manager.c
+index f080c689..5f68b698 100644
+--- a/xfce4-session/xfsm-manager.c
++++ b/xfce4-session/xfsm-manager.c
+@@ -1570,6 +1570,8 @@ xfsm_manager_close_connection_by_ice_conn (XfsmManager *manager,
+ 
+       if (sms != NULL && SmsGetIceConnection (sms) == ice_conn)
+         {
++          /* maybe we remove client from the queue here but as we also get out
++           * of the loop no need for extra precaution */
+           xfsm_manager_close_connection (manager, client, FALSE);
+           break;
+         }
+@@ -2070,9 +2072,10 @@ static void
+ remove_clients_for_connection (XfsmManager *manager,
+                                const gchar *service_name)
+ {
+-  GList       *lp;
++  /* we might remove elements in queue below so a copy is needed */
++  GList *list = g_list_copy (g_queue_peek_nth_link (manager->running_clients, 0));
+ 
+-  for (lp = g_queue_peek_nth_link (manager->running_clients, 0);
++  for (GList *lp = list;
+        lp;
+        lp = lp->next)
+     {
+@@ -2082,6 +2085,8 @@ remove_clients_for_connection (XfsmManager *manager,
+           xfsm_manager_close_connection (manager, client, FALSE);
+         }
+     }
++
++  g_list_free (list);
+ }
+ 
+ static void
+@@ -2710,6 +2715,8 @@ xfsm_manager_dbus_unregister_client (XfsmDbusManager *object,
+       XfsmClient *client = XFSM_CLIENT (lp->data);
+       if (g_strcmp0 (xfsm_client_get_object_path (client), arg_client_id) == 0)
+         {
++          /* maybe we remove client from the queue here but as we also get out
++           * of the loop no need for extra precaution */
+           xfsm_manager_close_connection (manager, client, FALSE);
+           xfsm_dbus_manager_complete_unregister_client (object, invocation);
+           return TRUE;
+-- 
+GitLab
+

--- a/srcpkgs/xfce4-session/template
+++ b/srcpkgs/xfce4-session/template
@@ -1,7 +1,7 @@
 # Template file for 'xfce4-session'
 pkgname=xfce4-session
 version=4.18.1
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--with-locales-dir=/usr/share/locale --disable-static --enable-polkit"
 hostmakedepends="xfce4-dev-tools pkg-config intltool gettext-devel glib-devel iceauth"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

Fix crashes reported on other distros when using malloc instead of glib's custom allocator. Try as I might, I can't reproduce the crashes on Void, but this reportedly fixes the issue on other distros.

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
