### PR TITLE
mate-control-center: update to 1.26.1.

### DIFF
--- a/srcpkgs/mate-control-center/template
+++ b/srcpkgs/mate-control-center/template
@@ -1,6 +1,6 @@
 # Template file for 'mate-control-center'
 pkgname=mate-control-center
-version=1.26.0
+version=1.26.1
 revision=1
 build_style=gnu-configure
 configure_args="--disable-static --disable-schemas-compile --disable-update-mimedb"
@@ -15,8 +15,8 @@ maintainer="skmpz <dem.procopiou@gmail.com>"
 license="GPL-2.0-or-later"
 homepage="https://mate-desktop.org"
 changelog="https://raw.githubusercontent.com/mate-desktop/mate-control-center/master/NEWS"
-distfiles="https://pub.mate-desktop.org/releases/${version%.*}/${pkgname}-${version}.tar.xz"
-checksum=286714ea778f6540fe74ef00aaf504c47141518d26ab224994f4a1af36b0134a
+distfiles="https://pub.mate-desktop.org/releases/${version%.*}/mate-control-center-${version}.tar.xz"
+checksum=e05f492a3b657aa56fc58f7cf71bc8c80df8e25351fde4db4f523ab8db5b5608
 
 post_install() {
 	rm -f ${DESTDIR}/usr/share/applications/mimeinfo.cache


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
