### PR TITLE
New package: linux-wifi-hotspot-4.5.0

### DIFF
--- a/srcpkgs/linux-wifi-hotspot/patches/makefile.patch
+++ b/srcpkgs/linux-wifi-hotspot/patches/makefile.patch
@@ -1,0 +1,24 @@
+--- a/src/Makefile
++++ b/src/Makefile
+@@ -1,7 +1,7 @@
+ CC=gcc
+ PKGCONFIG = $(shell which pkg-config)
+
+-CFLAGS=`pkg-config --cflags gtk+-3.0`
++CFLAGS_PKGCONF=`pkg-config --cflags gtk+-3.0`
+ LIBS=`pkg-config --libs gtk+-3.0 --libs x11` -lstdc++ -lpng -lqrencode
+
+ APP_NAME="wihotspot"
+@@ -32,10 +32,10 @@ resources.c: ui/glade/wifih.gresource.xml ui/glade/wifih.ui
+ 	@$(MAKE) -f $(THIS_FILE) wihotspot-gui
+
+ $(ODIR)/%.o: ui/%.c
+-	$(CC) -c -o $@ $< $(CFLAGS)
++	$(CC) -c -o $@ $< $(CFLAGS) $(CFLAGS_PKGCONF)
+
+ $(ODIR)/%.o: ui/%.cpp
+-	g++ -c -o $@ $<
++	$(CXX) -c -o $@ $< $(CXXFLAGS)
+
+ wihotspot-gui: $(OBJ)
+ 	$(CC) -o $(ODIR)/$@ $^ $(CFLAGS) $(LIBS)

--- a/srcpkgs/linux-wifi-hotspot/template
+++ b/srcpkgs/linux-wifi-hotspot/template
@@ -1,0 +1,19 @@
+# Template file for 'linux-wifi-hotspot'
+pkgname=linux-wifi-hotspot
+version=4.5.0
+revision=1
+build_style=gnu-makefile
+hostmakedepends="pkg-config which glib-devel"
+makedepends="gtk+3-devel libpng-devel qrencode-devel"
+depends="bash dnsmasq hostapd iproute2 iptables iw procps-ng util-linux"
+short_desc="Feature-rich wifi hotspot creator"
+maintainer="Bnyro <bnyro@tutanota.com>"
+license="BSD-2-Clause"
+homepage="https://github.com/lakinduakash/linux-wifi-hotspot"
+distfiles="https://github.com/lakinduakash/linux-wifi-hotspot/archive/refs/tags/v${version}.tar.gz"
+checksum=9e4222b7d3129347b01eef711911ec87c9a04e20efd12d88565f682a14eb91da
+conflicts="create_ap"
+
+post_install() {
+	vlicense LICENSE
+}


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)

`linux-wifi-hotspot` is the successor of `create_ap`, which got discontinued in 2021.
`linux-wifi-hotspot` additionally provides a gtk interface for creating hotspots, but it does contain a more updated version of `create_ap` too.
