### PR TITLE
python3-ipython: update to 8.13.2.

### DIFF
--- a/srcpkgs/python3-ipython/template
+++ b/srcpkgs/python3-ipython/template
@@ -1,6 +1,6 @@
 # Template file for 'python3-ipython'
 pkgname=python3-ipython
-version=8.13.1
+version=8.13.2
 revision=1
 build_style=python3-module
 hostmakedepends="python3-setuptools"
@@ -16,7 +16,7 @@ license="BSD-3-Clause"
 homepage="https://ipython.org/"
 changelog="https://github.com/ipython/ipython/raw/main/docs/source/whatsnew/version8.rst"
 distfiles="${PYPI_SITE}/i/ipython/ipython-${version}.tar.gz"
-checksum=9c8487ac18f330c8a683fc50ab6d7bc0fcf9ef1d7a9f6ce7926938261067b81f
+checksum=7dff3fad32b97f6488e02f87b970f309d082f758d7b7fc252e3b19ee0e432dbb
 conflicts="python-ipython<=5.8.0_2"
 
 post_install() {


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

This is a hotfix to make right arrow work again! It's broken since the update 8.12.0 -> 8.13.1.

```
IPython 8.12.2 and 8.13.2 contain UI fixes, with respect to right arrow not
working in some case in the terminal, and 8.12.2 contain also a requested
backport of :ghpull:`14029` (Allow safe access to the ``__getattribute__``
method of modules) for tab completion.
```

@ahesford

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
