### PR TITLE
cavestory: fix unwritable save

### DIFF
--- a/srcpkgs/cavestory/template
+++ b/srcpkgs/cavestory/template
@@ -1,7 +1,7 @@
 # Template file for 'cavestory'
 pkgname=cavestory
 version=1.2
-revision=2
+revision=3
 archs="x86_64 i686"
 create_wrksrc=yes
 short_desc="Japanese side-scrolling platformer game"
@@ -14,6 +14,7 @@ checksum="76466fc1b1901ce25e301a4ec8450aced806c9d499d66707d6f7b38efebc24c1
  a8711393c86cb6a7c6786883b22aed814f0e819cf935f8b273cb9dc5d58cfc6b"
 repository=nonfree
 nopie=yes
+nocheckperms=yes # The save is always placed next to the executable
 
 do_install() {
 	vmkdir usr/libexec/cavestory
@@ -23,6 +24,8 @@ do_install() {
 	vdoc linuxDoukutsu-1.01/doc/configfileformat.txt
 	vinstall linuxDoukutsu-${version}/doukutsu_${XBPS_TARGET_WORDSIZE}bits \
 		755 usr/libexec/cavestory doukutsu.bin
+	touch ${PKGDESTDIR}/usr/libexec/cavestory/Profile.dat
+	chmod 666 ${PKGDESTDIR}/usr/libexec/cavestory/Profile.dat
 	vbin ${FILESDIR}/cavestory
 	vinstall ${FILESDIR}/cavestory.desktop 644 usr/share/applications/
 	vinstall ${FILESDIR}/cavestory.png 644 usr/share/pixmaps/


### PR DESCRIPTION
The save file is always located in a file called `Profile.dat` next to the executable, but since that is installed, normally, in a root owned directory, when someone tries to play the game it wouldn't save because it couldn't write to the file (although the game provided no error message). This change just adds an empty `Profile.dat` with 666 perms.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
