### PR TITLE
Signal-Desktop: update to 6.23.0.

### DIFF
--- a/srcpkgs/Signal-Desktop/template
+++ b/srcpkgs/Signal-Desktop/template
@@ -1,6 +1,6 @@
 # Template file for 'Signal-Desktop'
 pkgname=Signal-Desktop
-version=6.22.0
+version=6.23.0
 revision=1
 # Signal officially only supports x86_64 
 # x86_64-musl could potentially work based on the Alpine port:
@@ -14,7 +14,7 @@ maintainer="anelki <akierig@fastmail.de>"
 license="AGPL-3.0-only"
 homepage="https://github.com/signalapp/Signal-Desktop"
 distfiles="https://github.com/signalapp/Signal-Desktop/archive/v${version}.tar.gz"
-checksum=b895314710284bb7b5caac67eb514d8b83e933ace2c0801bc690a9c621cbed94
+checksum=dc004b5a31c4896aa0478618ed9226cc931f819f44a26966956f9fe586967060
 nostrip_files="signal-desktop"
 
 post_extract() {


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64