### PR TITLE
build-style/python3-pep517: use a generic glob for wheels

### DIFF
--- a/common/build-style/python3-pep517.sh
+++ b/common/build-style/python3-pep517.sh
@@ -9,15 +9,12 @@ do_build() {
 }
 
 do_check() {
+	: ${make_install_target:="dist/*.whl"}
+
 	local testjobs
 	if python3 -c 'import pytest' >/dev/null 2>&1; then
 		if python3 -c 'import xdist' >/dev/null 2>&1; then
 			testjobs="-n $XBPS_MAKEJOBS"
-		fi
-
-		if [ -z "${make_install_target}" ]; then
-			local wheelbase="${pkgname#python3-}"
-			make_install_target="dist/${wheelbase//-/_}-${version}-*-*-*.whl"
 		fi
 
 		local testdir="${wrksrc}/tmp/$(date +%s)"
@@ -33,11 +30,8 @@ do_check() {
 }
 
 do_install() {
-	if [ -z "${make_install_target}" ]; then
-		# Default wheel name normalizes hyphens to underscores
-		local wheelbase="${pkgname#python3-}"
-		make_install_target="dist/${wheelbase//-/_}-${version}-*-*-*.whl"
-	fi
+	: ${make_install_args:=--no-compile-bytecode}
+	: ${make_install_target:="dist/*.whl"}
 
 	python3 -m installer --destdir ${DESTDIR} \
 		${make_install_args} ${make_install_target}

--- a/common/build-style/python3-pep517.sh
+++ b/common/build-style/python3-pep517.sh
@@ -9,24 +9,22 @@ do_build() {
 }
 
 do_check() {
-	: ${make_install_target:="dist/*.whl"}
-
-	local testjobs
-	if python3 -c 'import pytest' >/dev/null 2>&1; then
-		if python3 -c 'import xdist' >/dev/null 2>&1; then
-			testjobs="-n $XBPS_MAKEJOBS"
-		fi
-
-		local testdir="${wrksrc}/tmp/$(date +%s)"
-		python3 -m installer --destdir "${testdir}" \
-			${make_install_args} ${make_install_target}
-
-		PATH="${testdir}/usr/bin:${PATH}" PYTHONPATH="${testdir}/${py3_sitelib}" \
-			${make_check_pre} pytest3 ${testjobs} ${make_check_args} ${make_check_target}
-	else
-		msg_warn "Unable to determine tests for PEP517 Python templates\n"
+	if ! python3 -c 'import pytest' >/dev/null 2>&1; then
+		msg_warn "Testing of python3-pep517 templates requires pytest\n"
 		return 0
 	fi
+
+	local testjobs
+	if python3 -c 'import xdist' >/dev/null 2>&1; then
+		testjobs="-n $XBPS_MAKEJOBS"
+	fi
+
+	local testdir="${wrksrc}/tmp/$(date +%s)"
+	python3 -m installer --destdir "${testdir}" \
+		${make_install_args} ${make_install_target:-dist/*.whl}
+
+	PATH="${testdir}/usr/bin:${PATH}" PYTHONPATH="${testdir}/${py3_sitelib}" \
+		${make_check_pre} pytest3 ${testjobs} ${make_check_args} ${make_check_target}
 }
 
 do_install() {

--- a/srcpkgs/python3-PyHamcrest/template
+++ b/srcpkgs/python3-PyHamcrest/template
@@ -3,7 +3,6 @@ pkgname=python3-PyHamcrest
 version=2.0.4
 revision=1
 build_style=python3-pep517
-make_install_target="dist/pyhamcrest-${version}-*-*-*.whl"
 hostmakedepends="hatch-vcs"
 depends="python3"
 checkdepends="python3-pytest python3-numpy"

--- a/srcpkgs/python3-Pyphen/template
+++ b/srcpkgs/python3-Pyphen/template
@@ -3,7 +3,6 @@ pkgname=python3-Pyphen
 version=0.14.0
 revision=1
 build_style=python3-pep517
-make_install_target="dist/pyphen-${version}-*-*-*.whl"
 hostmakedepends="python3-poetry-core python3-flit_core"
 checkdepends="python3-pytest-isort python3-pytest-cov python3-pytest-flake8
  python3-pytest-xdist"

--- a/srcpkgs/python3-Sphinx/template
+++ b/srcpkgs/python3-Sphinx/template
@@ -3,7 +3,6 @@ pkgname=python3-Sphinx
 version=7.0.1
 revision=1
 build_style=python3-pep517
-make_install_target="dist/sphinx-$version-py3-none-any.whl"
 hostmakedepends="python3-flit_core python3-pyproject-hooks"
 depends="python3-Jinja2 python3-docutils python3-Pygments
  python3-snowballstemmer python3-Babel python3-alabaster python3-imagesize

--- a/srcpkgs/python3-WeasyPrint/template
+++ b/srcpkgs/python3-WeasyPrint/template
@@ -3,7 +3,6 @@ pkgname=python3-WeasyPrint
 version=59.0
 revision=1
 build_style=python3-pep517
-make_install_target="dist/weasyprint-${version}-py3-none-any.whl"
 _runtime_deps="fonttools python3-Pillow python3-cssselect2 python3-html5lib python3-cffi
  python3-Pyphen python3-pydyf glib pango"
 hostmakedepends="python3-poetry-core python3-flit_core ${_runtime_deps}"

--- a/srcpkgs/python3-ansible-lint/template
+++ b/srcpkgs/python3-ansible-lint/template
@@ -3,7 +3,6 @@ pkgname=python3-ansible-lint
 version=6.14.3
 revision=1
 build_style=python3-pep517
-make_install_target="dist/ansible_lint-*-*-*-*.whl"
 hostmakedepends="python3-wheel python3-setuptools_scm"
 depends="python3-ansible-compat ansible-core black python3-filelock
  python3-jsonschema python3-packaging python3-yaml python3-rich

--- a/srcpkgs/python3-b2sdk/template
+++ b/srcpkgs/python3-b2sdk/template
@@ -3,7 +3,6 @@ pkgname=python3-b2sdk
 version=1.20.0
 revision=1
 build_style=python3-pep517
-make_install_target="dist/b2sdk-${version}-*-*-*.whl"
 hostmakedepends="python3-setuptools_scm python3-wheel"
 depends="python3-logfury python3-Arrow python3-requests python3-tqdm"
 checkdepends="python3-pytest-lazy-fixture $depends python3-dateutil

--- a/srcpkgs/python3-gnupg/template
+++ b/srcpkgs/python3-gnupg/template
@@ -3,7 +3,6 @@ pkgname=python3-gnupg
 version=0.5.0
 revision=1
 build_style=python3-pep517
-make_install_target="dist/python_gnupg-${version}-py2.py3-none-any.whl"
 hostmakedepends="python3-setuptools python3-wheel"
 depends="python3 gnupg"
 checkdepends="${depends} python3-pytest"

--- a/srcpkgs/python3-ipython_ipykernel/template
+++ b/srcpkgs/python3-ipython_ipykernel/template
@@ -3,7 +3,6 @@ pkgname=python3-ipython_ipykernel
 version=6.19.2
 revision=1
 build_style=python3-pep517
-make_install_target="dist/ipykernel-${version}-*-*-*.whl"
 hostmakedepends="hatchling python3-jupyter_client python3-jupyter_core
  python3-platformdirs"
 depends="python3-ipython python3-traitlets python3-jupyter_client python3-tornado

--- a/srcpkgs/python3-logbook/template
+++ b/srcpkgs/python3-logbook/template
@@ -4,7 +4,6 @@ version=1.5.3
 revision=6
 build_style=python3-pep517
 make_check_args="--ignore=scripts"
-make_install_target="dist/Logbook-${version}-*-*-*_*.whl"
 hostmakedepends="python3-setuptools python3-wheel python3-devel python3-Cython"
 depends="python3"
 checkdepends="python3-execnet python3-pytest python3-pyzmq python3-SQLAlchemy

--- a/srcpkgs/python3-markdown-it/template
+++ b/srcpkgs/python3-markdown-it/template
@@ -3,7 +3,6 @@ pkgname=python3-markdown-it
 version=2.2.0
 revision=1
 build_style=python3-pep517
-make_install_target="dist/markdown_it_py-${version}-*-*-*.whl"
 hostmakedepends="python3-flit_core"
 depends="python3-mdurl"
 short_desc="Python port of the JavaScript mardown-it package"

--- a/srcpkgs/python3-mistune2/template
+++ b/srcpkgs/python3-mistune2/template
@@ -3,7 +3,6 @@ pkgname=python3-mistune2
 version=2.0.4
 revision=1
 build_style=python3-pep517
-make_install_target="dist/mistune-${version}-*-*-*.whl"
 hostmakedepends="python3-wheel"
 depends="python3"
 checkdepends="python3-pytest"

--- a/srcpkgs/python3-quart/template
+++ b/srcpkgs/python3-quart/template
@@ -3,7 +3,6 @@ pkgname=python3-quart
 version=0.18.4
 revision=1
 build_style=python3-pep517
-make_install_target="dist/quart-${version}-*-*-*.whl"
 hostmakedepends="python3-poetry-core"
 depends="python3-aiofiles python3-hypercorn python3-click python3-MarkupSafe
  python3-blinker python3-itsdangerous python3-Jinja2 python3-Werkzeug"

--- a/srcpkgs/python3-saml2/template
+++ b/srcpkgs/python3-saml2/template
@@ -6,7 +6,6 @@ build_style=python3-pep517
 make_check_args="--ignore=tests/test_36_mdbcache.py \
  --ignore=tests/test_75_mongodb.py \
  --ignore=tests/test_76_metadata_in_mdb.py"
-make_install_target="dist/pysaml2-${version}-*-*-*.whl"
 hostmakedepends="python3-poetry-core unzip"
 depends="python3-cryptography python3-openssl python3-dateutil python3-pytz
  python3-requests python3-six python3-defusedxml python3-xmlschema"

--- a/srcpkgs/python3-xcffib/template
+++ b/srcpkgs/python3-xcffib/template
@@ -1,7 +1,7 @@
 # Template file for 'python3-xcffib'
 pkgname=python3-xcffib
-version=0.11.1
-revision=2
+version=1.3.0
+revision=1
 build_style=python3-pep517
 hostmakedepends="python3-setuptools pkg-config cabal-install parallel xcb-proto python3-cffi python3-wheel"
 makedepends="python3-devel libffi-devel libxcb-devel python3-six"
@@ -11,7 +11,7 @@ maintainer="Kai Stian Olstad <void@olstad.com>"
 license="Apache-2.0"
 homepage="https://github.com/tych0/xcffib"
 distfiles="${homepage}/archive/v${version}.tar.gz"
-checksum=bd89c1e65cf4773fe10d70209ba069e0e1fe82c37c121501fc404aa9867d0ff3
+checksum=e0819e9cf56d47839a58755728af22eee02cad3b8b57157f8f682f187da96013
 nocross="Cannot yet cross compile with Haskell"
 
 pre_build() {

--- a/srcpkgs/python3-ytmusicapi/template
+++ b/srcpkgs/python3-ytmusicapi/template
@@ -3,7 +3,6 @@ pkgname=python3-ytmusicapi
 version=1.0.2
 revision=1
 build_style=python3-pep517
-make_install_target="dist/ytmusicapi-*.*.*-*-*-*.whl"
 hostmakedepends="python3-setuptools_scm python3-wheel"
 depends="python3-requests"
 checkdepends="$depends python3-coverage"

--- a/srcpkgs/rofi-rbw/template
+++ b/srcpkgs/rofi-rbw/template
@@ -3,7 +3,6 @@ pkgname=rofi-rbw
 version=1.2.0
 revision=1
 build_style=python3-pep517
-make_install_target="dist/rofi_rbw-${version}-py3-none-any.whl"
 hostmakedepends="python3-poetry-core"
 depends="python3 python3-ConfigArgParse rbw"
 short_desc="Rofi frontend for Bitwarden"

--- a/srcpkgs/synapse/template
+++ b/srcpkgs/synapse/template
@@ -5,7 +5,6 @@ revision=1
 build_style=python3-pep517
 build_helper=rust
 make_check_target=tests
-make_install_target="dist/matrix_synapse-${version}-*-*-*.whl"
 hostmakedepends="python3-poetry-core python3-setuptools-rust cargo"
 depends="python3-jsonschema python3-immutabledict python3-unpaddedbase64
  python3-canonicaljson python3-signedjson python3-pynacl


### PR DESCRIPTION
We replace the current glob of `"dist/${wheelbase//-/_}-${version}-*-*-*.whl"` for a much simpler `dist/*.whl`. The former is inconvenient since `wheelbase="${pkgname#python3-}"` is most of the time correct but often not, and fixing that in a different way seems more complicated than this solution.

Since we only run `python -m build` once, we should have only one wheel, so trying to be more specific doesn't seem useful. Nevertheless, this can still be overriden via `make_install_target` as before but hopefully it won't ever be necessary.

Note that several packages that currently need to set `make_install_target` for this purposes will now work out of the box.

If this is accepted I can have a look at those pkgs and clean up the override once it's no longer necessary.

#### Testing the changes
- I tested the changes in this PR: **YES**

I built all 150 packages that use pep517 as obtained by:
```
$ git grep -l style=.*pep517 srcpkgs/ | cut -d/ -f2 | wc -l
150
```
All of them succeed except for two that fail for unrelated reasons (`python3-xcffib` and `synapse`).


I also included a minor unrelated change: do not compile bytecode in `do_install()` since it will be removed in `post_install()`.


CC: @ahesford @icp1994 

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
