### PR TITLE
putty: update to 0.78

### DIFF
--- a/srcpkgs/putty/template
+++ b/srcpkgs/putty/template
@@ -1,6 +1,6 @@
 # Template file for 'putty'
 pkgname=putty
-version=0.77
+version=0.78
 revision=1
 build_style=cmake
 hostmakedepends="pkg-config perl"
@@ -11,7 +11,7 @@ license="MIT"
 homepage="https://www.chiark.greenend.org.uk/~sgtatham/putty/"
 changelog="https://www.chiark.greenend.org.uk/~sgtatham/putty/changes.html"
 distfiles="https://the.earth.li/~sgtatham/putty/latest/putty-${version}.tar.gz"
-checksum=419a76f45238fd45f2c76b42438993056e74fa78374f136052aaa843085beae5
+checksum=274e01bcac6bd155dfd647b2f18f791b4b17ff313753aa919fcae2e32d34614f
 
 CFLAGS="-Wno-error -UNDEBUG"
 


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64