### PR TITLE
go: update to 1.20.4.

### DIFF
--- a/srcpkgs/go/template
+++ b/srcpkgs/go/template
@@ -1,6 +1,6 @@
 # Template file for 'go'
 pkgname=go
-version=1.20.3
+version=1.20.4
 revision=1
 create_wrksrc=yes
 build_wrksrc=go
@@ -12,7 +12,7 @@ license="BSD-3-Clause"
 homepage="https://go.dev/"
 changelog="https://go.dev/doc/devel/release.html"
 distfiles="https://go.dev/dl/go${version}.src.tar.gz"
-checksum=e447b498cde50215c4f7619e5124b0fc4e25fb5d16ea47271c47f278e7aa763a
+checksum=9f34ace128764b7a3a4b238b805856cc1b2184304df9e5690825b0710f4202d6
 nostrip=yes
 noverifyrdeps=yes
 # on CI it tries to use `git submodule`, which is not part of chroot-git


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64

This version update has 3 security fixes for go:
 - https://github.com/golang/go/issues/59720 - CVE-2023-24539
 - https://github.com/golang/go/issues/59721 - CVE-2023-24540
 - https://github.com/golang/go/issues/59722 - CVE-2023-29400