### PR TITLE
muon: update to 0.2.0.

### DIFF
--- a/srcpkgs/muon/template
+++ b/srcpkgs/muon/template
@@ -1,23 +1,23 @@
 # Template file for 'muon'
 pkgname=muon
-version=0.1.0
+version=0.2.0
 revision=1
 build_style=meson
-build_helper=qemu
+build_helper="qemu"
 configure_args="
  -Dlibcurl=enabled
  -Dlibarchive=enabled
  -Dlibpkgconf=enabled
  -Dsamurai=disabled
  -Dbestline=enabled"
-hostmakedepends="pkg-config samurai cmake"
+hostmakedepends="pkg-config samurai cmake scdoc"
 makedepends="pkgconf-devel libcurl-devel libarchive-devel"
 depends="samurai"
-checkdepends="git"
 short_desc="Meson implementation in C"
 maintainer="Enno Boland <gottox@voidlinux.org>"
 license="GPL-3.0-only, Apache-2.0"
 homepage="https://muon.build"
-changelog="https://git.sr.ht/~lattis/muon/refs/$version"
+changelog="https://muon.build/releases/v${version}/docs/release_notes.html"
 distfiles="https://git.sr.ht/~lattis/muon/archive/$version.tar.gz"
-checksum="9d3825c2d562f8f8ad96d1f02167e89c4e84973decf205d127efd9293d7da35b"
+checksum=d73db1be5388821179a25a15ba76fd59a8bf7c8709347a4ec2cb91755203f36c
+make_check_pre="env PATH=/usr/libexec/chroot-git:${PATH}"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture: **x86_64**

https://github.com/void-linux/void-packages/commit/e78571c047ddc9fdcf1ebcdc079fcf60eee42a94 says "New package: muon-0.2.0" but it was actually `v0.1.0`.