### PR TITLE
Skarnet update

### DIFF
--- a/srcpkgs/execline-man-pages/template
+++ b/srcpkgs/execline-man-pages/template
@@ -1,15 +1,14 @@
 # Template file for 'execline-man-pages'
 pkgname=execline-man-pages
-version=2.9.2.0.2
+version=2.9.3.0.5
 revision=1
 build_style=gnu-makefile
-hostmakedepends="mdocml"
 short_desc="Mdoc versions of the documentation for the execline suite"
 maintainer="mobinmob <mobinmob@disroot.org>"
 license="ISC"
-homepage="https://github.com/flexibeast/execline-man-pages"
-distfiles="https://github.com/flexibeast/execline-man-pages/archive/v${version}.tar.gz"
-checksum=bc8ce8814b1e2c3b4b66dfb35cff8c38364877fe90f0b6fe4446dce130d43355
+homepage="https://git.sr.ht/~flexibeast/execline-man-pages"
+distfiles="https://git.sr.ht/~flexibeast/execline-man-pages/archive/v${version}.tar.gz"
+checksum=e626d5e8aca354a78ce21a028f8ac313ed0eec3bf96f1ba018bc2a3ce93cc9cc
 
 post_install() {
 	vlicense LICENSE

--- a/srcpkgs/execline/template
+++ b/srcpkgs/execline/template
@@ -1,11 +1,12 @@
 # Template file for 'execline'
 pkgname=execline
-version=2.9.2.0
+version=2.9.3.0
 revision=1
 build_style=configure
 configure_args="--libdir=/usr/lib --bindir=/usr/bin
  --with-sysdeps=${XBPS_CROSS_BASE}/usr/lib/skalibs/sysdeps
  --with-lib=${XBPS_CROSS_BASE}/usr/lib
+ --enable-pedantic-posix
  $(vopt_if static --enable-static-libc)
  $(vopt_if multicall --enable-multicall)"
 makedepends="skalibs-devel"
@@ -15,7 +16,7 @@ license="ISC"
 homepage="https://skarnet.org/software/execline/"
 changelog="https://skarnet.org/software/execline/upgrade.html"
 distfiles="https://skarnet.org/software/${pkgname}/${pkgname}-${version}.tar.gz"
-checksum=9365012558a1e3c019cafc6eb574b0f5890495fb02652f20efdd782d577b1601
+checksum=c8027fa70922d117cdee8cc20d277e38d03fd960e6d136d8cec32603d4ec238d
 
 CFLAGS="-fPIC"
 

--- a/srcpkgs/mdevd/files/mdevd/run
+++ b/srcpkgs/mdevd/files/mdevd/run
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+exec 2>&1
+[ -r ./conf ] && . ./conf
+exec mdevd ${OPTS:- -b 200000 -O4}

--- a/srcpkgs/mdevd/template
+++ b/srcpkgs/mdevd/template
@@ -1,7 +1,7 @@
 # Template file for 'mdevd'
 pkgname=mdevd
 version=0.1.6.2
-revision=1
+revision=2
 build_style=configure
 configure_args="--includedir=/usr/include --bindir=/usr/bin --libdir=/usr/lib
  --with-sysdeps=${XBPS_CROSS_BASE}/usr/lib/skalibs/sysdeps
@@ -15,9 +15,9 @@ homepage="https://skarnet.org/software/mdevd/"
 changelog="https://skarnet.org/software/mdevd/upgrade.html"
 distfiles="https://skarnet.org/software/mdevd/mdevd-${version}.tar.gz"
 checksum=ac2fcf9004f07904592c5894e2c401e15bb027ecf37bcb8ea661e2a7993447be
-
 build_options="static"
 desc_option_static="Build static binaries"
+make_check=no # no tests
 
 case "$XBPS_TARGET_MACHINE" in
 	*-musl)
