### PR TITLE
python3-Babel: update to 2.12.1.

### DIFF
--- a/srcpkgs/python3-Babel/template
+++ b/srcpkgs/python3-Babel/template
@@ -1,18 +1,25 @@
 # Template file for 'python3-Babel'
 pkgname=python3-Babel
-version=2.10.3
-revision=2
+version=2.12.1
+revision=1
 build_style=python3-module
 hostmakedepends="python3-setuptools"
-depends="python3-pytz"
-checkdepends="python3-pytest python3-pytz python3-freezegun"
+checkdepends="python3-pytest python3-freezegun faketime"
 short_desc="Tools for internationalizing Python applications (Python3)"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="BSD-3-Clause"
 homepage="https://babel.pocoo.org"
 changelog="https://raw.githubusercontent.com/python-babel/babel/master/CHANGES.rst"
 distfiles="${PYPI_SITE}/B/Babel/Babel-${version}.tar.gz"
-checksum=7614553711ee97490f732126dc077f8d0ae084ebc6a96e23db1482afabdb2c51
+checksum=cc2d99999cd01d44420ae725a21c9e3711b3aadc7976d6147f622d8581963455
+
+do_check() {
+	# If you see this is hanging, remove faketime
+	# it has problem with python's time.sleep
+	LD_PRELOAD=/usr/lib/faketime/libfaketime.so.1 \
+		FAKETIME="@2023-01-01 00:00:00" \
+		python3 -m pytest
+}
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

Using sphinx with current version of `python3-Babel` gives the following deprecation warning :
```
$ python -Wonce -c 'import sphinx.application'
/usr/lib/python3.11/site-packages/babel/messages/catalog.py:13: DeprecationWarning: 'cgi' is deprecated and slated for removal in Python 3.13
  from cgi import parse_header
```

The update fixes this. I had to include https://github.com/python-babel/babel/pull/998 so tests pass, since it only touches test code I think its safe to include.

I found this while doctesting sagemath. A bunch of tests fail because of this deprecation warning, and after this update everything passes.

Cc: @sgn, since this affects `python3-Sphinx`.

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
