### PR TITLE
mu4e: update to 1.10.4

### DIFF
--- a/srcpkgs/mu4e/template
+++ b/srcpkgs/mu4e/template
@@ -1,16 +1,16 @@
 # Template file for 'mu4e'
 pkgname=mu4e
-version=1.10.3
+version=1.10.4
 revision=1
 build_style=meson
 hostmakedepends="emacs libtool pkg-config texinfo glib-devel"
 makedepends="xapian-core-devel gmime3-devel"
 short_desc="Maildir-utils indexer/searcher and associated Emacs client"
-maintainer="Benjamin Slade <slade@lambda-y.net>"
+maintainer="Pascal Huber <pascal.huber@resolved.ch>"
 license="GPL-3.0-or-later"
 homepage="https://www.djcbsoftware.nl/code/mu/"
 changelog="https://github.com/djcb/mu/raw/master/NEWS.org"
 distfiles="https://github.com/djcb/mu/releases/download/v${version}/mu-${version}.tar.xz"
-checksum=c83970fcb6163c27d135c207d1a5eb6f38a5732161741a4a88da2ae894e0245f
+checksum=8eba7864aad442212b2bc62aac6491708084ba5d84416a22b8a8ddf2ee7240ec
 replaces="mu<${version}"
 provides="mu-${version}_${revision}"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc

