### PR TITLE
preload: generate manpage when not cross

### DIFF
--- a/srcpkgs/preload/patches/qemu-help2man.patch
+++ b/srcpkgs/preload/patches/qemu-help2man.patch
@@ -1,0 +1,30 @@
+--- preload-0.6.4/src/Makefile.in	2009-04-15 17:49:28.000000000 -0400
++++ preload-0.6.4.new/src/Makefile.in	2023-05-30 22:23:16.820648202 -0400
+@@ -222,6 +222,12 @@
+ dist_man_MANS = preload.8
+ RUNPREQ = preload preload.conf.debug
+ RUNCMD = ./preload -c preload.conf.debug -s preload.state -d $(ARGS)
++preload_binary = `if [ -n "$$CROSS_BUILD" ]; then \
++				 	echo "qemu-$$XBPS_TARGET_QEMU_MACHINE-static ./preload"; \
++				else \
++				 	echo './preload'; \
++				fi;`
++
+ all: all-am
+ 
+ .SUFFIXES:
+@@ -678,11 +684,11 @@
+ 	@$(top_builddir)/missing --run \
+ 	   help2man --no-info --section=8 --include=preload.8.i \
+ 	   	    --help-option="-H" --output="$@.tmp" \
+-		    --name 'Adaptive readahead daemon' ./preload \
++		    --name 'Adaptive readahead daemon' "$(preload_binary)" \
+ 	 && mv "$@.tmp" "$@" \
+ 	  || ($(RM) "$@"; \
+-	      echo Failed to update preload.8, the man page may be outdated >&2; \
+-	      (test -f "$@" || echo help2man is required to generate this file. >> "$@"));
++	      echo Failed to create preload.8 >&2; \
++		  exit 1);
+ 
+ install-data-hook:
+ 	@cd "$(DESTDIR)$(man8dir)" && gzip -c preload.8 > preload.8.gz.tmp && mv preload.8.gz.tmp preload.8.gz && $(RM) preload.8

--- a/srcpkgs/preload/template
+++ b/srcpkgs/preload/template
@@ -1,10 +1,12 @@
 # Template file for 'preload'
 pkgname=preload
 version=0.6.4
-revision=11
+revision=12
 build_style=gnu-configure
-hostmakedepends="pkg-config"
+build_helper=qemu
+hostmakedepends="pkg-config help2man"
 makedepends="libglib-devel"
+checkdepends="psmisc"
 short_desc="Adaptive readahead daemon"
 maintainer="bougyman <bougyman@voidlinux.org>"
 license="GPL-2.0-or-later"


### PR DESCRIPTION
If `help2man` isn't available at build time then the contents of man8/preload.8 are:

> help2man is required to generate this file.

 Apparently `makewhatis` has to run after the new file is installed so `man` knows to run the file through the formatter but I'd rather not add a post-install script.

This also adds psmisc to checkdepends because the test script uses `( sleep 1; killall ./preload 2>/dev/null ) &` to ensure the test ends.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **yes**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
