### PR TITLE
New package: briss-0.9

### DIFF
--- a/srcpkgs/briss/template
+++ b/srcpkgs/briss/template
@@ -1,0 +1,34 @@
+# Template file for 'briss'
+pkgname=briss
+version=0.9
+revision=1
+depends="virtual?java-runtime"
+short_desc="Simple cross-platform application for cropping PDF files"
+maintainer="Eloi Torrents <eloitor@disroot.org>"
+license="GPL-3.0-or-later"
+homepage="https://sourceforge.net/projects/briss/"
+changelog="https://sourceforge.net/p/briss/code/HEAD/tree/briss/CHANGELOG.txt?format=raw"
+distfiles="${SOURCEFORGE_SITE}/briss/briss-${version}.tar.gz"
+checksum=45dd668a9ceb9cd59529a9fefe422a002ee1554a61be07e6fc8b3baf33d733d9
+
+post_build() {
+	cat > briss <<_EOF
+#!/bin/sh -e
+cd /usr/share/briss
+exec java -jar briss-${version}.jar "\$@"
+_EOF
+}
+
+do_install() {
+	vinstall bcprov-jdk15-1.46.jar 644 usr/share/briss
+	vinstall itextpdf-5.2.0.jar 644 usr/share/briss
+	vinstall jai-core-1.0.jar 644 usr/share/briss
+	vinstall jpedal-4.74b27.jar 644 usr/share/briss
+	vinstall bcmail-jdk15-1.46.jar 644 usr/share/briss
+	vinstall bctsp-jdk15-1.46.jar 644 usr/share/briss
+	vinstall briss-0.9.jar 644 usr/share/briss
+	vinstall jai-codec-1.0.jar 644 usr/share/briss
+	vinstall jai-imageio-1.0.jar 644 usr/share/briss
+
+	vbin briss
+}


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**.  For now it uses the precompiled distribution (the LanguageTool package does this too). It should be possible to compile it if someone knows how to handle the dependencies.

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)

closes #37737

I attempted to compile from source:
`distfiles="https://sourceforge.net/code-snapshots/svn/b/br/briss/code/briss-code-r75-briss.zip"`

But some dependencies are missing and I don't know how to package it:
```
[ERROR] Failed to execute goal on project briss: Could not resolve dependencies for project at.laborg:briss:jar:0.9: The following artifacts could not be resolved: jpedal:jpedal:jar:4.74b27, jai:jai-imageio:jar:1.0, jai:jai-core:jar:1.0, jai:jai-codec:jar:1.0: Failure to find jpedal:jpedal:jar:4.74b27 in https://repo.maven.apache.org/maven2 was cached in the local repository, resolution will not be reattempted until the update interval of central has elapsed or updates are forced -> [Help 1]
```
