### PR TITLE
New package: KataGo-1.13.2

### DIFF
--- a/srcpkgs/KataGo-OpenCL/template
+++ b/srcpkgs/KataGo-OpenCL/template
@@ -1,0 +1,34 @@
+# Template file for 'KataGo-OpenCL'
+pkgname=KataGo-OpenCL
+version=1.13.2
+revision=1
+build_wrksrc=cpp
+build_style=cmake
+configure_args="-DUSE_BACKEND=OPENCL -DNO_GIT_REVISION=1"
+makedepends="ocl-icd-devel zlib-devel libzip-devel"
+short_desc="KataGo Go/Weiqi/Baduk analysis engine (OpenCL backend)"
+maintainer="Jason Elswick <jason@jasondavid.tv>"
+license="MIT"
+homepage="https://github.com/lightvector/KataGo/"
+distfiles="https://github.com/lightvector/KataGo/archive/refs/tags/v${version}.tar.gz"
+checksum=f1a5659ff6dcec246f11bd250dcb41f1879dbbd41d4e909ae030954acfebde41
+
+alternatives="katago:katago:/usr/bin/katago-opencl"
+
+case "$XBPS_TARGET_MACHINE" in
+	i686*) broken="size_t assert fails" ;;
+esac
+
+if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
+	configure_args+=" -DCMAKE_CXX_STANDARD_LIBRARIES=-latomic"
+	makedepends+=" libatomic-devel"
+fi
+
+do_check() {
+	build/katago runtests
+}
+
+do_install() {
+	vbin build/katago katago-opencl
+	vlicense "${wrksrc}"/LICENSE
+}

--- a/srcpkgs/KataGo-eigen/template
+++ b/srcpkgs/KataGo-eigen/template
@@ -1,0 +1,35 @@
+# Template file for 'KataGo-eigen'
+pkgname=KataGo-eigen
+version=1.13.2
+revision=1
+build_wrksrc=cpp
+build_style=cmake
+configure_args="-DUSE_BACKEND=EIGEN -DNO_GIT_REVISION=1"
+make_check_target="check"
+makedepends="zlib-devel libzip-devel eigen"
+short_desc="KataGo Go/Weiqi/Baduk analysis engine (eigen backend)"
+maintainer="Jason Elswick <jason@jasondavid.tv>"
+license="MIT"
+homepage="https://github.com/lightvector/KataGo/"
+distfiles="https://github.com/lightvector/KataGo/archive/refs/tags/v${version}.tar.gz"
+checksum=f1a5659ff6dcec246f11bd250dcb41f1879dbbd41d4e909ae030954acfebde41
+
+alternatives="katago:katago:/usr/bin/katago-eigen"
+
+case "$XBPS_TARGET_MACHINE" in
+	i686*) broken="size_t assert fails" ;;
+esac
+
+if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
+	configure_args+=" -DCMAKE_CXX_STANDARD_LIBRARIES=-latomic"
+	makedepends+=" libatomic-devel"
+fi
+
+do_check() {
+	build/katago runtests
+}
+
+do_install() {
+	vbin build/katago katago-eigen
+	vlicense "${wrksrc}"/LICENSE
+}


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: YES

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): YES

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl
  - armv7l
  - armv7l-musl
  - aarch64
  - aarch64-musl
