### PR TITLE
citations: fix build

### DIFF
--- a/srcpkgs/citations/template
+++ b/srcpkgs/citations/template
@@ -20,6 +20,8 @@ pre_build() {
 	if [ "${CROSS_BUILD}" ]; then
 		vsed -i build/build.ninja -e 's, && cp src/release/citations src/citations,,'
 	fi
+	# nom-bibtex was probably force pushed, the old git hash doesn't exist anymore
+	cargo update --package nom-bibtex --precise da0eda527c58e281acf41336512cc8627370cff9
 }
 
 # Take the cross-build folder into account when copying the file for the install


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

Citations 0.5.1 has a specific commit hash for nom-bibtex in it's Cargo.lock, but nom-bibtex doesn't have that commit in it's master which causes cargo to fail. I solved it by updating the commit to an equivalent commit which is in master, but it has a different hash probably because it's based on nom-bibtex 0.4.0 instead of 0.3.0.

cc @A6GibKm I am not sure if you are aware of this

```
[24/27] Generating src/cargo-build with a custom command
    Updating crates.io index
    Updating git repository `https://github.com/A6GibKm/nom-bibtex.git`
error: failed to get `nom-bibtex` as a dependency of package `cratebibtex v0.1.0 (/builddir/citations-0.5.1/cratebibtex)`
    ... which satisfies path dependency `cratebibtex` (locked to 0.1.0) of package `citations v0.5.1 (/builddir/citations-0.5.1)`

Caused by:
  failed to load source for dependency `nom-bibtex`

Caused by:
  Unable to update https://github.com/A6GibKm/nom-bibtex.git#3e20b1f6

Caused by:
  object not found - no match for id (3e20b1f6a1f8709bf61836f171b8d90cb84cd8b3); class=Odb (9); code=NotFound (-3)
[26/27] Generating data/org.gnome.World.Citations.metainfo.xml with a custom command
FAILED: src/citations 
/usr/bin/env CARGO_HOME=/builddir/citations-0.5.1/build/cargo-home /usr/bin/cargo build --manifest-path /builddir/citations-0.5.1/Cargo.toml --target-dir /builddir/citations-0.5.1/build/src --release && cp src/release/citations src/citations
ninja: build stopped: subcommand failed.
```