### PR TITLE
gnupg: update to 2.4.3.

### DIFF
--- a/srcpkgs/gnupg/patches/0002-Revert-gpg-Merge-rfc4880bis-features-into-gnupg.patch
+++ b/srcpkgs/gnupg/patches/0002-Revert-gpg-Merge-rfc4880bis-features-into-gnupg.patch
@@ -1,0 +1,210 @@
+From 810bc3c40fd262533f20e77a043b35583deeaa6e Mon Sep 17 00:00:00 2001
+From: psykose <alice@ayaya.dev>
+Date: Tue, 7 Feb 2023 10:14:34 +0100
+Subject: [PATCH 2/2] Revert "gpg: Merge --rfc4880bis features into --gnupg"
+
+This reverts commit 4583f4fe2e11b3dd070066628c3f16776cc74f72
+
+see:
+https://lore.kernel.org/distributions/F30D6590-3E0C-4865-A944-7DE118A619CF@gentoo.org/
+
+this reverts to the pre-2.4 default of key generation. the new one is
+(apparently) not compatible with a potential future specification, and
+generates incompatible keys by default.
+
+once this is figured out, find a better solution than this
+---
+ g10/gpg.c    | 35 ++++++++++++++++++++++++++++++++---
+ g10/keygen.c | 30 ++++++++++++++++++------------
+ 2 files changed, 50 insertions(+), 15 deletions(-)
+
+diff --git a/g10/gpg.c b/g10/gpg.c
+index 2ae3750a9..06b762ff7 100644
+--- a/g10/gpg.c
++++ b/g10/gpg.c
+@@ -249,6 +249,7 @@ enum cmd_and_opt_values
+     oGnuPG,
+     oRFC2440,
+     oRFC4880,
++    oRFC4880bis,
+     oOpenPGP,
+     oPGP7,
+     oPGP8,
+@@ -638,6 +639,7 @@ static gpgrt_opt_t opts[] = {
+   ARGPARSE_s_n (oGnuPG, "no-pgp8", "@"),
+   ARGPARSE_s_n (oRFC2440, "rfc2440", "@"),
+   ARGPARSE_s_n (oRFC4880, "rfc4880", "@"),
++  ARGPARSE_s_n (oRFC4880bis, "rfc4880bis", "@"),
+   ARGPARSE_s_n (oOpenPGP, "openpgp", N_("use strict OpenPGP behavior")),
+   ARGPARSE_s_n (oPGP7, "pgp6", "@"),
+   ARGPARSE_s_n (oPGP7, "pgp7", "@"),
+@@ -983,7 +985,6 @@ static gpgrt_opt_t opts[] = {
+   ARGPARSE_s_n (oNoop, "no-allow-multiple-messages", "@"),
+   ARGPARSE_s_s (oNoop, "aead-algo", "@"),
+   ARGPARSE_s_s (oNoop, "personal-aead-preferences","@"),
+-  ARGPARSE_s_n (oNoop, "rfc4880bis", "@"),
+   ARGPARSE_s_n (oNoop, "override-compliance-check", "@"),
+ 
+ 
+@@ -2232,7 +2233,7 @@ static struct gnupg_compliance_option compliance_options[] =
+   {
+     { "gnupg",      oGnuPG },
+     { "openpgp",    oOpenPGP },
+-    { "rfc4880bis", oGnuPG },
++    { "rfc4880bis", oRFC4880bis },
+     { "rfc4880",    oRFC4880 },
+     { "rfc2440",    oRFC2440 },
+     { "pgp6",       oPGP7 },
+@@ -2248,8 +2249,28 @@ static struct gnupg_compliance_option compliance_options[] =
+ static void
+ set_compliance_option (enum cmd_and_opt_values option)
+ {
++  opt.flags.rfc4880bis = 0;  /* Clear because it is initially set.  */
++
+   switch (option)
+     {
++    case oRFC4880bis:
++      opt.flags.rfc4880bis = 1;
++      opt.compliance = CO_RFC4880;
++      opt.flags.dsa2 = 1;
++      opt.flags.require_cross_cert = 1;
++      opt.rfc2440_text = 0;
++      opt.allow_non_selfsigned_uid = 1;
++      opt.allow_freeform_uid = 1;
++      opt.escape_from = 1;
++      opt.not_dash_escaped = 0;
++      opt.def_cipher_algo = 0;
++      opt.def_digest_algo = 0;
++      opt.cert_digest_algo = 0;
++      opt.compress_algo = -1;
++      opt.s2k_mode = 3; /* iterated+salted */
++      opt.s2k_digest_algo = DIGEST_ALGO_SHA256;
++      opt.s2k_cipher_algo = CIPHER_ALGO_AES256;
++      break;
+     case oOpenPGP:
+     case oRFC4880:
+       /* This is effectively the same as RFC2440, but with
+@@ -2293,6 +2314,7 @@ set_compliance_option (enum cmd_and_opt_values option)
+     case oPGP8:  opt.compliance = CO_PGP8;  break;
+     case oGnuPG:
+       opt.compliance = CO_GNUPG;
++      opt.flags.rfc4880bis = 1;
+       break;
+ 
+     case oDE_VS:
+@@ -2495,6 +2517,7 @@ main (int argc, char **argv)
+     opt.emit_version = 0;
+     opt.weak_digests = NULL;
+     opt.compliance = CO_GNUPG;
++    opt.flags.rfc4880bis = 1;
+ 
+     /* Check special options given on the command line.  */
+     orig_argc = argc;
+@@ -3041,6 +3064,7 @@ main (int argc, char **argv)
+           case oOpenPGP:
+           case oRFC2440:
+           case oRFC4880:
++          case oRFC4880bis:
+           case oPGP7:
+           case oPGP8:
+           case oGnuPG:
+@@ -3883,6 +3907,11 @@ main (int argc, char **argv)
+     if( may_coredump && !opt.quiet )
+ 	log_info(_("WARNING: program may create a core file!\n"));
+ 
++    if (!opt.flags.rfc4880bis)
++      {
++        opt.mimemode = 0; /* This will use text mode instead.  */
++      }
++
+     if (eyes_only) {
+       if (opt.set_filename)
+ 	  log_info(_("WARNING: %s overrides %s\n"),
+@@ -4099,7 +4128,7 @@ main (int argc, char **argv)
+     /* Check our chosen algorithms against the list of legal
+        algorithms. */
+ 
+-    if(!GNUPG)
++    if(!GNUPG && !opt.flags.rfc4880bis)
+       {
+ 	const char *badalg=NULL;
+ 	preftype_t badtype=PREFTYPE_NONE;
+diff --git a/g10/keygen.c b/g10/keygen.c
+index d5099dbb9..58bc9caba 100644
+--- a/g10/keygen.c
++++ b/g10/keygen.c
+@@ -404,7 +404,7 @@ keygen_set_std_prefs (const char *string,int personal)
+ 	      strcat(dummy_string,"S7 ");
+ 	    strcat(dummy_string,"S2 "); /* 3DES */
+ 
+-            if (!openpgp_aead_test_algo (AEAD_ALGO_OCB))
++            if (opt.flags.rfc4880bis && !openpgp_aead_test_algo (AEAD_ALGO_OCB))
+ 	      strcat(dummy_string,"A2 ");
+ 
+             if (personal)
+@@ -889,7 +889,7 @@ keygen_upd_std_prefs (PKT_signature *sig, void *opaque)
+   /* Make sure that the MDC feature flag is set if needed.  */
+   add_feature_mdc (sig,mdc_available);
+   add_feature_aead (sig, aead_available);
+-  add_feature_v5 (sig, 1);
++  add_feature_v5 (sig, opt.flags.rfc4880bis);
+   add_keyserver_modify (sig,ks_modify);
+   keygen_add_keyserver_url(sig,NULL);
+ 
+@@ -3382,7 +3382,10 @@ parse_key_parameter_part (ctrl_t ctrl,
+                 }
+             }
+           else if (!ascii_strcasecmp (s, "v5"))
+-            keyversion = 5;
++            {
++              if (opt.flags.rfc4880bis)
++                keyversion = 5;
++            }
+           else if (!ascii_strcasecmp (s, "v4"))
+             keyversion = 4;
+           else
+@@ -3641,7 +3644,7 @@ parse_key_parameter_part (ctrl_t ctrl,
+  *   ecdsa := Use algorithm ECDSA.
+  *   eddsa := Use algorithm EdDSA.
+  *   ecdh  := Use algorithm ECDH.
+- *   v5    := Create version 5 key
++ *   v5    := Create version 5 key (requires option --rfc4880bis)
+  *
+  * There are several defaults and fallbacks depending on the
+  * algorithm.  PART can be used to select which part of STRING is
+@@ -4513,9 +4516,9 @@ read_parameter_file (ctrl_t ctrl, const char *fname )
+ 	    }
+ 	}
+ 
+-        if ((keywords[i].key == pVERSION
+-             || keywords[i].key == pSUBVERSION))
+-          ; /* Ignore version.  */
++        if (!opt.flags.rfc4880bis && (keywords[i].key == pVERSION
++                                      || keywords[i].key == pSUBVERSION))
++          ; /* Ignore version unless --rfc4880bis is active.  */
+         else
+           {
+             r = xmalloc_clear( sizeof *r + strlen( value ) );
+@@ -4610,11 +4613,14 @@ quickgen_set_para (struct para_data_s *para, int for_subkey,
+       para = r;
+     }
+ 
+-  r = xmalloc_clear (sizeof *r + 20);
+-  r->key = for_subkey? pSUBVERSION : pVERSION;
+-  snprintf (r->u.value, 20, "%d", version);
+-  r->next = para;
+-  para = r;
++  if (opt.flags.rfc4880bis)
++    {
++      r = xmalloc_clear (sizeof *r + 20);
++      r->key = for_subkey? pSUBVERSION : pVERSION;
++      snprintf (r->u.value, 20, "%d", version);
++      r->next = para;
++      para = r;
++    }
+ 
+   if (keytime)
+     {
+-- 
+2.41.0
+

--- a/srcpkgs/gnupg/template
+++ b/srcpkgs/gnupg/template
@@ -1,6 +1,7 @@
 # Template file for 'gnupg'
+# minor version updates (2.3-> 2.4) often need a fix in reverse dependencies
 pkgname=gnupg
-version=2.4.0
+version=2.4.3
 revision=1
 # We're building outside of the source tree, because upstream told us to:
 # https://dev.gnupg.org/T6313#166339
@@ -23,7 +24,7 @@ maintainer="Jan Christian Grünhage <jan.christian@gruenhage.xyz>"
 license="GPL-3.0-or-later"
 homepage="https://www.gnupg.org/"
 distfiles="https://gnupg.org/ftp/gcrypt/gnupg/gnupg-${version}.tar.bz2"
-checksum=1d79158dd01d992431dd2e3facb89fdac97127f89784ea2cb610c600fb0c1483
+checksum=a271ae6d732f6f4d80c258ad9ee88dd9c94c8fdc33c3e45328c4d7c126bd219d
 make_check_pre='env TESTFLAGS="--parallel=${XBPS_MAKEJOBS}"'
 build_options="ldap"
 build_options_default="ldap"
@@ -34,7 +35,6 @@ post_extract() {
 
 post_install() {
 	vmkdir usr/share/examples
-	rm -r $DESTDIR/usr/share/doc/gnupg/examples/systemd-user
 	mv ${DESTDIR}/usr/share/doc/gnupg/examples \
 		${DESTDIR}/usr/share/examples/gnupg
 }

--- a/srcpkgs/libgpg-error/template
+++ b/srcpkgs/libgpg-error/template
@@ -1,6 +1,6 @@
 # Template file for 'libgpg-error'
 pkgname=libgpg-error
-version=1.46
+version=1.47
 revision=1
 build_style=gnu-configure
 configure_args="--enable-install-gpg-error-config"
@@ -9,7 +9,7 @@ maintainer="Jan Christian Grünhage <jan.christian@gruenhage.xyz>"
 license="LGPL-2.1-or-later, GPL-2.0-or-later"
 homepage="https://www.gnupg.org"
 distfiles="https://www.gnupg.org/ftp/gcrypt/${pkgname}/${pkgname}-${version}.tar.bz2"
-checksum=b7e11a64246bbe5ef37748de43b245abd72cfcd53c9ae5e7fc5ca59f1c81268d
+checksum=9e3c670966b96ecc746c28c2c419541e3bcb787d1a73930f5e5f5e1bcbbb9bdb
 
 if [ "$CROSS_BUILD" ]; then
 	hostmakedepends="qemu-user-static"

--- a/srcpkgs/libksba/template
+++ b/srcpkgs/libksba/template
@@ -1,6 +1,6 @@
 # Template file for 'libksba'
 pkgname=libksba
-version=1.6.3
+version=1.6.4
 revision=1
 build_style=gnu-configure
 makedepends="libgpg-error-devel"
@@ -9,7 +9,7 @@ maintainer="Jan Christian Grünhage <jan.christian@gruenhage.xyz>"
 license="GPL-2.0-or-later,LGPL-3.0-or-later"
 homepage="https://www.gnupg.org/related_software/libksba/index.html"
 distfiles="https://gnupg.org/ftp/gcrypt/libksba/libksba-${version}.tar.bz2"
-checksum=3f72c68db30971ebbf14367527719423f0a4d5f8103fc9f4a1c01a9fa440de5c
+checksum=bbb43f032b9164d86c781ffe42213a83bf4f2fee91455edfa4654521b8b03b6b
 
 libksba-devel_package() {
 	depends="libgpg-error-devel ${sourcepkg}>=${version}_${revision}"


### PR DESCRIPTION
#### Changes included in PR
- libksba: update to 1.6.4.
- libgpg-error: update to 1.47.
- gnupg: update to 2.4.3.
- gnupg: add a patch to do RFC conform PGP by default again, stolen from alpine

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
