### PR TITLE
bash-language-server: update to 4.9.2.

### DIFF
--- a/srcpkgs/bash-language-server/template
+++ b/srcpkgs/bash-language-server/template
@@ -1,6 +1,6 @@
 # Template file for 'bash-language-server'
 pkgname=bash-language-server
-version=4.9.1
+version=4.9.2
 revision=1
 hostmakedepends="jq yarn"
 depends="nodejs"
@@ -9,10 +9,10 @@ maintainer="sirkhancision <jsantiago12tone@gmail.com>"
 license="MIT"
 homepage="https://github.com/bash-lsp/bash-language-server"
 distfiles="https://github.com/bash-lsp/bash-language-server/archive/refs/tags/server-${version}.tar.gz"
-checksum=eef93c1167394fb01fc300c5b8c326fd9362dd3118a1e075549342e24e9d6e5c
+checksum=7d162baf072ba8807f4253d7fdbe7210507e5b0106e94cc0373668dd40a25fee
 
 do_build() {
-	yarn
+	yarn install
 	yarn run compile
 }
 


### PR DESCRIPTION
- I tested the changes in this PR: **YES**

- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures:
  - aarch64
