### PR TITLE
lame: fix ID3 tags on musl

### DIFF
--- a/srcpkgs/lame/patches/translit.patch
+++ b/srcpkgs/lame/patches/translit.patch
@@ -1,0 +1,26 @@
+--- lame/frontend/parse.c	2023-04-20 18:12:43.988212890 +0200
++++ -	2023-04-20 18:13:39.537622345 +0200
+@@ -232,7 +232,11 @@
+         dst = calloc(n+4, 4);
+         if (dst != 0) {
+             char* cur_code = nl_langinfo(CODESET);
++#ifdef __GNU_LIBRARY__
+             iconv_t xiconv = iconv_open("ISO_8859-1//TRANSLIT", cur_code);
++#else
++            iconv_t xiconv = iconv_open("ISO_8859-1", cur_code);
++#endif
+             if (xiconv != (iconv_t)-1) {
+                 char* i_ptr = (char*)src;
+                 char* o_ptr = dst;
+@@ -258,7 +262,11 @@
+         dst = calloc(n+4, 4);
+         if (dst != 0) {
+             char* cur_code = nl_langinfo(CODESET);
++#ifdef __GNU_LIBRARY__
+             iconv_t xiconv = iconv_open("UTF-16LE//TRANSLIT", cur_code);
++#else
++            iconv_t xiconv = iconv_open("UTF-16LE", cur_code);
++#endif
+             dst[0] = 0xff;
+             dst[1] = 0xfe;
+             if (xiconv != (iconv_t)-1) {

--- a/srcpkgs/lame/template
+++ b/srcpkgs/lame/template
@@ -1,7 +1,7 @@
 # Template file for 'lame'
 pkgname=lame
 version=3.100
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--enable-nasm --enable-shared"
 hostmakedepends="nasm"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

musl's iconv does not support transliterations causing `lame` to fail to write most of the ID3 tags.

I have modified the code so that it only does transliteration if the host libc is glibc. I don't know whether there are any other iconv implementations which support this, if so, please let me know and I can try to add them, although for Void's purposes it's needless at the moment.

I have not attempted to submit the patch upstream as it seems inactive, I might try to do so later.

#### Testing the changes
- I tested the changes in this PR: **YES** (on musl)

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-musl)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64
