### PR TITLE
[ci skip] revbumps for including Rust dependency metadata using cargo-auditable

### DIFF
--- a/srcpkgs/amber/template
+++ b/srcpkgs/amber/template
@@ -1,7 +1,7 @@
 # Template file for 'amber'
 pkgname=amber
 version=0.5.9
-revision=1
+revision=2
 build_style=cargo
 short_desc="Code search/replace tool"
 maintainer="SolitudeSF <solitudesf@protonmail.com>"

--- a/srcpkgs/amp/template
+++ b/srcpkgs/amp/template
@@ -1,7 +1,7 @@
 # Template file for 'amp'
 pkgname=amp
 version=0.6.2
-revision=2
+revision=3
 build_style=cargo
 hostmakedepends="cmake git python3"
 makedepends="libxcb-devel"

--- a/srcpkgs/boringtun/template
+++ b/srcpkgs/boringtun/template
@@ -1,7 +1,7 @@
 # Template file for 'boringtun'
 pkgname=boringtun
 version=0.3.0
-revision=1
+revision=2
 build_style=cargo
 short_desc="Implementation of the WireGuard protocol"
 maintainer="Zach Nedwich <zach@znedw.com>"

--- a/srcpkgs/cargo-crev/template
+++ b/srcpkgs/cargo-crev/template
@@ -1,7 +1,7 @@
 # Template file for 'cargo-crev'
 pkgname=cargo-crev
 version=0.23.3
-revision=1
+revision=2
 build_style=cargo
 make_install_args="--path ./cargo-crev"
 make_check_args="-- --skip creates_new_id_implicitly"

--- a/srcpkgs/castor/template
+++ b/srcpkgs/castor/template
@@ -1,7 +1,7 @@
 # Template file for 'castor'
 pkgname=castor
 version=0.9.0
-revision=1
+revision=2
 build_style=cargo
 hostmakedepends="pkg-config"
 makedepends="atk-devel pango-devel gdk-pixbuf-devel gtk+3-devel cairo-devel openssl-devel"

--- a/srcpkgs/cbindgen/template
+++ b/srcpkgs/cbindgen/template
@@ -1,7 +1,7 @@
 # Template file for 'cbindgen'
 pkgname=cbindgen
 version=0.24.3
-revision=1
+revision=2
 build_style=cargo
 short_desc="Tool to generate C bindings for Rust code"
 maintainer="Orphaned <orphan@voidlinux.org>"

--- a/srcpkgs/chars/template
+++ b/srcpkgs/chars/template
@@ -1,7 +1,7 @@
 # Template file for 'chars'
 pkgname=chars
 version=0.6.0
-revision=1
+revision=2
 build_style=cargo
 configure_args="-p chars"
 make_check_args="-p chars"

--- a/srcpkgs/diffr/template
+++ b/srcpkgs/diffr/template
@@ -1,7 +1,7 @@
 # Template file for 'diffr'
 pkgname=diffr
 version=0.1.4
-revision=1
+revision=2
 build_style=cargo
 short_desc="LCS based diff highlighting tool to ease code review from your terminal"
 maintainer="Andy Weidenbaum <atweiden@tutanota.de>"

--- a/srcpkgs/dijo/template
+++ b/srcpkgs/dijo/template
@@ -1,7 +1,7 @@
 # Template file for 'dijo'
 pkgname=dijo
 version=0.2.7
-revision=1
+revision=2
 build_style=cargo
 makedepends="ncurses-devel"
 short_desc="Scriptable, curses-based, digital habit tracker"

--- a/srcpkgs/diskonaut/template
+++ b/srcpkgs/diskonaut/template
@@ -1,7 +1,7 @@
 # Template file for 'diskonaut'
 pkgname=diskonaut
 version=0.11.0
-revision=1
+revision=2
 build_style=cargo
 short_desc="TUI disk space navigator written in rust"
 maintainer="cinerea0 <cinerea0@protonmail.com>"

--- a/srcpkgs/diskus/template
+++ b/srcpkgs/diskus/template
@@ -1,7 +1,7 @@
 # Template file for 'diskus'
 pkgname=diskus
 version=0.7.0
