### PR TITLE
Waybar: add libevdev to fix keyboard-status module

### DIFF
--- a/srcpkgs/Waybar/template
+++ b/srcpkgs/Waybar/template
@@ -1,7 +1,7 @@
 # Template file for 'Waybar'
 pkgname=Waybar
 version=0.9.16
-revision=1
+revision=2
 _date_version=3.0.1
 _mesonbuild_date_ver=3.0.0-1
 build_wrksrc=Waybar-${version}
@@ -21,7 +21,8 @@ makedepends="libinput-devel wayland-devel gtkmm-devel spdlog eudev-libudev-devel
  $(vopt_if pulseaudio pulseaudio-devel)
  $(vopt_if dbusmenugtk libdbusmenu-gtk3-devel)
  $(vopt_if mpd libmpdclient-devel)
- $(vopt_if sndio sndio-devel)"
+ $(vopt_if sndio sndio-devel)
+ $(vopt_if libevdev libevdev-devel)"
 short_desc="Polybar-like Wayland Bar for Sway and Wlroots based compositors"
 maintainer="Érico Nogueira <ericonr@disroot.org>"
 license="MIT"
@@ -35,12 +36,13 @@ checksum="37ebd7b10e32e802afe9236ea9374fabb77b1abb2c203ca6173b27dc03128096
  7a390f200f0ccd207e8cff6757e04817c1a0aec3e327b006b7eb451c57ee3538
  f2aa492b59893f69367228bf802cbb0a07c4d52fac2185dfd8ebb5d16295d893"
 
-build_options="libnl pulseaudio dbusmenugtk mpd sndio"
-build_options_default="libnl pulseaudio dbusmenugtk mpd sndio"
+build_options="libnl pulseaudio dbusmenugtk mpd sndio libevdev"
+build_options_default="libnl pulseaudio dbusmenugtk mpd sndio libevdev"
 
 desc_option_libnl="Enable libnl support for network related features"
 desc_option_dbusmenugtk="Enable support for tray"
 desc_option_mpd="Enable support for MPD"
+desc_option_libevdev="Enable support for num/caps/scroll lock visualization"
 
 post_extract() {
 	mv hinnant-date-${_mesonbuild_date_ver}/meson_options.txt date-${_date_version}/


### PR DESCRIPTION
This fixes the num lock / caps lock visualizer (available in the default waybar config for verification)
I noticed that these indicators were missing, apparently this module depends on libevdev at compile time.

#### Testing the changes
- I tested the changes in this PR: **YES**
- Waybar will spam a bunch of errors if `keyboard-state` is enabled and the current user is not part of the `input` group. Once the user is added to the group, the errors disappear and the indicators work as expected.

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc

