### PR TITLE
system-monitoring-center: update to 2.17.0

### DIFF
--- a/srcpkgs/system-monitoring-center/template
+++ b/srcpkgs/system-monitoring-center/template
@@ -1,6 +1,6 @@
 # Template file for 'system-monitoring-center'
 pkgname=system-monitoring-center
-version=2.14.0
+version=2.17.0
 revision=1
 build_style=meson
 hostmakedepends="kdelibs4support-devel gettext"
@@ -10,4 +10,4 @@ maintainer="zenobit <zen@osowoso.xyz>"
 license="GPL-3.0-only"
 homepage="https://github.com/hakandundar34coding/system-monitoring-center"
 distfiles="https://github.com/hakandundar34coding/system-monitoring-center/archive/refs/tags/v${version}.tar.gz"
-checksum=0ae387300d5a30c1323cb6f0f037cfe0d304270560018bb41933046eb20b2763
+checksum=433e0e06ba2e49c81c19eaa47641a354a5bc4a866db6cbb59544a84943edc831


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, (x64 glibc)