### PR TITLE
openblas: update to 0.3.23.

### DIFF
--- a/srcpkgs/openblas/template
+++ b/srcpkgs/openblas/template
@@ -1,8 +1,7 @@
 # Template file for 'openblas'
 pkgname=openblas
-reverts="0.3.22_1"
-version=0.3.21
-revision=2
+version=0.3.23
+revision=1
 build_style=gnu-makefile
 make_build_args="HOSTCC=gcc USE_OPENMP=1"
 make_install_args="OPENBLAS_INCLUDE_DIR=\$(PREFIX)/include/openblas"
@@ -12,9 +11,9 @@ short_desc="Optimized BLAS (Basic Linear Algebra Subprograms) based on GotoBLAS2
 maintainer="Andrew J. Hesford <ajh@sideband.org>"
 license="BSD-3-Clause"
 homepage="https://www.openblas.net/"
-changelog="https://raw.githubusercontent.com/xianyi/OpenBLAS/v${version}/Changelog.txt"
+changelog="https://raw.githubusercontent.com/xianyi/OpenBLAS/develop/Changelog.txt"
 distfiles="https://github.com/xianyi/OpenBLAS/archive/v${version}.tar.gz"
-checksum=f36ba3d7a60e7c8bcc54cd9aaa9b1223dd42eaf02c811791c37e8ca707c241ca
+checksum=5d9491d07168a5d00116cdc068a40022c3455bf9293c7cb86a65b1054d7e5114
 
 case "$XBPS_TARGET_MACHINE" in
 	ppc64*) ;;


### PR DESCRIPTION
Fixes a  bug that affects numpy/scipy/octave/sagemath

See: https://github.com/xianyi/OpenBLAS/issues/3976

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

I had >100 test failures in sagemath with 0.3.22_1 that should all be fixed in 0.3.23.

@ahesford 

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
