### PR TITLE
ferium: don't use portal-based gui

### DIFF
--- a/srcpkgs/ferium/template
+++ b/srcpkgs/ferium/template
@@ -1,9 +1,10 @@
 # Template file for 'ferium'
 pkgname=ferium
 version=4.4.1
-revision=1
+revision=2
 build_style=cargo
 build_helper=qemu
+configure_args="--no-default-features"
 short_desc="CLI program for managing Minecraft mods and modpacks"
 maintainer="yosh <yosh-git@riseup.net>"
 license="MPL-2.0"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**.

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)

Apologies for the quick revision, but I only realized after the merge that the package compiles with the GUI `xdg-desktop-portal` integration by default, which results in an inability to change some options through the TUI interface on systems without `xdg-desktop-portal`. This commit opts to make the `nogui` option the default and provide a build option for the GUI integration instead.