### PR TITLE
python3: mark as EXTERNALLY-MANAGED

### DIFF
--- a/srcpkgs/python3/files/EXTERNALLY-MANAGED
+++ b/srcpkgs/python3/files/EXTERNALLY-MANAGED
@@ -1,0 +1,21 @@
+[externally-managed]
+Error=
+ The system-wide Python installation in Void should be maintained
+ using the system package manager, xbps.
+
+ If the package in question is not packaged for Void, please
+ consider installing it inside a virtual environment, e.g.:
+
+   python3 -m venv /path/to/venv
+   . /path/to/venv/bin/activate
+   pip install mypackage
+
+ To exit the virtual environment, run:
+
+   deactivate
+
+ The virtual environment is not deleted, and can be re-entered by
+ re-sourcing the activate file.
+
+ To automatically manage virtual environments, pipx (from python3-pipx)
+ can be used.

--- a/srcpkgs/python3/template
+++ b/srcpkgs/python3/template
@@ -4,7 +4,7 @@
 #
 pkgname=python3
 version=3.11.3
-revision=1
+revision=2
 build_style="gnu-configure"
 configure_args="--enable-shared --enable-ipv6
  --enable-loadable-sqlite-extensions --with-computed-gotos
@@ -135,6 +135,9 @@ do_install() {
 		${DESTDIR}/usr/bin/python${version%.*}-config \
 		${DESTDIR}/usr/lib/python${version%.*}/_sysconfigdata_*_*.py \
 		${DESTDIR}/usr/lib/python${version%.*}/config-${version%.*}*/Makefile
+
+	# https://peps.python.org/pep-0668/
+	vinstall ${FILESDIR}/EXTERNALLY-MANAGED 644 usr/lib/python${version%.*}
 }
 
 python3-devel_package() {


### PR DESCRIPTION
this prevents users from breaking xbps-installed python3 packages by using pip outside of a virtual environment. Error message adapted from gentoo's, debian's, and the example from PEP 668

see https://peps.python.org/pep-0668/ for more details

closes #43703

```
$ pip install --user foo
error: externally-managed-environment

× This environment is externally managed
╰─> 
    The system-wide Python installation in Void should be maintained
    using the system package manager, xbps.
    
    If the package in question is not packaged for Void, please
    consider installing it inside a virtual environment, e.g.:
    
    python3 -m venv /path/to/venv
    . /path/to/venv/bin/activate
    pip install mypackage
    
    To exit the virtual environment, run:
    
    deactivate
    
    The virtual environment is not deleted, and can be re-entered by
    re-sourcing the activate file.
    
    To automatically manage virtual environments, pipx (from python3-pipx)
    can be used.

note: If you believe this is a mistake, please contact your Python installation or OS distribution provider. You can override this, at the risk of breaking your Python installation or OS, by passing --break-system-packages.
hint: See PEP 668 for the detailed specification.
```

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

#### TODOs

- [ ] write a news post notifying users of this change
- [x] (potentially) update [void-linux/void-containers](https://github.com/void-linux/void-containers) containers to not break due to this change

cc: @ahesford
