### PR TITLE
pyradio: set homepage to https

### DIFF
--- a/srcpkgs/pyradio/template
+++ b/srcpkgs/pyradio/template
@@ -1,14 +1,14 @@
 # Template file for 'pyradio'
 pkgname=pyradio
 version=0.9.2.2
-revision=1
+revision=2
 build_style=python3-module
 hostmakedepends="python3-setuptools"
 depends="python3-requests python3-dnspython python3-psutil python3-rich"
 short_desc="Curses based internet radio player"
 maintainer="Eloi Torrents <eloitor@disroot.org>"
 license="MIT"
-homepage="http://www.coderholic.com/pyradio/"
+homepage="https://www.coderholic.com/pyradio/"
 changelog="https://raw.githubusercontent.com/coderholic/pyradio/master/Changelog"
 distfiles="https://github.com/coderholic/pyradio/archive/${version}.tar.gz"
 checksum=bc92c6e1364d6867244500924a00ae5a918a58c29138484872e0dd168891762b


### PR DESCRIPTION
The homepage works with TLS, but doesn't properly redirect to it. We should probably link directly to the TLS version.

Tagging the maintainer @Eloitor.