### PR TITLE
New package: xidlehook-0.10.0

### DIFF
--- a/srcpkgs/xidlehook/template
+++ b/srcpkgs/xidlehook/template
@@ -1,0 +1,22 @@
+# Template file for 'xidlehook'
+pkgname=xidlehook
+version=0.10.0
+revision=1
+build_wrksrc="xidlehook-daemon"
+build_style=cargo
+configure_args="$(vopt_if pulseaudio '--features pulse' '--no-default-features')"
+hostmakedepends="pkg-config python3"
+makedepends="libxcb-devel libXScrnSaver-devel $(vopt_if pulseaudio pulseaudio-devel)"
+short_desc="Xautolock rewrite in Rust, with a few extra features"
+maintainer="MOIS3Y <stepan@zhukovsky.me>"
+license="MIT"
+homepage="https://gitlab.com/jD91mZM2/xidlehook"
+distfiles="https://gitlab.com/jD91mZM2/xidlehook/-/archive/${version}/xidlehook-${version}.tar.gz"
+checksum=66751b78c5174c0e430d9becd749771d593f388db348514d8c3256670dc77cd8
+build_options_default="pulseaudio"
+desc_option_pulseaudio="Don't invoke the timer when any audio is playing (Only works with Pulseaudio)"
+build_options="pulseaudio"
+
+post_install() {
+	vlicense ../LICENSE
+}


### PR DESCRIPTION
This PR is an updated version of https://github.com/void-linux/void-packages/pull/27774 since the original is closed. The requested changes have also been added.
There's also an associated package request for this PR: https://github.com/void-linux/void-packages/issues/27422

#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**


#### Local build testing
- I built this PR locally for my native architecture, (x86_64)
- I built this PR locally for these architectures:
    - armv6l
