### PR TITLE
restic: update to 0.15.2.

### DIFF
--- a/srcpkgs/restic/template
+++ b/srcpkgs/restic/template
@@ -1,7 +1,7 @@
 # Template file for 'restic'
 pkgname=restic
-version=0.15.1
-revision=2
+version=0.15.2
+revision=1
 build_style=go
 go_import_path=github.com/restic/restic
 go_package="${go_import_path}/cmd/restic"
@@ -12,7 +12,7 @@ license="BSD-2-Clause"
 homepage="https://restic.net/"
 changelog="https://raw.githubusercontent.com/restic/restic/master/CHANGELOG.md"
 distfiles="https://github.com/restic/restic/releases/download/v${version}/restic-${version}.tar.gz"
-checksum=fce382fdcdac0158a35daa640766d5e8a6e7b342ae2b0b84f2aacdff13990c52
+checksum=52aca841486eaf4fe6422b059aa05bbf20db94b957de1d3fca019ed2af8192b7
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
