### PR TITLE
dotool: update to 1.3;adopt.

### DIFF
--- a/srcpkgs/dotool/template
+++ b/srcpkgs/dotool/template
@@ -1,21 +1,24 @@
 # Template file for 'dotool'
 pkgname=dotool
-version=1.2
-revision=2
+version=1.3
+revision=1
 build_style=go
 go_import_path="git.sr.ht/~geb/dotool"
 go_ldflags="-X main.Version=${version}"
+hostmakedepends="pkg-config"
+makedepends="libxkbcommon-devel"
 short_desc="Command to simulate input anywhere (X11, Wayland, TTYs)"
-maintainer="Orphaned <orphan@voidlinux.org>"
+maintainer="André Cerqueira <acerqueira021@gmail.com>"
 license="GPL-3.0-only"
 homepage="https://sr.ht/~geb/dotool"
 changelog="https://git.sr.ht/~geb/dotool/blob/master/CHANGELOG.md"
 distfiles="https://git.sr.ht/~geb/dotool/archive/${version}.tar.gz"
-checksum=80dcbc1bc4877bbef3eb30cb8c0ad7db161fb76d4999bb9b5f4a484e2267e5a1
+checksum=fd17b1d445ce05edcb565a6a4f6a97d3b1bfd066681dc23fc22a2df1c33ab150
 system_accounts="_dotoold"
+triggers=hwdb.d-dir
 
 post_install() {
-	./_install.sh "${DESTDIR}" /usr/bin
+	cp -v dotoolc dotoold "${DESTDIR}/usr/bin"
 	vinstall 80-dotool.rules 644 usr/lib/udev/rules.d
 	vsv dotoold
 }


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc

```
SUMMARY
pkg      host         target        cross  result
dotool   x86_64       x86_64        n      OK
dotool   x86_64-musl  x86_64-musl   n      OK
dotool   i686         i686          n      OK
dotool   x86_64       aarch64-musl  y      OK
dotool   x86_64       aarch64       y      OK
dotool   x86_64       armv7l-musl   y      OK
dotool   x86_64       armv7l        y      OK
dotool   x86_64       armv6l-musl   y      OK
dotool   x86_64       armv6l        y      OK
```