### PR TITLE
update-check: no partial response and not trust insecure certificate

### DIFF
--- a/common/xbps-src/shutils/update_check.sh
+++ b/common/xbps-src/shutils/update_check.sh
@@ -94,7 +94,7 @@ update_check() {
                 echo "(folder) fetching $urlpfx and scanning with $rx" 1>&2
             fi
             skipdirs=
-            curl -A "xbps-src-update-check/$XBPS_SRC_VERSION" --max-time 10 -Lsk "$urlpfx" |
+            curl -A "xbps-src-update-check/$XBPS_SRC_VERSION" -Lsf "$urlpfx" |
                 grep -Po -i "$rx" |
                 # sort -V places 1.1/ before 1/, but 1A/ before 1.1A/
                 sed -e 's:$:A:' -e 's:/A$:A/:' | sort -Vru | sed -e 's:A/$:/A:' -e 's:A$::' |
@@ -200,7 +200,7 @@ update_check() {
         if [ -n "$XBPS_UPDATE_CHECK_VERBOSE" ]; then
             echo "fetching $url and scanning with $rx" 1>&2
         fi
-        curl -H 'Accept: text/html,application/xhtml+xml,application/xml,text/plain,application/rss+xml' -A "xbps-src-update-check/$XBPS_SRC_VERSION" --max-time 10 -Lsk "$url" |
+        curl -H 'Accept: text/html,application/xhtml+xml,application/xml,text/plain,application/rss+xml' -A "xbps-src-update-check/$XBPS_SRC_VERSION" -Lsf "$url" |
             grep -Po -i "$rx"
         fetchedurls[$url]=yes
     done |


### PR DESCRIPTION
1. My network is slow, `./xbps-src update-check xorg-server` takes 50s and `./xbps-src update-check xorg-server-xwayland` takes 11s, `curl --max-time 10` returns partial response but no error.  So I remove `--max-time 10` and add `-f` to forbid partial response. It's better to call `set -eo pipefail` for the whole script but I'm not sure whether it will break the script.  The CI job or interactive execution can have their own timeout.

2. `-k` means `--insecure`, it's bad, we should always validate HTTPS server certificate.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
