### PR TITLE
kirigami-addons: update to 0.7.2

### DIFF
--- a/srcpkgs/kirigami-addons/template
+++ b/srcpkgs/kirigami-addons/template
@@ -1,6 +1,6 @@
 # Template file for 'kirigami-addons'
 pkgname=kirigami-addons
-version=0.7.1
+version=0.7.2
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF -DBUILD_QCH=ON"
@@ -11,5 +11,5 @@ short_desc="Add-ons for the Kirigami framework"
 maintainer="José Santos <agarimos@tutanota.com>"
 license="GPL-3.0-or-later"
 homepage="https://invent.kde.org/libraries/kirigami-addons"
-distfiles="${KDE_SITE}/${pkgname}/${pkgname}-${version}.tar.xz"
-checksum=c4e94821e81fcda173e71e9bfd5def66961a276278dc784b9b0c6f7cbcd4a0c8
+distfiles="${KDE_SITE}/kirigami-addons/kirigami-addons-${version}.tar.xz"
+checksum=f8629c597d6df715b3eece9ffed94926bf3cab829f22f3aab22e3c822e2b7b76


### PR DESCRIPTION
I tested the changes in this PR: YES

- I built this PR locally for my native architecture, (X86_64)

