### PR TITLE
vivaldi: update to 6.0.2979.18, unrestrict, support user flags, adopt.

### DIFF
--- a/srcpkgs/vivaldi/files/redistribution-permission.eml
+++ b/srcpkgs/vivaldi/files/redistribution-permission.eml
@@ -1,0 +1,38 @@
+Subject: Re: Linux distro: permission to redistribute?
+From: Tatsuki Tomita <tatsuki at vivaldi dot com>
+Date: Thu, 4 May 2023 22:09:18 -0700
+Cc: =?utf-8?Q?Ruar=C3=AD_=C3=98degaard?= <ruario at vivaldi dot com>
+To: abby at voidlinux dot org
+
+Hello Abby,
+
+Thank you for reaching out and your interest in distributing Vivaldi.
+Yes, please feel free to distribute Vivaldi as an unrestricted package.
+
+We are excited to see that more Void linux user will discover and try Vivaldi.
+
+If you need any other assistance, please let us know.
+
+Kind regards,
+Tatsuki
+
+> On May 3, 2023, at 12:58 PM, abby <abby at voidlinux dot org> wrote:
+> 
+> Hello,
+> 
+> I am a maintainer of Void Linux (https://voidlinux.org).
+> 
+> Currently, we package Vivaldi as a "restricted" package (one the user has to
+> build themselves) because (as we read/understood it) there is no explicit
+> permission to redistribute the files in our repositories and mirrors as a
+> package for Void's package manager.
+> 
+> Recently, I noticed the "Linux Distributions" page on Vivaldi's website
+> (https://vivaldi.com/partners/linux/) and that some other distributions
+> package Vivaldi in their regular repositories (equivalent to an
+> "unrestricted" package on Void).
+> Do we need explicit permission to redistribute Vivaldi in this manner, and if
+> so, can we get that permission?
+> 
+> Thanks,
+> Abby

--- a/srcpkgs/vivaldi/patches/support-user-flags.patch
+++ b/srcpkgs/vivaldi/patches/support-user-flags.patch
@@ -1,0 +1,37 @@
+From 68c2dec905a7c88895c458dd40708ab9989385cf Mon Sep 17 00:00:00 2001
+From: BlackEagle <ike.devolder@gmail.com>
+Date: Wed, 19 Jan 2022 20:57:58 +0100
+Subject: [PATCH] add support for user flags
+
+Signed-off-by: BlackEagle <ike.devolder@gmail.com>
+---
+ opt/vivaldi/vivaldi | 9 ++++++++-
+ 1 file changed, 8 insertions(+), 1 deletion(-)
+
+diff --git a/opt/vivaldi/vivaldi b/opt/vivaldi/vivaldi
+index 5b5f1bf..8e95859 100755
+--- a/opt/vivaldi/vivaldi
++++ b/opt/vivaldi/vivaldi
+@@ -53,6 +53,13 @@ export CHROME_VERSION_EXTRA="stable"
+ # We don't want bug-buddy intercepting our crashes. http://crbug.com/24120
+ export GNOME_DISABLE_CRASH_DIALOG=SET_BY_GOOGLE_CHROME
+ 
++# Allow users to override command-line options
++XDG_CONFIG_HOME=${XDG_CONFIG_HOME:-$HOME/.config}
++VIVALDI_USER_FLAGS=""
++if [[ -f "$XDG_CONFIG_HOME/vivaldi-$CHROME_VERSION_EXTRA.conf" ]]; then
++   VIVALDI_USER_FLAGS="$(cat "$XDG_CONFIG_HOME/vivaldi-$CHROME_VERSION_EXTRA.conf")"
++fi
++
+ # Sanitize std{in,out,err} because they'll be shared with untrusted child
+ # processes (http://crbug.com/376567).
+ exec < /dev/null
+@@ -60,4 +67,4 @@ exec > >(exec cat)
+ exec 2> >(exec cat >&2)
+ 
+ # Note: exec -a below is a bashism.
+-exec -a "$0" "$HERE/vivaldi-bin" "$@"
++exec -a "$0" "$HERE/vivaldi-bin" $VIVALDI_USER_FLAGS "$@"
+-- 
+2.34.1
+

--- a/srcpkgs/vivaldi/template
+++ b/srcpkgs/vivaldi/template
@@ -1,30 +1,31 @@
 # Template file for 'vivaldi'
+# Permission to redistribute is granted.
+# see: srcpkgs/vivaldi/files/redistribution-permission.eml
 pkgname=vivaldi
-version=6.0.2979.15
+version=6.0.2979.18
 revision=1
 _release=1
 archs="x86_64 aarch64 armv7l"
-depends="desktop-file-utils hicolor-icon-theme xz"
+depends="desktop-file-utils hicolor-icon-theme xz libnotify xdg-utils"
 short_desc="Advanced browser made with the power user in mind"
-maintainer="Orphaned <orphan@voidlinux.org>"
+maintainer="classabbyamp <void@placeviolette.net>"
 license="custom:Proprietary"
 homepage="https://vivaldi.com"
 repository=nonfree
-restricted=yes
 nostrip=yes
 skiprdeps="/opt/vivaldi/libqt5_shim.so"
 case "$XBPS_TARGET_MACHINE" in
 x86_64)
 	distfiles="https://downloads.vivaldi.com/stable/vivaldi-stable_${version}-${_release}_amd64.deb"
-	checksum=bef374031acaa2da61608a64c8e28706010e42d1782ef601575701e7dd4809b7
+	checksum=baa8572fb9277661a838e6a5c90ea6571441de4f0bd75509cc00c29cd6a48fae
 	;;
 aarch64)
 	distfiles="https://downloads.vivaldi.com/stable/vivaldi-stable_${version}-${_release}_arm64.deb"
-	checksum=eab113c5e131b47c56aca14ed0c1f38cb82768751e44456ab0e07ddbae2366bf
+	checksum=4b76f49a65ac42158328fcf7e06cdbe74abec00511005344b7a22f0aaa3c08cb
 	;;
 armv7l)
 	distfiles="https://downloads.vivaldi.com/stable/vivaldi-stable_${version}-${_release}_armhf.deb"
-	checksum=da92a980b0b8c7c6f96f5a56204e3bff72d333c17131c6f8f3c990a9ba84c9d3
+	checksum=7ddd07ade52ef79aa41a3467737620b941491482250b03a7f06f11de2c71ec1e
 	;;
 *)
 	broken="No distfiles available for this target"


### PR DESCRIPTION
will now read the contents of `$XDG_CONFIG_HOME/vivaldi-stable.conf` and pass that to the underlying binary

patch comes from arch

for example, to force `prefers-color-scheme: dark` and work on wayland:
```
$ cat ~/.config/vivaldi-stable.conf
--force-dark-mode --ozone-platform-hint=auto
```

missing dependencies libnotify and xdg-utils also added

permission to redistribute has now been granted, see `srcpkgs/vivaldi/files/redistribution-permission.eml`

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

