### PR TITLE
New package: maddy-0.7.0.

### DIFF
--- a/srcpkgs/maddy/files/maddy/run
+++ b/srcpkgs/maddy/files/maddy/run
@@ -1,0 +1,4 @@
+#!/bin/sh
+umask 0027
+exec 2>&1
+exec chpst -u _maddy:_maddy -C /var/lib/maddy -o 131072 -p 512 /usr/bin/maddy run

--- a/srcpkgs/maddy/template
+++ b/srcpkgs/maddy/template
@@ -1,0 +1,31 @@
+# Template file for 'maddy'
+pkgname=maddy
+version=0.7.0
+revision=1
+build_style=go
+go_import_path="github.com/foxcpp/maddy"
+go_package="$go_import_path/cmd/maddy
+ $go_import_path/cmd/maddy-pam-helper
+ $go_import_path/cmd/maddy-shadow-helper"
+hostmakedepends="scdoc"
+makedepends="pam-devel"
+short_desc="Composable all-in-one mail server"
+maintainer="Michael Aldridge <maldridge@voidlinux.org>"
+license="GPL-3.0-or-later"
+homepage="https://maddy.email"
+distfiles="https://github.com/foxcpp/maddy/archive/refs/tags/v$version.tar.gz"
+checksum=d661a74a9a14e874610aba776a01aaeee742a32ef06592251d4a86306487dfa9
+make_dirs="/var/lib/maddy 0750 _maddy _maddy
+ /etc/maddy 0750 _maddy _maddy"
+system_accounts="_maddy"
+_maddy_homedir="/var/lib/maddy"
+
+post_build() {
+	scdoc < docs/man/maddy.1.scd > maddy.1
+}
+
+post_install() {
+	vsv maddy
+	vsconf maddy.conf
+	vman maddy.1
+}


### PR DESCRIPTION
This is the same software we already run as our internal mail server, but I'd like to have it packaged so we can create a Void specific container.  I believe this will lead to a generally cleaner configuration and will of course allow the underlying container to share blocks with other void containers on the same host.