### PR TITLE
python3-ipython: update to 8.13.1.

### DIFF
--- a/srcpkgs/python3-ipython/template
+++ b/srcpkgs/python3-ipython/template
@@ -1,6 +1,6 @@
 # Template file for 'python3-ipython'
 pkgname=python3-ipython
-version=8.12.0
+version=8.13.1
 revision=1
 build_style=python3-module
 hostmakedepends="python3-setuptools"
@@ -16,19 +16,8 @@ license="BSD-3-Clause"
 homepage="https://ipython.org/"
 changelog="https://github.com/ipython/ipython/raw/main/docs/source/whatsnew/version8.rst"
 distfiles="${PYPI_SITE}/i/ipython/ipython-${version}.tar.gz"
-checksum=a950236df04ad75b5bc7f816f9af3d74dc118fd42f2ff7e80e8e60ca1f182e2d
+checksum=9c8487ac18f330c8a683fc50ab6d7bc0fcf9ef1d7a9f6ce7926938261067b81f
 conflicts="python-ipython<=5.8.0_2"
-
-do_check() {
-	# Tests fail when building (and have for awhile) but don't hinder use
-	PYTHONPATH="$(cd build/lib* && pwd)" python3 -m pytest \
-		-k "not test_all_completions_dups and \
-			not test_deduplicate_completions and \
-			not test_magic_arguments and \
-			not test_pinfo_docstring_if_detail_and_no_source and \
-			not test_pprint_heap_allocated_type and \
-			not test_system_interrupt and not test_code_from_file"
-}
 
 post_install() {
 	# remove iptest


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

sagemath works and its testsuit passes with this update.

Some tests in ipython were skipped before, but it seems now they pass.

Cc: @ahesford 

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
