### PR TITLE
maxima: dont default sbcl on aarch64, dont makedepends on emacs

### DIFF
--- a/srcpkgs/maxima/template
+++ b/srcpkgs/maxima/template
@@ -4,7 +4,7 @@ version=5.45.1
 revision=4
 build_style=gnu-configure
 configure_args="$(vopt_enable clisp) $(vopt_enable sbcl sbcl-exec) $(vopt_enable ecl)"
-hostmakedepends="python3 perl emacs texinfo patchelf"
+hostmakedepends="python3 perl texinfo patchelf $(vopt_if ecl ecl)"
 makedepends="$(vopt_if clisp clisp) $(vopt_if sbcl sbcl) $(vopt_if ecl ecl)"
 depends="$(vopt_if clisp clisp) rlwrap"
 checkdepends="gnuplot"
@@ -32,7 +32,7 @@ build_options_default="ecl"
 
 # sbcl is only available for these architectures
 case "$XBPS_TARGET_MACHINE" in
-	i686|x86_64*|armv7l|aarch64|ppc64le*)
+	i686|x86_64*|armv7l|ppc64le*)
 		build_options_default+=" sbcl"
 		;;
 esac


### PR DESCRIPTION
@dkwo: try this.

 - Default to `~sbcl` for aarch64 since you say it's broken
 - Remove emacs from hostmakedepends; it seems the emacs support files don't really need emacs.

Let's see how this works. Note that your `maxima` package will not contain any binary, you will have to manually install `maxima-ecl`. If this is a good setup we can figure out how to address this. Not a problem for sagemath which depends on `maxima-ecl`.

For cross compiling, we would need to do something more fancy, i.e. an `ecl` binary that can cross-compile for aarch64. This is in principle possible as ecl compiles itself this way using the host ecl.
