### PR TITLE
nss: ship libfreeblpriv3.so

### DIFF
--- a/srcpkgs/nss/template
+++ b/srcpkgs/nss/template
@@ -4,7 +4,7 @@ _nsprver=4.35
 
 pkgname=nss
 version=3.91
-revision=1
+revision=2
 hostmakedepends="perl which"
 makedepends="nspr-devel sqlite-devel zlib-devel"
 depends="nspr>=${_nsprver}"
@@ -21,7 +21,6 @@ export BUILD_OPT=1
 export NSS_USE_SYSTEM_SQLITE=1
 export NSS_ENABLE_WERROR=0
 export NSS_ENABLE_ECC=1
-export FREEBL_NO_DEPEND=1
 export NSPR_INCLUDE_DIR=${XBPS_CROSS_BASE}/usr/include/nspr
 export NSPR_LIB_DIR=${XBPS_CROSS_BASE}/usr/lib
 
@@ -109,7 +108,7 @@ do_install() {
 		> ${DESTDIR}/usr/bin/nss-config
 	chmod 755 ${DESTDIR}/usr/bin/nss-config
 
-	for f in libsoftokn3.so libfreebl3.so libnss3.so libnssutil3.so \
+	for f in libsoftokn3.so libfreebl3.so libfreeblpriv3.so libnss3.so libnssutil3.so \
 		libssl3.so libsmime3.so libnssckbi.so libnssdbm3.so libnsssysinit.so; do
 		install -m755 dist/*.OBJ/lib/${f} ${DESTDIR}/usr/lib
 	done


### PR DESCRIPTION
ClearKey plugins need to dlopen(2) this shared object. ClearKey will run into crash if it's not found.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
