### PR TITLE
linux-firmware: move all mediatek WLAN/BT drivers to -network subpkg

### DIFF
--- a/srcpkgs/linux-firmware/template
+++ b/srcpkgs/linux-firmware/template
@@ -1,13 +1,13 @@
 # Template file for 'linux-firmware'
 pkgname=linux-firmware
 version=20230210
-revision=1
-depends="${pkgname}-amd>=${version}_${revision} ${pkgname}-network>=${version}_${revision}"
+revision=2
+depends="linux-firmware-amd>=${version}_${revision} linux-firmware-network>=${version}_${revision}"
 short_desc="Binary firmware blobs for the Linux kernel"
 maintainer="Érico Nogueira <ericonr@disroot.org>"
-license="See /usr/share/licenses/${pkgname}"
+license="custom:see /usr/share/licenses/linux-firmware"
 homepage="https://www.kernel.org/"
-distfiles="https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git/snapshot/${pkgname}-${version}.tar.gz"
+distfiles="https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git/snapshot/linux-firmware-${version}.tar.gz"
 checksum=ccc2ff9d475f368fa915e509fddb2c3815189f9461a008db1af0f096a2bfdbd3
 python_version=3
 nostrip=yes
@@ -93,7 +93,9 @@ linux-firmware-network_package() {
 		vmove usr/lib/firmware/kaweth
 		vmove usr/lib/firmware/libertas
 		vmove usr/lib/firmware/mrvl
-		vmove "usr/lib/firmware/mt*.bin"
+		vmove "usr/lib/firmware/mt7*.bin"
+		# don't move mediatek SoC firmware
+		( shopt -s extglob; vmove "usr/lib/firmware/mediatek/!(mt7986*|mt81*|sof*)" )
 		vmove usr/lib/firmware/ueagle-atm
 		vmove usr/lib/firmware/ti-connectivity
 		vmove usr/lib/firmware/dpaa2


### PR DESCRIPTION
based on https://github.com/chimera-linux/cports/blob/339c0eef5be61397707170c6789e09fa4c3b5810/main/firmware-linux/template.py#L83-L86

this shouldn't break anything because `linux-firmware` depends on `linux-firmware-network` already

fixes #43515 
fixes void-linux/void-mklive#224

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly** (the intended packages have the intended files)
