### PR TITLE
parted: update to 3.6

### DIFF
--- a/srcpkgs/parted/template
+++ b/srcpkgs/parted/template
@@ -1,6 +1,6 @@
 # Template file for 'parted'
 pkgname=parted
-version=3.5
+version=3.6
 revision=1
 build_style=gnu-configure
 # parted wants off_t as 64bit type
@@ -13,7 +13,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-3.0-or-later"
 homepage="http://www.gnu.org/software/parted/"
 distfiles="${GNU_SITE}/${pkgname}/${pkgname}-${version}.tar.xz"
-checksum=4938dd5c1c125f6c78b1f4b3e297526f18ee74aa43d45c248578b1d2470c05a2
+checksum=3b43dbe33cca0f9a18601ebab56b7852b128ec1a3df3a9b30ccde5e73359e612
 
 libparted_package() {
 	short_desc+=" - shared library"


### PR DESCRIPTION
It's just a version bump.

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures:
  - x86_64-musl