@@ -30,6 +30,7 @@ post_install() {
 	vlicense COPYING
 	vdoc README
 	vcopy "doc/*" usr/share/doc/${pkgname}
+	vsv mdevd
 }
 
 mdevd-doc_package() {

--- a/srcpkgs/s6-linux-utils/template
+++ b/srcpkgs/s6-linux-utils/template
@@ -1,6 +1,6 @@
 # Template file for 's6-linux-utils'
 pkgname=s6-linux-utils
-version=2.6.1.0
+version=2.6.1.2
 revision=1
 build_style=configure
 configure_args="--libdir=/usr/lib --includedir=/usr/include
@@ -15,7 +15,7 @@ license="ISC"
 homepage="https://skarnet.org/software/s6-linux-utils"
 changelog="https://skarnet.org/software/s6-linux-utils/upgrade.html"
 distfiles="${homepage}/${pkgname}-${version}.tar.gz"
-checksum=2accb5a443dd04203a6358534bdcf0dd369aceb4733e322612c2b8329260b7a2
+checksum=d863dc5d782de77e46504145188fb57dbb0b66250617a67d341eb0cb4a9d9cd9
 
 build_options="static multicall"
 desc_option_static="Build static binaries"

--- a/srcpkgs/s6-man-pages/template
+++ b/srcpkgs/s6-man-pages/template
@@ -1,14 +1,14 @@
 # Template file for 's6-man-pages'
 pkgname=s6-man-pages
-version=2.11.3.0.1
+version=2.11.3.2.4
 revision=1
 build_style=gnu-makefile
 short_desc="Ports of the HTML documentation for the s6 supervision suite to mdoc(7)"
 maintainer="mobinmob <mobinmob@disroot.org>"
 license="ISC"
-homepage="https://github.com/flexibeast/s6-man-pages"
-distfiles="https://github.com/flexibeast/s6-man-pages/archive/v${version}.tar.gz"
-checksum=223e7c843e3996338efe1aee8d2779ae5b4b30e9140fd625021dda5c403b88be
+homepage="https://git.sr.ht/~flexibeast/s6-man-pages"
+distfiles="https://git.sr.ht/~flexibeast/s6-man-pages/archive/v${version}.tar.gz"
+checksum=5fdfeecc6946e6bfe5904cd3c880dbe61956fd6060b622bd9f344d38594479c9
 
 post_install() {
 	vlicense LICENSE

--- a/srcpkgs/s6-networking-man-pages/template
+++ b/srcpkgs/s6-networking-man-pages/template
@@ -1,15 +1,15 @@
 # Template file for 's6-networking-man-pages'
 pkgname=s6-networking-man-pages
-version=2.5.1.3.1
+version=2.5.1.3.3
 revision=1
 build_style=gnu-makefile
 hostmakedepends="mdocml"
 short_desc="Mdoc versions of the documentation for the s6-networking suite"
 maintainer="mobinmob <mobinmob@disroot.org>"
 license="ISC"
-homepage="https://github.com/flexibeast/s6-networking-man-pages"
-distfiles="https://github.com/flexibeast/s6-networking-man-pages/archive/refs/tags/v${version}.tar.gz"
-checksum=6cff17453dc7946a2a5b94b8a4a48965db6c52c6000420acaedd443f9d069e8f
+homepage="https://git.sr.ht/~flexibeast/s6-networking-man-pages"
+distfiles="https://git.sr.ht/~flexibeast/s6-networking-man-pages/archive/v${version}.tar.gz"
+checksum=14c79600f7494aa3ea1ce69b5d0d2d9775d3ab5aa098ae363e6317f04e74dd21
 
 post_install() {
 	vlicense LICENSE

--- a/srcpkgs/s6-portable-utils-man-pages/template
+++ b/srcpkgs/s6-portable-utils-man-pages/template
@@ -1,15 +1,14 @@
 # Template file for 's6-portable-utils-man-pages'
 pkgname=s6-portable-utils-man-pages
-version=2.3.0.0.1
+version=2.3.0.2.2
 revision=1
 build_style=gnu-makefile
-hostmakedepends="mdocml"
 short_desc="Documentation for s6-portable-utils in mdoc(7) format"
 maintainer="mobinmob <mobinmob@disroot.org>"
 license="ISC"
-homepage="https://github.com/flexibeast/s6-portable-utils-man-pages"
-distfiles="https://github.com/flexibeast/s6-portable-utils-man-pages/archive/refs/tags/v${version}.tar.gz"
-checksum=1e1e5c53550bb11a2d7c12c1c745be9b1a68846a868bb8b3671d70450084c120
+homepage="https://git.sr.ht/~flexibeast/s6-portable-utils-man-pages"
+distfiles="https://git.sr.ht/~flexibeast/s6-portable-utils-man-pages/archive/v${version}.tar.gz"
+checksum=a80b865b44f89c070c6e008a5d447749d96c3cc732d75f7529e9ba957a1088e9
 
 post_install() {
 	vlicense LICENSE

--- a/srcpkgs/s6-portable-utils/template
+++ b/srcpkgs/s6-portable-utils/template
@@ -1,6 +1,6 @@
 # Template file for 's6-portable-utils'
 pkgname=s6-portable-utils
-version=2.3.0.0
+version=2.3.0.2
 revision=1
 build_style=configure
 configure_args="--prefix=/usr --libdir=/usr/lib --includedir=/usr/include
@@ -15,7 +15,7 @@ license="ISC"
 homepage="https://skarnet.org/software/s6-portable-utils/"
 changelog="https://skarnet.org/software/s6-portable-utils/upgrade.html"
 distfiles="https://skarnet.org/software/${pkgname}/${pkgname}-${version}.tar.gz"
-checksum=1e9066c430c1cb39a3a7b7004cd379ffebe566bd3d698db18de6125783002005
+checksum=8714269134f012650daac040e5646372dea5658b9c0d89a7ca03bb2abec4d1e8
 
 build_options="static multicall"
 desc_option_static="Build static binaries"

--- a/srcpkgs/s6-rc-man-pages/template
+++ b/srcpkgs/s6-rc-man-pages/template
@@ -1,0 +1,15 @@
+# Template file for 's6-rc-man-pages'
+pkgname=s6-rc-man-pages
+version=0.5.4.1.2
+revision=1
+build_style=gnu-makefile
+short_desc="Ports of the documentation for s6-rc to mdoc(7)"
+maintainer="mobinmob <mobinmob@disroot.org>"
+license="ISC"
+homepage="https://git.sr.ht/~flexibeast/s6-rc-man-pages"
+distfiles="https://git.sr.ht/~flexibeast/s6-rc-man-pages/archive/v${version}.tar.gz"
+checksum=5eddff7cce9237d3ec7efa9694bd246003369fb1a460cead42daea8dc41d1420
+
+post_install() {
+	vlicense LICENSE
+}

--- a/srcpkgs/s6/template
+++ b/srcpkgs/s6/template
@@ -1,6 +1,6 @@
 # Template file for 's6'
 pkgname=s6
-version=2.11.3.0
+version=2.11.3.2
 revision=1
 build_style=configure
 configure_args="--libdir=/usr/lib --bindir=/usr/bin
@@ -15,7 +15,7 @@ license="ISC"
 homepage="http://skarnet.org/software/s6/"
 changelog="https://skarnet.org/software/s6/upgrade.html"
 distfiles="http://skarnet.org/software/s6/s6-${version}.tar.gz"
-checksum=0ef2de80c40b603d58bf65ec5dd9f0bb1f227d35f311e8948d9e30f81efb5b81
+checksum=7c16138ad2f0ffbe0ed2ae8dd0cecada9f7c787edd33a69084d219110693df74
 
 build_options="static"
 desc_option_static="Build static binaries"

--- a/srcpkgs/skalibs/template
+++ b/srcpkgs/skalibs/template
@@ -1,6 +1,6 @@
 # Template file for 'skalibs'
 pkgname=skalibs
-version=2.13.1.0
+version=2.13.1.1
 revision=1
 build_style=configure
 configure_args="--libdir=/usr/lib --enable-static --enable-shared
@@ -14,7 +14,7 @@ license="ISC"
 homepage="https://skarnet.org/software/skalibs/"
 changelog="https://skarnet.org/software/skalibs/upgrade.html"
 distfiles="https://skarnet.org/software/${pkgname}/${pkgname}-${version}.tar.gz"
-checksum=b3c48938c7fba4b19a8b0dce6e7a11427717a0901160bb62cfc6823f8ac86d92
+checksum=b272a1ab799f7fac44b9b4fb5ace78a9616b2fe4882159754b8088c4d8199e33
 
 post_install() {
 	vlicense COPYING LICENSE


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

--
- Update to skarnet packages and manpages.
- A new package for s6-rc-man-pages is added and the man pages repos are now hosted on sourcehut, so homepage and distfiles are changed.

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
