### PR TITLE
pnpm: update to 8.6.2

### DIFF
--- a/srcpkgs/pnpm/template
+++ b/srcpkgs/pnpm/template
@@ -1,6 +1,6 @@
 # Template file for 'pnpm'
 pkgname=pnpm
-version=8.6.1
+version=8.6.2
 revision=1
 build_style=fetch
 hostmakedepends="nodejs jq"
@@ -10,7 +10,7 @@ maintainer="reback00 <reback00@protonmail.com>"
 license="MIT"
 homepage="https://pnpm.io/"
 distfiles="https://registry.npmjs.org/pnpm/-/pnpm-${version}.tgz"
-checksum=5380612e01e0a3029991d3f329f07429313f4825de47b885b4bb3d1aec9e44e1
+checksum=c6da9e00697e334b6193c034a5d1508e4c8605b12f249736b13f31139f4f0d73
 python_version=3
 
 do_install() {


### PR DESCRIPTION
pnpm reverted pnpm-lock v6.1 to v6.0 https://github.com/pnpm/pnpm/issues/6648 it's suggested to upgrade to v8.6.2

#### Testing the changes
- I tested the changes in this PR: **YES**