### PR TITLE
kdenlive: New dependency required

### DIFF
--- a/srcpkgs/kdenlive/template
+++ b/srcpkgs/kdenlive/template
@@ -1,7 +1,7 @@
 # Template file for 'kdenlive'
 pkgname=kdenlive
 version=23.04.0
-revision=1
+revision=2
 build_style=cmake
 hostmakedepends="
  extra-cmake-modules kconfig kcoreaddons kdoctools pkg-config python3
@@ -10,7 +10,7 @@ makedepends="
  kdeclarative-devel kfilemetadata5-devel knewstuff-devel knotifyconfig-devel
  kplotting-devel mlt7-devel qt5-multimedia-devel qt5-webkit-devel purpose-devel
  v4l-utils-devel ksolid-devel qt5-quickcontrols2-devel qt5-networkauth-devel"
-depends="breeze-icons dvdauthor ffmpeg frei0r-plugins kinit qt5-quickcontrols"
+depends="breeze-icons dvdauthor ffmpeg frei0r-plugins kinit qt5-quickcontrols qt5-graphicaleffects"
 checkdepends="$depends"
 short_desc="Non-linear video editor"
 maintainer="Orphaned <orphan@voidlinux.org>"


### PR DESCRIPTION
qt5-graphicaleffects is now needed for kdenlive to function.

<!-- Uncomment relevant sections and delete options which are not applicable -->

Testing the changes
- I tested the changes in this PR: **YES**

Local build testing
- I built this PR locally for my native architecture, (x86_64)
