### PR TITLE
Blueman Depends on Python 3

### DIFF
--- a/srcpkgs/blueman/template
+++ b/srcpkgs/blueman/template
@@ -8,7 +8,7 @@ hostmakedepends="intltool iproute2 pkg-config python3-Cython glib-devel
  python3-devel"
 makedepends="gtk+3-devel libbluetooth-devel python3-devel
  python3-gobject-devel startup-notification-devel"
-depends="bluez libnotify python3-gobject"
+depends="bluez libnotify pyhton3 python3-gobject"
 short_desc="GTK+ Bluetooth Manager"
 maintainer="Frank Steinborn <steinex@nognu.de>"
 license="GPL-3.0-or-later"

--- a/srcpkgs/blueman/template
+++ b/srcpkgs/blueman/template
@@ -8,7 +8,7 @@ hostmakedepends="intltool iproute2 pkg-config python3-Cython glib-devel
  python3-devel"
 makedepends="gtk+3-devel libbluetooth-devel python3-devel
  python3-gobject-devel startup-notification-devel"
-depends="bluez libnotify pyhton3 python3-gobject"
+depends="bluez libnotify python3 python3-gobject"
 short_desc="GTK+ Bluetooth Manager"
 maintainer="Frank Steinborn <steinex@nognu.de>"
 license="GPL-3.0-or-later"


### PR DESCRIPTION
When installing the `blueman` package on an outdated system, it was not working
properly. This is because blueman requires `python3` for execution, since it is
the given interpreter for `/bin/blueman`. I am including `python3` as a
dependency to ensure that the executables provided by the `blueman` package are
actually executable upon update or install, assuming one's `python3` package is
out of date.
