### PR TITLE
xorg-server: update to 21.1.8

### DIFF
--- a/srcpkgs/xorg-server/template
+++ b/srcpkgs/xorg-server/template
@@ -1,6 +1,6 @@
 # Template file for 'xorg-server'
 pkgname=xorg-server
-version=21.1.7
+version=21.1.8
 revision=1
 build_style=meson
 configure_args="-Dipv6=true -Dxorg=true -Dxnest=true -Dxephyr=true
@@ -24,7 +24,7 @@ maintainer="Leah Neukirchen <leah@vuxu.org>"
 license="MIT, BSD-3-Clause"
 homepage="https://xorg.freedesktop.org"
 distfiles="${XORG_SITE}/xserver/${pkgname}-${version}.tar.xz"
-checksum=d9c60b2dd0ec52326ca6ab20db0e490b1ff4f566f59ca742d6532e92795877bb
+checksum=38aadb735650c8024ee25211c190bf8aad844c5f59632761ab1ef4c4d5aeb152
 lib32disabled=yes
 provides="xserver-abi-extension-10_1 xserver-abi-input-24_1
  xserver-abi-video-25_1 xf86-video-modesetting-1_1"


### PR DESCRIPTION
Fixed https://github.com/void-linux/void-packages/issues/43174

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-musl)
