### PR TITLE
libmtp: update to 1.1.21.

### DIFF
--- a/srcpkgs/libmtp/template
+++ b/srcpkgs/libmtp/template
@@ -1,6 +1,6 @@
 # Template file for 'libmtp'
 pkgname=libmtp
-version=1.1.20
+version=1.1.21
 revision=1
 build_style=gnu-configure
 configure_args="--disable-static --with-udev=/usr/lib/udev
@@ -11,8 +11,9 @@ short_desc="Library for Microsoft's Media Transfer Protocol (MTP)"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="LGPL-2.1-or-later"
 homepage="https://libmtp.sourceforge.net"
+changelog="https://sourceforge.net/projects/libmtp/files/libmtp/${version}/README"
 distfiles="${SOURCEFORGE_SITE}/${pkgname}/${pkgname}-${version}.tar.gz"
-checksum=c9191dac2f5744cf402e08641610b271f73ac21a3c802734ec2cedb2c6bc56d0
+checksum=c4ffa5ab8c8f48c91b0047f2e253c101c418d5696a5ed65c839922a4280872a7
 
 if [ "$CROSS_BUILD" ]; then
 	# XXX needs host mtp-hotplug


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

I have it installed, works ok with my garmin watch via `gmtp`.

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
