### PR TITLE
gitoxide: update to 0.27.0.

### DIFF
--- a/srcpkgs/gitoxide/template
+++ b/srcpkgs/gitoxide/template
@@ -1,8 +1,11 @@
 # Template file for 'gitoxide'
 pkgname=gitoxide
-version=0.23.0
+version=0.27.0
 revision=1
 build_style=cargo
+# Disabling cargo-auditable for now due to
+# https://github.com/rust-secure-code/cargo-auditable/issues/124
+make_cmd=cargo
 hostmakedepends="pkg-config cmake"
 makedepends="zlib-devel openssl-devel"
 short_desc="Idiomatic, lean, fast and safe pure Rust implementation of Git"
@@ -11,7 +14,7 @@ license="MIT, Apache-2.0"
 homepage="https://github.com/Byron/gitoxide"
 changelog="https://github.com/Byron/gitoxide/raw/main/CHANGELOG.md"
 distfiles="https://github.com/Byron/gitoxide/archive/refs/tags/v${version}.tar.gz"
-checksum=45b4fc2fc6f5f1ed9fb019cbae8633b6a3129f349182774b5b8c601bbb3e17db
+checksum=5055074b1dca11bb6ed5ca0b04c87393cf955ca6a536071ea702127cc7907d39
 
 post_install() {
 	vlicense LICENSE-APACHE


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

This PR disables cargo-auditable for gitoxide temporarily, as it fails to build when cargo-auditable is used. This is reproducible both within void-packages, as well as when using rustup and building it out of tree.

Reported upstream at https://github.com/rust-secure-code/cargo-auditable/issues/124, although I'm not sure whether it belongs there or with gitoxide. As it's cargo-auditable that's panic'ing, I've opened the issue there.
<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
