### PR TITLE
Signal-Desktop: update to 6.15.0.

### DIFF
--- a/srcpkgs/Signal-Desktop/template
+++ b/srcpkgs/Signal-Desktop/template
@@ -1,6 +1,6 @@
 # Template file for 'Signal-Desktop'
 pkgname=Signal-Desktop
-version=6.14.0
+version=6.15.0
 revision=1
 # Signal officially only supports x86_64 
 # x86_64-musl could potentially based on the Alpine port:
@@ -14,7 +14,7 @@ maintainer="anelki <akierig@fastmail.de>"
 license="AGPL-3.0-only"
 homepage="https://github.com/signalapp/Signal-Desktop"
 distfiles="https://github.com/signalapp/Signal-Desktop/archive/v${version}.tar.gz"
-checksum=646595deb22f4071398e38ed1de77ad1636a3a7774e9150662defee882c782cd
+checksum=7c3426a3829e0856940650423043711ad15c53dab554f1084c18ac81e828013e
 nostrip_files="signal-desktop"
 
 post_extract() {


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64