### PR TITLE
nyxt: update to 3.2.0

### DIFF
--- a/srcpkgs/nyxt/patches/002-webkit2gtk.patch
+++ b/srcpkgs/nyxt/patches/002-webkit2gtk.patch
@@ -1,14 +1,14 @@
---- a/_build/cl-webkit/webkit2/webkit2.init.lisp	2022-01-14 03:22:05.000000000 -0700
-+++ b/_build/cl-webkit/webkit2/webkit2.init.lisp	2022-02-27 09:59:29.175938024 -0700
-@@ -18,9 +18,9 @@
-               "libwebkit2gtk-4.0.37.dylib"
+--- a/_build/cl-webkit/webkit2/webkit2.init.lisp    2023-06-19 18:14:54.899937994 +0200
++++ b/_build/cl-webkit/webkit2/webkit2.init.lisp    2023-06-19 18:15:45.707030674 +0200
+@@ -19,9 +19,9 @@
                "libwebkit2gtk-4.0.dylib"))
-     (:unix (:or "libwebkit2gtk-4.1.so"
--                "libwebkit2gtk-4.0.so"
-                 ;; Fedora only has this one?
--                "libwebkit2gtk-4.0.so.37")))
-+                "libwebkit2gtk-4.0.so.37"
-+                "libwebkit2gtk-4.0.so")))
+     (:unix (:or
+             "libwebkit2gtk-4.1.so"
+-            "libwebkit2gtk-4.0.so"
+             ;; Fedora only has this one?
+-            "libwebkit2gtk-4.0.so.37")))
++            "libwebkit2gtk-4.0.so.37"
++            "libwebkit2gtk-4.0.so")))
    (use-foreign-library libwebkit2))
  
  (defcfun "webkit_get_major_version" :int)

--- a/srcpkgs/nyxt/template
+++ b/srcpkgs/nyxt/template
@@ -1,19 +1,19 @@
 # Template file for 'nyxt'
 pkgname=nyxt
-version=2.2.4
-revision=3
+version=3.2.0
+revision=1
 create_wrksrc=yes
 build_style=gnu-makefile
 make_build_target=all
-hostmakedepends="sbcl git"
+hostmakedepends="sbcl git pkg-config"
 makedepends="webkit2gtk libfixposix-devel libgirepository"
 depends="dbus xclip enchant2 webkit2gtk libfixposix libgirepository"
 short_desc="Keyboard-oriented, extensible web-browser"
-maintainer="0x0f0f0f <sudo-woodo3@protonmail.com>"
+maintainer="Orphaned <orphan@voidlinux.org>"
 license="BSD-3-Clause"
 homepage="https://nyxt.atlas.engineer/"
 distfiles="https://github.com/atlas-engineer/nyxt/releases/download/${version}/${pkgname}-${version}-source-with-submodules.tar.xz"
-checksum=04f740f8405044cc89920d41d340d6d137e1d4f7be098d4813d1523f73d725a9
+checksum=3e7a2812563ea3f2fe0c039db0d693a4de99d22cef1b0dec09173d1b7fbaf691
 # Disable check because ASDF/USER::PROVE is not installed
 make_check=no
 nostrip=yes


### PR DESCRIPTION
- Updated 002-webkit2gtk.init.lisp patch. The patch itself is the same, but the structure of the source file to be patched changed.
- Included "pkg-config" into hostmakedepends.

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64*
