### PR TITLE
curl: disable ssh option to break build cycle

### DIFF
--- a/srcpkgs/curl/template
+++ b/srcpkgs/curl/template
@@ -1,7 +1,7 @@
 # Template file for 'curl'
 pkgname=curl
 version=8.0.1
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="ac_cv_sizeof_off_t=8 --enable-threaded-resolver --enable-ipv6
  --enable-websockets --with-random=/dev/urandom
@@ -27,7 +27,7 @@ changelog="https://curl.haxx.se/changes.html#${version//./_}"
 distfiles="${homepage}/download/curl-${version}.tar.bz2"
 checksum=9b6b1e96b748d04b968786b6bdf407aa5c75ab53a3d37c1c8c81cdb736555ccf
 build_options="gnutls gssapi ldap rtmp ssh ssl zstd"
-build_options_default="ssh ssl zstd"
+build_options_default="ssl zstd"
 vopt_conflict ssl gnutls
 
 if [ "$CROSS_BUILD" ]; then


### PR DESCRIPTION
Now that libssh2 builds with cmake, enabling SSH support in curl introduces a build cycle:

    binutils -> elfutils -> curl -> libssh2 -> cmake -> curl

Because SSH support in curl seems superfluous anyway, just disable it.

The other alternative is to go back to autotools for libssh2. I don't know if that's a long-term solution, but it seems possible for now.