### PR TITLE
xf86-input-libinput: update to 1.3.0.

### DIFF
--- a/srcpkgs/xf86-input-libinput/template
+++ b/srcpkgs/xf86-input-libinput/template
@@ -1,6 +1,6 @@
 # Template file for 'xf86-input-libinput'
 pkgname=xf86-input-libinput
-version=1.2.1
+version=1.3.0
 revision=1
 build_style=gnu-configure
 hostmakedepends="pkg-config"
@@ -13,7 +13,7 @@ homepage="https://xorg.freedesktop.org/"
 # no official changelog
 #changelog="https://gitlab.freedesktop.org/xorg/driver/xf86-input-libinput/-/commits/master/"
 distfiles="${XORG_SITE}/driver/${pkgname}-${version}.tar.xz"
-checksum=8151db5b9ddb317c0ce92dcb62da9a8db5079e5b8a95b60abc854da21e7e971b
+checksum=1446ba20a22bc968b5a4a0b4dbc3b8e037c50d9c59ac75fa3f7fc506c58c1abb
 lib32disabled=yes
 
 post_install() {


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)

