### PR TITLE
maxima: update to 5.47.0, patch and rebuilds sagemath for maxima, singular, numpy updates. 

### DIFF
--- a/srcpkgs/maxima/template
+++ b/srcpkgs/maxima/template
@@ -1,6 +1,6 @@
 # Template file for 'maxima'
 pkgname=maxima
-version=5.46.0
+version=5.47.0
 revision=1
 build_style=gnu-configure
 configure_args="$(vopt_enable clisp) $(vopt_enable sbcl sbcl-exec) $(vopt_enable ecl)"
@@ -14,7 +14,7 @@ license="GPL-2.0-only"
 homepage="http://maxima.sourceforge.net"
 changelog="https://sourceforge.net/p/maxima/code/ci/master/tree/changelogs/ChangeLog-${version%.*}.md?format=raw"
 distfiles="${SOURCEFORGE_SITE}/maxima/maxima-${version}.tar.gz"
-checksum=7390f06b48da65c9033e8b2f629b978b90056454a54022db7de70e2225aa8b07
+checksum=9104021b24fd53e8c03a983509cb42e937a925e8c0c85c335d7709a14fd40f7a
 nocross=yes
 
 # maxima-sbcl is nopie and should NOT be stripped or it won't work

--- a/srcpkgs/sagemath/patches/35619-maxima_5.46.0.patch
+++ b/srcpkgs/sagemath/patches/35619-maxima_5.46.0.patch
@@ -48,7 +48,7 @@ index ee1667aec16..72083337942 100644
  
  sdh_configure $SAGE_CONFIGURE_GMP \
 diff --git a/build/pkgs/giac/spkg-configure.m4 b/build/pkgs/giac/spkg-configure.m4
