### PR TITLE
newsboat: orphan

### DIFF
--- a/srcpkgs/newsboat/template
+++ b/srcpkgs/newsboat/template
@@ -12,7 +12,7 @@ makedepends="json-c-devel libcurl-devel libxml2-devel sqlite-devel stfl-devel
  rust-std"
 checkdepends="ncurses-base"
 short_desc="RSS/Atom feed reader for the text console"
-maintainer="Daniel Eyßer <daniel.eysser@gmail.com>"
+maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
 homepage="https://newsboat.org/"
 changelog="https://raw.githubusercontent.com/newsboat/newsboat/master/CHANGELOG.md"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->
Not longer using as I fully switched to newsraft #42998
#### Testing the changes
- I tested the changes in this PR: nothing to test

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
