### PR TITLE
common/environment/setup/install.sh: add vicons

### DIFF
--- a/Manual.md
+++ b/Manual.md
@@ -335,6 +335,14 @@ The following functions are defined by `xbps-src` and can be used on any templat
 	it will default to `pkgname`. The `shell` argument can be one of `bash`,
 	`fish` or `zsh`.
 
+- *vicons()* `<icon_name_scheme> [<name>]`
+
+	Installs icons of all supported resolutions (e.g. 512px) in the correct
+	location and skips the ones that don't exist for the provided pattern.
+	Therefore it replaces all occurences of `%` in `icon_name_scheme` with the
+	resolution of the current iteration, for example `512`. By default icons are
+	stored by their package name with png as extension if no `name` is provided.
+
 > Shell wildcards must be properly quoted, Example: `vmove "usr/lib/*.a"`.
 
 <a id="global_vars"></a>

--- a/common/environment/setup/install.sh
+++ b/common/environment/setup/install.sh
@@ -13,7 +13,7 @@ _noglob_helper() {
 }
 
 # Apply _noglob to v* commands
-for cmd in vinstall vcopy vcompletion vmove vmkdir vbin vman vdoc vconf vsconf vlicense vsv; do
+for cmd in vinstall vcopy vcompletion vmove vmkdir vbin vman vdoc vconf vsconf vlicense vsv vicons; do
        alias ${cmd}="set -f; _noglob_helper _${cmd}"
 done
 
@@ -273,4 +273,19 @@ _vcompletion() {
 			return 1
 			;;
 	esac
+}
+
+_vicons() {
+	local icon_name_scheme="$1" name="$2"
+
+	if [ -z "$icon_name_scheme" ]; then
+		msg_red "$pkgver: vicons: 1 argument expected: <icon_name_scheme>\n"
+		return 1
+	fi
+
+	_name="${name:-${pkgname}.png}"
+	for x in 16 32 64 128 256 512 1024; do
+		_file="${icon_name_scheme/\%/$x}"
+		[ -f "$_file" ] && vinstall "$_file" 644 "usr/share/icons/hicolor/${x}x${x}/apps/$_name"
+	done
 }


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **NO**

A lot of scripts, for example https://github.com/void-linux/void-packages/blob/d2a5b2d23b30e115335ffe5c3cb50ccc2b945131/srcpkgs/goxel/template#L36-L39 iterate over different resolutions of icons in order to install all of them to `usr/share/icons` which is quite some boilerplate code. In my eyes it would be very handy to have an inbuilt function that automatically iterates over all possible resolutions and installs the icons to `usr/share/icons`. If that would be generally accepted, I'd change existing templates to use that function too.

I'm very interested on thoughts about that :)
Cheers
