### PR TITLE
libde265: update to 1.0.12.

### DIFF
--- a/srcpkgs/libde265/template
+++ b/srcpkgs/libde265/template
@@ -1,6 +1,6 @@
 # Template file for 'libde265'
 pkgname=libde265
-version=1.0.11
+version=1.0.12
 revision=1
 build_style=gnu-configure
 hostmakedepends="pkg-config"
@@ -10,7 +10,12 @@ license="LGPL-3.0-or-later"
 homepage="https://www.libde265.org"
 changelog="https://github.com/strukturag/libde265/releases"
 distfiles="https://github.com/strukturag/libde265/releases/download/v${version}/libde265-${version}.tar.gz"
-checksum=2f8f12cabbdb15e53532b7c1eb964d4e15d444db1be802505e6ac97a25035bab
+checksum=62185ea2182e68cf68bba20cc6eb4c287407b509cf0a827d7ddb75614db77b5c
+
+post_install() {
+	# Why is this installed anyway?
+	rm -f ${DESTDIR}/bin/tests
+}
 
 libde265-devel_package() {
 	short_desc+=" - development files"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

Fixes a couple of security issues: https://github.com/strukturag/libde265/releases/tag/v1.0.12

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
