### PR TITLE
coredns: update to 1.10.1.

### DIFF
--- a/srcpkgs/coredns/template
+++ b/srcpkgs/coredns/template
@@ -1,20 +1,22 @@
 # Template file for 'coredns'
 pkgname=coredns
-version=1.8.6
-revision=3
+version=1.10.1
+revision=1
 build_style=go
 go_import_path=github.com/coredns/coredns
-hostmakedepends="git make mmark"
+hostmakedepends="mmark"
 short_desc="CoreDNS is a DNS server that chains plugins"
 maintainer="Noel Cower <ncower@nil.dev>"
 license="Apache-2.0"
 homepage="https://coredns.io"
+changelog="https://github.com/coredns/coredns/releases"
 distfiles="https://github.com/coredns/coredns/archive/v${version}.tar.gz"
-checksum=cbe3764afe2148b8047ea7e5cbba5108c298dee3a9a0391028e2980e35beaa2b
+checksum=f47186452e5f2925e2c71135669afd9e03b9b55831417d33d612ef2fa69924a7
 make_dirs="/etc/coredns 0750 root root"
 
-_git_commit=f59c03d09c3a3a12f571ad1087b979325f3dae30
-go_ldflags+="-X github.com/coredns/coredns/coremain.GitCommit=${_git_commit}"
+# Update this on each version bump.
+_git_commit=055b2c31a9cf28321734e5f71613ea080d216cd3
+go_ldflags="-X github.com/coredns/coredns/coremain.GitCommit=${_git_commit}"
 
 post_build() {
 	make -f Makefile.doc MMARK="$(command -v mmark) -man" man/coredns.1 man/corefile.5 plugins


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->
There have been a bunch of security fixes since 1.8.6, so it's a good idea to get this in soon.

#### Testing the changes
- I tested the changes in this PR: **briefly**

@nilium

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
