### PR TITLE
shutils/build_dependencies.sh: print "with" before build style/helper names

### DIFF
--- a/common/xbps-src/shutils/build_dependencies.sh
+++ b/common/xbps-src/shutils/build_dependencies.sh
@@ -138,7 +138,12 @@ install_pkg_deps() {
 
     [ -z "$pkgname" ] && return 2
     [ -z "$XBPS_CHECK_PKGS" ] && unset checkdepends
-    [[ $build_style ]] && style=" [$build_style]"
+
+    if [[ $build_style ]] || [[ $build_helper ]]; then
+        style=" with"
+    fi
+
+    [[ $build_style ]] && style+=" [$build_style]"
 
     for s in $build_helper; do
         style+=" [$s]"


### PR DESCRIPTION
Messages like "building [rust] for <platform>" could lead to mild panic as they might be read as "building [large toolchain] on your laptop".

Simply adding "with" before the style/helpers should solve that.

It works for build_style, build_helper, both, and none.

```
=> ircdog-0.4.0_2: building with [go] for x86_64...
=> firefox-111.0.1_1: building with [rust] for x86_64...
=> riff-2.23.2_1: building with [cargo] [rust] for x86_64...
=> discord-0.0.26_1: building for x86_64...
```

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
