### PR TITLE
New package: brother-brscan5-1.2.13

### DIFF
--- a/srcpkgs/brother-brscan5/INSTALL
+++ b/srcpkgs/brother-brscan5/INSTALL
@@ -1,0 +1,9 @@
+case "${ACTION}" in
+    post)
+	# Add brother driver to sane configuration
+	_SANE_CONF='/etc/sane.d/dll.conf'
+	if [ "$(grep brother5 ${_SANE_CONF})" = '' ]; then
+		echo brother5 >> ${_SANE_CONF}
+	fi;
+    ;;
+esac

--- a/srcpkgs/brother-brscan5/REMOVE
+++ b/srcpkgs/brother-brscan5/REMOVE
@@ -1,0 +1,7 @@
+case "${ACTION}" in
+    pre)
+	# remove brother driver from sane configuration
+	_SANE_CONF='/etc/sane.d/dll.conf'
+    sed -i -e '/brother5/d' ${_SANE_CONF}
+    ;;
+esac

--- a/srcpkgs/brother-brscan5/files/README.voidlinux
+++ b/srcpkgs/brother-brscan5/files/README.voidlinux
@@ -1,0 +1,2 @@
+In order to access networked scanners and multifunctionals, the SANE backend
+must be configured using 'brsaneconfig5'.

--- a/srcpkgs/brother-brscan5/template
+++ b/srcpkgs/brother-brscan5/template
@@ -1,0 +1,75 @@
+# Template file for 'brother-brscan5'
+pkgname=brother-brscan5
+version=1.2.13
+revision=1
+archs="i686 x86_64"
+depends="sane libusb-compat"
+short_desc="SANE scanner driver for brscan5-compatible printers"
+maintainer="Alexandru Barbur <alex@ctrlc.name>"
+license="custom:EULA"
+homepage="https://support.brother.com/"
+repository="nonfree"
+nopie=yes
+conf_files="/opt/brother/scanner/brscan5/brscan5.ini
+ /opt/brother/scanner/brscan5/brsanenetdevice.cfg
+ /opt/brother/scanner/brscan5/models/*.ini"
+
+_sane_library="libsane-brother5.so.1.0.7"
+_pkg_libraries="libLxBsScanCoreApi.so.3.2.0
+ libLxBsNetDevAccs.so.1.0.0
+ libLxBsDeviceAccs.so.1.0.0
+ libLxBsUsbDevAccs.so.1.0.0"
+
+if [ "$XBPS_TARGET_MACHINE" = "x86_64" ]; then
+	_rpmpkgid="0.x86_64"
+	distfiles="https://download.brother.com/welcome/dlf104036/brscan5-${version}-${_rpmpkgid}.rpm"
+	checksum="572d24efc23de14933cb15f8c8be20575af07d7aff32c3ddf0633bacffe9e098"
+	_rpmlibdir="usr/lib64"
+else
+	_rpmpkgid="0.i386"
+	distfiles="https://download.brother.com/welcome/dlf104035/brscan5-${version}-${_rpmpkgid}.rpm"
+	checksum="4cdca918fb7f994fc1e081a3a709db8f5b4420406d26aa04a6effc941e468fc2"
+	_rpmlibdir="usr/lib"
+fi
+
+do_install() {
+	vinstall opt/brother/scanner/brscan5/${_sane_library} 755 usr/lib/sane
+	ln -sf /usr/lib/sane/${_sane_library} ${DESTDIR}/usr/lib/sane/$(echo ${_sane_library} | sed -e 's/\.[0-9]\.[0-9]$//')
+	ln -sf /usr/lib/sane/${_sane_library} ${DESTDIR}/usr/lib/sane/$(echo ${_sane_library} | sed -e 's/\.[0-9]\.[0-9]\.[0-9]$//')
+
+	for library in $_pkg_libraries; do
+		vinstall opt/brother/scanner/brscan5/${library} 755 usr/lib
+		ln -sf /usr/lib/${library} ${DESTDIR}/usr/lib/$(echo ${library} | sed -e 's/\.[0-9]\.[0-9]$//')
+		ln -sf /usr/lib/${library} ${DESTDIR}/usr/lib/$(echo ${library} | sed -e 's/\.[0-9]\.[0-9]\.[0-9]$//')
+	done
+
+	pushd opt/brother/scanner/brscan5/udev-rules
+	sed '/SYSFS/d' NN-brother-mfp-brscan5-1.0.2-2.rules > 40-brother-mfp-brscan5-1.0.2-2.rules
+	vinstall 40-brother-mfp-brscan5-1.0.2-2.rules 644 usr/lib/udev/rules.d
+	popd
+
+	# note: configuration file locations are hard-coded in libsane-brother5.so
+	vinstall opt/brother/scanner/brscan5/brsaneconfig5 755 opt/brother/scanner/brscan5
+	vinstall opt/brother/scanner/brscan5/brscan5.ini 644 opt/brother/scanner/brscan5
+	vinstall opt/brother/scanner/brscan5/brsanenetdevice.cfg 644 opt/brother/scanner/brscan5
+	vinstall opt/brother/scanner/brscan5/brscan_cnetconfig 755 opt/brother/scanner/brscan5
+	vinstall opt/brother/scanner/brscan5/brscan_gnetconfig 755 opt/brother/scanner/brscan5
+
+	vmkdir etc/opt/brother/scanner/brscan5 755
+	ln -sf /opt/brother/scanner/brscan5/brscan5.ini ${DESTDIR}/etc/opt/brother/scanner/brscan5/brscan5.ini
+	ln -sf /opt/brother/scanner/brscan5/brsanenetdevice.cfg ${DESTDIR}/etc/opt/brother/scanner/brscan5/brsanenetdevice.cfg
+	ln -sf /opt/brother/scanner/brscan5/models ${DESTDIR}/etc/opt/brother/scanner/brscan5/models
+
+	vmkdir opt/brother/scanner/brscan5 755
+	vcopy opt/brother/scanner/brscan5/models opt/brother/scanner/brscan5
+
+	vlicense opt/brother/scanner/brscan5/doc/LICENSE_ENG.txt
+	vlicense opt/brother/scanner/brscan5/doc/LICENSE_JPN.txt
+	vlicense opt/brother/scanner/brscan5/doc/readme.txt # Independent JPEG blurb.
+
+	vbin opt/brother/scanner/brscan5/brsaneconfig5
+}
+
+post_install() {
+	vdoc "${FILESDIR}/README.voidlinux"
+}


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

Using a Brother ADS-1200 scanner over USB. I did not test the `brsaneconfig5` utility nor IP scanning.

EDIT: Someone else tested part of the network functionality (see https://github.com/void-linux/void-packages/pull/44235#issuecomment-1694736834).

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64