### PR TITLE
texlive: missing latexindent dependencies

### DIFF
--- a/srcpkgs/texlive/template
+++ b/srcpkgs/texlive/template
@@ -1,7 +1,7 @@
 # Template file for 'texlive'
 pkgname=texlive
 version=20210325
-revision=5
+revision=6
 build_wrksrc="build"
 build_style=gnu-configure
 configure_script="../configure"
@@ -68,7 +68,7 @@ hostmakedepends="pkg-config perl lua52-BitOp texinfo"
 makedepends="cairo-devel freetype-devel gd-devel graphite-devel gmp-devel
  harfbuzz-devel icu-devel libpaper-devel libpng-devel mpfr-devel
  pixman-devel libteckit-devel zlib-devel zziplib-devel libXaw-devel"
-depends="dialog ghostscript perl-Tk texlive-core texlive-latexmk xbps-triggers"
+depends="dialog ghostscript perl-File-HomeDir perl-Tk perl-Unicode-LineBreak perl-YAML-Tiny texlive-core texlive-latexmk xbps-triggers"
 short_desc="TeX Live"
 maintainer="fosslinux <fosslinux@aussies.space>"
 license="GPL-2.0-or-later"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc

#### Notes
- `texlive` includes `latexindent`, whose Perl dependencies were missing from the `texlive` package.
- I created a new pull request because I could not re-open the last one.