### PR TITLE
python-dbus: split python3-dbus subpackage, update python3-dbus to 1.3.2.

### DIFF
--- a/srcpkgs/python-dbus/template
+++ b/srcpkgs/python-dbus/template
@@ -3,9 +3,10 @@ pkgname=python-dbus
 version=1.2.18
 revision=3
 build_style=gnu-configure
-hostmakedepends="pkg-config python python3"
-makedepends="libglib-devel python3-devel python-devel"
+hostmakedepends="pkg-config python"
+makedepends="libglib-devel python-devel"
 depends="python dbus"
+checkdepends="${depends} python-gobject"
 short_desc="D-Bus Python2 bindings"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
@@ -14,77 +15,16 @@ distfiles="https://dbus.freedesktop.org/releases/dbus-python/dbus-python-${versi
 checksum=92bdd1e68b45596c833307a5ff4b217ee6929a1502f5341bae28fd120acf7260
 lib32disabled=yes
 
-pre_configure() {
-	mkdir -p dbus-${py2_ver}
-	mv * dbus-${py2_ver} || true
-	cp -a dbus-${py2_ver} dbus-${py3_ver}
-}
+export PYTHON_CPPFLAGS="-I${XBPS_CROSS_BASE}/${py2_inc}"
+export PYTHON_EXTRA_LIBS="-L${XBPS_CROSS_BASE}/usr/lib -lpython${py2_ver}"
+export PYTHON_VERSION="${py2_ver}"
 
-do_configure() {
-	local py_abiver py_inc pyver
-	for pyver in $py2_ver $py3_ver; do
-		case "${pyver}" in
-			"${py2_ver}")
-				py_inc="$py2_inc"
-				;;
-			*)
-				py_inc="$py3_inc"
-				py_abiver="$py3_abiver"
-				;;
-		esac
+post_install() {
+	vcopy dbus_python.egg-info "${py2_sitelib}/dbus_python-${version}-py${py2_ver}.egg-info"
 
-		export PYTHON_CPPFLAGS="-I${XBPS_CROSS_BASE}/${py_inc}"
-		export PYTHON_EXTRA_LIBS="-L${XBPS_CROSS_BASE}/usr/lib -lpython${pyver}${py_abiver}"
-		export PYTHON_VERSION="${pyver}"
+	vlicense COPYING
 
-		( cd dbus-${pyver} && ./configure ${configure_args} )
-
-	done
-
-	unset PYTHON_CPPFLAGS PYTHON_EXTRA_LIBS PYTHON_VERSION
-}
-
-do_build() {
-	local pyver
-	for pyver in $py2_ver $py3_ver; do
-		( cd dbus-${pyver} && make ${makejobs} )
-	done
-}
-
-do_install() {
-	local pyver pysite eggver
-	for pyver in $py2_ver $py3_ver; do
-		case "${pyver}" in
-			"${py2_ver}") pysite="${py2_sitelib}" ;;
-			*) pysite="${py3_sitelib}" ;;
-		esac
-
-		eggver="dbus_python-${version}-py${pyver}"
-		(
-			cd dbus-${pyver}
-			make DESTDIR=${DESTDIR} install
-			vcopy dbus_python.egg-info "${pysite}/${eggver}.egg-info"
-		)
-	done
-
-	vlicense dbus-${py2_ver}/COPYING
-}
-
-python3-dbus_package() {
-	lib32disabled=yes
-	depends="python3 dbus"
-	short_desc="${short_desc/Python2/Python3}"
-	pkg_install() {
-		vmove usr/lib/python3*
-		vlicense dbus-${py3_ver}/COPYING
-	}
-}
-
-python3-dbus-devel_package() {
-	depends="python3-devel python3-dbus>=${version}_${revision}"
-	short_desc="${short_desc/Python2/Python3} - development files"
-	pkg_install() {
-		vmove usr/include
-		vmove usr/lib/pkgconfig
-	}
+	# Conflict with python3-dbus-devel.
+	rm ${DESTDIR}/usr/include/dbus-1.0/dbus/dbus-python.h \
+	 ${DESTDIR}/usr/lib/pkgconfig/dbus-python.pc
 }

--- a/srcpkgs/python3-dbus
+++ b/srcpkgs/python3-dbus
@@ -1,1 +1,0 @@
-python-dbus

--- a/srcpkgs/python3-dbus-devel
+++ b/srcpkgs/python3-dbus-devel
@@ -1,1 +1,1 @@
-python-dbus
+python3-dbus

--- a/srcpkgs/python3-dbus/template
+++ b/srcpkgs/python3-dbus/template
@@ -1,0 +1,34 @@
+# Template file for 'python3-dbus'
+pkgname=python3-dbus
+version=1.3.2
+revision=1
+build_style=gnu-configure
+hostmakedepends="pkg-config python3"
+makedepends="libglib-devel python3-devel"
+depends="python3 dbus"
+checkdepends="${depends} python3-gobject"
+short_desc="D-Bus Python3 bindings"
+maintainer="Orphaned <orphan@voidlinux.org>"
+license="MIT"
+homepage="https://www.freedesktop.org/wiki/Software/DBusBindings"
+distfiles="https://dbus.freedesktop.org/releases/dbus-python/dbus-python-${version}.tar.gz"
+checksum=ad67819308618b5069537be237f8e68ca1c7fcc95ee4a121fe6845b1418248f8
+lib32disabled=yes
+
+export PYTHON_CPPFLAGS="-I${XBPS_CROSS_BASE}/${py3_inc}"
+export PYTHON_EXTRA_LIBS="-L${XBPS_CROSS_BASE}/usr/lib -lpython${py3_ver}${py3_abiver}"
+
+post_install() {
+	vcopy dbus_python.egg-info "${py3_sitelib}/dbus_python-${version}-py${py3_ver}.egg-info"
+
+	vlicense COPYING
+}
+
+python3-dbus-devel_package() {
+	depends="python3-devel python3-dbus>=${version}_${revision}"
+	short_desc+=" - development files"
+	pkg_install() {
+		vmove usr/include
+		vmove usr/lib/pkgconfig
+	}
+}


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
