### PR TITLE
ci: add step to verify the functionality of update-check

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -37,7 +37,7 @@ jobs:
           # Upgrade again (in case there was a xbps update)
           xbps-install -yu
           # install tools needed for lints
-          xbps-install -y grep
+          xbps-install -y grep curl
       - name: Clone and checkout
         uses: classabbyamp/treeless-checkout-action@v1
       - name: Create hostrepo and prepare masterdir
@@ -47,7 +47,12 @@ jobs:
          common/travis/prepare.sh &&
          common/travis/fetch-xtools.sh
       - run: common/travis/changed_templates.sh
-      - run: common/travis/xlint.sh
+      - name: Run lints
+        run: |
+          rv=0
+          common/travis/xlint.sh || rv=1
+          common/travis/verify-update-check.sh || rv=1
+          exit $rv
 
   # Build changed packages.
   build:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,17 +20,33 @@ jobs:
     name: Lint templates
     runs-on: ubuntu-latest
 
-    env:
-      PATH: '/usr/libexec/chroot-git:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/sbin:/usr/local/bin:/tmp/bin'
-      XLINT: '1'
-      LICENSE_LIST: common/travis/license.lst
+    container:
+      image: 'ghcr.io/void-linux/void-buildroot-musl:20230904R2'
+      env:
+        PATH: '/usr/libexec/chroot-git:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/sbin:/usr/local/bin:/tmp/bin'
+        LICENSE_LIST: common/travis/license.lst
 
     steps:
+      - name: Prepare container
+        run: |
+          # switch to repo-ci mirror
+          mkdir -p /etc/xbps.d && cp /usr/share/xbps.d/*-repository-*.conf /etc/xbps.d/
+          sed -i 's|repo-default|repo-ci|g' /etc/xbps.d/*-repository-*.conf
+          # Sync and upgrade once, assume error comes from xbps update
+          xbps-install -Syu || xbps-install -yu xbps
+          # Upgrade again (in case there was a xbps update)
+          xbps-install -yu
+          # install tools needed for lints
+          xbps-install -y grep
       - name: Clone and checkout
         uses: classabbyamp/treeless-checkout-action@v1
+      - name: Create hostrepo and prepare masterdir
+        run: |
+         ln -s "$(pwd)" /hostrepo &&
+         common/travis/set_mirror.sh &&
+         common/travis/prepare.sh &&
+         common/travis/fetch-xtools.sh
       - run: common/travis/changed_templates.sh
-      - run: common/travis/fetch-xbps.sh
-      - run: common/travis/fetch-xtools.sh
       - run: common/travis/xlint.sh
 
   # Build changed packages.

--- a/Manual.md
+++ b/Manual.md
@@ -905,6 +905,10 @@ in url. Defaults to `(|v|$pkgname)[-_.]*`.
 part that follows numeric part of version directory
 in url. Defaults to `(|\.x)`.
 
+- `disabled` can be set to disable update checking for the package,
+in cases where checking for updates is impossible or does not make sense.
+This should be set to a string describing why it is disabled.
+
 <a id="patches"></a>
 ### Handling patches
 

--- a/common/travis/prepare.sh
+++ b/common/travis/prepare.sh
@@ -2,8 +2,6 @@
 #
 # prepare.sh
 
-[ "$XLINT" ] && exit 0
-
 /bin/echo -e '\x1b[32mUpdating etc/conf...\x1b[0m'
 echo XBPS_BUILD_ENVIRONMENT=void-packages-ci >> etc/conf
 echo XBPS_ALLOW_RESTRICTED=yes >> etc/conf

--- a/common/travis/verify-update-check.sh
+++ b/common/travis/verify-update-check.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+# runs update-check on all changed templates, then errors only if there was an
+# issue with the update-check. does not error if further updates are available,
+# as there may be a good reason not to update to those versions
+
+set -e
+
+export XBPS_UPDATE_CHECK_VERBOSE=yes
+err=0
+
+while read -r pkg; do
+	/bin/echo -e "\x1b[34mVerifying update-check of $pkg:\x1b[0m"
+	./xbps-src update-check "$pkg" 2>&1 > /tmp/update-check.log || err=1
+	cat /tmp/update-check.log
+	if grep -q 'NO VERSION' /tmp/update-check.log; then
+		echo "::warning file=srcpkgs/$pkg/template,line=1,title=update-check failed::verify and fix update-check for $pkg"
+	fi
+done < /tmp/templates
+
+exit $err

--- a/common/travis/xlint.sh
+++ b/common/travis/xlint.sh
@@ -2,8 +2,6 @@
 #
 # xlint.sh
 
-[ "$XLINT" ] || exit 0
-
 EXITCODE=0
 read base tip < /tmp/revisions
 

--- a/common/xbps-src/shutils/update_check.sh
+++ b/common/xbps-src/shutils/update_check.sh
@@ -13,6 +13,9 @@ update_check() {
         if [ "$XBPS_UPDATE_CHECK_VERBOSE" ]; then
             echo "using $XBPS_TARGET_PKG/update overrides" 1>&2
         fi
+        if [ -n "$disabled" ]; then
+            echo "update-check DISABLED for $original_pkgname: $disabled" 1>&2
+        fi
     elif [ -z "$distfiles" ]; then
         if [ "$XBPS_UPDATE_CHECK_VERBOSE" ]; then
             echo "NO DISTFILES found for $original_pkgname" 1>&2


### PR DESCRIPTION
runs update-check on all changed templates, then errors only if there was an issue with the update-check. does not error if further updates are available, as there may be a good reason not to update to those versions

example output: 
![image](https://github.com/void-linux/void-packages/assets/5366828/e3d8d36d-c22a-4095-a570-4defd5c29747)


#### Testing the changes
- I tested the changes in this PR: **YES**

