### PR TITLE
glibmm2.68: update to 2.76.0.

### DIFF
--- a/srcpkgs/glibmm2.68/template
+++ b/srcpkgs/glibmm2.68/template
@@ -1,8 +1,9 @@
 # Template file for 'glibmm2.68'
 pkgname=glibmm2.68
-version=2.68.1
+version=2.76.0
 revision=1
 build_style=meson
+configure_args="-Dbuild-examples=false"
 hostmakedepends="glib-devel perl pkg-config"
 makedepends="libglib-devel libsigc++3-devel"
 checkdepends="glib-networking"
@@ -10,8 +11,9 @@ short_desc="C++ bindings for GLib"
 maintainer="Enno Boland <gottox@voidlinux.org>"
 license="LGPL-2.1-or-later"
 homepage="https://www.gtkmm.org"
+changelog="https://gitlab.gnome.org/GNOME/glibmm/-/raw/master/NEWS"
 distfiles="${GNOME_SITE}/glibmm/${version%.*}/glibmm-${version}.tar.xz"
-checksum=6664e27c9a9cca81c29e35687f49f2e0d173a2fc9e98c3428311f707db532f8c
+checksum=8637d80ceabd94fddd6e48970a082a264558d4ab82684e15ffc87e7ef3462ab2
 
 glibmm2.68-devel_package() {
 	depends="${makedepends} ${sourcepkg}>=${version}_${revision}"

--- a/srcpkgs/glibmm2.68/update
+++ b/srcpkgs/glibmm2.68/update
@@ -1,3 +1,3 @@
 pkgname=glibmm
 site=https://gitlab.gnome.org/GNOME/glibmm/-/tags
-pattern="$pkgname-\K[0-9]\.[0-9]*[02468]\.[0-9.]*[0-9](?=)"
+ignore="*.*[13579].*"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, glibc, x64

Note: Tested only telegram-desktop, unsure which applications depend on glibmm2.68