### PR TITLE
python3: enable optimizations.

### DIFF
--- a/srcpkgs/python3-tkinter/template
+++ b/srcpkgs/python3-tkinter/template
@@ -9,9 +9,9 @@ _desc="Python programming language"
 
 pkgname=python3-tkinter
 version=3.11.4
-revision=1
+revision=2
 build_style="gnu-configure"
-configure_args="--enable-shared --enable-ipv6
+configure_args="--enable-shared --enable-ipv6 --enable-optimizations
  --enable-loadable-sqlite-extensions --with-computed-gotos
  --with-dbmliborder=gdbm:ndbm --with-system-expat --with-system-ffi
  --without-ensurepip"

--- a/srcpkgs/python3/template
+++ b/srcpkgs/python3/template
@@ -4,9 +4,9 @@
 #
 pkgname=python3
 version=3.11.4
-revision=1
+revision=2
 build_style="gnu-configure"
-configure_args="--enable-shared --enable-ipv6
+configure_args="--enable-shared --enable-ipv6 --enable-optimizations
  --enable-loadable-sqlite-extensions --with-computed-gotos
  --with-dbmliborder=gdbm:ndbm --with-system-expat --with-system-ffi
  --without-ensurepip ac_cv_working_tzset=yes"


### PR DESCRIPTION
This `--enable-optimizations` flag enables profile-guided optimizations (PGO) and link-time optimization (LTO, but apparently only sometimes, depending on the platform). My rudimentary benchmarking indicates that compared to python3 from the repos, python3 built from this PR yielded performance improvements of around 10%-12% (I tried building python3 from master locally, but that one had horrendous performance for some reason). I'm not a benchmarking expert though, so I wanted others to try out their own benchmarks and post their results here.

On my potato laptop, this change tripled build time from 5 minutes to 15 minutes. I don't think this is an issue however because changes to the python3 template are not done often (averaging once per month in the last 12 months), and the builders are much beefier than my laptop, so their build times will be even shorter anyway.

TODO:
- [ ] Is this also needed for `python3-tkinter`? (I don't think so, but better check)
- [ ] Are there similar performance improvements with cross builds? (PGO runs and profiles a Python that is compiled for the host architecture, which is why I want to confirm this)

#### Testing the changes
- I tested the changes in this PR: **YES** (only python3, not python3-tkinter)

@ahesford

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
