### PR TITLE
atop: Remove ineffective vsed

### DIFF
--- a/srcpkgs/atop/template
+++ b/srcpkgs/atop/template
@@ -15,9 +15,7 @@ checksum=ca48d2f17e071deead5e6e9cc9e388bf6a3270d695e61976b3794d4d927b5c4e
 make_dirs="/var/log/atop 755 root root"
 
 pre_install() {
-	vsed -e '/chown/d' \
-		-e 's/04711/0755/' \
-		-e 's,sbin,bin,g' \
+	vsed -e 's,sbin,bin,g' \
 		-e '/$(DEFPATH)/d' -i Makefile
 	vsed -e 's,bin/sh,bin/bash,' -i atop.daily
 }


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

Addresses part of tracking issue #42441
- [x] atop

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
#### Local build testing
- I built this PR locally for my native architecture, x86\_64-glibc
- I built this PR locally for these architectures:
  - i686
  - aarch64
