### PR TITLE
kamoso: update to 23.04.2

### DIFF
--- a/srcpkgs/kamoso/template
+++ b/srcpkgs/kamoso/template
@@ -1,6 +1,6 @@
 # Template file for 'kamoso'
 pkgname=kamoso
-version=23.04.0
+version=23.04.2
 revision=1
 build_style=cmake
 hostmakedepends="
@@ -13,11 +13,11 @@ makedepends="
 depends="
  kconfigwidgets kcompletion ksolid knotifyconfig gst-plugins-good1
  gst-plugins-bad1 phonon-qt5 qt5-graphicaleffects qt5-quickcontrols kirigami2
- purpose"
+ purpose breeze-icons"
 short_desc="Simple and friendly program to use your webcam recorder"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="https://apps.kde.org/kamoso/"
 changelog="https://kde.org/announcements/changelogs/gear/${version}/#kamoso"
 distfiles="${KDE_SITE}/release-service/${version}/src/${pkgname}-${version}.tar.xz"
-checksum=6ab8690e45616087e205c7fc80accc27a8a887108f58477877b66e24061c12f2
+checksum=8fefb862a7d1d70b35a460fc160e08e9510e76091e3782f04f7b8b4430d36b57


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64

**Note**: added `breeze-icons` to fix missing icons.