### PR TITLE
hidapi: update to 0.13.1.

### DIFF
--- a/srcpkgs/hidapi/template
+++ b/srcpkgs/hidapi/template
@@ -1,22 +1,19 @@
 # Template file for 'hidapi'
 pkgname=hidapi
-version=0.11.2
+version=0.13.1
 revision=1
-build_style=gnu-configure
-hostmakedepends="automake libtool pkg-config"
+build_style=cmake
+hostmakedepends="pkg-config"
 makedepends="eudev-libudev-devel libusb-devel"
 short_desc="Simple library for communicating with USB and Bluetooth HID devices"
 maintainer="Ulf <void@uw.anonaddy.com>"
 license="BSD-3-Clause"
 homepage="https://github.com/libusb/hidapi"
-distfiles="https://github.com/libusb/hidapi/archive/hidapi-${version}.tar.gz"
-checksum=bc4ac0f32a6b21ef96258a7554c116152e2272dacdec1e4620fc44abeea50c27
+changelog="https://github.com/libusb/hidapi/releases"
+distfiles="https://github.com/libusb/hidapi/archive/refs/tags/hidapi-${version}.tar.gz"
+checksum=476a2c9a4dc7d1fc97dd223b84338dbea3809a84caea2dcd887d9778725490e3
 
-pre_configure() {
-	./bootstrap
-}
 post_install() {
-	rm -r ${DESTDIR}/usr/share
 	vlicense LICENSE-bsd.txt LICENSE
 }
 
@@ -25,8 +22,8 @@ hidapi-devel_package() {
 	depends="${makedepends} ${sourcepkg}>=${version}_${revision}"
 	pkg_install() {
 		vmove usr/include
-		vmove usr/lib/*.a
 		vmove usr/lib/*.so
 		vmove usr/lib/pkgconfig
+		vmove usr/lib/cmake
 	}
 }


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-musl
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - armv6l-musl

The autotools build method is deprecated upstream, cmake is recommended instead
