### PR TITLE
openjdk11: fix armv7l-musl build.

### DIFF
--- a/srcpkgs/openjdk11/files/musl_patches/arm.patch
+++ b/srcpkgs/openjdk11/files/musl_patches/arm.patch
@@ -1,0 +1,30 @@
+Patches for musl taken from Alpine linux: https://git.alpinelinux.org/aports/commit/?id=8a1ae17d4a9af54285c7891a680620e7e24c6280
+--- old/src/hotspot/os_cpu/linux_arm/os_linux_arm.cpp
++++ new/src/hotspot/os_cpu/linux_arm/os_linux_arm.cpp
+@@ -71,7 +71,6 @@
+ # include <pwd.h>
+ # include <poll.h>
+ # include <ucontext.h>
+-# include <fpu_control.h>
+ # include <asm/ptrace.h>
+
+ #define SPELL_REG_SP  "sp"
+@@ -104,6 +103,18 @@
+ #define ARM_REGS_IN_CONTEXT  31
+
+ #else
++
++// Stupid hack as the origin if below doesnt compile with gcc 8.2.0:
++//
++// os_linux_arm.cpp:114:5: error: missing binary operator before token "("
++//  #if NGREG == 16
++//       ^~~~~
++//
++// The NGREG is 18, so force it to that value.
++#ifdef NGREG
++#  undef NGREG
++#endif
++#define NGREG 18
+
+ #if NGREG == 16
+ // These definitions are based on the observation that until

--- a/srcpkgs/openjdk11/patches/fix-musl-detection.diff
+++ b/srcpkgs/openjdk11/patches/fix-musl-detection.diff
@@ -1,0 +1,20 @@
+--- a/make/autoconf/platform.m4	2023-07-05 08:22:24.000000000 +0100
++++ b/make/autoconf/platform.m4	2023-07-22 14:48:46.291451605 +0100
+@@ -214,7 +214,7 @@
+ AC_DEFUN([PLATFORM_EXTRACT_VARS_FROM_LIBC],
+ [
+   case "$1" in
+-    *linux*-musl)
++    *linux*-musl*)
+       VAR_LIBC=musl
+       ;;
+     *linux*-gnu)
+@@ -232,7 +232,7 @@
+ AC_DEFUN([PLATFORM_EXTRACT_VARS_FROM_ABI],
+ [
+   case "$1" in
+-    *linux*-musl)
++    *linux*-musl*)
+       VAR_ABI=musl
+       ;;
+     *linux*-gnu)

--- a/srcpkgs/openjdk11/template
+++ b/srcpkgs/openjdk11/template
@@ -9,6 +9,7 @@ build_style=gnu-configure
 configure_args="
  --disable-warnings-as-errors
  --prefix=${XBPS_DESTDIR}/${XBPS_CROSS_TRIPLET}/${pkgname}-${version}/usr/lib
+ --with-jobs=${XBPS_ORIG_MAKEJOBS}
  --enable-unlimited-crypto
  --with-zlib=system
  --with-libjpeg=system


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **NO** (just tested build)

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
