### PR TITLE
thrift: update to 0.18.1, fix dead distfiles

### DIFF
--- a/srcpkgs/thrift/template
+++ b/srcpkgs/thrift/template
@@ -1,7 +1,7 @@
 # Template file for 'thrift'
 pkgname=thrift
-version=0.13.0
-revision=6
+version=0.18.1
+revision=1
 build_style=gnu-configure
 configure_args="--without-python"
 makedepends="boost-devel openssl-devel"
@@ -10,8 +10,8 @@ short_desc="Apache Thrift compiler"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="Apache-2.0"
 homepage="https://thrift.apache.org/"
-distfiles="http://www-us.apache.org/dist/thrift/${version}/thrift-${version}.tar.gz"
-checksum=7ad348b88033af46ce49148097afe354d513c1fca7c607b59c33ebb6064b5179
+distfiles="https://dlcdn.apache.org/thrift/${version}/thrift-${version}.tar.gz"
+checksum=04c6f10e5d788ca78e13ee2ef0d2152c7b070c0af55483d6b942e29cff296726
 
 if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
 	makedepends+=" libatomic-devel"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)

fixes thrift at  #42403

