### PR TITLE
openssh: fix default path

### DIFF
--- a/srcpkgs/openssh/template
+++ b/srcpkgs/openssh/template
@@ -9,7 +9,7 @@ configure_args="--datadir=/usr/share/openssh
  --disable-strip --with-privsep-path=/var/chroot/ssh
  --with-pid-dir=/run --with-pam
  --with-libedit --with-Werror
- --with-default-path='/usr/local/sbin:/usr/local/bin:/usr/bin'
+ --with-default-path=/usr/local/sbin:/usr/local/bin:/usr/bin
  $(vopt_if ldns --with-ldns=$XBPS_CROSS_BASE/usr)
  $(vopt_if ssl --with-ssl-engine --without-openssl)
  $(vopt_if gssapi --with-kerberos5=$XBPS_CROSS_BASE/usr --without-kerberos5)


### PR DESCRIPTION
set default path to '/usr/local/sbin:/usr/local/bin:/usr/bin'. 

by default, openssh's default path is `/usr/bin:/bin:/usr/sbin:/sbin`, according to `appendpath` function in `/etc/profile`, /usr/local/{bin,sbin} will be append to the end of user's $PATH when it is a **ssh connection**. This fixes the issue.

[ref1 : archlinux](https://github.com/archlinux/svntogit-packages/blob/0a37d1bd869f9f1e4e6f9d6f5b249510f84140f0/trunk/PKGBUILD#L79)
[ref2 : alpine linux](https://git.alpinelinux.org/aports/tree/main/openssh/APKBUILD#n116)

@leahneukirchen @classabbyamp 