### PR TITLE
tachyon: update to 0.99.5.

### DIFF
--- a/srcpkgs/tachyon/template
+++ b/srcpkgs/tachyon/template
@@ -1,6 +1,6 @@
 # Template file for 'tachyon'
 pkgname=tachyon
-version=0.99~b6+dsx
+version=0.99.5
 revision=1
 build_wrksrc=unix
 build_style=gnu-makefile
@@ -9,9 +9,9 @@ makedepends="libpng-devel libjpeg-turbo-devel"
 short_desc="Multithreaded ray tracing software"
 maintainer="Gonzalo Tornaría <tornaria@cmat.edu.uy>"
 license="BSD-3-Clause"
-homepage="http://jedi.ks.uiuc.edu/~johns/raytracer/"
-distfiles="${DEBIAN_SITE}/main/t/tachyon/tachyon_${version}.orig.tar.xz"
-checksum=ec90074f569d6d797576611527caa6b1aac96125aea1ec89a31b2867f1cdf7ff
+homepage="https://mirrors.mit.edu/sage/spkg/upstream/tachyon/index.html"
+distfiles="https://mirrors.mit.edu/sage/spkg/upstream/tachyon/tachyon-${version}.tar.bz2"
+checksum=09203c102311149f5df5cc367409f96c725742666d19c24db5ba994d5a81a6f5
 
 pre_build() {
 	export LIBS+=" -ltachyon -ljpeg -lpng -lm -lpthread"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

I've been using this version for a while. I didn't PR before because the homepage was down and I thought it was transient.

Many months after the fact, the webpage is still down, so I moved the homepage to sagemath mirror (https://mirrors.mit.edu/sage/spkg/upstream/tachyon/index.html). Note that this package is essential for sagemath (for 3d plots) and so this mirror should be good for long.

The file in the mirror is exactly the same one that was originally distributed by upstream. You can see arch is shipping the same version and the same sha256 here: https://github.com/archlinux/svntogit-community/blob/packages/tachyon/trunk/PKGBUILD.



<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
