### PR TITLE
New package: juliaup-1.8.16

### DIFF
--- a/srcpkgs/juliaup/template
+++ b/srcpkgs/juliaup/template
@@ -1,0 +1,21 @@
+# Template file for 'juliaup'
+pkgname=juliaup
+version=1.8.16
+revision=1
+archs="x86_64* i686 aarch64"
+build_style=cargo
+short_desc="Julia installer and version multiplexer"
+maintainer="Bryce Vandegrift <bryce@brycevandegrift.xyz>"
+license="MIT"
+homepage="https://github.com/JuliaLang/juliaup"
+distfiles="https://github.com/JuliaLang/juliaup/archive/refs/tags/v${version}.tar.gz"
+checksum=99b0d62b589c8a330fffaa2252b8e4251124bfd59077f0789a6a456d3b1ae81a
+
+if [ "$XBPS_TARGET_MACHINE" = x86_64-musl ]; then
+	# command_add test fails, doesn't seem to be able to launch the downloaded julia in the test
+	make_check=no
+fi
+
+post_install() {
+	vlicense LICENSE
+}


### PR DESCRIPTION
This package should allow Julia to be installed since it was [removed](https://github.com/void-linux/void-packages/pull/39919).
Package only supports x86_64, i686, and aarch64

#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl (crossbuild)
  - i686-glibc (crossbuild)
  - aarch64-glibc (crossbuild)