### PR TITLE
New packages: font-latinmodern, font-latinmodern-math

### DIFF
--- a/srcpkgs/font-latinmodern-math/template
+++ b/srcpkgs/font-latinmodern-math/template
@@ -1,0 +1,18 @@
+# Template file for 'font-latinmodern-math'
+pkgname=font-latinmodern-math
+version=1.959
+revision=1
+depends="font-util"
+short_desc="Improved version of Computer Modern math font as used in LaTeX"
+maintainer="classabbyamp <void@placeviolette.net>"
+license="custom:GFL"
+homepage="https://www.gust.org.pl/projects/e-foundry/lm-math"
+distfiles="https://www.gust.org.pl/projects/e-foundry/lm-math/download/latinmodern-math-${version//./}.zip"
+checksum=aaaa060b4ffc091461e875efb9498b9abfa7c7a48f38eb33882868839903a4f8
+font_dirs="/usr/share/fonts/latinmodern"
+
+do_install() {
+	vmkdir usr/share/fonts/latinmodern
+	vcopy otf/*.otf usr/share/fonts/latinmodern
+	vlicense doc/GUST-FONT-LICENSE.txt
+}

--- a/srcpkgs/font-latinmodern/template
+++ b/srcpkgs/font-latinmodern/template
@@ -1,0 +1,21 @@
+# Template file for 'font-latinmodern'
+pkgname=font-latinmodern
+version=2.004
+revision=1
+depends="font-util"
+short_desc="Improved version of Computer Modern fonts as used in LaTeX"
+maintainer="classabbyamp <void@placeviolette.net>"
+license="custom:GFL"
+homepage="https://www.gust.org.pl/projects/e-foundry/latin-modern"
+changelog="https://www.gust.org.pl/projects/e-foundry/latin-modern/download/lm-hist.txt"
+distfiles="https://www.gust.org.pl/projects/e-foundry/latin-modern/download/lm${version}otf.zip
+ https://www.gust.org.pl/projects/e-foundry/licenses/GUST-FONT-LICENSE.txt"
+checksum="5b0236051d3728be6616f1b274e3b910473875b5a3ef9382f0ef00384ddb161b
+ a746108477b2fa685845e7596b7ad8342bc358704b2b7da355f2df0a0cb8ad85"
+font_dirs="/usr/share/fonts/latinmodern"
+
+do_install() {
+	vmkdir usr/share/fonts/latinmodern
+	vcopy *.otf usr/share/fonts/latinmodern
+	vlicense GUST-FONT-LICENSE.txt
+}


### PR DESCRIPTION
- New package: font-latinmodern-2.004
- New package: font-latinmodern-math-1.959

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES** and **MAYBE**

I believe that `font-latinmodern-math` definitely meets package requirements, because it provides a font that allows things like MathML in browsers to render properly, without having fontconfig know about the font from texlive's dirs.

`font-latinmodern` is a maybe: it's just a version of the default text fonts from LaTeX, so I'm not sure it provides any value beyond the aesthetics.
