### PR TITLE
imhex: use gtk file picker by default

### DIFF
--- a/srcpkgs/imhex/template
+++ b/srcpkgs/imhex/template
@@ -1,14 +1,15 @@
 # Template file for 'imhex'
 pkgname=imhex
 version=1.30.1
-revision=1
+revision=2
 build_wrksrc="ImHex"
 build_style=cmake
 build_helper=qemu
 # XXX: when capstone v5 is out, -DUSE_SYSTEM_CAPSTONE=ON
 configure_args="-DIMHEX_OFFLINE_BUILD=ON -DIMHEX_STRIP_RELEASE=OFF
  -DUSE_SYSTEM_CURL=ON -DUSE_SYSTEM_FMT=ON -DUSE_SYSTEM_LLVM=ON
- -DUSE_SYSTEM_YARA=ON -DUSE_SYSTEM_NLOHMANN_JSON=ON -DIMHEX_DISABLE_UPDATE_CHECK=ON"
+ -DUSE_SYSTEM_YARA=ON -DUSE_SYSTEM_NLOHMANN_JSON=ON -DIMHEX_DISABLE_UPDATE_CHECK=ON
+ -DIMHEX_USE_GTK_FILE_PICKER=ON"
 hostmakedepends="pkg-config clang-tools-extra"
 makedepends="libcurl-devel fmt-devel llvm jansson-devel yara-devel json-c++
  freetype-devel glfw-devel gtk+3-devel python3-devel file-devel mbedtls-devel


### PR DESCRIPTION
Some xdg-desktop-portal environments dont support a file picker (eg wlroots based ones), so use gtk file picker by default.

See also https://github.com/WerWolv/ImHex/issues/882#issuecomment-1382268291

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **NO**
