### PR TITLE
sane: update to 1.2.1

### DIFF
--- a/srcpkgs/sane/template
+++ b/srcpkgs/sane/template
@@ -1,25 +1,25 @@
 # Template file for 'sane'
 pkgname=sane
-_gitlab_release_hash=7d30fab4e115029d91027b6a58d64b43
-version=1.1.1
-revision=2
+_gitlab_release_hash=110fc43336d0fb5e514f1fdc7360dd87
+version=1.2.1
+revision=1
 build_style=gnu-configure
 configure_args="--disable-locking --enable-ipv6 --enable-pthread
  --with-usb --docdir=/usr/share/doc/sane ac_cv_func_mmap_fixed_mapped=yes
  $(vopt_with snmp)"
 hostmakedepends="pkg-config python3"
 makedepends="libjpeg-turbo-devel tiff-devel libgphoto2-devel v4l-utils-devel
- libusb-devel openssl-devel libxml2-devel $(vopt_if snmp net-snmp-devel)
- $(vopt_if avahi 'avahi-libs-devel libcurl-devel')"
+ libusb-devel openssl-devel libxml2-devel libpng-devel
+ $(vopt_if snmp net-snmp-devel) $(vopt_if avahi 'avahi-libs-devel libcurl-devel')"
 depends="$(vopt_if snmp net-snmp)"
 conf_files="/etc/sane.d/*.conf"
 short_desc="Scanner Access Now Easy"
 maintainer="Piraty <mail@piraty.dev>"
 license="custom:GPL-2.0-or-later-with-SANE-exception"
 homepage="http://www.sane-project.org/"
-changelog="https://gitlab.com/sane-project/backends/-/raw/master/NEWS"
+changelog="https://gitlab.com/sane-project/backends/-/raw/${version}/NEWS"
 distfiles="https://gitlab.com/sane-project/backends/uploads/${_gitlab_release_hash}/sane-backends-${version}.tar.gz"
-checksum=dd4b04c37a42f14c4619e8eea6a957f4c7c617fe59e32ae2872b373940a8b603
+checksum=f832395efcb90bb5ea8acd367a820c393dda7e0dd578b16f48928b8f5bdd0524
 noshlibprovides="avoid false detection of device drivers"
 
 # additional group 'lp' is required by saned to access some all-in-one devices


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

Building with libpng allows to use `scanimage --format=png`.

@Piraty

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
