### PR TITLE
kdenlive: depend on mediainfo-cli instead of mediainfo-gui

### DIFF
--- a/srcpkgs/kdenlive/template
+++ b/srcpkgs/kdenlive/template
@@ -1,7 +1,7 @@
 # Template file for 'kdenlive'
 pkgname=kdenlive
 version=23.04.2
-revision=1
+revision=2
 build_style=cmake
 hostmakedepends="
  extra-cmake-modules kconfig kcoreaddons kdoctools pkg-config python3
@@ -11,7 +11,7 @@ makedepends="
  kplotting-devel mlt7-devel qt5-multimedia-devel qt5-webkit-devel purpose-devel
  v4l-utils-devel ksolid-devel qt5-quickcontrols2-devel qt5-networkauth-devel"
 depends="breeze-icons dvdauthor ffmpeg frei0r-plugins kinit qt5-quickcontrols
- kirigami2 mediainfo"
+ kirigami2 mediainfo-cli"
 checkdepends="$depends"
 short_desc="Non-linear video editor"
 maintainer="Orphaned <orphan@voidlinux.org>"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

mediainfo-cli is an optional dependency of Kdenlive.

On other distros the `mediainfo` package provides the cli application and the `mediainfo-gui` package provides the gui application. On void, the `mediainfo` package installs the gui application and `mediainfo-cli` installs the cli application.

The package was updated to install the gui package instead of the cli package, when only the cli application is used afaict.

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
