### PR TITLE
mu4e: update to 1.10.3

### DIFF
--- a/srcpkgs/mu4e/patches/fix-root-test.patch
+++ b/srcpkgs/mu4e/patches/fix-root-test.patch
@@ -1,0 +1,20 @@
+Remove a test which fails when run as root.
+
+diff --git a/lib/tests/test-mu-store.cc b/lib/tests/test-mu-store.cc
+index 872c56e3..c4e7eeb2 100644
+--- a/lib/tests/test-mu-store.cc
++++ b/lib/tests/test-mu-store.cc
+@@ -470,13 +470,6 @@ test_store_fail()
+ 		const auto store = Store::make("/root/non-existent-path/12345");
+ 		g_assert_false(!!store);
+ 	}
+-
+-	{
+-		const auto store = Store::make_new("/../../root/non-existent-path/12345",
+-						   "/../../root/non-existent-path/54321",
+-						   {}, {});
+-		g_assert_false(!!store);
+-	}
+ }
+ 
+ int

--- a/srcpkgs/mu4e/template
+++ b/srcpkgs/mu4e/template
@@ -1,22 +1,16 @@
 # Template file for 'mu4e'
 pkgname=mu4e
-version=1.8.14
+version=1.10.3
 revision=1
-build_style=gnu-configure
-configure_args="--enable-mu4e $(vopt_if guile --enable-guile)"
-hostmakedepends="automake emacs libtool pkg-config texinfo glib-devel"
-makedepends="xapian-core-devel gmime3-devel libuuid-devel $(vopt_if guile guile)"
+build_style=meson
+hostmakedepends="emacs libtool pkg-config texinfo glib-devel"
+makedepends="xapian-core-devel gmime3-devel"
 short_desc="Maildir-utils indexer/searcher and associated Emacs client"
 maintainer="Benjamin Slade <slade@lambda-y.net>"
 license="GPL-3.0-or-later"
 homepage="https://www.djcbsoftware.nl/code/mu/"
 changelog="https://github.com/djcb/mu/raw/master/NEWS.org"
 distfiles="https://github.com/djcb/mu/releases/download/v${version}/mu-${version}.tar.xz"
-checksum=1a9c5e15b5e8b67622f7e58dfadd453abf232c0b715bd5f89b955e704455219c
+checksum=c83970fcb6163c27d135c207d1a5eb6f38a5732161741a4a88da2ae894e0245f
 replaces="mu<${version}"
 provides="mu-${version}_${revision}"
-
-pre_configure() {
-	sed -i 's,-I${prefix}/include,,' contrib/Makefile.am
-	autoreconf -fi
-}


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **Yes**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl  (crossbuild)
  - aarch64 (crossbuild)
  - armv7l (crossbuild)

#### Notes
 - changed build style to `meson` as it is the primary build option of `mu`
 - removed `guile` build option because it depends on `guile-3.x`.
 - users will have to re-initialize their database (`mu-init(1)`)
