### PR TITLE
mumble: backport fix for segfault with pipewire

### DIFF
--- a/srcpkgs/mumble/patches/pipewire-fix.patch
+++ b/srcpkgs/mumble/patches/pipewire-fix.patch
@@ -1,0 +1,38 @@
+From 24b9276d97cac459284143b936e46b626d7396f0 Mon Sep 17 00:00:00 2001
+From: Robert Adam <dev@robert-adam.de>
+Date: Tue, 11 Apr 2023 13:50:47 +0200
+Subject: [PATCH] FIX(client): PipeWire crash
+
+When destroying the PipeWire object we first destroyed the thread loop
+and then the stream, but this has to be done in reverse order in order
+to avoid crashes.
+
+Fixes #6101
+
+Source: https://github.com/mumble-voip/mumble/pull/6103
+---
+ src/mumble/PipeWire.cpp | 7 ++++---
+ 1 file changed, 4 insertions(+), 3 deletions(-)
+
+diff --git a/src/mumble/PipeWire.cpp b/src/mumble/PipeWire.cpp
+index 91924e4fb1..c206ab5bbb 100644
+--- a/src/mumble/PipeWire.cpp
++++ b/src/mumble/PipeWire.cpp
+@@ -213,13 +213,14 @@ PipeWireEngine::~PipeWireEngine() {
+ 		return;
+ 	}
+ 
++	if (m_stream) {
++		pws->pw_stream_destroy(m_stream);
++	}
++
+ 	if (m_thread) {
+ 		pws->pw_thread_loop_destroy(m_thread);
+ 	}
+ 
+-	if (m_stream) {
+-		pws->pw_stream_destroy(m_stream);
+-	}
+ 
+ 	if (m_loop) {
+ 		pws->pw_loop_destroy(m_loop);

--- a/srcpkgs/mumble/template
+++ b/srcpkgs/mumble/template
@@ -1,7 +1,7 @@
 # Template file for 'mumble'
 pkgname=mumble
 version=1.4.287
-revision=2
+revision=3
 build_style=cmake
 make_cmd=make
 configure_args="-Doverlay-xcompile=OFF -Dbundled-opus=OFF


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Description
Currently due to a libpipewire change (most likely >= 0.3.68) the Mumble client segfaults when trying to change any setting. This backported patch fixes the issue (small change).

#### Testing the changes
- I tested the changes in this PR: YES

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
#### Local build testing
- I built this PR locally for my native architecture, x86_68-glibc
