### PR TITLE
New package: autorestic-1.7.7

### DIFF
--- a/srcpkgs/autorestic/template
+++ b/srcpkgs/autorestic/template
@@ -1,0 +1,14 @@
+# Template file for 'autorestic'
+pkgname=autorestic
+version=1.7.7
+revision=1
+build_style=go
+go_import_path="github.com/cupcakearmy/autorestic"
+depends="restic"
+short_desc="Config driven, easy backup cli for restic"
+maintainer="Emil Miler <em@0x45.cz>"
+license="Apache-2.0"
+homepage="https://autorestic.vercel.app/"
+changelog="https://github.com/cupcakearmy/autorestic/blob/master/CHANGELOG.md"
+distfiles="https://github.com/cupcakearmy/autorestic/archive/refs/tags/v${version}.tar.gz"
+checksum=f2c38729882e7d0529347ab115e7ce068f6062677a63c92eb4bd0efc1ae67cbb


### PR DESCRIPTION
[Autorestic](https://github.com/cupcakearmy/autorestic) is a wrapper for [restic](https://restic.net/) similar to what [borgmatic](https://torsion.org/borgmatic/) is for [borg](https://www.borgbackup.org/).

#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)
- I built this PR locally for these architectures:
  - x86_64-musl
