### PR TITLE
New package: libXnvctrl-525.116.04; updating MangoHud too to depend on this new package to fix Nvidia GPU detection

### DIFF
--- a/srcpkgs/MangoHud/template
+++ b/srcpkgs/MangoHud/template
@@ -1,13 +1,13 @@
 # Template file for 'MangoHud'
 pkgname=MangoHud
 version=0.6.8
-revision=1
+revision=2
 build_style=meson
-configure_args="-Duse_system_vulkan=enabled -Dwith_xnvctrl=disabled
+configure_args="-Duse_system_vulkan=enabled -Dwith_xnvctrl=enabled
  -Dwith_nvml=disabled -Duse_system_spdlog=enabled"
 hostmakedepends="Vulkan-Headers python3-Mako glslang pkg-config"
-makedepends="libglvnd-devel dbus-devel vulkan-loader Vulkan-Headers
- spdlog"
+makedepends="libglvnd-devel dbus-devel vulkan-loader Vulkan-Headers libXnvctrl-devel spdlog"
+depends="libXnvctrl-devel"
 short_desc="Vulkan and OpenGL overlay for monitoring FPS, temperatures and more"
 maintainer="John <me@johnnynator.dev>"
 license="MIT"

--- a/srcpkgs/libXnvctrl-devel
+++ b/srcpkgs/libXnvctrl-devel
@@ -1,0 +1,1 @@
+libXnvctrl

--- a/srcpkgs/libXnvctrl/patches/nvidia-settings-libxnvctrl_so.patch
+++ b/srcpkgs/libXnvctrl/patches/nvidia-settings-libxnvctrl_so.patch
@@ -1,0 +1,38 @@
+diff --git a/src/Makefile b/src/Makefile
+index 68eb140..6d0aab8 100644
+--- a/src/Makefile
++++ b/src/Makefile
+@@ -345,7 +345,7 @@ endif
+ 
+ ifdef BUILD_GTK3LIB
+ $(eval $(call DEBUG_INFO_RULES, $(GTK3LIB)))
+-$(GTK3LIB).unstripped: $(LIBXNVCTRL) $(GTK3_OBJS) $(XCP_OBJS) $(IMAGE_OBJS) $(VERSION_MK)
++$(GTK3LIB).unstripped: $(LIBXNVCTRL) $(LIBXNVCTRL_SHARED) $(GTK3_OBJS) $(XCP_OBJS) $(IMAGE_OBJS) $(VERSION_MK)
+ 	$(call quiet_cmd,LINK) -shared $(CFLAGS) $(LDFLAGS)  $(BIN_LDFLAGS) \
+ 	    $(LIBXNVCTRL) $(LIBS) $(GTK3_LIBS) \
+ 	    -Wl,--unresolved-symbols=ignore-all -o $@ \
+diff --git a/src/libXNVCtrl/xnvctrl.mk b/src/libXNVCtrl/xnvctrl.mk
+index e6be2ef..c0921c4 100644
+--- a/src/libXNVCtrl/xnvctrl.mk
++++ b/src/libXNVCtrl/xnvctrl.mk
+@@ -39,6 +39,11 @@ XNVCTRL_CFLAGS ?=
+ 
+ LIBXNVCTRL = $(OUTPUTDIR)/libXNVCtrl.a
+ 
++LIBXNVCTRL_SHARED = $(OUTPUTDIR)/libXNVCtrl.so
++LIBXNVCTRL_ABI_VERSION_MAJOR = 0
++LIBXNVCTRL_ABI_VERSION_MINOR = 0
++LIBXNVCTRL_LIBS += -lXext -lX11
++
+ LIBXNVCTRL_SRC = $(XNVCTRL_DIR)/NVCtrl.c
+ 
+ LIBXNVCTRL_OBJ = $(call BUILD_OBJECT_LIST,$(LIBXNVCTRL_SRC))
+@@ -47,3 +52,8 @@ $(eval $(call DEFINE_OBJECT_RULE,TARGET,$(LIBXNVCTRL_SRC)))
+ 
+ $(LIBXNVCTRL) : $(LIBXNVCTRL_OBJ)
+ 	$(call quiet_cmd,AR) ru $@ $(LIBXNVCTRL_OBJ)
++
++$(LIBXNVCTRL_SHARED) : $(LIBXNVCTRL_OBJ)
++	$(CC) -shared $(CFLAGS) $(LDFLAGS) -Wl,-soname=$(notdir $@).${LIBXNVCTRL_ABI_VERSION_MAJOR} -o $@.$(LIBXNVCTRL_ABI_VERSION_MAJOR).$(LIBXNVCTRL_ABI_VERSION_MINOR).0 $^ $(LIBXNVCTRL_LIBS)
++	ln -s $(notdir $@).$(LIBXNVCTRL_ABI_VERSION_MAJOR).$(LIBXNVCTRL_ABI_VERSION_MINOR).0 $@
++	ln -s $(notdir $@).$(LIBXNVCTRL_ABI_VERSION_MAJOR).$(LIBXNVCTRL_ABI_VERSION_MINOR).0 $@.$(LIBXNVCTRL_ABI_VERSION_MAJOR)

