### PR TITLE
Fix GitLab update-checks

### DIFF
--- a/common/xbps-src/shutils/update_check.sh
+++ b/common/xbps-src/shutils/update_check.sh
@@ -136,7 +136,7 @@ update_check() {
                     */-/*) pkgurlname="$(printf %s "$url" | sed -e 's%/-/.*%%g; s%/$%%')";;
                     *) pkgurlname="$(printf %s "$url" | cut -d / -f 1-5)";;
                 esac
-                url="$pkgurlname/tags"
+                url="$pkgurlname/-/tags"
                 rx='/archive/[^/]+/\Q'"$pkgname"'\E-v?\K[\d.]+(?=\.tar\.gz")';;
             *bitbucket.org*)
                 pkgurlname="$(printf %s "$url" | cut -d/ -f4,5)"

--- a/srcpkgs/goimapnotify/update
+++ b/srcpkgs/goimapnotify/update
@@ -1,2 +1,0 @@
-site="https://gitlab.com/shackra/goimapnotify/-/tags/"
-pattern="goimapnotify-\K[\d.]*(?=\.tar\.gz)"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->
Something changed recently (in GitLab 16.1?) and it now requires the `-/` similar to the archive URL.

Fixed (`GitLab Enterprise Edition 16.1.0-pre 563cf02c7b5`):
```
XBPS_UPDATE_CHECK_VERBOSE=1 ./xbps-src update-check corectrl
```
Unchanged (`GitLab Community Edition 15.11.4`):
```
XBPS_UPDATE_CHECK_VERBOSE=1 ./xbps-src update-check wlroots
```

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
