### PR TITLE
common/environment/setup/install.sh: support encoding in vman

### DIFF
--- a/common/environment/setup/install.sh
+++ b/common/environment/setup/install.sh
@@ -94,9 +94,9 @@ _vman() {
 		suffix=${target##*.}
 	fi
 
-	if  [[ $target =~ (.*)\.([a-z][a-z](_[A-Z][A-Z])?)\.(.*) ]]
+	if  [[ $target =~ (.*)\.([a-z][a-z](_[A-Z][A-Z])?(\.[^.]+)?)\.(.*) ]]
 	then
-		name=${BASH_REMATCH[1]}.${BASH_REMATCH[4]}
+		name=${BASH_REMATCH[1]}.${BASH_REMATCH[5]}
 		mandir=${BASH_REMATCH[2]}/man${suffix:0:1}
 	else
 		name=$target


### PR DESCRIPTION
`vman out/foo.fr.UTF-8.1` should install `usr/share/man/fr.UTF-8/man1/foo.1`, not `usr/share/man/fr/man1/foo.UTF-8.1`

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

