### PR TITLE
android-tools: update to 34.0.1.

### DIFF
--- a/srcpkgs/android-tools/template
+++ b/srcpkgs/android-tools/template
@@ -1,6 +1,6 @@
 # Template file for 'android-tools'
 pkgname=android-tools
-version=34.0.0
+version=34.0.1
 revision=1
 archs="armv* aarch64* x86_64* i686* ppc64le*"
 build_style=cmake
@@ -13,7 +13,7 @@ maintainer="John <me@johnnynator.dev>"
 license="Apache-2.0, ISC, GPL-2.0-only, MIT"
 homepage="https://developer.android.com/tools/help/adb.html"
 distfiles="https://github.com/nmeum/android-tools/releases/download/${version}/android-tools-${version}.tar.xz"
-checksum=f88ec5686937f7fb2f689c3b0506123f2399276a14673164b0f95454a4c7b97a
+checksum=60234ecbca19a17a7e2f46a4581960d645b7c55b870d924a21494c76a6f548ec
 
 if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
 	makedepends+=" libatomic-devel"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

@Johnnynator

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
