### PR TITLE
Signal-Desktop: update to 6.19.0.

### DIFF
--- a/srcpkgs/Signal-Desktop/template
+++ b/srcpkgs/Signal-Desktop/template
@@ -1,6 +1,6 @@
 # Template file for 'Signal-Desktop'
 pkgname=Signal-Desktop
-version=6.18.1
+version=6.19.0
 revision=1
 # Signal officially only supports x86_64 
 # x86_64-musl could potentially work based on the Alpine port:
@@ -14,14 +14,15 @@ maintainer="anelki <akierig@fastmail.de>"
 license="AGPL-3.0-only"
 homepage="https://github.com/signalapp/Signal-Desktop"
 distfiles="https://github.com/signalapp/Signal-Desktop/archive/v${version}.tar.gz"
-checksum=1527060bb666a459f6797d7161e237095fc3665323fed30d1cc0bc0828d5311c
+checksum=965702b217b39131c61e62c63fb25b073750a8f6febdffa9db236626124c6e50
 nostrip_files="signal-desktop"
 
 post_extract() {
 	# git-lfs hook needs to be installed for one of the dependencies
 	git lfs install
 
-	vsed 's/"node": "/&>=/' -i package.json
+	#vsed 's/"node": "/&>=/' -i package.json
+	vsed 's/"node": "18.14.0"/"node": ">=16.19.0"/' -i package.json
 
 	# Dependencies have to be installed before applying patch
 	yarn install --ignore-engines --frozen-lockfile


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64

-----

This uses a hacky `vsed` command to build with our version of node (16.19.0). It works for me, but it'd be much better if #41239 was merged soon.