### PR TITLE
PrismLauncher: update to 7.1.

### DIFF
--- a/srcpkgs/PrismLauncher/template
+++ b/srcpkgs/PrismLauncher/template
@@ -1,10 +1,10 @@
 # Template file for 'PrismLauncher'
 pkgname=PrismLauncher
-version=6.3
+version=7.1
 revision=1
 build_style=cmake
-configure_args="-DLauncher_BUILD_PLATFORM=Void"
-hostmakedepends="extra-cmake-modules openjdk8 pkg-config qt5-host-tools
+configure_args="-DLauncher_BUILD_PLATFORM=Void -DLauncher_QT_VERSION_MAJOR='5'"
+hostmakedepends="extra-cmake-modules openjdk17 pkg-config qt5-host-tools
  qt5-qmake scdoc"
 makedepends="qt5-devel"
 depends="virtual?java-runtime qt5-svg qt5-imageformats"
@@ -13,7 +13,7 @@ maintainer="Philipp David <pd@3b.pm>"
 license="GPL-3.0-only"
 homepage="https://prismlauncher.org/"
 distfiles="https://github.com/PrismLauncher/PrismLauncher/releases/download/${version}/PrismLauncher-${version}.tar.gz"
-checksum=fc1896df6422248dbd767d4a82066fe6044ae104354ebf75fc5ae92252f2fb1a
+checksum=dc7aeff6e0dc12f4f2065e718418a4110ccdbad3e49fbd58e416a213fde7ebb1
 
 if [ -z "$XBPS_CHECK_PKGS" ]; then
 	configure_args+=" -DBUILD_TESTING=0"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**


#### Local build testing
- I built this PR locally for my native architecture, (x64-GlibC)


#### Additional notes for the PR
- Updated Openjdk in the template as the compatibility with prism is verified up until openjdk 20. Also added a QT5 argument as building Prism using QT6 will cause issues. It should be kept as is up until QT6-cmake is available in void repos.