### PR TITLE
mkvtoolnix: update to 76.0

### DIFF
--- a/srcpkgs/mkvtoolnix/template
+++ b/srcpkgs/mkvtoolnix/template
@@ -1,7 +1,7 @@
 # Template file for 'mkvtoolnix'
 pkgname=mkvtoolnix
-version=75.0.0
-revision=2
+version=76.0
+revision=1
 build_style=gnu-configure
 build_helper=qmake
 configure_args="--with-docbook-xsl-root=/usr/share/xsl/docbook --enable-qt
@@ -17,7 +17,7 @@ license="GPL-2.0-only"
 homepage="https://mkvtoolnix.download"
 changelog="https://mkvtoolnix.download/doc/NEWS.md"
 distfiles="https://mkvtoolnix.download/sources/mkvtoolnix-${version}.tar.xz"
-checksum=e7ad116f374cdf8370fa566ed7fe23ecdcf413dbe6dd90ab3f82904d0cf7516f
+checksum=6ace661b61a49d1026b1a97336051d7aa85d56fb34527f2ca97d8933f7efe90d
 
 if [ "$CROSS_BUILD" ]; then
 	configure_args+=" --with-boost=${XBPS_CROSS_BASE}/usr"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

---

Sticking with Qt5 since `QMediaPlayer` used by `mkvtoolnix-gui` is broken on Qt 6.5.0 (on all platforms, not just Windows as [QTBUG-111951](https://bugreports.qt.io/browse/QTBUG-111951) incorrectly suggests).
