### PR TITLE
qca-qt5: update to 2.3.6.

### DIFF
--- a/srcpkgs/qca-qt5/template
+++ b/srcpkgs/qca-qt5/template
@@ -1,9 +1,9 @@
 # Template file for 'qca-qt5'
 pkgname=qca-qt5
-version=2.3.4
+version=2.3.6
 revision=1
 build_style=cmake
-configure_args="-DBUILD_TESTS=0 -DQCA_FEATURE_INSTALL_DIR=/usr/share/qca-qt5/mkspecs
+configure_args="-DQCA_FEATURE_INSTALL_DIR=/usr/share/qca-qt5/mkspecs
  -DUSE_RELATIVE_PATHS=true"
 hostmakedepends="pkg-config ca-certificates"
 makedepends="nss-devel libgcrypt-devel qt5-devel ca-certificates openssl-devel"
@@ -13,10 +13,16 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://userbase.kde.org/QCA"
 distfiles="${KDE_SITE}/qca/${version}/qca-${version}.tar.xz"
-checksum=6b695881a7e3fd95f73aaee6eaeab96f6ad17e515e9c2b3d4b3272d7862ff5c4
+checksum=ee59d531d4b82fb1685f4d8d74c2caa0777f501800f7426eaa372109a4305249
 
 if [ "$CROSS_BUILD" ]; then
 	hostmakedepends+=" qt5-host-tools qt5-devel"
+fi
+
+if [ "$XBPS_CHECK_PKGS" ]; then
+	configure_args+=" -DBUILD_TESTS=1"
+else
+	configure_args+=" -DBUILD_TESTS=0"
 fi
 
 qca-qt5-ossl_package() {
@@ -35,6 +41,6 @@ qca-qt5-devel_package() {
 		vmove usr/lib/pkgconfig
 		vmove usr/lib/cmake
 		vmove usr/share/qca-qt5/mkspecs
-		vmove usr/lib/*.so
+		vmove "usr/lib/*.so"
 	}
 }


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

@Johnnynator

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
