### PR TITLE
bash-language-server: update to 4.10.1.

### DIFF
--- a/srcpkgs/bash-language-server/template
+++ b/srcpkgs/bash-language-server/template
@@ -1,6 +1,6 @@
 # Template file for 'bash-language-server'
 pkgname=bash-language-server
-version=4.9.2
+version=4.10.1
 revision=1
 hostmakedepends="jq yarn"
 depends="nodejs"
@@ -9,7 +9,7 @@ maintainer="sirkhancision <jsantiago12tone@gmail.com>"
 license="MIT"
 homepage="https://github.com/bash-lsp/bash-language-server"
 distfiles="https://github.com/bash-lsp/bash-language-server/archive/refs/tags/server-${version}.tar.gz"
-checksum=7d162baf072ba8807f4253d7fdbe7210507e5b0106e94cc0373668dd40a25fee
+checksum=f8c7fed6812e166dadefceb156ba8e1737e57914f9f06b4bba06f93bed7dc9b4
 
 do_build() {
 	yarn install


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
