### PR TITLE
webkit2gtk: update to 2.40.3.

### DIFF
--- a/srcpkgs/webkit2gtk/template
+++ b/srcpkgs/webkit2gtk/template
@@ -1,7 +1,7 @@
 # Template file for 'webkit2gtk'
 pkgname=webkit2gtk
-version=2.40.0
-revision=3
+version=2.40.3
+revision=1
 build_style=cmake
 build_helper="gir"
 configure_args="-DPORT=GTK -DUSE_LD_GOLD=OFF
@@ -15,7 +15,9 @@ configure_args="-DPORT=GTK -DUSE_LD_GOLD=OFF
  -DENABLE_WAYLAND_TARGET=$(vopt_if wayland ON OFF)
  -DENABLE_X11_TARGET=$(vopt_if x11 ON OFF)
  -DENABLE_SAMPLING_PROFILER=$(vopt_if sampling_profiler ON OFF)
- -DENABLE_BUBBLEWRAP_SANDBOX=$(vopt_if bubblewrap ON OFF)"
+ -DENABLE_BUBBLEWRAP_SANDBOX=$(vopt_if bubblewrap ON OFF)
+ -DBWRAP_EXECUTABLE=/usr/bin/bwrap
+ -DDBUS_PROXY_EXECUTABLE=/usr/bin/xdg-dbus-proxy"
 # Don't remove which from hostmakedepends
 # Otherwise, they invoke /usr/bin/ccache /usr/lib/ccache/bin/$CC
 hostmakedepends="perl python3 pkg-config gperf flex ruby gettext glib-devel
@@ -36,7 +38,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="LGPL-2.1-or-later, BSD-2-Clause"
 homepage="https://webkitgtk.org/"
 distfiles="https://webkitgtk.org/releases/webkitgtk-${version}.tar.xz"
-checksum=a4607ea1bf89669e89b1cb2c63faaec513f93de09b6ae60cc71d6a8aab7ab393
+checksum=cc0aa83f40dbc64c1c6ae42ec6b85af4be2a9dbf524cfcb95f89a367fb5098dd
 make_check=no # TODO
 
 replaces="webkit2gtk-common>0"


### PR DESCRIPTION
[ci skip]

Fixes `nyxt` package.

#### Testing the changes
- I tested the changes in this PR: **YES**

Tested using `luakit`, `nyxt` and `/usr/libexec/webkit2gtk-4.0/MiniBrowser` - all works.

#### Local build testing
- [x] I built this PR locally for my native architecture, x86_64-glibc
- [x] I built this PR locally for these architectures:
  - [x] armv6l