### PR TITLE
openssl: update to 1.1.1u

### DIFF
--- a/srcpkgs/openssl/template
+++ b/srcpkgs/openssl/template
@@ -1,6 +1,6 @@
 # Template file for 'openssl'
 pkgname=openssl
-version=1.1.1t
+version=1.1.1u
 revision=1
 bootstrap=yes
 build_style=configure
@@ -17,7 +17,7 @@ maintainer="John <me@johnnynator.dev>"
 license="OpenSSL"
 homepage="https://www.openssl.org"
 distfiles="https://www.openssl.org/source/openssl-${version}.tar.gz"
-checksum=8dee9b24bdb1dcbf0c3d1e9b02fb8f6bf22165e807f45adeb7c9677536859d3b
+checksum=e2f8d84b523eecd06c7be7626830370300fbcc15386bf5142d72758f6963ebc6
 conf_files="/etc/ssl/openssl.cnf"
 replaces="libressl>=0"
 


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: YES

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc

See https://www.openssl.org/news/openssl-1.1.1-notes.html#openssl-1.1.1-series-release-notes