### PR TITLE
nv-codec-header: update to 12.0.16.1.

### DIFF
--- a/srcpkgs/nv-codec-headers/template
+++ b/srcpkgs/nv-codec-headers/template
@@ -1,6 +1,6 @@
 # Template file for 'nv-codec-headers'
 pkgname=nv-codec-headers
-version=11.1.5.1
+version=12.0.16.1
 revision=1
 build_style=gnu-makefile
 short_desc="FFmpeg version of headers required to interface with Nvidias codec APIs"
@@ -8,7 +8,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
 homepage="http://git.videolan.org/?p=ffmpeg/nv-codec-headers.git"
 distfiles="https://github.com/FFmpeg/nv-codec-headers/archive/n${version}.tar.gz"
-checksum=d095fbd56aa93772471a323be0ebe65504a0f43f06c76a30b6d25da77b06ae9c
+checksum=37e31c7ed0c9bf2da74646a3ec426c38a6d29e60b1fb7bff3e03a99b9412e050
 
 post_install() {
 	sed -n '4,25p' include/ffnvcodec/nvEncodeAPI.h > LICENSE


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

I've build ffmpeg successfully with this version and also tested streaming with the codec via obs studio with my Nvidia Geforce RTX 2080 Super.

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl
  - aarch64-musl (crossbuild)
  - armv7l (crossbuild)
  - armv6l-musl (crossbuild)

We could also update to 12.1.x but this versions are no longer compatible with ffmpeg 4.4.4.

That's why for the moment I would update only to 12.0.16.1. This versions builds successfully with all packages that rely on it.

The new version would no longer allow users of nvidia470 to use the package. But 12.x brings so many relevant features for last and current generations of Nvidia graphics cards that this shouldn't be an argument.