### PR TITLE
rpi-imager: update to 1.7.5.

### DIFF
--- a/srcpkgs/rpi-imager/template
+++ b/srcpkgs/rpi-imager/template
@@ -1,6 +1,6 @@
 # Template file for 'rpi-imager'
 pkgname=rpi-imager
-version=1.7.4
+version=1.7.5
 revision=1
 build_wrksrc=src
 build_style=cmake
@@ -14,7 +14,7 @@ maintainer="Adam Gausmann <adam@gaussian.dev>"
 license="Apache-2.0"
 homepage="https://github.com/raspberrypi/rpi-imager"
 distfiles="https://github.com/raspberrypi/rpi-imager/archive/v${version}.tar.gz"
-checksum=c605a4770da5dbae67fa775bad226311529450fd6ef1fdec708f9f384d1aff34
+checksum=876c4e22483cb28bba975ad000589963e4e952e541f5a985fa68e44490e235a0
 
 pre_configure() {
 	ln -sf /bin/true $XBPS_WRAPPERDIR/lsblk


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
