### PR TITLE
fastd: remove -Db_lto=true.

### DIFF
--- a/srcpkgs/fastd/template
+++ b/srcpkgs/fastd/template
@@ -3,7 +3,7 @@ pkgname=fastd
 version=21
 revision=1
 build_style=meson
-configure_args="-Db_lto=true -Dcipher_aes128-ctr=disabled"
+configure_args="-Dcipher_aes128-ctr=disabled"
 hostmakedepends="bison pkg-config"
 makedepends="json-c-devel libcap-devel libuecc-devel libsodium-devel"
 short_desc="Fast and Secure Tunneling Daemon"


### PR DESCRIPTION
This is now the default in void-packages for packages with build_style=meson.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **NO**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
