### PR TITLE
activityrelay: update to 0.2.4.

### DIFF
--- a/srcpkgs/activityrelay/files/activityrelay/run
+++ b/srcpkgs/activityrelay/files/activityrelay/run
@@ -2,4 +2,4 @@
 [ -r ./conf ] && . ./conf
 exec 2>&1
 exec chpst -u _activityrelay:_activityrelay activityrelay \
-	-c ${CONFIG_FILE:-/etc/activityrelay/activityrelay.yaml}
+	-c ${CONFIG_FILE:-/etc/activityrelay/activityrelay.yaml} run

--- a/srcpkgs/activityrelay/template
+++ b/srcpkgs/activityrelay/template
@@ -1,17 +1,17 @@
 # Template file for 'activityrelay'
 pkgname=activityrelay
-version=0.2.2
-revision=2
+version=0.2.4
+revision=1
 build_style=python3-module
 hostmakedepends="python3-setuptools"
-depends="python3-aiohttp python3-cachetools python3-click python3-pycryptodome
+depends="python3-aiohttp python3-aputils python3-cachetools python3-click
  python3-yaml"
 short_desc="Generic LitePub relay (works with LitePub consumers and Mastodon)"
 maintainer="Joel Beckmeyer <joel@beckmeyer.us>"
 license="AGPL-3.0-or-later"
 homepage="https://git.pleroma.social/pleroma/relay"
 distfiles="https://git.pleroma.social/pleroma/relay/-/archive/${version}/relay-${version}.tar.gz"
-checksum=f460037a522e45fd030735da893e5851d90b6340caab0bcd24346996474aac25
+checksum=32c127b789d3305301f6a408299a9d59035665674dae6806fb4bb3206698b40e
 make_check=no # no tests specified
 
 system_accounts="_activityrelay"

--- a/srcpkgs/python3-aputils/template
+++ b/srcpkgs/python3-aputils/template
@@ -1,0 +1,18 @@
+# Template file for 'python3-aputils'
+pkgname=python3-aputils
+version=0.1.4
+revision=1
+build_style=python3-pep517
+hostmakedepends="python3-setuptools python3-wheel"
+depends="python3-pycryptodome"
+short_desc="Various classes and functions for ActivityPub servers"
+maintainer="Joel Beckmeyer <joel@beckmeyer.us>"
+license="custom:CNPL"
+homepage="https://git.barkshark.xyz/barkshark/aputils"
+changelog="https://git.barkshark.xyz/barkshark/aputils/releases"
+distfiles="https://git.barkshark.xyz/barkshark/aputils/archive/${version}.tar.gz"
+checksum=2fa255df5998f10d9eeb2791ce3fe6ea3fc4f1701d84942d81ba8e4f66642896
+
+post_install() {
+	vlicense LICENSE.md
+}

--- a/srcpkgs/python3-aputils/update
+++ b/srcpkgs/python3-aputils/update
@@ -1,0 +1,2 @@
+site="https://git.barkshark.xyz/barkshark/aputils/tags"
+pattern='<a.*>\K[\d.]+(?=</a>)'


### PR DESCRIPTION
- New package: python3-aputils-0.1.4
This one might be a gamebreaker, not sure about this license...

- activityrelay: update to 0.2.4.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
