### PR TITLE
python3-docstring-to-markdown: update to 0.12.

### DIFF
--- a/srcpkgs/python3-docstring-to-markdown/template
+++ b/srcpkgs/python3-docstring-to-markdown/template
@@ -1,14 +1,14 @@
 # Template file for 'python3-docstring-to-markdown'
 pkgname=python3-docstring-to-markdown
-version=0.11
+version=0.12
 revision=1
 build_style=python3-module
 hostmakedepends="python3-setuptools_scm"
 depends="python3"
-short_desc="Python implementation of the Language Server Protocol"
+short_desc="On the fly conversion of Python docstrings to markdown"
 maintainer="Cameron Nemo <cam@nohom.org>"
 license="LGPL-2.1-or-later"
 homepage="https://pypi.org/project/docstring-to-markdown/"
 changelog="https://github.com/python-lsp/docstring-to-markdown/releases"
 distfiles="${PYPI_SITE}/d/docstring-to-markdown/docstring-to-markdown-${version}.tar.gz"
-checksum=5b1da2c89d9d0d09b955dec0ee111284ceadd302a938a03ed93f66e09134f9b5
+checksum=40004224b412bd6f64c0f3b85bb357a41341afd66c4b4896709efa56827fb2bb


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-musl)
