### PR TITLE
electron19: fix build

### DIFF
--- a/srcpkgs/electron19/patches/python-3.11.patch
+++ b/srcpkgs/electron19/patches/python-3.11.patch
@@ -1,0 +1,11 @@
+--- a/src/tools/grit/grit/util.py	2022-06-14 05:15:31.000000000 -0400
++++ b/src/tools/grit/grit/util.py	2023-04-10 09:06:50.593197014 -0400
+@@ -209,7 +209,7 @@
+     mode = 'rb'
+     encoding = None
+   else:
+-    mode = 'rU'
++    mode = 'r'
+ 
+   with io.open(filename, mode, encoding=encoding) as f:
+     return f.read()

--- a/srcpkgs/electron19/patches/sql-relax-constraints-on-VirtualCursor-layout.patch
+++ b/srcpkgs/electron19/patches/sql-relax-constraints-on-VirtualCursor-layout.patch
@@ -1,0 +1,50 @@
+From 7d1394bd639e3bcf68082ac3fc33eeed6a00d2e6 Mon Sep 17 00:00:00 2001
+From: Elly Fong-Jones <ellyjones@chromium.org>
+Date: Thu, 2 Mar 2023 00:15:11 +0000
+Subject: [PATCH] sql: relax constraints on VirtualCursor layout
+
+VirtualCursor::FromSqliteCursor required that VirtualCursor had a
+standard layout, but in fact VirtualCursor shouldn't have a standard
+layout, and the fact that it does with libc++ is a deviation from the
+C++ standard. This change:
+
+1. Relaxes the requirement that VirtualCursor has a standard layout, and
+2. Relaxes the requirement that the sqlite_cursor_ field has to be at
+   offset 0
+
+by use of offsetof() and pointer subtraction. This change both improves
+standards compliance and makes this code build with libstdc++.
+
+Bug: 1380656
+Change-Id: I9c47abd9197b187da0360ca5619ccf7dadab4f33
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4292313
+Reviewed-by: Austin Sullivan <asully@chromium.org>
+Commit-Queue: Elly Fong-Jones <ellyjones@chromium.org>
+Cr-Commit-Position: refs/heads/main@{#1111925}
+---
+ sql/recover_module/cursor.h | 10 ++++------
+ 1 file changed, 4 insertions(+), 6 deletions(-)
+
+Copied from void chromium patches
+
+diff --git a/sql/recover_module/cursor.h b/sql/recover_module/cursor.h
+index 1970bdca8c6..4cb06557009 100644
+--- a/src/sql/recover_module/cursor.h
++++ b/src/sql/recover_module/cursor.h
+@@ -63,12 +63,10 @@ class VirtualCursor {
+   // |sqlite_cursor| must have been returned by VirtualTable::SqliteCursor().
+   static inline VirtualCursor* FromSqliteCursor(
+       sqlite3_vtab_cursor* sqlite_cursor) {
+-    static_assert(std::is_standard_layout<VirtualCursor>::value,
+-                  "needed for the reinterpret_cast below");
+-    static_assert(offsetof(VirtualCursor, sqlite_cursor_) == 0,
+-                  "sqlite_cursor_ must be the first member of the class");
+-    VirtualCursor* result = reinterpret_cast<VirtualCursor*>(sqlite_cursor);
+-    DCHECK_EQ(sqlite_cursor, &result->sqlite_cursor_);
++    VirtualCursor* result = reinterpret_cast<VirtualCursor*>(
++        (reinterpret_cast<char*>(sqlite_cursor) -
++         offsetof(VirtualCursor, sqlite_cursor_)));
++    CHECK_EQ(sqlite_cursor, &result->sqlite_cursor_);
+     return result;
+   }
+ 


### PR DESCRIPTION
[ci skip]

#### Testing the changes
- I tested the changes in this PR: **NO** (but yes? because it's for the build)

#### Local build testing
- I built this PR locally for my native architecture, **x86_64**


#### Comments

While checking ffmpeg5/6 changes I was having trouble building `electron19`. There have been a few big changes lately and the last build fix was months ago, so I'm not sure what changed. (Looks like a lot of active patching or something in the template?)

~~Going to verify non-ffmpeg change build tonight if I remember.~~

part https://github.com/void-linux/void-packages/issues/39083 (not on list)

question: revbump?