### PR TITLE
common/build-style/go.sh: use -modcacherw

### DIFF
--- a/common/build-style/go.sh
+++ b/common/build-style/go.sh
@@ -40,7 +40,7 @@ do_build() {
 			# default behavior.
 			go_mod_mode=
 		fi
-		go install -p "$XBPS_MAKEJOBS" -mod="${go_mod_mode}" -x -tags "${go_build_tags}" -ldflags "${go_ldflags}" ${go_package}
+		go install -p "$XBPS_MAKEJOBS" -mod="${go_mod_mode}" -modcacherw -x -tags "${go_build_tags}" -ldflags "${go_ldflags}" ${go_package}
 	else
 		# Otherwise, build using GOPATH
 		go get -p "$XBPS_MAKEJOBS" -x -tags "${go_build_tags}" -ldflags "${go_ldflags}" ${go_package}


### PR DESCRIPTION
makes sure the go mod cache is not read only and ./xbps-src zap can properly remove it

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

If someone wants to test this, try to build go-ipfs which fails and then zap the masterdir. Without this change, you will get a lot of error messages about not removing a read only file.

cc @the-maldridge 