### PR TITLE
hackrf: update to 2023.01.1.

### DIFF
--- a/srcpkgs/hackrf/template
+++ b/srcpkgs/hackrf/template
@@ -1,6 +1,6 @@
 # Template file for 'hackrf'
 pkgname=hackrf
-version=2022.09.1
+version=2023.01.1
 revision=1
 build_wrksrc=host
 build_style=cmake
@@ -14,7 +14,7 @@ maintainer="DragonGhost7 <darkiridiumghost@gmail.com>"
 license="GPL-2.0-or-later"
 homepage="https://greatscottgadgets.com/hackrf/"
 distfiles="https://github.com/greatscottgadgets/hackrf/releases/download/v${version}/${pkgname}-${version}.tar.xz"
-checksum=bacd4e7937467ffa14654624444c8b5c716ab470d8c1ee8d220d2094ae2adb3e
+checksum=32a03f943a30be4ba478e94bf69f14a5b7d55be6761007f4a4f5453418206a11
 
 post_install() {
 	for f in ../firmware-bin/*.{bin,dfu}; do


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**



#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl
  - aarch64
  - aarch64-musl
  - armv7l
  - armv6l
  - i686