### PR TITLE
telegram-desktop: update to 4.8.0.

### DIFF
--- a/srcpkgs/glibmm2.68/template
+++ b/srcpkgs/glibmm2.68/template
@@ -1,8 +1,9 @@
 # Template file for 'glibmm2.68'
 pkgname=glibmm2.68
-version=2.68.1
+version=2.76.0
 revision=1
 build_style=meson
+configure_args="-Dbuild-examples=false"
 hostmakedepends="glib-devel perl pkg-config"
 makedepends="libglib-devel libsigc++3-devel"
 checkdepends="glib-networking"
@@ -10,8 +11,9 @@ short_desc="C++ bindings for GLib"
 maintainer="Enno Boland <gottox@voidlinux.org>"
 license="LGPL-2.1-or-later"
 homepage="https://www.gtkmm.org"
+changelog="https://gitlab.gnome.org/GNOME/glibmm/-/raw/master/NEWS"
 distfiles="${GNOME_SITE}/glibmm/${version%.*}/glibmm-${version}.tar.xz"
-checksum=6664e27c9a9cca81c29e35687f49f2e0d173a2fc9e98c3428311f707db532f8c
+checksum=8637d80ceabd94fddd6e48970a082a264558d4ab82684e15ffc87e7ef3462ab2
 
 glibmm2.68-devel_package() {
 	depends="${makedepends} ${sourcepkg}>=${version}_${revision}"

--- a/srcpkgs/glibmm2.68/update
+++ b/srcpkgs/glibmm2.68/update
@@ -1,3 +1,3 @@
 pkgname=glibmm
 site=https://gitlab.gnome.org/GNOME/glibmm/-/tags
-pattern="$pkgname-\K[0-9]\.[0-9]*[02468]\.[0-9.]*[0-9](?=)"
+ignore="*.*[13579].*"

--- a/srcpkgs/telegram-desktop/template
+++ b/srcpkgs/telegram-desktop/template
@@ -1,6 +1,6 @@
 # Template file for 'telegram-desktop'
 pkgname=telegram-desktop
-version=4.8.0
+version=4.8.1
 revision=1
 build_style=cmake
 build_helper="qemu"
@@ -25,7 +25,7 @@ license="GPL-3.0-or-later, OpenSSL"
 homepage="https://desktop.telegram.org/"
 changelog="https://github.com/telegramdesktop/tdesktop/blob/v${version}/changelog.txt"
 distfiles="https://github.com/telegramdesktop/tdesktop/releases/download/v${version}/tdesktop-${version}-full.tar.gz"
-checksum=99d50c75171c8c6e74b2b9298db48deff32a60ced35195f9279469914b8ee1f9
+checksum=96660bb151c035a80c5b32a8fe043cecb54e9fe450329cf612ecb752db68c06f
 
 build_options="spellcheck"
 build_options_default="spellcheck"

--- a/srcpkgs/telegram-desktop/template
+++ b/srcpkgs/telegram-desktop/template
@@ -1,6 +1,6 @@
 # Template file for 'telegram-desktop'
 pkgname=telegram-desktop
-version=4.6.5
+version=4.8.0
 revision=1
 build_style=cmake
 build_helper="qemu"
@@ -25,7 +25,7 @@ license="GPL-3.0-or-later, OpenSSL"
 homepage="https://desktop.telegram.org/"
 changelog="https://github.com/telegramdesktop/tdesktop/blob/v${version}/changelog.txt"
 distfiles="https://github.com/telegramdesktop/tdesktop/releases/download/v${version}/tdesktop-${version}-full.tar.gz"
-checksum=3448d879afdc7c5c06d2b0f9cabe339b08093cb25f380a3e398d32daa96a9c36
+checksum=99d50c75171c8c6e74b2b9298db48deff32a60ced35195f9279469914b8ee1f9
 
 build_options="spellcheck"
 build_options_default="spellcheck"


### PR DESCRIPTION
Testing the changes

I tested the changes in this PR: YES

Local build testing

I built this PR locally for my native architecture, glibc, x64

Note: PR depends on PR https://github.com/void-linux/void-packages/pull/43231 to build