### PR TITLE
gptfdisk: fix sgdisk crashing with popt-1.19.

### DIFF
--- a/srcpkgs/gptfdisk/patches/fix-sgdisk-crash.patch
+++ b/srcpkgs/gptfdisk/patches/fix-sgdisk-crash.patch
@@ -1,0 +1,97 @@
+From 5d5e76d369a412bfb3d2cebb5fc0a7509cef878d Mon Sep 17 00:00:00 2001
+From: Rod Smith <rodsmith@rodsbooks.com>
+Date: Fri, 15 Apr 2022 18:10:14 -0400
+Subject: [PATCH 1/2] Fix failure & crash of sgdisk when compiled with latest
+ popt (commit 740; presumably eventually release 1.19)
+
+---
+ NEWS      | 8 ++++++++
+ gptcl.cc  | 2 +-
+ support.h | 2 +-
+ 3 files changed, 10 insertions(+), 2 deletions(-)
+
+diff --git a/NEWS b/NEWS
+index c7add56..9e153fd 100644
+--- a/NEWS
++++ b/NEWS
+@@ -1,3 +1,11 @@
++1.0.10 (?/??/2022):
++-------------------
++
++- Fixed problem that caused sgdisk to crash with errors about being unable
++  to read the disk's partition table when compiled with the latest popt
++  (commit 740, which is pre-release as I type; presumably version 1.19 and
++  later once released).
++
+ 1.0.9 (4/14/2022):
+ ------------------
+ 
+diff --git a/gptcl.cc b/gptcl.cc
+index 34c9421..0d578eb 100644
+--- a/gptcl.cc
++++ b/gptcl.cc
+@@ -155,7 +155,7 @@ int GPTDataCL::DoOptions(int argc, char* argv[]) {
+    } // while
+ 
+    // Assume first non-option argument is the device filename....
+-   device = (char*) poptGetArg(poptCon);
++   device = strdup((char*) poptGetArg(poptCon));
+    poptResetContext(poptCon);
+ 
+    if (device != NULL) {
+diff --git a/support.h b/support.h
+index 8ba9ad1..f91f1bc 100644
+--- a/support.h
++++ b/support.h
+@@ -8,7 +8,7 @@
+ #include <stdlib.h>
+ #include <string>
+ 
+-#define GPTFDISK_VERSION "1.0.9"
++#define GPTFDISK_VERSION "1.0.9.1"
+ 
+ #if defined (__FreeBSD__) || defined (__FreeBSD_kernel__) || defined (__APPLE__)
+ // Darwin (Mac OS) & FreeBSD: disk IOCTLs are different, and there is no lseek64
+-- 
+2.40.1
+
+From f5de3401b974ce103ffd93af8f9d43505a04aaf9 Mon Sep 17 00:00:00 2001
+From: Damian Kurek <starfire24680@gmail.com>
+Date: Thu, 7 Jul 2022 03:39:16 +0000
+Subject: [PATCH 2/2] Fix NULL dereference when duplicating string argument
+
+poptGetArg can return NULL if there are no additional arguments, which
+makes strdup dereference NULL on strlen
+---
+ gptcl.cc | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/gptcl.cc b/gptcl.cc
+index 0d578eb..ab95239 100644
+--- a/gptcl.cc
++++ b/gptcl.cc
+@@ -155,10 +155,11 @@ int GPTDataCL::DoOptions(int argc, char* argv[]) {
+    } // while
+ 
+    // Assume first non-option argument is the device filename....
+-   device = strdup((char*) poptGetArg(poptCon));
+-   poptResetContext(poptCon);
++   device = (char*) poptGetArg(poptCon);
+ 
+    if (device != NULL) {
++      device = strdup(device);
++      poptResetContext(poptCon);
+       JustLooking(); // reset as necessary
+       BeQuiet(); // Tell called functions to be less verbose & interactive
+       if (LoadPartitions((string) device)) {
+@@ -498,6 +499,7 @@ int GPTDataCL::DoOptions(int argc, char* argv[]) {
+          cerr << "Error encountered; not saving changes.\n";
+          retval = 4;
+       } // if
++      free(device);
+    } // if (device != NULL)
+    poptFreeContext(poptCon);
+    return retval;
+-- 
+2.40.1
+

--- a/srcpkgs/gptfdisk/template
+++ b/srcpkgs/gptfdisk/template
@@ -1,7 +1,7 @@
 # Template file for 'gptfdisk'
 pkgname=gptfdisk
 version=1.0.9
-revision=1
+revision=2
 build_style=gnu-makefile
 make_check_target=test
 makedepends="ncurses-devel popt-devel libuuid-devel"


### PR DESCRIPTION
Fixes #43677.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **NO**

@atweiden can you see if this PR fixes the issue for you?

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
