### PR TITLE
usbredir: update to 0.13.0.

### DIFF
--- a/srcpkgs/usbredir/template
+++ b/srcpkgs/usbredir/template
@@ -1,24 +1,23 @@
 # Template file for 'usbredir'
 pkgname=usbredir
-version=0.10.0
+version=0.13.0
 revision=1
 build_style=meson
-configure_args="--sbindir=/usr/bin -Ddefault_library=both"
 hostmakedepends="pkg-config"
 makedepends="libusb-devel glib-devel"
 short_desc="USB traffic redirection protocol"
 maintainer="Andrea Brancaleoni <abc@pompel.me>"
-license="GPL-2.0-or-later"
+license="GPL-2.0-or-later,LGPL-2.1-or-later"
 homepage="https://spice-space.org"
+changelog="https://gitlab.freedesktop.org/spice/usbredir/-/raw/main/ChangeLog.md"
 distfiles="https://gitlab.freedesktop.org/spice/usbredir/-/archive/usbredir-${version}/usbredir-usbredir-${version}.tar.bz2"
-checksum=10143222c3ab3333252b546954cd3ee14bebe657c4e94e07ddef7071007cb7d1
+checksum=f8281022a7ede923b532dd1f869e5348898d44ccf1ccb4af22e8bf20810d9737
 
 usbredir-devel_package() {
 	depends="${makedepends} ${sourcepkg}-${version}_${revision}"
 	short_desc+=" - development files"
 	pkg_install() {
 		vmove usr/include
-		vmove "usr/lib/*.a"
 		vmove "usr/lib/*.so"
 		vmove usr/lib/pkgconfig
 	}


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc


Should I orphan this package?  Its maintainer seems to not be active for a long time.