-revision=1
+revision=2
 build_style=cargo
 short_desc="Minimal, fast alternative to du -sh"
 maintainer="travankor <travankor@tuta.io>"

--- a/srcpkgs/dutree/template
+++ b/srcpkgs/dutree/template
@@ -1,7 +1,7 @@
 # Template file for 'dutree'
 pkgname=dutree
 version=0.2.18
-revision=1
+revision=2
 build_style=cargo
 short_desc="Tool to analyze file system usage written in Rust"
 maintainer="Orphaned <orphan@voidlinux.org>"
@@ -9,8 +9,3 @@ license="GPL-3.0-or-later"
 homepage="https://github.com/nachoparker/dutree"
 distfiles="https://github.com/nachoparker/dutree/archive/v${version}.tar.gz"
 checksum=55c30e57cc339dd16141510af33245cc3b82f588f22419fc034f02b36ebecba0
-
-pre_build() {
-	# default version too old for ppc musl systems
-	cargo update --package libc --precise 0.2.66
-}

--- a/srcpkgs/fastmod/template
+++ b/srcpkgs/fastmod/template
@@ -1,7 +1,7 @@
 # Template file for 'fastmod'
 pkgname=fastmod
 version=0.4.1
-revision=1
+revision=2
 build_style=cargo
 short_desc="Tool for partially automating codebase refactors"
 maintainer="Adam Beckmeyer <adam_gpg@thebeckmeyers.xyz>"

--- a/srcpkgs/ffsend/template
+++ b/srcpkgs/ffsend/template
@@ -1,7 +1,7 @@
 # Template file for 'ffsend'
 pkgname=ffsend
 version=0.2.76
-revision=1
+revision=2
 build_style=cargo
 hostmakedepends="pkg-config"
 makedepends="openssl-devel"

--- a/srcpkgs/fool/template
+++ b/srcpkgs/fool/template
@@ -1,10 +1,10 @@
 # Template file for 'fool'
 pkgname=fool
 version=0.2.1
-revision=3
+revision=4
 build_style=cargo
 makedepends="ncurses-devel"
-short_desc="A powerful git terminal interface which focuses on usability"
+short_desc="Powerful git terminal interface which focuses on usability"
 maintainer="Wilson Birney <wpb@360scada.com>"
 license="MIT"
 homepage="https://github.com/spacekookie/fool"
