### PR TITLE
New package: libpurple-discord-0.9.2023.02.15.git.4a09188

### DIFF
--- a/srcpkgs/libpurple-discord/template
+++ b/srcpkgs/libpurple-discord/template
@@ -1,0 +1,13 @@
+# Template file for 'libpurple-discord'
+pkgname=libpurple-discord
+version=0.9.2023.02.15.git.4a09188
+revision=1
+build_style=gnu-makefile
+hostmakedepends="pkg-config ImageMagick gettext"
+makedepends="json-glib-devel libpurple-devel nss-devel qrencode-devel"
+short_desc="Discord plugin for libpurple"
+maintainer="Spark <sparksman@disroot.org>"
+license="GPL-2.0-or-later"
+homepage="https://github.com/EionRobb/purple-discord"
+distfiles="https://github.com/EionRobb/purple-discord/tarball/4a091883e646f2c103ae68c41d04b1b880e8d0bf>purple-discord.tar.gz"
+checksum=4f462facf18d200f7ff9f4c3e96f6a6b95f6c13f553d343c91eb861d1b2bebdd


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->
#### Description
Discord plugin for libpurple

#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
#### Local build testing
- I built this PR locally for my native architecture: **x86_64**
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - i686 (crossbuild)
  - armv6l (crossbuild)
  - armv7l (crossbuild)

#### Notes
- Has been tested on x86_64 and appears to be working fine at runtime (with pidgin) over the course of several days, however no testing has been made for alternative architectures/musl despite successful builds.
- Authors have never provided versions/releases, latest git commit at the time of writing is being used instead.