### PR TITLE
libfcitx-qt*: rebuild for qt 6.5.0

### DIFF
--- a/srcpkgs/libfcitx-qt5/template
+++ b/srcpkgs/libfcitx-qt5/template
@@ -1,7 +1,7 @@
 # Template file for 'libfcitx-qt5'
 pkgname=libfcitx-qt5
 version=1.2.7
-revision=2
+revision=3
 build_style=cmake
 configure_args="-DENABLE_QT6=ON -DQT_HOST_PATH=/usr"
 hostmakedepends="extra-cmake-modules pkg-config qt5-qmake


### PR DESCRIPTION
Fixes private symbol issue in `libfcitx-qt6`:

```
symbol lookup error: libfcitxplatforminputcontextplugin-qt6.so: undefined symbol: _ZN22QWindowSystemInterface22handleExtendedKeyEventEP7QWindowmN6QEvent4TypeEi6QFlagsIN2Qt16KeyboardModifierEEjjjRK7QStringbtb, version Qt_6_PRIVATE_API
```
---
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**
