### PR TITLE
fotoxx: update to 23.32.

### DIFF
--- a/srcpkgs/fotoxx/template
+++ b/srcpkgs/fotoxx/template
@@ -1,6 +1,6 @@
 # Template file for 'fotoxx'
 pkgname=fotoxx
-version=23.2
+version=23.32
 revision=1
 build_style=gnu-makefile
 make_use_env=yes
@@ -13,7 +13,7 @@ license="GPL-3.0-or-later"
 homepage="https://www.kornelix.net/fotoxx/fotoxx.html"
 changelog="https://www.kornelix.net/downloads/recent_changes.txt"
 distfiles="https://www.kornelix.net/downloads/downloads/fotoxx-${version}-source.tar.gz"
-checksum=9e8098582c4b3dec51c6bf232670204e939372d0e9b66f281a0661ac36c2cce9
+checksum=3d88f483b671f4ba7005a9f9195994408ceb97289a77acd3981462ac92397537
 
 CXXFLAGS="-I${XBPS_CROSS_BASE}/usr/include/champlain-0.12"
 


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (X86_64-LIBC)
