### PR TITLE
common/travis: make check-install use new rootdir.

### DIFF
--- a/common/travis/check-install.sh
+++ b/common/travis/check-install.sh
@@ -6,20 +6,30 @@ export XBPS_TARGET_ARCH="$2" XBPS_DISTDIR=/hostrepo
 
 if [ "$1" != "$XBPS_TARGET_ARCH" ]; then
 	triplet="$(/hostrepo/xbps-src -a "$XBPS_TARGET_ARCH" show-var XBPS_CROSS_TRIPLET)"
-	ROOTDIR="-r /usr/$triplet"
+	CONFDIR="-C /usr/$triplet/etc/xbps.d"
+else
+	CONFDIR="-C /etc/xbps.d"
 fi
+
+mkdir /check-install
+
+mkdir -p /check-install/var/db/xbps/keys
+cp /var/db/xbps/keys/* /check-install/var/db/xbps/keys/
 
 ADDREPO="--repository=$HOME/hostdir/binpkgs/bootstrap
  --repository=$HOME/hostdir/binpkgs
  --repository=$HOME/hostdir/binpkgs/nonfree"
+ROOTDIR="-r /check-install"
+
+xbps-install $ROOTDIR $ADDREPO $CONFDIR -S
 
 while read -r pkg; do
 	for subpkg in $(xsubpkg $pkg); do
 		/bin/echo -e "\x1b[32mTrying to install dependants of $subpkg:\x1b[0m"
 		for dep in $(xbps-query $ADDREPO -RX "$subpkg"); do
 			xbps-install \
-				$ROOTDIR $ADDREPO \
-				-Sny \
+				$ROOTDIR $ADDREPO $CONFDIR \
+				-ny \
 				"$subpkg" "$(xbps-uhelper getpkgname "$dep")"
 			ret="$?"
 			if [ "$ret" -eq 8 ] || [ "$ret" -eq 11 ]; then


### PR DESCRIPTION
The CI has `base-chroot` installed, but sometimes this script would try to install `base-system,` causing conflicts. This PR fixes that issue by using a brand-new rootdir.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **NO**

How should I test this?

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
