### PR TITLE
New package: timer-cli-0.1.2

### DIFF
--- a/srcpkgs/python3-art/template
+++ b/srcpkgs/python3-art/template
@@ -1,0 +1,19 @@
+# Template file for 'python3-art'
+pkgname=python3-art
+version=5.9
+revision=1
+build_style=python3-module
+hostmakedepends="python3-setuptools"
+depends="python3"
+short_desc="ASCII art library for Python"
+maintainer="Andrew Benson <abenson+void@gmail.com>"
+license="MIT"
+homepage="https://www.ascii-art.site/"
+changelog="https://raw.githubusercontent.com/sepandhaghighi/art/master/CHANGELOG.md"
+distfiles="${PYPI_SITE}/a/art/art-${version}.tar.gz"
+checksum=6a311ec0a227c6554c6789e91e74c3f2c86453a2a8e76947788695b7a91ccff0
+make_check=no # no tests available
+
+post_install() {
+	vlicense LICENSE
+}

--- a/srcpkgs/timer-cli/template
+++ b/srcpkgs/timer-cli/template
@@ -1,0 +1,14 @@
+# Template file for 'timer-cli'
+pkgname=timer-cli
+version=0.1.2
+revision=1
+build_style=python3-pep517
+hostmakedepends="python3-poetry-core"
+depends="python3-rich python3-click python3-art"
+short_desc="Simple CLI countdown timer"
+maintainer="Andrew Benson <abenson+void@gmail.com>"
+license="Apache-2.0"
+homepage="https://github.com/1Blademaster/timer-cli"
+distfiles="https://github.com/1Blademaster/timer-cli/archive/v${version}.tar.gz"
+checksum=4dec55b71e2e5e5b1fa4a9022ae7b1d84a417de969749b8c50a37de4329505e6
+make_check=no # no tests available


### PR DESCRIPTION

#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

#### Local build testing
~~~
pkg          host         target        cross  result
python3-art  x86_64       x86_64        n      OK
timer-cli    x86_64       x86_64        n      OK
python3-art  x86_64-musl  x86_64-musl   n      OK
timer-cli    x86_64-musl  x86_64-musl   n      OK
python3-art  i686         i686          n      OK
timer-cli    i686         i686          n      OK
python3-art  x86_64       aarch64-musl  y      OK
timer-cli    x86_64       aarch64-musl  y      OK
python3-art  x86_64       aarch64       y      OK
timer-cli    x86_64       aarch64       y      OK
python3-art  x86_64       armv7l-musl   y      OK
timer-cli    x86_64       armv7l-musl   y      OK
python3-art  x86_64       armv7l        y      OK
timer-cli    x86_64       armv7l        y      OK
python3-art  x86_64       armv6l-musl   y      OK
timer-cli    x86_64       armv6l-musl   y      OK
python3-art  x86_64       armv6l        y      OK
timer-cli    x86_64       armv6l        y      OK
~~~
