### PR TITLE
primecount: update to 7.8.

### DIFF
--- a/srcpkgs/primecount/template
+++ b/srcpkgs/primecount/template
@@ -1,6 +1,6 @@
 # Template file for 'primecount'
 pkgname=primecount
-version=7.6
+version=7.8
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTS=ON -DBUILD_LIBPRIMESIEVE=OFF
@@ -12,7 +12,7 @@ license="BSD-2-Clause"
 homepage="https://github.com/kimwalisch/primecount/"
 changelog="https://raw.githubusercontent.com/kimwalisch/primecount/master/ChangeLog"
 distfiles="https://github.com/kimwalisch/primecount/archive/refs/tags/v${version}.tar.gz"
-checksum=e9a1fa2c41b9a7b84f2bead21b53cc9f7e2a5a0a34ddd818431a4e789aa44230
+checksum=7588b241cd268f4cc6c836135088a143ca65c181278ee0ba3b3309ac055d5ae8
 
 build_options="native_build"
 


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

This is a very minor update to fix the following:
```
$ python -c 'from primecountpy.primecount import prime_pi ; print(prime_pi(-1))'
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "primecountpy/primecount.pyx", line 25, in primecountpy.primecount.prime_pi
  File "primecountpy/primecount.pyx", line 47, in primecountpy.primecount.prime_pi
cysignals.signals.SignalError: Bus error
```

After the update
```
$ python -c 'from primecountpy.primecount import prime_pi ; print(prime_pi(-1))'
0
```

We can now sleep in the comfort that such an important calculation can be done in void linux with success.

As expected, other values of `π(x)` are still ok and quick:
```
$ python -c 'from primecountpy.primecount import prime_pi ; print(prime_pi(1_000_000_000_000))'
37607912018
$ python -c 'from primecountpy.primecount import prime_pi ; print(prime_pi(1_000_000_000_000_000))'
29844570422669
```

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
