### PR TITLE
bottom: update to 0.8.0.

### DIFF
--- a/srcpkgs/bottom/template
+++ b/srcpkgs/bottom/template
@@ -1,6 +1,6 @@
 # Template file for 'bottom'
 pkgname=bottom
-version=0.6.8
+version=0.8.0
 revision=1
 build_style=cargo
 short_desc="Yet another cross-platform graphical process/system monitor"
@@ -9,7 +9,11 @@ license="MIT"
 homepage="https://github.com/ClementTsang/bottom"
 changelog="https://raw.githubusercontent.com/ClementTsang/bottom/master/CHANGELOG.md"
 distfiles="https://github.com/ClementTsang/bottom/archive/${version}.tar.gz"
-checksum=4e4eb251972a7af8c46dd36bcf1335fea334fb670569434fbfd594208905b2d9
+checksum=0fe6a826d18570ab33b2af3b26ce28c61e3aa830abb2b622f2c3b81da802437a
+
+pre_build() {
+	export BTM_GENERATE=true
+}
 
 post_install() {
 	vdoc README.md


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

When building locally, this failed due to dependency resolution problems, which are caused by our inconsistent use of the `--locked` and `--offline` flags for cargo. Once we've got #43233 in, this will build just fine though.

EDIT: heh, I'm confused. Now this built just fine in CI without `--locked`, maybe this was just a random local failure.

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
