### PR TITLE
Raspberry PI Updates

### DIFF
--- a/srcpkgs/rpi-firmware/template
+++ b/srcpkgs/rpi-firmware/template
@@ -1,22 +1,24 @@
 # Template file for 'rpi-firmware'
-_githash="62efc6a69d4e717bf2833c649d622c8298a37e9c"
-_gitshort="${_githash:0:7}"
-
 pkgname=rpi-firmware
-version=20220823
-revision=2
+version=20230623
+revision=1
+_githash="a7f7e2da955ef01b50516ea9722f6126e8d521a8"
+_gitshort="${_githash:0:7}"
 archs="armv6l* armv7l* aarch64*"
-provides="linux-firmware-broadcom-${version}_${revision}"
-replaces="linux-firmware-broadcom>=0"
 short_desc="Firmware files for the Raspberry Pi (git ${_gitshort})"
 maintainer="Piraty <mail@piraty.dev>"
 license="BSD-3-Clause, custom:Cypress"
 homepage="https://github.com/raspberrypi/firmware"
 distfiles="https://github.com/raspberrypi/firmware/archive/${_githash}.tar.gz"
-checksum=3fc5ab7155bde7221245f439971217558300dcbc988ade861cfef4e737de9909
+checksum=ead7a45c0013c0f2a56848fcde2532d2fe493533e6c1e5cc954c921893caae43
+provides="linux-firmware-broadcom-${version}_${revision}"
+replaces="linux-firmware-broadcom>=0"
 
 conf_files="/boot/cmdline.txt /boot/config.txt"
 nostrip=yes
