### PR TITLE
gwe: update to 0.15.5.

### DIFF
--- a/srcpkgs/gwe/template
+++ b/srcpkgs/gwe/template
@@ -1,20 +1,17 @@
 # Template file for 'gwe'
 pkgname=gwe
-version=0.15.2
-revision=4
+version=0.15.5
+revision=1
 build_style=meson
-hostmakedepends="pkg-config meson ninja glib-devel gtk+3-devel python3 python3-devel
- python3-matplotlib python3-peewee python3-gobject python3-xlib python3-xdg
- python3-requests python3-rx python3-nvml python3-injector python3-urllib3 python3-six
- python3-chardet python3-idna python3-xlib python3-numpy python3-parsing python3-cycler python3-dateutil python3-Pillow"
-makedepends="gobject-introspection appstream-glib"
-depends="python3 gobject-introspection libayatana-appindicator libdazzle python3-matplotlib
+hostmakedepends="gobject-introspection pkg-config ninja appstream-glib glib-devel"
+makedepends="gtk+3-devel python3-devel"
+depends="python3 libayatana-appindicator libdazzle python3-matplotlib
  python3-peewee python3-gobject python3-xlib python3-xdg python3-requests python3-rx
- python3-nvml python3-injector python3-urllib3 python3-six python3-chardet python3-idna
- python3-xlib python3-numpy python3-parsing python3-cycler python3-dateutil python3-Pillow"
+ python3-nvml python3-injector"
 short_desc="Utility for overclocking NVIDIA cards"
 maintainer="Duje Mihanovic <mihaduje@pm.me>"
 license="GPL-3.0-or-later"
-homepage="https://www.gitlab.com/leinardi/gwe"
+homepage="https://gitlab.com/leinardi/gwe"
+changelog="https://gitlab.com/leinardi/gwe/-/raw/release/CHANGELOG.md"
 distfiles="https://gitlab.com/leinardi/gwe/-/archive/${version}/gwe-${version}.tar.gz"
-checksum=a827eeb8f18fd08213fb22e0e1ef6437ea749eb4b34fcea9d0ae5282912753a0
+checksum=67c30c735b6160c2f4af61ce353108dc9709b6c850ce8bc21d2d2a506dfa3b70


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly** (just checked that the app launches properly on a non-nVidia system, so testing from nVidia users is appreciated)

@LegoLivesMatter

Related to https://github.com/void-linux/void-packages/pull/43699 (I was checking python-urllib3 dependents and found that gwe doesn't use it anymore).

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
