### PR TITLE
mobile-broadband-provider-info: update to 20230416

### DIFF
--- a/srcpkgs/mobile-broadband-provider-info/template
+++ b/srcpkgs/mobile-broadband-provider-info/template
@@ -1,6 +1,6 @@
 # Template file for 'mobile-broadband-provider-info'
 pkgname=mobile-broadband-provider-info
-version=20220511
+version=20230416
 revision=1
 build_style=gnu-configure
 hostmakedepends="automake libxslt"
@@ -10,7 +10,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="custom:Creative Commons Public Domain"
 homepage="https://gitlab.gnome.org/GNOME/mobile-broadband-provider-info/"
 distfiles="https://gitlab.gnome.org/GNOME/mobile-broadband-provider-info/-/archive/${version}/mobile-broadband-provider-info-${version}.tar.bz2"
-checksum=1ccbf314cac06048fd8c57ffad28c4e4273cc096e4eb8fca9beb38280428450f
+checksum=09617fb0e67c18d551aac6807c8398f5f21ed25146a38697b20e4d97322df106
 
 pre_configure() {
 	autoreconf -fi


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **NO**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-LIBC)