### PR TITLE
Signal-Desktop: update to 6.17.0.

### DIFF
--- a/srcpkgs/Signal-Desktop/template
+++ b/srcpkgs/Signal-Desktop/template
@@ -1,11 +1,11 @@
 # Template file for 'Signal-Desktop'
 pkgname=Signal-Desktop
-version=6.16.0
+version=6.17.0
 revision=1
 # Signal officially only supports x86_64 
-# x86_64-musl could potentially based on the Alpine port:
+# x86_64-musl could potentially work based on the Alpine port:
 # https://git.alpinelinux.org/aports/tree/testing/signal-desktop
-# armv7hf/arm64: https://github.com/signalapp/Signal-Desktop/issues/3410
+# ARM: https://github.com/signalapp/Signal-Desktop/issues/3410
 archs="x86_64"
 hostmakedepends="git git-lfs nodejs python3 tar yarn"
 depends="cairo gtk+3 libvips pango"
@@ -14,7 +14,7 @@ maintainer="anelki <akierig@fastmail.de>"
 license="AGPL-3.0-only"
 homepage="https://github.com/signalapp/Signal-Desktop"
 distfiles="https://github.com/signalapp/Signal-Desktop/archive/v${version}.tar.gz"
-checksum=cfd68731007b41f72026a1cb32fb8f25c7131eb6e61edb0db4f9ebfd4878300c
+checksum=791aa4712cbf4072dc7498cb427a548809f28159b2b2a25cde80adea38b50a30
 nostrip_files="signal-desktop"
 
 post_extract() {


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64