### PR TITLE
New package: wraith-master-1.2.1

### DIFF
--- a/srcpkgs/wraith-master-cli
+++ b/srcpkgs/wraith-master-cli
@@ -1,0 +1,1 @@
+wraith-master

--- a/srcpkgs/wraith-master-gtk
+++ b/srcpkgs/wraith-master-gtk
@@ -1,0 +1,1 @@
+wraith-master

--- a/srcpkgs/wraith-master/template
+++ b/srcpkgs/wraith-master/template
@@ -1,0 +1,55 @@
+# Template file for 'wraith-master'
+
+pkgname=wraith-master
+version=1.2.1
+revision=1
+build_style=gnu-makefile
+# Don't build experimental ELF frontend yet, https://gitlab.com/serebit/wraith-master/-/issues/26.
+make_build_target="common cli gtk"
+# Don't download gradle.
+make_build_args="GRADLE=gradle"
+# Gradle can't build PIE executables?
+nopie_files="/usr/bin/wraith-master /usr/bin/wraith-master-gtk"
+makedepends="scdoc tar libusb-devel gtk+3-devel openjdk11 gradle"
+short_desc="Wraith Prism RGB control application built with GTK+ and Kotlin/Native"
+maintainer="adigitoleo <adigitoleo@dissimulo.com>"
+license="Apache-2.0"
+homepage="https://gitlab.com/serebit/wraith-master"
+changelog="https://gitlab.com/serebit/wraith-master/-/raw/master/CHANGELOG.md"
+distfiles="https://gitlab.com/serebit/wraith-master/-/archive/v$version/$pkgname-v$version.tar.gz"
+checksum=fcf150b5f45e9b9ffad60e1a72f7251d4488fba28d5b325688c931f5098e21ca
+
+pre_build() {
+	export GRADLE_USER_HOME=$PWD/.gradle
+	export KONAN_DATA_DIR=$PWD/.konan
+	export JAVA_HOME=/usr/lib/jvm/openjdk11/bin/java
+}
+
+do_install() {
+	vmkdir /usr/lib/udev/rules.d/
+	vcopy build/PACKAGE/udev/* /usr/lib/udev/rules.d/
+}
+
+wraith-master-cli_package() {
+	short_desc+=" - CLI frontend"
+	depends="$sourcepkg>=${version}_$revision"
+	pkg_install() {
+		vbin build/PACKAGE/wraith-master
+		vman build/PACKAGE/man/wraith-master.1
+	}
+}
+
+wraith-master-gtk_package() {
+	short_desc+=" - GTK frontend"
+	depends="$sourcepkg>=${version}_$revision"
+	pkg_install() {
+		vbin build/PACKAGE/wraith-master-gtk
+		vman build/PACKAGE/man/wraith-master-gtk.1
+		vmkdir /usr/share/icons/
+		vcopy build/PACKAGE/icons/* /usr/share/icons/
+		vmkdir /usr/share/metainfo/
+		vcopy build/PACKAGE/metainfo/* /usr/share/metainfo/
+		vmkdir /usr/share/applications/
+		vcopy build/PACKAGE/desktop/* /usr/share/applications/
+	}
+}


### PR DESCRIPTION
Package for RGB control of AMD Wraith Master cooling fans. As far as I am aware, the gradle build system is not capable of producing PIE executables, hence the use of `nopie_files`. The GTK3 and cli frontends can be built separately, as per upstream build options (and the AUR PKGBUILD).

#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES** (system-wide install, compiled)

#### Local build testing
- I built this PR locally for my native architecture, (glibc x86_64)