### PR TITLE
[WIP] New package: deno-1.32.3

### DIFF
--- a/srcpkgs/deno/template
+++ b/srcpkgs/deno/template
@@ -1,0 +1,18 @@
+# Template file for 'deno'
+pkgname=deno
+version=1.32.3
+revision=1
+build_style=cargo
+make_cmd="env V8_FROM_SOURCE=1 cargo auditable"
+hostmakedepends="python3 pkg-config gn"
+makedepends="libglib-devel"
+short_desc="Modern runtime for JavaScript and TypeScript"
+maintainer="astral <astral@astralchan.xyz>"
+license="MIT"
+homepage="https://deno.land"
+distfiles="https://github.com/denoland/deno/releases/download/v${version}/deno_src.tar.gz"
+checksum=c0ccbf75108a3f1853bdac9956829fb4aa1eb090c3896f631a09c1c1d53b108c
+
+post_install() {
+	vlicense LICENSE.md
+}

--- a/srcpkgs/gn/template
+++ b/srcpkgs/gn/template
@@ -1,0 +1,38 @@
+# Template file for 'gn'
+pkgname=gn
+# Google never releases versions - give date of commit
+version=07.04.2023
+revision=1
+_commit=ffeea1b1fd070cb6a8d47154a03f8523486b50a7
+hostmakedepends="python3 ninja"
+short_desc="Meta-build system that generates build files for Ninja"
+maintainer="astral <astral@astralchan.xyz>"
+license="BSD-3-Clause"
+homepage="https://gn.googlesource.com/gn"
+distfiles="https://gn.googlesource.com/gn/+archive/${_commit}.tar.gz"
+checksum=4e205708436b3804e58efe463f83baed8982971e94d492b80d803e932ba3e11c
+
+post_extract() {
+	printf '#define LAST_COMMIT_POSITION "%s"\n' "${_commit}" > src/gn/last_commit_position.h
+	printf '#define LAST_COMMIT_POSITION_NUM 0\n' >> src/gn/last_commit_position.h
+}
+
+pre_build() {
+	python3 build/gen.py --allow-warning --no-last-commit-position
+}
+
+do_build() {
+	ninja -C out
+}
+
+do_check() {
+	./out/gnunittests
+}
+
+do_install() {
+	vbin out/gn
+}
+
+post_install() {
+	vlicense LICENSE
+}

--- a/srcpkgs/gn/update
+++ b/srcpkgs/gn/update
@@ -1,0 +1,2 @@
+# Google never tags any releases.
+ignore="*"


### PR DESCRIPTION
[ci skip]

Closes [21937](https://github.com/void-linux/void-packages/issues/21937)

Supersedes:
- [22043](https://github.com/void-linux/void-packages/pull/22043)
- [25436](https://github.com/void-linux/void-packages/pull/25436)

#### Testing the changes
- I tested the changes in this PR: **NO**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):

Current error log:

```
   Compiling futures v0.3.27
error: failed to run custom build command for `v8 v0.68.0`

Caused by:
  process didn't exit successfully: `/builddir/deno-1.32.3/target/release/build/v8-b2ba9187d5e6450d/build-script-build` (exit status: 101)
  --- stdout
  cargo:rerun-if-changed=.gn
  cargo:rerun-if-changed=BUILD.gn
  cargo:rerun-if-changed=src/binding.cc
  cargo:rerun-if-env-changed=CCACHE
  cargo:rerun-if-env-changed=CLANG_BASE_PATH
  cargo:rerun-if-env-changed=DENO_TRYBUILD
  cargo:rerun-if-env-changed=DOCS_RS
  cargo:rerun-if-env-changed=GN
  cargo:rerun-if-env-changed=GN_ARGS
  cargo:rerun-if-env-changed=HOST
  cargo:rerun-if-env-changed=NINJA
  cargo:rerun-if-env-changed=OUT_DIR
  cargo:rerun-if-env-changed=RUSTY_V8_ARCHIVE
  cargo:rerun-if-env-changed=RUSTY_V8_MIRROR
  cargo:rerun-if-env-changed=SCCACHE
  cargo:rerun-if-env-changed=V8_FORCE_DEBUG
  cargo:rerun-if-env-changed=V8_FROM_SOURCE
  cargo:rerun-if-env-changed=PYTHON
  cargo:rustc-link-lib=static=rusty_v8
  download lockfile: "/builddir/deno-1.32.3/target/release/build/lib_download.fslock"
  static lib URL: https://github.com/denoland/rusty_v8/releases/download/v0.68.0/librusty_v8_release_x86_64-unknown-linux-gnu.a
  cargo:rustc-link-search=/builddir/deno-1.32.3/target/release/gn_out/obj
  Downloading https://github.com/denoland/rusty_v8/releases/download/v0.68.0/librusty_v8_release_x86_64-unknown-linux-gnu.a
  Python downloader failed, trying with curl.

  --- stderr
  thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Os { code: 2, kind: NotFound, message: "No such file or directory" }', /host/cargo/registry/src/index.crates.io-6f17d22bba15001f/v8-0.68.0/build.rs:409:10
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
warning: build failed, waiting for other jobs to finish...
=> ERROR: deno-1.32.3_1: do_build: '${make_cmd} build --release --target ${RUST_TARGET} ${configure_args}' exited with 101
=> ERROR:   in do_build() at common/build-style/cargo.sh:8
```