### PR TITLE
New package: solo2-cli-0.2.2

### DIFF
--- a/srcpkgs/solo2-cli/template
+++ b/srcpkgs/solo2-cli/template
@@ -1,0 +1,30 @@
+# Template file for 'solo2-cli'
+pkgname=solo2-cli
+version=0.2.2
+revision=1
+build_style=cargo
+hostmakedepends="pkg-config"
+makedepends="eudev-libudev-devel pcsclite-devel"
+short_desc="CLI tools for SoloKeys Solo 2 security keys"
+maintainer="Philipp David <pd@3b.pm>"
+license="Apache-2.0"
+homepage="https://github.com/solokeys/solo2-cli"
+distfiles="https://github.com/solokeys/solo2-cli/archive/v${version}.tar.gz
+ https://github.com/solokeys/solo2-cli/releases/download/v$version/solo2.completions.bash
+ https://github.com/solokeys/solo2-cli/releases/download/v$version/solo2.completions.fish
+ https://github.com/solokeys/solo2-cli/releases/download/v$version/solo2.completions.zsh"
+checksum="49a30c5ee6f38be968a520089741f8b936099611e98e6bf2b25d05e5e9335fb4
+ 09e5ae1da36e3fbb2e9183188c93277ac113fc2397f3e2447abdf7c718037f0e
+ d002a00bc6a58b23828d2cf7fcc49793dc34185c13aa6858622cda9a28a45379
+ eeda949e2a282cbbc759be939df1e0d96c50578a441dc6caa86a48a7a264a200"
+skip_extraction="solo2.completions.bash
+ solo2.completions.fish
+ solo2.completions.zsh"
+
+post_install() {
+	for shell in bash fish zsh; do
+		vcompletion "$XBPS_SRCDISTDIR/${pkgname}-${version}/solo2.completions.${shell}" \
+			"${shell}" solo2
+	done
+	vinstall 70-solo2.rules 644 usr/lib/udev/rules.d
+}


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->

Companion software for solo v2 security keys. Successfully updated two keys' firmware. Bash and zsh completions work, didn't try fish.