### PR TITLE
fail2ban: add filter for sshd with socklog

### DIFF
--- a/srcpkgs/fail2ban/files/filter.d/sshd-socklog.conf
+++ b/srcpkgs/fail2ban/files/filter.d/sshd-socklog.conf
@@ -1,0 +1,12 @@
+# Fail2Ban filter for openssh, modified to work with socklog on Void Linux.
+#
+# The default logpath for sshd's output under socklog is
+# /var/log/socklog/secure/current
+
+[INCLUDES]
+before = sshd.conf
+
+[Definition]
+prefregex = ^ auth[a-z]*\.[a-z]+: \w{3} \d{2} \d{2}:\d{2}:\d{2} <F-MLFID><_daemon><__pid_re></F-MLFID>: <F-CONTENT>.+</F-CONTENT>$
+
+# Author: Dexter Gaon-Shatford

--- a/srcpkgs/fail2ban/template
+++ b/srcpkgs/fail2ban/template
@@ -1,7 +1,7 @@
 # Template file for 'fail2ban'
 pkgname=fail2ban
 version=1.0.2
-revision=1
+revision=2
 build_style=python3-module
 hostmakedepends="pkg-config python3"
 depends="python3"
@@ -25,4 +25,5 @@ pre_build() {
 
 post_install() {
 	vsv fail2ban
+	vcopy ${FILESDIR}/filter.d/*.conf etc/fail2ban/filter.d
 }


### PR DESCRIPTION
The sshd filter distributed with fail2ban does not work properly with socklog out of the box.

Ideally, socklog would have comprehensive support upstream, but the configuration to make it work with *just* sshd is very straighforward and the fail2ban package should be able to protect sshd out of the box with void's preferred syslog implementation.

This change doesn't override any of fail2ban's default configuration. It adds a new filter defined in `sshd-socklock.conf` which inherits from the default `sshd.conf` and overrides only what is needed to make it work.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
