### PR TITLE
xbps-src: new vopt_feature helper

### DIFF
--- a/Manual.md
+++ b/Manual.md
@@ -1204,6 +1204,11 @@ package accordingly. Additionally, the following functions are available:
   Outputs `-D<property>=true` if the option is set, or
   `-D<property>=false` otherwise.
 
+- *vopt_feature()* `vopt_feature <option> <property>`
+
+  Same as `vopt_bool`, but uses `-D<property=enabled` and
+	`-D<property>=disabled` respectively. 
+
 The following example shows how to change a source package that uses GNU
 configure to enable a new build option to support PNG images:
 

--- a/common/environment/setup/options.sh
+++ b/common/environment/setup/options.sh
@@ -36,3 +36,11 @@ vopt_bool() {
     fi
     vopt_if "$1" "-D${prop}=true" "-D${prop}=false"
 }
+
+vopt_feature() {
+    local opt="$1" prop="${2:-$1}"
+    if [ "$#" -gt "2" ]; then
+        msg_error "vopt_feature $opt: $(($# - 2)) excess parameter(s)\n"
+    fi
+    vopt_if "$1" "-D${prop}=enabled" "-D${prop}=disabled"
+}


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

I didn't check this against every template where the pattern appears, but it works in the test cases I tried.

---

This helper function reduces boilerplate for [Meson's "feature" build options](https://mesonbuild.com/Build-options.html#features). Right now these are handled using the pattern `-D<property>=$(vopt_if <option> enabled disabled)`, which occurs 78 times in our templates.

Note that this does *not* allow you to set the property to "auto", but I can't think of any situation where that would be desirable.