### PR TITLE
gnome-remote-desktop: update to 44.0.

### DIFF
--- a/srcpkgs/gnome-remote-desktop/template
+++ b/srcpkgs/gnome-remote-desktop/template
@@ -1,10 +1,10 @@
 # Template file for 'gnome-remote-desktop'
 pkgname=gnome-remote-desktop
-version=43.2
+version=44.0
 revision=1
 build_style=meson
 configure_args="-Drdp=true -Dvnc=true -Dsystemd=false
- -Dsystemd_user_unit_dir=/var/lib/systemd/user"
+ -Dsystemd_user_unit_dir=/usr/lib/systemd/user"
 hostmakedepends="pkg-config gettext glib-devel asciidoc"
 makedepends="glib-devel pipewire-devel libsecret-devel libnotify-devel
  freerdp-devel freerdp-server-devel fuse3-devel libvncserver-devel
@@ -14,5 +14,5 @@ maintainer="Michal Vasilek <michal@vasilek.cz>"
 license="GPL-2.0-or-later"
 homepage="https://wiki.gnome.org/Projects/Mutter/RemoteDesktop"
 distfiles="${GNOME_SITE}/gnome-remote-desktop/${version%%.*}/gnome-remote-desktop-${version}.tar.xz"
-checksum=84a9fd65a9bad8cef73482fda2d20acd122f0b8521b1de86c9413889b9fa9771
+checksum=f7e5088c18fdb08690ae034bf76a1aead59a7dcd17b26e1f7c9975480510a0fd
 make_check=no # xvfb failed to start


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

Depends on: https://github.com/void-linux/void-packages/pull/43002

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
