### PR TITLE
fselect: fix for rust 1.70

### DIFF
--- a/srcpkgs/fselect/template
+++ b/srcpkgs/fselect/template
@@ -1,7 +1,7 @@
 # Template file for 'fselect'
 pkgname=fselect
 version=0.8.3
-revision=1
+revision=2
 build_style=cargo
 hostmakedepends="pkg-config"
 makedepends="libzstd-devel"
@@ -22,6 +22,10 @@ if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
 	makedepends+=" libatomic-devel"
 	XBPS_CROSS_RUSTFLAGS+=" -latomic"
 fi
+
+post_patch() {
+	cargo update --package mp4parse@0.12.0 --precise 0.12.1
+}
 
 post_install() {
 	vlicense LICENSE-MIT


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

Fix for https://github.com/void-linux/void-packages/pull/44220#issuecomment-1575510972

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
