### PR TITLE
git-brws: fix build on Rust 1.64+

### DIFF
--- a/srcpkgs/git-brws/template
+++ b/srcpkgs/git-brws/template
@@ -1,7 +1,7 @@
 # Template file for 'git-brws'
 pkgname=git-brws
 version=0.11.12
-revision=2
+revision=3
 build_style=cargo
 hostmakedepends="pkg-config"
 makedepends="openssl-devel"
@@ -11,10 +11,15 @@ license="MIT"
 homepage="https://rhysd.github.io/git-brws/"
 distfiles="https://github.com/rhysd/git-brws/archive/v${version}.tar.gz"
 checksum=3a4bbf93f0b16562260ca66c2b60c655d5bfc690d0229d11757be76d95cb81c5
+# Tests require git checkout and partially also GitHub tokens
+make_check=no
 
 pre_build() {
 	# fixes an indexmap error when cross compiling
 	cargo update --package autocfg:1.0.1 --precise 1.1.0
+
+	# fixes compilation on Rust 1.64 and higher
+	cargo update --package socket2:0.3.15 --precise 0.3.16
 }
 
 post_install() {


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
