### PR TITLE
cargo-outdated: update to 0.13.1.

### DIFF
--- a/srcpkgs/cargo-outdated/template
+++ b/srcpkgs/cargo-outdated/template
@@ -1,6 +1,6 @@
 # Template file for 'cargo-outdated'
 pkgname=cargo-outdated
-version=0.11.2
+version=0.13.1
 revision=1
 build_style=cargo
 hostmakedepends="pkg-config zlib-devel"
@@ -11,7 +11,7 @@ license="MIT"
 homepage="https://github.com/kbknapp/cargo-outdated"
 changelog="https://raw.githubusercontent.com/kbknapp/cargo-outdated/master/CHANGELOG.md"
 distfiles="https://github.com/kbknapp/cargo-outdated/archive/refs/tags/v${version}.tar.gz"
-checksum=7e82d1507594d86cb1c2007d58e329a9780a22bdb0f38d5e71d2692a7f1727d9
+checksum=571910b0c44f0bcf0b6e5c24184247e4603f474c7bde5f0eaa1203ce802b4a4a
 
 post_install() {
 	vlicense LICENSE-MIT


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture: **x86_64**