### PR TITLE
python3-fastjsonschema: update to 2.17.1.

### DIFF
--- a/srcpkgs/python3-fastjsonschema/template
+++ b/srcpkgs/python3-fastjsonschema/template
@@ -1,6 +1,6 @@
 # Template file for 'python3-fastjsonschema'
 pkgname=python3-fastjsonschema
-version=2.16.3
+version=2.17.1
 revision=1
 build_style=python3-module
 make_check_args="--deselect tests/benchmarks/test_benchmark.py"
@@ -13,7 +13,7 @@ license="BSD-3-Clause"
 homepage="https://github.com/horejsek/python-fastjsonschema"
 changelog="https://raw.githubusercontent.com/horejsek/python-fastjsonschema/master/CHANGELOG.txt"
 distfiles="https://github.com/horejsek/python-fastjsonschema/archive/refs/tags/v${version}.tar.gz"
-checksum=f9834e4994830942d58949043820024261dc22e2640bcf787391deb607cc91c6
+checksum=9295090b468152cea7a53c651a46d6a1afb83f0124f86c9a64da43fd3453a9f4
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

The jupyter notebook seems to work ok (only pkg depending on this) although I'm not sure what action would really test it.

I tried to `./xbps-src check python3-jupyter_nbformat` but this is currently broken for a different reason.

I'm inclined to push this, in case someone finds a problem we'll at least know how to test in the future.

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
