### PR TITLE
linux6.2: update to 6.2.10

### DIFF
--- a/srcpkgs/linux6.2/patches/v3-wireless-mt76-mt7921-Fix-use-after-free-in-fw-features-query.diff
+++ b/srcpkgs/linux6.2/patches/v3-wireless-mt76-mt7921-Fix-use-after-free-in-fw-features-query.diff
@@ -1,0 +1,40 @@
+Taken from https://patchwork.kernel.org/project/linux-wireless/patch/51fd8f76494348aa9ecbf0abc471ebe47a983dfd.1679502607.git.lorenzo@kernel.org/
+
+diff --git a/drivers/net/wireless/mediatek/mt76/mt7921/init.c b/drivers/net/wireless/mediatek/mt76/mt7921/init.c
+index 80c71acfe159..cc94531185da 100644
+--- a/drivers/net/wireless/mediatek/mt76/mt7921/init.c
++++ b/drivers/net/wireless/mediatek/mt76/mt7921/init.c
+@@ -171,12 +171,12 @@ mt7921_mac_init_band(struct mt7921_dev *dev, u8 band)
+ 
+ u8 mt7921_check_offload_capability(struct device *dev, const char *fw_wm)
+ {
+-	struct mt7921_fw_features *features = NULL;
+ 	const struct mt76_connac2_fw_trailer *hdr;
+ 	struct mt7921_realease_info *rel_info;
+ 	const struct firmware *fw;
+ 	int ret, i, offset = 0;
+ 	const u8 *data, *end;
++	u8 offload_caps = 0;
+ 
+ 	ret = request_firmware(&fw, fw_wm, dev);
+ 	if (ret)
+@@ -208,7 +208,10 @@ u8 mt7921_check_offload_capability(struct device *dev, const char *fw_wm)
+ 		data += sizeof(*rel_info);
+ 
+ 		if (rel_info->tag == MT7921_FW_TAG_FEATURE) {
++			struct mt7921_fw_features *features;
++
+ 			features = (struct mt7921_fw_features *)data;
++			offload_caps = features->data;
+ 			break;
+ 		}
+ 
+@@ -218,7 +221,7 @@ u8 mt7921_check_offload_capability(struct device *dev, const char *fw_wm)
+ out:
+ 	release_firmware(fw);
+ 
+-	return features ? features->data : 0;
++	return offload_caps;
+ }
+ EXPORT_SYMBOL_GPL(mt7921_check_offload_capability);
+ 

--- a/srcpkgs/linux6.2/template
+++ b/srcpkgs/linux6.2/template
@@ -1,6 +1,6 @@
 # Template file for 'linux6.2'
 pkgname=linux6.2
-version=6.2.8
+version=6.2.11
 revision=1
 short_desc="Linux kernel and modules (${version%.*} series)"
 maintainer="John <me@johnnynator.dev>"
@@ -14,7 +14,7 @@ if [ "${version##*.}" != 0 ]; then
 fi
 
 checksum="74862fa8ab40edae85bb3385c0b71fe103288bce518526d63197800b3cbdecb1
- 3d53cfde45e0c38921dd96fb8d4fee2b2730da6ad86d324ce9ed61ebbeb029dc"
+ 923cbd9f2120a7972a45cfdfcfd1871f76735de36cee2630d10a6a3d5c845149"
 python_version=3
 
 # XXX Restrict archs until a proper <arch>-dotconfig is available in FILESDIR.


### PR DESCRIPTION
+ backport of patch for mt62 wireless driver - I had recurring issues with this free-after-use error that led to a crash in the network driver

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
