### PR TITLE
mit-krb5: update to 1.21.1

### DIFF
--- a/srcpkgs/mit-krb5/template
+++ b/srcpkgs/mit-krb5/template
@@ -2,42 +2,50 @@
 # if there is a bump in .so version,
 # also update srcpkgs/libgssglue/files/gssapi_mech.conf
 pkgname=mit-krb5
-version=1.20.1
+version=1.21.1
 revision=1
+_distver=$(echo $version | cut -d. -f-2)
 build_style=gnu-configure
+configure_args="--sbindir=/usr/bin --disable-rpath --with-system-et
+ --without-system-verto --with-system-ss --enable-shared --with-system-db
+ $(vopt_with ldap) $(vopt_with lmdb)"
 hostmakedepends="e2fsprogs-devel flex perl pkg-config"
-makedepends="e2fsprogs-devel libldap-devel"
+makedepends="e2fsprogs-devel db-devel $(vopt_if ldap libldap-devel)
+ $(vopt_if lmdb lmdb-devel)"
 short_desc="MIT Kerberos 5 implementation"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
 homepage="http://web.mit.edu/kerberos"
-distfiles="http://web.mit.edu/kerberos/dist/krb5/${version%.*}/krb5-${version}.tar.gz"
-checksum=704aed49b19eb5a7178b34b2873620ec299db08752d6a8574f95d41879ab8851
+distfiles="http://kerberos.org/dist/krb5/${_distver}/krb5-${version}.tar.gz"
+checksum=7881c3aaaa1b329bd27dbc6bf2bf1c85c5d0b6c7358aff2b35d513ec2d50fa1f
+build_options="ldap lmdb"
+build_options_default="ldap"
+desc_option_lmdb="Enable LMDB database backend"
 
 post_patch() {
-	vsed -e "/LDFLAGS=/d" -i src/build-tools/krb5-config.in
-
 	# Fix db plugin.
-	sed -i -e "s|<db.h>|<db_185.h>|" $wrksrc/src/plugins/kdb/db2/*.[ch]
+	vsed -i -e "s|<db.h>|<db_185.h>|" \
+		src/plugins/kdb/db2/{adb_openclose.c,db2_exp.c,kdb_db2.c,policy_db.h}
 }
 
 do_configure() {
-	WARN_CFLAGS= ./src/configure ${configure_args} --sbindir=/usr/bin \
-		--disable-rpath --with-system-et --without-system-verto --with-ldap \
-		--with-system-ss --with-system-db --enable-shared --without-tcl \
+	./src/configure ${configure_args} \
 		ac_cv_func_pthread_once=yes ac_cv_func_pthread_rwlock_init=yes \
 		acx_pthread_ok=yes ac_cv_func_regcomp=yes ac_cv_printf_positional=yes \
 		krb5_cv_attr_constructor_destructor=yes,yes
-}
-
-do_build() {
-	make
 }
 
 post_install() {
 	vsv krb5kdc
 	vsv kadmind
 	vlicense NOTICE
+
+	# Install schema files for LDAP database backend
+	if [ -n "$(vopt_if ldap present)" ]; then
+		for schema in kerberos.{schema,ldif,openldap.ldif}; do
+			vdoc src/plugins/kdb/ldap/libkdb_ldap/$schema
+		done
+	fi
 }
 
 mit-krb5-client_package() {


### PR DESCRIPTION
- update changed upstream mirror
- move configure options to configure_args
- add build options
  - ldap: enable LDAP database backend, enabled by default
  - lmdb: enable LMDB database backend, disabled by default
- remove --without-tcl (not recognized by configure)
- remove vsed that doesn't do anything
- change sed to vsed and restrict it to files which need the changes
- remove unnecessary do_build

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for my native architecture, (x86_64-musl)
- I built this PR locally for these architectures:
  - aarch64-musl
  - armv7l
  - armv6l-musl
  - x86_64-musl