### PR TITLE
browsh: temporarily not depends on firefox

### DIFF
--- a/srcpkgs/browsh/template
+++ b/srcpkgs/browsh/template
@@ -1,13 +1,14 @@
 # Template file for 'browsh'
 pkgname=browsh
 version=1.6.4
-revision=2
+revision=3
 build_wrksrc=interfacer
 build_style=go
 go_import_path="github.com/browsh-org/browsh"
 go_package=./cmd/browsh
 hostmakedepends="go-bindata"
-depends="firefox"
+# Commented out until firefox-esr has been rebuilt.
+# depends="firefox"
 short_desc="Fully-modern text-based browser, rendering to TTY and browsers"
 maintainer="zhengqunkoo <root@zhengqunkoo.com>"
 license="LGPL-2.1-only"


### PR DESCRIPTION
Fix: #43298

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**|**briefly**|**NO**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
