### PR TITLE
New packages: rustypaste-0.8.4, rustypaste-cli-0.3.0

### DIFF
--- a/srcpkgs/rustypaste-cli/template
+++ b/srcpkgs/rustypaste-cli/template
@@ -1,0 +1,19 @@
+# Template file for 'rustypaste-cli'
+pkgname=rustypaste-cli
+version=0.3.0
+revision=1
+build_style=cargo
+short_desc="CLI tool for rustypaste"
+maintainer="Lukas Jordan <dev@lukasjordan.com>"
+license="MIT"
+homepage="https://github.com/orhun/rustypaste-cli"
+changelog="https://raw.githubusercontent.com/orhun/rustypaste-cli/master/CHANGELOG.md"
+distfiles="https://github.com/orhun/rustypaste-cli/archive/refs/tags/v${version}.tar.gz"
+checksum=691fd3ddcf2c7c9c17728a304bd4299a35812940902b8b31059902abb49b037e
+
+post_install() {
+	vlicense LICENSE
+	vdoc README.md
+	vman man/rpaste.1
+	vsconf config.toml
+}

--- a/srcpkgs/rustypaste/files/rustypaste/run
+++ b/srcpkgs/rustypaste/files/rustypaste/run
@@ -1,0 +1,6 @@
+#!/bin/sh
+exec 2>&1
+[ -r conf ] && . ./conf
+export CONFIG=${CONFIG:-/etc/rustypaste/config.toml}
+cd /var/lib/rustypaste
+exec chpst -u _rustypaste:_rustypaste rustypaste

--- a/srcpkgs/rustypaste/template
+++ b/srcpkgs/rustypaste/template
@@ -1,0 +1,27 @@
+# Template file for 'rustypaste'
+pkgname=rustypaste
+version=0.8.4
+revision=1
+build_style=cargo
+make_check_args="-- --test-threads 1"
+short_desc="Minimal file upload/pastebin service"
+maintainer="Lukas Jordan <dev@lukasjordan.com>"
+license="MIT"
+homepage="https://github.com/orhun/rustypaste"
+changelog="https://raw.githubusercontent.com/orhun/rustypaste/master/CHANGELOG.md"
+distfiles="https://github.com/orhun/rustypaste/archive/refs/tags/v${version}.tar.gz"
+checksum=ccdfa0ae412f25b3ea8e3756ff8d8c0ecfee1332b3bc2e584899914056ed2e2d
+conf_files="/etc/rustypaste/config.toml"
+
+system_accounts="_rustypaste"
+_rustypaste_homedir="/var/lib/rustypaste"
+_rustypaste_descr="Minimal file upload/pastebin service"
+
+make_dirs="/var/lib/rustypaste 0750 _rustypaste _rustypaste"
+
+post_install() {
+	vinstall config.toml 644 etc/rustypaste
+	vlicense LICENSE
+	vdoc README.md
+	vsv rustypaste
+}


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-musl
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - armv6l
