### PR TITLE
kalarm: update to 23.04.2

### DIFF
--- a/srcpkgs/kalarm/template
+++ b/srcpkgs/kalarm/template
@@ -1,7 +1,7 @@
 # Template file for 'kalarm'
 pkgname=kalarm
-version=23.04.0
-revision=2
+version=23.04.2
+revision=1
 build_style=cmake
 hostmakedepends="extra-cmake-modules qt5-qmake qt5-host-tools libxslt kdoctools
  kauth kconfig gettext"
@@ -12,5 +12,5 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="https://www.kde.org/applications/utilities/kalarm"
 distfiles="${KDE_SITE}/release-service/${version}/src/${pkgname}-${version}.tar.xz"
-checksum=3aad46389998c50e587f2fa467b143ca978c3e04ed9de37d923f4e0b255aa131
+checksum=53aa011ca6ed69b2a63837423f094ed271e3e602aad0f7e3de090e6c7b830e18
 replaces="kalarmcal>=0"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64