### PR TITLE
mkinitcpio: add missing runtime dependency

### DIFF
--- a/srcpkgs/mkinitcpio/template
+++ b/srcpkgs/mkinitcpio/template
@@ -1,10 +1,10 @@
 # Template file for 'mkinitcpio'
 pkgname=mkinitcpio
 version=35.2
-revision=1
+revision=2
 build_style=gnu-makefile
 hostmakedepends="asciidoc"
-depends="busybox-static bsdtar bash"
+depends="busybox-static bsdtar bash zstd"
 checkdepends="busybox-static bats-assert lz4 xz zstd"
 short_desc="Next generation of initramfs creation"
 maintainer="Andrea Brancaleoni <abc@pompel.me>"


### PR DESCRIPTION
Because this error shows up when generating a new initramfs:
```
/usr/lib/initcpio/functions: line 1030: zstd: command not found
```

#### Testing the changes
- I tested the changes in this PR: **NO** (N/A?)

#### Local build testing
- I built this PR locally for my native architecture, (**x86_64**)
