### PR TITLE
hardinfo: revbump for remove_linefeed fixes

### DIFF
--- a/srcpkgs/hardinfo/patches/fix-runtime.patch
+++ b/srcpkgs/hardinfo/patches/fix-runtime.patch
@@ -1,19 +1,19 @@
-diff --git hardinfo.h hardinfo.h
-index 9f52f63..aeb84d9 100644
---- a/hardinfo.h
-+++ b/hardinfo.h
-@@ -64,8 +64,8 @@ struct _ModuleAbout {
+--- a/hardinfo.h	2023-04-14 16:50:28.324202873 -0400
++++ b/hardinfo.h	2023-04-14 16:51:11.470129493 -0400
+@@ -64,9 +64,9 @@
  };
  
  /* String utility functions */
 -inline void  remove_quotes(gchar *str);
 -inline char *strend(gchar *str, gchar chr);
+-inline void  remove_linefeed(gchar *str);
 +void  remove_quotes(gchar *str);
 +char *strend(gchar *str, gchar chr);
- inline void  remove_linefeed(gchar *str);
++void  remove_linefeed(gchar *str);
  gchar       *strreplace(gchar *string, gchar *replace, gchar new_char);
  
-@@ -91,7 +91,7 @@ gpointer __idle_free(gpointer ptr, gchar *f, gint l);
+ /* Widget utility functions */
+@@ -91,7 +91,7 @@
  
  
  gchar	     *find_program(gchar *program_name);
@@ -22,11 +22,9 @@ index 9f52f63..aeb84d9 100644
  void          nonblock_sleep(guint msec);
  void          open_url(gchar *url);
  GSList	     *modules_load_selected(void);
-diff --git util.c util.c
-index 266ce4e..e6c81fd 100644
---- a/util.c
-+++ b/util.c
-@@ -111,7 +111,7 @@ gchar *seconds_to_string(unsigned int seconds)
+--- a/util.c 16:50:36.611380820 -0400
++++ b/util.c	2023-04-14 16:51:25.031420828 -0400
+@@ -111,7 +111,7 @@
  			   plural(hours), minutes, plural(minutes));
  }
  
@@ -35,7 +33,7 @@ index 266ce4e..e6c81fd 100644
  {
      if (size < KiB)
  	return g_strdup_printf("%.1f B", size);
-@@ -123,7 +123,7 @@ inline gchar *size_human_readable(gfloat size)
+@@ -123,7 +123,7 @@
      return g_strdup_printf("%.1f GiB", size / GiB);
  }
  
@@ -44,7 +42,7 @@ index 266ce4e..e6c81fd 100644
  {
      if (!str)
  	return NULL;
-@@ -135,7 +135,7 @@ inline char *strend(gchar * str, gchar chr)
+@@ -135,7 +135,7 @@
      return str;
  }
  
@@ -53,4 +51,12 @@ index 266ce4e..e6c81fd 100644
  {
      if (!str)
  	return;
-
+@@ -146,7 +146,7 @@
+     strend(str, '"');
+ }
+ 
+-inline void remove_linefeed(gchar * str)
++void remove_linefeed(gchar * str)
+ {
+     strend(str, '\n');
+ }

--- a/srcpkgs/hardinfo/template
+++ b/srcpkgs/hardinfo/template
@@ -1,7 +1,7 @@
 # Template file for 'hardinfo'
 pkgname=hardinfo
 version=0.5.1
-revision=12
+revision=13
 build_style=gnu-configure
 hostmakedepends="pkg-config which"
 makedepends="gtk+-devel libsoup-devel desktop-file-utils"
@@ -9,7 +9,7 @@ depends="desktop-file-utils"
 short_desc="System information and benchmark tool"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later"
-homepage="http://sourceforge.net/projects/hardinfo.berlios/"
+homepage="https://www.berlios.de/software/hardinfo/"
 distfiles="${SOURCEFORGE_SITE}/${pkgname}.berlios/${pkgname}-${version}.tar.bz2"
 checksum=a0df6c0d7c92a7d20710b8eb551197398a965aaae053782b89a32a160b731b7a
 lib32disabled=yes


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, **x86_64**

#### Comments

Clicking on the `sensors` page gave `hardinfo: symbol lookup error: /usr/lib64/hardinfo/modules/devices.so: undefined symbol: remove_linefeed`

Copied what was in current `fix-runtime.patch`. Not how it worked before, last updated 2020.