### PR TITLE
pnpm: update to 8.6.0

### DIFF
--- a/srcpkgs/pnpm/template
+++ b/srcpkgs/pnpm/template
@@ -1,6 +1,6 @@
 # Template file for 'pnpm'
 pkgname=pnpm
-version=7.30.5
+version=8.6.0
 revision=1
 build_style=fetch
 hostmakedepends="nodejs jq"
@@ -10,7 +10,7 @@ maintainer="reback00 <reback00@protonmail.com>"
 license="MIT"
 homepage="https://pnpm.io/"
 distfiles="https://registry.npmjs.org/pnpm/-/pnpm-${version}.tgz"
-checksum=c8d730294f671574458704cd56e81dc0eb8d345a444e4c7a728d8d2cdc4f5045
+checksum=1e9c17c34c2eebaba02e78b619e296db08d302c296e58c2f51b0cd4e3e5bcda2
 python_version=3
 
 do_install() {


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)

cc @fnogcps

The 7.x branch of pnpm is no longer maintained (according to https://pnpm.io/versions), and I couldn't find any reasons to not switch to the 8.x branch. 
pnpm 8 dropped support for nodejs 14, but since we're already using nodejs 16 that shouldn't be an issue.
