### PR TITLE
dhcpcd: fix dhcpv6-pd for pppoe

### DIFF
--- a/srcpkgs/dhcpcd/patches/Linux-Improve-learning-IPv6-address-flags.patch
+++ b/srcpkgs/dhcpcd/patches/Linux-Improve-learning-IPv6-address-flags.patch
@@ -1,0 +1,62 @@
+From 45e441ada6d3ea4355d623cf12d9a559a5c2afde Mon Sep 17 00:00:00 2001
+From: Roy Marples <roy@marples.name>
+Date: Tue, 23 May 2023 22:14:57 +0100
+Subject: [PATCH] Linux: Improve learning IPv6 address flags
+
+Rather than matching addresses during netlink message processing,
+extract the local, address and flag parts.
+Once done, then match local and address to the address we are
+looking for and if equal apply the flags.
+
+Fixes #201 and maybe #149.
+---
+ src/if-linux.c | 24 +++++++++++++++++-------
+ 1 file changed, 17 insertions(+), 7 deletions(-)
+
+diff --git a/src/if-linux.c b/src/if-linux.c
+index f2f609ed..212ed5df 100644
+--- a/src/if-linux.c
++++ b/src/if-linux.c
+@@ -1996,7 +1996,8 @@ _if_addrflags6(__unused struct dhcpcd_ctx *ctx,
+ 	size_t len;
+ 	struct rtattr *rta;
+ 	struct ifaddrmsg *ifa;
+-	bool matches_addr = false;
++	struct in6_addr *local = NULL, *address = NULL;
++	uint32_t *flags = NULL;
+ 
+ 	ifa = NLMSG_DATA(nlm);
+ 	if (ifa->ifa_index != ia->ifa_ifindex || ifa->ifa_family != AF_INET6)
+@@ -2007,17 +2008,26 @@ _if_addrflags6(__unused struct dhcpcd_ctx *ctx,
+ 	for (; RTA_OK(rta, len); rta = RTA_NEXT(rta, len)) {
+ 		switch (rta->rta_type) {
+ 		case IFA_ADDRESS:
+-			if (IN6_ARE_ADDR_EQUAL(&ia->ifa_addr, (struct in6_addr *)RTA_DATA(rta)))
+-				ia->ifa_found = matches_addr = true;
+-			else
+-				matches_addr = false;
++			address = (struct in6_addr *)RTA_DATA(rta);
++			break;
++		case IFA_LOCAL:
++			local = (struct in6_addr *)RTA_DATA(rta);
+ 			break;
+ 		case IFA_FLAGS:
+-			if (matches_addr)
+-				memcpy(&ia->ifa_flags, RTA_DATA(rta), sizeof(ia->ifa_flags));
++			flags = (uint32_t *)RTA_DATA(rta);
+ 			break;
+ 		}
+ 	}
++
++	if (local) {
++	       if (IN6_ARE_ADDR_EQUAL(&ia->ifa_addr, local))
++			ia->ifa_found = true;
++	} else if (address) {
++	       if (IN6_ARE_ADDR_EQUAL(&ia->ifa_addr, address))
++			ia->ifa_found = true;
++	}
++	if (flags && ia->ifa_found)
++		memcpy(&ia->ifa_flags, flags, sizeof(ia->ifa_flags));
+ 	return 0;
+ }
+ 

--- a/srcpkgs/dhcpcd/template
+++ b/srcpkgs/dhcpcd/template
@@ -1,7 +1,7 @@
 # Template file for 'dhcpcd'
 pkgname=dhcpcd
 version=10.0.1
-revision=1
+revision=2
 build_style=configure
 make_check_target=test
 configure_args="


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

Adds https://github.com/NetworkConfiguration/dhcpcd/commit/1a70f1b51c453c66993fab8172e57924059bd34b to solve https://github.com/NetworkConfiguration/dhcpcd/issues/149


#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