+
+_debian_firmware_nonfree_repo=https://raw.githubusercontent.com/RPi-Distro/firmware-nonfree/buster
+_bluez_firmware_repo=https://raw.githubusercontent.com/RPi-Distro/bluez-firmware/master
 
 do_install() {
 	rm -f boot/*.img
@@ -34,49 +36,51 @@ do_install() {
 	vinstall ${FILESDIR}/cmdline.txt 644 boot
 	vinstall ${FILESDIR}/config.txt 644 boot
 
-	$XBPS_FETCH_CMD https://raw.githubusercontent.com/RPi-Distro/firmware-nonfree/buster/LICENCE.cypress
+	$XBPS_FETCH_CMD "${_debian_firmware_nonfree_repo}/LICENCE.cypress"
 	vlicense LICENCE.cypress
 
-	# Firmware for rpi3 b and zero wifi chip
-	for f in bin txt; do
-		$XBPS_FETCH_CMD https://raw.githubusercontent.com/RPi-Distro/firmware-nonfree/buster/brcm/brcmfmac43430-sdio.${f}
-		vinstall brcmfmac43430-sdio.${f} 0644 usr/lib/firmware/brcm
+	_wifi_firmware_with_blob=(
+		# For rpi3 b+
+		"brcmfmac43455-sdio"
+		# For rpi zero 2w
+		"brcmfmac43436-sdio"
+		# For rpi4/rpi400
+		"brcmfmac43456-sdio"
+	)
+
+	_wifi_firmware=(
+		# For rpi3 b and zero
+		"brcmfmac43430-sdio"
+		# For rpi zero 2w
+		"brcmfmac43436s-sdio"
+	)
+
+	for filename in ${_wifi_firmware_with_blob[@]}; do
+		for ext in bin txt clm_blob; do
+			$XBPS_FETCH_CMD "${_debian_firmware_nonfree_repo}/brcm/${filename}.${ext}"
+			vinstall ${filename}.${ext} 0644 usr/lib/firmware/brcm
+		done
 	done
 
-	# Firmware for rpi3 b and zero bluetooth chip
-	$XBPS_FETCH_CMD https://raw.githubusercontent.com/RPi-Distro/bluez-firmware/master/broadcom/BCM43430A1.hcd
-	vinstall BCM43430A1.hcd 0644 usr/lib/firmware/brcm
-
-	# Firmware for rpi3 b+ wifi chip
-	for f in bin txt clm_blob; do
-		$XBPS_FETCH_CMD https://raw.githubusercontent.com/RPi-Distro/firmware-nonfree/buster/brcm/brcmfmac43455-sdio.${f}
-		vinstall brcmfmac43455-sdio.${f} 0644 usr/lib/firmware/brcm
+	for filename in ${_wifi_firmware[@]}; do
+		for ext in bin txt; do
+			$XBPS_FETCH_CMD "${_debian_firmware_nonfree_repo}/brcm/${filename}.${ext}"
+			vinstall ${filename}.${ext} 0644 usr/lib/firmware/brcm
+		done
 	done
 
-	# Firmware for rpi3 b+ bluetooth chip
-	$XBPS_FETCH_CMD https://raw.githubusercontent.com/RPi-Distro/bluez-firmware/master/broadcom/BCM4345C0.hcd
-	vinstall BCM4345C0.hcd 0644 usr/lib/firmware/brcm
+	_bluez_firmware=(
+		# For rpi3 b and zero
+		"BCM43430A1.hcd"
+		# For rpi3 b+
+		"BCM4345C0.hcd"
+		# For rpi4/rpi400
+		"BCM4345C5.hcd"
+		"BCM43430B0.hcd"
+	)
 
-	# Firmware for rpi zero 2w wifi chip
-	for f in bin txt clm_blob; do
-		$XBPS_FETCH_CMD https://raw.githubusercontent.com/RPi-Distro/firmware-nonfree/buster/brcm/brcmfmac43436-sdio.${f}
-		vinstall brcmfmac43436-sdio.${f} 0644 usr/lib/firmware/brcm
+	for firmware in ${_bluez_firmware[@]}; do
+		$XBPS_FETCH_CMD "${_bluez_firmware_repo}/broadcom/${firmware}"
+		vinstall $firmware 0644 usr/lib/firmware/brcm
 	done
-	for f in bin txt; do
-		$XBPS_FETCH_CMD https://raw.githubusercontent.com/RPi-Distro/firmware-nonfree/buster/brcm/brcmfmac43436s-sdio.${f}
-		vinstall brcmfmac43436s-sdio.${f} 0644 usr/lib/firmware/brcm
-	done
-
-	# Firmware for rpi4/rpi400 wifi chip
-	for f in bin txt clm_blob; do
-		$XBPS_FETCH_CMD https://raw.githubusercontent.com/RPi-Distro/firmware-nonfree/buster/brcm/brcmfmac43456-sdio.${f}
-		vinstall brcmfmac43456-sdio.${f} 0644 usr/lib/firmware/brcm
-	done
-
-	# Firmware for rpi4/rpi400 bluetooth chip
-	$XBPS_FETCH_CMD https://raw.githubusercontent.com/RPi-Distro/bluez-firmware/master/broadcom/BCM4345C5.hcd
-	vinstall BCM4345C5.hcd 0644 usr/lib/firmware/brcm
-
-	$XBPS_FETCH_CMD https://raw.githubusercontent.com/RPi-Distro/bluez-firmware/master/broadcom/BCM43430B0.hcd
-	vinstall BCM43430B0.hcd 0644 usr/lib/firmware/brcm
 }

--- a/srcpkgs/rpi-kernel/template
+++ b/srcpkgs/rpi-kernel/template
@@ -11,20 +11,19 @@
 # [1] https://github.com/raspberrypi/linux/tags
 #
 # Upstream documentation: https://www.raspberrypi.com/documentation/computers/linux_kernel.html
-
 pkgname=rpi-kernel
-version=5.15.72
+version=6.1.35
 revision=1
-_githash="3b98eb7a4aeaecd5274108dc1be7a5df94253500"
+_githash=4b60cbf0149f5b5fa5eb9149bd35c750cbc02b25
 archs="armv6l* armv7l* aarch64*"
 hostmakedepends="perl kmod uboot-mkimage openssl-devel bc bison flex xz"
 makedepends="ncurses-devel"
-maintainer="Piraty <mail@piraty.dev>"
-homepage="http://www.kernel.org"
-license="GPL-2.0-only"
 short_desc="Linux kernel for Raspberry Pi (${version%.*} series [git ${_githash:0:7}])"
+maintainer="Piraty <mail@piraty.dev>"
+license="GPL-2.0-only"
+homepage="http://www.kernel.org"
 distfiles="https://github.com/raspberrypi/linux/archive/${_githash}.tar.gz"
-checksum=5cad1fd22f309ddd7b996df748aa21ced72f88d47fdbb8d4bfd9ef3a8a9b6ce9
+checksum=74793a0d0c5cbec213913ea921384c00cf9112e0ce39d8215cda7a9048208d44
 python_version=3
 
 _kernver="${version}_${revision}"

--- a/srcpkgs/rpi-userland/template
+++ b/srcpkgs/rpi-userland/template
@@ -1,19 +1,18 @@
 # Template file for 'rpi-userland'
-_githash="97bc8180ad682b004ea224d1db7b8e108eda4397"
-_gitshort="${_githash:0:7}"
-
 pkgname=rpi-userland
-version=20210623
+version=20230420
 revision=1
+_githash="cc1ca18fb0689b01cc2ca2aa4b400dcee624a213"
+_gitshort="${_githash:0:7}"
 build_style=cmake
-hostmakedepends="pkg-config"
 configure_args="-DCMAKE_INSTALL_RPATH=\$ORIGIN/../lib"
+hostmakedepends="pkg-config"
 short_desc="Raspberry Pi GPU userland libraries and utilities (git ${_gitshort})"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="BSD-3-Clause"
 homepage="https://github.com/raspberrypi/userland"
 distfiles="https://github.com/raspberrypi/userland/archive/${_githash}.tar.gz"
-checksum=d67def03931215f41b741aed5a3a1bc2bd62fa33f5cc14692e9a4d65f2e0ea27
+checksum=8a4bbfcd7181b2656b2781566c9e10eafdf6834399d2a0d2cf0c50923eec65f6
 
 LDFLAGS="-Wl,--no-as-needed"
 archs="armv6l* armv7l* aarch64*"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for these architectures:
  - aarch64 (for rpi4)

#### Contributor's notes
- The rpi-kernel package (both the one currently and this updated version) doesn't USB boot without an initramfs.
  - I used dracut to successfully make this work.