### PR TITLE
Fix some Qt6 QML imports

### DIFF
--- a/srcpkgs/qt6-multimedia/template
+++ b/srcpkgs/qt6-multimedia/template
@@ -1,7 +1,7 @@
 # Template file for 'qt6-multimedia'
 pkgname=qt6-multimedia
 version=6.5.0
-revision=1
+revision=2
 build_style=cmake
 configure_args="-DQT_FEATURE_gstreamer=ON"
 hostmakedepends="perl qt6-declarative-host-tools pkg-config qt6-shadertools"
@@ -43,7 +43,6 @@ qt6-multimedia-devel_package() {
 		vmove usr/lib/pkgconfig
 		vmove usr/lib/qt6/mkspecs
 		vmove usr/lib/qt6/qml/QtMultimedia/plugins.qmltypes
-		vmove usr/lib/qt6/qml/QtMultimedia/qmldir
 		vmove "usr/lib/*.so"
 		vmove "usr/lib/*.a"
 		vmove "usr/lib/*.prl"

--- a/srcpkgs/qt6-remoteobjects/template
+++ b/srcpkgs/qt6-remoteobjects/template
@@ -1,7 +1,7 @@
 # Template file for 'qt6-remoteobjects'
 pkgname=qt6-remoteobjects
 version=6.5.0
-revision=1
+revision=2
 build_style=cmake
 hostmakedepends="perl qt6-declarative-host-tools pkg-config"
 makedepends="qt6-declarative-devel"
@@ -39,7 +39,6 @@ qt6-remoteobjects-devel_package() {
 		vmove usr/lib/pkgconfig
 		vmove usr/lib/qt6/mkspecs
 		vmove usr/lib/qt6/qml/QtRemoteObjects/plugins.qmltypes
-		vmove usr/lib/qt6/qml/QtRemoteObjects/qmldir
 		vmove "usr/lib/*.so"
 		vmove "usr/lib/*.prl"
 	}

--- a/srcpkgs/qt6-sensors/template
+++ b/srcpkgs/qt6-sensors/template
@@ -1,7 +1,7 @@
 # Template file for 'qt6-sensors'
 pkgname=qt6-sensors
 version=6.5.0
-revision=1
+revision=2
 build_style=cmake
 hostmakedepends="perl qt6-declarative-host-tools pkg-config"
 makedepends="qt6-declarative-devel qt6-svg-devel"
@@ -27,7 +27,6 @@ qt6-sensors-devel_package() {
 		vmove usr/lib/pkgconfig
 		vmove usr/lib/qt6/mkspecs
 		vmove usr/lib/qt6/qml/QtSensors/plugins.qmltypes
-		vmove usr/lib/qt6/qml/QtSensors/qmldir
 		vmove "usr/lib/*.so"
 		vmove "usr/lib/*.prl"
 	}

--- a/srcpkgs/qt6-webchannel/template
+++ b/srcpkgs/qt6-webchannel/template
@@ -1,7 +1,7 @@
 # Template file for 'qt6-webchannel'
 pkgname=qt6-webchannel
 version=6.5.0
-revision=1
+revision=2
 build_style=cmake
 hostmakedepends="perl qt6-base qt6-declarative-host-tools"
 makedepends="qt6-base-devel qt6-declarative-devel qt6-websockets-devel"
@@ -31,7 +31,6 @@ qt6-webchannel-devel_package() {
 		vmove usr/lib/pkgconfig
 		vmove usr/lib/qt6/mkspecs
 		vmove usr/lib/qt6/qml/QtWebChannel/plugins.qmltypes
-		vmove usr/lib/qt6/qml/QtWebChannel/qmldir
 		vmove "usr/lib/*.so"
 		vmove "usr/lib/*.prl"
 		vmove usr/lib/qt6/modules


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->
Moving `qmldir` to `-devel` subpackage in case of these packages breaks `import QtMultimedia`, `import QtRemoteObjects`, `import QtSensors` & `import QtWebChannel` preventing any QML from using them without the `-devel` subpackages which makes no sense; let's just include it in the main packages.

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
