### PR TITLE
rustypaste-cli: update to 0.6.0.

### DIFF
--- a/srcpkgs/rustypaste-cli/template
+++ b/srcpkgs/rustypaste-cli/template
@@ -1,6 +1,6 @@
 # Template file for 'rustypaste-cli'
 pkgname=rustypaste-cli
-version=0.5.0
+version=0.6.0
 revision=1
 build_style=cargo
 short_desc="CLI tool for rustypaste"
@@ -9,7 +9,7 @@ license="MIT"
 homepage="https://github.com/orhun/rustypaste-cli"
 changelog="https://raw.githubusercontent.com/orhun/rustypaste-cli/master/CHANGELOG.md"
 distfiles="https://github.com/orhun/rustypaste-cli/archive/refs/tags/v${version}.tar.gz"
-checksum=6af63a98fdd852e4a930568d74b75442c48cea741410ef87efc7694910d94be2
+checksum=a63e3deaa4c0ab9cb8dfe91d267157f4e2a75c7aeb47a798e351b4d948b1e4d6
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-musl
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - armv6l-musl
