### PR TITLE
sway: fix `bindsym --to-code`.

### DIFF
--- a/srcpkgs/sway/patches/7633.patch
+++ b/srcpkgs/sway/patches/7633.patch
@@ -1,0 +1,34 @@
+From 872552b4d636379fca795d5db1aae71034d363f8 Mon Sep 17 00:00:00 2001
+From: Marko <marko@pepega.club>
+Date: Sat, 10 Jun 2023 19:55:24 +0200
+Subject: [PATCH] Fix #7535
+
+---
+https://github.com/swaywm/sway/pull/7633
+
+ sway/input/input-manager.c | 12 ++++++++++++
+ 1 file changed, 12 insertions(+)
+
+diff --git a/sway/input/input-manager.c b/sway/input/input-manager.c
+index 1115ba5ecc..5f7dfb4284 100644
+--- a/sway/input/input-manager.c
++++ b/sway/input/input-manager.c
+@@ -532,6 +532,18 @@ static void retranslate_keysyms(struct input_config *input_config) {
+ 			return;
+ 		}
+ 	}
++
++	for (int i = 0; i < config->input_type_configs->length; ++i) {
++		struct input_config *ic = config->input_type_configs->items[i];
++		if (ic->xkb_layout || ic->xkb_file) {
++			// this is the first config with xkb_layout or xkb_file
++			if (ic->identifier == input_config->identifier) {
++				translate_keysyms(ic);
++			}
++
++			return;
++		}
++	}
+ }
+ 
+ static void input_manager_configure_input(

--- a/srcpkgs/sway/template
+++ b/srcpkgs/sway/template
@@ -1,7 +1,7 @@
 # Template file for 'sway'
 pkgname=sway
 version=1.8.1
-revision=1
+revision=2
 build_style=meson
 configure_args="-Dwerror=false -Db_ndebug=false"
 conf_files="/etc/sway/config"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
