### PR TITLE
grep: update to 3.10

### DIFF
--- a/srcpkgs/grep/template
+++ b/srcpkgs/grep/template
@@ -1,6 +1,6 @@
 # Template file for 'grep'
 pkgname=grep
-version=3.8
+version=3.10
 revision=1
 build_style=gnu-configure
 hostmakedepends="pkg-config"
@@ -11,4 +11,4 @@ maintainer="Enno Boland <gottox@voidlinux.org>"
 license="GPL-3.0-or-later"
 homepage="https://www.gnu.org/software/grep/"
 distfiles="${GNU_SITE}/${pkgname}/${pkgname}-${version}.tar.xz"
-checksum=498d7cc1b4fb081904d87343febb73475cf771e424fb7e6141aff66013abc382
+checksum=24efa5b595fb5a7100879b51b8868a0bb87a71c183d02c4c602633b88af6855b


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->
@Gottox I took the trouble of making a pull request to update the template of the grep package, the package that you usually maintain.

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, **musl**
- I built this PR locally for these architectures:
  - i686
  - x86_64