### PR TITLE
New package: fiss-0.1.1

### DIFF
--- a/srcpkgs/fiss/template
+++ b/srcpkgs/fiss/template
@@ -7,18 +7,17 @@ maintainer="Friedel Schon <derfriedmundschoen@gmail.com>"
 license="Zlib"
 homepage="https://github.com/friedelschoen/fiss"
 distfiles="https://github.com/friedelschoen/fiss/archive/refs/tags/v$version.tar.gz"
-checksum=0a9f26445a9d379d3ee4d753ae932a298754756f5e1c64712fd5f1750ac40ee4
+checksum=3755f199d09d63b8f984d58d99cbc0c89c52a9037840c3cbd59c7f78fe3cfce2
+conflicts="runit runit-void"
 
 do_build() {
 	make all
-
-	rm -r etc/service.d/agetty-*
 }
 
 do_install() {
 	vlicense LICENSE
 
-	vcopy usr /
+	vcopy share /usr
 	vcopy etc /
 	vcopy bin /usr
 

--- a/srcpkgs/python3-trustme/template
+++ b/srcpkgs/python3-trustme/template
@@ -1,14 +1,15 @@
 # Template file for 'python3-trustme'
 pkgname=python3-trustme
-version=0.9.0
-revision=2
-build_style=python3-module
-hostmakedepends="python3-setuptools"
+version=1.0.0
+revision=1
+build_style=python3-pep517
+hostmakedepends="python3-setuptools python3-wheel"
 depends="python3-cryptography python3-idna"
 checkdepends="python3-pytest python3-service_identity python3-openssl $depends"
 short_desc="Fake CA for testing"
 maintainer="Michal Vasilek <michal@vasilek.cz>"
 license="GPL-3.0-or-later"
 homepage="https://trustme.rtfd.io/"
+changelog="https://github.com/python-trio/trustme/blob/master/docs/source/index.rst#change-history"
 distfiles="https://github.com/python-trio/trustme/archive/refs/tags/v$version.tar.gz"
-checksum=e9f2544bcc39583a62b5d39d9f0ce3da8528ee448911035a679f7ddb1edeab5e
+checksum=2cdfdd50081cb959a20d4878b631e7174593e926b9f8b87f2d5cabc3ca21c1ab


### PR DESCRIPTION
The old request did not cross-compile and conflicts with `runit`/`runit-void`
- above packages are added to `removes`
- cross-compiling still failed by stripping the binaries

Anyways:
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
#### Local build testing
- I built this PR locally for my native architecture, (x86_64-musl)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - only x86_64-* works, as cross-compile-strip will fail (unrecognized file-format)