### PR TITLE
davmail: update to 6.1.0.

### DIFF
--- a/srcpkgs/davmail/template
+++ b/srcpkgs/davmail/template
@@ -1,16 +1,17 @@
 # Template file for 'davmail'
 pkgname=davmail
-version=6.0.1
+version=6.1.0
 revision=1
-_commit=3390
+_commit=3423
 hostmakedepends="openjdk8 apache-ant"
+depends="virtual?java-runtime"
 short_desc="POP/IMAP/SMTP/Caldav/Carddav/LDAP exchange gateway"
 maintainer="Anachron <gith@cron.world>"
 license="GPL-2.0-only"
 homepage="https://davmail.sourceforge.net"
 changelog="https://raw.githubusercontent.com/mguessan/davmail/master/RELEASE-NOTES.md"
 distfiles="${SOURCEFORGE_SITE}/davmail/davmail-src-${version}-${_commit}.tgz"
-checksum=ce3b33cd187787a30ccc136e75f1cdf197b0a2874c20ab3f3ea3e426b32b9ab1
+checksum=08e7103d14e9f05ec269caceef7585dcf8be202a35c471fa6fc12729cf99ef2f
 
 do_build() {
 	. /etc/profile.d/openjdk.sh
@@ -24,11 +25,11 @@ do_install() {
 	vmkdir usr/share/davmail/lib
 	vcopy "lib/*" usr/share/davmail/lib
 	vbin src/bin/davmail
-}
 
-post_install() {
 	case "$XBPS_TARGET_MACHINE" in
-		x86_64) return 0 ;;
+		x86_64) ;;
+		*) rm -f ${DESTDIR}/usr/share/davmail/lib/swt-* ;;
 	esac
-	rm -f ${DESTDIR}/usr/share/davmail/lib/swt-*
+
+	vsconf src/etc/davmail.properties
 }


### PR DESCRIPTION
Template improvements:
- Add an example `davmail.properties`
- Remove superfluous `post_install`
- Add dependency on `java-runtime` virtual, because a Java application needs a JRE

#### Testing the changes
- I tested the changes in this PR: pending

I don't yet have a viable workflow for davmail but will see if I can get it going.

cc: @Anachron 