### PR TITLE
nushell: update to 0.78.0.

### DIFF
--- a/common/build-helper/rust.sh
+++ b/common/build-helper/rust.sh
@@ -51,3 +51,6 @@ export OPENSSL_NO_VENDOR=1
 
 # pcre2-sys, only necessary for musl targets
 export PCRE2_SYS_STATIC=0
+
+# zstd-sys
+export ZSTD_SYS_USE_PKG_CONFIG=1

--- a/srcpkgs/nushell/patches/0001-use-system-libraries.patch
+++ b/srcpkgs/nushell/patches/0001-use-system-libraries.patch
@@ -1,121 +1,69 @@
-From c26c60ed459918ed817ac52cfc36733563a570b7 Mon Sep 17 00:00:00 2001
+From b740aa919b96451231e26a6827b5cfe7bc568e22 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Jan=20Christian=20Gr=C3=BCnhage?=
  <jan.christian@gruenhage.xyz>
 Date: Wed, 8 Jun 2022 16:15:55 +0200
 Subject: [PATCH] use system libraries
 
 ---
- Cargo.lock                                  | 3 ++-
- Cargo.toml                                  | 7 +++++--
- crates/nu-cli/Cargo.toml                    | 2 +-
- crates/nu-command/Cargo.toml                | 4 ++--
- crates/old/nu_plugin_from_sqlite/Cargo.toml | 2 +-
- crates/old/nu_plugin_to_sqlite/Cargo.toml   | 2 +-
- 6 files changed, 12 insertions(+), 8 deletions(-)
+ Cargo.lock                   | 1 -
+ Cargo.toml                   | 2 +-
+ crates/nu-cli/Cargo.toml     | 2 +-
+ crates/nu-command/Cargo.toml | 4 ++--
+ 4 files changed, 4 insertions(+), 5 deletions(-)
 
 diff --git a/Cargo.lock b/Cargo.lock
-index 7e75169c2..f74c8d9fc 100644
+index e2b876e3c..2d5772965 100644
 --- a/Cargo.lock
 +++ b/Cargo.lock
-@@ -2025,7 +2025,6 @@ version = "0.25.1"
+@@ -2208,7 +2208,6 @@ version = "0.25.2"
  source = "registry+https://github.com/rust-lang/crates.io-index"
- checksum = "9f0455f2c1bc9a7caa792907026e469c1d91761fb0ea37cbb16427c77280cf35"
+ checksum = "29f835d03d717946d28b1d1ed632eb6f0e24a299388ee623d0c23118d3e8a7fa"
  dependencies = [
 - "cc",
   "pkg-config",
   "vcpkg",
  ]
-@@ -2498,6 +2497,7 @@ dependencies = [
-  "tempfile",
-  "time 0.3.14",
-  "winres",
-+ "zstd",
- ]
- 
- [[package]]
-@@ -5786,4 +5786,5 @@ checksum = "9fd07cbbc53846d9145dbffdf6dd09a7a0aa52be46741825f5c97bdd4f73f12b"
- dependencies = [
-  "cc",
-  "libc",
-+ "pkg-config",
- ]
 diff --git a/Cargo.toml b/Cargo.toml
-index e9ab2c589..6b24e54d2 100644
+index 3db073901..318186fda 100644
 --- a/Cargo.toml
 +++ b/Cargo.toml
-@@ -52,7 +52,7 @@ nu-system = { path = "./crates/nu-system", version = "0.71.0" }
- nu-table = { path = "./crates/nu-table", version = "0.71.0"  }
- nu-term-grid = { path = "./crates/nu-term-grid", version = "0.71.0"  }
- nu-utils = { path = "./crates/nu-utils", version = "0.71.0"  }
--reedline = { version = "0.14.0", features = ["bashisms", "sqlite"]}
-+reedline = { version = "0.14.0", features = ["bashisms", "sqlite-dynlib"]}
+@@ -63,7 +63,7 @@ nu-term-grid = { path = "./crates/nu-term-grid", version = "0.78.0" }
+ nu-utils = { path = "./crates/nu-utils", version = "0.78.0" }
  
- rayon = "1.5.1"
+ nu-ansi-term = "0.47.0"
+-reedline = { version = "0.18.0", features = ["bashisms", "sqlite"] }
++reedline = { version = "0.18.0", features = ["bashisms", "sqlite-dynlib"] }
+ 
+ rayon = "1.7.0"
  is_executable = "1.0.1"
-@@ -130,4 +130,7 @@ path = "src/main.rs"
- # To use a development version of a dependency please use a global override here
- # changing versions in each sub-crate of the workspace is tedious
- [patch.crates-io]
--# reedline = { git = "https://github.com/nushell/reedline.git", branch = "main" }
-+
-+[dependencies.zstd]
-+features = ["pkg-config"]
-+version = ">=0.0.0"
 diff --git a/crates/nu-cli/Cargo.toml b/crates/nu-cli/Cargo.toml
-index dbe2b639c..8bfcb0dd8 100644
+index 2d3ef54c4..d10497bcc 100644
 --- a/crates/nu-cli/Cargo.toml
 +++ b/crates/nu-cli/Cargo.toml
