### PR TITLE
[RFC] base-files: add kernel hook for /boot freespace

### DIFF
--- a/srcpkgs/linux-base/files/50-bootsize.postinst
+++ b/srcpkgs/linux-base/files/50-bootsize.postinst
@@ -1,0 +1,38 @@
+#!/bin/sh
+#
+# Kernel hook to check for filled /boot partitions
+#
+# Arguments passed to this script: $1 pkgname, $2 version.
+#
+PKGNAME="$1"
+VERSION="$2"
+
+# freespace = blocksize * freeblocks
+freespace=$(( $(stat -f -c '%S * %f' /boot) ))
+
+vmlinuz=$(find /boot -maxdepth 1 -type f -name 'vmlinuz*' -printf '%s\n' | sort -n | tail -n1)
+initramfs=$(find /boot -maxdepth 1 -type f -name 'initramfs*' -printf '%s\n' | sort -n | tail -n1)
+totalneeded=$(( 2 * (initramfs + vmlinuz) ))
+
+# freespace for /boot is <=  2*(largest kernel + largest initrd)
+if [ $freespace -le $totalneeded ]; then
+	color=false
+	if [ -z "$NO_COLOR" ] && [ -t 1 ]; then
+		# Set output to be bold and red, if supported
+		color=true
+		tput setaf 1
+		tput bold
+	fi
+	cat <<-'ENDMSG'
+	 * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+	 * WARNING: /boot may not have enough space for the next kernel. Use     *
+	 * `vkpurge` to ensure there will be sufficient space to write the next  *
+	 * kernel and generate its initrd. Your system may otherwise become      *
+	 * unbootable.                                                           *
+	 * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+	ENDMSG
+	if $color; then
+		# Reset output back to normal
+		tput sgr0
+	fi
+fi

--- a/srcpkgs/linux-base/template
+++ b/srcpkgs/linux-base/template
@@ -1,8 +1,7 @@
 # Template file for 'linux-base'
 pkgname=linux-base
-version=2021.07.21
+version=2023.05.29
 revision=1
-build_style=meta
 short_desc="Linux kernel base dependencies"
 maintainer="Érico Nogueira <ericonr@disroot.org>"
 license="Public Domain"
@@ -16,3 +15,7 @@ case "$XBPS_TARGET_MACHINE" in
 		depends="linux-firmware-amd linux-firmware-nvidia linux-firmware-network dracut"
 		;;
 esac
+
+do_install() {
+	vinstall ${FILESDIR}/50-bootsize.postinst 0755 etc/kernel.d/post-install 50-bootsize
+}


### PR DESCRIPTION
    <leah2> we should make a kernel install hook check that prints a big
            warning if /boot is full after running it...

Thoughts:

1. Change the threshold size? Make it configurable?
2. Change the threshold to a percentage? I think that's less useful.
3. Change what package this is shipped with? I'm not sure if it applies to all configurations we support/consider.
4. Wording of the message?