### PR TITLE
xbps-triggers: exit kernel hook on error

### DIFF
--- a/srcpkgs/xbps-triggers/files/kernel-hooks
+++ b/srcpkgs/xbps-triggers/files/kernel-hooks
@@ -38,11 +38,10 @@ run)
 
 		# A package may export "kernel_hooks_version" as a hint
 		# to pass this version to the hooks.
-		if [ -n "${kernel_hooks_version}" ]; then
-			env ROOTDIR="." ${_file_} ${PKGNAME} ${kernel_hooks_version}
-		else
-			env ROOTDIR="." ${_file_} ${PKGNAME} ${VERSION}
+		if [ -z "${kernel_hooks_version}" ]; then
+			kernel_hooks_version="${VERSION}"
 		fi
+		env ROOTDIR="." ${_file_} ${PKGNAME} ${kernel_hooks_version} || exit 1
 	done
 	;;
 *)

--- a/srcpkgs/xbps-triggers/template
+++ b/srcpkgs/xbps-triggers/template
@@ -1,7 +1,7 @@
 # Template file for 'xbps-triggers'
 pkgname=xbps-triggers
 version=0.124
-revision=1
+revision=2
 bootstrap=yes
 short_desc="XBPS triggers for Void Linux"
 maintainer="Enno Boland <gottox@voidlinux.org>"


### PR DESCRIPTION
Exit kernel-hook scripts with error in case of error in hook.

Close: #42047

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)

