### PR TITLE
fzf: update to 0.39.0.

### DIFF
--- a/srcpkgs/fzf/template
+++ b/srcpkgs/fzf/template
@@ -1,7 +1,7 @@
 # Template file for 'fzf'
 pkgname=fzf
-version=0.38.0
-revision=2
+version=0.39.0
+revision=1
 build_style=go
 go_import_path="github.com/junegunn/fzf"
 go_ldflags="-X main.version=${version} -X main.revision="
@@ -12,7 +12,7 @@ license="MIT"
 homepage="https://github.com/junegunn/fzf"
 changelog="https://raw.githubusercontent.com/junegunn/fzf/master/CHANGELOG.md"
 distfiles="https://github.com/junegunn/fzf/archive/refs/tags/${version}.tar.gz"
-checksum=75ad1bdb2ba40d5b4da083883e65a2887d66bd2d4dbfa29424cb3f09c37efaa7
+checksum=ac665ac269eca320ca9268227142f01b10ad5d25364ff274658b5a9f709a7259
 
 post_install() {
 	cd ${wrksrc}


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures:
  - aarch64
  - i686
  - x86_64-musl
