### PR TITLE
common/build-style/python3-pep517.sh: ignore tests in temp destdir

### DIFF
--- a/common/build-style/python3-pep517.sh
+++ b/common/build-style/python3-pep517.sh
@@ -19,7 +19,7 @@ do_check() {
 		testjobs="-n $XBPS_MAKEJOBS"
 	fi
 
-	local testdir="${wrksrc}/tmp/$(date +%s)"
+	local testdir="${wrksrc}/.xbps-testdir/$(date +%s)"
 	python3 -m installer --destdir "${testdir}" \
 		${make_install_args} ${make_install_target:-dist/*.whl}
 

--- a/srcpkgs/python3-colorama/template
+++ b/srcpkgs/python3-colorama/template
@@ -1,18 +1,20 @@
 # Template file for 'python3-colorama'
 pkgname=python3-colorama
-version=0.4.5
-revision=2
-build_style=python3-module
-hostmakedepends="unzip python3-setuptools"
+version=0.4.6
+revision=1
+build_style=python3-pep517
+hostmakedepends="hatchling"
 depends="python3"
+checkdepends="python3-pytest"
 short_desc="Cross-platform colored terminal text (Python3)"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="BSD-3-Clause"
 homepage="https://github.com/tartley/colorama"
 changelog="https://github.com/tartley/colorama/raw/master/CHANGELOG.rst"
 distfiles="${PYPI_SITE}/c/colorama/colorama-${version}.tar.gz"
-checksum=e6c6b4334fc50988a639d9b98aa429a0b57da6e17b9a44f0451f930b6967b7a4
+checksum=08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44
 
 post_install() {
 	vlicense LICENSE.txt
+	rm -r ${DESTDIR}/${py3_sitelib}/colorama/tests
 }


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

An edge case I came across today. On rare cases, packages include tests in their built wheel. While testing with these wheels extracted in a temporary directory, it conflicts with the tests in the source tree as pytest cannot run testfiless with same name in different directories (ref: https://github.com/pytest-dev/pytest/issues/3151).

See [this run](https://github.com/void-linux/void-packages/actions/runs/5021644643/jobs/9004230165) as an example. The same package passes checks correctly in this PR.