### PR TITLE
vscode: update to 1.80.1

### DIFF
--- a/srcpkgs/vscode/template
+++ b/srcpkgs/vscode/template
@@ -1,8 +1,8 @@
 # Template file for 'vscode'
 pkgname=vscode
-version=1.79.2
+version=1.80.1
 revision=1
-_electronver=24.2.0
+_electronver=24.3.0
 _npmver=8.6.0
 hostmakedepends="pkg-config python3 nodejs yarn tar git ripgrep"
 makedepends="libxkbfile-devel libsecret-devel libxml2-devel ncurses-devel electron24"
@@ -12,7 +12,7 @@ maintainer="shizonic <realtiaz@gmail.com>, Alex Lohr <alex.lohr@logmein.com>"
 license="MIT"
 homepage="https://code.visualstudio.com/"
 distfiles="https://github.com/microsoft/vscode/archive/refs/tags/${version}.tar.gz"
-checksum=2719ccbb573f5b7c174bd5bbcad97d3fe4d917e16327a6b72162ff7014c17c9b
+checksum=54f3a14fa31b73aac84ff3c80d8d4237a90bc2c26822e463a17c3762901d386f
 nocross=yes # x64 build does not cut it, it contains native code
 
 if [ "$XBPS_TARGET_WORDSIZE" = "32" ]; then
@@ -66,6 +66,9 @@ do_build() {
 	echo "ignore-engines true" >> .yarnrc
 
 	yarn install --frozen-lockfile --arch=x64
+
+	# do not checksum electron, since we're using our own build
+	vsed -e "s/validateChecksum: true/validateChecksum: false/g" -i build/lib/electron.*s
 
 	export CFLAGS="$CFLAGS -I/usr/include/node"
 	yarn run gulp vscode-linux-x64-min


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**
<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
The new version tests the checksum of the electron package; since we are using our own build of electron, we need to disable this check.