### PR TITLE
php8.1: update to 8.1.17; php8.2: update to 8.2.4; xdebug8.*: update to 3.2.1.

### DIFF
--- a/srcpkgs/php8.0-imagick/template
+++ b/srcpkgs/php8.0-imagick/template
@@ -1,7 +1,7 @@
 # Template file for 'php8.0-imagick'
 pkgname=php8.0-imagick
 version=3.7.0
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--with-imagick=${XBPS_CROSS_BASE}/usr \
  --with-php-config=/usr/bin/php-config8.0"

--- a/srcpkgs/php8.1-imagick/template
+++ b/srcpkgs/php8.1-imagick/template
@@ -1,7 +1,7 @@
 # Template file for 'php8.1-imagick'
 pkgname=php8.1-imagick
 version=3.7.0
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--with-imagick=${XBPS_CROSS_BASE}/usr \
  --with-php-config=/usr/bin/php-config8.1"

--- a/srcpkgs/php8.1/template
+++ b/srcpkgs/php8.1/template
@@ -1,6 +1,6 @@
 # Template file for 'php8.1'
 pkgname=php8.1
-version=8.1.16
+version=8.1.17
 revision=1
 _php_version=8.1
 hostmakedepends="bison pkg-config apache-devel"
@@ -17,7 +17,7 @@ changelog="https://raw.githubusercontent.com/php/php-src/php-${version}/NEWS"
 # this is the source where the www.php.net code pulls the tarballs it serves
 # at https://www.php.net/distributions/
 distfiles="https://github.com/php/web-php-distributions/raw/master/php-${version}.tar.gz"
-checksum=a929fb9ed3bc364a5dea4f64954e8aaaa3408b87df04d7c6f743a190f5594e84
+checksum=ef270156291d90a80ce83d68eee812f301cf5e48836a0ff6fd2931913f8e25c5
 
 conf_files="/etc/php${_php_version}/php.ini"
 

--- a/srcpkgs/php8.2-imagick/template
+++ b/srcpkgs/php8.2-imagick/template
@@ -1,7 +1,7 @@
 # Template file for 'php8.2-imagick'
 pkgname=php8.2-imagick
 version=3.7.0
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--with-imagick=${XBPS_CROSS_BASE}/usr \
  --with-php-config=/usr/bin/php-config8.2"

--- a/srcpkgs/php8.2/patches/php-cross-config.patch
+++ b/srcpkgs/php8.2/patches/php-cross-config.patch
@@ -1,22 +1,22 @@
 diff --git a/configure b/configure
-index 697eba3..5e01011 100755
+index e4b82d1..1a8678f 100755
 --- a/configure
 +++ b/configure
-@@ -60778,7 +60778,7 @@ $as_echo_n "checking for pg_config... " >&6; }
+@@ -62424,7 +62424,7 @@ printf %s "checking for pg_config... " >&6; }
      fi
    done
  
 -  if test -n "$PG_CONFIG"; then
 +  if test -n "$PG_CONFIG" && test "x$cross_compiling" != "xyes"; then
-     { $as_echo "$as_me:${as_lineno-$LINENO}: result: $PG_CONFIG" >&5
- $as_echo "$PG_CONFIG" >&6; }
+     { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $PG_CONFIG" >&5
+ printf "%s\n" "$PG_CONFIG" >&6; }
      PGSQL_INCLUDE=`$PG_CONFIG --includedir`
-@@ -62304,7 +62304,7 @@ $as_echo_n "checking for pg_config... " >&6; }
+@@ -63948,7 +63948,7 @@ printf %s "checking for pg_config... " >&6; }
      fi
    done
  
 -  if test -n "$PG_CONFIG"; then
 +  if test -n "$PG_CONFIG" && test "x$cross_compiling" != "xyes"; then
-     { $as_echo "$as_me:${as_lineno-$LINENO}: result: $PG_CONFIG" >&5
- $as_echo "$PG_CONFIG" >&6; }
+     { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $PG_CONFIG" >&5
+ printf "%s\n" "$PG_CONFIG" >&6; }
      PGSQL_INCLUDE=`$PG_CONFIG --includedir`

--- a/srcpkgs/php8.2/template
+++ b/srcpkgs/php8.2/template
@@ -1,6 +1,6 @@
 # Template file for 'php8.2'
 pkgname=php8.2
