### PR TITLE
aqemu: fix segfault

### DIFF
--- a/srcpkgs/aqemu/patches/widgets.patch
+++ b/srcpkgs/aqemu/patches/widgets.patch
@@ -1,0 +1,53 @@
+Taken from https://github.com/tobimensch/aqemu/pull/116, and simplified
+
+PATCH MUST KEEP CRLF LINE TERMINATORS
+
+--
+
+From dc19121a923c71eed248cd6310b9b06ec0af6abe Mon Sep 17 00:00:00 2001
+From: Moskaliou Nikita <44800696+nikitamos@users.noreply.github.com>
+Date: Sun, 5 Dec 2021 19:36:44 +0300
+Subject: [PATCH] Change widgets names
+
+Several widgets in the src/Main_Window.ui file had the same name ("widget"), for several users AQEMU crashed with SEGFAULT. So, the names were changed and now everything works fine
+
+diff --git a/src/Main_Window.ui b/src/Main_Window.ui
+index fab69f4..52b7c71 100644
+--- a/src/Main_Window.ui
++++ b/src/Main_Window.ui
+@@ -226,7 +226,7 @@
+              </widget>
+             </item>
+             <item>
+-             <widget class="QWidget" name="widget" native="true">
++             <widget class="QWidget" name="general_Machine_Sets" native="true">
+               <layout class="QGridLayout" name="gridLayout_12">
+                <property name="leftMargin">
+                 <number>24</number>
+@@ -1333,7 +1315,7 @@
+              </widget>
+             </item>
+            </layout>
+-           <zorder>widget</zorder>
++           <zorder>general_Machine_Sets</zorder>
+            <zorder>GB_Options</zorder>
+            <zorder>GB_Audio</zorder>
+            <zorder>GB_Memory</zorder>
+@@ -2457,7 +2439,7 @@
+                     </layout>
+                    </item>
+                    <item row="1" column="0" colspan="2">
+-                    <widget class="QWidget" name="widget" native="true">
++                    <widget class="QWidget" name="protocol_Sets" native="true">
+                      <layout class="QHBoxLayout" name="Widget_Redirection_Protocol">
+                       <property name="spacing">
+                        <number>6</number>
+@@ -2515,7 +2497,7 @@
+                     </widget>
+                    </item>
+                    <item row="2" column="0" colspan="2">
+-                    <widget class="QWidget" name="widget" native="true">
++                    <widget class="QWidget" name="ip_Sets" native="true">
+                      <layout class="QHBoxLayout" name="Widget_Redirection_Net">
+                       <property name="spacing">
+                        <number>6</number>

--- a/srcpkgs/aqemu/template
+++ b/srcpkgs/aqemu/template
@@ -1,7 +1,7 @@
 # Template file for 'aqemu'
 pkgname=aqemu
 version=0.9.4
-revision=2
+revision=3
 build_style=cmake
 configure_args="-DWITHOUT_EMBEDDED_DISPLAY=1"
 makedepends="qt5-devel qemu desktop-file-utils"


### PR DESCRIPTION
A repeated error in a UI layout file ceased to be accepted in recent-ish QT versions.

Closes #39101

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
