### PR TITLE
New package: osc-1.1.4

### DIFF
--- a/srcpkgs/osc/template
+++ b/srcpkgs/osc/template
@@ -1,0 +1,15 @@
+# Template file for 'osc'
+pkgname=osc
+version=1.1.4
+revision=1
+build_style=python3-module
+hostmakedepends="python3-setuptools python3-cryptography python3-devel
+ rpm-python3 python3-urllib3"
+depends="python3-cryptography rpm-python3 python3-urllib3"
+checkdepends="diffstat"
+short_desc="Command Line Interface for Open Build Service"
+maintainer="Emil Miler <em@0x45.cz>"
+license="GPL-2.0-or-later"
+homepage="https://github.com/openSUSE/osc"
+distfiles="https://github.com/openSUSE/osc/archive/refs/tags/${version}.tar.gz"
+checksum=8407ccdcaa6089601e3b9f42c03c015d938ba756b1553f65e2eb122ff00b83e5


### PR DESCRIPTION
[OSC (Open Build Service Commander)](https://github.com/openSUSE/osc) is a command line interface for [OBS](https://openbuildservice.org/).

#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)
