### PR TITLE
helix: update to 23.03

### DIFF
--- a/srcpkgs/helix/template
+++ b/srcpkgs/helix/template
@@ -1,6 +1,6 @@
 # Template file for 'helix'
 pkgname=helix
-version=22.12
+version=23.03
 revision=1
 build_style=cargo
 make_install_args="--path helix-term"
@@ -10,13 +10,7 @@ license="MPL-2.0"
 homepage="https://helix-editor.com/"
 changelog="https://raw.githubusercontent.com/helix-editor/helix/master/CHANGELOG.md"
 distfiles="https://github.com/helix-editor/helix/releases/download/${version}/helix-${version}-source.tar.xz"
-checksum=295b42a369fbc6282693eb984a77fb86260f7baf3ba3a8505d62d1c619c2f3f4
-
-# skip problematic doctests on i686
-case "$XBPS_TARGET_MACHINE" in
-	i686*) make_check_args="-- --skip src/";;
-	*) ;;
-esac
+checksum=60e5d8927f2f43807ff4ed3c96e7071746ce23d0b7ebaa27e380723726710703
 
 case "$XBPS_TARGET_MACHINE" in
 	ppc64*) ;;


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
