### PR TITLE
etcd: fixed go_import_path

### DIFF
--- a/srcpkgs/etcd/template
+++ b/srcpkgs/etcd/template
@@ -1,16 +1,15 @@
 # Template file for 'etcd'
 pkgname=etcd
 version=3.4.24
-revision=2
+revision=3
 build_style=go
-go_import_path="github.com/etcd-io/etcd"
+go_import_path="go.etcd.io/etcd"
 go_package="${go_import_path} ${go_import_path}/etcdctl"
-go_mod_mode=off
 short_desc="Distributed reliable key-value store"
 maintainer="Andrea Brancaleoni <abc@pompel.me>"
 license="Apache-2.0"
 homepage="https://coreos.com/etcd/docs/latest/"
-distfiles="https://${go_import_path}/archive/v${version}.tar.gz"
+distfiles="https://github.com/etcd-io/etcd/archive/v${version}.tar.gz"
 checksum=cc490495ffc04ced61a7f549dffd4f9a2e62723245c66432394659361d6ab659
 conf_files="/etc/sv/etcd/conf"
 system_accounts="etcd"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: YES

#### Local build testing
- I built this PR locally for my native architecture, x86_64

The original package contains no binaries:

```
$ xls etcd
/etc/sv/etcd/conf
/etc/sv/etcd/log/run
/etc/sv/etcd/run
/etc/sv/etcd/log/supervise -> /run/runit/supervise.etcd-log
/etc/sv/etcd/supervise -> /run/runit/supervise.etcd
```

Looks like the name of the Go import path was changed.

With this fix:

```
$ xls etcd
/etc/sv/etcd/conf
/etc/sv/etcd/log/run
/etc/sv/etcd/run
/usr/bin/etcd
/usr/bin/etcdctl
/etc/sv/etcd/log/supervise -> /run/runit/supervise.etcd-log
/etc/sv/etcd/supervise -> /run/runit/supervise.etcd
```

I set it up and it is running; I can put and get a value form it.