### PR TITLE
MangoHud: upload revision that depends on libXnvctrl to support Nvidia cards

### DIFF
--- a/srcpkgs/MangoHud/template
+++ b/srcpkgs/MangoHud/template
@@ -1,13 +1,13 @@
 # Template file for 'MangoHud'
 pkgname=MangoHud
 version=0.6.8
-revision=1
+revision=2
 build_style=meson
-configure_args="-Duse_system_vulkan=enabled -Dwith_xnvctrl=disabled
+configure_args="-Duse_system_vulkan=enabled -Dwith_xnvctrl=enabled
  -Dwith_nvml=disabled -Duse_system_spdlog=enabled"
 hostmakedepends="Vulkan-Headers python3-Mako glslang pkg-config"
-makedepends="libglvnd-devel dbus-devel vulkan-loader Vulkan-Headers
- spdlog"
+makedepends="libglvnd-devel dbus-devel vulkan-loader Vulkan-Headers libXnvctrl-devel spdlog"
+depends="libXnvctrl-devel"
 short_desc="Vulkan and OpenGL overlay for monitoring FPS, temperatures and more"
 maintainer="John <me@johnnynator.dev>"
 license="MIT"


### PR DESCRIPTION
Set MangoHud to depend on libXnvctrl to fix Nvidia detection. This fixes a bug in the normal Void Linux package as is currently, where Nvidia GPUs aren't read at all, even if you force the Nvidia lspci number.  This is due to a lack of needed development files that libXnvctrl contains, so here I made this package dependent on that package and changed the settings to make it use the library in compilation.

That said this may mean the package may end up being x86_64 only as I didn't test a i386 version or other arches. Worst comes to worst, could it be possible then there would be a Nvidia version of this package?

EDIT: and oh yeah the CI will fail for this pull req as it requires #44050 to work.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)

