### PR TITLE
bandwhich: fix build on Rust 1.64+

### DIFF
--- a/srcpkgs/bandwhich/patches/0001-upgrade-resolv-conf-pnet-and-ipnetwork.patch
+++ b/srcpkgs/bandwhich/patches/0001-upgrade-resolv-conf-pnet-and-ipnetwork.patch
@@ -1,0 +1,68 @@
+From b4ae95b7dbe7b6108dd7ff3ac7416506d288296a Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Jan=20Christian=20Gr=C3=BCnhage?=
+ <jan.christian@gruenhage.xyz>
+Date: Thu, 13 Apr 2023 12:55:07 +0200
+Subject: [PATCH] upgrade resolv-conf, pnet and ipnetwork
+
+---
+ Cargo.toml                    | 12 +++++++-----
+ src/tests/fakes/fake_input.rs |  1 +
+ 2 files changed, 8 insertions(+), 5 deletions(-)
+
+diff --git a/Cargo.toml b/Cargo.toml
+index eff9522..d873e03 100644
+--- a/Cargo.toml
++++ b/Cargo.toml
+@@ -19,8 +19,8 @@ license = "MIT"
+ exclude = ["src/tests/*", "demo.gif"]
+ 
+ [dependencies]
+-pnet = "0.26.0"
+-ipnetwork = "0.16.0"
++pnet = "0.33.0"
++ipnetwork = "0.20.0"
+ tui = { version = "0.12", default-features = false, features = ["crossterm"]}
+ crossterm = "0.17.7"
+ structopt = "0.3"
+@@ -32,7 +32,7 @@ tokio = { version = "0.2", features = ["rt-core", "sync"] }
+ trust-dns-resolver = "0.18.1"
+ async-trait = "0.1.21"
+ unicode-width = "0.1.8"
+-resolv-conf = "0.6.3"
++resolv-conf = "0.7.0"
+ 
+ [target.'cfg(target_os="windows")'.dependencies]
+ netstat2 = "0.9.0"
+@@ -43,9 +43,9 @@ procfs = "0.7.4"
+ 
+ [dev-dependencies]
+ insta = "0.12.0"
+-pnet_base = "0.26.0"
++pnet_base = "0.33.0"
+ cargo-insta = "0.11.0"
+-packet-builder = "0.5.0"
++packet-builder = "0.7.0"
+ regex = "1"
+ 
+ [target.'cfg(target_os="windows")'.build-dependencies]
+@@ -54,3 +54,5 @@ zip = "0.5.6"
+ 
+ [patch.crates-io]
+ resolv-conf = { git = 'https://github.com/tailhook/resolv-conf', rev = '83c0f25ebcb0615550488692c5213ca1ae4acd8f' }
++# https://github.com/hughesac/packet_builder/pull/5
++packet-builder = { git = "https://github.com/jcgruenhage/packet_builder", branch = "upgrades-2023-04-10" }
+diff --git a/src/tests/fakes/fake_input.rs b/src/tests/fakes/fake_input.rs
+index 0fdf63a..9c3f0a0 100644
+--- a/src/tests/fakes/fake_input.rs
++++ b/src/tests/fakes/fake_input.rs
+@@ -146,6 +146,7 @@ pub fn get_open_sockets() -> OpenSockets {
+ pub fn get_interfaces() -> Vec<NetworkInterface> {
+     vec![NetworkInterface {
+         name: String::from("interface_name"),
++        description: String::new(),
+         index: 42,
+         mac: None,
+         ips: vec![IpNetwork::V4("10.0.0.2".parse().unwrap())],
+-- 
+2.40.0
+

--- a/srcpkgs/bandwhich/template
+++ b/srcpkgs/bandwhich/template
@@ -1,7 +1,7 @@
 # Template file for 'bandwhich'
 pkgname=bandwhich
 version=0.20.0
-revision=1
+revision=2
 build_style=cargo
 short_desc="Terminal bandwidth utilization tool"
 maintainer="Jan Christian Grünhage <jan.christian@gruenhage.xyz>"
@@ -9,6 +9,17 @@ license="MIT"
 homepage="https://github.com/imsnif/bandwhich"
 distfiles="${homepage}/archive/${version}.tar.gz"
 checksum=4bbf05be32439049edd50bd1e4d5a2a95b0be8d36782e4100732f0cc9f19ba12
+# cba for now
+make_check=no
+
+post_patch() {
+	# We're patching in Cargo.toml without patching in Cargo.lock, so the
+	# lockfile is out of date after patching. Aside of that, we need to
+	# update some transitive dependencies to fix the build (socket2,
+	# failure and linked-hash-map), which is also done by just regenerating
+	# Cargo.lock.
+	cargo generate-lockfile
+}
 
 post_install() {
 	vlicense LICENSE.md


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

I've upgraded the dependencies in here, which fixes the compile error for 1.64 and also a runtime problem (https://github.com/imsnif/bandwhich/issues/263). The changes are also in a PR upstream (https://github.com/imsnif/bandwhich/pull/265), but I currently wouldn't assume that upstream will merge this, as the project is largely unmaintained.

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
