### PR TITLE
certbot: update to 2.6.0

### DIFF
--- a/srcpkgs/certbot-apache/template
+++ b/srcpkgs/certbot-apache/template
@@ -1,7 +1,7 @@
 # Template file for 'certbot-apache'
 pkgname=certbot-apache
-version=1.31.0
-revision=2
+version=2.6.0
+revision=1
 build_style=python3-module
 hostmakedepends="python3-setuptools"
 depends="certbot python3-acme python3-augeas python3-zope.interface"
@@ -11,4 +11,4 @@ maintainer="Kartik S. <kartik.ynwa@gmail.com>"
 license="Apache-2.0"
 homepage="https://certbot.eff.org/"
 distfiles="${PYPI_SITE}/c/certbot-apache/certbot-apache-${version}.tar.gz"
-checksum=b4736a29233068022b217034acdbf53198a43d19a8ca00a0928771f2b107276b
+checksum=9fa677d8bb286c84f6fed9c109fe7ba4b88d4074f1c18e6b43230a7d5954160c

--- a/srcpkgs/certbot-nginx/template
+++ b/srcpkgs/certbot-nginx/template
@@ -1,7 +1,7 @@
 # Template file for 'certbot-nginx'
 pkgname=certbot-nginx
-version=1.31.0
-revision=2
+version=2.6.0
+revision=1
 build_style=python3-module
 hostmakedepends="python3-setuptools"
 depends="certbot python3-acme python3-parsing python3-zope.interface"
@@ -11,4 +11,4 @@ maintainer="Kartik Singh <kartik.ynwa@gmail.com>"
 license="Apache-2.0"
 homepage="https://certbot.eff.org/"
 distfiles="${PYPI_SITE}/c/certbot-nginx/certbot-nginx-${version}.tar.gz"
-checksum=8f109c5e14061bcffba8c4c6c7341c8bc814756c00461e32136e556abe638510
+checksum=426038336f0eb305579aa1bd71d021cfbbfa0925d165198054763b7225d64a05

--- a/srcpkgs/certbot/template
+++ b/srcpkgs/certbot/template
@@ -1,7 +1,7 @@
 # Template file for 'certbot'
 pkgname=certbot
-version=1.31.0
-revision=2
+version=2.6.0
+revision=1
 build_style=python3-module
 hostmakedepends="python3-setuptools"
 depends="python3-acme python3-ConfigArgParse python3-configobj
@@ -14,4 +14,4 @@ maintainer="Alex Childs <misuchiru03+void@gmail.com>"
 license="Apache-2.0"
 homepage="https://certbot.eff.org/"
 distfiles="${PYPI_SITE}/c/certbot/certbot-${version}.tar.gz"
-checksum=29af531d33aaa87c8104864cd31ac2af541f0ec973a7252d7f7f5b15e10479db
+checksum=c4de6bb0d092729650ed90a5bdb513932bdc47ec5f7f98049180ab8e4a835dab

--- a/srcpkgs/python3-acme/template
+++ b/srcpkgs/python3-acme/template
@@ -1,7 +1,7 @@
 # Template file for 'python3-acme'
 pkgname=python3-acme
-version=1.31.0
-revision=2
+version=2.6.0
+revision=1
 build_style=python3-module
 hostmakedepends="python3-setuptools"
 depends="python3-cryptography python3-openssl python3-pyrfc3339
@@ -13,4 +13,4 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="Apache-2.0"
 homepage="https://github.com/certbot/certbot"
 distfiles="${PYPI_SITE}/a/acme/acme-${version}.tar.gz"
-checksum=f5e13262fa1101c38dd865378ac8b4639f819120eb66c5538fc6c09b7576fc53
+checksum=607360db73e458150ab63825a82b220bdf04badbd81c6d3218e5d993c6be491c


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64, GLIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl

