### PR TITLE
python3-pybind11: add symlinks to include, cmake, pkg-config dirs

### DIFF
--- a/srcpkgs/python3-pybind11/template
+++ b/srcpkgs/python3-pybind11/template
@@ -1,7 +1,7 @@
 # Template file for 'python3-pybind11'
 pkgname=python3-pybind11
 version=2.10.4
-revision=1
+revision=2
 build_style=python3-module
 hostmakedepends="cmake python3-setuptools
  python3-pytest python3-sphinx_rtd_theme python3-breathe"
@@ -48,4 +48,15 @@ post_install() {
 	_manpage=docs/.build/man/pybind11.1
 	vsed -i ${_manpage} -e '/^\.TH/ s/"1"/"7"/'
 	vman ${_manpage} pybind11.7
+
+	vmkdir /usr/include
+	vmkdir /usr/share/pkgconfig
+	vmkdir /usr/share/cmake
+
+	ln -s /${py3_sitelib}/pybind11/include/pybind11 \
+		${DESTDIR}/usr/include/pybind11
+	ln -s /${py3_sitelib}/pybind11/share/cmake/pybind11 \
+		${DESTDIR}/usr/share/cmake/pybind11
+	ln -s /${py3_sitelib}/pybind11/share/pkgconfig/pybind11.pc \
+		${DESTDIR}/usr/share/pkgconfig/pybind11.pc
 }


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-LIBC)

#### Note
Before this change, cmake and pkg-config couldn't find the library.
P.S. I could've moved the dirs, but decided to play it safe, and create symlinks instead.