### PR TITLE
checkbashisms: update to 2.23.5.

### DIFF
--- a/srcpkgs/checkbashisms/template
+++ b/srcpkgs/checkbashisms/template
@@ -1,6 +1,6 @@
 # Template file for 'checkbashisms'
 pkgname=checkbashisms
-version=2.23.4
+version=2.23.5
 revision=1
 depends="perl"
 checkdepends="shunit2 perl"
@@ -10,7 +10,7 @@ license="GPL-2.0-or-later"
 homepage="https://tracker.debian.org/pkg/devscripts"
 changelog="https://salsa.debian.org/debian/devscripts/-/raw/master/debian/changelog"
 distfiles="${DEBIAN_SITE}/main/d/devscripts/devscripts_${version}.tar.xz"
-checksum=3dc68972734c0aeb310beb35d01b83d85e445270acefd8caeda6a6fef6f6f4f3
+checksum=8f47d45534bf94f28576078c864b22273dbe139928074ec82b6b848f9e44586d
 
 pre_install() {
 	vsed -i "s|###VERSION###|${version}|" scripts/checkbashisms.pl
@@ -21,6 +21,7 @@ do_check() {
 }
 
 do_install() {
+	vcompletion scripts/checkbashisms.bash_completion bash
 	vbin scripts/checkbashisms.pl checkbashisms
 	vman scripts/checkbashisms.1
 }


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture: **x86_64**

Although this version doesn't change the `checkbashisms` script itself (as per the changelog), I wanted to add the bash completions.