### PR TITLE
New package: minipro-0.6

### DIFF
--- a/srcpkgs/minipro/template
+++ b/srcpkgs/minipro/template
@@ -1,0 +1,27 @@
+# Template file for 'minipro'
+pkgname=minipro
+version=0.6
+revision=1
+build_style=gnu-makefile
+make_use_env=compliant
+hostmakedepends="pkg-config which"
+makedepends="libusb-devel"
+depends="libusb"
+short_desc="Program for controlling the MiniPRO TL866xx series of chip programmers"
+maintainer="Bryce Vandegrift <bryce@brycevandegrift.xyz>"
+license="GPL-3.0-or-later"
+homepage="https://gitlab.com/DavidGriffith/minipro"
+distfiles="${homepage}/-/archive/${version}/${pkgname}-${version}.tar.gz"
+checksum=16b4220b5fc07dddc4d1d49cc181a2c6a735c833cc27f24ab73eac2572c9304a
+
+post_patch() {
+	vsed -i Makefile -e 's/CC=gcc/CC?=gcc/'
+}
+
+post_install() {
+	vmkdir usr/lib/udev/rules.d
+	mv udev/* $DESTDIR/usr/lib/udev/rules.d
+
+	vmkdir usr/share/bash-completion/completions
+	mv bash_completion.d/minipro $DESTDIR/usr/share/bash-completion/completions
+}


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported, mark crossbuilds):
  - x86_64-musl (crossbuild)
  - i686 (crossbuild)
  - armv6l (crossbuild)
  - armv6l-musl (crossbuild)
  - armv7l (crossbuild)
  - armv7l-musl (crossbuild)
  - aarch64 (crossbuild)
  - aarch64-musl (crossbuild)
