### PR TITLE
inkscape: fix update-check

### DIFF
--- a/srcpkgs/inkscape/update
+++ b/srcpkgs/inkscape/update
@@ -1,2 +1,2 @@
 site="https://inkscape.org/release/"
-pattern='release/inkscape-\K[0-9.]+(?=/)'
+pattern='Inkscape \K[0-9.]+'


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

The old Regex also detects development releases (1.3), although it's not an official release yet. (Current should be 1.2.2).

cc @atk 