### PR TITLE
xdg-desktop-portal-wlr: update to 0.7.0

### DIFF
--- a/srcpkgs/xdg-desktop-portal-wlr/template
+++ b/srcpkgs/xdg-desktop-portal-wlr/template
@@ -1,6 +1,6 @@
 # Template file for 'xdg-desktop-portal-wlr'
 pkgname=xdg-desktop-portal-wlr
-version=0.6.0
+version=0.7.0
 revision=1
 build_style=meson
 hostmakedepends="pkg-config wayland-devel scdoc"
@@ -12,7 +12,7 @@ maintainer="Isaac Freund <mail@isaacfreund.com>"
 license="MIT"
 homepage="https://github.com/emersion/xdg-desktop-portal-wlr"
 distfiles="https://github.com/emersion/xdg-desktop-portal-wlr/archive/v${version}.tar.gz"
-checksum=20f145f00a40b41221aca73b1423f3ea4633980e1a2b1c4b25045d5eacd313e2
+checksum=78377c976645c07fe5a099c75976ac3477db4764899acfe43f0910803cadf450
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES** (obs+discord)


#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)

Fixes black screen due to failed stream nagotiation on rx 7X00xt graphics cards in OBS