### PR TITLE
X.org fonts: updated font versions and source URLs

### DIFF
--- a/srcpkgs/font-adobe-100dpi/template
+++ b/srcpkgs/font-adobe-100dpi/template
@@ -1,7 +1,7 @@
 # Template file for 'font-adobe-100dpi'
 pkgname=font-adobe-100dpi
-version=1.0.3
-revision=7
+version=1.0.4
+revision=1
 build_style=gnu-configure
 hostmakedepends="pkg-config bdftopcf font-util"
 makedepends="font-util"
@@ -10,8 +10,8 @@ short_desc="Standard 100dpi Adobe PCF fonts"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
 homepage="http://xorg.freedesktop.org/"
-distfiles="${XORG_SITE}/font/$pkgname-$version.tar.bz2"
-checksum=b2c08433eab5cb202470aa9f779efefce8d9cab2534f34f3aa4a31d05671c054
+distfiles="${XORG_SITE}/font/$pkgname-$version.tar.gz"
+checksum=f11f4776f53fa9663dce71b71978f3fde07a1fc87c6995623e30bf3c5d05a2a1
 font_dirs="/usr/share/fonts/X11/100dpi"
 
 post_install() {

--- a/srcpkgs/font-adobe-75dpi/template
+++ b/srcpkgs/font-adobe-75dpi/template
@@ -1,7 +1,7 @@
 # Template file for 'font-adobe-75dpi'
 pkgname=font-adobe-75dpi
-version=1.0.3
-revision=7
+version=1.0.4
+revision=1
 build_style=gnu-configure
 hostmakedepends="pkg-config bdftopcf font-util"
 makedepends="font-util"
@@ -10,8 +10,8 @@ short_desc="Standard 75pi Adobe PCF fonts"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
 homepage="http://xorg.freedesktop.org/"
-distfiles="${XORG_SITE}/font/$pkgname-$version.tar.bz2"
-checksum=c6024a1e4a1e65f413f994dd08b734efd393ce0a502eb465deb77b9a36db4d09
+distfiles="${XORG_SITE}/font/$pkgname-$version.tar.gz"
+checksum=6a2be7148406fc5df4f1b5258955418fdacb17ee19946613164517ff501c41c7
 font_dirs="/usr/share/fonts/X11/75dpi"
 
 post_install() {

--- a/srcpkgs/font-adobe-utopia-100dpi/template
+++ b/srcpkgs/font-adobe-utopia-100dpi/template
@@ -1,7 +1,7 @@
 # Template file for 'font-adobe-utopia-100dpi'
 pkgname=font-adobe-utopia-100dpi
-version=1.0.4
-revision=7
+version=1.0.5
+revision=1
 build_style=gnu-configure
 hostmakedepends="pkg-config bdftopcf font-util"
 makedepends="font-util"
@@ -10,8 +10,8 @@ short_desc="100dpi Adobe Utopia PCF fonts"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
 homepage="http://xorg.freedesktop.org/"
-distfiles="${XORG_SITE}/font/$pkgname-$version.tar.bz2"
-checksum=d16f5e3f227cc6dd07a160a71f443559682dbc35f1c056a5385085aaec4fada5
+distfiles="${XORG_SITE}/font/$pkgname-$version.tar.gz"
+checksum=1a67e926dc13e46181ad6106dc0cdc4d1767500865444709dc28e9262a640f4f
 font_dirs="/usr/share/fonts/X11/100dpi"
 
 post_install() {

--- a/srcpkgs/font-adobe-utopia-75dpi/template
+++ b/srcpkgs/font-adobe-utopia-75dpi/template
@@ -1,7 +1,7 @@
 # Template file for 'font-adobe-utopia-75dpi'
 pkgname=font-adobe-utopia-75dpi
-version=1.0.4
-revision=7
+version=1.0.5
+revision=1
 build_style=gnu-configure
 hostmakedepends="pkg-config bdftopcf font-util"
 makedepends="font-util"
@@ -10,8 +10,8 @@ short_desc="100dpi Adobe Utopia PCF fonts"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
 homepage="http://xorg.freedesktop.org/"
-distfiles="${XORG_SITE}/font/$pkgname-$version.tar.bz2"
-checksum=8732719c61f3661c8bad63804ebfd54fc7de21ab848e9a26a19b1778ef8b5c94
+distfiles="${XORG_SITE}/font/$pkgname-$version.tar.gz"
+checksum=92575acc11a3b2f8375de649605dcb00950b7b6f94373b48ef14b34cf81a808d
 font_dirs="/usr/share/fonts/X11/75dpi"
 
 post_install() {

--- a/srcpkgs/font-adobe-utopia-type1/template
+++ b/srcpkgs/font-adobe-utopia-type1/template
@@ -1,7 +1,7 @@
 # Template file for 'font-adobe-utopia-type1'
 pkgname=font-adobe-utopia-type1
-version=1.0.4
-revision=7
+version=1.0.5
+revision=1
 build_style=gnu-configure
 hostmakedepends="pkg-config bdftopcf font-util"
 makedepends="font-util"
@@ -10,8 +10,8 @@ short_desc="Adobe Utopia Type1 fonts"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
 homepage="http://xorg.freedesktop.org/"
-distfiles="${XORG_SITE}/font/$pkgname-$version.tar.bz2"
-checksum=979435105f897a70f8993fa02c8362160b0513366c2ab896965416f96dbb8077
+distfiles="${XORG_SITE}/font/$pkgname-$version.tar.gz"
+checksum=cd0b5acf8413d5a28afca6432c03ad0c9910fa707a38709bc9f235e9d7545e4d
 font_dirs="/usr/share/fonts/X11/Type1"
 
 post_install() {

--- a/srcpkgs/font-alias/template
+++ b/srcpkgs/font-alias/template
@@ -1,14 +1,14 @@
 # Template file for 'font-alias'
 pkgname=font-alias
-version=1.0.4
-revision=2
+version=1.0.5
+revision=1
 build_style=gnu-configure
 short_desc="Standard aliases for X11 PCF fonts"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
 homepage="http://xorg.freedesktop.org/"
-distfiles="${XORG_SITE}/font/$pkgname-$version.tar.bz2"
-checksum=f3111ae8bf2e980f5f56af400e8eefe5fc9f4207f4a412ea79637fd66c945276
+distfiles="${XORG_SITE}/font/$pkgname-$version.tar.gz"
+checksum=f8e0ca6537003f11fcaf36c598f7de9c0428f8ed587388a8a37ff18ccc597730
 
 post_install() {
 	vlicense COPYING

--- a/srcpkgs/font-bh-100dpi/template
+++ b/srcpkgs/font-bh-100dpi/template
@@ -1,18 +1,18 @@
 # Template file for 'font-bh-100dpi'
 pkgname=font-bh-100dpi
-version=1.0.3
-revision=6
+version=1.0.4
+revision=1
 build_style=gnu-configure
 hostmakedepends="pkg-config bdftopcf font-util"
 makedepends="font-util"
 depends="font-util"
-font_dirs="/usr/share/fonts/X11/100dpi"
 short_desc="Standard 100dpi Bigelow and Holmes PCF fonts"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
 homepage="http://xorg.freedesktop.org/"
-distfiles="${XORG_SITE}/font/$pkgname-$version.tar.bz2"
-checksum=23c07162708e4b79eb33095c8bfa62c783717a9431254bbf44863734ea239481
+distfiles="${XORG_SITE}/font/$pkgname-$version.tar.gz"
+checksum=cfd9b6bf6dae77eb7186afa296ad7233bb43d9c2f840d8010e197d55a2cc21dc
+font_dirs="/usr/share/fonts/X11/100dpi"
 
 post_install() {
 	vlicense COPYING

--- a/srcpkgs/font-bh-75dpi/template
+++ b/srcpkgs/font-bh-75dpi/template
@@ -1,18 +1,18 @@
 # Template file for 'font-bh-75dpi'
 pkgname=font-bh-75dpi
-version=1.0.3
-revision=6
+version=1.0.4
+revision=1
 build_style=gnu-configure
 hostmakedepends="pkg-config bdftopcf font-util"
 makedepends="font-util"
 depends="font-util"
-font_dirs="/usr/share/fonts/X11/75dpi"
 short_desc="Standard 75dpi Bigelow and Holmes PCF fonts"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
 homepage="http://xorg.freedesktop.org/"
-distfiles="${XORG_SITE}/font/$pkgname-$version.tar.bz2"
-checksum=3486aa51ac92c646a448fe899c5c3dae0024b1fef724d5100d52640d1cac721c
+distfiles="${XORG_SITE}/font/$pkgname-$version.tar.gz"
+checksum=1d1be5cfe1a929d440acc6132fd50312d982815ba284cd6504d8cf457ef853b6
+font_dirs="/usr/share/fonts/X11/75dpi"
 
 post_install() {
 	vlicense COPYING

--- a/srcpkgs/font-bh-lucidatypewriter-100dpi/template
+++ b/srcpkgs/font-bh-lucidatypewriter-100dpi/template
@@ -1,18 +1,18 @@
 # Template file for 'font-bh-lucidatypewriter-100dpi'
 pkgname=font-bh-lucidatypewriter-100dpi
-version=1.0.3
-revision=6
+version=1.0.4
+revision=1
 build_style=gnu-configure
 hostmakedepends="pkg-config bdftopcf font-util"
 makedepends="font-util"
 depends="font-util"
-font_dirs="/usr/share/fonts/X11/100dpi"
 short_desc="100dpi Bigelow and Holmes Lucida Typewriter PCF fonts"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
 homepage="http://xorg.freedesktop.org/"
-distfiles="${XORG_SITE}/font/$pkgname-$version.tar.bz2"
-checksum=62a83363c2536095fda49d260d21e0847675676e4e3415054064cbdffa641fbb
+distfiles="${XORG_SITE}/font/$pkgname-$version.tar.gz"
+checksum=28dbf07022e608ecca198dfee9455a33bf1efa1323936a853b894515fbb4992a
+font_dirs="/usr/share/fonts/X11/100dpi"
 
 post_install() {
 	vlicense COPYING

--- a/srcpkgs/font-bh-lucidatypewriter-75dpi/template
+++ b/srcpkgs/font-bh-lucidatypewriter-75dpi/template
@@ -1,18 +1,18 @@
 # Template file for 'font-bh-lucidatypewriter-75dpi'
 pkgname=font-bh-lucidatypewriter-75dpi
-version=1.0.3
-revision=6
+version=1.0.4
+revision=1
 build_style=gnu-configure
 hostmakedepends="pkg-config bdftopcf font-util"
 makedepends="font-util"
 depends="font-util"
-font_dirs="/usr/share/fonts/X11/75dpi"
 short_desc="75dpi Bigelow and Holmes Lucida Typewriter PCF fonts"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
 homepage="http://xorg.freedesktop.org/"
-distfiles="${XORG_SITE}/font/$pkgname-$version.tar.bz2"
-checksum=4ac16afbe205480cc5572e2977ea63488c543d05be0ea8e5a94c845a6eebcb31
+distfiles="${XORG_SITE}/font/$pkgname-$version.tar.gz"
+checksum=8e502a1a7e81c1b95f08725f40e7e137d4d06700794d006b327d54b7c8d07f88
+font_dirs="/usr/share/fonts/X11/75dpi"
 
 post_install() {
 	vlicense COPYING

--- a/srcpkgs/font-bh-ttf/template
+++ b/srcpkgs/font-bh-ttf/template
@@ -1,18 +1,18 @@
 # Template file for 'font-bh-ttf'
 pkgname=font-bh-ttf
-version=1.0.3
-revision=6
+version=1.0.4
+revision=1
 build_style=gnu-configure
 hostmakedepends="pkg-config bdftopcf font-util"
 makedepends="font-util"
 depends="font-util"
-font_dirs="/usr/share/fonts/X11/TTF"
 short_desc="Standard Bigelow and Holmes TrueType fonts"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
 homepage="http://xorg.freedesktop.org/"
-distfiles="${XORG_SITE}/font/$pkgname-$version.tar.bz2"
-checksum=1b4bea63271b4db0726b5b52c97994c3313b6023510349226908090501abd25f
+distfiles="${XORG_SITE}/font/$pkgname-$version.tar.gz"
+checksum=bf662d20107d60a964ade831b8ad575a58510e0f2fb9f67e8f064bbbeaae45b4
+font_dirs="/usr/share/fonts/X11/TTF"
 
 post_install() {
 	vlicense COPYING

--- a/srcpkgs/font-bh-type1/template
+++ b/srcpkgs/font-bh-type1/template
@@ -1,18 +1,18 @@
 # Template file for 'font-bh-type1'
 pkgname=font-bh-type1
-version=1.0.3
-revision=6
+version=1.0.4
+revision=1
 build_style=gnu-configure
 hostmakedepends="pkg-config bdftopcf font-util"
 makedepends="font-util"
 depends="font-util"
-font_dirs="/usr/share/fonts/X11/Type1"
 short_desc="Standard Bigelow and Holmes Type1 fonts"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
 homepage="http://xorg.freedesktop.org/"
-distfiles="${XORG_SITE}/font/$pkgname-$version.tar.bz2"
-checksum=761455a297486f3927a85d919b5c948d1d324181d4bea6c95d542504b68a63c1
+distfiles="${XORG_SITE}/font/$pkgname-$version.tar.gz"
+checksum=2ec07192aa73197958d65900c7048e8abd8fd00b187ea3d4871121a5c76aee99
+font_dirs="/usr/share/fonts/X11/Type1"
 
 post_install() {
 	vlicense COPYING

--- a/srcpkgs/font-bitstream-100dpi/template
+++ b/srcpkgs/font-bitstream-100dpi/template
@@ -1,18 +1,18 @@
 # Template file for 'font-bitstream-100dpi'
 pkgname=font-bitstream-100dpi
-version=1.0.3
-revision=6
+version=1.0.4
+revision=1
 build_style=gnu-configure
 hostmakedepends="pkg-config bdftopcf font-util"
 makedepends="font-util"
 depends="font-util"
-font_dirs="/usr/share/fonts/X11/100dpi"
 short_desc="Standard 100dpi Bitstream PCF fonts"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
 homepage="http://xorg.freedesktop.org/"
-distfiles="${XORG_SITE}/font/$pkgname-$version.tar.bz2"
-checksum=ebe0d7444e3d7c8da7642055ac2206f0190ee060700d99cd876f8fc9964cb6ce
+distfiles="${XORG_SITE}/font/$pkgname-$version.tar.gz"
+checksum=1d4b38aaf700b13c17c5d7c7816a1abe7edf8fcfd5b584fc619d42b13a10e751
+font_dirs="/usr/share/fonts/X11/100dpi"
 
 post_install() {
 	vlicense COPYING

--- a/srcpkgs/font-bitstream-75dpi/template
+++ b/srcpkgs/font-bitstream-75dpi/template
@@ -1,18 +1,18 @@
 # Template file for 'font-bitstream-75dpi'
 pkgname=font-bitstream-75dpi
-version=1.0.3
-revision=6
+version=1.0.4
+revision=1
 build_style=gnu-configure
 hostmakedepends="pkg-config bdftopcf font-util"
 makedepends="font-util"
 depends="font-util"
-font_dirs="/usr/share/fonts/X11/75dpi"
 short_desc="Standard 100dpi Bitstream PCF fonts"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
 homepage="http://xorg.freedesktop.org/"
-distfiles="${XORG_SITE}/font/$pkgname-$version.tar.bz2"
-checksum=ba3f5e4610c07bd5859881660753ec6d75d179f26fc967aa776dbb3d5d5cf48e
+distfiles="${XORG_SITE}/font/$pkgname-$version.tar.gz"
+checksum=4d48e8e02ee6434eb44afc228ac78aea70ba2f1bf7a635082c13662864e3d522
+font_dirs="/usr/share/fonts/X11/75dpi"
 
 post_install() {
 	vlicense COPYING

--- a/srcpkgs/font-bitstream-speedo/template
+++ b/srcpkgs/font-bitstream-speedo/template
@@ -9,8 +9,8 @@ short_desc="Standard Speedo Bitstream PCF fonts"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
 homepage="http://xorg.freedesktop.org/"
-distfiles="${XORG_SITE}/font/${pkgname}-${version}.tar.bz2"
-checksum=0708fe0046947b88c082b55844af8a861741dcdf087f0624bdf23fb773d76763
+distfiles="${XORG_SITE}/font/${pkgname}-${version}.tar.gz"
+checksum=aeea5f130480a3f05149bde13d240e668d8fb4b32c02b18914fcccd1182abe72
 
 font_dirs="/usr/share/fonts/X11/Speedo"
 

--- a/srcpkgs/font-bitstream-type1/template
+++ b/srcpkgs/font-bitstream-type1/template
@@ -6,13 +6,13 @@ build_style=gnu-configure
 hostmakedepends="pkg-config bdftopcf font-util"
 makedepends="font-util"
 depends="font-util"
-font_dirs="/usr/share/fonts/X11/Type1"
 short_desc="Standard Type1 Bitstream PCF fonts"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
 homepage="http://xorg.freedesktop.org/"
-distfiles="${XORG_SITE}/font/$pkgname-$version.tar.bz2"
-checksum=c6ea0569adad2c577f140328dc3302e729cb1b1ea90cd0025caf380625f8a688
+distfiles="${XORG_SITE}/font/$pkgname-$version.tar.gz"
+checksum=3399b7586c18be509cdaeceeebf754b861faa1d8799dda1aae01aeb2a7a30f01
+font_dirs="/usr/share/fonts/X11/Type1"
 
 post_install() {
 	vlicense COPYING

--- a/srcpkgs/font-cursor-misc/template
+++ b/srcpkgs/font-cursor-misc/template
@@ -1,18 +1,18 @@
 # Template file for 'font-cursor-misc'
 pkgname=font-cursor-misc
-version=1.0.3
-revision=6
+version=1.0.4
+revision=1
 build_style=gnu-configure
 hostmakedepends="pkg-config bdftopcf font-util"
 makedepends="font-util"
 depends="font-util"
-font_dirs="/usr/share/fonts/X11/misc"
 short_desc="Standard X11 cursors in PCF format"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
 homepage="http://xorg.freedesktop.org/"
-distfiles="${XORG_SITE}/font/$pkgname-$version.tar.bz2"
-checksum=17363eb35eece2e08144da5f060c70103b59d0972b4f4d77fd84c9a7a2dba635
+distfiles="${XORG_SITE}/font/$pkgname-$version.tar.gz"
+checksum=37ef2363b3cfa6f5e20b65feab736db77fad484127c267b78de95d55fa39f61d
+font_dirs="/usr/share/fonts/X11/misc"
 
 post_install() {
 	vlicense COPYING

--- a/srcpkgs/font-daewoo-misc/template
+++ b/srcpkgs/font-daewoo-misc/template
@@ -1,18 +1,18 @@
 # Template file for 'font-daewoo-misc'
 pkgname=font-daewoo-misc
-version=1.0.3
-revision=6
+version=1.0.4
+revision=1
 build_style=gnu-configure
 hostmakedepends="pkg-config bdftopcf font-util"
 makedepends="font-util"
 depends="font-util"
-font_dirs="/usr/share/fonts/X11/misc"
 short_desc="Daewoo Gothic PCF format"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
 homepage="http://xorg.freedesktop.org/"
-distfiles="${XORG_SITE}/font/$pkgname-$version.tar.bz2"
-checksum=bc65de70bee12698caa95b523d3b652c056347e17b68cc8b5d6bbdff235c4be8
+distfiles="${XORG_SITE}/font/$pkgname-$version.tar.gz"
+checksum=54d9c3778a676f1ad4e467d6cc6e4c596147a85ac2dd4cfee2ba0e893a6eaf59
+font_dirs="/usr/share/fonts/X11/misc"
 
 post_install() {
 	vlicense COPYING

--- a/srcpkgs/font-dec-misc/template
+++ b/srcpkgs/font-dec-misc/template
@@ -1,18 +1,18 @@
 # Template file for 'font-dec-misc'
 pkgname=font-dec-misc
-version=1.0.3
-revision=6
+version=1.0.4
+revision=1
 build_style=gnu-configure
 hostmakedepends="pkg-config bdftopcf font-util"
 makedepends="font-util"
 depends="font-util"
-font_dirs="/usr/share/fonts/X11/misc"
 short_desc="DEC cursor and session PCF fonts"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
 homepage="http://xorg.freedesktop.org/"
-distfiles="${XORG_SITE}/font/$pkgname-$version.tar.bz2"
-checksum=e19ddf8b5f8de914d81675358fdfe37762e9ce524887cc983adef34f2850ff7b
+distfiles="${XORG_SITE}/font/$pkgname-$version.tar.gz"
+checksum=a2273c3a06df0b6a61b56a82a06cd86a5721ac26251dab2e3f4173a4ce954729
+font_dirs="/usr/share/fonts/X11/misc"
 
 post_install() {
 	vlicense COPYING

--- a/srcpkgs/font-ibm-type1/template
+++ b/srcpkgs/font-ibm-type1/template
@@ -1,18 +1,19 @@
 # Template file for 'font-ibm-type1'
 pkgname=font-ibm-type1
-version=1.0.3
-revision=6
+version=1.0.4
+revision=1
 build_style=gnu-configure
 hostmakedepends="pkg-config bdftopcf font-util"
 makedepends="font-util"
 depends="font-util"
-font_dirs="/usr/share/fonts/X11/Type1"
 short_desc="IBM Courier Type1 fonts"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
 homepage="http://xorg.freedesktop.org/"
-distfiles="${XORG_SITE}/font/$pkgname-$version.tar.bz2"
-checksum=fddb28d3db5a07f4b4ca15388488a9680a10e1367a18f358f903b2a608a5d2df
+distfiles="${XORG_SITE}/font/$pkgname-$version.tar.gz"
+checksum=9129d73e3037709b03ea2bf61658ffa65e9a259a25b1df9a1e19c9ed8fcd1518
+font_dirs="/usr/share/fonts/X11/Type1"
+
 
 post_install() {
 	vlicense COPYING

--- a/srcpkgs/font-isas-misc/template
+++ b/srcpkgs/font-isas-misc/template
@@ -6,13 +6,13 @@ build_style=gnu-configure
 hostmakedepends="pkg-config bdftopcf font-util"
 makedepends="font-util"
 depends="font-util"
-font_dirs="/usr/share/fonts/X11/misc"
 short_desc="72dpi PCF versions of the Chinese Song Ti fonts"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
 homepage="http://xorg.freedesktop.org/"
-distfiles="${XORG_SITE}/font/$pkgname-$version.tar.bz2"
-checksum=5824ab4b485951107dd245b8f7717d2822f1a6dbf6cea98f1ac7f49905c0a867
+distfiles="${XORG_SITE}/font/$pkgname-$version.tar.gz"
+checksum=493965263070a5ee2a301dfdb2e87c1ca3c00c7882bfb3dd99368565ba558ff5
+font_dirs="/usr/share/fonts/X11/misc"
 
 post_install() {
 	vlicense COPYING

--- a/srcpkgs/font-jis-misc/template
+++ b/srcpkgs/font-jis-misc/template
@@ -10,9 +10,10 @@ short_desc="78dpi PCF versions of the Japanese fixed fonts"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
 homepage="http://xorg.freedesktop.org/"
-distfiles="${XORG_SITE}/font/$pkgname-$version.tar.bz2"
-checksum=2b18ce10b367ebafe95a17de799b6db9a24e2337188d124adaf68af05b1fac65
+distfiles="${XORG_SITE}/font/$pkgname-$version.tar.gz"
+checksum=57c2db8824865117287d57d47f2c8cf4b2842d036c7475534b5054be69690c73
 font_dirs="/usr/share/fonts/X11/misc"
+
 
 post_install() {
 	vlicense COPYING

--- a/srcpkgs/font-misc-misc/template
+++ b/srcpkgs/font-misc-misc/template
@@ -6,13 +6,13 @@ build_style=gnu-configure
 hostmakedepends="pkg-config bdftopcf font-util"
 makedepends="font-util"
 depends="font-util"
-font_dirs="/usr/share/fonts/X11/misc"
 short_desc="Standard X11 fixed PCF fonts"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
 homepage="http://xorg.freedesktop.org/"
-distfiles="${XORG_SITE}/font/$pkgname-$version.tar.bz2"
-checksum=b8e77940e4e1769dc47ef1805918d8c9be37c708735832a07204258bacc11794
+distfiles="${XORG_SITE}/font/$pkgname-$version.tar.gz"
+checksum=46142c876e176036c61c0c24c0a689079704d5ca5b510d48c025861ee2dbf829
+font_dirs="/usr/share/fonts/X11/misc"
 
 post_install() {
 	vlicense COPYING

--- a/srcpkgs/font-mutt-misc/template
+++ b/srcpkgs/font-mutt-misc/template
@@ -6,13 +6,13 @@ build_style=gnu-configure
 hostmakedepends="pkg-config bdftopcf font-util"
 makedepends="font-util"
 depends="font-util"
-font_dirs="/usr/share/fonts/X11/misc"
 short_desc="100dpi PCF versions of the ClearlyU fonts"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
 homepage="http://xorg.freedesktop.org/"
-distfiles="${XORG_SITE}/font/$pkgname-$version.tar.bz2"
-checksum=bd5f7adb34367c197773a9801df5bce7b019664941900b2a31fbfe1ff2830f8f
+distfiles="${XORG_SITE}/font/$pkgname-$version.tar.gz"
+checksum=fcecbfc475dfe5826d137f8edc623ba27d58d32f069165c248a013b3c566bb59
+font_dirs="/usr/share/fonts/X11/misc"
 
 post_install() {
 	vlicense COPYING


### PR DESCRIPTION
- updated various X.org fonts with minor version bump
 
- updated the URLS from bz2 to gz

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, x86_64
