### PR TITLE
tinyssh: update to 20230101.

### DIFF
--- a/srcpkgs/tinyssh/template
+++ b/srcpkgs/tinyssh/template
@@ -1,16 +1,16 @@
 # Template file for 'tinyssh'
 pkgname=tinyssh
-version=20220801
-revision=2
+version=20230101
+revision=1
 build_style=gnu-makefile
 make_dirs="/etc/tinyssh 0755 root root"
 depends="ucspi-tcp"
 short_desc="Minimalistic SSH server"
 maintainer="Christopher Brannon <chris@the-brannons.com>"
-license="Public Domain"
+license="CC0-1.0"
 homepage="https://tinyssh.org"
 distfiles="https://github.com/janmojzis/tinyssh/archive/${version}.tar.gz"
-checksum=234656fc8d369608eb5d0f3a26280e0e38e2e6b134cfc610b6e24bce176acd4f
+checksum=74a434389dd05bf421feb6b6fab241f763b78222750d21100bd81d9ba626b28c
 
 if [ -n "${CROSS_BUILD}" ] ; then
 	make_build_target=cross-compile
@@ -28,6 +28,5 @@ pre_build() {
 }
 
 post_install() {
-	vlicense LICENCE
 	vsv tinysshd
 }


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

As of this version, upstream license has changed from Public Domain to CC0.

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
