### PR TITLE
New Package: mlton-20210117

### DIFF
--- a/srcpkgs/mlton/template
+++ b/srcpkgs/mlton/template
@@ -1,0 +1,26 @@
+# Template file for 'mlton'
+pkgname=mlton
+version=20210117
+revision=1
+archs="x86_64"
+build_style=gnu-makefile
+hostmakedepends="wget gcc make tar patch"
+makedepends="gmp-devel"
+build_wrksrc="mlton-$version/"
+short_desc="Optimizing compiler for the Standard ML programming language"
+maintainer="Adam Pschorr <adampschorr13@aol.com>"
+license="HPND"
+homepage="http://www.mlton.org/"
+distfiles="https://github.com/MLton/mlton/releases/download/on-$version-release/mlton-$version.src.tgz
+https://github.com/MLton/mlton/releases/download/on-$version-release/mlton-$version-1.amd64-linux-glibc2.31.tgz"
+checksum="ec7a5a54deb39c7c0fa746d17767752154e9cb94dbcf3d15b795083b3f0f154b
+749cb59d6baccd644143709be866105228d2b6dcd40c507a90b89c9b5e0f45d2"
+
+post_extract() {
+	cd $wrksrc/mlton-$version-1.amd64-linux-glibc2.31
+	make
+}
+
+post_install() {
+	vlicense LICENSE
+}

--- a/srcpkgs/mlton/update
+++ b/srcpkgs/mlton/update
@@ -1,0 +1,2 @@
+site="https://github.com/MLton/mlton/releases"
+pattern="on-\K[0-9]+(?=-release)"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**


#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64

MAJOR NOTE: Similar to openjdk mlton needs to be built with a binary of itself. These binaries are only available for x86_64. Cross compile should be completely possible but compilation on platforms other than x86_64 is not possible unless a binary is made for that arch. Comments and ideas welcome and needed as this is why the archs are restricted to x86_64.