### PR TITLE
webp-pixbuf-loader: update to 0.2.4.

### DIFF
--- a/srcpkgs/webp-pixbuf-loader/template
+++ b/srcpkgs/webp-pixbuf-loader/template
@@ -1,6 +1,6 @@
 # Template file for 'webp-pixbuf-loader'
 pkgname=webp-pixbuf-loader
-version=0.2.2
+version=0.2.4
 revision=1
 build_style=meson
 hostmakedepends="pkg-config gdk-pixbuf"
@@ -11,4 +11,4 @@ license="LGPL-2.0-or-later"
 homepage="https://github.com/aruiz/webp-pixbuf-loader"
 changelog="https://github.com/aruiz/webp-pixbuf-loader/releases"
 distfiles="https://github.com/aruiz/webp-pixbuf-loader/archive/refs/tags/${version}.tar.gz"
-checksum=a5515697f0703c85fd1651e2b0df3caa5ae4cbfb3393e84a229cd61b91905f76
+checksum=54f448383d1c384409bd1690cdde9b44535c346855902e29bd37a18a7237c547


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
