### PR TITLE
Revert "openblas: update to 0.3.22."

### DIFF
--- a/srcpkgs/openblas/template
+++ b/srcpkgs/openblas/template
@@ -1,8 +1,8 @@
 # Template file for 'openblas'
 pkgname=openblas
-reverts="0.3.19_1"
-version=0.3.22
-revision=1
+reverts="0.3.22_1"
+version=0.3.21
+revision=2
 build_style=gnu-makefile
 make_build_args="HOSTCC=gcc USE_OPENMP=1"
 make_install_args="OPENBLAS_INCLUDE_DIR=\$(PREFIX)/include/openblas"
@@ -14,7 +14,7 @@ license="BSD-3-Clause"
 homepage="https://www.openblas.net/"
 changelog="https://raw.githubusercontent.com/xianyi/OpenBLAS/v${version}/Changelog.txt"
 distfiles="https://github.com/xianyi/OpenBLAS/archive/v${version}.tar.gz"
-checksum=7fa9685926ba4f27cfe513adbf9af64d6b6b63f9dcabb37baefad6a65ff347a7
+checksum=f36ba3d7a60e7c8bcc54cd9aaa9b1223dd42eaf02c811791c37e8ca707c241ca
 
 case "$XBPS_TARGET_MACHINE" in
 	ppc64*) ;;


### PR DESCRIPTION
Just staging here until the LLVM builds settle down...

Version 0.3.22 apparently breaks Octave:

    https://github.com/xianyi/OpenBLAS/issues/3976

This reverts commit 0ef7a0ec7c6b126d63cfb9f485786f0ef772b516.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**|**briefly**|**NO**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
