### PR TITLE
Imath 3.1.9 + Openexr 3.1.9.

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -4259,7 +4259,7 @@ libdspy-1.so.1 d-spy-1.4.0_1
 libpanel-1.so.1 libpanel-1.0.1_1
 libqrtr.so.1 qrtr-ns-1.0_1
 libbpf.so.1 libbpf-1.0.0_1
-libImath-3_1.so.30 imath-3.1.7_1
+libImath-3_1.so.29 imath-3.1.9_1
 libIex-3_1.so.30 libopenexr-3.1.5_1
 libIlmThread-3_1.so.30 libopenexr-3.1.5_1
 libOpenEXR-3_1.so.30 libopenexr-3.1.5_1

--- a/srcpkgs/Field3D/template
+++ b/srcpkgs/Field3D/template
@@ -1,7 +1,7 @@
 # Template file for 'Field3D'
 pkgname=Field3D
 version=1.7.3
-revision=7
+revision=8
 build_style=cmake
 makedepends="boost-devel hdf5-devel imath-devel libopenexr-devel"
 short_desc="Library for storing voxel data on disk and in memory"

--- a/srcpkgs/alembic/template
+++ b/srcpkgs/alembic/template
@@ -1,7 +1,7 @@
 # Template file for 'alembic'
 pkgname=alembic
 version=1.8.5
-revision=1
+revision=2
 build_style=cmake
 hostmakedepends="pkg-config"
 makedepends="zlib-devel imath-devel"

--- a/srcpkgs/blender/template
+++ b/srcpkgs/blender/template
@@ -1,7 +1,7 @@
 # Template file for 'blender'
 pkgname=blender
 version=3.5.1
-revision=1
+revision=2
 archs="x86_64* ppc64*"
 build_style="cmake"
 pycompile_dirs="/usr/share/blender/${version%.*}/scripts"

--- a/srcpkgs/calligra/template
+++ b/srcpkgs/calligra/template
@@ -1,7 +1,7 @@
 # Template file for 'calligra'
 pkgname=calligra
 version=3.2.1
-revision=14
+revision=15
 build_style=cmake
 configure_args="-Wno-dev -DCALLIGRA_SHOULD_BUILD_UNMAINTAINED=ON
  -DBUILD_TESTING=OFF"

--- a/srcpkgs/darktable/template
+++ b/srcpkgs/darktable/template
@@ -1,7 +1,7 @@
 # Template file for 'darktable'
 pkgname=darktable
 version=4.2.1
-revision=5
+revision=6
 # upstream only supports these archs:
 archs="x86_64* aarch64* ppc64le*"
 build_style=cmake

--- a/srcpkgs/gmic/template
+++ b/srcpkgs/gmic/template
@@ -1,7 +1,7 @@
 # Template file for 'gmic'
 pkgname=gmic
 version=3.1.6
-revision=3
+revision=4
 _zart_hash=34ebf6cce0bafb98abe57cec83c4a02cd1abeca0
 create_wrksrc=yes
 build_wrksrc="src"

--- a/srcpkgs/hugin/template
+++ b/srcpkgs/hugin/template
@@ -1,7 +1,7 @@
 # Template file for 'hugin'
 pkgname=hugin
 version=2022.0.0
-revision=6
+revision=7
 build_style=cmake
 build_helper=cmake-wxWidgets-gtk3
 pycompile_dirs="usr/share/hugin/data/plugins usr/share/hugin/data/plugins-templates"

--- a/srcpkgs/imath/template
+++ b/srcpkgs/imath/template
@@ -1,7 +1,7 @@
 # Template file for 'imath'
 pkgname=imath
-version=3.1.7
-revision=2
+version=3.1.9
+revision=1
 build_style=cmake
 configure_args="-DPYTHON=ON"
 hostmakedepends="python3-numpy"
@@ -12,7 +12,7 @@ license="BSD-3-Clause"
 homepage="https://imath.readthedocs.io/"
 changelog="https://raw.githubusercontent.com/AcademySoftwareFoundation/Imath/main/CHANGES.md"
 distfiles="https://github.com/AcademySoftwareFoundation/Imath/archive/v${version}/imath-${version}.tar.gz"
-checksum=bff1fa140f4af0e7f02c6cb78d41b9a7d5508e6bcdfda3a583e35460eb6d4b47
+checksum=f1d8aacd46afed958babfced3190d2d3c8209b66da451f556abd6da94c165cf3
 
 if [ "$XBPS_CHECK_PKGS" ]; then
 	configure_args+=" -DBUILD_TESTING=ON"

--- a/srcpkgs/kimageformats/template
+++ b/srcpkgs/kimageformats/template
@@ -1,7 +1,7 @@
 # Template file for 'kimageformats'
 pkgname=kimageformats
 version=5.107.0
-revision=2
+revision=3
 build_style=cmake
 configure_args="-DKIMAGEFORMATS_HEIF=ON"
 hostmakedepends="kcoreaddons extra-cmake-modules qt5-qmake qt5-host-tools

