### PR TITLE
common/build-style/python3-pep517: use absolute path for check temp dir + trustme update

### DIFF
--- a/common/build-style/python3-pep517.sh
+++ b/common/build-style/python3-pep517.sh
@@ -20,7 +20,7 @@ do_check() {
 			make_install_target="dist/${wheelbase//-/_}-${version}-*-*-*.whl"
 		fi
 
-		local testdir="tmp/$(date +%s)"
+		local testdir="${wrksrc}/tmp/$(date +%s)"
 		python3 -m installer --destdir "${testdir}" \
 			${make_install_args} ${make_install_target}
 

--- a/srcpkgs/python3-trustme/template
+++ b/srcpkgs/python3-trustme/template
@@ -1,14 +1,15 @@
 # Template file for 'python3-trustme'
 pkgname=python3-trustme
-version=0.9.0
-revision=2
-build_style=python3-module
-hostmakedepends="python3-setuptools"
+version=1.0.0
+revision=1
+build_style=python3-pep517
+hostmakedepends="python3-setuptools python3-wheel"
 depends="python3-cryptography python3-idna"
 checkdepends="python3-pytest python3-service_identity python3-openssl $depends"
 short_desc="Fake CA for testing"
 maintainer="Michal Vasilek <michal@vasilek.cz>"
 license="GPL-3.0-or-later"
 homepage="https://trustme.rtfd.io/"
+changelog="https://github.com/python-trio/trustme/blob/master/docs/source/index.rst#change-history"
 distfiles="https://github.com/python-trio/trustme/archive/refs/tags/v$version.tar.gz"
-checksum=e9f2544bcc39583a62b5d39d9f0ce3da8528ee448911035a679f7ddb1edeab5e
+checksum=2cdfdd50081cb959a20d4878b631e7174593e926b9f8b87f2d5cabc3ca21c1ab


### PR DESCRIPTION
some tests change cwd which causes relative tmpdir to point to a non-existent location, this PR also includes a trustme update which is affected by this

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

cc @ahesford @icp1994 

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