-version=8.2.3
+version=8.2.4
 revision=1
 _php_version=8.2
 hostmakedepends="bison pkg-config apache-devel"
@@ -17,7 +17,7 @@ changelog="https://raw.githubusercontent.com/php/php-src/php-${version}/NEWS"
 # this is the source where the www.php.net code pulls the tarballs it serves
 # at https://www.php.net/distributions/
 distfiles="https://github.com/php/web-php-distributions/raw/master/php-${version}.tar.gz"
-checksum=7c475bcbe61d28b6878604b1b6f387f39d1a63b5f21fa8156fd7aa615d43e259
+checksum=cee7748015a2ddef1739d448b980b095dccd09ed589cf1b6c6ee2d16f5e73c50
 
 conf_files="/etc/php${_php_version}/php.ini"
 

--- a/srcpkgs/xdebug8.0/template
+++ b/srcpkgs/xdebug8.0/template
@@ -1,6 +1,6 @@
 # Template file for 'xdebug8.0'
 pkgname=xdebug8.0
-version=3.2.0
+version=3.2.1
 revision=1
 build_style=gnu-configure
 configure_args="--with-php-config=/usr/bin/php-config8.0"
@@ -12,7 +12,7 @@ license="PHP-3.0"
 homepage="http://xdebug.org"
 changelog="https://xdebug.org/updates"
 distfiles="http://xdebug.org/files/xdebug-${version}.tgz"
-checksum=7769b20eecdadf5fbe9f582512c10b394fb575b6f7a8c3a3a82db6883e0032b7
+checksum=ef4cb3c228192798874e4530cccceee76840cc80821909740088a1e1a8f00445
 
 pre_configure() {
 	phpize8.0

--- a/srcpkgs/xdebug8.1/template
+++ b/srcpkgs/xdebug8.1/template
@@ -1,6 +1,6 @@
 # Template file for 'xdebug8.1'
 pkgname=xdebug8.1
-version=3.2.0
+version=3.2.1
 revision=1
 build_style=gnu-configure
 configure_args="--with-php-config=/usr/bin/php-config8.1"
@@ -12,7 +12,7 @@ license="PHP-3.0"
 homepage="http://xdebug.org"
 changelog="https://xdebug.org/updates"
 distfiles="http://xdebug.org/files/xdebug-${version}.tgz"
-checksum=7769b20eecdadf5fbe9f582512c10b394fb575b6f7a8c3a3a82db6883e0032b7
+checksum=ef4cb3c228192798874e4530cccceee76840cc80821909740088a1e1a8f00445
 
 pre_configure() {
 	phpize8.1

--- a/srcpkgs/xdebug8.2/template
+++ b/srcpkgs/xdebug8.2/template
@@ -1,6 +1,6 @@
 # Template file for 'xdebug8.2'
 pkgname=xdebug8.2
-version=3.2.0
+version=3.2.1
 revision=1
 build_style=gnu-configure
 configure_args="--with-php-config=/usr/bin/php-config8.2"
@@ -12,7 +12,7 @@ license="PHP-3.0"
 homepage="http://xdebug.org"
 changelog="https://xdebug.org/updates"
 distfiles="http://xdebug.org/files/xdebug-${version}.tgz"
-checksum=7769b20eecdadf5fbe9f582512c10b394fb575b6f7a8c3a3a82db6883e0032b7
+checksum=ef4cb3c228192798874e4530cccceee76840cc80821909740088a1e1a8f00445
 
 pre_configure() {
 	phpize8.2


### PR DESCRIPTION
- php8.1: update to 8.1.17.
- php8.2: update to 8.2.4.
- xdebug8.0: update to 3.2.1.
- xdebug8.1: update to 3.2.1.
- xdebug8.2: update to 3.2.1.
- php8.0-imagick: rebuild against libmagick-7.1.1.5
- php8.1-imagick: rebuild against libmagick-7.1.1.5
- php8.2-imagick: rebuild against libmagick-7.1.1.5

The latest imagick update made PHP start complaining:
```
PHP Warning:  Version warning: Imagick was compiled against ImageMagick version 1808 but version 1809 is loaded. Imagick will run but may behave surprisingly in Unknown on line 0
```

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
