### PR TITLE
libssh2: update to 1.11.0

### DIFF
--- a/srcpkgs/libssh2/template
+++ b/srcpkgs/libssh2/template
@@ -1,16 +1,16 @@
 # Template file for 'libssh2'
 pkgname=libssh2
-version=1.10.0
+version=1.11.0
 revision=1
-build_style=gnu-configure
-configure_args="--with-libssl-prefix=${XBPS_CROSS_BASE}/usr"
+build_style=cmake
+configure_args="-DENABLE_ZLIB_COMPRESSION=ON -DRUN_DOCKER_TESTS=OFF"
 makedepends="zlib-devel openssl-devel"
 short_desc="Library implementing the SSH2 protocol"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="BSD-3-Clause"
 homepage="http://www.libssh2.org/"
 distfiles="http://www.libssh2.org/download/${pkgname}-${version}.tar.gz"
-checksum=2d64e90f3ded394b91d3a2e774ca203a4179f69aebee03003e5a6fa621e41d51
+checksum=3736161e41e2693324deb38c26cfdc3efe6209d634ba4258db1cecff6a5ad461
 
 post_install() {
 	vlicense COPYING LICENSE
@@ -21,9 +21,11 @@ libssh2-devel_package() {
 	short_desc+=" - development files"
 	pkg_install() {
 		vmove usr/include
+		vmove usr/lib/cmake
 		vmove usr/lib/pkgconfig
 		vmove "usr/lib/*.a"
 		vmove "usr/lib/*.so"
-		vmove usr/share
+		vmove usr/share/doc
+		vmove usr/share/man
 	}
 }


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
