### PR TITLE
krita: enable JPEG XL support

### DIFF
--- a/srcpkgs/krita/template
+++ b/srcpkgs/krita/template
@@ -1,7 +1,7 @@
 # Template file for 'krita'
 pkgname=krita
 version=5.0.8
-revision=6
+revision=7
 build_style=cmake
 configure_args="-Wno-dev -DBUILD_TESTING=OFF"
 hostmakedepends="extra-cmake-modules gettext pkg-config python3
@@ -15,7 +15,7 @@ makedepends="karchive-devel kconfig-devel kwidgetsaddons-devel kcompletion-devel
  poppler-qt5-devel giflib-devel python3-devel python3-PyQt5
  python3-PyQt5-devel quazip-devel libheif-devel seexpr-krita-devel
  libopenjpeg2-devel qt5-plugin-mysql qt5-plugin-sqlite qt5-plugin-odbc
- qt5-plugin-pgsql qt5-plugin-tds libwebp-devel libmypaint-devel"
+ qt5-plugin-pgsql qt5-plugin-tds libwebp-devel libmypaint-devel libjxl-devel"
 depends="qt5-plugin-sqlite"
 short_desc="Painting and image editing program"
 maintainer="John <me@johnnynator.dev>"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

Required by the Krita JPEG-XL filter

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
#### Local build testing
- I built this PR locally for my native architecture, (x86_64)
