### PR TITLE
wireplumber: create /var/lib/wireplumber

### DIFF
--- a/srcpkgs/wireplumber/template
+++ b/srcpkgs/wireplumber/template
@@ -1,7 +1,7 @@
 # Template file for 'wireplumber'
 pkgname=wireplumber
 version=0.4.14
-revision=2
+revision=3
 build_style=meson
 build_helper=gir
 configure_args="-Dintrospection=enabled -Dsystem-lua=true"
@@ -16,6 +16,7 @@ changelog="https://gitlab.freedesktop.org/pipewire/wireplumber/-/raw/master/NEWS
 distfiles="https://gitlab.freedesktop.org/pipewire/wireplumber/-/archive/$version/wireplumber-$version.tar.gz"
 checksum=b160424ce7c3eeeccba388726f6a448f53501d25085e5fa1bf6c690c1bcd85ea
 provides="pipewire-session-manager-0_1"
+make_dirs="/var/lib/wireplumber 0755 _pipewire _pipewire"
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
- I tested the changes in this PR: yes
- I built this PR locally for my native architecture, (x86_64-musl)

This fixes a warning from pipewire complaining that the folder does not exist.