### PR TITLE
neochat: update to 23.04.3.

### DIFF
--- a/srcpkgs/neochat/template
+++ b/srcpkgs/neochat/template
@@ -1,6 +1,6 @@
 # Template file for 'neochat'
 pkgname=neochat
-version=23.01.0
+version=23.04.3
 revision=1
 build_style=cmake
 hostmakedepends="extra-cmake-modules gettext pkg-config qt5-qmake
@@ -15,8 +15,8 @@ short_desc="Client for matrix from KDE"
 maintainer="Justin Jagieniak <justin@jagieniak.net>"
 license="GPL-3.0-only, GPL-3.0-or-later, GPL-2.0-or-later, BSD-2-Clause"
 homepage="https://apps.kde.org/en/neochat"
-distfiles="${KDE_SITE}/plasma-mobile/${version}/neochat-${version}.tar.xz"
-checksum=4dfb8b5c931ab440491ca511d84a493ec658ca3c4aedd4358131780e39d26a5e
+distfiles="${KDE_SITE}/release-service/${version}/src/neochat-${version}.tar.xz"
+checksum=2e7a006e24eea80049a0213897048291d1ddb52d484aae8d2d0f48bbb020af04
 
 if [ "$CROSS_BUILD" ]; then
 	hostmakedepends+=" kdoctools"

--- a/srcpkgs/qcoro-qt5/template
+++ b/srcpkgs/qcoro-qt5/template
@@ -1,6 +1,6 @@
 # Template file for 'qcoro-qt5'
 pkgname=qcoro-qt5
-version=0.8.0
+version=0.9.0
 revision=1
 build_style=cmake
 configure_args="-DUSE_QT_VERSION=5"
@@ -12,7 +12,7 @@ maintainer="Joel Beckmeyer <joel@beckmeyer.us>"
 license="MIT"
 homepage="https://qcoro.dvratil.cz/"
 distfiles="https://github.com/danvratil/qcoro/archive/refs/tags/v${version}.tar.gz"
-checksum=28f90d817f42352084242f7a1ff090c5cff92359e4dbecea8f04d39ebcf630f8
+checksum=cfaf6b778450f06adac4ce5e353eb6eae213a3b62b8c8740520d58cf9fe3ec1a
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
- qcoro-qt5: update to 0.9.0.
- neochat: update to 23.04.3.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
