### PR TITLE
helix: update to 23.05

### DIFF
--- a/srcpkgs/helix/patches/skip_grammar_fetch.patch
+++ b/srcpkgs/helix/patches/skip_grammar_fetch.patch
@@ -1,0 +1,13 @@
+diff --git a/helix-term/build.rs b/helix-term/build.rs
+index b47dae8..96c7b30 100644
+--- a/helix-term/build.rs
++++ b/helix-term/build.rs
+@@ -2,7 +2,7 @@
+ 
+ fn main() {
+     if std::env::var("HELIX_DISABLE_AUTO_GRAMMAR_BUILD").is_err() {
+-        fetch_grammars().expect("Failed to fetch tree-sitter grammars");
++        // fetch_grammars().expect("Failed to fetch tree-sitter grammars");
+         build_grammars(Some(std::env::var("TARGET").unwrap()))
+             .expect("Failed to compile tree-sitter grammars");
+     }

--- a/srcpkgs/helix/template
+++ b/srcpkgs/helix/template
@@ -1,6 +1,6 @@
 # Template file for 'helix'
 pkgname=helix
-version=23.03
+version=23.05
 revision=1
 build_style=cargo
 make_install_args="--path helix-term"
@@ -10,7 +10,7 @@ license="MPL-2.0"
 homepage="https://helix-editor.com/"
 changelog="https://raw.githubusercontent.com/helix-editor/helix/master/CHANGELOG.md"
 distfiles="https://github.com/helix-editor/helix/releases/download/${version}/helix-${version}-source.tar.xz"
-checksum=60e5d8927f2f43807ff4ed3c96e7071746ce23d0b7ebaa27e380723726710703
+checksum=c1ca69facde99d708175c686ce5bf3585e119e372c83e1c3dc1d562c7a8e3d87
 
 case "$XBPS_TARGET_MACHINE" in
 	ppc64*) ;;


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
