### PR TITLE
gspell: update to 1.12.1.

### DIFF
--- a/srcpkgs/gspell/template
+++ b/srcpkgs/gspell/template
@@ -1,7 +1,7 @@
 # Template file for 'gspell'
 pkgname=gspell
-version=1.12.0
-revision=2
+version=1.12.1
+revision=1
 build_style=gnu-configure
 build_helper="gir"
 configure_args="--disable-static $(vopt_enable gir introspection)
@@ -16,7 +16,7 @@ license="LGPL-2.1-or-later"
 homepage="https://gitlab.gnome.org/GNOME/gspell"
 changelog="https://gitlab.gnome.org/GNOME/gspell/-/raw/master/NEWS"
 distfiles="${GNOME_SITE}/gspell/${version%.*}/gspell-${version}.tar.xz"
-checksum=40d2850f1bb6e8775246fa1e39438b36caafbdbada1d28a19fa1ca07e1ff82ad
+checksum=8ec44f32052e896fcdd4926eb814a326e39a5047e251eec7b9056fbd9444b0f1
 make_check_pre="xvfb-run"
 
 # Package build options


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)

