### PR TITLE
disklow: workaround distfiles cert error.

### DIFF
--- a/srcpkgs/disklow/template
+++ b/srcpkgs/disklow/template
@@ -1,7 +1,7 @@
 # Template file for 'disklow'
 pkgname=disklow
 version=1.2
-revision=1
+revision=2
 depends="perl-Filesys-Df perl-Config-General perl-Mail-Sendmail
  perl-Net-SMTP-SSL perl-Authen-SASL"
 short_desc="Fine grained disk space reporting with emphasis on mail functionality"
@@ -10,6 +10,9 @@ license="Artistic-1.0-Perl"
 homepage="https://loomsday.co.nz/development?id=linuxutils"
 distfiles="https://loomsday.co.nz/sources/disklow-${version}.tar.gz"
 checksum=05b9f510278147f24b0556eb745ff2b71c98c00fedf33434744fbe76ec884c26
+
+# xbps-fetch cannot verify this cert
+fetch_cmd="env SSL_NO_VERIFY_PEER=1 $XBPS_FETCH_CMD"
 
 do_install() {
 	vbin  disklow


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)

Addresses #42403.
I tried finding any precedence for an alive distfile but with broken certs and could only find #7512. Don't know if this is still the right way to workaround this 4 years later.