### PR TITLE
prometheus: update to 2.43.0.

### DIFF
--- a/srcpkgs/prometheus/files/prometheus/run
+++ b/srcpkgs/prometheus/files/prometheus/run
@@ -3,8 +3,10 @@ exec 2>&1
 
 [ -f ./conf ] && . ./conf
 
+ulimit -n ${MAX_OPEN_FILES:-8192}
+
 : ${WRKDIR:=/var/lib/prometheus}
 
 cd "${WRKDIR}"
 
-exec chpst -o 8192 -u _prometheus prometheus --config.file=/etc/prometheus/prometheus.yml $ARGS 2>&1
+exec chpst -u _prometheus prometheus --config.file=/etc/prometheus/prometheus.yml $ARGS 2>&1

--- a/srcpkgs/prometheus/template
+++ b/srcpkgs/prometheus/template
@@ -1,6 +1,6 @@
 # Template file for 'prometheus'
 pkgname=prometheus
-version=2.40.7
+version=2.43.0
 revision=1
 build_style=go
 go_import_path="github.com/prometheus/prometheus"
@@ -18,7 +18,7 @@ license="Apache-2.0, MIT"
 homepage="https://prometheus.io/"
 changelog="https://raw.githubusercontent.com/prometheus/prometheus/master/CHANGELOG.md"
 distfiles="https://github.com/prometheus/prometheus/archive/v${version}.tar.gz"
-checksum=83b4e891204500fc798b5a9e86d0189cbef7f8274c3303c215da5e2c75df6cde
+checksum=0cd8860e5f10d0ecb35d20d23252ddc459e8319882dc163bf71b723e3bcafd71
 
 system_accounts="_prometheus"
 


### PR DESCRIPTION
update run script to properly increase max open files limit

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
