### PR TITLE
sssd: fix build (wrong hostmakedepend)

### DIFF
--- a/srcpkgs/sssd/template
+++ b/srcpkgs/sssd/template
@@ -12,7 +12,7 @@ configure_args="--without-selinux --without-semanage --without-oidc-child
  --disable-cifs-idmap-plugin --without-samba --with-os=fedora
  --with-test-dir=/dev/shm --with-python3-bindings --with-pid-path=/run
  --with-sudo-lib-path=/usr/lib/sssd am_cv_python_version=${py3_ver}"
-hostmakedepends="libxslt pkg-config bind docbook-xsl python3"
+hostmakedepends="libxslt pkg-config bind-utils docbook-xsl python3"
 makedepends="pam-devel popt-devel talloc-devel tdb-devel tevent-devel ldb-devel
  ding-libs-devel libldap-devel mit-krb5-devel c-ares-devel glib-devel
  libnfsidmap-devel p11-kit-devel jansson-devel python3-devel libcurl-devel


### PR DESCRIPTION
nsupdate has been moved from bind to bind-utils in #42866. Noticed the build failure while building revbumps for #41948.

#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)