### PR TITLE
goreleaser: update to 1.19.2.

### DIFF
--- a/srcpkgs/goreleaser/template
+++ b/srcpkgs/goreleaser/template
@@ -1,15 +1,16 @@
 # Template file for 'goreleaser'
 pkgname=goreleaser
-version=1.8.3
-revision=2
+version=1.19.2
+revision=1
 build_style=go
 go_import_path=github.com/goreleaser/goreleaser
+go_ldflags="-X main.version=${version}"
 short_desc="Deliver Go binaries as fast and easily as possible"
 maintainer="Michael Aldridge <maldridge@voidlinux.org>"
 license="MIT"
 homepage="https://goreleaser.com/"
 distfiles="https://github.com/goreleaser/goreleaser/archive/refs/tags/v$version.tar.gz"
-checksum=3ac091dacf81357a83b5c8bf17bbcb325371111b88bc59fa79c8354be2273145
+checksum=60e94d9371f7106878441deb006814339e3cf3d7f574d25cb22a9a45ec14939b
 
 post_install() {
 	vlicense LICENSE.md


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - aarch64
  - armv7l-musl
  - armv7l
  - armv6l-musl
  - armv6l
  - i686-musl
  - i686

