### PR TITLE
puzzles: update to 20230505.63346a8.

### DIFF
--- a/srcpkgs/puzzles/template
+++ b/srcpkgs/puzzles/template
@@ -1,17 +1,17 @@
 # Template file for 'puzzles'
 pkgname=puzzles
-version=20230404.2499eb4
+version=20230505.63346a8
 revision=1
 build_style=cmake
 configure_args="-DNAME_PREFIX=puzzles-"
-hostmakedepends="pkg-config"
+hostmakedepends="pkg-config halibut perl ImageMagick"
 makedepends="gtk+3-devel"
 short_desc="Simon Tatham's Portable Puzzle Collection"
 maintainer="Leah Neukirchen <leah@vuxu.org>"
 license="MIT"
 homepage="https://www.chiark.greenend.org.uk/~sgtatham/puzzles/"
-distfiles="https://git.tartarus.org/?p=simon/puzzles.git;a=snapshot;h=2499eb47fa4e0c86bc1b6100b4922026670b2ad8;sf=tgz>${pkgname}-${version#*.}.tgz"
-checksum=10a5dc2b9e20a45ad683de7536dd33648a4a1ad69da189c90ae5d656cdbd6b8e
+distfiles="https://git.tartarus.org/?p=simon/puzzles.git;a=snapshot;h=63346a8ceac9ac1061e59af2a99ab1a44c851392;sf=tgz>${pkgname}-${version#*.}.tgz"
+checksum=77a7a06fa21a987cbc1475bc689b0374633a3fdbe6f76a66832b448697de5d40
 
 post_install() {
 	vlicense LICENCE LICENSE

--- a/srcpkgs/puzzles/update
+++ b/srcpkgs/puzzles/update
@@ -1,2 +1,0 @@
-site="http://svn.tartarus.org/sgt/puzzles/"
-pattern='Revision\s\K\d+(?=.*of)'


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture: **x86_64**

Fixes https://github.com/void-linux/void-packages/issues/43759