### PR TITLE
build-style/cargo: use env var to select sparse index mode

### DIFF
--- a/common/build-style/cargo.sh
+++ b/common/build-style/cargo.sh
@@ -5,13 +5,13 @@
 do_build() {
 	: ${make_cmd:=cargo auditable}
 
-	${make_cmd} --config 'registries.crates-io.protocol="sparse"' build --release --target ${RUST_TARGET} ${configure_args}
+	${make_cmd} build --release --target ${RUST_TARGET} ${configure_args}
 }
 
 do_check() {
 	: ${make_cmd:=cargo auditable}
 
-	${make_check_pre} ${make_cmd} --config 'registries.crates-io.protocol="sparse"' test --release --target ${RUST_TARGET} ${configure_args} \
+	${make_check_pre} ${make_cmd} test --release --target ${RUST_TARGET} ${configure_args} \
 		${make_check_args}
 }
 
@@ -19,7 +19,7 @@ do_install() {
 	: ${make_cmd:=cargo auditable}
 	: ${make_install_args:=--path .}
 
-	${make_cmd} --config 'registries.crates-io.protocol="sparse"' install --target ${RUST_TARGET} --root="${DESTDIR}/usr" \
+	${make_cmd} install --target ${RUST_TARGET} --root="${DESTDIR}/usr" \
 		--offline --locked ${configure_args} ${make_install_args}
 
 	rm -f "${DESTDIR}"/usr/.crates.toml

--- a/common/environment/build-style/cargo.sh
+++ b/common/environment/build-style/cargo.sh
@@ -8,4 +8,6 @@ if [ "$CROSS_BUILD" ]; then
 	makedepends+=" rust-std"
 fi
 
+export CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse
+
 build_helper+=" rust"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
