### PR TITLE
wxPython4: revbump for wxWidgets-3.0.5.1

### DIFF
--- a/srcpkgs/wxPython4/template
+++ b/srcpkgs/wxPython4/template
@@ -1,7 +1,7 @@
 # Template file for 'wxPython4'
 pkgname=wxPython4
 version=4.0.7
-revision=6
+revision=7
 build_style=python3-module
 make_build_args="--skip-build"
 make_install_args="--skip-build"


### PR DESCRIPTION
Various programs relying on wxPython, including KiCad, complain about an ABI mismatch between wxPython and the system wxWidgets binaries; as wxPython was never revbumped when [wxWidgets: update to 3.0.5.1](../commit/5464524f084cce8b41d9d22e6ff6b20cd39a8a46) (and possibly earlier) happened.

#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, **x86_64**