--- a/srcpkgs/libXnvctrl/template
+++ b/srcpkgs/libXnvctrl/template
@@ -24,7 +24,9 @@ checksum=32db97759c2a58fea86a63a69a423f1bf65198496cb2ac2279f4210b50097358
 
 do_install() {
 	if [ ${XBPS_TARGET_MACHINE} =  "i686" ]; then
-        	vcopy src/_out/Linux_x86/libXNVCtrl.* /usr/lib/
+		vcopy src/_out/Linux_x86/libXNVCtrl.* /usr/lib/
+	elif [ ${XBPS_TARGET_MACHINE} = 'x86_64-musl' ]; then
+		vcopy src/_out/Linux_x86_64/libXNVCtrl.* /usr/lib/
 	else
 		vcopy src/_out/Linux_${XBPS_TARGET_MACHINE}/libXNVCtrl.* /usr/lib/
 	fi
@@ -33,5 +35,5 @@ do_install() {
 libXnvctrl-devel_package() {
 	short_desc+=" - development files"
 	vmkdir /usr/include/NVCtrl 755
-        vcopy src/libXNVCtrl/*.h /usr/include/NVCtrl/
+	vcopy src/libXNVCtrl/*.h /usr/include/NVCtrl/
 }

--- a/srcpkgs/libXnvctrl/template
+++ b/srcpkgs/libXnvctrl/template
@@ -2,18 +2,12 @@
 pkgname=libXnvctrl
 version=525.116.04
 revision=1
-#archs="i686 x86_64"
-#build_wrksrc=
 build_style=gnu-makefile
 make_use_env=yes
-#configure_args=""
-#make_build_args=""
+make_build_args="OUTPUTDIR=out"
 #make_install_args=""
-#conf_files=""
-#make_dirs="/var/log/dir 0755 root root"
 hostmakedepends="inetutils base-devel"
 makedepends="jansson-devel gtk+3-devel libXv-devel libvdpau-devel libXext-devel libXxf86vm-devel"
-# depends=""
 short_desc="Nvidia hardware monitoring library"
 maintainer="Kira Taylor Patton <roundduckkira@protonmail.com>"
 license="GPL-2.0-only"
@@ -23,13 +17,7 @@ distfiles="https://github.com/NVIDIA/nvidia-settings/archive/refs/tags/${version
 checksum=32db97759c2a58fea86a63a69a423f1bf65198496cb2ac2279f4210b50097358
 
 do_install() {
-	if [ ${XBPS_TARGET_MACHINE} =  "i686" ]; then
-		vcopy src/_out/Linux_x86/libXNVCtrl.* /usr/lib/
-	elif [ ${XBPS_TARGET_MACHINE} = 'x86_64-musl' ]; then
-		vcopy src/_out/Linux_x86_64/libXNVCtrl.* /usr/lib/
-	else
-		vcopy src/_out/Linux_${XBPS_TARGET_MACHINE}/libXNVCtrl.* /usr/lib/
-	fi
+	vcopy src/out/libXNVCtrl.* /usr/lib/
 }
 
 libXnvctrl-devel_package() {

--- a/srcpkgs/libXnvctrl/template
+++ b/srcpkgs/libXnvctrl/template
@@ -23,7 +23,15 @@ distfiles="https://github.com/NVIDIA/nvidia-settings/archive/refs/tags/${version
 checksum=32db97759c2a58fea86a63a69a423f1bf65198496cb2ac2279f4210b50097358
 
 do_install() {
+	if [ ${XBPS_TARGET_MACHINE} =  "i686" ]; then
+        	vcopy src/_out/Linux_x86/libXNVCtrl.* /usr/lib/
+	else
+		vcopy src/_out/Linux_${XBPS_TARGET_MACHINE}/libXNVCtrl.* /usr/lib/
+	fi
+}
+
+libXnvctrl-devel_package() {
+	short_desc+=" - development files"
 	vmkdir /usr/include/NVCtrl 755
-	vcopy src/libXNVCtrl/*.h /usr/include/NVCtrl/
-	vcopy src/_out/Linux_x86_64/libXNVCtrl.* /usr/lib/
+        vcopy src/libXNVCtrl/*.h /usr/include/NVCtrl/
 }

--- a/srcpkgs/libXnvctrl/template
+++ b/srcpkgs/libXnvctrl/template
@@ -1,0 +1,29 @@
+# Template file for 'libXnvctrl'
+pkgname=libXnvctrl
+version=525.116.04
+revision=1
+#archs="i686 x86_64"
+#build_wrksrc=
+build_style=gnu-makefile
+make_use_env=yes
+#configure_args=""
+#make_build_args=""
+#make_install_args=""
+#conf_files=""
+#make_dirs="/var/log/dir 0755 root root"
+hostmakedepends="inetutils base-devel"
+makedepends="jansson-devel gtk+3-devel libXv-devel libvdpau-devel libXext-devel libXxf86vm-devel"
+# depends=""
+short_desc="Nvidia hardware monitoring library"
+maintainer="Kira Taylor Patton <roundduckkira@protonmail.com>"
+license="GPL-2.0-only"
+homepage="https://github.com/NVIDIA/nvidia-settings"
+#changelog=""
+distfiles="https://github.com/NVIDIA/nvidia-settings/archive/refs/tags/${version}.tar.gz"
+checksum=32db97759c2a58fea86a63a69a423f1bf65198496cb2ac2279f4210b50097358
+
+do_install() {
+	vmkdir /usr/include/NVCtrl 755
+	vcopy src/libXNVCtrl/*.h /usr/include/NVCtrl/
+	vcopy src/_out/Linux_x86_64/libXNVCtrl.* /usr/lib/
+}


### PR DESCRIPTION
create new libXnvctrl package for Nvidia hardware monitoring, the lack of this package means MangoHUD can't be fixed to support Nvidia GPUs.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES, I am using this package in my daily driver**


#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**


<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)

