### PR TITLE
knot-resolver: config fixes + add garbage collector service

### DIFF
--- a/srcpkgs/knot-resolver/files/kres-cache-gc/run
+++ b/srcpkgs/knot-resolver/files/kres-cache-gc/run
@@ -2,4 +2,4 @@
 exec 2>&1
 [ -r ./conf ] && . ./conf
 install -d -m0755 -o _knot_resolver -g _knot_resolver /run/knot-resolver
-exec kresd ${OPTS:- --noninteractive -c /etc/knot-resolver/kresd.conf /run/knot-resolver}
+exec kres-cache-gc ${OPTS:- -d 1000 -c /run/knot-resolver}

--- a/srcpkgs/knot-resolver/template
+++ b/srcpkgs/knot-resolver/template
@@ -1,7 +1,7 @@
 # Template file for 'knot-resolver'
 pkgname=knot-resolver
 version=5.6.0
-revision=1
+revision=2
 build_style=meson
 configure_args="
  -Dclient=enabled
@@ -36,6 +36,7 @@ post_install() {
 	vinstall etc/root.hints 644 var/lib/knot-resolver
 	vinstall etc/root.keys 644 var/lib/knot-resolver
 	vsv kresd
+	vsv kres-cache-gc
 }
 
 knot-resolver-devel_package() {


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

## First
In the default installation the default config file (/etc/knot-resolver/kresd.conf)  is not read: so making changes to it, did nothing.

Per https://github.com/void-linux/void-packages/blob/master/Manual.md#writing_runit_services
you _could_ change CLI flags in **conf** file in the service directory, but I think this option should be enabled by default because the file /etc/knot-resolver/kresd.conf is also installed and otherwise it's confusing.

## Second
Added working directory to kresd service file, otherwise it uses the service directory itself.

## Third
change: in default CLI variable:

```
-f 1 
```
to
 ```
--noninteractive
```
because _-f 1_ will be deprecated per warning on command line.

## Fourth
knot-resolver comes with a garbage collector (kres-cache-gc).
I added a service file for it.