### PR TITLE
python3-cryptography: update to 41.0.0.

### DIFF
--- a/srcpkgs/python3-PyJWT/template
+++ b/srcpkgs/python3-PyJWT/template
@@ -1,7 +1,7 @@
 # Template file for 'python3-PyJWT'
 pkgname=python3-PyJWT
-version=2.1.0
-revision=3
+version=2.7.0
+revision=1
 build_style=python3-module
 hostmakedepends="python3-setuptools"
 depends="python3-cryptography"
@@ -11,7 +11,7 @@ maintainer="fosslinux <fosslinux@aussies.space>"
 license="MIT"
 homepage="https://pyjwt.readthedocs.io/"
 distfiles="https://github.com/jpadilla/pyjwt/archive/${version}.tar.gz"
-checksum=054d212924baff4052fc587d71b8d489082e675c22d86a035a133b119e79bb29
+checksum=9a4e2843c027dc4ee0c0b514e3b21b7549b40b75fd8f50351f6b6e9ab2807f40
 
 post_install() {
 	vlicense LICENSE

--- a/srcpkgs/python3-cryptography/template
+++ b/srcpkgs/python3-cryptography/template
@@ -1,23 +1,23 @@
 # Template file for 'python3-cryptography'
 pkgname=python3-cryptography
-version=39.0.2
+version=41.0.0
 revision=1
 build_style=python3-module
 build_helper="rust"
 make_check_args="--ignore tests/bench/test_x509.py --ignore tests/bench/test_aead.py"
-hostmakedepends="python3-setuptools-rust python3-cffi cargo"
+hostmakedepends="python3-setuptools-rust python3-cffi cargo pkg-config"
 makedepends="python3-devel openssl-devel"
 depends="python3-cffi"
 checkdepends="python3-pytest-subtests python3-pytest-xdist
  python3-iso8601 python3-pytz python3-cryptography_vectors
- python3-pretend python3-hypothesis $depends"
+ python3-pretend python3-hypothesis python3-pytest-benchmark $depends"
 short_desc="Python3 library that provides cryptographic recipes and primitives"
 maintainer="Andrew J. Hesford <ajh@sideband.org>"
 license="BSD-3-Clause, Apache-2.0"
 homepage="https://github.com/pyca/cryptography"
 changelog="https://raw.githubusercontent.com/pyca/cryptography/master/CHANGELOG.rst"
 distfiles="${PYPI_SITE}/c/cryptography/cryptography-${version}.tar.gz"
-checksum=bc5b871e977c8ee5a1bbc42fa8d19bcc08baf0c51cbf1586b0e87a2694dde42f
+checksum=6b71f64beeea341c9b4f963b48ee3b62d62d57ba93eb120e1196b31dc1025e78
 
 if [ "$CROSS_BUILD" ]; then
 	makedepends+=" rust-std"

--- a/srcpkgs/python3-cryptography_vectors/template
+++ b/srcpkgs/python3-cryptography_vectors/template
@@ -1,16 +1,16 @@
 # Template file for 'python3-cryptography_vectors'
 pkgname=python3-cryptography_vectors
-version=39.0.2
+version=41.0.0
 revision=1
-build_style=python3-module
-hostmakedepends="python3-setuptools"
+build_style=python3-pep517
+hostmakedepends="python3-setuptools python3-wheel"
 depends="python3"
 short_desc="Test vectors for python3-cryptography"
 maintainer="Andrew J. Hesford <ajh@sideband.org>"
 license="BSD-3-Clause, Apache-2.0"
 homepage="https://github.com/pyca/cryptography"
 distfiles="${PYPI_SITE}/c/cryptography_vectors/cryptography_vectors-${version}.tar.gz"
-checksum=a68f106f7a4322cf1e7ed51e3fc6d5c1e0b11d337ed918ec879e8afe0c2a5220
+checksum=7c77787f6f1e3065aed0af9b0113d3736f2d0a80e0ed1ddbd296cf5ac638df00
 
 post_install() {
 	vlicense LICENSE

--- a/srcpkgs/python3-fido2/template
+++ b/srcpkgs/python3-fido2/template
@@ -1,10 +1,10 @@
 # Template file for 'python3-fido2'
 pkgname=python3-fido2
 _pkgname=fido2
-version=1.1.0
+version=1.1.1
 revision=1
-build_style=python3-module
-hostmakedepends="python3-setuptools"
+build_style=python3-pep517
+hostmakedepends="python3-poetry-core"
 depends="python3-six python3-cryptography python3-pyscard"
 # Missing fakefs will be pulled from pypi
 checkdepends="$depends python3-mock python3-pytest"
@@ -13,12 +13,7 @@ maintainer="Đoàn Trần Công Danh <congdanhqx@gmail.com>"
 license="BSD-2-Clause"
 homepage="https://github.com/Yubico/python-fido2"
 distfiles="${PYPI_SITE}/f/${_pkgname}/${_pkgname}-${version}.tar.gz"
-checksum=2b4b4e620c2100442c20678e0e951ad6d1efb3ba5ca8ebb720c4c8d543293674
-
-post_extract() {
-	# pytest mis-recognises this file as a test case
-	rm -f examples/test_config.py
-}
+checksum=5dc495ca8c59c1c337383b4b8c314d46b92d5c6fc650e71984c6d7f954079fc3
 
 post_install() {
 	vlicense COPYING

--- a/srcpkgs/python3-ntlm-auth/template
+++ b/srcpkgs/python3-ntlm-auth/template
@@ -5,6 +5,7 @@ revision=4
 build_style=python3-module
 hostmakedepends="python3-setuptools"
 depends="python3 python3-six python3-cryptography"
+checkdepends="python3-pytest python3-requests $depends"
 short_desc="Creates NTLM authentication structures"
 maintainer="Leah Neukirchen <leah@vuxu.org>"
 license="MIT"

--- a/srcpkgs/python3-openssl/template
+++ b/srcpkgs/python3-openssl/template
@@ -1,6 +1,6 @@
 # Template file for 'python3-openssl'
 pkgname=python3-openssl
-version=23.1.1
+version=23.2.0
 revision=1
 build_style=python3-module
 hostmakedepends="python3-setuptools"
@@ -12,7 +12,7 @@ license="Apache-2.0"
 homepage="https://pyopenssl.org/"
 changelog="https://raw.githubusercontent.com/pyca/pyopenssl/master/CHANGELOG.rst"
 distfiles="${PYPI_SITE}/p/pyOpenSSL/pyOpenSSL-${version}.tar.gz"
-checksum=841498b9bec61623b1b6c47ebbc02367c07d60e0e195f19790817f10cc8db0b7
+checksum=276f931f55a452e7dea69c7173e984eb2a4407ce413c918aa34b55f82f9b8bac
 
 if [ "$XBPS_TARGET_WORDSIZE" = "32" ]; then
 	# https://github.com/pyca/pyopenssl/issues/974

--- a/srcpkgs/yubikey-manager/template
+++ b/srcpkgs/yubikey-manager/template
@@ -1,9 +1,9 @@
 # Template file for 'yubikey-manager'
 pkgname=yubikey-manager
-version=5.0.0
+version=5.1.1
 revision=1
-build_style=python3-module
-hostmakedepends="python3-setuptools"
+build_style=python3-pep517
+hostmakedepends="python3-poetry-core"
 depends="libfido2 python3-click python3-fido2 python3-cryptography
  python3-setuptools python3-keyring python3-pyscard"
 checkdepends="$depends python3-pytest python3-makefun"
@@ -12,7 +12,7 @@ maintainer="Đoàn Trần Công Danh <congdanhqx@gmail.com>"
 license="BSD-2-Clause"
 homepage="https://developers.yubico.com/yubikey-manager/"
 distfiles="https://developers.yubico.com/yubikey-manager/Releases/${pkgname/-/_}-${version}.tar.gz"
-checksum=c741747200ced1b5803dfdef6718b07a41e109ccb03dd7b72d3a307a3fb33bb5
+checksum=6487db976d8b5b52965db55d084f9d2aef2b96f77da785dc13f6dfdd3302aace
 
 post_install() {
 	vman man/ykman.1


### PR DESCRIPTION
#### Testing the changes
The major version bump might break some version restrictions. The following dependants need to be checked and, when necessary, updated or patched for compatibility:
- [x] Electron-Cash-4.2.10_3
- [x] Uranium-4.13.1_2
- [x] ansible-core-2.14.4_1
- [x] buku-4.8_1
- [x] certbot-1.31.0_2
- [x] electrum-4.2.0_3
- [x] esptool-4.5.1_1
- [x] gajim-omemo-2.9.0_1
- [x] jrnl-3.3_1
- [ ] mitmproxy-9.0.1_1
- [x] pass-import-3.4_1
- [x] python3-PGPy-0.6.0_1
- [x] python3-PyFxA-0.7.3_5
- [x] python3-PyJWT-2.1.0_3
- [x] python3-SecretStorage-3.3.1_3
- [x] python3-acme-1.31.0_2
- [x] python3-autobahn-23.1.2_1
- [x] python3-axolotl-0.2.3_6
- [x] python3-etesync-0.12.1_4
- [x] python3-fido2-1.1.0_1
- [x] python3-josepy-1.13.0_2
- [x] python3-msoffcrypto-tool-5.0.1_1
- [x] python3-ntlm-auth-1.5.0_4
- [x] python3-opcua-0.98.13_3
- [x] python3-openssl-23.0.0_1
- [x] python3-paramiko-2.11.0_3
- [x] python3-pdfminer.six-20221105_1
- [x] python3-ripe-atlas-sagan-1.3.0_6
- [x] python3-saml2-7.4.1_1
- [x] python3-service_identity-18.1.0_7
- [x] python3-stem-1.8.1_2
- [x] python3-trustme-1.0.0_1
- [x] python3-txtorcon-22.0.0_1
- [ ] sabnzbd-3.7.1_1
- [x] synapse-1.82.0_1
- [x] yubikey-manager-5.0.0_1