### PR TITLE
New package: UxPlay-1.68.3

### DIFF
--- a/srcpkgs/UxPlay/files/README.voidlinux
+++ b/srcpkgs/UxPlay/files/README.voidlinux
@@ -1,0 +1,5 @@
+Additional GStreamer plugins you may need to install:
+- `gstreamer-vaapi` is needed for hardware-accelerated h264 video decoding by Intel or AMD graphics (but not for use with NVIDIA using proprietary drivers)
+- `gstreamer1-pipewire` may be needed for audio sharing when your system is set up to use pipewire
+
+Additionally, UxPlay requires a running DNS-SD server (for example `avahi`).

--- a/srcpkgs/UxPlay/template
+++ b/srcpkgs/UxPlay/template
@@ -1,0 +1,21 @@
+# Template file for 'UxPlay'
+pkgname=UxPlay
+version=1.68.3
+revision=1
+build_style=cmake
+configure_args="-DNO_MARCH_NATIVE=ON"
+hostmakedepends="pkg-config"
+makedepends="openssl-devel libplist-devel avahi-compat-libs-devel gstreamer1-devel gst-plugins-base1-devel libX11-devel"
+depends="gst-plugins-base1 gst-libav gst-plugins-good1 gst-plugins-bad1"
+short_desc="AirPlay Unix mirroring server"
+maintainer="T0mstone <realt0mstone@gmail.com>"
+license="GPL-3.0-or-later"
+homepage="https://github.com/FDH2/UxPlay"
+changelog="https://github.com/FDH2/UxPlay/releases"
+distfiles="https://github.com/FDH2/UxPlay/archive/refs/tags/v${version}.tar.gz"
+checksum=aa3f15e6a8568fdc3ad1f0a02956178964ca122e9bcdbff544e25a59a61127ae
+
+post_install() {
+	vdoc ${FILESDIR}/README.voidlinux
+	mv $DESTDIR/usr/share/doc/uxplay/* $DESTDIR/usr/share/doc/UxPlay/
+}


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->
Spiritual successor to #33191.

#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl

#### OpenSSL
> UxPlay's GPLv3 license does not have an added "GPL exception" explicitly allowing it to be distributed in compiled form when linked to OpenSSL versions prior to v. 3.0.0 (older versions of OpenSSL have a license clause incompatible with the GPL unless OpenSSL can be regarded as a "System Library", which it is in *BSD). Many Linux distributions treat OpenSSL as a "System Library", but some (e.g. Debian) do not: in this case, the issue is solved by linking with OpenSSL-3.0.0 or later.

~~How does Void handle this? Can OpenSSL be considered a "System Library"? Once #37681 lands, this won't be a concern anymore, of course. Until then, I've made the package `restricted=yes` for now.~~

**Update**: Since OpenSSL is now on version 3, I have removed the restriction.