### PR TITLE
puzzles: update to 20230606.4227ac1.

### DIFF
--- a/srcpkgs/puzzles/template
+++ b/srcpkgs/puzzles/template
@@ -1,6 +1,6 @@
 # Template file for 'puzzles'
 pkgname=puzzles
-version=20230505.63346a8
+version=20230606.4227ac1
 revision=1
 build_style=cmake
 configure_args="-DNAME_PREFIX=puzzles-"
@@ -10,8 +10,8 @@ short_desc="Simon Tatham's Portable Puzzle Collection"
 maintainer="Leah Neukirchen <leah@vuxu.org>"
 license="MIT"
 homepage="https://www.chiark.greenend.org.uk/~sgtatham/puzzles/"
-distfiles="https://git.tartarus.org/?p=simon/puzzles.git;a=snapshot;h=63346a8ceac9ac1061e59af2a99ab1a44c851392;sf=tgz>${pkgname}-${version#*.}.tgz"
-checksum=77a7a06fa21a987cbc1475bc689b0374633a3fdbe6f76a66832b448697de5d40
+distfiles="https://git.tartarus.org/?p=simon/puzzles.git;a=snapshot;h=4227ac1fd5dc25c247e7526526079b85e1890766;sf=tgz>${pkgname}-${version#*.}.tgz"
+checksum=9613c6091e04eef3f47d596ac78ad465cf8656c5502e376059419bcbe87da5b1
 
 post_install() {
 	vlicense LICENCE LICENSE


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture: **x86_64**