### PR TITLE
NoiseTorch: update to 0.12.2.

### DIFF
--- a/srcpkgs/NoiseTorch/template
+++ b/srcpkgs/NoiseTorch/template
@@ -1,17 +1,33 @@
 # Template file for 'NoiseTorch'
 pkgname=NoiseTorch
-version=0.11.4
+version=0.12.2
 revision=1
+build_wrksrc="NoiseTorch-${version}"
 build_style=go
 go_ldflags="-X main.version=${version} -X main.distribution=VoidLinux"
 go_import_path="noisetorch"
 depends="libcap-progs"
 short_desc="Real-time microphone noise suppression on Linux"
-maintainer="Soc Virnyl S. Estela <renegan.ronin@gmail.com>"
+maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-3.0-or-later"
-homepage="https://github.com/lawl/NoiseTorch"
-distfiles="https://github.com/lawl/NoiseTorch/archive/${version}.tar.gz"
-checksum=3da6cad119ecca6f4e131c8bca86eb122d2363d5d30dcd1da41974af5887a3c1
+homepage="https://github.com/NoiseTorch/NoiseTorch"
+_c_ringbuf_commit=2037560fb90dea5d2538611d983964d790bdbac2
+_rnnoise_commit=1cbdbcf1283499bbb2230a6b0f126eb9b236defd
+distfiles="https://github.com/NoiseTorch/NoiseTorch/archive/v${version}.tar.gz
+ https://github.com/NoiseTorch/c-ringbuf/archive/${_c_ringbuf_commit}.tar.gz
+ https://github.com/NoiseTorch/rnnoise/archive/${_rnnoise_commit}.tar.gz"
+checksum="4a30650314a6f83d979f3303d49618847ba58e39e3e26482dfe58b5e261c5611
+ 877b08413c59baac56b4cc7720fa56cf0eb399192a0ec652ce7b590c9cd9ad8a
+ 68c7ab4e408426088603e19955e746bb2a412d84bb121b6f39834c60fc8068b7"
+
+post_extract() {
+	ln -sf ${wrksrc}/c-ringbuf-${_c_ringbuf_commit}/* ${build_wrksrc}/c/c-ringbuf
+	ln -sf ${wrksrc}/rnnoise-${_rnnoise_commit}/* ${build_wrksrc}/c/rnnoise
+}
+
+post_patch() {
+	vsed -e '/git submodule/d' -i Makefile
+}
 
 pre_build() {
 	make rnnoise


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **Briefly**

- I built this PR locally for my native architecture, (x86_64-glibc)

Addresses #41656 and #42403.
I tried building using `rnnoise-devel`; it would build without errors, but would not actually function when testing. Because of this, I'm pretty sure the `*.c` files from rnnoise are required to build the ladspa library that gets integrated into this, so I used the vendored submodules.
Everything seems to work, but I only tried with pipewire (I doubt it'd break anywhere else if pipewire's working fine)