### PR TITLE
python-constantly: split python3-constantly to a new package

### DIFF
--- a/srcpkgs/python3-constantly
+++ b/srcpkgs/python3-constantly
@@ -1,1 +1,0 @@
-python-constantly

--- a/srcpkgs/python3-constantly/template
+++ b/srcpkgs/python3-constantly/template
@@ -1,11 +1,11 @@
-# Template file for 'python-constantly'
-pkgname=python-constantly
+# Template file for 'python3-constantly'
+pkgname=python3-constantly
 version=15.1.0
 revision=7
-build_style=python2-module
-hostmakedepends="python-setuptools python3-setuptools"
-depends="python"
-short_desc="Symbolic constants in Python (Python2)"
+build_style=python3-module
+hostmakedepends="python3-setuptools"
+depends="python3"
+short_desc="Symbolic constants in Python (Python3)"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
 homepage="https://github.com/twisted/constantly"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
