### PR TITLE
eventviews: update to 23.04.2

### DIFF
--- a/srcpkgs/eventviews/template
+++ b/srcpkgs/eventviews/template
@@ -1,6 +1,6 @@
 # Template file for 'eventviews'
 pkgname=eventviews
-version=23.04.0
+version=23.04.2
 revision=1
 build_style=cmake
 hostmakedepends="extra-cmake-modules qt5-qmake qt5-host-tools kcoreaddons kconfig
@@ -11,7 +11,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="https://community.kde.org/KDE_PIM"
 distfiles="${KDE_SITE}/release-service/${version}/src/${pkgname}-${version}.tar.xz"
-checksum=16ab833f540470366a65fb6b57b46bfc5b272e1dd473df33a7df47497df4430d
+checksum=7e11000ace5ae7b5d40d29e979ea09c59d1d1352c8e7c1a924fe27b88e2b6108
 
 eventviews-devel_package() {
 	short_desc+=" - development"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **NO**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64