### PR TITLE
mdcat: add mdless symlink

### DIFF
--- a/srcpkgs/mdcat/template
+++ b/srcpkgs/mdcat/template
@@ -1,7 +1,7 @@
 # Template file for 'mdcat'
 pkgname=mdcat
 version=1.0.0
-revision=1
+revision=2
 build_style=cargo
 hostmakedepends="pkg-config ruby-asciidoctor"
 makedepends="openssl-devel"
@@ -30,4 +30,5 @@ post_install() {
 
 	man_page=$(find ${wrksrc}/target -name mdcat.1 -print -quit)
 	vman ${man_page}
+	ln -sf /usr/bin/mdcat ${DESTDIR}/usr/bin/mdless
 }


### PR DESCRIPTION
mdcat has different behaviour if invoked as mdless. other distros package this symlink too.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

cc maintainer @cinerea0
