### PR TITLE
kops: update to 1.26.2

### DIFF
--- a/srcpkgs/kops/template
+++ b/srcpkgs/kops/template
@@ -1,6 +1,6 @@
 # Template file for 'kops'
 pkgname=kops
-version=1.24.2
+version=1.26.2
 revision=1
 archs="x86_64*"
 build_style=go
@@ -12,7 +12,7 @@ maintainer="Mate Gabri <iam@theguy.io>"
 license="Apache-2.0"
 homepage="https://github.com/kubernetes/kops"
 distfiles="https://github.com/kubernetes/kops/archive/refs/tags/v${version}.tar.gz"
-checksum=3ac82ce779e6a878b0434278e1bc2c4951c7c2a3f32376557bba7a23d1dc2cf9
+checksum=01d1af58b3cc2ff0917aa0ef95c7f1761bf3572b90e48608637771c2ba779813
 
 post_install() {
 	${DESTDIR}/usr/bin/kops completion bash >kops-completion.bash


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**


- I built this PR locally for my native architecture, (amd64-glibc)