### PR TITLE
common/travis/xlint: make xlint only fatal for new templates

### DIFF
--- a/common/travis/changed_templates.sh
+++ b/common/travis/changed_templates.sh
@@ -20,9 +20,17 @@ base="$(git merge-base origin/HEAD "$tip")"
 echo "$base $tip" >/tmp/revisions
 
 /bin/echo -e '\x1b[32mChanged packages:\x1b[0m'
-git diff-tree -r --no-renames --name-only --diff-filter=AM \
+git diff-tree -r --no-renames --name-only --diff-filter=M \
 	"$base" "$tip" \
 	-- 'srcpkgs/*/template' |
 	cut -d/ -f 2 |
 	tee /tmp/templates |
+	sed "s/^/  /" >&2
+/bin/echo -e '\x1b[32mNew packages:\x1b[0m'
+git diff-tree -r --no-renames --name-only --diff-filter=A \
+	"$base" "$tip" \
+	-- 'srcpkgs/*/template' |
+	cut -d/ -f 2 |
+	tee -a /tmp/templates |
+	tee /tmp/new-templates |
 	sed "s/^/  /" >&2

--- a/common/travis/xlint.sh
+++ b/common/travis/xlint.sh
@@ -11,8 +11,13 @@ common/scripts/lint-commits $base $tip || EXITCODE=$?
 
 for t in $(awk '{ print "srcpkgs/" $0 "/template" }' /tmp/templates); do
 	/bin/echo -e "\x1b[32mLinting $t...\x1b[0m"
-	xlint "$t" > /tmp/xlint_out || EXITCODE=$?
-	common/scripts/lint-version-change "$t" $base $tip > /tmp/vlint_out || EXITCODE=$?
+	if grep -q "^$t\$" /tmp/new-templates; then
+		# only fatal if xlint fails for new templates
+		xlint "$t" > /tmp/xlint_out || EXITCODE=$?
+	else
+		xlint "$t" > /tmp/xlint_out || true
+	fi
+	common/scripts/lint-version-change "srcpkgs/$t/template" $base $tip > /tmp/vlint_out || EXITCODE=$?
 	awk -f common/scripts/lint2annotations.awk /tmp/xlint_out /tmp/vlint_out
 done
 exit $EXITCODE


### PR DESCRIPTION
per discussion on irc, to help updates and other changes go more smoothly, xlint should only cause a CI failure if the linted template is new.

examples:
- succeeds because only a changed template errors: https://github.com/void-linux/void-packages/actions/runs/5496798220/jobs/10017025380
- fails because of a new package with errors: https://github.com/void-linux/void-packages/actions/runs/5496783595/jobs/10017001341

this does not affect the *reporting* of lint issues, those are still produced as annotations on the 'files changed' tab.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

