### PR TITLE
rsClock: update to 0.1.9.

### DIFF
--- a/srcpkgs/rsClock/template
+++ b/srcpkgs/rsClock/template
@@ -1,14 +1,15 @@
 # Template file for 'rsClock'
 pkgname=rsClock
-version=0.1.7
+version=0.1.9
 revision=1
 build_style=cargo
 short_desc="Simple terminal clock written in Rust"
 maintainer="0x0f0f0f <sudo-woodo3@protonmail.com>"
 license="MIT"
 homepage="https://github.com/valebes/rsClock"
-distfiles="https://github.com/valebes/rsClock/archive/refs/tags/v.${version}.tar.gz"
-checksum=60852e63e02629208919e2cd0bc0ba3a4d9e7b26af3b983f1141c507de1a411e
+changelog="https://github.com/valebes/rsClock/releases"
+distfiles="https://github.com/valebes/rsClock/archive/refs/tags/v${version}.tar.gz"
+checksum=1535a9e317e7434bae31ab526ccfa1086ae58fb395db799a3b414332ce08418c
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture: **x86_64**