### PR TITLE
New package: clifm-1.11

### DIFF
--- a/srcpkgs/clifm/template
+++ b/srcpkgs/clifm/template
@@ -1,0 +1,14 @@
+# Template file for 'clifm'
+pkgname=clifm
+version=1.11
+revision=1
+build_style=gnu-makefile
+make_install_args="MANDIR=/usr/share/man"
+makedepends="libcap-devel acl-devel file-devel readline-devel"
+short_desc="Command Line Interface File Manager"
+maintainer="Greg Beard <gmbeard@googlemail.com>"
+license="GPL-2.0-or-later"
+homepage="https://github.com/leo-arch/clifm"
+changelog="https://raw.githubusercontent.com/leo-arch/clifm/master/CHANGELOG"
+distfiles="https://github.com/leo-arch/clifm/releases/download/v${version}/clifm-${version}.tar.gz"
+checksum=32f69ab2215bfcf10e8fe3920c5b4ffd6e699a68463577b32c39f9189d5a9c56


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->
> Clifm is a Command Line Interface File Manager: all input and interaction is performed via commands. This is its main feature and strength.

<https://github.com/leo-arch/clifm>

#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
#### Local build testing
- I built this PR locally for my native architecture, x86\_64-glibc
- I built this PR locally for these architectures:
  - x86\_64-musl
  - i686
  - aarch64
