### PR TITLE
libmicrohttpd: remove unused dependencies, fix

### DIFF
--- a/srcpkgs/libmicrohttpd/template
+++ b/srcpkgs/libmicrohttpd/template
@@ -1,20 +1,18 @@
 # Template file for 'libmicrohttpd'
 pkgname=libmicrohttpd
 version=0.9.77
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="
- --enable-largefile
  --enable-https
  --enable-messages"
-hostmakedepends="texinfo"
-makedepends="libgcrypt-devel gnutls-devel"
+makedepends="gnutls-devel"
 checkdepends="libcurl-devel"
 short_desc="Library embedding HTTP server functionality"
 maintainer="Duncaen <duncaen@voidlinux.org>"
 license="LGPL-2.1-or-later"
 homepage="https://www.gnu.org/software/libmicrohttpd/"
-changelog="https://git.gnunet.org/libmicrohttpd.git/plain/ChangeLog"
+changelog="https://git.gnunet.org/libmicrohttpd.git/tree/ChangeLog?h=v${version}"
 distfiles="${GNU_SITE}/libmicrohttpd/libmicrohttpd-${version}.tar.gz"
 checksum=9e7023a151120060d2806a6ea4c13ca9933ece4eacfc5c9464d20edddb76b0a0
 


### PR DESCRIPTION
A few simplification for libmicrohttpd:
* Removed unneeded `--enable-largefile`. This is detected automatically by `configure`.
* Removed unneeded `gettext` dependency. It was needed for one broken tarball in the past (the timestamp was wrong resulting in documentation useless rebuild). Current tarballs have no problem with timestamps.
* Removed unneeded `libgcrypt` dependency. It was needed for ten years old GnuTLS versions for proper initialisaion.
* Fixed `changelog` URL. Some releases are made not with `master` branch, which content is returned by default. Releases are always tagged so the link should be always valid and actual.