### PR TITLE
python3-yapf: fix egg-info permission

### DIFF
--- a/srcpkgs/python3-yapf/template
+++ b/srcpkgs/python3-yapf/template
@@ -1,7 +1,7 @@
 # Template file for 'python3-yapf'
 pkgname=python3-yapf
 version=0.33.0
-revision=1
+revision=2
 build_style=python3-module
 hostmakedepends="python3-setuptools"
 depends="python3-tomli"
@@ -12,3 +12,7 @@ homepage="https://github.com/google/yapf"
 changelog="https://raw.githubusercontent.com/google/yapf/main/CHANGELOG"
 distfiles="${PYPI_SITE}/y/yapf/yapf-${version}.tar.gz"
 checksum=da62bdfea3df3673553351e6246abed26d9fe6780e548a5af9e70f6d2b4f5b9a
+
+post_install() {
+	chmod -R a+r "${DESTDIR}/${py3_sitelib}/yapf-${version}-py${py3_ver}.egg-info/"
+}


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture: **x86_64**

Fixes https://github.com/void-linux/void-packages/issues/43726