### PR TITLE
python-dateutil: split python3-dateutil to a new package

### DIFF
--- a/srcpkgs/python3-dateutil
+++ b/srcpkgs/python3-dateutil
@@ -1,1 +1,0 @@
-python-dateutil

--- a/srcpkgs/python3-dateutil/patches/pytest8.patch
+++ b/srcpkgs/python3-dateutil/patches/pytest8.patch
@@ -1,0 +1,46 @@
+From 2bdd63158b7f981fc6d70a869680451bdfd8d848 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Jakub=20Kul=C3=ADk?= <kulikjak@gmail.com>
+Date: Thu, 10 Feb 2022 10:28:42 +0100
+Subject: [PATCH] Remove deprecated pytest.warns(None) from test_internals.py
+
+---
+ tests/test_internals.py | 14 +++++++-------
+ 1 file changed, 7 insertions(+), 7 deletions(-)
+
+diff --git a/tests/test_internals.py b/tests/test_internals.py
+index 530813147..b32e6723f 100644
+--- a/dateutil/test/test_internals.py
++++ b/dateutil/test/test_internals.py
+@@ -9,6 +9,7 @@ code that may be difficult to reach through the standard API calls.
+ 
+ import sys
+ import pytest
++import warnings
+ 
+ from dateutil.parser._parser import _ymd
+ from dateutil import tz
+@@ -65,18 +66,17 @@ def test_parser_parser_private_not_warns():
+     from dateutil.parser._parser import _timelex, _tzparser
+     from dateutil.parser._parser import _parsetz
+ 
+-    with pytest.warns(None) as recorder:
++    with warnings.catch_warnings():
++        warnings.simplefilter("error")
+         _tzparser()
+-        assert len(recorder) == 0
+ 
+-    with pytest.warns(None) as recorder:
++    with warnings.catch_warnings():
++        warnings.simplefilter("error")
+         _timelex('2014-03-03')
+ 
+-        assert len(recorder) == 0
+-
+-    with pytest.warns(None) as recorder:
++    with warnings.catch_warnings():
++        warnings.simplefilter("error")
+         _parsetz('+05:00')
+-        assert len(recorder) == 0
+ 
+ 
+ @pytest.mark.tzstr

--- a/srcpkgs/python3-dateutil/template
+++ b/srcpkgs/python3-dateutil/template
@@ -1,20 +1,17 @@
-# Template file for 'python-dateutil'
-pkgname=python-dateutil
+# Template file for 'python3-dateutil'
+pkgname=python3-dateutil
 version=2.8.2
 revision=2
-build_style=python2-module
-hostmakedepends="python-setuptools"
-depends="python-six tzdata"
-short_desc="Extensions to the standard Python2 datetime module"
+build_style=python3-module
+hostmakedepends="python3-setuptools_scm"
+depends="python3-six tzdata"
+checkdepends="python3-pytest-cov python3-hypothesis python3-freezegun ${depends}"
+short_desc="Extensions to the standard Python3 datetime module"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="Apache-2.0, BSD-3-Clause"
 homepage="https://github.com/dateutil/dateutil"
 distfiles="${PYPI_SITE}/p/python-dateutil/python-dateutil-${version}.tar.gz"
 checksum=0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86
-
-post_patch() {
-	vsed -i setup.py -e "s/%PKGVERSION%/'${version}'/"
-}
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
