### PR TITLE
python3-Sphinx: fix check, add changelog

### DIFF
--- a/srcpkgs/python3-Sphinx/template
+++ b/srcpkgs/python3-Sphinx/template
@@ -12,11 +12,12 @@ depends="python3-Jinja2 python3-docutils python3-Pygments
  python3-sphinxcontrib-jsmath python3-sphinxcontrib-qthelp
  python3-sphinxcontrib-serializinghtml"
 checkdepends="$depends python3-html5lib python3-mypy ImageMagick gettext
- python3-pytest python3-setuptools"
+ python3-pytest python3-setuptools python3-filelock"
 short_desc="Python 3 documentation generator"
 maintainer="Đoàn Trần Công Danh <congdanhqx@gmail.com>"
 license="BSD-3-Clause"
 homepage="http://sphinx-doc.org"
+changelog="https://github.com/sphinx-doc/sphinx/raw/master/CHANGES"
 distfiles="${PYPI_SITE}/S/Sphinx/Sphinx-${version}.tar.gz"
 checksum=61e025f788c5977d9412587e733733a289e2b9fdc2fef8868ddfbfc4ccfe881d
 conflicts="python-Sphinx>=0"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

currently checks fail with `ModuleNotFoundError: No module named 'filelock'`. Just adding `python3-filelock` to `checkdepends` fixes it.

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
