### PR TITLE
pounce: update to 3.1, build pounce-notify and pounce-palaver.

### DIFF
--- a/srcpkgs/pounce/template
+++ b/srcpkgs/pounce/template
@@ -1,15 +1,16 @@
 # Template file for 'pounce'
 pkgname=pounce
-version=3.0
-revision=3
+version=3.1
+revision=1
 build_style=gnu-configure
+configure_args="--enable-notify --enable-palaver"
 make_build_target="all"
 hostmakedepends="pkg-config"
-makedepends="libtls-devel"
+makedepends="libtls-devel libcurl-devel sqlite-devel"
 depends="openssl"
 short_desc="Multi-client, TLS-only IRC bouncer"
 maintainer="Michal Vasilek <michal@vasilek.cz>"
 license="GPL-3.0-or-later"
 homepage="https://git.causal.agency/pounce/"
 distfiles="https://git.causal.agency/pounce/snapshot/pounce-$version.tar.gz"
-checksum=f776f7f170493697a97923e7dce9597dff5577fd40ba756e9a1bcfab17199df0
+checksum=97f245556b1cc940553fca18f4d7d82692e6c11a30f612415e5e391e5d96604e


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-glibc