-index 5859e35f12e..b677184b7be 100644
+index 5859e35f12e..53e3a8301cd 100644
 --- a/build/pkgs/giac/spkg-configure.m4
 +++ b/build/pkgs/giac/spkg-configure.m4
 @@ -5,7 +5,7 @@ SAGE_SPKG_CONFIGURE([giac], [
@@ -56,10 +56,17 @@ index 5859e35f12e..b677184b7be 100644
         AC_CACHE_CHECK([for giac >= ]GIAC_MIN_VERSION[, <= ]GIAC_MAX_VERSION, [ac_cv_path_GIAC], [
           AC_PATH_PROGS_FEATURE_CHECK([GIAC], [giac], [
 -            giac_version=$($ac_path_GIAC --version 2> /dev/null | tail -1)
-+            giac_version=$($ac_path_GIAC --version 2> /dev/null | tail -n -1)
++            giac_version=$($ac_path_GIAC --version 2> /dev/null | tail -n 1)
              AS_IF([test -n "$giac_version"], [
                  AX_COMPARE_VERSION([$giac_version], [ge], GIAC_MIN_VERSION, [
                      AX_COMPARE_VERSION([$giac_version], [le], GIAC_MAX_VERSION, [
+diff --git a/build/pkgs/info/distros/fedora.txt b/build/pkgs/info/distros/fedora.txt
+index 283aa462f74..c0d8f74e0ad 100644
+--- a/build/pkgs/info/distros/fedora.txt
++++ b/build/pkgs/info/distros/fedora.txt
+@@ -1 +1 @@
+-texinfo
++texinfo info
 diff --git a/build/pkgs/info/spkg-configure.m4 b/build/pkgs/info/spkg-configure.m4
 index 0980a4b8ef8..85fe1ea4731 100644
 --- a/build/pkgs/info/spkg-configure.m4
@@ -108,6 +115,16 @@ index a804c7b831f..0f594389fe6 100644
 +md5=3c01f1daa6936e11d8713fef7751d3fe
 +cksum=2420393096
  upstream_url=https://sourceforge.net/projects/maxima/files/Maxima-source/VERSION-source/maxima-VERSION.tar.gz/download
+diff --git a/build/pkgs/maxima/dependencies b/build/pkgs/maxima/dependencies
+index fffb89e2050..55c7e0d8d14 100644
+--- a/build/pkgs/maxima/dependencies
++++ b/build/pkgs/maxima/dependencies
+@@ -1,4 +1,4 @@
+-ecl
++ecl info
+ 
+ ----------
+ All lines of this file are ignored except the first.
 diff --git a/build/pkgs/maxima/distros/arch.txt b/build/pkgs/maxima/distros/arch.txt
 index 6400290f44d..6ac052fa62b 100644
 --- a/build/pkgs/maxima/distros/arch.txt
@@ -198,7 +215,7 @@ index 74db62e7f9f..00000000000
 - 			  (let ((x (symbol-value (find-symbol "*AUTOCONF-LD-FLAGS*"
 diff --git a/build/pkgs/maxima/spkg-configure.m4 b/build/pkgs/maxima/spkg-configure.m4
 new file mode 100644
-index 00000000000..dc54525320e
+index 00000000000..86de8c1dfc1
 --- /dev/null
 +++ b/build/pkgs/maxima/spkg-configure.m4
 @@ -0,0 +1,46 @@
@@ -209,7 +226,7 @@ index 00000000000..dc54525320e
 +    dnl we still use pexpect to communicate with it in a few places.
 +    AC_CACHE_CHECK([for Maxima >= $SAGE_MAXIMA_MINVER], [ac_cv_path_MAXIMA], [
 +        AC_PATH_PROGS_FEATURE_CHECK([MAXIMA], [maxima], [
-+            maxima_version=`$ac_path_MAXIMA --version 2>&1 | tail -n -1\
++            maxima_version=`$ac_path_MAXIMA --version 2>&1 | tail -n 1\
 +                | $SED -n -e 's/Maxima *\([[0-9]]*\.[[0-9]]*\.[[0-9]]*\)/\1/p'`
 +            AS_IF([test -n "$maxima_version"], [
 +                AX_COMPARE_VERSION([$maxima_version], [ge], [SAGE_MAXIMA_MINVER], [
@@ -282,7 +299,7 @@ index 3ae6382f9ba..cdb6fbf2069 100644
  
  sdh_make
 diff --git a/build/pkgs/tox/spkg-configure.m4 b/build/pkgs/tox/spkg-configure.m4
-index 7d8ade4c14b..3de0b9b710d 100644
+index 7d8ade4c14b..5a260439cdd 100644
 --- a/build/pkgs/tox/spkg-configure.m4
 +++ b/build/pkgs/tox/spkg-configure.m4
 @@ -5,7 +5,7 @@ SAGE_SPKG_CONFIGURE([tox], [
@@ -290,7 +307,7 @@ index 7d8ade4c14b..3de0b9b710d 100644
         AC_CACHE_CHECK([for tox 3 >= ]TOX3_MIN_VERSION[ or tox 4 >= ]TOX4_MIN_VERSION, [ac_cv_path_TOX], [
           AC_PATH_PROGS_FEATURE_CHECK([TOX], [tox], [
 -            tox_version=$($ac_path_TOX --version 2> /dev/null | tail -1)
-+            tox_version=$($ac_path_TOX --version 2> /dev/null | tail -n -1)
++            tox_version=$($ac_path_TOX --version 2> /dev/null | tail -n 1)
              AS_IF([test -n "$tox_version"], [
                  AX_COMPARE_VERSION([$tox_version], [lt], [4], [
                      AX_COMPARE_VERSION([$tox_version], [ge], TOX3_MIN_VERSION, [

--- a/srcpkgs/sagemath/patches/35707-maxima_5.47.0.patch
+++ b/srcpkgs/sagemath/patches/35707-maxima_5.47.0.patch
@@ -1,0 +1,879 @@
+diff --git a/src/doc/de/tutorial/interfaces.rst b/src/doc/de/tutorial/interfaces.rst
+index edb4f383363..d83225b5315 100644
+--- a/src/doc/de/tutorial/interfaces.rst
++++ b/src/doc/de/tutorial/interfaces.rst
+@@ -272,8 +272,8 @@ deren :math:`i,j` Eintrag gerade :math:`i/j` ist, für :math:`i,j=1,\ldots,4`.
+     matrix([1,1/2,1/3,1/4],[0,0,0,0],[0,0,0,0],[0,0,0,0])
+     sage: A.eigenvalues()
+     [[0,4],[3,1]]
+-    sage: A.eigenvectors()
+-    [[[0,4],[3,1]],[[[1,0,0,-4],[0,1,0,-2],[0,0,1,-4/3]],[[1,2,3,4]]]]
++    sage: A.eigenvectors().sage()
++    [[[0, 4], [3, 1]], [[[1, 0, 0, -4], [0, 1, 0, -2], [0, 0, 1, -4/3]], [[1, 2, 3, 4]]]]
+ 
+ Hier ein anderes Beispiel:
+ 
+@@ -332,12 +332,9 @@ Und der letzte ist die berühmte Kleinsche Flasche:
+ 
+ ::
+ 
+-    sage: maxima("expr_1: 5*cos(x)*(cos(x/2)*cos(y) + sin(x/2)*sin(2*y)+ 3.0) - 10.0")
+-    5*cos(x)*(sin(x/2)*sin(2*y)+cos(x/2)*cos(y)+3.0)-10.0
+-    sage: maxima("expr_2: -5*sin(x)*(cos(x/2)*cos(y) + sin(x/2)*sin(2*y)+ 3.0)")
+-    -5*sin(x)*(sin(x/2)*sin(2*y)+cos(x/2)*cos(y)+3.0)
+-    sage: maxima("expr_3: 5*(-sin(x/2)*cos(y) + cos(x/2)*sin(2*y))")
+-    5*(cos(x/2)*sin(2*y)-sin(x/2)*cos(y))
++    sage: _ = maxima("expr_1: 5*cos(x)*(cos(x/2)*cos(y) + sin(x/2)*sin(2*y)+ 3.0) - 10.0")
++    sage: _ = maxima("expr_2: -5*sin(x)*(cos(x/2)*cos(y) + sin(x/2)*sin(2*y)+ 3.0)")
++    sage: _ = maxima("expr_3: 5*(-sin(x/2)*cos(y) + cos(x/2)*sin(2*y))")
+     sage: maxima.plot3d ("[expr_1, expr_2, expr_3]", "[x, -%pi, %pi]", # not tested
+     ....:     "[y, -%pi, %pi]", "['grid, 40, 40]",
+     ....:     '[plot_format, openmath]')
+diff --git a/src/doc/de/tutorial/tour_algebra.rst b/src/doc/de/tutorial/tour_algebra.rst
+index baba2553a25..59eed8f1888 100644
+--- a/src/doc/de/tutorial/tour_algebra.rst
++++ b/src/doc/de/tutorial/tour_algebra.rst
+@@ -209,9 +209,12 @@ Lösung: Berechnen Sie die Laplace-Transformierte der ersten Gleichung
+ 
+ ::
+ 
+-    sage: de1 = maxima("2*diff(x(t),t, 2) + 6*x(t) - 2*y(t)")
+-    sage: lde1 = de1.laplace("t","s"); lde1
+-    2*((-%at('diff(x(t),t,1),t = 0))+s^2*'laplace(x(t),t,s)-x(0)*s) -2*'laplace(y(t),t,s)+6*'laplace(x(t),t,s)
++    sage: t,s = SR.var('t,s')
++    sage: x = function('x')
++    sage: y = function('y')
++    sage: f = 2*x(t).diff(t,2) + 6*x(t) - 2*y(t)
++    sage: f.laplace(t,s)
++    2*s^2*laplace(x(t), t, s) - 2*s*x(0) + 6*laplace(x(t), t, s) - 2*laplace(y(t), t, s) - 2*D[0](x)(0)
+ 
+ Das ist schwierig zu lesen, es besagt jedoch, dass
+ 
+@@ -226,8 +229,8 @@ Laplace-Transformierte der zweiten Gleichung:
+ ::
+ 
+     sage: de2 = maxima("diff(y(t),t, 2) + 2*y(t) - 2*x(t)")
+-    sage: lde2 = de2.laplace("t","s"); lde2
+-    (-%at('diff(y(t),t,1),t = 0))+s^2*'laplace(y(t),t,s) +2*'laplace(y(t),t,s)-2*'laplace(x(t),t,s) -y(0)*s
++    sage: lde2 = de2.laplace("t","s"); lde2.sage()
++    s^2*laplace(y(t), t, s) - s*y(0) - 2*laplace(x(t), t, s) + 2*laplace(y(t), t, s) - D[0](y)(0)
+ 
+ Dies besagt
+ 
+diff --git a/src/doc/en/constructions/linear_algebra.rst b/src/doc/en/constructions/linear_algebra.rst
+index 8894de9a5fd..4e76c65ad0a 100644
+--- a/src/doc/en/constructions/linear_algebra.rst
++++ b/src/doc/en/constructions/linear_algebra.rst
+@@ -277,8 +277,8 @@ Another approach is to use the interface with Maxima:
+ 
+     sage: A = maxima("matrix ([1, -4], [1, -1])")
+     sage: eig = A.eigenvectors()
+-    sage: eig
+-    [[[-sqrt(3)*%i,sqrt(3)*%i],[1,1]], [[[1,(sqrt(3)*%i+1)/4]],[[1,-(sqrt(3)*%i-1)/4]]]]
++    sage: eig.sage()
++    [[[-I*sqrt(3), I*sqrt(3)], [1, 1]], [[[1, 1/4*I*sqrt(3) + 1/4]], [[1, -1/4*I*sqrt(3) + 1/4]]]]
+ 
+ This tells us that :math:`\vec{v}_1 = [1,(\sqrt{3}i + 1)/4]` is
+ an eigenvector of :math:`\lambda_1 = - \sqrt{3}i` (which occurs
+diff --git a/src/doc/en/tutorial/interfaces.rst b/src/doc/en/tutorial/interfaces.rst
+index b0e55345669..19c28f636d4 100644
+--- a/src/doc/en/tutorial/interfaces.rst
++++ b/src/doc/en/tutorial/interfaces.rst
+@@ -267,8 +267,8 @@ whose :math:`i,j` entry is :math:`i/j`, for
+     matrix([1,1/2,1/3,1/4],[0,0,0,0],[0,0,0,0],[0,0,0,0])
+     sage: A.eigenvalues()
+     [[0,4],[3,1]]
+-    sage: A.eigenvectors()
+-    [[[0,4],[3,1]],[[[1,0,0,-4],[0,1,0,-2],[0,0,1,-4/3]],[[1,2,3,4]]]]
++    sage: A.eigenvectors().sage()
++    [[[0, 4], [3, 1]], [[[1, 0, 0, -4], [0, 1, 0, -2], [0, 0, 1, -4/3]], [[1, 2, 3, 4]]]]
+ 
+ Here's another example:
+ 
+@@ -320,8 +320,8 @@ The next plot is the famous Klein bottle (do not type the ``....:``)::
+ 
+     sage: maxima("expr_1: 5*cos(x)*(cos(x/2)*cos(y) + sin(x/2)*sin(2*y)+ 3.0) - 10.0")
+     5*cos(x)*(sin(x/2)*sin(2*y)+cos(x/2)*cos(y)+3.0)-10.0
+-    sage: maxima("expr_2: -5*sin(x)*(cos(x/2)*cos(y) + sin(x/2)*sin(2*y)+ 3.0)")
+-    -5*sin(x)*(sin(x/2)*sin(2*y)+cos(x/2)*cos(y)+3.0)
++    sage: maxima("expr_2: -5*sin(x)*(cos(x/2)*cos(y) + sin(x/2)*sin(2*y)+ 3.0)").sage()
++    -5*(cos(1/2*x)*cos(y) + sin(1/2*x)*sin(2*y) + 3.0)*sin(x)
+     sage: maxima("expr_3: 5*(-sin(x/2)*cos(y) + cos(x/2)*sin(2*y))")
+     5*(cos(x/2)*sin(2*y)-sin(x/2)*cos(y))
+     sage: maxima.plot3d ("[expr_1, expr_2, expr_3]", "[x, -%pi, %pi]",  # not tested
+diff --git a/src/doc/en/tutorial/tour_algebra.rst b/src/doc/en/tutorial/tour_algebra.rst
+index 2e872cc9059..225606a729f 100644
+--- a/src/doc/en/tutorial/tour_algebra.rst
++++ b/src/doc/en/tutorial/tour_algebra.rst
+@@ -216,9 +216,12 @@ the notation :math:`x=x_{1}`, :math:`y=x_{2}`):
+ 
+ ::
+ 
+-    sage: de1 = maxima("2*diff(x(t),t, 2) + 6*x(t) - 2*y(t)")
+-    sage: lde1 = de1.laplace("t","s"); lde1
+-    2*((-%at('diff(x(t),t,1),t = 0))+s^2*'laplace(x(t),t,s)-x(0)*s) -2*'laplace(y(t),t,s)+6*'laplace(x(t),t,s)
++    sage: t,s = SR.var('t,s')
++    sage: x = function('x')
++    sage: y = function('y')
++    sage: f = 2*x(t).diff(t,2) + 6*x(t) - 2*y(t)
++    sage: f.laplace(t,s)
++    2*s^2*laplace(x(t), t, s) - 2*s*x(0) + 6*laplace(x(t), t, s) - 2*laplace(y(t), t, s) - 2*D[0](x)(0)
+ 
+ This is hard to read, but it says that
+ 
+@@ -232,8 +235,8 @@ Laplace transform of the second equation:
+ ::
+ 
+     sage: de2 = maxima("diff(y(t),t, 2) + 2*y(t) - 2*x(t)")
+-    sage: lde2 = de2.laplace("t","s"); lde2
+-    (-%at('diff(y(t),t,1),t = 0))+s^2*'laplace(y(t),t,s) +2*'laplace(y(t),t,s)-2*'laplace(x(t),t,s) -y(0)*s
++    sage: lde2 = de2.laplace("t","s"); lde2.sage()
++    s^2*laplace(y(t), t, s) - s*y(0) - 2*laplace(x(t), t, s) + 2*laplace(y(t), t, s) - D[0](y)(0)
+ 
+ This says
+ 
+diff --git a/src/doc/es/tutorial/tour_algebra.rst b/src/doc/es/tutorial/tour_algebra.rst
+index dc1a7a96719..42c818fe8d7 100644
+--- a/src/doc/es/tutorial/tour_algebra.rst
++++ b/src/doc/es/tutorial/tour_algebra.rst
+@@ -197,8 +197,8 @@ la notación :math:`x=x_{1}`, :math:`y=x_{2}`):
+ ::
+ 
+     sage: de1 = maxima("2*diff(x(t),t, 2) + 6*x(t) - 2*y(t)")
+-    sage: lde1 = de1.laplace("t","s"); lde1
+-    2*((-%at('diff(x(t),t,1),t = 0))+s^2*'laplace(x(t),t,s)-x(0)*s) -2*'laplace(y(t),t,s)+6*'laplace(x(t),t,s)
++    sage: lde1 = de1.laplace("t","s"); lde1.sage()
++    2*s^2*laplace(x(t), t, s) - 2*s*x(0) + 6*laplace(x(t), t, s) - 2*laplace(y(t), t, s) - 2*D[0](x)(0)
+ 
+ El resultado puede ser difícil de leer, pero significa que
+ 
+@@ -211,9 +211,12 @@ Toma la transformada de Laplace de la segunda ecuación:
+ 
+ ::
+ 
+-    sage: de2 = maxima("diff(y(t),t, 2) + 2*y(t) - 2*x(t)")
+-    sage: lde2 = de2.laplace("t","s"); lde2
+-    (-%at('diff(y(t),t,1),t = 0))+s^2*'laplace(y(t),t,s) +2*'laplace(y(t),t,s)-2*'laplace(x(t),t,s) -y(0)*s
++    sage: t,s = SR.var('t,s')
++    sage: x = function('x')
++    sage: y = function('y')
++    sage: f = 2*x(t).diff(t,2) + 6*x(t) - 2*y(t)
++    sage: f.laplace(t,s)
++    2*s^2*laplace(x(t), t, s) - 2*s*x(0) + 6*laplace(x(t), t, s) - 2*laplace(y(t), t, s) - 2*D[0](x)(0)
+ 
+ Esto dice
+ 
+diff --git a/src/doc/fr/tutorial/interfaces.rst b/src/doc/fr/tutorial/interfaces.rst
+index 1cd662f3083..2cb14e772eb 100644
+--- a/src/doc/fr/tutorial/interfaces.rst
++++ b/src/doc/fr/tutorial/interfaces.rst
+@@ -273,8 +273,8 @@ pour :math:`i,j=1,\ldots,4`.
+     matrix([1,1/2,1/3,1/4],[0,0,0,0],[0,0,0,0],[0,0,0,0])
+     sage: A.eigenvalues()
+     [[0,4],[3,1]]
+-    sage: A.eigenvectors()
+-    [[[0,4],[3,1]],[[[1,0,0,-4],[0,1,0,-2],[0,0,1,-4/3]],[[1,2,3,4]]]]
++    sage: A.eigenvectors().sage()
++    [[[0, 4], [3, 1]], [[[1, 0, 0, -4], [0, 1, 0, -2], [0, 0, 1, -4/3]], [[1, 2, 3, 4]]]]
+ 
+ Un deuxième exemple :
+ 
+@@ -334,12 +334,9 @@ Et la fameuse bouteille de Klein (n'entrez pas les ``....:``):
+ 
+ ::
+ 
+-    sage: maxima("expr_1: 5*cos(x)*(cos(x/2)*cos(y) + sin(x/2)*sin(2*y)+ 3.0) - 10.0")
+-    5*cos(x)*(sin(x/2)*sin(2*y)+cos(x/2)*cos(y)+3.0)-10.0
+-    sage: maxima("expr_2: -5*sin(x)*(cos(x/2)*cos(y) + sin(x/2)*sin(2*y)+ 3.0)")
+-    -5*sin(x)*(sin(x/2)*sin(2*y)+cos(x/2)*cos(y)+3.0)
+-    sage: maxima("expr_3: 5*(-sin(x/2)*cos(y) + cos(x/2)*sin(2*y))")
+-    5*(cos(x/2)*sin(2*y)-sin(x/2)*cos(y))
++    sage: _ = maxima("expr_1: 5*cos(x)*(cos(x/2)*cos(y) + sin(x/2)*sin(2*y)+ 3.0) - 10.0")
++    sage: _ = maxima("expr_2: -5*sin(x)*(cos(x/2)*cos(y) + sin(x/2)*sin(2*y)+ 3.0)")
++    sage: _ = maxima("expr_3: 5*(-sin(x/2)*cos(y) + cos(x/2)*sin(2*y))")
+     sage: maxima.plot3d ("[expr_1, expr_2, expr_3]", "[x, -%pi, %pi]", # not tested
+     ....:     "[y, -%pi, %pi]", "['grid, 40, 40]",
+     ....:     '[plot_format, openmath]')
+diff --git a/src/doc/fr/tutorial/tour_algebra.rst b/src/doc/fr/tutorial/tour_algebra.rst
+index 658894b2e8b..267bd1dd4f9 100644
+--- a/src/doc/fr/tutorial/tour_algebra.rst
++++ b/src/doc/fr/tutorial/tour_algebra.rst
+@@ -182,8 +182,8 @@ Solution : Considérons la transformée de Laplace de la première équation
+ ::
+ 
+     sage: de1 = maxima("2*diff(x(t),t, 2) + 6*x(t) - 2*y(t)")
+-    sage: lde1 = de1.laplace("t","s"); lde1
+-    2*((-%at('diff(x(t),t,1),t = 0))+s^2*'laplace(x(t),t,s)-x(0)*s) -2*'laplace(y(t),t,s)+6*'laplace(x(t),t,s)
++    sage: lde1 = de1.laplace("t","s"); lde1.sage()
++    2*s^2*laplace(x(t), t, s) - 2*s*x(0) + 6*laplace(x(t), t, s) - 2*laplace(y(t), t, s) - 2*D[0](x)(0)
+ 
+ La réponse n'est pas très lisible, mais elle signifie que
+ 
+@@ -196,9 +196,12 @@ la seconde équation :
+ 
+ ::
+ 
+-    sage: de2 = maxima("diff(y(t),t, 2) + 2*y(t) - 2*x(t)")
+-    sage: lde2 = de2.laplace("t","s"); lde2
+-    (-%at('diff(y(t),t,1),t = 0))+s^2*'laplace(y(t),t,s) +2*'laplace(y(t),t,s)-2*'laplace(x(t),t,s) -y(0)*s
++    sage: t,s = SR.var('t,s')
++    sage: x = function('x')
++    sage: y = function('y')
++    sage: f = 2*x(t).diff(t,2) + 6*x(t) - 2*y(t)
++    sage: f.laplace(t,s)
++    2*s^2*laplace(x(t), t, s) - 2*s*x(0) + 6*laplace(x(t), t, s) - 2*laplace(y(t), t, s) - 2*D[0](x)(0)
+ 
+ Ceci signifie
+ 
+diff --git a/src/doc/it/tutorial/tour_algebra.rst b/src/doc/it/tutorial/tour_algebra.rst
+index 5a5311e9b1c..cde427d3090 100644
+--- a/src/doc/it/tutorial/tour_algebra.rst
++++ b/src/doc/it/tutorial/tour_algebra.rst
+@@ -183,8 +183,8 @@ la notazione :math:`x=x_{1}`, :math:`y=x_{2}`:
+ ::
+ 
+     sage: de1 = maxima("2*diff(x(t),t, 2) + 6*x(t) - 2*y(t)")
+-    sage: lde1 = de1.laplace("t","s"); lde1
+-    2*((-%at('diff(x(t),t,1),t = 0))+s^2*'laplace(x(t),t,s)-x(0)*s) -2*'laplace(y(t),t,s)+6*'laplace(x(t),t,s)
++    sage: lde1 = de1.laplace("t","s"); lde1.sage()
++    2*s^2*laplace(x(t), t, s) - 2*s*x(0) + 6*laplace(x(t), t, s) - 2*laplace(y(t), t, s) - 2*D[0](x)(0)
+ 
+ Questo è di difficile lettura, ma dice che
+ 
+@@ -197,9 +197,12 @@ trasformata di Laplace della seconda equazione:
+ 
+ ::
+ 
+-    sage: de2 = maxima("diff(y(t),t, 2) + 2*y(t) - 2*x(t)")
+-    sage: lde2 = de2.laplace("t","s"); lde2
+-    (-%at('diff(y(t),t,1),t = 0))+s^2*'laplace(y(t),t,s) +2*'laplace(y(t),t,s)-2*'laplace(x(t),t,s) -y(0)*s
++    sage: t,s = SR.var('t,s')
++    sage: x = function('x')
++    sage: y = function('y')
++    sage: f = 2*x(t).diff(t,2) + 6*x(t) - 2*y(t)
++    sage: f.laplace(t,s)
++    2*s^2*laplace(x(t), t, s) - 2*s*x(0) + 6*laplace(x(t), t, s) - 2*laplace(y(t), t, s) - 2*D[0](x)(0)
+ 
+ che significa
+ 
+diff --git a/src/doc/ja/tutorial/interfaces.rst b/src/doc/ja/tutorial/interfaces.rst
+index 9c16b2eba08..892fc6f852f 100644
+--- a/src/doc/ja/tutorial/interfaces.rst
++++ b/src/doc/ja/tutorial/interfaces.rst
+@@ -239,8 +239,8 @@ Sage/Maximaインターフェイスの使い方を例示するため，ここで
+     matrix([1,1/2,1/3,1/4],[0,0,0,0],[0,0,0,0],[0,0,0,0])
+     sage: A.eigenvalues()
+     [[0,4],[3,1]]
+-    sage: A.eigenvectors()
+-    [[[0,4],[3,1]],[[[1,0,0,-4],[0,1,0,-2],[0,0,1,-4/3]],[[1,2,3,4]]]]
++    sage: A.eigenvectors().sage()
++    [[[0, 4], [3, 1]], [[[1, 0, 0, -4], [0, 1, 0, -2], [0, 0, 1, -4/3]], [[1, 2, 3, 4]]]]
+ 
+ 
+ 使用例をもう一つ示す:
+@@ -299,11 +299,8 @@ Sage/Maximaインターフェイスの使い方を例示するため，ここで
+ 
+ ::
+ 
+-    sage: maxima("expr_1: 5*cos(x)*(cos(x/2)*cos(y) + sin(x/2)*sin(2*y)+ 3.0) - 10.0")
+-    5*cos(x)*(sin(x/2)*sin(2*y)+cos(x/2)*cos(y)+3.0)-10.0
+-    sage: maxima("expr_2: -5*sin(x)*(cos(x/2)*cos(y) + sin(x/2)*sin(2*y)+ 3.0)")
+-    -5*sin(x)*(sin(x/2)*sin(2*y)+cos(x/2)*cos(y)+3.0)
+-    sage: maxima("expr_3: 5*(-sin(x/2)*cos(y) + cos(x/2)*sin(2*y))")
+-    5*(cos(x/2)*sin(2*y)-sin(x/2)*cos(y))
++    sage: _ = maxima("expr_1: 5*cos(x)*(cos(x/2)*cos(y) + sin(x/2)*sin(2*y)+ 3.0) - 10.0")
++    sage: _ = maxima("expr_2: -5*sin(x)*(cos(x/2)*cos(y) + sin(x/2)*sin(2*y)+ 3.0)")
++    sage: _ = maxima("expr_3: 5*(-sin(x/2)*cos(y) + cos(x/2)*sin(2*y))")
+     sage: maxima.plot3d ("[expr_1, expr_2, expr_3]", "[x, -%pi, %pi]",  # not tested
+     ....:     "[y, -%pi, %pi]", "['grid, 40, 40]", '[plot_format, openmath]')
+diff --git a/src/doc/ja/tutorial/tour_algebra.rst b/src/doc/ja/tutorial/tour_algebra.rst
+index 784fd0d5c40..746cbb4475c 100644
+--- a/src/doc/ja/tutorial/tour_algebra.rst
++++ b/src/doc/ja/tutorial/tour_algebra.rst
+@@ -213,8 +213,8 @@ Sageを使って常微分方程式を研究することもできる． :math:`x'
+ ::
+ 
+     sage: de1 = maxima("2*diff(x(t),t, 2) + 6*x(t) - 2*y(t)")
+-    sage: lde1 = de1.laplace("t","s"); lde1
+-    2*((-%at('diff(x(t),t,1),t = 0))+s^2*'laplace(x(t),t,s)-x(0)*s) -2*'laplace(y(t),t,s)+6*'laplace(x(t),t,s)
++    sage: lde1 = de1.laplace("t","s"); lde1.sage()
++    2*s^2*laplace(x(t), t, s) - 2*s*x(0) + 6*laplace(x(t), t, s) - 2*laplace(y(t), t, s) - 2*D[0](x)(0)
+ 
+ この出力は読みにくいけれども，意味しているのは
+ 
+@@ -226,9 +226,12 @@ Sageを使って常微分方程式を研究することもできる． :math:`x'
+ 
+ ::
+ 
+-    sage: de2 = maxima("diff(y(t),t, 2) + 2*y(t) - 2*x(t)")
+-    sage: lde2 = de2.laplace("t","s"); lde2
+-    (-%at('diff(y(t),t,1),t = 0))+s^2*'laplace(y(t),t,s) +2*'laplace(y(t),t,s)-2*'laplace(x(t),t,s) -y(0)*s
++    sage: t,s = SR.var('t,s')
++    sage: x = function('x')
++    sage: y = function('y')
++    sage: f = 2*x(t).diff(t,2) + 6*x(t) - 2*y(t)
++    sage: f.laplace(t,s)
++    2*s^2*laplace(x(t), t, s) - 2*s*x(0) + 6*laplace(x(t), t, s) - 2*laplace(y(t), t, s) - 2*D[0](x)(0)
+ 
+ 意味するところは
+ 
+diff --git a/src/doc/pt/tutorial/interfaces.rst b/src/doc/pt/tutorial/interfaces.rst
+index 386ef6456e5..5badb31ab35 100644
+--- a/src/doc/pt/tutorial/interfaces.rst
++++ b/src/doc/pt/tutorial/interfaces.rst
+@@ -269,8 +269,8 @@ entrada :math:`i,j` é :math:`i/j`, para :math:`i,j=1,\ldots,4`.
+     matrix([1,1/2,1/3,1/4],[0,0,0,0],[0,0,0,0],[0,0,0,0])
+     sage: A.eigenvalues()
+     [[0,4],[3,1]]
+-    sage: A.eigenvectors()
+-    [[[0,4],[3,1]],[[[1,0,0,-4],[0,1,0,-2],[0,0,1,-4/3]],[[1,2,3,4]]]]
++    sage: A.eigenvectors().sage()
++    [[[0, 4], [3, 1]], [[[1, 0, 0, -4], [0, 1, 0, -2], [0, 0, 1, -4/3]], [[1, 2, 3, 4]]]]
+ 
+ Aqui vai outro exemplo:
+ 
+@@ -330,13 +330,10 @@ E agora a famosa garrafa de Klein:
+ 
+ ::
+ 
+-    sage: maxima("expr_1: 5*cos(x)*(cos(x/2)*cos(y) + sin(x/2)*sin(2*y)+ 3.0)"
++    sage: _ = maxima("expr_1: 5*cos(x)*(cos(x/2)*cos(y) + sin(x/2)*sin(2*y)+ 3.0)"
+     ....:        "- 10.0")
+-    5*cos(x)*(sin(x/2)*sin(2*y)+cos(x/2)*cos(y)+3.0)-10.0
+-    sage: maxima("expr_2: -5*sin(x)*(cos(x/2)*cos(y) + sin(x/2)*sin(2*y)+ 3.0)")
+-    -5*sin(x)*(sin(x/2)*sin(2*y)+cos(x/2)*cos(y)+3.0)
+-    sage: maxima("expr_3: 5*(-sin(x/2)*cos(y) + cos(x/2)*sin(2*y))")
+-    5*(cos(x/2)*sin(2*y)-sin(x/2)*cos(y))
++    sage: _ = maxima("expr_2: -5*sin(x)*(cos(x/2)*cos(y) + sin(x/2)*sin(2*y)+ 3.0)")
++    sage: _ = maxima("expr_3: 5*(-sin(x/2)*cos(y) + cos(x/2)*sin(2*y))")
+     sage: maxima.plot3d("[expr_1, expr_2, expr_3]", "[x, -%pi, %pi]", # not tested
+     ....:               "[y, -%pi, %pi]", "['grid, 40, 40]",
+     ....:               '[plot_format, openmath]')
+diff --git a/src/doc/pt/tutorial/tour_algebra.rst b/src/doc/pt/tutorial/tour_algebra.rst
+index baeb37b1c71..170e0d8a367 100644
+--- a/src/doc/pt/tutorial/tour_algebra.rst
++++ b/src/doc/pt/tutorial/tour_algebra.rst
+@@ -205,8 +205,8 @@ equação (usando a notação :math:`x=x_{1}`, :math:`y=x_{2}`):
+ ::
+ 
+     sage: de1 = maxima("2*diff(x(t),t, 2) + 6*x(t) - 2*y(t)")
+-    sage: lde1 = de1.laplace("t","s"); lde1
+-    2*((-%at('diff(x(t),t,1),t = 0))+s^2*'laplace(x(t),t,s)-x(0)*s) -2*'laplace(y(t),t,s)+6*'laplace(x(t),t,s)
++    sage: lde1 = de1.laplace("t","s"); lde1.sage()
++    2*s^2*laplace(x(t), t, s) - 2*s*x(0) + 6*laplace(x(t), t, s) - 2*laplace(y(t), t, s) - 2*D[0](x)(0)
+ 
+ O resultado é um pouco difícil de ler, mas diz que
+ 
+@@ -219,9 +219,12 @@ calcule a transformada de Laplace da segunda equação:
+ 
+ ::
+ 
+-    sage: de2 = maxima("diff(y(t),t, 2) + 2*y(t) - 2*x(t)")
+-    sage: lde2 = de2.laplace("t","s"); lde2
+-    (-%at('diff(y(t),t,1),t = 0))+s^2*'laplace(y(t),t,s) +2*'laplace(y(t),t,s)-2*'laplace(x(t),t,s) -y(0)*s
++    sage: t,s = SR.var('t,s')
++    sage: x = function('x')
++    sage: y = function('y')
++    sage: f = 2*x(t).diff(t,2) + 6*x(t) - 2*y(t)
++    sage: f.laplace(t,s)
++    2*s^2*laplace(x(t), t, s) - 2*s*x(0) + 6*laplace(x(t), t, s) - 2*laplace(y(t), t, s) - 2*D[0](x)(0)
+ 
+ O resultado significa que
+ 
+diff --git a/src/doc/ru/tutorial/interfaces.rst b/src/doc/ru/tutorial/interfaces.rst
+index ea84527f478..061818ca4a5 100644
+--- a/src/doc/ru/tutorial/interfaces.rst
++++ b/src/doc/ru/tutorial/interfaces.rst
+@@ -264,8 +264,8 @@ gnuplot, имеет методы решения и манипуляции мат
+     matrix([1,1/2,1/3,1/4],[0,0,0,0],[0,0,0,0],[0,0,0,0])
+     sage: A.eigenvalues()
+     [[0,4],[3,1]]
+-    sage: A.eigenvectors()
+-    [[[0,4],[3,1]],[[[1,0,0,-4],[0,1,0,-2],[0,0,1,-4/3]],[[1,2,3,4]]]]
++    sage: A.eigenvectors().sage()
++    [[[0, 4], [3, 1]], [[[1, 0, 0, -4], [0, 1, 0, -2], [0, 0, 1, -4/3]], [[1, 2, 3, 4]]]]
+ 
+ Вот другой пример:
+ 
+@@ -323,12 +323,9 @@ gnuplot, имеет методы решения и манипуляции мат
+ 
+ ::
+ 
+-    sage: maxima("expr_1: 5*cos(x)*(cos(x/2)*cos(y) + sin(x/2)*sin(2*y)+ 3.0) - 10.0")
+-    5*cos(x)*(sin(x/2)*sin(2*y)+cos(x/2)*cos(y)+3.0)-10.0
+-    sage: maxima("expr_2: -5*sin(x)*(cos(x/2)*cos(y) + sin(x/2)*sin(2*y)+ 3.0)")
+-    -5*sin(x)*(sin(x/2)*sin(2*y)+cos(x/2)*cos(y)+3.0)
+-    sage: maxima("expr_3: 5*(-sin(x/2)*cos(y) + cos(x/2)*sin(2*y))")
+-    5*(cos(x/2)*sin(2*y)-sin(x/2)*cos(y))
++    sage: _ = maxima("expr_1: 5*cos(x)*(cos(x/2)*cos(y) + sin(x/2)*sin(2*y)+ 3.0) - 10.0")
++    sage: _ = maxima("expr_2: -5*sin(x)*(cos(x/2)*cos(y) + sin(x/2)*sin(2*y)+ 3.0)")
++    sage: _ = maxima("expr_3: 5*(-sin(x/2)*cos(y) + cos(x/2)*sin(2*y))")
+     sage: maxima.plot3d ("[expr_1, expr_2, expr_3]", "[x, -%pi, %pi]", # not tested
+     ....:     "[y, -%pi, %pi]", "['grid, 40, 40]",
+     ....:     '[plot_format, openmath]')
+diff --git a/src/doc/ru/tutorial/tour_algebra.rst b/src/doc/ru/tutorial/tour_algebra.rst
+index 9f08c41d118..bc0d4926f83 100644
+--- a/src/doc/ru/tutorial/tour_algebra.rst
++++ b/src/doc/ru/tutorial/tour_algebra.rst
+@@ -199,8 +199,8 @@ Sage может использоваться для решения диффер
+ ::
+ 
+     sage: de1 = maxima("2*diff(x(t),t, 2) + 6*x(t) - 2*y(t)")
+-    sage: lde1 = de1.laplace("t","s"); lde1
+-    2*((-%at('diff(x(t),t,1),t = 0))+s^2*'laplace(x(t),t,s)-x(0)*s) -2*'laplace(y(t),t,s)+6*'laplace(x(t),t,s)
++    sage: lde1 = de1.laplace("t","s"); lde1.sage()
++    2*s^2*laplace(x(t), t, s) - 2*s*x(0) + 6*laplace(x(t), t, s) - 2*laplace(y(t), t, s) - 2*D[0](x)(0)
+ 
+ Данный результат тяжело читаем, однако должен быть понят как
+ 
+@@ -210,9 +210,12 @@ Sage может использоваться для решения диффер
+ 
+ ::
+ 
+-    sage: de2 = maxima("diff(y(t),t, 2) + 2*y(t) - 2*x(t)")
+-    sage: lde2 = de2.laplace("t","s"); lde2
+-    (-%at('diff(y(t),t,1),t = 0))+s^2*'laplace(y(t),t,s) +2*'laplace(y(t),t,s)-2*'laplace(x(t),t,s) -y(0)*s
++    sage: t,s = SR.var('t,s')
++    sage: x = function('x')
++    sage: y = function('y')
++    sage: f = 2*x(t).diff(t,2) + 6*x(t) - 2*y(t)
++    sage: f.laplace(t,s)
++    2*s^2*laplace(x(t), t, s) - 2*s*x(0) + 6*laplace(x(t), t, s) - 2*laplace(y(t), t, s) - 2*D[0](x)(0)
+ 
+ Результат:
+ 
+diff --git a/src/sage/calculus/calculus.py b/src/sage/calculus/calculus.py
+index c707530b9f1..f7ce8b95727 100644
+--- a/src/sage/calculus/calculus.py
++++ b/src/sage/calculus/calculus.py
+@@ -783,7 +783,7 @@ def nintegral(ex, x, a, b,
+     Now numerically integrating, we see why the answer is wrong::
+ 
+         sage: f.nintegrate(x,0,1)
+-        (-480.0000000000001, 5.32907051820075...e-12, 21, 0)
++        (-480.000000000000..., 5.32907051820075...e-12, 21, 0)
+ 
+     It is just because every floating point evaluation of return -480.0
+     in floating point.
+@@ -1336,7 +1336,7 @@ def limit(ex, dir=None, taylor=False, algorithm='maxima', **argv):
+         sage: limit(floor(x), x=0, dir='+')
+         0
+         sage: limit(floor(x), x=0)
+-        und
++        ...nd
+ 
+     Maxima gives the right answer here, too, showing
+     that :trac:`4142` is fixed::
+diff --git a/src/sage/calculus/desolvers.py b/src/sage/calculus/desolvers.py
+index e0c31925f44..6e91f7e2bb4 100644
+--- a/src/sage/calculus/desolvers.py
++++ b/src/sage/calculus/desolvers.py
+@@ -295,7 +295,7 @@ def desolve(de, dvar, ics=None, ivar=None, show_method=False, contrib_ode=False,
+     Clairaut equation: general and singular solutions::
+ 
+         sage: desolve(diff(y,x)^2+x*diff(y,x)-y==0,y,contrib_ode=True,show_method=True)
+-        [[y(x) == _C^2 + _C*x, y(x) == -1/4*x^2], 'clairault']
++        [[y(x) == _C^2 + _C*x, y(x) == -1/4*x^2], 'clairau...']
+ 
+     For equations involving more variables we specify an independent variable::
+ 
+@@ -1325,7 +1325,7 @@ def desolve_rk4(de, dvar, ics=None, ivar=None, end_points=None, step=0.1, output
+ 
+         sage: x,y = var('x,y')
+         sage: desolve_rk4(x*y*(2-y),y,ics=[0,1],end_points=1,step=0.5)
+-        [[0, 1], [0.5, 1.12419127424558], [1.0, 1.461590162288825]]
++        [[0, 1], [0.5, 1.12419127424558], [1.0, 1.46159016228882...]]
+ 
+     Variant 1 for input - we can pass ODE in the form used by
+     desolve function In this example we integrate backwards, since
+@@ -1333,7 +1333,7 @@ def desolve_rk4(de, dvar, ics=None, ivar=None, end_points=None, step=0.1, output
+ 
+         sage: y = function('y')(x)
+         sage: desolve_rk4(diff(y,x)+y*(y-1) == x-2,y,ics=[1,1],step=0.5, end_points=0)
+-        [[0.0, 8.904257108962112], [0.5, 1.909327945361535], [1, 1]]
++        [[0.0, 8.904257108962112], [0.5, 1.90932794536153...], [1, 1]]
+ 
+     Here we show how to plot simple pictures. For more advanced
+     applications use list_plot instead. To see the resulting picture
+diff --git a/src/sage/functions/bessel.py b/src/sage/functions/bessel.py
+index 95405c3d72f..48607c49f56 100644
+--- a/src/sage/functions/bessel.py
++++ b/src/sage/functions/bessel.py
+@@ -293,9 +293,6 @@ class Function_Bessel_J(BuiltinFunction):
+         sage: f = bessel_J(2, x)
+         sage: f.integrate(x)
+         1/24*x^3*hypergeometric((3/2,), (5/2, 3), -1/4*x^2)
+-        sage: m = maxima(bessel_J(2, x))
+-        sage: m.integrate(x)
+-        (hypergeometric([3/2],[5/2,3],-_SAGE_VAR_x^2/4)*_SAGE_VAR_x^3)/24
+ 
+     Visualization (set plot_points to a higher value to get more detail)::
+ 
+@@ -1118,11 +1115,11 @@ def Bessel(*args, **kwds):
+     Conversion to other systems::
+ 
+         sage: x,y = var('x,y')
+-        sage: f = maxima(Bessel(typ='K')(x,y))
+-        sage: f.derivative('_SAGE_VAR_x')
+-        (%pi*csc(%pi*_SAGE_VAR_x) *('diff(bessel_i(-_SAGE_VAR_x,_SAGE_VAR_y),_SAGE_VAR_x,1) -'diff(bessel_i(_SAGE_VAR_x,_SAGE_VAR_y),_SAGE_VAR_x,1))) /2 -%pi*bessel_k(_SAGE_VAR_x,_SAGE_VAR_y)*cot(%pi*_SAGE_VAR_x)
+-        sage: f.derivative('_SAGE_VAR_y')
+-        -(bessel_k(_SAGE_VAR_x+1,_SAGE_VAR_y)+bessel_k(_SAGE_VAR_x-1, _SAGE_VAR_y))/2
++        sage: f = Bessel(typ='K')(x,y)
++        sage: expected = f.derivative(y)
++        sage: actual = maxima(f).derivative('_SAGE_VAR_y').sage()
++        sage: bool(actual == expected)
++        True
+ 
+     Compute the particular solution to Bessel's Differential Equation that
+     satisfies `y(1) = 1` and `y'(1) = 1`, then verify the initial conditions
+diff --git a/src/sage/functions/hypergeometric.py b/src/sage/functions/hypergeometric.py
+index 752b8422fc6..fc2fb5875ce 100644
+--- a/src/sage/functions/hypergeometric.py
++++ b/src/sage/functions/hypergeometric.py
+@@ -19,8 +19,11 @@
+     sage: sum(((2*I)^x/(x^3 + 1)*(1/4)^x), x, 0, oo)
+     hypergeometric((1, 1, -1/2*I*sqrt(3) - 1/2, 1/2*I*sqrt(3) - 1/2),...
+     (2, -1/2*I*sqrt(3) + 1/2, 1/2*I*sqrt(3) + 1/2), 1/2*I)
+-    sage: sum((-1)^x/((2*x + 1)*factorial(2*x + 1)), x, 0, oo)
++    sage: res = sum((-1)^x/((2*x + 1)*factorial(2*x + 1)), x, 0, oo)
++    sage: res  # not tested - depends on maxima version
+     hypergeometric((1/2,), (3/2, 3/2), -1/4)
++    sage: res in [hypergeometric((1/2,), (3/2, 3/2), -1/4), sin_integral(1)]
++    True
+ 
+ Simplification (note that ``simplify_full`` does not yet call
+ ``simplify_hypergeometric``)::
+diff --git a/src/sage/functions/orthogonal_polys.py b/src/sage/functions/orthogonal_polys.py
+index 7398c763971..6127f5d9490 100644
+--- a/src/sage/functions/orthogonal_polys.py
++++ b/src/sage/functions/orthogonal_polys.py
+@@ -974,7 +974,7 @@ def __init__(self):
+             sage: chebyshev_U(x, x)._sympy_()
+             chebyshevu(x, x)
+             sage: maxima(chebyshev_U(2,x, hold=True))
+-            3*((-(8*(1-_SAGE_VAR_x))/3)+(4*(1-_SAGE_VAR_x)^2)/3+1)
++            3*(...-...(8*(1-_SAGE_VAR_x))/3)+(4*(1-_SAGE_VAR_x)^2)/3+1)
+             sage: maxima(chebyshev_U(n,x, hold=True))
+             chebyshev_u(_SAGE_VAR_n,_SAGE_VAR_x)
+         """
+diff --git a/src/sage/functions/other.py b/src/sage/functions/other.py
+index 3e2570e889e..5a0f06a27f8 100644
+--- a/src/sage/functions/other.py
++++ b/src/sage/functions/other.py
+@@ -498,10 +498,10 @@ def __init__(self):
+             <class 'sage.rings.integer.Integer'>
+             sage: var('x')
+             x
+-            sage: a = floor(5.4 + x); a
+-            floor(x + 5.40000000000000)
++            sage: a = floor(5.25 + x); a
++            floor(x + 5.25000000000000)
+             sage: a.simplify()
+-            floor(x + 0.4000000000000004) + 5
++            floor(x + 0.25) + 5
+             sage: a(x=2)
+             7
+ 
+diff --git a/src/sage/functions/special.py b/src/sage/functions/special.py
+index faa6a73cc7e..d72e780836a 100644
+--- a/src/sage/functions/special.py
++++ b/src/sage/functions/special.py
+@@ -455,9 +455,8 @@ class EllipticE(BuiltinFunction):
+         sage: z = var("z")
+         sage: elliptic_e(z, 1)
+         elliptic_e(z, 1)
+-        sage: # this is still wrong: must be abs(sin(z)) + 2*round(z/pi)
+-        sage: elliptic_e(z, 1).simplify()
+-        2*round(z/pi) + sin(z)
++        sage: elliptic_e(z, 1).simplify() # not tested - gives wrong answer with maxima < 5.47
++        2*round(z/pi) - sin(pi*round(z/pi) - z)
+         sage: elliptic_e(z, 0)
+         z
+         sage: elliptic_e(0.5, 0.1)  # abs tol 2e-15
+diff --git a/src/sage/interfaces/interface.py b/src/sage/interfaces/interface.py
+index 6baa4eb597c..f8237d3ad94 100644
+--- a/src/sage/interfaces/interface.py
++++ b/src/sage/interfaces/interface.py
+@@ -1579,20 +1579,20 @@ def _mul_(self, right):
+         ::
+ 
+             sage: f = maxima.function('x','sin(x)')
+-            sage: g = maxima('-cos(x)') # not a function!
++            sage: g = maxima('cos(x)') # not a function!
+             sage: f*g
+-            -cos(x)*sin(x)
++            cos(x)*sin(x)
+             sage: _(2)
+-            -cos(2)*sin(2)
++            cos(2)*sin(2)
+ 
+         ::
+ 
+             sage: f = maxima.function('x','sin(x)')
+-            sage: g = maxima('-cos(x)')
++            sage: g = maxima('cos(x)')
+             sage: g*f
+-            -cos(x)*sin(x)
++            cos(x)*sin(x)
+             sage: _(2)
+-            -cos(2)*sin(2)
++            cos(2)*sin(2)
+             sage: 2*f
+             2*sin(x)
+         """
+@@ -1612,20 +1612,20 @@ def _div_(self, right):
+         ::
+ 
+             sage: f = maxima.function('x','sin(x)')
+-            sage: g = maxima('-cos(x)')
++            sage: g = maxima('cos(x)')
+             sage: f/g
+-            -sin(x)/cos(x)
++            sin(x)/cos(x)
+             sage: _(2)
+-            -sin(2)/cos(2)
++            sin(2)/cos(2)
+ 
+         ::
+ 
+             sage: f = maxima.function('x','sin(x)')
+-            sage: g = maxima('-cos(x)')
++            sage: g = maxima('cos(x)')
+             sage: g/f
+-            -cos(x)/sin(x)
++            cos(x)/sin(x)
+             sage: _(2)
+-            -cos(2)/sin(2)
++            cos(2)/sin(2)
+             sage: 2/f
+             2/sin(x)
+         """
+diff --git a/src/sage/interfaces/maxima.py b/src/sage/interfaces/maxima.py
+index 4829560f98b..959e75459a2 100644
+--- a/src/sage/interfaces/maxima.py
++++ b/src/sage/interfaces/maxima.py
+@@ -49,9 +49,14 @@
+ 
+ ::
+ 
++    sage: x,y = SR.var('x,y')
+     sage: F = maxima.factor('x^5 - y^5')
+-    sage: F
+-    -(y-x)*(y^4+x*y^3+x^2*y^2+x^3*y+x^4)
++    sage: F # not tested - depends on maxima version
++    -((y-x)*(y^4+x*y^3+x^2*y^2+x^3*y+x^4))
++    sage: actual = F.sage()
++    sage: expected = -(y-x)*(y^4+x*y^3+x^2*y^2+x^3*y+x^4)
++    sage: bool(actual == expected)
++    True
+     sage: type(F)
+     <class 'sage.interfaces.maxima.MaximaElement'>
+ 
+@@ -71,18 +76,19 @@
+ 
+ ::
+ 
++    sage: F = maxima('x * y')
+     sage: repr(F)
+-    '-(y-x)*(y^4+x*y^3+x^2*y^2+x^3*y+x^4)'
++    'x*y'
+     sage: F.str()
+-    '-(y-x)*(y^4+x*y^3+x^2*y^2+x^3*y+x^4)'
++    'x*y'
+ 
+ The ``maxima.eval`` command evaluates an expression in
+ maxima and returns the result as a *string* not a maxima object.
+ 
+ ::
+ 
+-    sage: print(maxima.eval('factor(x^5 - y^5)'))
+-    -(y-x)*(y^4+x*y^3+x^2*y^2+x^3*y+x^4)
++    sage: print(maxima.eval('factor(x^5 - 1)'))
++    (x-1)*(x^4+x^3+x^2+x+1)
+ 
+ We can create the polynomial `f` as a Maxima polynomial,
+ then call the factor method on it. Notice that the notation
+@@ -91,11 +97,11 @@
+ 
+ ::
+ 
+-    sage: f = maxima('x^5 - y^5')
++    sage: f = maxima('x^5 + y^5')
+     sage: f^2
+-    (x^5-y^5)^2
++    (y^5+x^5)^2
+     sage: f.factor()
+-    -(y-x)*(y^4+x*y^3+x^2*y^2+x^3*y+x^4)
++    (y+x)*(y^4-x*y^3+x^2*y^2-x^3*y+x^4)
+ 
+ Control-C interruption works well with the maxima interface,
+ because of the excellent implementation of maxima. For example, try
+@@ -161,20 +167,20 @@
+ 
+     sage: eqn = maxima(['a+b*c=1', 'b-a*c=0', 'a+b=5'])
+     sage: s = eqn.solve('[a,b,c]'); s
+-    [[a = -(sqrt(79)*%i-11)/4,b = (sqrt(79)*%i+9)/4, c = (sqrt(79)*%i+1)/10], [a = (sqrt(79)*%i+11)/4,b = -(sqrt(79)*%i-9)/4, c = -(sqrt(79)*%i-1)/10]]
++    [[a = -...(sqrt(79)*%i-11)/4...,b = (sqrt(79)*%i+9)/4, c = (sqrt(79)*%i+1)/10], [a = (sqrt(79)*%i+11)/4,b = -...(sqrt(79)*%i-9)/4..., c = -...(sqrt(79)*%i-1)/10...]]
+ 
+ Here is an example of solving an algebraic equation::
+ 
+     sage: maxima('x^2+y^2=1').solve('y')
+     [y = -sqrt(1-x^2),y = sqrt(1-x^2)]
+     sage: maxima('x^2 + y^2 = (x^2 - y^2)/sqrt(x^2 + y^2)').solve('y')
+-    [y = -sqrt(((-y^2)-x^2)*sqrt(y^2+x^2)+x^2), y = sqrt(((-y^2)-x^2)*sqrt(y^2+x^2)+x^2)]
++    [y = -sqrt((...-y^2...-x^2)*sqrt(y^2+x^2)+x^2), y = sqrt((...-y^2...-x^2)*sqrt(y^2+x^2)+x^2)]
+ 
+ 
+ You can even nicely typeset the solution in latex::
+ 
+     sage: latex(s)
+-    \left[ \left[ a=-{{\sqrt{79}\,i-11}\over{4}} , b={{\sqrt{79}\,i+9  }\over{4}} , c={{\sqrt{79}\,i+1}\over{10}} \right]  , \left[ a={{  \sqrt{79}\,i+11}\over{4}} , b=-{{\sqrt{79}\,i-9}\over{4}} , c=-{{  \sqrt{79}\,i-1}\over{10}} \right]  \right]
++    \left[ \left[ a=-...{{\sqrt{79}\,i-11}\over{4}}... , b={{...\sqrt{79}\,i+9...}\over{4}} , c={{\sqrt{79}\,i+1}\over{10}} \right]  , \left[ a={{...\sqrt{79}\,i+11}\over{4}} , b=-...{{\sqrt{79}\,i-9...}\over{4}}... , c=-...{{...\sqrt{79}\,i-1}\over{10}}... \right]  \right]
+ 
+ To have the above appear onscreen via ``xdvi``, type
+ ``view(s)``. (TODO: For OS X should create pdf output
+@@ -200,7 +206,7 @@
+     sage: f.diff('x')
+     k*x^3*%e^(k*x)*sin(w*x)+3*x^2*%e^(k*x)*sin(w*x)+w*x^3*%e^(k*x) *cos(w*x)
+     sage: f.integrate('x')
+-    (((k*w^6+3*k^3*w^4+3*k^5*w^2+k^7)*x^3 +(3*w^6+3*k^2*w^4-3*k^4*w^2-3*k^6)*x^2+((-18*k*w^4)-12*k^3*w^2+6*k^5)*x-6*w^4 +36*k^2*w^2-6*k^4) *%e^(k*x)*sin(w*x) +(((-w^7)-3*k^2*w^5-3*k^4*w^3-k^6*w)*x^3 +(6*k*w^5+12*k^3*w^3+6*k^5*w)*x^2+(6*w^5-12*k^2*w^3-18*k^4*w)*x-24*k*w^3 +24*k^3*w) *%e^(k*x)*cos(w*x)) /(w^8+4*k^2*w^6+6*k^4*w^4+4*k^6*w^2+k^8)
++    (((k*w^6+3*k^3*w^4+3*k^5*w^2+k^7)*x^3 +(3*w^6+3*k^2*w^4-3*k^4*w^2-3*k^6)*x^2+(...-...18*k*w^4)-12*k^3*w^2+6*k^5)*x-6*w^4 +36*k^2*w^2-6*k^4) *%e^(k*x)*sin(w*x) +((...-w^7...-3*k^2*w^5-3*k^4*w^3-k^6*w)*x^3...+(6*k*w^5+12*k^3*w^3+6*k^5*w)*x^2...+(6*w^5-12*k^2*w^3-18*k^4*w)*x-24*k*w^3 +24*k^3*w) *%e^(k*x)*cos(w*x)) /(w^8+4*k^2*w^6+6*k^4*w^4+4*k^6*w^2+k^8)
+ 
+ ::
+ 
+@@ -234,7 +240,7 @@
+     sage: A.eigenvalues()
+     [[0,4],[3,1]]
+     sage: A.eigenvectors()
+-    [[[0,4],[3,1]],[[[1,0,0,-4],[0,1,0,-2],[0,0,1,-4/3]],[[1,2,3,4]]]]
++    [[[0,4],[3,1]],[[[1,0,0,-4],[0,1,0,-2],[0,0,1,-...4/3...]],[[1,2,3,4]]]]
+ 
+ We can also compute the echelon form in Sage::
+ 
+@@ -287,12 +293,12 @@
+ ::
+ 
+     sage: maxima("laplace(diff(x(t),t,2),t,s)")
+-    (-%at('diff(x(t),t,1),t = 0))+s^2*'laplace(x(t),t,s)-x(0)*s
++    ...-...%at('diff(x(t),t,1),t = 0))+s^2*'laplace(x(t),t,s)-x(0)*s
+ 
+ It is difficult to read some of these without the 2d
+ representation::
+ 
+-    sage: print(maxima("laplace(diff(x(t),t,2),t,s)"))
++    sage: print(maxima("laplace(diff(x(t),t,2),t,s)")) # not tested - depends on maxima version
+                              !
+                     d        !          2
+                  (- -- (x(t))!     ) + s  laplace(x(t), t, s) - x(0) s
+@@ -396,7 +402,7 @@
+ 
+     sage: g = maxima('exp(3*%i*x)/(6*%i) + exp(%i*x)/(2*%i) + c')
+     sage: latex(g)
+-    -{{i\,e^{3\,i\,x}}\over{6}}-{{i\,e^{i\,x}}\over{2}}+c
++    -...{{i\,e^{3\,i\,x}}\over{6}}...-{{i\,e^{i\,x}}\over{2}}+c
+ 
+ Long Input
+ ----------
+@@ -684,7 +690,7 @@ def _expect_expr(self, expr=None, timeout=None):
+             sage: maxima.assume('a>0')
+             [a > 0]
+             sage: maxima('integrate(1/(x^3*(a+b*x)^(1/3)),x)')
+-            (-(b^2*log((b*x+a)^(2/3)+a^(1/3)*(b*x+a)^(1/3)+a^(2/3)))/(9*a^(7/3))) +(2*b^2*atan((2*(b*x+a)^(1/3)+a^(1/3))/(sqrt(3)*a^(1/3))))/(3^(3/2)*a^(7/3)) +(2*b^2*log((b*x+a)^(1/3)-a^(1/3)))/(9*a^(7/3)) +(4*b^2*(b*x+a)^(5/3)-7*a*b^2*(b*x+a)^(2/3)) /(6*a^2*(b*x+a)^2-12*a^3*(b*x+a)+6*a^4)
++            ...-...(b^2*log((b*x+a)^(2/3)+a^(1/3)*(b*x+a)^(1/3)+a^(2/3)))/(9*a^(7/3))) +(2*b^2*atan((2*(b*x+a)^(1/3)+a^(1/3))/(sqrt(3)*a^(1/3))))/(3^(3/2)*a^(7/3)) +(2*b^2*log((b*x+a)^(1/3)-a^(1/3)))/(9*a^(7/3)) +(4*b^2*(b*x+a)^(5/3)-7*a*b^2*(b*x+a)^(2/3)) /(6*a^2*(b*x+a)^2-12*a^3*(b*x+a)+6*a^4)
+             sage: maxima('integrate(x^n,x)')
+             Traceback (most recent call last):
+             ...
+diff --git a/src/sage/interfaces/maxima_abstract.py b/src/sage/interfaces/maxima_abstract.py
+index 4f6306ba4fc..aecfcba5e23 100644
+--- a/src/sage/interfaces/maxima_abstract.py
++++ b/src/sage/interfaces/maxima_abstract.py
+@@ -856,9 +856,9 @@ def de_solve(self, de, vars, ics=None):
+             sage: maxima.de_solve('diff(y,x,2) + 3*x = y', ['x','y'])
+             y = %k1*%e^x+%k2*%e^-x+3*x
+             sage: maxima.de_solve('diff(y,x) + 3*x = y', ['x','y'])
+-            y = (%c-3*((-x)-1)*%e^-x)*%e^x
++            y = (%c-3*(...-x...-1)*%e^-x)*%e^x
+             sage: maxima.de_solve('diff(y,x) + 3*x = y', ['x','y'],[1,1])
+-            y = -%e^-1*(5*%e^x-3*%e*x-3*%e)
++            y = -...%e^-1*(5*%e^x-3*%e*x-3*%e)...
+         """
+         if not isinstance(vars, str):
+             str_vars = '%s, %s'%(vars[1], vars[0])
+@@ -1572,8 +1572,9 @@ def integral(self, var='x', min=None, max=None):
+ 
+         ::
+ 
+-            sage: f = maxima('exp(x^2)').integral('x',0,1); f
+-            -(sqrt(%pi)*%i*erf(%i))/2
++            sage: f = maxima('exp(x^2)').integral('x',0,1)
++            sage: f.sage()
++            -1/2*I*sqrt(pi)*erf(I)
+             sage: f.numer()
+             1.46265174590718...
+         """
+diff --git a/src/sage/interfaces/maxima_lib.py b/src/sage/interfaces/maxima_lib.py
+index bba8504aa92..cd1be891872 100644
+--- a/src/sage/interfaces/maxima_lib.py
++++ b/src/sage/interfaces/maxima_lib.py
+@@ -134,10 +134,11 @@
+ else:
+     ecl_eval("(require 'maxima)")
+ ecl_eval("(in-package :maxima)")
+-ecl_eval("(setq $nolabels t))")
+-ecl_eval("(defvar *MAXIMA-LANG-SUBDIR* NIL)")
+ ecl_eval("(set-locale-subdir)")
+ 
++# This workaround has to happen before any call to (set-pathnames).
++# To be safe please do not call anything other than
++# (set-locale-subdir) before this block.
+ try:
+     ecl_eval("(set-pathnames)")
+ except RuntimeError:
+@@ -154,6 +155,8 @@
+     # Call `(set-pathnames)` again to complete its job.
+     ecl_eval("(set-pathnames)")
+ 
++ecl_eval("(initialize-runtime-globals)")
++ecl_eval("(setq $nolabels t))")
+ ecl_eval("(defun add-lineinfo (x) x)")
+ ecl_eval('(defun principal nil (cond ($noprincipal (diverg)) ((not pcprntd) (merror "Divergent Integral"))))')
+ ecl_eval("(remprop 'mfactorial 'grind)")  # don't use ! for factorials (#11539)
+diff --git a/src/sage/matrix/matrix1.pyx b/src/sage/matrix/matrix1.pyx
+index f38c429d994..47df9fc80a5 100644
+--- a/src/sage/matrix/matrix1.pyx
++++ b/src/sage/matrix/matrix1.pyx
+@@ -248,7 +248,7 @@ cdef class Matrix(Matrix0):
+             sage: a = maxima(m); a
+             matrix([0,1,2],[3,4,5],[6,7,8])
+             sage: a.charpoly('x').expand()
+-            (-x^3)+12*x^2+18*x
++            ...-x^3...+12*x^2+18*x
+             sage: m.charpoly()
+             x^3 - 12*x^2 - 18*x
+         """
+diff --git a/src/sage/modules/free_module_element.pyx b/src/sage/modules/free_module_element.pyx
+index 0532ea0c9bd..6ea2bd4473d 100644
+--- a/src/sage/modules/free_module_element.pyx
++++ b/src/sage/modules/free_module_element.pyx
+@@ -4053,7 +4053,7 @@ cdef class FreeModuleElement(Vector):   # abstract base class
+             sage: t=var('t')
+             sage: r=vector([t,t^2,sin(t)])
+             sage: vec,answers=r.nintegral(t,0,1)
+-            sage: vec
++            sage: vec # abs tol 1e-15
+             (0.5, 0.3333333333333334, 0.4596976941318602)
+             sage: type(vec)
+             <class 'sage.modules.vector_real_double_dense.Vector_real_double_dense'>
+diff --git a/src/sage/symbolic/relation.py b/src/sage/symbolic/relation.py
+index a72ab547c76..51dcaf8d847 100644
+--- a/src/sage/symbolic/relation.py
++++ b/src/sage/symbolic/relation.py
+@@ -657,7 +657,7 @@ def solve(f, *args, **kwds):
+     equations, at times approximations will be given by Maxima, due to the
+     underlying algorithm::
+ 
+-        sage: sols = solve([x^3==y,y^2==x], [x,y]); sols[-1], sols[0]
++        sage: sols = solve([x^3==y,y^2==x], [x,y]); sols[-1], sols[0] # abs tol 1e-15
+         ([x == 0, y == 0],
+          [x == (0.3090169943749475 + 0.9510565162951535*I),
+           y == (-0.8090169943749475 - 0.5877852522924731*I)])

--- a/srcpkgs/sagemath/patches/35825-singular_4.3.2p2.patch
+++ b/srcpkgs/sagemath/patches/35825-singular_4.3.2p2.patch
@@ -1,0 +1,24 @@
+diff --git a/src/sage/rings/asymptotic/asymptotics_multivariate_generating_functions.py b/src/sage/rings/asymptotic/asymptotics_multivariate_generating_functions.py
+index ea027e8a716..a1fe036917e 100644
+--- a/src/sage/rings/asymptotic/asymptotics_multivariate_generating_functions.py
++++ b/src/sage/rings/asymptotic/asymptotics_multivariate_generating_functions.py
+@@ -1251,7 +1251,7 @@ def leinartas_decomposition(self):
+             sage: H = R(f.denominator())
+             sage: ff = FFPD(G, H.factor())
+             sage: decomp = ff.leinartas_decomposition()
+-            sage: decomp
++            sage: decomp  # random - non canonical depends on singular version
+             (0, []) +
+             (-(x*y^2*sin(x) + x^2*y + x*y + y*sin(x) + x)*y, [(y, 1)]) +
+             ((x*y^2*sin(x) + x^2*y + x*y + y*sin(x) + x)*x*y, [(x*y + 1, 1)]) +
+@@ -1611,9 +1611,7 @@ def asymptotics(self, p, alpha, N, asy_var=None, numerical=0,
+             (-16, [(x + 2*y + z - 4, 1), (2*x + y + z - 4, 2)])
+             sage: alpha = [3, 3, 2]
+             sage: decomp = F.asymptotic_decomposition(alpha); decomp
+-            (0, []) +
+-            (16*r*(3/x - 2/z) + 16/x - 16/z,
+-             [(x + 2*y + z - 4, 1), (2*x + y + z - 4, 1)])
++            (0, []) + (..., [(x + 2*y + z - 4, 1), (2*x + y + z - 4, 1)])
+             sage: F1 = decomp[1]
+             sage: p = {x: 1, y: 1, z: 1}
+             sage: asy = F1.asymptotics(p, alpha, 2, verbose=True) # long time

--- a/srcpkgs/sagemath/patches/35826-numpy_1.25.0.patch
+++ b/srcpkgs/sagemath/patches/35826-numpy_1.25.0.patch
@@ -1,0 +1,83 @@
+diff --git a/src/sage/calculus/desolvers.py b/src/sage/calculus/desolvers.py
+index 55ed3a0fe10..4cfa22a97e4 100644
+--- a/src/sage/calculus/desolvers.py
++++ b/src/sage/calculus/desolvers.py
+@@ -1598,7 +1598,7 @@ def desolve_odeint(des, ics, times, dvars, ivar=None, compute_jac=False, args=()
+         sage: ic=epsilon
+         sage: t=srange(0,2/epsilon,1)
+         sage: sol=desolve_odeint(f,ic,t,y,rtol=1e-9,atol=1e-10,compute_jac=True)
+-        sage: p=points(zip(t,sol))
++        sage: p=points(zip(t,sol[:,0]))
+         sage: p.show()
+ 
+     Another stiff system with some optional parameters with no
+@@ -1637,7 +1637,7 @@ def desolve_odeint_inner(ivar):
+                 J = fast_float(J, dvar, ivar)
+ 
+                 def Dfun(y, t):
+-                    return [J(y, t)]
++                    return [J(y.item(), t)]
+ 
+         # n-dimensional systems:
+         else:
+diff --git a/src/sage/matrix/matrix2.pyx b/src/sage/matrix/matrix2.pyx
+index d5402d5c3b0..a00912951c5 100644
+--- a/src/sage/matrix/matrix2.pyx
++++ b/src/sage/matrix/matrix2.pyx
+@@ -430,12 +430,12 @@ cdef class Matrix(Matrix1):
+             try:
+                 return self.transpose().solve_right(B, check=check)
+             except ValueError as e:
+-                raise ValueError(str(e).replace('row', 'column'))
++                raise e.__class__(str(e).replace('row', 'column'))
+         else:
+             try:
+                 return self.transpose().solve_right(B.transpose(), check=check).transpose()
+             except ValueError as e:
+-                raise ValueError(str(e).replace('row', 'column'))
++                raise e.__class__(str(e).replace('row', 'column'))
+ 
+     def solve_right(self, B, check=True):
+         r"""
+diff --git a/src/sage/matrix/matrix_numpy_dense.pyx b/src/sage/matrix/matrix_numpy_dense.pyx
+index 5b75ed133ff..17867f9a65c 100644
+--- a/src/sage/matrix/matrix_numpy_dense.pyx
++++ b/src/sage/matrix/matrix_numpy_dense.pyx
+@@ -382,8 +382,9 @@ cdef class Matrix_numpy_dense(Matrix_dense):
+             sage: m = matrix(RDF,[[1,2],[3,4]])
+             sage: n = m.numpy()
+             sage: import numpy
+-            sage: numpy.linalg.eig(n)
+-            (array([-0.37228132,  5.37228132]), array([[-0.82456484, -0.41597356],
++            sage: tuple(numpy.linalg.eig(n))
++            (array([-0.37228132,  5.37228132]),
++             array([[-0.82456484, -0.41597356],
+                    [ 0.56576746, -0.90937671]]))
+             sage: m = matrix(RDF, 2, range(6)); m
+             [0.0 1.0 2.0]
+diff --git a/src/sage/plot/plot3d/list_plot3d.py b/src/sage/plot/plot3d/list_plot3d.py
+index d64b766001e..0158f856dbb 100644
+--- a/src/sage/plot/plot3d/list_plot3d.py
++++ b/src/sage/plot/plot3d/list_plot3d.py
+@@ -602,7 +602,7 @@ def g(x, y):
+         from .parametric_surface import ParametricSurface
+ 
+         def g(x, y):
+-            z = f([x, y])
++            z = f([x, y]).item()
+             return (x, y, z)
+         G = ParametricSurface(g, (list(numpy.r_[xmin:xmax:num_points * j]),
+                                   list(numpy.r_[ymin:ymax:num_points * j])),
+diff --git a/src/sage/plot/plot3d/plot3d.py b/src/sage/plot/plot3d/plot3d.py
+index e9bbfaa8370..9ba89595d70 100644
+--- a/src/sage/plot/plot3d/plot3d.py
++++ b/src/sage/plot/plot3d/plot3d.py
+@@ -378,7 +378,7 @@ def to_cartesian(self, func, params=None):
+             ....: [ 0.16763356,  0.19993708,  0.31403568,  0.47359696, 0.55282422],
+             ....: [ 0.16763356,  0.25683223,  0.16649297,  0.10594339, 0.55282422]])
+             sage: import scipy.interpolate
+-            sage: f=scipy.interpolate.RectBivariateSpline(v_phi,v_theta,m_r)
++            sage: f=scipy.interpolate.RectBivariateSpline(v_phi,v_theta,m_r).ev
+             sage: spherical_plot3d(f,(0,2*pi),(0,pi))
+             Graphics3d Object
+ 

--- a/srcpkgs/sagemath/patches/35831-setuptools_68.0.0.patch
+++ b/srcpkgs/sagemath/patches/35831-setuptools_68.0.0.patch
@@ -1,0 +1,13 @@
+diff --git a/src/sage/all__sagemath_repl.py b/src/sage/all__sagemath_repl.py
+index 6800eb9a27b..8d0b43679ca 100644
+--- a/src/sage/all__sagemath_repl.py
++++ b/src/sage/all__sagemath_repl.py
+@@ -44,7 +44,7 @@
+ warnings.filterwarnings('ignore', category=DeprecationWarning,
+     message='pkg_resources is deprecated as an API|'
+             'Deprecated call to `pkg_resources.declare_namespace(.*)`',
+-    module='pkg_resources')
++    module='pkg_resources|setuptools.sandbox')
+ warnings.filterwarnings('ignore', category=DeprecationWarning,
+     message='msvccompiler is deprecated and slated to be removed',
+     module='distutils.msvccompiler')

--- a/srcpkgs/sagemath/patches/get_patches
+++ b/srcpkgs/sagemath/patches/get_patches
@@ -18,10 +18,18 @@ get_pr() {
 # run from patches dir
 cd $(dirname "$0")
 
-# positive review
+# merged in 10.0.beta0
 get_pr 35584 "networkx 3.1"
+
+# merged in 10.0.beta1
 get_pr 35612 "linbox 1.7.0"
 get_pr 35635 "sympy 1.12"
+get_pr 35619 "maxima 5.46.0"
+
+# positive review
+get_pr 35707 "maxima 5.47.0"
+get_pr 35831 "setuptools 68.0.0"
 
 # needs review
-get_pr 35619 "maxima 5.46.0"
+get_pr 35825 "singular 4.3.2p2"
+get_pr 35826 "numpy 1.25.0"

--- a/srcpkgs/sagemath/template
+++ b/srcpkgs/sagemath/template
@@ -1,7 +1,7 @@
 # Template file for 'sagemath'
 pkgname=sagemath
 version=10.0
-revision=1
+revision=2
 build_wrksrc=pkgs/sagemath-standard
 build_style=python3-module
 _bindir=/usr/lib/sagemath/$version/bin


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

This updates maxima to 5.47.0, which needs a patch and rebuild for sagemath (https://github.com/sagemath/sage/pull/35707/).

Also:
 - patch sagemath to support singular 4.3.2p2 (https://github.com/sagemath/sage/pull/35825)
 - patch sagemath to support numpy 1.25.0 (https://github.com/sagemath/sage/pull/35826)

This PR can be safely merged before updating singular and numpy. Afther this is merged numpy  (#44529) and singular updates can be merged.

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
