### PR TITLE
libspnav: update to 1.1, minor fixes

### DIFF
--- a/srcpkgs/libspnav/template
+++ b/srcpkgs/libspnav/template
@@ -1,24 +1,20 @@
 # Template file for 'libspnav'
 pkgname=libspnav
-version=1.0
-revision=2
+version=1.1
+revision=1
 build_style=gnu-configure
-configure_args="--disable-opt"
 makedepends="libX11-devel"
 short_desc="Open source alternative to 3DConnextion drivers"
 maintainer="yopito <pierre.bourgin@free.fr>"
 license="BSD-3-Clause"
 homepage="http://spacenav.sourceforge.net/"
-distfiles="${SOURCEFORGE_SITE}/spacenav/${pkgname}-${version}.tar.gz"
-checksum=8849b7f7826d750f6956cf8f4f53937f2359ab6da97d6c834c71d5f771212e7c
-
-do_build() {
-	make CC="${CC}" AR="${AR}"
-}
+distfiles="https://github.com/FreeSpacenav/libspnav/archive/refs/tags/v${version}.tar.gz"
+checksum=04b297f68a10db4fa40edf68d7f823ba7b9d0442f2b665181889abe2cea42759
 
 post_install() {
 	vlicense LICENSE
 }
+
 libspnav-devel_package() {
 	short_desc+=" - development files"
 	depends="${makedepends} ${sourcepkg}>=${version}_${revision}"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

Using a SpaceMouse Pro Wireless with the latest upstream versions of `spacenavd`, `spnavcfg`, and the latest version of FreeCAD in the repository.

![libspnav-1 1-test-spacemouse-pro-wireless](https://github.com/void-linux/void-packages/assets/4819590/652ba122-021a-4f17-954d-7243073f1f2e)

#### Local build testing
- I built this PR locally for my native architecture, x86_64

#### Notes

* The upstream sources are now accessible on GitHub (for all three related packages). The 1.1 version is not on SourceForge so I switched the `distfiles` to GitHub.
* I dropped the `do_build()` section as it doesn't seem to be necessary when using the `gnu-configure` build style. If there's something I missed here for why this should be kept in please let me know.
* The library supports a non-X11 build but I'm not sure how to expose that. Does XBPS support variants like that? If it matters to someone and you can point me to the relevant documentation I would be willing to add it.
* I plan to package `spacenavd` and `spnavcfg` next which will depend on this library.
