### PR TITLE
librepcb: add missing qt5-plugin-sqlite dependency.

### DIFF
--- a/srcpkgs/librepcb/template
+++ b/srcpkgs/librepcb/template
@@ -1,11 +1,12 @@
 # Template file for 'librepcb'
 pkgname=librepcb
 version=0.1.5
-revision=1
+revision=2
 build_style=qmake
 configure_args="-r librepcb.pro"
 hostmakedepends="unzip qt5-qmake qt5-host-tools"
 makedepends="qt5-devel qt5-svg-devel zlib-devel"
+depends="qt5-plugin-sqlite"
 short_desc="Powerful, innovative and intuitive EDA tool for everyone"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-3.0-or-later"


### PR DESCRIPTION
Fixes #44294.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
