### PR TITLE
python3-importlib_metadata: update to 6.6.0.

### DIFF
--- a/srcpkgs/python3-importlib_metadata/template
+++ b/srcpkgs/python3-importlib_metadata/template
@@ -1,6 +1,6 @@
 # Template file for 'python3-importlib_metadata'
 pkgname=python3-importlib_metadata
-version=6.3.0
+version=6.6.0
 revision=1
 build_style=python3-pep517
 hostmakedepends="python3-setuptools_scm python3-wheel"
@@ -11,4 +11,4 @@ license="Apache-2.0"
 homepage="https://pypi.org/project/importlib-metadata/"
 changelog="https://raw.githubusercontent.com/python/importlib_metadata/main/CHANGES.rst"
 distfiles="${PYPI_SITE}/i/importlib_metadata/importlib_metadata-${version}.tar.gz"
-checksum=23c2bcae4762dfb0bbe072d358faec24957901d75b6c4ab11172c0c982532402
+checksum=92501cdf9cc66ebd3e612f1b4f0c0765dfa42f0fa38ffb319b6bd84dd675d705


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture: **x86_64**