### PR TITLE
jupyterlab: add missing dependency

### DIFF
--- a/srcpkgs/jupyterlab/template
+++ b/srcpkgs/jupyterlab/template
@@ -1,12 +1,12 @@
 # Template file for 'jupyterlab'
 pkgname=jupyterlab
 version=3.5.0
-revision=2
+revision=3
 build_style=python3-module
 hostmakedepends="python3-setuptools"
 depends="python3-jupyterlab_server nodejs python3-nbclassic
  python3-requests-unixsocket python3-jupyter_ipywidgets
- python3-notebook_shim"
+ python3-notebook_shim python3-tomli"
 short_desc="JupyterLab computational environment"
 maintainer="dkwo <nicolopiazzalunga@gmail.com>"
 license="custom:jupyterlab"


### PR DESCRIPTION
needed for `jupyter labextension` functionality

@dkwo

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**
