### PR TITLE
io.elementary.videos: update to 2.9.1

### DIFF
--- a/srcpkgs/io.elementary.videos/template
+++ b/srcpkgs/io.elementary.videos/template
@@ -1,6 +1,6 @@
 # Template file for 'io.elementary.videos'
 pkgname=io.elementary.videos
-version=2.8.3
+version=2.9.1
 revision=1
 build_style=meson
 hostmakedepends="gettext pkg-config vala AppStream"
@@ -11,4 +11,4 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-3.0-or-later"
 homepage="https://github.com/elementary/videos"
 distfiles="${homepage}/archive/${version}.tar.gz"
-checksum=09c5db6433e4f6d570950609ff1d95a86df2179e7a65677a1e14c0549bbceba6
+checksum=11204b2bc4cedb8561dfb4d9906a2b9a747f551b25f88a0472436daf60e8d4e4


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - aarch64