### PR TITLE
common/build-style/python3-{module,pep517}.sh: enable `PY_IGNORE_IMPORTMISMATCH` for testing

### DIFF
--- a/common/build-style/python3-module.sh
+++ b/common/build-style/python3-module.sh
@@ -12,7 +12,7 @@ do_check() {
 		if python3 -c 'import xdist' >/dev/null 2>&1; then
 			testjobs="-n $XBPS_MAKEJOBS"
 		fi
-		PYTHONPATH="$(cd build/lib* && pwd)" \
+		PYTHONPATH="$(cd build/lib* && pwd)" PY_IGNORE_IMPORTMISMATCH=1 \
 			${make_check_pre} \
 			python3 -m pytest ${testjobs} ${make_check_args} ${make_check_target}
 	else

--- a/common/build-style/python3-pep517.sh
+++ b/common/build-style/python3-pep517.sh
@@ -33,7 +33,7 @@ do_check() {
 	python3 -m installer --destdir "${testdir}" \
 		${make_install_args} ${make_install_target:-dist/*.whl}
 
-	PATH="${testdir}/usr/bin:${PATH}" PYTHONPATH="${testdir}/${py3_sitelib}" \
+	PATH="${testdir}/usr/bin:${PATH}" PYTHONPATH="${testdir}/${py3_sitelib}" PY_IGNORE_IMPORTMISMATCH=1 \
 		${make_check_pre} pytest3 ${testjobs} ${make_check_args} ${make_check_target}
 }
 

--- a/srcpkgs/python3-keyring/template
+++ b/srcpkgs/python3-keyring/template
@@ -14,7 +14,6 @@ homepage="https://pypi.org/project/keyring/"
 changelog="https://raw.githubusercontent.com/jaraco/keyring/main/NEWS.rst"
 distfiles="${PYPI_SITE}/k/keyring/keyring-${version}.tar.gz"
 checksum=ca0746a19ec421219f4d713f848fa297a661a8a8c1504867e55bfb5e09091509
-make_check_pre="env PY_IGNORE_IMPORTMISMATCH=1"
 
 pre_check() {
 	vsed -e '/addopts/d' -i pytest.ini


### PR DESCRIPTION
Python packages which enables pytest's `--doctest-modules` flag fails while testing against an installed package - ref. https://github.com/pytest-dev/pytest/issues/2042#issuecomment-381309723. Currently it's worked around in `python3-keyring` & `python3-fpylll` but is needed for `python3-path`, `python3-inflect`, `python3-zipp` etc - basically anything that follows https://github.com/jaraco/skeleton and there's quite a few of those in our repos.