### PR TITLE
aerc: update to 0.15.1

### DIFF
--- a/srcpkgs/aerc/template
+++ b/srcpkgs/aerc/template
@@ -1,6 +1,6 @@
 # Template file for 'aerc'
 pkgname=aerc
-version=0.15.0
+version=0.15.1
 revision=1
 build_style=go
 go_import_path="git.sr.ht/~rjarry/aerc"
@@ -14,7 +14,7 @@ license="MIT"
 homepage="https://aerc-mail.org"
 changelog="https://git.sr.ht/~rjarry/aerc/blob/master/CHANGELOG.md"
 distfiles="https://git.sr.ht/~rjarry/aerc/archive/${version}.tar.gz"
-checksum=dbeb41abc71d4469da9067d401146843732d9838972067d18f836729006ca033
+checksum=55cd54e45634d684590658ffc14c047cdf7366bbdf163d0445e2f093474ddef5
 ignore_elf_dirs="/usr/share/aerc/filters"
 
 post_install() {


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
