### PR TITLE
rustypaste: update to 0.9.0.

### DIFF
--- a/srcpkgs/rustypaste/template
+++ b/srcpkgs/rustypaste/template
@@ -1,6 +1,6 @@
-# Template file for 'rustypaste' 
+# Template file for 'rustypaste'
 pkgname=rustypaste
-version=0.8.4
+version=0.9.0
 revision=1
 build_style=cargo
 make_check_args="-- --test-threads 1"
@@ -12,7 +12,7 @@ license="MIT"
 homepage="https://github.com/orhun/rustypaste"
 changelog="https://raw.githubusercontent.com/orhun/rustypaste/master/CHANGELOG.md"
 distfiles="https://github.com/orhun/rustypaste/archive/refs/tags/v${version}.tar.gz"
-checksum=ccdfa0ae412f25b3ea8e3756ff8d8c0ecfee1332b3bc2e584899914056ed2e2d
+checksum=16197a881ae0f1fd32d90956b656d82429a1bb111c918837487eef943a14fd76
 conf_files="/etc/rustypaste/config.toml"
 
 system_accounts="_rustypaste"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-musl
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - armv6l-musl
