### PR TITLE
ghex: update to 44.1

### DIFF
--- a/srcpkgs/ghex/template
+++ b/srcpkgs/ghex/template
@@ -1,6 +1,6 @@
 # Template file for 'ghex'
 pkgname=ghex
-version=44.0
+version=44.1
 revision=1
 build_style=meson
 build_helper=gir
@@ -16,7 +16,7 @@ license="GPL-2.0-only, GFDL-1.1-only"
 homepage="https://gitlab.gnome.org/GNOME/ghex"
 changelog="https://gitlab.gnome.org/GNOME/ghex/-/raw/ghex-44/NEWS"
 distfiles="${GNOME_SITE}/ghex/${version%.*}/ghex-${version}.tar.xz"
-checksum=58aa47cfdbed1280a3c131951c1a24596129404a0b0d347a3dbfffb6ff683976
+checksum=404bdf649eaa13922a80ae32f19fe40e71f0ee0f461c45edac72888a00ead6c2
 
 build_options="gir gtk_doc"
 build_options_default="gir gtk_doc"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - aarch64