### PR TITLE
python3-sympy: update to 1.12.

### DIFF
--- a/srcpkgs/python3-sympy/template
+++ b/srcpkgs/python3-sympy/template
@@ -1,7 +1,7 @@
 # Template file for 'python3-sympy'
 pkgname=python3-sympy
-version=1.11.1
-revision=2
+version=1.12
+revision=1
 build_style=python3-module
 hostmakedepends="python3-setuptools"
 depends="python3-mpmath"
@@ -12,7 +12,7 @@ license="BSD-3-Clause"
 homepage="https://sympy.org/"
 changelog="https://github.com/sympy/sympy/wiki/Release-Notes"
 distfiles="${PYPI_SITE}/s/sympy/sympy-${version}.tar.gz"
-checksum=e32380dce63cb7c0108ed525570092fd45168bdae2faa17e528221ef72e88658
+checksum=ebf595c8dac3e0fdc4152c51878b498396ec7f30e7a914d6071e674d49420fb8
 
 post_install() {
 	vman doc/man/isympy.1


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

Works fine with sagemath. A few tests need to be fixed as in https://github.com/sagemath/sage/pull/35635 but it's all cosmetic, nothing critical, so this can be merged just fine. We will fix those dooctests when the next release of sagemath is ready (10.0, prerelease in #43659).

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
