### PR TITLE
bird: update to 2.13.1

### DIFF
--- a/srcpkgs/bird/template
+++ b/srcpkgs/bird/template
@@ -1,6 +1,6 @@
 # Template file for 'bird'
 pkgname=bird
-version=2.13
+version=2.13.1
 revision=1
 build_style=gnu-configure
 hostmakedepends="flex"
@@ -11,7 +11,7 @@ license="GPL-2.0-or-later"
 homepage="https://bird.network.cz"
 changelog="https://gitlab.nic.cz/labs/bird/-/raw/master/NEWS"
 distfiles="https://bird.network.cz/download/bird-${version}.tar.gz"
-checksum=8d895e3e311880e9efb888b4386cbec2f7e18bfb8334e8d4c8ca7c4341092638
+checksum=97bb8d57be9bc5083e2b566416d27e314162856a12ca7c77e202e467d20d4080
 
 conf_files="/etc/bird.conf"
 system_accounts="_bird"


### PR DESCRIPTION
Security update, from changelog:
  o BGP: Fix role check when no capability option is present
  o Filter: Fixed segfault when a case option had an empty block

#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for my native architecture, (x86_64-musl)