### PR TITLE
android-udev-rules: update to 20230614.

### DIFF
--- a/srcpkgs/android-udev-rules/template
+++ b/srcpkgs/android-udev-rules/template
@@ -1,13 +1,14 @@
 # Template file for 'android-udev-rules'
 pkgname=android-udev-rules
-version=20230303
+version=20230614
 revision=1
 short_desc="Android udev rules list aimed to be the most comprehensive on the net"
 maintainer="Mohammed Anas <triallax@tutanota.com>"
 license="GPL-3.0-or-later"
 homepage="https://github.com/M0Rf30/android-udev-rules"
+changelog="https://github.com/M0Rf30/android-udev-rules/releases"
 distfiles="https://github.com/M0Rf30/android-udev-rules/archive/${version}.tar.gz"
-checksum=be0ef595f1ff1262696ac63fa2fc16998da02c170b49be461cfc712cd4317a9f
+checksum=563b8f3194110b7173dfaad61e74da2842b28c4f2409dedce04d5572ef2f056f
 system_groups="adbusers"
 
 do_install() {


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
