### PR TITLE
swayimg: update to 1.12.

### DIFF
--- a/srcpkgs/swayimg/template
+++ b/srcpkgs/swayimg/template
@@ -1,18 +1,19 @@
 # Template file for 'swayimg'
 pkgname=swayimg
-version=1.11
+version=1.12
 revision=1
 build_style=meson
 hostmakedepends="pkg-config wayland-devel"
 makedepends="wayland-devel cairo-devel json-c-devel libxkbcommon-devel
  wayland-protocols libheif-devel giflib-devel libjpeg-turbo-devel
- libpng-devel librsvg-devel libwebp-devel libexif-devel"
+ libpng-devel librsvg-devel libwebp-devel libexif-devel tiff-devel
+ libopenexr-devel libjxl-devel"
 short_desc="Image viewer for Sway/Wayland"
-maintainer="Orphan <orphan@voidlinux.org>"
+maintainer="voidbert <humbertogilgomes@protonmail.com>"
 license="MIT"
 homepage="https://github.com/artemsen/swayimg"
 distfiles="https://github.com/artemsen/swayimg/archive/v${version}.tar.gz"
-checksum=b7853417caf3c928195107644df31ba80a906fc3ecca180db2841abbfac27736
+checksum=4617322a1ec17985770dc351eea69b42b1464f2d838eb5015314634b2a30f126
 
 post_install() {
 	vcompletion extra/bash.completion bash


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-musl)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - armv6l-musl

#### Discussion

I added dependencies for other image formats (EXR, on this new version, and TIFF, already supported on previous versions). I would like to know if this is OK or if it'd be better to add build options for build customization.
