### PR TITLE
Enable seccomp for podman and buildah

### DIFF
--- a/srcpkgs/buildah/template
+++ b/srcpkgs/buildah/template
@@ -1,7 +1,7 @@
 # Template file for 'buildah'
 pkgname=buildah
-version=1.28.2
-revision=2
+version=1.31.0
+revision=1
 build_style=go
 go_import_path=github.com/containers/buildah
 go_package="${go_import_path}/cmd/buildah"
@@ -9,14 +9,14 @@ go_build_tags=containers_image_ostree_stub
 hostmakedepends="pkg-config go-md2man"
 makedepends="libostree-devel libbtrfs-devel device-mapper-devel gpgme-devel
  libassuan-devel libseccomp-devel"
-depends="runc containers.image containers.storage"
+depends="runc containers.image containers.storage containers-common"
 short_desc="Dockerfile compatible OCI image building tool"
 maintainer="Cameron Nemo <cam@nohom.org>"
 license="Apache-2.0"
 homepage="https://github.com/containers/buildah"
 changelog="https://github.com/containers/buildah/blob/master/CHANGELOG.md"
 distfiles="https://github.com/containers/buildah/archive/refs/tags/v${version}.tar.gz"
-checksum=2dc5b1686473f972fbfa15637ecd1a9e2aeefd057c86dd097d1f19e2a6959411
+checksum=c119921e8e4b2d7fd7e1041dfbcfdfac0882e3dea4f7dabdc5175f9bbc70d868
 
 post_build() {
 	make -C docs GOMD2MAN=go-md2man

--- a/srcpkgs/containers-common/template
+++ b/srcpkgs/containers-common/template
@@ -1,0 +1,18 @@
+# Template file for 'containers-common'
+pkgname=containers-common
+version=0.55.2
+revision=1
+build_style=gnu-makefile
+make_build_args="-C docs"
+make_install_args="-C docs"
+hostmakedepends="go-md2man"
+short_desc="Docs and configs shared by podman, buildah, and skopeo"
+maintainer="Cameron Nemo <cam@nohom.org>"
+license="Apache-2.0"
+homepage="https://github.com/containers/common"
+distfiles="https://github.com/containers/common/archive/v${version}.tar.gz"
+checksum=997529c8aed1b6b71ff732d0cb75e67560222012402a3715ccab765b92ce0479
+
+post_install() {
+	vinstall pkg/seccomp/seccomp.json 0644 usr/share/containers
+}

--- a/srcpkgs/podman/template
+++ b/srcpkgs/podman/template
@@ -1,22 +1,22 @@
 # Template file for 'podman'
 pkgname=podman
-version=4.4.4
-revision=2
+version=4.5.1
+revision=1
 build_style=go
 go_import_path="github.com/containers/podman/v4"
 go_package="${go_import_path}/cmd/podman ${go_import_path}/cmd/rootlessport"
 go_build_tags="seccomp apparmor containers_image_ostree_stub"
 hostmakedepends="pkg-config go-md2man python3"
 makedepends="gpgme-devel libseccomp-devel device-mapper-devel libbtrfs-devel"
-depends="runc conmon cni-plugins slirp4netns containers.image containers.storage
- fuse-overlayfs"
+depends="runc conmon cni-plugins slirp4netns fuse-overlayfs
+ containers-common containers.image containers.storage"
 short_desc="Simple management tool for containers and images"
 maintainer="Cameron Nemo <cam@nohom.org>"
 license="Apache-2.0"
 homepage="https://podman.io/"
 changelog="https://raw.githubusercontent.com/containers/podman/main/RELEASE_NOTES.md"
 distfiles="https://github.com/containers/podman/archive/v${version}.tar.gz"
-checksum=2dacfe7041b83e2cb05fda58bd1fbdae61348a427f5b9073b96b36154de894a1
+checksum=ee2c8b02b7fe301057f0382637b995a9c6c74e8d530692d6918e4c509ade6e39
 
 if [ "$CROSS_BUILD" ]; then
 	go_build_tags+=" containers_image_openpgp"


### PR DESCRIPTION
- New package: containers.common-0.55.2
- buildah: update to 1.31.0, enable seccomp
- podman: update to 4.5.1, enable seccomp

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
