### PR TITLE
gst-plugins-bad1: enable 'va' plugin

### DIFF
--- a/srcpkgs/gst-plugins-bad1/template
+++ b/srcpkgs/gst-plugins-bad1/template
@@ -1,7 +1,7 @@
 # Template file for 'gst-plugins-bad1'
 pkgname=gst-plugins-bad1
 version=1.22.2
-revision=1
+revision=2
 build_helper="gir"
 build_style=meson
 configure_args="-Dpackage-origin=https://voidlinux.org -Ddoc=disabled
@@ -28,7 +28,7 @@ makedepends="alsa-lib-devel celt-devel openssl-devel exempi-devel
  fdk-aac-devel flite-devel fluidsynth-devel liblrdf-devel ladspa-sdk
  lilv-devel lv2 libopenjpeg2-devel sbc-devel spandsp-devel vulkan-loader
  Vulkan-Headers webrtc-audio-processing-devel libzbar-devel ffmpeg-devel
- srt-devel
+ srt-devel libva-devel
  $(vopt_if gme libgme-devel)"
 depends="gst-plugins-base1>=${version}"
 short_desc="GStreamer plugins from the bad set (v1.x)"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc

---


```
17:55:12 $ gst-inspect-1.0 va
Plugin Details:
  Name                     va
  Description              VA-API codecs plugin
  Filename                 /usr/lib/gstreamer-1.0/libgstva.so
  Version                  1.22.2
  License                  LGPL
  Source module            gst-plugins-bad
  Documentation            https://gstreamer.freedesktop.org/documentation/va/
  Source release date      2023-04-11
  Binary package           GStreamer Bad Plug-ins source release
  Origin URL               https://voidlinux.org

  vacompositor: VA-API Video Compositor
  vadeinterlace: VA-API Deinterlacer
  vah264dec: VA-API H.264 Decoder
  vah264enc: VA-API H.264 Encoder
  vah265dec: VA-API H.265 Decoder
  vah265enc: VA-API H.265 Encoder
  vajpegdec: VA-API JPEG Decoder
  vampeg2dec: VA-API Mpeg2 Decoder
  vapostproc: VA-API Video Postprocessor
  vavp9dec: VA-API VP9 Decoder

  10 features:
  +-- 10 elements

```

and I have successfully used it to encoded a video on my amd gpu