### PR TITLE
xorg-docs: add missing https:// schema

### DIFF
--- a/srcpkgs/xorg-docs/template
+++ b/srcpkgs/xorg-docs/template
@@ -6,7 +6,7 @@ build_style=gnu-configure
 short_desc="Misc docs for the X Window System that don't fit into other packages"
 maintainer="runrin <run.rin@rin.run>"
 license="MIT, BSD-3-Clause"
-homepage="www.x.org"
+homepage="https://www.x.org"
 distfiles="${XORG_SITE}/doc/${pkgname}-${version}.tar.bz2"
 checksum=2391b8af472626c12d3c3814b5e7a0ea43c3a96eda94255b7ed8bdff0fbf08e3
 


### PR DESCRIPTION
As reported in repology:

> 2023-07-11 22:22:53 SweetHome3D: ERROR: homepage: "www.sweethome3d.com" does not look like an URL (schema missing)

ref: https://repology.org/log/934775

[skip ci]

#### Testing the changes
- I tested the changes in this PR: **NO**

