### PR TITLE
docker-compose: update to 2.17.3.

### DIFF
--- a/srcpkgs/docker-compose/template
+++ b/srcpkgs/docker-compose/template
@@ -1,6 +1,6 @@
 # Template file for 'docker-compose'
 pkgname=docker-compose
-version=2.17.2
+version=2.17.3
 revision=1
 build_style=go
 go_import_path="github.com/docker/compose/v2/cmd"
@@ -12,7 +12,7 @@ license="Apache-2.0"
 homepage="https://docs.docker.com/compose/"
 changelog="https://github.com/docker/compose/releases"
 distfiles="https://github.com/docker/compose/archive/refs/tags/v${version}.tar.gz"
-checksum=d6e6de858ecdb0104991c86c66dde5dd4fb6a1160d707308d8ad3167450c8094
+checksum=e5e9bdfc3a827240381b656da88f92b408ea2e203c3f8cfd9e0bbfe03f825f16
 
 post_install() {
 	mkdir -p ${DESTDIR}/usr/libexec/docker/cli-plugins


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl (cross-build)
  - armv7l (cross-build)
  - armv6l-musl (cross-build)