### PR TITLE
opencollada: add patch to fix incompatibility with nullptr

### DIFF
--- a/srcpkgs/opencollada/patches/musl-1.2.3.patch
+++ b/srcpkgs/opencollada/patches/musl-1.2.3.patch
@@ -1,0 +1,11 @@
+--- a/COLLADAStreamWriter/src/COLLADASWLibraryAnimations.cpp	2018-11-26 23:43:10.000000000 +0100
++++ -	2023-02-23 13:47:42.819812753 +0100
+@@ -62,7 +62,7 @@
+ 
+     //---------------------------------------------------------------
+     LibraryAnimations::LibraryAnimations ( COLLADASW::StreamWriter * streamWriter )
+-            : Library ( streamWriter, CSWC::CSW_ELEMENT_LIBRARY_ANIMATIONS ), mOpenAnimations ( NULL )
++            : Library ( streamWriter, CSWC::CSW_ELEMENT_LIBRARY_ANIMATIONS ), mOpenAnimations ( {} )
+     {}
+ 
+     //---------------------------------------------------------------


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**|**briefly**|**NO**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
