### PR TITLE
python3-Markdown: update to 3.4.3

### DIFF
--- a/srcpkgs/python3-Markdown/template
+++ b/srcpkgs/python3-Markdown/template
@@ -1,18 +1,22 @@
 # Template file for 'python3-Markdown'
 pkgname=python3-Markdown
-version=3.3.4
-revision=3
-build_style=python3-module
-hostmakedepends="python3-setuptools"
-depends="python3-setuptools"
+version=3.4.3
+revision=1
+build_style=python3-pep517
+hostmakedepends="python3-wheel"
+depends="python3"
 checkdepends="python3-yaml"
 short_desc="Python3 implementation of John Gruber's Markdown"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="BSD-3-Clause"
 homepage="https://github.com/Python-Markdown/markdown"
 distfiles="${PYPI_SITE}/M/Markdown/Markdown-${version}.tar.gz"
-checksum=31b5b491868dcc87d6c24b7e3d19a0d730d59d3e46f4eea6430a321bed387a49
+checksum=8bf101198e004dc93e84a12a7395e31aac6a9c9942848ae1d99b9d72cf9b3520
 conflicts="python-Markdown>=0"
+
+do_check() {
+	python3 -m unittest discover tests
+}
 
 post_install() {
 	vlicense LICENSE.md LICENSE


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64