### PR TITLE
puzzles: update to 20230404.2499eb4.

### DIFF
--- a/srcpkgs/puzzles/template
+++ b/srcpkgs/puzzles/template
@@ -1,6 +1,6 @@
 # Template file for 'puzzles'
 pkgname=puzzles
-version=20230303.c0f715f
+version=20230404.2499eb4
 revision=1
 build_style=cmake
 configure_args="-DNAME_PREFIX=puzzles-"
@@ -10,8 +10,8 @@ short_desc="Simon Tatham's Portable Puzzle Collection"
 maintainer="Leah Neukirchen <leah@vuxu.org>"
 license="MIT"
 homepage="https://www.chiark.greenend.org.uk/~sgtatham/puzzles/"
-distfiles="https://git.tartarus.org/?p=simon/puzzles.git;a=snapshot;h=c0f715fbaca77fbb6e86de604098d82687bdea48;sf=tgz>${pkgname}-${version#*.}.tgz"
-checksum=dfd601d277f304cac5bb38a99dc478fe4e7ec2019951461c18f1516c64c7fd8b
+distfiles="https://git.tartarus.org/?p=simon/puzzles.git;a=snapshot;h=2499eb47fa4e0c86bc1b6100b4922026670b2ad8;sf=tgz>${pkgname}-${version#*.}.tgz"
+checksum=10a5dc2b9e20a45ad683de7536dd33648a4a1ad69da189c90ae5d656cdbd6b8e
 
 post_install() {
 	vlicense LICENCE LICENSE


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture: **x86_64**