-@@ -20,7 +20,7 @@ nu-protocol = { path = "../nu-protocol", version = "0.71.0"  }
- nu-utils = { path = "../nu-utils", version = "0.71.0"  }
- nu-ansi-term = "0.46.0"
- nu-color-config = { path = "../nu-color-config", version = "0.71.0"  }
--reedline = { version = "0.14.0", features = ["bashisms", "sqlite"]}
-+reedline = { version = "0.14.0", features = ["bashisms", "sqlite-dynlib"]}
+@@ -24,7 +24,7 @@ nu-utils = { path = "../nu-utils", version = "0.78.0" }
+ nu-color-config = { path = "../nu-color-config", version = "0.78.0" }
+ 
+ nu-ansi-term = "0.47.0"
+-reedline = { version = "0.18.0", features = ["bashisms", "sqlite"] }
++reedline = { version = "0.18.0", features = ["bashisms", "sqlite-dynlib"] }
  
  atty = "0.2.14"
- chrono = "0.4.21"
+ chrono = { default-features = false, features = ["std"], version = "0.4.23" }
 diff --git a/crates/nu-command/Cargo.toml b/crates/nu-command/Cargo.toml
-index 99deb0cfc..647b56e9a 100644
+index ba02a8518..9006484fb 100644
 --- a/crates/nu-command/Cargo.toml
 +++ b/crates/nu-command/Cargo.toml
-@@ -86,9 +86,9 @@ unicode-segmentation = "1.8.0"
- url = "2.2.1"
- uuid = { version = "1.1.2", features = ["v4"] }
- which = { version = "4.3.0", optional = true }
--reedline = { version = "0.14.0", features = ["bashisms", "sqlite"]}
-+reedline = { version = "0.14.0", features = ["bashisms", "sqlite-dynlib"]}
- wax = { version =  "0.5.0" }
+@@ -85,8 +85,8 @@ serde_yaml = "0.9.4"
+ sha2 = "0.10.0"
+ # Disable default features b/c the default features build Git (very slow to compile)
+ percent-encoding = "2.2.0"
+-reedline = { version = "0.18.0", features = ["bashisms", "sqlite"] }
 -rusqlite = { version = "0.28.0", features = ["bundled"], optional = true }
++reedline = { version = "0.18.0", features = ["bashisms", "sqlite-dynlib"] }
 +rusqlite = { version = "0.28.0", optional = true }
- sqlparser = { version = "0.23.0", features = ["serde"], optional = true }
- 
- [target.'cfg(windows)'.dependencies]
-diff --git a/crates/old/nu_plugin_from_sqlite/Cargo.toml b/crates/old/nu_plugin_from_sqlite/Cargo.toml
-index 3166d3203..520052cfd 100644
---- a/crates/old/nu_plugin_from_sqlite/Cargo.toml
-+++ b/crates/old/nu_plugin_from_sqlite/Cargo.toml
-@@ -18,7 +18,7 @@ nu-source = { path="../nu-source", version = "0.71.0" }
- tempfile = "3.2.0"
- 
- [dependencies.rusqlite]
--features = ["bundled", "blob"]
-+features = ["blob"]
- version = "0.26.1"
- 
- [build-dependencies]
-diff --git a/crates/old/nu_plugin_to_sqlite/Cargo.toml b/crates/old/nu_plugin_to_sqlite/Cargo.toml
-index 085163b21..923301c9f 100644
---- a/crates/old/nu_plugin_to_sqlite/Cargo.toml
-+++ b/crates/old/nu_plugin_to_sqlite/Cargo.toml
-@@ -18,7 +18,7 @@ nu-source = { path="../nu-source", version = "0.71.0" }
- tempfile = "3.2.0"
- 
- [dependencies.rusqlite]
--features = ["bundled", "blob"]
-+features = ["blob"]
- version = "0.26.1"
- 
- [build-dependencies]
+ sqlparser = { version = "0.32.0", features = ["serde"], optional = true }
+ sysinfo = "0.28.2"
+ tabled = "0.10.0"
 -- 
-2.38.1
+2.40.0
 

--- a/srcpkgs/nushell/template
+++ b/srcpkgs/nushell/template
@@ -1,6 +1,6 @@
 # Template file for 'nushell'
 pkgname=nushell
-version=0.71.0
+version=0.78.0
 revision=1
 build_style=cargo
 configure_args="--features=extra"
@@ -14,7 +14,7 @@ license="MIT"
 homepage="https://www.nushell.sh/"
 changelog="https://www.nushell.sh/blog/"
 distfiles="https://github.com/nushell/nushell/archive/refs/tags/${version}.tar.gz"
-checksum=0f3a279ead004c86c44b6c9991e9e838b819dad23d65add7250a9691ad29f209
+checksum=eff55bf4e0739113cfdc890c0ed90f46ebbfd722b49f7ce65e76b347733bc654
 register_shell="/usr/bin/nu"
 # all tests fail with argument --target
 make_check=no


### PR DESCRIPTION
- common/build-helper/rust.sh: dynamic linking to zstd
- nushell: update to 0.78.0.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
