### PR TITLE
python3-markdown-it: update to 3.0.0.

### DIFF
--- a/srcpkgs/python3-markdown-it/template
+++ b/srcpkgs/python3-markdown-it/template
@@ -1,6 +1,6 @@
 # Template file for 'python3-markdown-it'
 pkgname=python3-markdown-it
-version=2.2.0
+version=3.0.0
 revision=1
 build_style=python3-pep517
 hostmakedepends="python3-flit_core"
@@ -11,7 +11,7 @@ license="MIT"
 homepage="https://github.com/executablebooks/markdown-it-py"
 changelog="https://raw.githubusercontent.com/executablebooks/markdown-it-py/master/CHANGELOG.md"
 distfiles="${PYPI_SITE}/m/markdown-it-py/markdown-it-py-${version}.tar.gz"
-checksum=7c9a5e412688bc771c67432cbfebcdd686c93ce6484913dccf06cb5a0bea35a1
+checksum=e3f60a94fa066dc52ec76661e37c851cb232d92f9886b15cb560aaada2df8feb
 # Tests not shipped in PYPI tarball
 make_check=no
 


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture: **x86_64**

#### Rev dep checks
- [x] python3-rich