### PR TITLE
remmina: compile with kwallet support

### DIFF
--- a/srcpkgs/remmina-kwallet
+++ b/srcpkgs/remmina-kwallet
@@ -1,0 +1,1 @@
+remmina

--- a/srcpkgs/remmina/template
+++ b/srcpkgs/remmina/template
@@ -1,12 +1,12 @@
 # Template file for 'remmina'
 pkgname=remmina
 version=1.4.31
-revision=1
+revision=2
 build_style=cmake
-configure_args="-DCMAKE_USE_PTHREADS_INIT=ON"
-hostmakedepends="glib-devel intltool pkg-config shared-mime-info"
+configure_args="-DCMAKE_USE_PTHREADS_INIT=ON -DWITH_KF5WALLET=on"
+hostmakedepends="glib-devel intltool pkg-config shared-mime-info qt5-host-tools qt5-qmake"
 makedepends="avahi-glib-libs-devel avahi-ui-libs-devel freerdp-devel
- gobject-introspection gstreamermm-devel json-glib-devel
+ gobject-introspection gstreamermm-devel json-glib-devel kwallet-devel
  libgcrypt-devel libgnome-keyring-devel liblz4-devel libsasl-devel
  libsecret-devel libsodium-devel libsoup3-devel libssh-devel libva-devel
  libvncserver-devel libxkbfile-devel opus-devel phodav-devel
@@ -24,3 +24,11 @@ checksum=cfe9d4a6f2951d35533e5b2235f76640573c91f1be3bd8118637fbf68234500a
 if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
 	makedepends+=" libexecinfo-devel"
 fi
+
+remmina-kwallet_package() {
+	short_desc+=" - kwallet plugin"
+	depends="${sourcepkg}>=${version}_${revision} kwallet"
+	pkg_install() {
+		vmove usr/lib/remmina/plugins/remmina-plugin-kwallet.so
+	}
+}


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, x86_64
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl
  - aarch64

### Description
Adds compile flag and dependency to support *KWallet* in Remmina so passwords can be stored.