### PR TITLE
python3-numpy: update to 1.25.0.

### DIFF
--- a/srcpkgs/python3-numpy/patches/fix-pytest-warning.patch
+++ b/srcpkgs/python3-numpy/patches/fix-pytest-warning.patch
@@ -1,0 +1,8 @@
+--- a/pytest.ini	2023-06-16 22:48:37.211072200 -0300
++++ b/pytest.ini	2023-06-19 22:52:00.230063231 -0300
+@@ -27,3 +27,5 @@
+     ignore:\n\n  `numpy.distutils`:DeprecationWarning
+ # Ignore mypy >= 0.971 DeprecationWarnings
+     ignore:path is deprecated\. Use files\(\) instead:DeprecationWarning:mypy
++# Ignore warning raised when importing setuptools.command.
++    ignore:pkg_resources is deprecated as an API:DeprecationWarning

--- a/srcpkgs/python3-numpy/template
+++ b/srcpkgs/python3-numpy/template
@@ -1,21 +1,21 @@
 # Template file for 'python3-numpy'
 pkgname=python3-numpy
-version=1.24.3
+version=1.25.0
 revision=1
 build_style=python3-module
 hostmakedepends="python3-setuptools python3-Cython gcc-fortran"
 makedepends="python3-devel
  $(vopt_if openblas 'openblas-devel' 'lapack-devel cblas-devel')"
 depends="python3-setuptools"
+checkdepends="python3-pytest-xdist python3-hypothesis python3-pytz"
 short_desc="Fast and sophisticated array facility to Python3"
 maintainer="Andrew J. Hesford <ajh@sideband.org>"
 license="BSD-3-Clause"
 homepage="https://www.numpy.org/"
-distfiles="https://github.com/numpy/numpy/archive/v${version}.tar.gz"
-checksum=0d78333b35bd704826892a56e2af71af69139ee02fa155c8c83aeec58bee4744
+changelog="https://numpy.org/doc/stable/release.html"
+distfiles="${PYPI_SITE}/n/numpy/numpy-${version}.tar.gz"
+checksum=f1accae9a28dc3cda46a91de86acf69de0d1b5f4edd44a9b0c3ceb8036dfff19
 alternatives="numpy:f2py:/usr/bin/f2py3"
-# Tests do not function propery in a build directory
-make_check="no"
 
 build_options="openblas"
 
@@ -65,6 +65,31 @@ pre_build() {
 		runtime_library_dirs = ${XBPS_CROSS_BASE}/usr/lib
 		EOF
 	done
+}
+
+do_check() {
+	local testjobs="-n $XBPS_MAKEJOBS"
+	local _skip
+
+	case $XBPS_TARGET_MACHINE in
+		# this triggers a known bug in musl libm, fixed in:
+		# https://git.musl-libc.org/cgit/musl/commit/?id=aa2d23e57c9c95f0ffeb80cb035e5a5be52d8ef0
+		*-musl) _skip+="or(test_against_cmath)" ;;
+	esac
+
+	if [ ${XBPS_TARGET_MACHINE%-musl} = "i686" ]; then
+		# see: https://github.com/numpy/numpy/issues/18388
+		_skip+="or(test_float_remainder_overflow)"
+		_skip+="or(test_identityless_reduction_huge_array)"
+		_skip+="or((TestKind)and(test_int))"
+		# these 3 fail in CI but not locally
+		_skip+="or(test_einsum_sums_int8)"
+		_skip+="or(test_einsum_sums_uint8)"
+		_skip+="or(test_einsum_sums_int16)"
+	fi
+
+	echo python3 runtests.py -- ${testjobs} ${_skip+-k "not(${_skip#or})"}
+	python3 runtests.py -- ${testjobs} ${_skip+-k "not(${_skip#or})"}
 }
 
 post_install() {


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

I enabled check, and I'm currently testing with sagemath to see what fails and fix it. So far I've only tried x86_64.

I didn't change the build-style to pep517 because that won't allow parallel build. For testing, a custom `do_check()` is needed in any case. Moreover, it seems numpy will soon move to meson for building so we may as well wait for that.

@ahesford 


<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
