### PR TITLE
variety: depend on qt5-tools for KDE support.

### DIFF
--- a/srcpkgs/variety/template
+++ b/srcpkgs/variety/template
@@ -1,13 +1,13 @@
 # Template file for 'variety'
 pkgname=variety
 version=0.8.10
-revision=1
+revision=2
 build_style=python3-module
 pycompile_dirs="usr/share/variety/plugins"
 hostmakedepends="python3-setuptools python3-distutils-extra intltool"
 depends="ImageMagick gtk+3 libgexiv2 libnotify python3-BeautifulSoup4
  python3-Pillow python3-configobj python3-dbus python3-gobject python3-httplib2
- python3-lxml python3-requests python3-cairo"
+ python3-lxml python3-requests python3-cairo qt5-tools"
 checkdepends="python3-pytest pylint $depends"
 short_desc="Changes the wallpaper on a regular interval"
 maintainer="Ishaan Bhimwal <ishaanbhimwal@protonmail.com>"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

Not sure if this is the right choice or if we should just put a note in
`INSTALL.msg`. I did a quick look through
`/usr/share/variety/scripts/set_wallpaper` and it seems like most other DEs
include the needed tool for variety to set the wallpaper.

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
