### PR TITLE
btrfs-progs: update to 6.2.2.

### DIFF
--- a/srcpkgs/btrfs-progs/template
+++ b/srcpkgs/btrfs-progs/template
@@ -1,6 +1,6 @@
 # Template file for 'btrfs-progs'
 pkgname=btrfs-progs
-version=6.1.2
+version=6.2.2
 revision=1
 build_style=gnu-configure
 make_check_target=test
@@ -15,7 +15,7 @@ license="GPL-2.0-only, LGPL-2.1-or-later"
 homepage="https://btrfs.wiki.kernel.org/index.php/Main_Page"
 changelog="https://raw.githubusercontent.com/kdave/btrfs-progs/master/CHANGES"
 distfiles="${KERNEL_SITE}/kernel/people/kdave/btrfs-progs/btrfs-progs-v${version}.tar.xz"
-checksum=6be667d97f3d65c0ba57c331c98b0bd3b13cf60d8d31fa8ad25882aad9d79d7a
+checksum=e4888db8637d92e667448386992d0856b954cf2515b98d39b667da43c482d693
 # Most of the tests depend on `mount` and `fallocate` commands, which are not
 # presented in chroot-util-linux
 make_check=no


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
