### PR TITLE
New package: tessen-2.2.1

### DIFF
--- a/srcpkgs/tessen/template
+++ b/srcpkgs/tessen/template
@@ -2,7 +2,9 @@
 pkgname=tessen
 version=2.2.1
 revision=1
+build_style=gnu-makefile
 hostmakedepends="scdoc"
+checkdepends="shellcheck shfmt"
 short_desc="Interactive menu to autotype and copy pass and gopass data"
 maintainer="reedts <j.reedts@gmail.com>"
 license="GPL-2.0-only"
@@ -10,8 +12,7 @@ homepage="https://git.sr.ht/~ayushnix/tessen"
 distfiles="https://git.sr.ht/~ayushnix/tessen/refs/download/v${version}/tessen-${version}.tar.gz"
 checksum=31d510d5ffac5825bc7e63f13283c5d432eb102db2d2483ee937c9135c8cfc04
 
-do_install() {
-	make PREFIX=/usr DESTDIR=${DESTDIR} install
+post_install() {
 	vcompletion completion/tessen.bash-completion bash
 	vcompletion completion/tessen.fish-completion fish
 }

--- a/srcpkgs/tessen/template
+++ b/srcpkgs/tessen/template
@@ -1,0 +1,17 @@
+# Template file for 'tessen'
+pkgname=tessen
+version=2.2.1
+revision=1
+hostmakedepends="scdoc"
+short_desc="Interactive menu to autotype and copy pass and gopass data"
+maintainer="reedts <j.reedts@gmail.com>"
+license="GPL-2.0-only"
+homepage="https://git.sr.ht/~ayushnix/tessen"
+distfiles="https://git.sr.ht/~ayushnix/tessen/refs/download/v${version}/tessen-${version}.tar.gz"
+checksum=31d510d5ffac5825bc7e63f13283c5d432eb102db2d2483ee937c9135c8cfc04
+
+do_install() {
+	make PREFIX=/usr DESTDIR=${DESTDIR} install
+	vcompletion completion/tessen.bash-completion bash
+	vcompletion completion/tessen.fish-completion fish
+}

--- a/srcpkgs/tessen/template
+++ b/srcpkgs/tessen/template
@@ -11,8 +11,3 @@ license="GPL-2.0-only"
 homepage="https://git.sr.ht/~ayushnix/tessen"
 distfiles="https://git.sr.ht/~ayushnix/tessen/refs/download/v${version}/tessen-${version}.tar.gz"
 checksum=31d510d5ffac5825bc7e63f13283c5d432eb102db2d2483ee937c9135c8cfc04
-
-post_install() {
-	vcompletion completion/tessen.bash-completion bash
-	vcompletion completion/tessen.fish-completion fish
-}


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **NO**

While technically this PR does not conform to rule *2* of the package requirements, I consider this as a direct replacement for `rofi-pass` (which itself is also only a shell script) for users running Wayland. As we package `rofi-pass`, I think providing an alternative for Wayland makes sense.