--- a/srcpkgs/krita/template
+++ b/srcpkgs/krita/template
@@ -1,7 +1,7 @@
 # Template file for 'krita'
 pkgname=krita
 version=5.0.8
-revision=7
+revision=8
 build_style=cmake
 configure_args="-Wno-dev -DBUILD_TESTING=OFF"
 hostmakedepends="extra-cmake-modules gettext pkg-config python3

--- a/srcpkgs/libgdal/template
+++ b/srcpkgs/libgdal/template
@@ -1,7 +1,7 @@
 # Template file for 'libgdal'
 pkgname=libgdal
 version=3.5.3
-revision=7
+revision=8
 build_style=cmake
 build_helper=python3
 configure_args="-DGDAL_USE_OPENCL=ON

--- a/srcpkgs/opencolorio/template
+++ b/srcpkgs/opencolorio/template
@@ -1,7 +1,7 @@
 # Template file for 'opencolorio'
 pkgname=opencolorio
 version=2.1.2
-revision=2
+revision=3
 build_style=cmake
 configure_args="-DCMAKE_CONFIGURATION_TYPES=None
  -DOCIO_INSTALL_EXT_PACKAGES=NONE

--- a/srcpkgs/openexr/template
+++ b/srcpkgs/openexr/template
@@ -1,6 +1,6 @@
 # Template file for 'openexr'
 pkgname=openexr
-version=3.1.7
+version=3.1.9
 revision=1
 build_style=cmake
 build_helper="qemu"
@@ -12,7 +12,7 @@ license="BSD-3-Clause"
 homepage="https://www.openexr.com/"
 changelog="https://raw.githubusercontent.com/AcademySoftwareFoundation/openexr/main/CHANGES.md"
 distfiles="https://github.com/openexr/openexr/archive/v${version}.tar.gz>openexr-${version}.tar.gz"
-checksum=78dbca39115a1c526e6728588753955ee75fa7f5bb1a6e238bed5b6d66f91fd7
+checksum=103e902d3902800ab07b5f3a298be7afd2755312737b2cdbfa01326ff99dac07
 
 if [ "$XBPS_CHECK_PKGS" ]; then
 	configure_args+=" -DBUILD_TESTING=ON"

--- a/srcpkgs/openimageio/template
+++ b/srcpkgs/openimageio/template
@@ -1,7 +1,7 @@
 # Template file for 'openimageio'
 pkgname=openimageio
 version=2.4.9.0
-revision=4
+revision=5
 build_style=cmake
 build_helper=qemu
 configure_args="-DUSE_QT=0 -DUSE_PYTHON=0 -DOIIO_BUILD_TESTS=0

--- a/srcpkgs/synfig/template
+++ b/srcpkgs/synfig/template
@@ -2,7 +2,7 @@
 # Should be kept in sync with 'synfigstudio' and 'ETL'
 pkgname=synfig
 version=1.4.4
-revision=2
+revision=3
 build_style=gnu-configure
 configure_args="--with-boost-libdir=${XBPS_CROSS_BASE}/usr/lib"
 hostmakedepends="boost-build ImageMagick pkg-config intltool"

--- a/srcpkgs/synfigstudio/template
+++ b/srcpkgs/synfigstudio/template
@@ -2,7 +2,7 @@
 # Should be kept in sync with 'synfig' and 'ETL'
 pkgname=synfigstudio
 version=1.4.4
-revision=2
+revision=3
 build_style=gnu-configure
 configure_args="--disable-update-mimedb"
 hostmakedepends="pkg-config intltool gettext synfig"

--- a/srcpkgs/vigra/template
+++ b/srcpkgs/vigra/template
@@ -1,7 +1,7 @@
 # Template file for 'vigra'
 pkgname=vigra
 version=1.11.1
-revision=10
+revision=11
 build_style=cmake
 configure_args="-DWITH_OPENEXR=1"
 hostmakedepends="python3"


### PR DESCRIPTION
[ci-skip] [ci skip]
<!-- Uncomment relevant sections and delete options which are not applicable -->

# TODO:

- **Review**. (If someone could do a rebuild of everything changed here would be highly appreciated, I am currently
leaving my laptop overnight compiling everything with xxbuild for a specific arch, see below what I have already tested, getting some crossbuilding testing would be nice)


## Local build testing

- x86_64  (native)
<!--
- x86_64-musl (native) 
- i686 (native)
- armv6l (crossbuilding)
- armv7l-musl  (crossbuilding)
- armv7l  (crossbuilding)
- armv6l-musl  (crossbuilding)
- armv6l (crossbuilding)
-->

#### Testing the changes
- I tested the changes in this PR: **briefly**, as in didn't test some package that were revbumped.

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc

Previously closed the imath 3.1.8 update because of the changed shlib and the high number of packages that would need to be revbumped. Waited for openexr to release a new version and re-opened this.
