### PR TITLE
rustup: update to 1.26.0

### DIFF
--- a/srcpkgs/rustup/template
+++ b/srcpkgs/rustup/template
@@ -1,6 +1,6 @@
 # Template file for 'rustup'
 pkgname=rustup
-version=1.25.2
+version=1.26.0
 revision=1
 # rustup doesn't recognize this target
 archs="~armv*-musl"
@@ -16,7 +16,7 @@ license="Apache-2.0, MIT"
 homepage="https://www.rustup.rs"
 changelog="https://github.com/rust-lang/rustup/raw/master/CHANGELOG.md"
 distfiles="https://github.com/rust-lang/rustup/archive/refs/tags/${version}.tar.gz"
-checksum=dc9bb5d3dbac5cea9afa9b9c3c96fcf644a1e7ed6188a6b419dfe3605223b5f3
+checksum=6f20ff98f2f1dbde6886f8d133fe0d7aed24bc76c670ea1fca18eb33baadd808
 
 case "$XBPS_TARGET_MACHINE" in
 	x86_64*|i686*|arm*|aarch64*)


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
