### PR TITLE
gtklock: update to 2.1.0

### DIFF
--- a/srcpkgs/gtklock/template
+++ b/srcpkgs/gtklock/template
@@ -1,6 +1,6 @@
 # Template file for 'gtklock'
 pkgname=gtklock
-version=2.0.1
+version=2.1.0
 revision=1
 build_style=gnu-makefile
 make_use_env=yes
@@ -11,7 +11,7 @@ maintainer="Jovan Lanik <jox969@gmail.com>"
 license="GPL-3.0-or-later"
 homepage="https://github.com/jovanlanik/gtklock"
 distfiles="https://github.com/jovanlanik/gtklock/archive/refs/tags/v${version}.tar.gz"
-checksum=d1802a7fcb8cace0408ab34627841d7ea28d630f934c8b7884536f9dfa76910e
+checksum=47cc09ab773e90e3a28240faaabb8d9ac4e36f5234a2b5c3a956039783365f43
 
 post_install() {
 	# copying CSS example provided


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
