### PR TITLE
dunst: update to 1.9.1, adopt

### DIFF
--- a/srcpkgs/dunst/template
+++ b/srcpkgs/dunst/template
@@ -1,6 +1,6 @@
 # Template file for 'dunst'
 pkgname=dunst
-version=1.9.0
+version=1.9.1
 revision=1
 build_style=gnu-makefile
 make_check_target=test
@@ -13,12 +13,12 @@ makedepends="gdk-pixbuf-devel libXScrnSaver-devel libXinerama-devel libXrandr-de
 checkdepends="dbus"
 conf_files="/etc/dunst/dunstrc"
 short_desc="Lightweight and customizable notification daemon"
-maintainer="Orphaned <orphan@voidlinux.org>"
+maintainer="Rodrigo Oliveira <mdkcore@qtrnn.io>"
 license="BSD-3-Clause"
 homepage="https://dunst-project.org"
 changelog="https://raw.githubusercontent.com/dunst-project/dunst/master/CHANGELOG.md"
 distfiles="https://github.com/dunst-project/dunst/archive/v${version}.tar.gz"
-checksum=b7b8d7d6560bb241b1e4d37eba770cdf19b9d5dbfc1d4d47572ad676f3f7c98a
+checksum=571d82d5feef995e69a35e708a400a0cfa12a0f81854c5a3357e17844bf6249a
 
 build_options="wayland"
 build_options_default="wayland"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-libc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - armv7l (crossbuild)
  - i686-libc