### PR TITLE
evince: update to 44.1

### DIFF
--- a/srcpkgs/evince/template
+++ b/srcpkgs/evince/template
@@ -1,12 +1,11 @@
 # Template file for 'evince'
 pkgname=evince
-version=44.0
-revision=2
+version=44.1
+revision=1
 build_helper="gir"
 build_style=meson
 configure_args="$(vopt_bool gir introspection) $(vopt_bool gtk_doc gtk_doc)
- -Dcomics=enabled -Ddjvu=enabled -Dps=enabled -Dxps=enabled -Ddvi=disabled -Dpdf=enabled
- -Dnautilus=false"
+ -Dcomics=enabled -Ddjvu=enabled -Dps=enabled -Dxps=enabled -Ddvi=disabled -Dpdf=enabled"
 hostmakedepends="adwaita-icon-theme gettext $(vopt_if gtk_doc gi-docgen)
  glib-devel itstool pkg-config perl-XML-Parser appstream-glib desktop-file-utils"
 # XXX missing packages for DVI backend.
@@ -21,7 +20,7 @@ homepage="https://wiki.gnome.org/Apps/Evince"
 #changelog="https://gitlab.gnome.org/GNOME/evince/-/raw/main/NEWS"
 changelog="https://gitlab.gnome.org/GNOME/evince/-/raw/gnome-44/NEWS"
 distfiles="${GNOME_SITE}/evince/${version%.*}/evince-${version}.tar.xz"
-checksum=339ee9e005dd7823a13fe21c71c2ec6d2c4cb74548026e4741eee7b2703e09da
+checksum=15afd3bb15ffb38fecab34c23350950ad270ab03a85b94e333d9dd7ee6a74314
 
 build_options="gir gtk_doc"
 build_options_default="gir gtk_doc"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl (crossbuild)
  - armv7l  (crossbuild)
  - aarch64  (crossbuild)
