### PR TITLE
taplo: Handle LSP shutdown request

### DIFF
--- a/srcpkgs/taplo/patches/0001-handle-lsp-shutdown-request.patch
+++ b/srcpkgs/taplo/patches/0001-handle-lsp-shutdown-request.patch
@@ -1,0 +1,26 @@
+From https://github.com/tamasfe/taplo/pull/354
+From: Michael Davis <mcarsondavis@gmail.com>
+Date: Sun, 20 Nov 2022 12:25:43 -0600
+Subject: [PATCH] Handle LSP shutdown request
+
+These lines in the Server loop discard any messages with the shutdown
+method. The Server can handle and correctly respond to shutdown
+requests, though, so there's no need to discard the message.
+---
+ crates/lsp-async-stub/src/listen.rs | 2 --
+ 1 file changed, 2 deletions(-)
+
+diff --git a/crates/lsp-async-stub/src/listen.rs b/crates/lsp-async-stub/src/listen.rs
+index fca0a2980..b6b00f5fd 100644
+--- a/crates/lsp-async-stub/src/listen.rs
++++ b/crates/lsp-async-stub/src/listen.rs
+@@ -64,8 +64,6 @@ impl<W: Clone + 'static> Server<W> {
+                                     drop(output);
+                                     drop(input);
+                                     break;
+-                                } else if msg.method.as_ref().map(|m| m == "shutdown").unwrap_or(false) {
+-                                    continue;
+                                 }
+ 
+                                 let task_fut = self.handle_message(
+

--- a/srcpkgs/taplo/template
+++ b/srcpkgs/taplo/template
@@ -1,7 +1,7 @@
 # Template file for 'taplo'
 pkgname=taplo
 version=0.8.0
-revision=1
+revision=2
 build_wrksrc="crates/taplo-cli"
 build_style=cargo
 # no-default-features: allows selecting custom feature set


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture: **x86_64**

The language server hangs till timeout while quitting Helix with a `toml` buffer. This patch was sent upstream by Helix primary author.

\cc @cinerea0 