### PR TITLE
dolphin-emu: update to 5.0.19368.

### DIFF
--- a/srcpkgs/dolphin-emu/patches/0001-Add-musl-fix.patch
+++ b/srcpkgs/dolphin-emu/patches/0001-Add-musl-fix.patch
@@ -1,0 +1,39 @@
+From 3a08670281daa82c75a96a6076f00d42280cb309 Mon Sep 17 00:00:00 2001
+From: AnErrupTion <anerruption@disroot.org>
+Date: Fri, 7 Jul 2023 18:31:59 +0200
+Subject: [PATCH] Add musl fix
+
+---
+ Source/Core/Common/Network.cpp | 9 ++++++++-
+ 1 file changed, 8 insertions(+), 1 deletion(-)
+
+diff --git a/Source/Core/Common/Network.cpp b/Source/Core/Common/Network.cpp
+index a5e56b74d2..3e1d47b279 100644
+--- a/Source/Core/Common/Network.cpp
++++ b/Source/Core/Common/Network.cpp
+@@ -18,6 +18,13 @@
+ 
+ #include <fmt/format.h>
+ 
++#define _GNU_SOURCE
++#include <features.h>
++#ifndef __USE_GNU
++    #define __MUSL__ 
++#endif
++#undef _GNU_SOURCE
++
+ #include "Common/BitUtils.h"
+ #include "Common/Random.h"
+ #include "Common/StringUtil.h"
+@@ -563,7 +570,7 @@ const char* DecodeNetworkError(s32 error_code)
+                  sizeof(buffer), nullptr);
+   return buffer;
+ #elif defined(IS_BSD_STRERROR) ||                                                                  \
+-    ((_POSIX_C_SOURCE >= 200112L || _XOPEN_SOURCE >= 600) && !_GNU_SOURCE)
++    ((_POSIX_C_SOURCE >= 200112L || _XOPEN_SOURCE >= 600) && !_GNU_SOURCE) || defined(__MUSL__)
+   strerror_r(error_code, buffer, sizeof(buffer));
+   return buffer;
+ #else
+-- 
+2.41.0
+

--- a/srcpkgs/dolphin-emu/template
+++ b/srcpkgs/dolphin-emu/template
@@ -1,20 +1,29 @@
 # Template file for 'dolphin-emu'
 pkgname=dolphin-emu
-version=5.0.16101
+version=5.0.19368
 revision=1
-_dolphin_commit=8ecfa537a242de74d2e372e30d9d79b14584b2fb
-_mgba_commit=40d4c430fc36caeb7ea32fd39624947ed487d2f2
+_dolphin_commit=dadbeb4bae7e7fa23af2b46e0add4143094dc107
+_mgba_commit=44e074a15e9651481f7f652ac006a7c9d58cbeb9
+_googletest_commit=be03d00f5f0cc3a997d1a368bee8a1fe93651f48
+_zlib_ng_commit=cf89cf35037f152ce7adfeca864656de5d33ea1e
+_cubeb_commit=27d2a102b0b75d9e49d43bc1ea516233fb87d778
+_sanitizers_cmake_commit=c3dc841af4dbf44669e65b82cb68a575864326bd
+_implot_commit=cc5e1daa5c7f2335a9460ae79c829011dc5cef2d
+_libspng_commit=e5c1fc470fceaca08b8c30dc40768c28b82b9e12
+_rcheevos_commit=3af1e2fc5188d6e932ee379942f4049ea877e648
+_vma_commit=d9a2e4641ba4808e803ff555be132f280366ab47
+_spirv_cross_commit=b8e742c91ba47eb3238c939ee11ec9ba2ba247bf
 #Version/hash pair can be found at https://dolphin-emu.org/download/
