### PR TITLE
SweetHome3D: add missing https:// schema

### DIFF
--- a/srcpkgs/SweetHome3D/template
+++ b/srcpkgs/SweetHome3D/template
@@ -9,7 +9,7 @@ depends="virtual?java-runtime shared-mime-info desktop-file-utils libXext libXre
 short_desc="Free architectural design application"
 maintainer="1is7ac3 <isaac.qa13@gmail.com>"
 license="GPL-2.0-or-later"
-homepage="www.sweethome3d.com"
+homepage="https://www.sweethome3d.com"
 distfiles="${SOURCEFORGE_SITE}/sweethome3d/SweetHome3D-${version}-src.zip"
 checksum=04b7453410ec918971cf69aeb5d0a8d1284369ffe544f8d49e8b81d2bd39b2a2
 


### PR DESCRIPTION
As reported in repology
  
> 2023-07-11 22:22:53   SweetHome3D: ERROR: homepage: "www.sweethome3d.com" does not look like an URL (schema missing)

ref: https://repology.org/log/934775

[skip ci] 

#### Testing the changes
- I tested the changes in this PR:**NO**
