### PR TITLE
lua-language-server: update to 3.6.23.

### DIFF
--- a/srcpkgs/lua-language-server/template
+++ b/srcpkgs/lua-language-server/template
@@ -1,6 +1,6 @@
 # Template file for 'lua-language-server'
 pkgname=lua-language-server
-version=3.6.22
+version=3.6.23
 revision=1
 hostmakedepends="ninja"
 short_desc="Lua LSP implementation written in Lua"
@@ -9,7 +9,7 @@ license="MIT"
 homepage="https://github.com/LuaLS/lua-language-server"
 changelog="https://raw.githubusercontent.com/LuaLS/lua-language-server/master/changelog.md"
 distfiles="https://github.com/LuaLS/lua-language-server/releases/download/${version}/lua-language-server-${version}-submodules.zip"
-checksum=e4bb02a5e32f0af584298da424ad3a0517bd1b9b359cc88c0d64d02a5452608f
+checksum=039de8c34b8d9db0bc350e19391e4e437b362b7d2016fde9bc3ff3588e6787cb
 
 do_build() {
 	ninja -C 3rd/luamake -f compile/ninja/linux.ninja


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
