### PR TITLE
interception-tools: add logging service

### DIFF
--- a/srcpkgs/interception-tools/template
+++ b/srcpkgs/interception-tools/template
@@ -1,7 +1,7 @@
 # Template file for 'interception-tools'
 pkgname=interception-tools
 version=0.6.7
-revision=2
+revision=3
 build_style=cmake
 hostmakedepends="pkg-config"
 makedepends="boost-devel eudev-libudev-devel libevdev-devel yaml-cpp-devel"


### PR DESCRIPTION
Startup messages from the udevmon service were polluting the TTY at boot, adding a logging service fixes this.

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64
  - aarch64-musl