### PR TITLE
transmission: don't use deprecated --log-error

### DIFF
--- a/srcpkgs/transmission/files/transmission-daemon/run
+++ b/srcpkgs/transmission/files/transmission-daemon/run
@@ -1,3 +1,3 @@
 #!/bin/sh
 exec 2>&1
-exec chpst -u transmission:transmission transmission-daemon -f --log-error
+exec chpst -u transmission:transmission transmission-daemon -f --log-level=error

--- a/srcpkgs/transmission/template
+++ b/srcpkgs/transmission/template
@@ -1,13 +1,14 @@
 # Template file for 'transmission'
 pkgname=transmission
 version=4.0.3
-revision=1
+revision=2
 build_style=cmake
 configure_args="-DENABLE_CLI=ON -DENABLE_GTK=ON -DENABLE_QT=ON -DENABLE_MAC=OFF"
 hostmakedepends="autoconf automake intltool glib-devel
  libtool pkg-config qt5-host-tools qt5-qmake"
 makedepends="dbus-glib-devel gtkmm4-devel glibmm-devel
- libcurl-devel libevent-devel qt5-tools-devel qt5-svg-devel"
+ libcurl-devel libevent-devel qt5-tools-devel qt5-svg-devel
+ libdeflate-devel miniupnpc-devel"
 short_desc="Fast, easy and free BitTorrent client"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT, GPL-2.0-or-later"


### PR DESCRIPTION
Even though the man page for transmission-daemon was not updated to reflect the change, `--log-error` has been deprecated by `--log-level=error` (see `transmission-daemon --help`).
A warning is logged if the old flag is used.


<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**


<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
