### PR TITLE
teeworlds: fix CVE-2021-43518

### DIFF
--- a/srcpkgs/teeworlds/patches/CVE-2021-43518.patch
+++ b/srcpkgs/teeworlds/patches/CVE-2021-43518.patch
@@ -1,0 +1,38 @@
+upstream issue: https://github.com/teeworlds/teeworlds/issues/2981
+upstream fix: https://github.com/teeworlds/teeworlds/pull/3018
+patch source: https://sources.debian.org/src/teeworlds/0.7.5-2/debian/patches/CVE-2021-43518.patch/
+
+Backport 91e5492d4c210f82f1ca6b43a73417fef5463368 as the hotfix for CVE-2021-43518
+
+--- teeworlds-0.7.5.orig/src/game/client/components/maplayers.cpp
++++ teeworlds-0.7.5/src/game/client/components/maplayers.cpp
+@@ -254,7 +254,7 @@ void CMapLayers::LoadEnvPoints(const CLa
+ 				p.m_Time = pEnvPoint_v1->m_Time;
+ 				p.m_Curvetype = pEnvPoint_v1->m_Curvetype;
+ 
+-				for(int c = 0; c < pItem->m_Channels; c++)
++				for(int c = 0; c < min(pItem->m_Channels, 4); c++)
+ 				{
+ 					p.m_aValues[c] = pEnvPoint_v1->m_aValues[c];
+ 					p.m_aInTangentdx[c] = 0;
+--- teeworlds-0.7.5.orig/src/game/editor/io.cpp
++++ teeworlds-0.7.5/src/game/editor/io.cpp
+@@ -478,7 +478,8 @@ int CEditorMap::Load(class IStorage *pSt
+ 			for(int e = 0; e < Num; e++)
+ 			{
+ 				CMapItemEnvelope *pItem = (CMapItemEnvelope *)DataFile.GetItem(Start+e, 0, 0);
+-				CEnvelope *pEnv = new CEnvelope(pItem->m_Channels);
++				const int Channels = min(pItem->m_Channels, 4);
++				CEnvelope *pEnv = new CEnvelope(Channels);
+ 				pEnv->m_lPoints.set_size(pItem->m_NumPoints);
+ 				for(int n = 0; n < pItem->m_NumPoints; n++)
+ 				{
+@@ -495,7 +496,7 @@ int CEditorMap::Load(class IStorage *pSt
+ 						pEnv->m_lPoints[n].m_Time = pEnvPoint_v1->m_Time;
+ 						pEnv->m_lPoints[n].m_Curvetype = pEnvPoint_v1->m_Curvetype;
+ 
+-						for(int c = 0; c < pItem->m_Channels; c++)
++						for(int c = 0; c < Channels; c++)
+ 						{
+ 							pEnv->m_lPoints[n].m_aValues[c] = pEnvPoint_v1->m_aValues[c];
+ 						}

--- a/srcpkgs/teeworlds/template
+++ b/srcpkgs/teeworlds/template
@@ -1,7 +1,7 @@
 # Template file for 'teeworlds'
 pkgname=teeworlds
 version=0.7.5
-revision=2
+revision=3
 hostmakedepends="bam python3 pkg-config"
 makedepends="zlib-devel SDL2-devel glu-devel freetype-devel"
 short_desc="Retro multiplayer shooter"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly** (just playing the game, not the vulnerability)

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl (crossbuild)
  - armv7l-glibc (crossbuild)
  - aarch64b-glibc (crossbuild)

