### PR TITLE
pan: updated checksum, enabled libsecret

### DIFF
--- a/srcpkgs/pan/template
+++ b/srcpkgs/pan/template
@@ -1,12 +1,12 @@
 # Template file for 'pan'
 pkgname=pan
 version=0.154
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--with-gnutls --enable-libnotify --enable-gkr"
 hostmakedepends="gettext pkg-config yelp-tools autoconf gettext-devel-tools automake libtool"
 makedepends="gmime3-devel gnutls-devel gtk+3-devel libsecret-devel gtkspell3-devel libnotify-devel
- glib-devel enchant2-devel"
+ glib-devel enchant2-devel gcr-devel"
 depends="desktop-file-utils hicolor-icon-theme"
 short_desc="Usenet newsreader that's good at both text and binaries"
 maintainer="mobinmob <mobinmob@disroot.org>"
@@ -14,7 +14,7 @@ license="GFDL-1.1-or-later, GPL-2.0-only"
 homepage="http://pan.rebelbase.com"
 changelog="https://gitlab.gnome.org/GNOME/pan/-/raw/master/NEWS"
 distfiles="https://gitlab.gnome.org/GNOME/pan/-/archive/v${version}/pan-v${version}.tar.bz2"
-checksum=87721838dfa59f05f5c2c2fec8742606dad13d920f9fa8884497c4513a8d72b9
+checksum=440317954df7217689100df3dfb68865770f5aed1b8ed2b45432d771bb80a8c9
 
 if [ -n "$CROSS_BUILD" ]; then
 		hostmakedepends+=" gdk-pixbuf-devel"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, amd64-glibc

I don't know why, but sha256 in package's template was incorrect.
Also, I added `gcr-devel` which in turn (when combined with `libsecret-devel`) enabled secret storage