### PR TITLE
openjdk17: update to 17.0.8+6.

### DIFF
--- a/srcpkgs/openjdk17/template
+++ b/srcpkgs/openjdk17/template
@@ -1,6 +1,6 @@
 # Template file for 'openjdk17'
 pkgname=openjdk17
-version=17.0.8+5
+version=17.0.8+6
 revision=1
 _gtest_ver=1.8.1
 _java_ver="${version%%.*}"
@@ -45,7 +45,7 @@ license="GPL-2.0-only WITH Classpath-exception-2.0"
 homepage="http://openjdk.java.net/"
 distfiles="https://github.com/openjdk/jdk${_java_ver}u/archive/jdk-${version}.tar.gz
  https://github.com/google/googletest/archive/refs/tags/release-${_gtest_ver}.tar.gz"
-checksum="adf42ea4a9bb2cffa4689c9eb98605a7cd804034cb88312c2b7bf4c5285e32ce
+checksum="ce6e1b61c70cc9d7f3c4c27bda1fa9c21d5a54f5cdb98512c30425703dee9ce4
  9bf1fe5182a604b4135edc1a425ae356c9ad15e9b23f9f12a02e80184c3a249c"
 provides="java-environment-${version}_1"
 patch_args="-Np1 --directory=$build_wrksrc"
@@ -229,7 +229,7 @@ openjdk17-static-libs_package() {
 
 openjdk17-jmods_package() {
 	short_desc+=" - JMODs"
-	depends="${pkgname}-${version}_${revision}"
+	depends="${sourcepkg}-${version}_${revision}"
 	pkg_install() {
 		vmove $_jdk_home/jmods
 	}


### PR DESCRIPTION
Also fix openjdk17-jmods depending on itself instead of openjdk17.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

@classabbyamp

[ci skip]

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
