### PR TITLE
obconf: move to gtk3

### DIFF
--- a/srcpkgs/obconf/template
+++ b/srcpkgs/obconf/template
@@ -1,14 +1,35 @@
 # Template file for 'obconf'
 pkgname=obconf
 version=2.0.4
-revision=6
+revision=7
+_patch_commit=77fdc7a76e9b9e0ac5513af7f9cee0a33199f9a9
+build_wrksrc="${pkgname}-${version}"
 build_style=gnu-configure
-hostmakedepends="pkg-config tar"
-makedepends="gtk+-devel libglade-devel libSM-devel imlib2-devel openbox-devel startup-notification-devel"
+hostmakedepends="pkg-config tar automake autoconf gettext-devel-tools"
+makedepends="gtk+3-devel libSM-devel imlib2-devel openbox-devel startup-notification-devel"
 depends="desktop-file-utils shared-mime-info"
-short_desc="A GTK2 based configuration tool for the Openbox windowmanager"
+short_desc="GTK-based configuration tool for the Openbox windowmanager"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="http://openbox.org/wiki/ObConf:About"
-distfiles="http://openbox.org/dist/obconf/obconf-${version}.tar.gz"
-checksum=71a3e5f4ee246a27421ba85044f09d449f8de22680944ece9c471cd46a9356b9
+distfiles="http://openbox.org/dist/obconf/obconf-${version}.tar.gz
+ https://raw.githubusercontent.com/archlinux/svntogit-community/${_patch_commit}/trunk/stop-using-libglade.patch>stop-using-libglade-${_patch_commit}.patch
+ https://raw.githubusercontent.com/archlinux/svntogit-community/${_patch_commit}/trunk/switch-to-gtk3.patch>switch-to-gtk3-${_patch_commit}.patch"
+checksum="71a3e5f4ee246a27421ba85044f09d449f8de22680944ece9c471cd46a9356b9
+ 2b1fcb0ca2b85b90a45fc667d061852172aa9f27a35b263ecc9a7ffcc8c5b026
+ f1bcd1720e35ef2c8b9f8ad0a202a150d9affe116779d3ceb9b569a0ed32b010"
+
+post_extract() {
+	mv *.patch "${build_wrksrc}"
+}
+
+post_patch() {
+	for p in stop-using-libglade switch-to-gtk3; do
+		msg_normal "${pkgname}-${version}_${revision}: patching: ${p}-${_patch_commit}.patch.\n"
+		patch -s -Np1 < "${p}-${_patch_commit}.patch"
+	done
+}
+
+pre_configure() {
+	autoreconf -fi
+}


### PR DESCRIPTION
patches are downloaded directly from the source because they are so large.

closes #40398
progress on libglade removal (for #38229) and gtk2 removal

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **NO** (I don't run openbox)

