### PR TITLE
ReText: update to 7.2.3.

### DIFF
--- a/srcpkgs/ReText/template
+++ b/srcpkgs/ReText/template
@@ -1,26 +1,22 @@
 # Template file for 'ReText'
 pkgname=ReText
-version=7.2.1
-revision=3
+version=7.2.3
+revision=1
 build_style=python3-module
 hostmakedepends="ImageMagick python3 qt5-host-tools qt5-tools python3-setuptools"
 makedepends="python3-Markdown python3-Markups python3-PyQt5-webkit qt5-tools"
 depends="desktop-file-utils python3-chardet python3-docutils python3-Markdown
  python3-Markups python3-PyQt5-webkit python3-Pygments python3-enchant"
-checkdepends="${depends} xvfb-run"
+checkdepends="${depends} python3-pytest"
 short_desc="Simple editor for Markdown and reStructuredText"
 maintainer="Enno Boland <gottox@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="https://github.com/retext-project/retext"
+changelog="https://raw.githubusercontent.com/retext-project/retext/master/changelog.md"
 distfiles="https://github.com/retext-project/retext/archive/${version}.tar.gz"
-checksum=a1e8784fcb4e186a6e6e42a0f2be4098c27bedb96a9711aa17a9846278e7d932
-
-do_check() {
-	# taken from
-	# https://github.com/retext-project/retext/blob/8329423add3a8edea94d8536a5325a3cc46a7a86/.github/workflows/main.yml
-	# FIXME: run tests under xvfb-run as well, fails with "Could not initialize GLX"
-	python3 -m unittest discover -s tests -v
-}
+checksum=45c47f58c4f9939429da09340833c0ffbe507f2c806e16b30aa1cf90eb954274
+# FIXME: fails with "Fatal Python error: Aborted"
+# make_check_pre="xvfb-run"
 
 post_install() {
 	local icondir=usr/share/icons/hicolor


### PR DESCRIPTION
Fixes #43323.

There's ReText 8.0.0, but it migrates to Qt 6 and I don't have the time to do the migration at the moment.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
