### PR TITLE
Signal-Desktop: update to 6.17.1.

### DIFF
--- a/srcpkgs/Signal-Desktop/template
+++ b/srcpkgs/Signal-Desktop/template
@@ -1,6 +1,6 @@
 # Template file for 'Signal-Desktop'
 pkgname=Signal-Desktop
-version=6.17.0
+version=6.17.1
 revision=1
 # Signal officially only supports x86_64 
 # x86_64-musl could potentially work based on the Alpine port:
@@ -14,7 +14,7 @@ maintainer="anelki <akierig@fastmail.de>"
 license="AGPL-3.0-only"
 homepage="https://github.com/signalapp/Signal-Desktop"
 distfiles="https://github.com/signalapp/Signal-Desktop/archive/v${version}.tar.gz"
-checksum=791aa4712cbf4072dc7498cb427a548809f28159b2b2a25cde80adea38b50a30
+checksum=37625d977bbf0e64494662e4d9cd45fa7ff04cca68f7ea53a3e13d7b23cc7fdd
 nostrip_files="signal-desktop"
 
 post_extract() {


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64
