### PR TITLE
tpm2-totp: switch to prebuilt source destfile

### DIFF
--- a/srcpkgs/tpm2-totp/template
+++ b/srcpkgs/tpm2-totp/template
@@ -1,9 +1,9 @@
 # Template file for 'tpm2-totp'
 pkgname=tpm2-totp
 version=0.3.0
-revision=2
+revision=3
 build_style=gnu-configure
-hostmakedepends="autoconf autoconf-archive automake doxygen libtool pkg-config $(vopt_if man pandoc)"
+hostmakedepends="autoconf autoconf-archive automake libtool pkg-config"
 makedepends="dracut mkinitcpio qrencode-devel tpm2-tss-devel"
 checkdepends="iproute2 oath-toolkit-devel swtpm tpm2-tools"
 short_desc="Attest the trustworthiness of a device using TOTP"
@@ -11,23 +11,12 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="BSD-3-Clause"
 homepage="https://github.com/tpm2-software/tpm2-totp"
 changelog="https://raw.githubusercontent.com/tpm2-software/tpm2-totp/master/CHANGELOG.md"
-distfiles="https://github.com/tpm2-software/tpm2-totp/archive/refs/tags/v${version}.tar.gz"
-checksum=5ff29164979d21bc0a51afce17aee80929ccce3270d0f4abce996fd36a4469e1
-
-build_options="man"
-desc_option_man="Use pandoc for manpages"
-
-case "$XBPS_MACHINE" in
-	x86_64*|i686|ppc64le*|ppc64) build_options_default="man" ;;
-esac
+distfiles="https://github.com/tpm2-software/tpm2-totp/releases/download/v${version}/tpm2-totp-${version}.tar.gz"
+checksum=1a8c83dc0d0dc58bd85a3fbfc9da6e39414c0d33f1a19886cde20f063f0c527b
 
 if [ -n "$XBPS_CHECK_PKGS" ]; then
 	configure_args="--enable-integration"
 fi
-
-pre_configure() {
-	autoreconf -isv
-}
 
 libtpm2-totp_package() {
 	short_desc+=" - library files"
@@ -45,9 +34,6 @@ tpm2-totp-devel_package() {
 		vmove usr/lib/pkgconfig
 		vmove "usr/lib/*.a"
 		vmove "usr/lib/*.so"
-
-		if [ -n "$build_option_man" ]; then
-			vmove usr/share/man/man3
-		fi
+		vmove usr/share/man/man3
 	}
 }


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

Avoids using pandoc or doxygen altogether

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
