### PR TITLE
xorg-server-xwayland: update to 23.1.1

### DIFF
--- a/srcpkgs/xorg-server-xwayland/template
+++ b/srcpkgs/xorg-server-xwayland/template
@@ -1,6 +1,6 @@
 # Template file for 'xorg-server-xwayland'
 pkgname=xorg-server-xwayland
-version=23.1.0
+version=23.1.1
 revision=1
 build_style=meson
 configure_args="-Dipv6=true -Dxvfb=false -Dxdmcp=false -Dxcsecurity=true
@@ -16,7 +16,7 @@ maintainer="Michal Vasilek <michal@vasilek.cz>"
 license="MIT"
 homepage="https://xorg.freedesktop.org"
 distfiles="https://gitlab.freedesktop.org/xorg/xserver/-/archive/xwayland-$version/xserver-xwayland-$version.tar.gz"
-checksum=0f9e1a1e2b628149565707edceb4150b8841d09709590824023513fdf4cad3ec
+checksum=5a10b26c62495435449f9bd5aad3db8ad29fe8eccd7cf7324011cd981d82dbf0
 make_check=no # needs xtest repository
 
 post_install() {


### PR DESCRIPTION
Fixed https://github.com/void-linux/void-packages/issues/43174

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-musl)
