### PR TITLE
python3-ansible-lint: update to 6.17.1

### DIFF
--- a/srcpkgs/python3-ansible-lint/template
+++ b/srcpkgs/python3-ansible-lint/template
@@ -1,6 +1,6 @@
 # Template file for 'python3-ansible-lint'
 pkgname=python3-ansible-lint
-version=6.16.2
+version=6.17.1
 revision=1
 build_style=python3-pep517
 hostmakedepends="python3-wheel python3-setuptools_scm"
@@ -17,7 +17,7 @@ maintainer="Jan Christian Grünhage <jan.christian@gruenhage.xyz>"
 license="GPL-3.0-only"
 homepage="https://github.com/ansible/ansible-lint"
 distfiles="${PYPI_SITE}/a/ansible-lint/ansible-lint-${version}.tar.gz"
-checksum=93ad8a04adcda6025d4ff218a10694120fe70cb91da8ac9f85c5dc82b32456e4
+checksum=f34e333f3555c99ff34c778f61d470d1e3a1eb6dc76090d0dd7b95b2c94745c2
 # cba anymore, the list of failing tests changes with every update
 make_check="no"
 


### PR DESCRIPTION
Tagging the maintainer: @jcgruenhage

#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl

