### PR TITLE
memtest86+: update to 6.20, adopt.

### DIFF
--- a/srcpkgs/memtest86+/files/20_memtest86+
+++ b/srcpkgs/memtest86+/files/20_memtest86+
@@ -9,21 +9,49 @@ fi
 
 . /usr/share/grub/grub-mkconfig_lib
 
-if test -e /boot/memtest86+ ; then
-  MEMTESTPATH=$( make_system_path_relative_to_its_root "/boot/memtest86+" )
-  echo "Found memtest86+ image: $MEMTESTPATH" >&2
-  cat << EOF
-menuentry "Memory test (memtest86+)" {
-EOF
-  prepare_grub_to_access_device ${GRUB_DEVICE_BOOT} | sed -e "s/^/\t/"
-  cat << EOF
-	linux16 $MEMTESTPATH
-}
-menuentry "Memory test (memtest86+, serial console 115200)" {
-EOF
-  prepare_grub_to_access_device ${GRUB_DEVICE_BOOT} | sed -e "s/^/\t/"
-  cat << EOF
-	linux16 $MEMTESTPATH console=ttyS0,115200n8
-}
-EOF
+if [ "${grub_platform}" != "efi" ]; then
+	MEMTESTSFX="bin"
+else
+	MEMTESTSFX="efi"
+fi
+
+if [ -e /boot/memtest.bin ]; then
+	MEMTESTPATH=$( make_system_path_relative_to_its_root "/boot/memtest.bin" )
+	echo "Found memtest86+ image: $MEMTESTPATH" >&2
+	cat <<- EOF
+	if [ "\${grub_platform}" != "efi" ]; then
+	menuentry "Memory test (memtest86+)" {
+	EOF
+	prepare_grub_to_access_device "${GRUB_DEVICE_BOOT}" | sed -e "s/^/\t/"
+	cat <<- EOF
+		linux $MEMTESTPATH
+	}
+	menuentry "Memory test (memtest86+, serial console 115200)" {
+	EOF
+	prepare_grub_to_access_device "${GRUB_DEVICE_BOOT}" | sed -e "s/^/\t/"
+	cat <<- EOF
+		linux $MEMTESTPATH console=ttyS0,115200n8
+	}
+	fi
+	EOF
+fi
+if [ -e /boot/memtest.efi ]; then
+	MEMTESTPATH=$( make_system_path_relative_to_its_root "/boot/memtest.efi" )
+	echo "Found memtest86+ image: $MEMTESTPATH" >&2
+	cat <<- EOF
+	if [ "\${grub_platform}" = "efi" ]; then
+	menuentry "Memory test (memtest86+)" {
+	EOF
+	prepare_grub_to_access_device "${GRUB_DEVICE_BOOT}" | sed -e "s/^/\t/"
+	cat <<- EOF
+		linux $MEMTESTPATH
+	}
+	menuentry "Memory test (memtest86+, serial console 115200)" {
+	EOF
+	prepare_grub_to_access_device "${GRUB_DEVICE_BOOT}" | sed -e "s/^/\t/"
+	cat <<- EOF
+		linux $MEMTESTPATH console=ttyS0,115200n8
+	}
+	fi
+	EOF
 fi

--- a/srcpkgs/memtest86+/template
+++ b/srcpkgs/memtest86+/template
@@ -1,20 +1,19 @@
 # Template file for 'memtest86+'
 pkgname=memtest86+
-version=5.01
-revision=6
+version=6.20
+revision=1
 archs="i686* x86_64*"
 short_desc="Advanced Memory Diagnostic Tool - upstream binary"
-maintainer="Orphaned <orphan@voidlinux.org>"
+maintainer="classabbyamp <void@placeviolette.net>"
 license="GPL-2.0-or-later"
 homepage="http://www.memtest.org"
-distfiles="https://www.memtest.org/download/${version}/memtest86+-${version}.bin.gz"
-checksum=78f6625b093de69537d99ed68e35b2a9e5d666504cb2533affab1967bd888fc8
-
-create_wrksrc=yes
+distfiles="https://www.memtest.org/download/v${version}/mt86plus_${version}.binaries.zip"
+checksum=ccabd43063b65e53be4fddb08de0cc6bedc94b4ab44706855e4145e17fa52c72
 nostrip=yes
 noverifyrdeps=yes
 
 do_install() {
-	vinstall memtest86+-5.01.bin 755 boot memtest86+
-	vinstall ${FILESDIR}/20_memtest86+ 755 etc/grub.d
+	vinstall "memtest${XBPS_TARGET_WORDSIZE}.bin" 755 boot memtest.bin
+	vinstall "memtest${XBPS_TARGET_WORDSIZE}.efi" 755 boot memtest.efi
+	vinstall "${FILESDIR}/20_memtest86+" 755 etc/grub.d
 }

--- a/srcpkgs/memtest86+/update
+++ b/srcpkgs/memtest86+/update
@@ -1,1 +1,2 @@
-ignore="*[!0-9]"
+site="https://github.com/memtest86plus/memtest86plus/tags"
+pattern='/archive/refs/tags/v\K[0-9.]+(?=\.tar\.gz)'


### PR DESCRIPTION
- improve grub hook to support the efi bundle from upstream
- fix update check

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

