### PR TITLE
qt6ct: update to 0.8

### DIFF
--- a/srcpkgs/qt6ct/template
+++ b/srcpkgs/qt6ct/template
@@ -1,7 +1,7 @@
 # Template file for 'qt6ct'
 pkgname=qt6ct
-version=0.7
-revision=3
+version=0.8
+revision=1
 build_style=cmake
 hostmakedepends="qt6-tools qt6-base"
 makedepends="qt6-base-devel"
@@ -11,8 +11,7 @@ maintainer="Adam Pschorr <adampschorr13@aol.com>"
 license="BSD-2-Clause"
 homepage="https://github.com/trialuser02/qt6ct"
 distfiles="https://github.com/trialuser02/qt6ct/archive/refs/tags/${version}.tar.gz"
-checksum=6bc4c35e7c567908d8e123b8ccc11a55d27b5353ad035905cfa44b98c29ca862
-
+checksum=ca3706770cbdbce769ee4393de9f7469be043810fe40283690612f5f6552018a
 post_install() {
 	vlicense COPYING
 	vinstall ${FILESDIR}/qt6ct.sh 644 etc/profile.d


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)

I noticed that there is some discussion about the need of qt6ct.sh. I am merely updating qt6ct in this commit but if a conclusion is arrived at in #40619 I can modify this PR. 