### PR TITLE
electron24: add launcher

### DIFF
--- a/srcpkgs/electron24/files/electron-launcher.sh
+++ b/srcpkgs/electron24/files/electron-launcher.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/bash
+
+set -euo pipefail
+
+name=@ELECTRON@
+flags_file="${XDG_CONFIG_HOME:-$HOME/.config}/${name}-flags.conf"
+
+declare -a flags
+
+if [[ -f "${flags_file}" ]]; then
+    mapfile -t < "${flags_file}"
+fi
+
+for line in "${MAPFILE[@]}"; do
+    if [[ ! "${line}" =~ ^[[:space:]]*#.* ]]; then
+        flags+=("${line}")
+    fi
+done
+
+exec /usr/lib/${name}/electron "${flags[@]}" "$@"

--- a/srcpkgs/electron24/template
+++ b/srcpkgs/electron24/template
@@ -1,7 +1,7 @@
 # Template file for 'electron24'
 pkgname=electron24
 version=24.3.0
-revision=1
+revision=2
 _nodever=18.14.0
 _chromiumver=112.0.5615.165
 archs="x86_64* aarch64*"
@@ -436,6 +436,6 @@ do_install() {
 	vlicense ${wrksrc}/src/electron/LICENSE electron.LICENSE
 	vlicense ${wrksrc}/src/third_party/electron_node/LICENSE node.LICENSE
 
-	vmkdir /usr/bin
-	ln -s ../lib/$pkgname/electron "$DESTDIR"/usr/bin/$pkgname
+	vbin "${FILESDIR}"/electron-launcher.sh "${pkgname}"
+	sed -i "s/@ELECTRON@/${pkgname}/" ${DESTDIR}/usr/bin/${pkgname}
 }


### PR DESCRIPTION
Felt inspired by https://wiki.archlinux.org/title/wayland#Configuration_file to add this functionality to this package.

The config file must be `${XDG_CONFIG_HOME}/${pkgname}-flags.conf` or `~/.config/${pkgname}-flags.conf`.

#### Testing the changes
- I tested the changes in this PR: **YES**
<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
