### PR TITLE
evolution: fix expose shared lib

### DIFF
--- a/srcpkgs/evolution/template
+++ b/srcpkgs/evolution/template
@@ -1,7 +1,7 @@
 # Template file for 'evolution'
 pkgname=evolution
 version=3.48.0
-revision=1
+revision=2
 build_style=cmake
 build_helper="qemu"
 configure_args="-DSYSCONF_INSTALL_DIR=/etc
@@ -22,7 +22,8 @@ changelog="https://gitlab.gnome.org/GNOME/evolution/-/raw/gnome-44/NEWS"
 distfiles="${GNOME_SITE}/evolution/${version%.*}/evolution-${version}.tar.xz"
 checksum=2d8472819589e92efcce4f2dc3bd124e93d379d3300978f69a9653c592a60ef6
 shlib_provides="libevolution-calendar.so libevolution-util.so libemail-engine.so
- libevolution-mail.so libevolution-shell.so libevolution-mail-formatter.so"
+ libevolution-mail.so libevolution-shell.so libevolution-mail-formatter.so
+ libevolution-mail-composer.so"
 
 evolution-devel_package() {
 	depends="libwebkit2gtk41-devel gtk+3-devel libglib-devel evolution-data-server-devel


### PR DESCRIPTION
The package 'evolution-ews' cannot neither be installed nor updated because cannot resolve a shared lib.
In the [evolution: update to 3.48.0](https://github.com/void-linux/void-packages/commit/e8be9699344508280a43193b9a7e20b2632e4aae) an evolution lib was included in common/shlibs but is not exposed in the package template, thus 'evolution-ews' cannot find the package that provides it.

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-LIBC)
