### PR TITLE
fribidi: update to 1.0.13, adopt.

### DIFF
--- a/srcpkgs/fribidi/template
+++ b/srcpkgs/fribidi/template
@@ -1,26 +1,20 @@
 # Template file for 'fribidi'
 pkgname=fribidi
-version=1.0.12
+version=1.0.13
 revision=1
 build_style=gnu-configure
-configure_args="--disable-docs"
-hostmakedepends="automake libtool pkg-config"
+hostmakedepends="pkg-config"
 short_desc="Free Implementation of the Unicode Bidirectional Algorithm"
-maintainer="Orphaned <orphan@voidlinux.org>"
+maintainer="Mohammed Anas <triallax@tutanota.com>"
 license="LGPL-2.1-or-later"
 homepage="https://github.com/fribidi/fribidi/"
 changelog="https://raw.githubusercontent.com/fribidi/fribidi/master/NEWS"
-distfiles="https://github.com/fribidi/fribidi/archive/v${version}.tar.gz"
-checksum=2e9e859876571f03567ac91e5ed3b5308791f31cda083408c2b60fa1fe00a39d
-disable_parallel_build=yes
-
-pre_configure() {
-	NOCONFIGURE=1 autoreconf -fi
-}
+distfiles="https://github.com/fribidi/fribidi/releases/download/v${version}/fribidi-${version}.tar.xz"
+checksum=7fa16c80c81bd622f7b198d31356da139cc318a63fc7761217af4130903f54a2
 
 pre_build() {
 	if [ "$CROSS_BUILD" ]; then
-		sed -i gen.tab/Makefile \
+		vsed -i gen.tab/Makefile \
 			-e "s;^\(CC =\) .*;\1 cc;" \
 			-e "s;^\(CFLAGS =\) .*;\1 -O2 -pipe;" \
 			-e "s;^\(LDFLAGS =\) .*;\1 -s;"
@@ -28,7 +22,7 @@ pre_build() {
 }
 
 fribidi-devel_package() {
-	depends="fribidi>=${version}_${revision}"
+	depends="${sourcepkg}>=${version}_${revision}"
 	short_desc+=" - development files"
 	pkg_install() {
 		vmove usr/include


### PR DESCRIPTION
Fixes empty manpages, see https://github.com/fribidi/fribidi/issues/197.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
