### PR TITLE
docker-compose: update to 2.18.1

### DIFF
--- a/srcpkgs/docker-compose/template
+++ b/srcpkgs/docker-compose/template
@@ -1,6 +1,6 @@
 # Template file for 'docker-compose'
 pkgname=docker-compose
-version=2.17.2
+version=2.18.1
 revision=1
 build_style=go
 go_import_path="github.com/docker/compose/v2/cmd"
@@ -12,7 +12,7 @@ license="Apache-2.0"
 homepage="https://docs.docker.com/compose/"
 changelog="https://github.com/docker/compose/releases"
 distfiles="https://github.com/docker/compose/archive/refs/tags/v${version}.tar.gz"
-checksum=d6e6de858ecdb0104991c86c66dde5dd4fb6a1160d707308d8ad3167450c8094
+checksum=192c47c177d9bfd8492ed0c49214af0c740586da6db0b7e9c9a07da37c9dc722
 
 post_install() {
 	mkdir -p ${DESTDIR}/usr/libexec/docker/cli-plugins


### PR DESCRIPTION
Tagging the maintainer @paper42
It's just a version bump.

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures:
  - x86_64-musl


