### PR TITLE
python-cffi: split python3-cffi to a new package

### DIFF
--- a/srcpkgs/python-cffi/template
+++ b/srcpkgs/python-cffi/template
@@ -2,11 +2,10 @@
 pkgname=python-cffi
 version=1.15.1
 revision=2
-build_style=python-module
-hostmakedepends="python-setuptools python3-setuptools libffi-devel"
-makedepends="python-devel python3-devel libffi-devel"
+build_style=python2-module
+hostmakedepends="python-setuptools libffi-devel"
+makedepends="python-devel libffi-devel"
 depends="python-pycparser"
-checkdepends="python3-pytest python3-pycparser"
 short_desc="C foreign function interface for Python2"
 maintainer="Andrew J. Hesford <ajh@sideband.org>"
 license="MIT"
@@ -15,28 +14,6 @@ changelog="https://cffi.readthedocs.io/en/latest/whatsnew.html"
 distfiles="${PYPI_SITE}/c/cffi/cffi-${version}.tar.gz"
 checksum=d400bfb9a37b1351253cb402671cea7e89bdecc294e8016a707f6d1d8ac934f9
 
-do_check() {
-	# glibc libm.so is a GNU ld script that isn't properly handled
-	# on dlopen; libm symbols required in these tests are missing
-	local excludes='not sin'
-	excludes+=' and not test_dlopen'
-	excludes+=' and not test_function_typedef'
-	excludes+=' and not test_wraps_from_stdlib'
-	excludes+=' and not test_stdcall_only_on_windows'
-
-	PYTHONPATH="$(cd build-${py3_ver}/lib* && pwd)" \
-		python3 -m pytest c/ testing/ -x -k "$excludes"
-}
-
 post_install() {
 	vlicense LICENSE
-}
-
-python3-cffi_package() {
-	depends="python3-pycparser"
-	short_desc="${short_desc/Python2/Python3}"
-	pkg_install() {
-		vmove usr/lib/python3*
-		vlicense LICENSE
-	}
 }

--- a/srcpkgs/python3-cffi
+++ b/srcpkgs/python3-cffi
@@ -1,1 +1,0 @@
-python-cffi

--- a/srcpkgs/python3-cffi/template
+++ b/srcpkgs/python3-cffi/template
@@ -1,0 +1,33 @@
+# Template file for 'python3-cffi'
+pkgname=python3-cffi
+version=1.15.1
+revision=2
+build_style=python3-module
+hostmakedepends="python3-setuptools libffi-devel"
+makedepends="python3-devel libffi-devel"
+depends="python3-pycparser"
+checkdepends="python3-pytest ${depends}"
+short_desc="C foreign function interface for Python3"
+maintainer="Andrew J. Hesford <ajh@sideband.org>"
+license="MIT"
+homepage="https://cffi.readthedocs.io/"
+changelog="https://cffi.readthedocs.io/en/latest/whatsnew.html"
+distfiles="${PYPI_SITE}/c/cffi/cffi-${version}.tar.gz"
+checksum=d400bfb9a37b1351253cb402671cea7e89bdecc294e8016a707f6d1d8ac934f9
+
+do_check() {
+	# glibc libm.so is a GNU ld script that isn't properly handled
+	# on dlopen; libm symbols required in these tests are missing
+	local excludes='not sin'
+	excludes+=' and not test_dlopen'
+	excludes+=' and not test_function_typedef'
+	excludes+=' and not test_wraps_from_stdlib'
+	excludes+=' and not test_stdcall_only_on_windows'
+
+	PYTHONPATH="$(cd build/lib* && pwd)" \
+		python3 -m pytest c/ testing/ -x -k "$excludes"
+}
+
+post_install() {
+	vlicense LICENSE
+}


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

@ahesford 
<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
