### PR TITLE
OTPClient: update to 3.1.9

### DIFF
--- a/srcpkgs/OTPClient/template
+++ b/srcpkgs/OTPClient/template
@@ -1,6 +1,6 @@
 # Template file for 'OTPClient'
 pkgname=OTPClient
-version=3.1.8
+version=3.1.9
 revision=1
 build_style=cmake
 hostmakedepends="pkg-config"
@@ -12,4 +12,4 @@ maintainer="Emil Miler <em@0x45.cz>"
 license="GPL-3.0-or-later"
 homepage="https://github.com/paolostivanin/OTPClient"
 distfiles="https://github.com/paolostivanin/OTPClient/archive/refs/tags/v${version}.tar.gz"
-checksum=5b85aefa4bd10d96c7866a6b77264b416124f272b3082fb7b854e68762129c14
+checksum=f4e4c94904ecc7e129cb16fb0d50086491cae34a83c6ce68d811995eeb6ea7c0


### PR DESCRIPTION
Simple version bump.

#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)