### PR TITLE
common/xbps-src/shutils/update_check.sh: fix url for gitlab

### DIFF
--- a/common/xbps-src/shutils/update_check.sh
+++ b/common/xbps-src/shutils/update_check.sh
@@ -136,7 +136,7 @@ update_check() {
                     */-/*) pkgurlname="$(printf %s "$url" | sed -e 's%/-/.*%%g; s%/$%%')";;
                     *) pkgurlname="$(printf %s "$url" | cut -d / -f 1-5)";;
                 esac
-                url="$pkgurlname/tags"
+                url="$pkgurlname/-/tags"
                 rx='/archive/[^/]+/\Q'"$pkgname"'\E-v?\K[\d.]+(?=\.tar\.gz")';;
             *bitbucket.org*)
                 pkgurlname="$(printf %s "$url" | cut -d/ -f4,5)"

--- a/srcpkgs/goimapnotify/update
+++ b/srcpkgs/goimapnotify/update
@@ -1,2 +1,0 @@
-site="https://gitlab.com/shackra/goimapnotify/-/tags/"
-pattern="goimapnotify-\K[\d.]*(?=\.tar\.gz)"

--- a/srcpkgs/megapixels/update
+++ b/srcpkgs/megapixels/update
@@ -1,1 +1,0 @@
-site="https://gitlab.com/postmarketOS/megapixels/-/tags"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

All update checks which only rely on Gitlab are currently broken. The `code.videolan.org` counterpart also works with this change.