### PR TITLE
python3-ipython: update to 8.14.0.

### DIFF
--- a/srcpkgs/python3-ipython/patches/fix-race.patch
+++ b/srcpkgs/python3-ipython/patches/fix-race.patch
@@ -1,0 +1,28 @@
+See: https://github.com/ipython/ipython/issues/12164
+
+diff --git a/IPython/utils/_process_posix.py b/IPython/utils/_process_posix.py
+index 59b5c2389..e83da39c6 100644
+--- a/IPython/utils/_process_posix.py
++++ b/IPython/utils/_process_posix.py
+@@ -136,6 +136,7 @@ def system(self, cmd):
+         # record how far we've printed, so that next time we only print *new*
+         # content from the buffer.
+         out_size = 0
++        child = None
+         try:
+             # Since we're not really searching the buffer for text patterns, we
+             # can set pexpect's search window to be tiny and it won't matter.
+@@ -158,6 +159,13 @@ def system(self, cmd):
+                 # Update the pointer to what we've already printed
+                 out_size = len(child.before)
+         except KeyboardInterrupt:
++
++            if child is None:
++                # the interrupt was received before pexpect.spawn()
++                # was done... recover as best as possible.
++                import signal
++                return -signal.SIGINT
++
+             # We need to send ^C to the process.  The ascii code for '^C' is 3
+             # (the character is known as ETX for 'End of Text', see
+             # curses.ascii.ETX).

--- a/srcpkgs/python3-ipython/template
+++ b/srcpkgs/python3-ipython/template
@@ -3,7 +3,7 @@ pkgname=python3-ipython
 version=8.14.0
 revision=1
 build_style=python3-pep517
-hostmakedepends="python3-wheel"
+hostmakedepends="python3-setuptools python3-wheel"
 depends="python3-jedi python3-decorator python3-pickleshare
  python3-traitlets python3-prompt_toolkit python3-Pygments python3-backcall
  python3-matplotlib-inline python3-pexpect python3-stack_data"
@@ -19,16 +19,7 @@ distfiles="${PYPI_SITE}/i/ipython/ipython-${version}.tar.gz"
 checksum=1d197b907b6ba441b692c48cf2a3a2de280dc0ac91a3405b39349a50272ca0a1
 conflicts="python-ipython<=5.8.0_2"
 
-do_check() {
-	# Running via PYTHONPATH breaks... venv works
-	# This could be moved to build-style/python3-pep517.sh
-	local testdir="${wrksrc}/.xbps-testdir"
-	rm -rf "${testdir}"
-	python3 -m venv --system-site-packages --without-pip "${testdir}"
-	local -x PATH="${testdir}/bin:${PATH}"
-	python3 -m installer dist/*.whl
-	python3 -m pytest
-}
+make_check_pre='env PYTHONPATH=.'
 
 post_install() {
 	# remove iptest

--- a/srcpkgs/python3-ipython/template
+++ b/srcpkgs/python3-ipython/template
@@ -1,23 +1,34 @@
 # Template file for 'python3-ipython'
 pkgname=python3-ipython
-version=8.13.2
+version=8.14.0
 revision=1
-build_style=python3-module
-hostmakedepends="python3-setuptools"
-depends="python3-setuptools python3-jedi python3-decorator python3-pickleshare
+build_style=python3-pep517
+hostmakedepends="python3-wheel"
+depends="python3-jedi python3-decorator python3-pickleshare
  python3-traitlets python3-prompt_toolkit python3-Pygments python3-backcall
  python3-matplotlib-inline python3-pexpect python3-stack_data"
-checkdepends="python3-pytest $depends python3-matplotlib python3-Pillow
- python3-requests python3-testpath python3-numpy python3-ipython_ipykernel
- python3-jupyter_nbformat python3-Pygments"
+checkdepends="$depends python3-pytest-asyncio python3-testpath
+ python3-curio python3-jupyter_nbformat python3-matplotlib
+ python3-numpy python3-pandas python3-trio"
 short_desc="Enhanced interactive Python3 shell"
 maintainer="Andrew J. Hesford <ajh@sideband.org>"
 license="BSD-3-Clause"
 homepage="https://ipython.org/"
 changelog="https://github.com/ipython/ipython/raw/main/docs/source/whatsnew/version8.rst"
 distfiles="${PYPI_SITE}/i/ipython/ipython-${version}.tar.gz"
-checksum=7dff3fad32b97f6488e02f87b970f309d082f758d7b7fc252e3b19ee0e432dbb
+checksum=1d197b907b6ba441b692c48cf2a3a2de280dc0ac91a3405b39349a50272ca0a1
 conflicts="python-ipython<=5.8.0_2"
+
+do_check() {
+	# Running via PYTHONPATH breaks... venv works
+	# This could be moved to build-style/python3-pep517.sh
+	local testdir="${wrksrc}/.xbps-testdir"
+	rm -rf "${testdir}"
+	python3 -m venv --system-site-packages --without-pip "${testdir}"
+	local -x PATH="${testdir}/bin:${PATH}"
+	python3 -m installer dist/*.whl
+	python3 -m pytest
+}
 
 post_install() {
 	# remove iptest


### PR DESCRIPTION
 - switch to pep517 build style: needs using a venv
 - update depends and checkdepends
 - break unnecessary checkdepends cycle with ipython_ipykernel

#### Testing the changes
- I tested the changes in this PR: **briefly**

I will run sagemath testsuite with this update and report back.

@ahesford here's one package where testing with `PYTHONPATH` breaks and testing in a venv works. I wrote a custom `do_check()` function but you'll see it's quite generic and could be moved to `build-style/python3-pep517.sh`.

Maybe you can figure out a different way to make the generic testing with `PYTHONPATH` to work.

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
