### PR TITLE
qt6-webengine: enable proprietary codecs

### DIFF
--- a/srcpkgs/qt6-webengine/template
+++ b/srcpkgs/qt6-webengine/template
@@ -10,6 +10,7 @@ configure_args="
  -DQT_FEATURE_webengine_system_icu=ON
  -DQT_FEATURE_webengine_webrtc_pipewire=ON
  -DQT_FEATURE_webengine_embedded_build=OFF
+ -DQT_FEATURE_webengine_proprietary_codecs=ON
  -DQT_FEATURE_pdf_v8=ON
  -DNinja_EXECUTABLE=$XBPS_WRAPPERDIR/ninja
  -DQT_BUILD_EXAMPLES=ON"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl

[ci skip]
