### PR TITLE
qflipper: update to 1.3.2.

### DIFF
--- a/srcpkgs/qflipper/template
+++ b/srcpkgs/qflipper/template
@@ -1,21 +1,21 @@
 # Template file for 'qflipper'
 pkgname=qflipper
-version=1.2.2
+version=1.3.2
 revision=1
 _nanopb_version=0.4.6
-create_wrksrc=yes
 build_style=qmake
 configure_args="CONFIG+=qtquickcompiler DEFINES+=DISABLE_APPLICATION_UPDATES"
-hostmakedepends="qt5-qmake pkg-config qt5-host-tools"
-makedepends="qt5-devel qt5-serialport-devel libusb-devel qt5-quickcontrols2-devel qt5-svg-devel qt5-declarative-devel"
-depends="qt5-graphicaleffects qt5-quickcontrols"
+hostmakedepends="pkg-config qt6-tools-devel"
+makedepends="qt6-serialport-devel qt6-declarative-devel qt6-wayland-devel
+ qt6-qt5compat-devel qt6-svg-devel libusb-devel"
+depends="qt6-plugin-tls-openssl"
 short_desc="Desktop application for updating Flipper Zero firmware via PC"
 maintainer="Toyam Cox <Vaelatern@voidlinux.org>"
 license="GPL-3.0-only"
 homepage="https://flipperzero.one"
 distfiles="https://github.com/flipperdevices/qFlipper/archive/refs/tags/${version}.tar.gz
  https://github.com/nanopb/nanopb/archive/refs/tags/${_nanopb_version}.tar.gz"
-checksum="486543a66fcf899073972d4f081f89a709a66628d71e9412c74be0a7a1fb79a7
+checksum="96c5d6e0c479128520800d97b080c5aa7efe72e4e44da07ae96aceb8155fa07e
  caa97d55fb9c98b4cfa0b069acd9657f706e9629af0baeaefcae0a0e8c4a64d2"
 
 post_extract() {


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc

---

Tagging the maintainer, @Vaelatern

---

Updated the build to Qt6, as well.