### PR TITLE
flite: add deps to flite-devel subpkg

### DIFF
--- a/srcpkgs/flite/template
+++ b/srcpkgs/flite/template
@@ -1,7 +1,7 @@
 # Template file for 'flite'
 pkgname=flite
 version=2.2
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--enable-shared --with-audio=alsa"
 makedepends="alsa-lib-devel"
@@ -18,7 +18,7 @@ post_install() {
 
 flite-devel_package() {
 	short_desc+=" - development files"
-	depends="flite>=${version}_${revision}"
+	depends="${makedepends} ${sourcepkg}>=${version}_${revision}"
 	pkg_install() {
 		vmove usr/include
 		vmove usr/lib/*.a


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-LIBC)

#### Note
flite is compiled with alsa, but there was no alsa in deps of a subpkg. I fixed it.