### PR TITLE
rpi-{kernel,firmware}: bring up to date

### DIFF
--- a/srcpkgs/rpi-firmware/template
+++ b/srcpkgs/rpi-firmware/template
@@ -1,10 +1,10 @@
 # Template file for 'rpi-firmware'
-_githash="62efc6a69d4e717bf2833c649d622c8298a37e9c"
+_githash="13fbbc4f5ea698353486915986de8b48f18018f6"
 _gitshort="${_githash:0:7}"
 
 pkgname=rpi-firmware
-version=20220823
-revision=2
+version=20230607
+revision=1
 archs="armv6l* armv7l* aarch64*"
 provides="linux-firmware-broadcom-${version}_${revision}"
 replaces="linux-firmware-broadcom>=0"
@@ -13,7 +13,7 @@ maintainer="Piraty <mail@piraty.dev>"
 license="BSD-3-Clause, custom:Cypress"
 homepage="https://github.com/raspberrypi/firmware"
 distfiles="https://github.com/raspberrypi/firmware/archive/${_githash}.tar.gz"
-checksum=3fc5ab7155bde7221245f439971217558300dcbc988ade861cfef4e737de9909
+checksum=613acb04b7330e1d44c2cb061bee03ed4d5e8245ffb00cebaef20c9a568eb300
 
 conf_files="/boot/cmdline.txt /boot/config.txt"
 nostrip=yes

--- a/srcpkgs/rpi-kernel/template
+++ b/srcpkgs/rpi-kernel/template
@@ -1,9 +1,9 @@
 # Template file for 'rpi-kernel'
 #
 # We track the latest Raspberry Pi LTS kernel as that is what is used in the
-# official Raspberry Pi OS distribution. This is currently 5.15:
+# official Raspberry Pi OS distribution. This is currently 6.1:
 #
-# https://forums.raspberrypi.com/viewtopic.php?t=322879
+# https://forums.raspberrypi.com/viewtopic.php?t=344246
 #
 # Commit hash is picked from latest tag [1], if appropriate, or from latest
 # "Merge remote-tracking branch 'stable/linux-5.x.y' into rpi-5.x.y" commit.
@@ -13,9 +13,9 @@
 # Upstream documentation: https://www.raspberrypi.com/documentation/computers/linux_kernel.html
 
 pkgname=rpi-kernel
-version=5.15.72
+version=6.1.32
 revision=1
-_githash="3b98eb7a4aeaecd5274108dc1be7a5df94253500"
+_githash="bb63dc31e48948bc2649357758c7a152210109c4"
 archs="armv6l* armv7l* aarch64*"
 hostmakedepends="perl kmod uboot-mkimage openssl-devel bc bison flex xz"
 makedepends="ncurses-devel"
@@ -24,7 +24,7 @@ homepage="http://www.kernel.org"
 license="GPL-2.0-only"
 short_desc="Linux kernel for Raspberry Pi (${version%.*} series [git ${_githash:0:7}])"
 distfiles="https://github.com/raspberrypi/linux/archive/${_githash}.tar.gz"
-checksum=5cad1fd22f309ddd7b996df748aa21ced72f88d47fdbb8d4bfd9ef3a8a9b6ce9
+checksum=41898b9bd88eec0843e4115156f239bd5bfc086814b3ada52e3db7116a337474
 python_version=3
 
 _kernver="${version}_${revision}"


### PR DESCRIPTION
I don't have any systems that can test the 32-bit builds. Also, for `rpi-firmware`, I don't know if there's a dated version encoded somewhere in the source; I just updated the version to the date of the commit I pulled.

#### Testing the changes
- I tested the changes in this PR: **briefly**
  (The updates boot on my RPi 4b.)

cc: @Piraty 

Ed.: This should fix the USB boot issue, but I haven't tested it.