### PR TITLE
helix: switch from launcher script to symlink

### DIFF
--- a/srcpkgs/helix/files/hx
+++ b/srcpkgs/helix/files/hx
@@ -1,2 +1,0 @@
-#!/bin/sh
-HELIX_RUNTIME=/usr/lib/helix/runtime exec /usr/lib/helix/hx "$@"

--- a/srcpkgs/helix/template
+++ b/srcpkgs/helix/template
@@ -1,7 +1,7 @@
 # Template file for 'helix'
 pkgname=helix
 version=23.05
-revision=1
+revision=2
 build_style=cargo
 make_install_args="--path helix-term"
 short_desc="Post-modern modal text editor"
@@ -30,7 +30,7 @@ post_install() {
 	vinstall contrib/helix.png 644 usr/share/icons/hicolor/128x128/apps
 
 	vmkdir usr/lib/helix
-	mv ${DESTDIR}/usr/bin/hx ${DESTDIR}/usr/lib/helix/
 	vcopy runtime usr/lib/helix
-	vbin ${FILESDIR}/hx
+	mv ${DESTDIR}/usr/bin/hx ${DESTDIR}/usr/lib/helix/
+	ln -s /usr/lib/helix/hx ${DESTDIR}/usr/bin/
 }


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

Allows users to set their own `HELIX_RUNTIME` variable and also autodetect the system runtime dir `/usr/lib/helix/runtime`

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
