### PR TITLE
btdu: update to 0.5.1.

### DIFF
--- a/srcpkgs/btdu/template
+++ b/srcpkgs/btdu/template
@@ -1,10 +1,7 @@
 # Template file for 'btdu'
 pkgname=btdu
-version=0.5.0
+version=0.5.1
 revision=1
-# fails to build on musl due to different argument types for ioctl
-# struct packing seems to differ on i686 archs and therefore d-btrfs fails
-archs="x86_64"
 hostmakedepends="ldc dub"
 makedepends="zlib-devel ncurses-devel"
 short_desc="Sampling disk usage profiler for btrfs"
@@ -12,7 +9,7 @@ maintainer="Siddhartha Menon <siddharthamenon+void@outlook.com>"
 license="GPL-2.0-only"
 homepage="https://github.com/CyberShadow/btdu"
 distfiles="https://github.com/CyberShadow/btdu/archive/v${version}.tar.gz"
-checksum=90ba4d8997575993e9d39a503779fb32b37bb62b8d9386776e95743bfc859606
+checksum=566269f365811f6db53280fc5476a7fcf34791396ee4e090c150af4280b35ba5
 nocross="dmd compilation fails on cross"
 
 do_build() {


### PR DESCRIPTION
enable musl builds - tested on `x86_64-musl`

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
