### PR TITLE
python3-pycryptodome: update to 3.17.

### DIFF
--- a/srcpkgs/python3-pycryptodome/template
+++ b/srcpkgs/python3-pycryptodome/template
@@ -1,7 +1,7 @@
 # Template file for 'python3-pycryptodome'
 pkgname=python3-pycryptodome
-version=3.9.7
-revision=5
+version=3.17
+revision=1
 build_style=python3-module
 hostmakedepends="python3-setuptools"
 makedepends="python3-devel"
@@ -12,7 +12,7 @@ license="Public Domain, BSD-2-Clause"
 homepage="https://www.pycryptodome.org/"
 changelog="https://raw.githubusercontent.com/Legrandin/pycryptodome/master/Changelog.rst"
 distfiles="${PYPI_SITE}/p/pycryptodome/pycryptodome-${version}.tar.gz"
-checksum=f1add21b6d179179b3c177c33d18a2186a09cc0d3af41ff5ed3f377360b869f2
+checksum=bce2e2d8e82fcf972005652371a3e8731956a0c1fbb719cc897943b3695ad91b
 
 provides="python3-crypto-${version}_1"
 replaces="python3-crypto>=0"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

The package size decreased by an order of magnitude with this bump, I've yet to investigate why this happened and if it might cause issues.


<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
