### PR TITLE
python3: force sem_gevalue for all cross arches

### DIFF
--- a/srcpkgs/python3/template
+++ b/srcpkgs/python3/template
@@ -4,7 +4,7 @@
 #
 pkgname=python3
 version=3.11.3
-revision=1
+revision=2
 build_style="gnu-configure"
 configure_args="--enable-shared --enable-ipv6
  --enable-loadable-sqlite-extensions --with-computed-gotos
@@ -39,6 +39,7 @@ alternatives="
 if [ "$CROSS_BUILD" ]; then
 	hostmakedepends+=" python3"
 	configure_args+=" --with-build-python=python3.11"
+	configure_args+=" ac_cv_broken_sem_getvalue=no"
 fi
 
 post_extract() {


### PR DESCRIPTION
- I tested the changes in this PR: yes
- I built this PR locally for my native architecture, (aarch64)

As discussed in https://github.com/void-linux/void-packages/pull/43659 this is checked by compiling and running a program that won't work in cross, but we know `sem_gevalue` is ok at least on `aarch64` (to be more conservative, I could also only enable it there, rather than all arches).

cc @ahesford 