### PR TITLE
linux6.3: update to 6.3.12

### DIFF
--- a/srcpkgs/linux6.3/template
+++ b/srcpkgs/linux6.3/template
@@ -1,6 +1,6 @@
 # Template file for 'linux6.3'
 pkgname=linux6.3
-version=6.3.10
+version=6.3.12
 revision=1
 short_desc="Linux kernel and modules (${version%.*} series)"
 maintainer="Đoàn Trần Công Danh <congdanhqx@gmail.com>"
@@ -14,7 +14,7 @@ if [ "${version##*.}" != 0 ]; then
 fi
 
 checksum="ba3491f5ed6bd270a370c440434e3d69085fcdd528922fa01e73d7657db73b1e
- 74d4dfb345540e91de4b41cbe9d81d2e5f90a2777419beac97c80cf6578408b1"
+ 37c340dc4c902708e9c224b9792db6fb7617683d8d8a77c703cfd76dbf3794c0"
 python_version=3
 
 # XXX Restrict archs until a proper <arch>-dotconfig is available in FILESDIR.


### PR DESCRIPTION
- I tested the changes in this PR: no

https://www.bleepingcomputer.com/news/security/new-stackrot-linux-kernel-flaw-allows-privilege-escalation/

[ci skip]