### PR TITLE
Signal-Desktop: update to 6.12.0

### DIFF
--- a/srcpkgs/Signal-Desktop/template
+++ b/srcpkgs/Signal-Desktop/template
@@ -1,6 +1,6 @@
 # Template file for 'Signal-Desktop'
 pkgname=Signal-Desktop
-version=6.11.0
+version=6.12.0
 revision=1
 # Signal officially only supports x86_64 
 # x86_64-musl fails because of its dependency on 'node-gyp' which depends on a glibc specific extension
@@ -9,11 +9,11 @@ archs="x86_64"
 hostmakedepends="git git-lfs nodejs python3 tar yarn"
 depends="cairo gtk+3 libvips pango"
 short_desc="Signal Private Messenger for Linux"
-maintainer="akierig <anelki@fastmail.de>"
+maintainer="anelki <akierig@fastmail.de>"
 license="AGPL-3.0-only"
 homepage="https://github.com/signalapp/Signal-Desktop"
 distfiles="https://github.com/signalapp/Signal-Desktop/archive/v${version}.tar.gz"
-checksum=1dfc7ce32b663c37513303fe102fd154ae767b5b425885b9e56fc1e46c2af2fd
+checksum=c07dccc9c032623e3b93eda2992da1c59e2dc6a93c84646d0d5bbfe4e08de4d6
 nostrip_files="signal-desktop"
 
 post_extract() {


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64
