### PR TITLE
New package: clojure-lsp-2024.04.22

### DIFF
--- a/srcpkgs/clojure-lsp/patches/remove-pgo.patch
+++ b/srcpkgs/clojure-lsp/patches/remove-pgo.patch
@@ -1,0 +1,11 @@
+--- a/cli/build.clj
++++ b/cli/build.clj
+@@ -134,8 +134,6 @@
+                         "--features=clj_easy.graal_build_time.InitClojureClasses"
+                         (when-not (fs/windows?) "-march=compatibility")
+                         "-O1"
+-                        (when-not (or (:pgo-instrument opts)
+-                                      (fs/windows?)) "--pgo=graalvm/default.iprof")
+                         (or (System/getenv "CLOJURE_LSP_XMX")
+                             "-J-Xmx8g")
+                         (when (= "true" (System/getenv "CLOJURE_LSP_STATIC"))

--- a/srcpkgs/clojure-lsp/template
+++ b/srcpkgs/clojure-lsp/template
@@ -1,0 +1,32 @@
+# Template file for 'clojure-lsp'
+pkgname=clojure-lsp
+version=2024.04.22
+revision=1
+_ver_hms="11.50.26"
+hostmakedepends="mandrel leiningen babashka clojure"
+makedepends="zlib-devel"
+short_desc="Clojure & ClojureScript language server implementation"
+maintainer="icp <pangolin@vivaldi.net>"
+license="MIT"
+homepage="https://clojure-lsp.io"
+changelog="https://raw.githubusercontent.com/clojure-lsp/clojure-lsp/master/CHANGELOG.md"
+distfiles="https://github.com/clojure-lsp/clojure-lsp/archive/refs/tags/${version}-${_ver_hms}.tar.gz"
+checksum=0fe5dd9b27cfe7583f1cb3ae5520a5e85d710af5d281785ecd0618eb222095fd
+nocross="mandrel"
+
+do_build() {
+	export GRAALVM_HOME=/usr/lib/jvm/mandrel21
+	export PATH="/usr/libexec/chroot-git:${PATH}"
+
+	if [ "$XBPS_TARGET_LIBC" = musl ]; then
+		export CLOJURE_LSP_STATIC=true
+		export CLOJURE_LSP_MUSL=true
+	fi
+
+	bb native-cli
+}
+
+do_install() {
+	vbin clojure-lsp
+	vlicense LICENSE
+}

--- a/srcpkgs/clojure-lsp/update
+++ b/srcpkgs/clojure-lsp/update
@@ -1,0 +1,2 @@
+site="https://clojure-lsp.io/CHANGELOG/"
+pattern="\K\d{4}\.\d{2}\.\d{2}(?=-\d{2}\.\d{2}\.\d{2})"


### PR DESCRIPTION
#### Description
[Clj-kondo](https://github.com/clj-kondo/clj-kondo) performs static analysis on Clojure, ClojureScript and EDN, without the need of a running REPL.

#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

#### Local build testing
- I built this PR locally for my native architecture: **x86_64**