### PR TITLE
linux: update to 6.3, linux-lts: update to 6.1

### DIFF
--- a/srcpkgs/linux-lts/template
+++ b/srcpkgs/linux-lts/template
@@ -1,6 +1,6 @@
 # Template file for 'linux-lts'
 pkgname=linux-lts
-version=5.15
+version=6.1
 revision=1
 build_style=meta
 depends="linux${version} linux-base"

--- a/srcpkgs/linux/template
+++ b/srcpkgs/linux/template
@@ -1,6 +1,6 @@
 # Template file for 'linux'
 pkgname=linux
-version=6.1
+version=6.3
 revision=1
 build_style=meta
 depends="linux${version} linux-base"


### PR DESCRIPTION
linux:
- [x] zfs-2.1.12 supports 6.3
- [x] @abenson does nvidia support 6.3 yet?

linux-lts:
- 6.1 is the [latest lts branch](https://kernel.org), do we want to switch to it already?

#### Testing the changes
- I tested the changes in this PR: **YES**

