### PR TITLE
python3-curio: update to 1.6.

### DIFF
--- a/srcpkgs/python3-curio/template
+++ b/srcpkgs/python3-curio/template
@@ -1,7 +1,7 @@
 # Template file for 'python3-curio'
 pkgname=python3-curio
-version=1.5
-revision=3
+version=1.6
+revision=1
 build_style=python3-module
 hostmakedepends="python3-setuptools"
 depends="python3"
@@ -10,8 +10,9 @@ short_desc="Coroutine-based library for concurrent programming using async/await
 maintainer="Arjan Mossel <arjanmossel@gmail.com>"
 license="BSD-3-Clause"
 homepage="https://github.com/dabeaz/curio"
-distfiles="${PYPI_SITE}/c/curio/curio-${version}.tar.gz"
-checksum=af08212e590bb7da8e4cc39c42012711494dc20d622f162155ba296cc2e3bc10
+changelog="https://raw.githubusercontent.com/dabeaz/curio/master/CHANGES"
+distfiles="https://github.com/dabeaz/curio/archive/${version}.tar.gz"
+checksum=8bf9f1fa8b16f8f9f202c9c7d7189f3757ecc38e3823a0afa363b59acb087123
 
 do_check() {
 	# CI container has different privileges than expected in test_errors()


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **NO**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