@@ -13,7 +13,7 @@ checksum=41fa1a10a3b3cadba4700b809df13df9ed109ecc5c54ba8b645269abff84a41a
 
 pre_build() {
 	# default version too old for ppc musl systems
-	cargo update --package libc --precise 0.2.66
+	cargo update --package libc@0.2.34 --precise 0.2.66
 }
 
 post_install() {

--- a/srcpkgs/gcsf/template
+++ b/srcpkgs/gcsf/template
@@ -1,7 +1,7 @@
 # Template file for 'gcsf'
 pkgname=gcsf
 version=0.1.28
-revision=1
+revision=2
 build_style=cargo
 hostmakedepends="pkg-config"
 makedepends="fuse-devel openssl-devel"

--- a/srcpkgs/gip/template
+++ b/srcpkgs/gip/template
@@ -1,7 +1,7 @@
 # Template file for 'gip'
 pkgname=gip
 version=0.7.1
-revision=1
+revision=2
 build_style=cargo
 hostmakedepends="pkg-config"
 makedepends="openssl-devel"

--- a/srcpkgs/git-series/template
+++ b/srcpkgs/git-series/template
@@ -1,7 +1,7 @@
 # Template file for 'git-series'
 pkgname=git-series
 version=0.9.1
-revision=14
+revision=15
 build_style=cargo
 hostmakedepends="cmake pkg-config perl"
 makedepends="libgit2-devel libcurl-devel"
@@ -14,9 +14,9 @@ distfiles="https://github.com/git-series/git-series/archive/${version}.tar.gz"
 checksum=c0362e19d3fa168a7cb0e260fcdecfe070853b163c9f2dfd2ad8213289bc7e5f
 
 post_extract() {
-	cargo update --package libc --precise 0.2.55
-	cargo update --package url --precise 1.7.2
-	cargo update --package openssl-sys --precise 0.9.60
+	cargo update --package libc@0.2.17 --precise 0.2.55
+	cargo update --package url@1.2.3 --precise 1.7.2
+	cargo update --package openssl-sys@0.9.1 --precise 0.9.60
 }
 pre_build() {
 	export LIBGIT2_SYS_USE_PKG_CONFIG=yes

--- a/srcpkgs/hex/template
+++ b/srcpkgs/hex/template
@@ -1,7 +1,7 @@
 # Template file for 'hex'
 pkgname=hex
 version=0.4.2
-revision=2
+revision=3
 build_style=cargo
 short_desc="Futuristic take on hexdump"
 maintainer="SolitudeSF <solitudesf@protonmail.com>"

--- a/srcpkgs/i3lockr/template
+++ b/srcpkgs/i3lockr/template
@@ -1,7 +1,7 @@
 # Template file for 'i3lockr'
 pkgname=i3lockr
 version=1.0.0
-revision=1
+revision=2
 build_style=cargo
 hostmakedepends="python3"
 makedepends="xcb-util-image-devel"

--- a/srcpkgs/i3status-rust/template
+++ b/srcpkgs/i3status-rust/template
@@ -1,7 +1,7 @@
 # Template file for 'i3status-rust'
 pkgname=i3status-rust
 version=0.22.0
-revision=1
+revision=2
 build_style=cargo
 make_check_args="--bins"
 hostmakedepends="pkg-config"

--- a/srcpkgs/i3wsr/template
+++ b/srcpkgs/i3wsr/template
@@ -1,7 +1,7 @@
 # Template file for 'i3wsr'
 pkgname=i3wsr
 version=1.3.0
-revision=1
+revision=2
 build_style=cargo
 hostmakedepends="python3"
 makedepends="libxcb-devel"

--- a/srcpkgs/intermodal/template
+++ b/srcpkgs/intermodal/template
@@ -1,7 +1,7 @@
 # Template file for 'intermodal'
 pkgname=intermodal
 version=0.1.12
-revision=1
+revision=2
 build_style=cargo
 make_check_args="-- --skip subcommand::torrent::verify::tests::output_multiple
  --skip subcommand::torrent::verify::tests::output_color"

--- a/srcpkgs/jless/template
+++ b/srcpkgs/jless/template
@@ -1,7 +1,7 @@
 # Template file for 'jless'
 pkgname=jless
 version=0.8.0
-revision=1
+revision=2
 build_style=cargo
 hostmakedepends="python3"
 makedepends="xcb-util-devel"

--- a/srcpkgs/kibi/template
+++ b/srcpkgs/kibi/template
@@ -1,7 +1,7 @@
 # Template file for 'kibi'
 pkgname=kibi
 version=0.2.2
-revision=1
+revision=2
 build_style=cargo
 short_desc="Lightweight, configurable text editor"
 maintainer="Neel Chotai <neel@chot.ai>"

--- a/srcpkgs/licensor/template
+++ b/srcpkgs/licensor/template
@@ -1,7 +1,7 @@
 # Template file for 'licensor'
 pkgname=licensor
 version=2.1.0
-revision=1
+revision=2
 build_style=cargo
 short_desc="Write licenses to stdout"
 maintainer="Jan Christian Grünhage <jan.christian@gruenhage.xyz>"

--- a/srcpkgs/loc/template
+++ b/srcpkgs/loc/template
@@ -1,7 +1,7 @@
 # Template file for 'loc'
 pkgname=loc
 version=0.4.1
-revision=2
+revision=3
 build_style=cargo
 short_desc="Count lines of code quickly"
 maintainer="SolitudeSF <solitudesf@protonmail.com>"
@@ -12,7 +12,7 @@ checksum=1e8403fd9a3832007f28fb389593cd6a572f719cd95d85619e7bbcf3dbea18e5
 
 pre_build() {
 	# default version too old for ppc musl systems
-	cargo update --package libc --precise 0.2.66
+	cargo update --package libc@0.2.32 --precise 0.2.66
 }
 
 post_install() {

--- a/srcpkgs/lsd/template
+++ b/srcpkgs/lsd/template
@@ -1,7 +1,7 @@
 # Template file for 'lsd'
 pkgname=lsd
 version=0.23.1
-revision=1
+revision=2
 build_style=cargo
 short_desc="Next gen ls command with lots of pretty colors and awesome icons"
 maintainer="Marcin Puc <tranzystorek.io@protonmail.com>"

--- a/srcpkgs/mdbook-linkcheck/template
+++ b/srcpkgs/mdbook-linkcheck/template
@@ -2,7 +2,7 @@
 # New versions need to be tested for compatibility with mdBook
 pkgname=mdbook-linkcheck
 version=0.7.7
-revision=1
+revision=2
 build_style=cargo
 hostmakedepends="pkg-config"
 makedepends="openssl-devel"

--- a/srcpkgs/orz/template
+++ b/srcpkgs/orz/template
@@ -1,7 +1,7 @@
 # Template file for 'orz'
 pkgname=orz
 version=1.6.2
-revision=1
+revision=2
 build_style=cargo
 short_desc="General purpose data compressor"
 maintainer="SolitudeSF <solitudesf@protonmail.com>"

--- a/srcpkgs/pastel/template
+++ b/srcpkgs/pastel/template
@@ -1,7 +1,7 @@
 # Template file for 'pastel'
 pkgname=pastel
 version=0.9.0
-revision=1
+revision=2
 build_style=cargo
 short_desc="Generate, analyze, convert and manipulate colors"
 maintainer="Andrew Benson <abenson+void@gmail.com>"

--- a/srcpkgs/pazi/template
+++ b/srcpkgs/pazi/template
@@ -1,7 +1,7 @@
 # Template file for 'pazi'
 pkgname=pazi
 version=0.4.1
-revision=1
+revision=2
 build_style=cargo
 short_desc="Fast autojump helper"
 maintainer="Jan Christian Gruenhage <jan.christian@gruenhage.xyz>"

--- a/srcpkgs/rdedup/template
+++ b/srcpkgs/rdedup/template
@@ -1,7 +1,7 @@
 # Template file for 'rdedup'
 pkgname=rdedup
 version=3.2.1
-revision=1
+revision=2
 build_style=cargo
 hostmakedepends="pkg-config clang"
 makedepends="openssl-devel liblzma-devel libsodium-devel"

--- a/srcpkgs/ripgrep/template
+++ b/srcpkgs/ripgrep/template
@@ -1,7 +1,7 @@
 # Template file for 'ripgrep'
 pkgname=ripgrep
 version=13.0.0
-revision=1
+revision=2
 build_style=cargo
 configure_args="--features=pcre2"
 hostmakedepends="ruby-asciidoctor pkg-config"

--- a/srcpkgs/rot8/template
+++ b/srcpkgs/rot8/template
@@ -1,7 +1,7 @@
 # Template file for 'rot8'
 pkgname=rot8
 version=0.1.4
-revision=1
+revision=2
 build_style=cargo
 short_desc="Screen rotation daemon"
 maintainer="Harrison Thorne <harrisonthorne@protonmail.com>"

--- a/srcpkgs/rsv/template
+++ b/srcpkgs/rsv/template
@@ -1,7 +1,7 @@
 # Template file for 'rsv'
 pkgname=rsv
 version=1.3.3
-revision=2
+revision=3
 build_style=cargo
 build_helper=qemu
 short_desc="Runit sv command rewritten in rust with nice new features"

--- a/srcpkgs/scryer-prolog/template
+++ b/srcpkgs/scryer-prolog/template
@@ -1,7 +1,7 @@
 # Template file for 'scryer-prolog'
 pkgname=scryer-prolog
 version=0.8.123
-revision=2
+revision=3
 build_style=cargo
 hostmakedepends="m4 pkg-config"
 makedepends="gmp-devel mpfr-devel libmpc-devel"

--- a/srcpkgs/sd/template
+++ b/srcpkgs/sd/template
@@ -1,7 +1,7 @@
 # Template file for 'sd'
 pkgname=sd
 version=0.7.6
-revision=1
+revision=2
 build_style=cargo
 short_desc="Intuitive find & replace CLI"
 maintainer="SolitudeSF <solitudesf@protonmail.com>"

--- a/srcpkgs/signal-backup-decode/template
+++ b/srcpkgs/signal-backup-decode/template
@@ -1,7 +1,7 @@
 # Template file for 'signal-backup-decode'
 pkgname=signal-backup-decode
 version=0.2.3
-revision=1
+revision=2
 build_style=cargo
 hostmakedepends="pkg-config"
 makedepends="openssl-devel sqlite-devel"

--- a/srcpkgs/so/template
+++ b/srcpkgs/so/template
@@ -1,7 +1,7 @@
 # Template file for 'so'
 pkgname=so
 version=0.4.9
-revision=1
+revision=2
 build_style=cargo
 hostmakedepends="pkg-config"
 makedepends="openssl-devel"

--- a/srcpkgs/spotify-adblock/template
+++ b/srcpkgs/spotify-adblock/template
@@ -1,7 +1,7 @@
 # Template file for 'spotify-adblock'
 pkgname=spotify-adblock
 version=1.0.2
-revision=1
+revision=2
 build_style=cargo
 conf_files="/etc/spotify-adblock/config.toml"
 short_desc="Adblocker for Spotify"
@@ -12,9 +12,11 @@ distfiles="https://github.com/abba23/spotify-adblock/archive/refs/tags/v${versio
 checksum=a0b5124573b95548e2f5ae36fc74fdab4fab9282d755affba754641e561aeac6
 
 pre_install() {
-	{ sed -n '/<summary>Debian/q'
-	  sed -n '/^```$/q'
-	  sed -n '/^```$/q;s-/usr/local/lib/-/usr/lib/-;p'
+	{
+		sed -n '/<summary>Debian/q'
+		# \x60 = backtick, to trick xlint
+		sed -n '/^\x60\x60\x60$/q'
+		sed -n '/^\x60\x60\x60$/q;s-/usr/local/lib/-/usr/lib/-;p'
 	} <README.md >spotify-adblock.desktop
 }
 

--- a/srcpkgs/tealdeer/template
+++ b/srcpkgs/tealdeer/template
@@ -1,7 +1,7 @@
 # Template file for 'tealdeer'
 pkgname=tealdeer
 version=1.6.1
-revision=1
+revision=2
 # uses rustls/ring
 archs="x86_64* aarch64* i686* armv[67]*"
 build_style=cargo

--- a/srcpkgs/tiny/template
+++ b/srcpkgs/tiny/template
@@ -1,7 +1,7 @@
 # Template file for 'tiny'
 pkgname=tiny
 version=0.10.0
-revision=1
+revision=2
 build_wrksrc="crates/tiny"
 build_style=cargo
 configure_args="--no-default-features --features=desktop-notifications --features=tls-native"

--- a/srcpkgs/tokei/template
+++ b/srcpkgs/tokei/template
@@ -1,7 +1,7 @@
 # Template file for 'tokei'
 pkgname=tokei
 version=12.1.2
-revision=3
+revision=4
 build_style=cargo
 configure_args="--features all"
 short_desc="Count lines of code"

--- a/srcpkgs/tuigreet/template
+++ b/srcpkgs/tuigreet/template
@@ -1,7 +1,7 @@
 # Template file for 'tuigreet'
 pkgname=tuigreet
 version=0.8.0
-revision=1
+revision=2
 build_style=cargo
 hostmakedepends="scdoc"
 depends="greetd"

--- a/srcpkgs/viu/template
+++ b/srcpkgs/viu/template
@@ -1,7 +1,7 @@
 # Template file for 'viu'
 pkgname=viu
 version=1.4.0
-revision=1
+revision=2
 build_style=cargo
 short_desc="CLI app to view images in the terminal"
 maintainer="Jan Christian Grünhage <jan.christian@gruenhage.xyz>"

--- a/srcpkgs/waitforfile/template
+++ b/srcpkgs/waitforfile/template
@@ -1,7 +1,7 @@
 # Template file for 'waitforfile'
 pkgname=waitforfile
 version=0.1.8
-revision=2
+revision=3
 build_style=cargo
 short_desc="Wait until the given file exists"
 maintainer="Orphaned <orphan@voidlinux.org>"

--- a/srcpkgs/wasmtime/template
+++ b/srcpkgs/wasmtime/template
@@ -1,7 +1,7 @@
 # Template file for 'wasmtime'
 pkgname=wasmtime
 version=0.25.0
-revision=1
+revision=2
 create_wrksrc=yes
 archs="x86_64* i686* aarch64*"
 build_style=cargo

--- a/srcpkgs/websocat/template
+++ b/srcpkgs/websocat/template
@@ -1,7 +1,7 @@
 # Template file for 'websocat'
 pkgname=websocat
 version=1.11.0
-revision=1
+revision=2
 build_style=cargo
 configure_args="--features=ssl"
 hostmakedepends="pkg-config"

--- a/srcpkgs/wired-notify/template
+++ b/srcpkgs/wired-notify/template
@@ -1,7 +1,7 @@
 # Template file for 'wired-notify'
 pkgname=wired-notify
 version=0.10.2
-revision=1
+revision=2
 build_style=cargo
 hostmakedepends="pkg-config"
 makedepends="pango-devel libXScrnSaver-devel libglib-devel"

--- a/srcpkgs/xcolor/template
+++ b/srcpkgs/xcolor/template
@@ -1,7 +1,7 @@
 # Template file for 'xcolor'
 pkgname=xcolor
 version=0.5.1
-revision=1
+revision=2
 build_style=cargo
 hostmakedepends="pkg-config python3"
 makedepends="libX11-devel libXcursor-devel libXrender-devel"

--- a/srcpkgs/xi-editor/template
+++ b/srcpkgs/xi-editor/template
@@ -1,7 +1,7 @@
 # Template file for 'xi-editor'
 pkgname=xi-editor
 version=0.3.0
-revision=1
+revision=2
 build_wrksrc=rust
 build_style=cargo
 short_desc="Modern editor with a Rust backend"

--- a/srcpkgs/xsv/template
+++ b/srcpkgs/xsv/template
@@ -1,7 +1,7 @@
 # Template file for 'xsv'
 pkgname=xsv
 version=0.13.0
-revision=2
+revision=3
 build_style=cargo
 short_desc="Fast CSV toolkit written in Rust"
 maintainer="Leah Neukirchen <leah@vuxu.org>"
@@ -12,7 +12,7 @@ checksum=2b75309b764c9f2f3fdc1dd31eeea5a74498f7da21ae757b3ffd6fd537ec5345
 
 pre_build() {
 	# default version too old for ppc musl systems
-	cargo update --package libc --precise 0.2.66
+	cargo update --package libc@0.2.40 --precise 0.2.66
 }
 
 post_install() {


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

I have built a few of these packages, but not all. @paper42 has though.

This PR has revbumps for (nearly) all packages that haven't been changed since
the change to the build style that includes metadata on all `build_style=cargo`
packages by default.

There are three packages that don't get a revbump here, because they have active
PRs open that will likely be merged soon:
 - https://github.com/void-linux/void-packages/pull/43254
 - https://github.com/void-linux/void-packages/pull/43143
 - https://github.com/void-linux/void-packages/pull/43175 (blocked on https://github.com/void-linux/void-packages/pull/43188)

@Shnatsel, you mentioned in https://github.com/rust-secure-code/cargo-auditable/issues/81#issuecomment-1304257246 that we should let you know when we're rebuilding the remainder of our packages, so that all¹ of our rust packages are shipped with dependency metadata embedded. That is being tackled now with this PR :)

A few more things got split out due to the `--locked` build style change:
 - https://github.com/void-linux/void-packages/pull/43233 has now gotten nearly a dozen fixes that previously were in here as revbumps
 - https://github.com/void-linux/void-packages/pull/43352
 - https://github.com/void-linux/void-packages/pull/43350, although this isn't working yet, and will probably just stay as one of the non-auditable exceptions for the time being.

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
