### PR TITLE
python3-typing_extensions: update to 4.7.1.

### DIFF
--- a/srcpkgs/python3-typing_extensions/template
+++ b/srcpkgs/python3-typing_extensions/template
@@ -1,6 +1,6 @@
 # Template file for 'python3-typing_extensions'
 pkgname=python3-typing_extensions
-version=4.5.0
+version=4.7.1
 revision=1
 build_style=python3-pep517
 hostmakedepends="python3-flit_core"
@@ -11,7 +11,7 @@ license="Python-2.0"
 homepage="https://github.com/python/typing_extensions"
 changelog="https://github.com/python/typing_extensions/raw/main/CHANGELOG.md"
 distfiles="${PYPI_SITE}/t/typing_extensions/typing_extensions-${version}.tar.gz"
-checksum=5cb5f4a79139d699607b3ef622a1dedafa84e115ab0024e0d9c044a9479ca7cb
+checksum=b75ddc264f0ba5615db7ba217daeb99701ad295353c45f9e95963337ceeeffb2
 # Depends on the `test` module, which is intentionally not included in the
 # `python3` package.
 make_check=no


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
