### PR TITLE
python3-SecretStorage: update to 3.3.3

### DIFF
--- a/srcpkgs/python3-SecretStorage/template
+++ b/srcpkgs/python3-SecretStorage/template
@@ -1,7 +1,7 @@
 # Template file for 'python3-SecretStorage'
 pkgname=python3-SecretStorage
-version=3.3.1
-revision=3
+version=3.3.3
+revision=1
 build_style=python3-module
 hostmakedepends="python3-setuptools"
 depends="python3-jeepney python3-cryptography"
@@ -11,8 +11,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="BSD-3-Clause"
 homepage="https://github.com/mitya57/secretstorage"
 distfiles="${PYPI_SITE}/S/SecretStorage/SecretStorage-${version}.tar.gz"
-checksum=fd666c51a6bf200643495a04abb261f83229dcb6fd8472ec393df7ffc8b6f195
-make_check=ci-skip
+checksum=2403533ef369eca6d2ba81718576c5e0f564d5cca1b58f73a8b23e7d4eeebd77
 
 do_check() {
 	dbus-run-session -- python3 -m unittest discover -s tests


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **NO**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-LIBC)