### PR TITLE
libinput-debug-gui: update to 1.23.0, add update-check

### DIFF
--- a/srcpkgs/libinput-debug-gui/template
+++ b/srcpkgs/libinput-debug-gui/template
@@ -2,19 +2,20 @@
 # keep in sync with libinput
 # split to avoid cycle: gst-plugins-bad1 -> zbar -> qt5 -> libinput -> gtk4 -> gst-plugins-bad1
 pkgname=libinput-debug-gui
-version=1.21.0
+version=1.23.0
 revision=1
 build_style=meson
 configure_args="-Db_ndebug=false -Dtests=false -Ddebug-gui=true"
 hostmakedepends="pkg-config wayland-devel"
 makedepends="libevdev-devel libwacom-devel mtdev-devel eudev-libudev-devel
  gtk4-devel"
+checkdepends="valgrind check-devel python3-pytest"
 short_desc="Provides handling input devices in Wayland compositors and X"
 maintainer="Michal Vasilek <michal@vasilek.cz>"
 license="MIT"
 homepage="https://www.freedesktop.org/wiki/Software/libinput"
 distfiles="https://gitlab.freedesktop.org/libinput/libinput/-/archive/${version}/libinput-${version}.tar.gz"
-checksum=1b23c180f5b297303ed36f5a549910f5d320b0eb21052eac67a966d4eaa4e01d
+checksum=7a7c90fbc59f1f65c781a51fa634e4f79e460bf6e16ad68afbe7965d25d09738
 
 post_install() {
 	mv ${DESTDIR}/usr/libexec/libinput/libinput-debug-gui ${DESTDIR}/libinput-debug-gui

--- a/srcpkgs/libinput-debug-gui/update
+++ b/srcpkgs/libinput-debug-gui/update
@@ -1,0 +1,2 @@
+pattern="libinput \K[\d.]+(?=</a>)"
+ignore="*.99.* *.9[0-9][0-9]"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - armv6l