### PR TITLE
gtk4: fix TreeList item order

### DIFF
--- a/srcpkgs/gtk4/patches/4a187d7f1d0f1aea8a5697a50299594ef523faf7.patch
+++ b/srcpkgs/gtk4/patches/4a187d7f1d0f1aea8a5697a50299594ef523faf7.patch
@@ -1,0 +1,100 @@
+From 4f47683710bbb4b56c286c6ee6a5c394fcf2b755 Mon Sep 17 00:00:00 2001
+From: Matthias Clasen <mclasen@redhat.com>
+Date: Wed, 29 Mar 2023 02:23:46 +0000
+Subject: [PATCH] Merge branch 'wip/otte/trelistmodel-fixage' into 'main'
+
+treelistmodel: Don't add items in reverse
+
+Closes #5707
+
+See merge request GNOME/gtk!5744
+
+(cherry picked from commit c5a53f235a2ed1b0acd0a8c29153e62377262d04)
+
+1718db14 treelistmodel: Don't add items in reverse
+cd860beb Add a test for splicing treelistmodel
+---
+ gtk/gtktreelistmodel.c        |  2 +-
+ testsuite/gtk/treelistmodel.c | 46 +++++++++++++++++++++++++++++++++++
+ 2 files changed, 47 insertions(+), 1 deletion(-)
+
+diff --git a/gtk/gtktreelistmodel.c b/gtk/gtktreelistmodel.c
+index dd3b3009ccc..1e55323c0a4 100644
+--- a/gtk/gtktreelistmodel.c
++++ b/gtk/gtktreelistmodel.c
+@@ -357,7 +357,7 @@ gtk_tree_list_model_items_changed_cb (GListModel *model,
+     }
+ 
+   tree_added = added;
+-  for (i = 0; i < added; i++)
++  for (i = added; i-- > 0;)
+     {
+       child = gtk_rb_tree_insert_before (node->children, child);
+       child->parent = node;
+diff --git a/testsuite/gtk/treelistmodel.c b/testsuite/gtk/treelistmodel.c
+index 941ac3d306b..98493a3ba56 100644
+--- a/testsuite/gtk/treelistmodel.c
++++ b/testsuite/gtk/treelistmodel.c
+@@ -261,6 +261,51 @@ test_remove_some (void)
+   g_object_unref (tree);
+ }
+ 
++static void
++splice (GListStore *store,
++        guint       pos,
++        guint       removed,
++        guint      *numbers,
++        guint       added)
++{
++  GObject **objects = g_newa (GObject *, added);
++  guint i;
++
++  for (i = 0; i < added; i++)
++    {
++      /* 0 cannot be differentiated from NULL, so don't use it */
++      g_assert_cmpint (numbers[i], !=, 0);
++      objects[i] = g_object_new (G_TYPE_OBJECT, NULL);
++      g_object_set_qdata (objects[i], number_quark, GUINT_TO_POINTER (numbers[i]));
++    }
++
++  g_list_store_splice (store, pos, removed, (gpointer *) objects, added);
++
++  for (i = 0; i < added; i++)
++    g_object_unref (objects[i]);
++}
++
++static void
++test_splice (void)
++{
++  GtkTreeListModel *tree = new_model (100, TRUE);
++  gpointer item;
++
++  assert_model (tree, "100 100 100 99 98 97 96 95 94 93 92 91 90 90 89 88 87 86 85 84 83 82 81 80 80 79 78 77 76 75 74 73 72 71 70 70 69 68 67 66 65 64 63 62 61 60 60 59 58 57 56 55 54 53 52 51 50 50 49 48 47 46 45 44 43 42 41 40 40 39 38 37 36 35 34 33 32 31 30 30 29 28 27 26 25 24 23 22 21 20 20 19 18 17 16 15 14 13 12 11 10 10 9 8 7 6 5 4 3 2 1");
++  assert_changes (tree, "");
++
++  item = g_list_model_get_item (G_LIST_MODEL (tree), 1);
++  g_assert_true (G_IS_LIST_MODEL (item));
++  splice (item, 0, 5, (guint[5]) { 300, 301, 302, 303, 304 }, 5);
++  /* expected */
++  assert_model (tree, "100 100 300 301 302 303 304 95 94 93 92 91 90 90 89 88 87 86 85 84 83 82 81 80 80 79 78 77 76 75 74 73 72 71 70 70 69 68 67 66 65 64 63 62 61 60 60 59 58 57 56 55 54 53 52 51 50 50 49 48 47 46 45 44 43 42 41 40 40 39 38 37 36 35 34 33 32 31 30 30 29 28 27 26 25 24 23 22 21 20 20 19 18 17 16 15 14 13 12 11 10 10 9 8 7 6 5 4 3 2 1");
++  /* real outcome */
++  // assert_model (tree, "100 100 304 303 302 301 300 95 94 93 92 91 90 90 89 88 87 86 85 84 83 82 81 80 80 79 78 77 76 75 74 73 72 71 70 70 69 68 67 66 65 64 63 62 61 60 60 59 58 57 56 55 54 53 52 51 50 50 49 48 47 46 45 44 43 42 41 40 40 39 38 37 36 35 34 33 32 31 30 30 29 28 27 26 25 24 23 22 21 20 20 19 18 17 16 15 14 13 12 11 10 10 9 8 7 6 5 4 3 2 1");
++  assert_changes (tree, "2-5+5");
++
++  g_object_unref (tree);
++}
++
+ /* Test for https://gitlab.gnome.org/GNOME/gtk/-/issues/4595 */
+ typedef struct _DemoNode DemoNode;
+ 
+@@ -391,6 +436,7 @@ main (int argc, char *argv[])
+ 
+   g_test_add_func ("/treelistmodel/expand", test_expand);
+   g_test_add_func ("/treelistmodel/remove_some", test_remove_some);
++  g_test_add_func ("/treelistmodel/remove_splice", test_splice);
+   g_test_add_func ("/treelistmodel/collapse-change", test_collapse_change);
+ 
+   return g_test_run ();
+-- 
+GitLab
+

--- a/srcpkgs/gtk4/template
+++ b/srcpkgs/gtk4/template
@@ -1,7 +1,7 @@
 # Template file for 'gtk4'
 pkgname=gtk4
 version=4.10.3
-revision=1
+revision=2
 build_style=meson
 build_helper="gir"
 configure_args="-Dman-pages=true -Dgtk_doc=true


### PR DESCRIPTION
This also fixes an issue in nautilus where removed items appear at the front of the file list.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
