### PR TITLE
pkgconf: move to new domain

### DIFF
--- a/srcpkgs/pkgconf/template
+++ b/srcpkgs/pkgconf/template
@@ -10,7 +10,7 @@ maintainer="Enno Boland <gottox@voidlinux.org>"
 license="MIT"
 homepage="http://pkgconf.org/"
 changelog="https://raw.githubusercontent.com/pkgconf/pkgconf/master/NEWS"
-distfiles="https://distfiles.dereferenced.org/pkgconf/pkgconf-${version}.tar.xz"
+distfiles="https://distfiles.ariadne.space/pkgconf/pkgconf-${version}.tar.xz"
 checksum=5fb355b487d54fb6d341e4f18d4e2f7e813a6622cf03a9e87affa6a40565699d
 
 alternatives="


### PR DESCRIPTION
dereferenced.org has been hijacked, see https://social.treehouse.systems/@ariadne/110643909699308207.