### PR TITLE
openbox: fix use after free

### DIFF
--- a/srcpkgs/openbox/patches/d41128e5a1002af41c976c8860f8299cfcd3cd72.patch
+++ b/srcpkgs/openbox/patches/d41128e5a1002af41c976c8860f8299cfcd3cd72.patch
@@ -1,0 +1,50 @@
+From d41128e5a1002af41c976c8860f8299cfcd3cd72 Mon Sep 17 00:00:00 2001
+From: pldubouilh <pldubouilh@gmail.com>
+Date: Fri, 17 Mar 2023 18:23:47 +0100
+Subject: [PATCH] Fix list traversal issue in client_calc_layer
+
+The calls to client_calc_layer_internal can modify stacking_list, which
+can cause us to follow dangling ->next pointers (either by the pointer
+itself already being freed, or it pointing to a freed area). Avoid this
+by copying the list first, the goal is to visit every client in the list
+once so this should be fine.
+---
+ openbox/client.c | 9 +++++++--
+ 1 file changed, 7 insertions(+), 2 deletions(-)
+
+diff --git a/openbox/client.c b/openbox/client.c
+index 7168b2407..b8264587c 100644
+--- a/openbox/client.c
++++ b/openbox/client.c
+@@ -2742,9 +2742,12 @@ static void client_calc_layer_internal(ObClient *self)
+ void client_calc_layer(ObClient *self)
+ {
+     GList *it;
++    /* the client_calc_layer_internal calls below modify stacking_list,
++       so we have to make a copy to iterate over */
++    GList *list = g_list_copy(stacking_list);
+ 
+     /* skip over stuff above fullscreen layer */
+-    for (it = stacking_list; it; it = g_list_next(it))
++    for (it = list; it; it = g_list_next(it))
+         if (window_layer(it->data) <= OB_STACKING_LAYER_FULLSCREEN) break;
+ 
+     /* find the windows in the fullscreen layer, and mark them not-visited */
+@@ -2757,7 +2760,7 @@ void client_calc_layer(ObClient *self)
+     client_calc_layer_internal(self);
+ 
+     /* skip over stuff above fullscreen layer */
+-    for (it = stacking_list; it; it = g_list_next(it))
++    for (it = list; it; it = g_list_next(it))
+         if (window_layer(it->data) <= OB_STACKING_LAYER_FULLSCREEN) break;
+ 
+     /* now recalc any windows in the fullscreen layer which have not
+@@ -2768,6 +2771,8 @@ void client_calc_layer(ObClient *self)
+                  !WINDOW_AS_CLIENT(it->data)->visited)
+             client_calc_layer_internal(it->data);
+     }
++
++    g_list_free(it);
+ }
+ 
+ gboolean client_should_show(ObClient *self)

--- a/srcpkgs/openbox/template
+++ b/srcpkgs/openbox/template
@@ -1,7 +1,7 @@
 # Template file for 'openbox'
 pkgname=openbox
 version=3.6.1
-revision=4
+revision=5
 build_style=gnu-configure
 configure_args="--enable-startup-notification $(vopt_enable svg librsvg)"
 hostmakedepends="automake libtool pkg-config gettext-devel"
@@ -15,7 +15,7 @@ conf_files="
 	/etc/xdg/openbox/autostart"
 short_desc="Standards compliant, fast, light-weight, extensible window manager"
 maintainer="Orphaned <orphan@voidlinux.org>"
-license="GPL-2"
+license="GPL-2.0-or-later"
 homepage="http://www.openbox.org"
 distfiles="http://openbox.org/dist/openbox/openbox-$version.tar.xz"
 checksum=abe75855cc5616554ffd47134ad15291fe37ebbebf1a80b69cbde9d670f0e26d


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

Fix crashes reported on other distros when using malloc instead of glib's custom allocator. Try as I might, I can't reproduce the crashes on Void, but this reportedly fixes the issue on other distros.

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
