### PR TITLE
tuxedo-keyboard: update to 3.2.1

### DIFF
--- a/srcpkgs/tuxedo-keyboard/template
+++ b/srcpkgs/tuxedo-keyboard/template
@@ -1,6 +1,6 @@
 # Template file for 'tuxedo-keyboard'
 pkgname=tuxedo-keyboard
-version=3.2.0
+version=3.2.1
 revision=1
 depends="dkms"
 short_desc="TUXEDO kernel module drivers for keyboard & general hardware I/O"
@@ -8,7 +8,7 @@ maintainer="newbluemoon <blaumolch@mailbox.org>"
 license="GPL-3.0-or-later"
 homepage="https://github.com/tuxedocomputers/tuxedo-keyboard"
 distfiles="https://github.com/tuxedocomputers/tuxedo-keyboard/archive/v${version}.tar.gz"
-checksum=160bfb396116203b0f0309eda0d3b81ab109003d35e6a820529bbd455337ffd7
+checksum=baa2b8e9edd108422cb9fb2859459bb9ca04cc9fa15fd1b9828f69047c76a4fe
 
 dkms_modules="tuxedo-keyboard ${version}"
 


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)