-archs="x86_64* aarch64* ppc64le* i686*"
+archs="x86_64* aarch64* ppc64le*"
 create_wrksrc=yes
 build_style=cmake
 configure_args="-DUSE_SHARED_ENET=ON
  -DDOLPHIN_WC_DESCRIBE=${version%.*}-${version##*.}
  -DDOLPHIN_WC_REVISION=$_dolphin_commit
  -DDOLPHIN_WC_BRANCH=master"
-hostmakedepends="pkg-config qt5-host-tools qt5-qmake"
+hostmakedepends="pkg-config qt6-tools qt6-base gettext-devel"
 makedepends="
- zlib-devel glew-devel libusb-devel qt5-devel miniupnpc-devel libevdev-devel
+ zlib-devel glew-devel libusb-devel qt6-base-devel miniupnpc-devel libevdev-devel
  SDL2-devel pulseaudio-devel alsa-lib-devel ffmpeg-devel libgomp-devel libcurl-devel
  portaudio-devel libopenal-devel soundtouch-devel lzo-devel libbluetooth-devel
  mbedtls-devel SFML-devel libenet-devel liblzma-devel pugixml-devel"
@@ -24,9 +33,27 @@ maintainer="Henry Naguski <henry@nilsu.org>"
 license="GPL-2.0-or-later"
 homepage="http://dolphin-emu.org"
 distfiles="https://github.com/dolphin-emu/dolphin/archive/${_dolphin_commit}.tar.gz
- https://github.com/mgba-emu/mgba/archive/${_mgba_commit}.tar.gz"
-checksum="a7bff69fce6466668c36e6c7ac3838434d64bb315cd2ad22817c943a9887f6e5
- 3cabf00a97cf4fb15fe8524b3d02190acdd003f25967cdbbf8de958649b8061b"
+ https://github.com/mgba-emu/mgba/archive/${_mgba_commit}.tar.gz
+ https://github.com/google/googletest/archive/${_googletest_commit}.tar.gz
+ https://github.com/zlib-ng/zlib-ng/archive/${_zlib_ng_commit}.tar.gz
+ https://github.com/mozilla/cubeb/archive/${_cubeb_commit}.tar.gz
+ https://github.com/arsenm/sanitizers-cmake/archive/${_sanitizers_cmake_commit}.tar.gz
+ https://github.com/epezent/implot/archive/${_implot_commit}.tar.gz
+ https://github.com/randy408/libspng/archive/${_libspng_commit}.tar.gz
+ https://github.com/RetroAchievements/rcheevos/archive/${_rcheevos_commit}.tar.gz
+ https://github.com/GPUOpen-LibrariesAndSDKs/VulkanMemoryAllocator/archive/${_vma_commit}.tar.gz
+ https://github.com/KhronosGroup/SPIRV-Cross/archive/${_spirv_cross_commit}.tar.gz"
+checksum="ef9af8103ec35808a6250b7eadda1a33877719ffb2aad2d65571843e7ae0f69a
+ 9fed790727c64dd113b32445061a890d33bf12d237aacef533d818a0721534f0
+ 92c9f67f20c6cc71589408d6d7d25e8c82df045b432da5993b51837e637b93fa
+ d151f75cb7f3d26b3901ab6962dbe2469a49980e52dd48f8571f057ee2c07c1b
+ 9326a22d41b30b6d613c248a8ea2eb56c5ffc76a7080b0127165682fd8eba13e
+ 19d511a3a4ddc872c89ab62c070dd8d1fcc733e6ea4655f5876a60237cd556ba
+ af51940ae6482c0e96ffb4309982fa309f9aa383cd8f980081681010c8c3a835
+ e3094cf323d7b5c3a69210c2a8d97725b8ec2867aa83007b864c2c468e63b468
+ 2350d4479a9ca725a269eee5c1aeccf3e54ea2cf7bf9dd82bd0f07c59f96f5bd
+ 5e12a559454dfdf46a7935f33c759f2e2fb2f59539aeec8779d5f32375c91c4b
+ 6f65717f6b4b4cf1a5f37bcc60708b6a78f6ae316d460107ad57b8b15f7a2b42"
 nopie=yes
 
 case "$XBPS_TARGET_MACHINE" in
@@ -37,7 +64,27 @@ esac
 post_extract() {
 	mv dolphin-${_dolphin_commit}/* .
 	rmdir Externals/mGBA/mgba
+	rmdir Externals/cubeb/cubeb
+	rmdir Externals/gtest
+	rmdir Externals/zlib-ng/zlib-ng
+	rmdir Externals/implot/implot
+	rmdir Externals/libspng/libspng
+	rmdir Externals/rcheevos/rcheevos
+	rmdir Externals/VulkanMemoryAllocator
+	rmdir Externals/spirv_cross/SPIRV-Cross
 	mv mgba-${_mgba_commit} Externals/mGBA/mgba
+	mv cubeb-${_cubeb_commit} Externals/cubeb/cubeb
+	cp -r googletest-${_googletest_commit} Externals/gtest
+	mv zlib-ng-${_zlib_ng_commit} Externals/zlib-ng/zlib-ng
+	mv implot-${_implot_commit} Externals/implot/implot
+	mv libspng-${_libspng_commit} Externals/libspng/libspng
+	mv rcheevos-${_rcheevos_commit} Externals/rcheevos/rcheevos
+	mv VulkanMemoryAllocator-${_vma_commit} Externals/VulkanMemoryAllocator
+	mv SPIRV-Cross-${_spirv_cross_commit} Externals/spirv_cross/SPIRV-Cross
+	rmdir Externals/cubeb/cubeb/googletest
+	rmdir Externals/cubeb/cubeb/cmake/sanitizers-cmake
+	mv googletest-${_googletest_commit} Externals/cubeb/cubeb/googletest
+	mv sanitizers-cmake-${_sanitizers_cmake_commit} Externals/cubeb/cubeb/cmake/sanitizers-cmake
 }
 
 post_install() {


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-glibc
  - x86_64-musl

I've added a patch to fix builds on musl, as well as removing the i686 target (Dolphin stopped supported i686).