### PR TITLE
git-cola: Add python3-packaging to depends

### DIFF
--- a/srcpkgs/git-cola/template
+++ b/srcpkgs/git-cola/template
@@ -1,10 +1,10 @@
 # Template file for 'git-cola'
 pkgname=git-cola
 version=4.2.1
-revision=1
+revision=2
 build_style=python3-pep517
 hostmakedepends="python3-setuptools_scm python3-wheel"
-depends="git qt5-svg python3-PyQt5-webkit python3-QtPy"
+depends="git qt5-svg python3-PyQt5-webkit python3-QtPy python3-packaging"
 short_desc="Highly caffeinated Git GUI"
 maintainer="Andrea Brancaleoni <abc@pompel.me>"
 license="GPL-2.0-only"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

Without python3-packaging, git-cola doesn't start.

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
#### Local build testing
- I built this PR locally for my native architecture, (x86_64-GLIBC)
