### PR TITLE
python3-cvxopt: update to 1.3.1.

### DIFF
--- a/srcpkgs/python3-cvxopt/template
+++ b/srcpkgs/python3-cvxopt/template
@@ -1,7 +1,7 @@
 # Template file for 'python3-cvxopt'
 pkgname=python3-cvxopt
-version=1.3.0
-revision=4
+version=1.3.1
+revision=1
 build_style=python3-module
 hostmakedepends="python3-setuptools"
 makedepends="python3-devel SuiteSparse-devel gsl-devel glpk-devel fftw-devel
@@ -12,8 +12,9 @@ short_desc="Python software for convex optimization"
 maintainer="Gonzalo Tornaría <tornaria@cmat.edu.uy>"
 license="GPL-3.0-or-later"
 homepage="http://cvxopt.org/"
+changelog="https://github.com/cvxopt/cvxopt/releases"
 distfiles="${PYPI_SITE}/c/cvxopt/cvxopt-${version}.tar.gz"
-checksum=00b1b232f9d1f902d578a9d75814b67fa020758d5ae422e28ca8cef6269fa5c6
+checksum=8d567981cbfa2a4ba1667b3e6f73cb941cf1c6992bf1438911035963294aa498
 
 build_options="openblas"
 


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly** (tested with sagemath 9.8 and 10.0.rc2)

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
