### PR TITLE
neochat: add missing kitemmodels runtime dep.

### DIFF
--- a/srcpkgs/neochat/template
+++ b/srcpkgs/neochat/template
@@ -1,7 +1,7 @@
 # Template file for 'neochat'
 pkgname=neochat
 version=23.04.3
-revision=1
+revision=2
 build_style=cmake
 hostmakedepends="extra-cmake-modules gettext pkg-config qt5-qmake
  qt5-host-tools kcoreaddons kconfig AppStream"
@@ -10,7 +10,7 @@ makedepends="kquickimageeditor-devel libQuotient-devel qtkeychain-qt5-devel
  knotifications-devel kconfig-devel kcoreaddons-devel qqc2-desktop-style-devel
  sonnet-devel kitemmodels-devel kirigami-addons kconfigwidgets-devel kio-devel
  qcoro-qt5-devel"
-depends="kquickimageeditor"
+depends="kquickimageeditor kitemmodels"
 short_desc="Client for matrix from KDE"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-3.0-only, GPL-3.0-or-later, GPL-2.0-or-later, BSD-2-Clause"


### PR DESCRIPTION
Otherwise it exits with this error:
```
qrc:/RoomListPage.qml:11:1: module "org.kde.kitemmodels" is not installed
```

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **NO** (didn't build the package locally, just tested that it works correctly with kitemmodels)

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
