### PR TITLE
add $CRATES_SITE

### DIFF
--- a/srcpkgs/pijul/template
+++ b/srcpkgs/pijul/template
@@ -11,7 +11,7 @@ short_desc="Distributed version control system based on patches"
 maintainer="Toyam Cox <Vaelatern@voidlinux.org>"
 license="GPL-2.0-only"
 homepage="https://pijul.org/"
-distfiles="https://crates.io/api/v1/crates/pijul/${version}/download>pijul-${version}.tar.gz
+distfiles="https://static.crates.io/crates/pijul/pijul-${version}.crate
  https://gitlab.com/sequoia-pgp/sequoia/-/archive/v${_sequoia_ver}/sequoia-v${_sequoia_ver}.tar.gz"
 checksum="f92a3f4063e780ca45c161ceb0f42baf34dfeddf3359ebf6c2e0442d9abb5889
  71823c88b9666611f3cfa6b1d923bd66fda92fa6a53368b195bd2f962fdf7f4b"


### PR DESCRIPTION
by codifying `https://static.crates.io/crates` as `$CRATES_SITE`, this should point people towards using `$CRATES_SITE/pkgname/pkgname-${version}.crate` for distfiles (if using crates.io instead of git tarballs), instead of other options like whatever `pijul` was doing.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES** (confirmed that no checksums changed)

[ci skip]