### PR TITLE
opencl2-headers: install pkg-config and cmake cfg.

### DIFF
--- a/srcpkgs/opencl2-headers/template
+++ b/srcpkgs/opencl2-headers/template
@@ -1,16 +1,13 @@
 # Template file for 'opencl2-headers'
 pkgname=opencl2-headers
 version=2023.04.17
-revision=1
+revision=2
+build_style=cmake
 short_desc="OpenCL 2.2 (Open Computing Language) header files"
 maintainer="Andrew J. Hesford <ajh@sideband.org>"
 license="Apache-2.0"
 homepage="https://github.com/KhronosGroup/OpenCL-Headers"
-distfiles="${homepage}/archive/v${version}.tar.gz"
+distfiles="https://github.com/KhronosGroup/OpenCL-Headers/archive/v${version}.tar.gz"
 checksum=0ce992f4167f958f68a37918dec6325be18f848dee29a4521c633aae3304915d
 provides="opencl-headers-${version}_${revision}"
 replaces="opencl-headers>=0"
-
-do_install() {
-	install -m 0644 -D -t ${DESTDIR}/usr/include/CL CL/*.h
-}


### PR DESCRIPTION
Switched to cmake provided by upstream.

I couldn't build some software that uses opencl due to pkg-config complaining about missing OpenCL-Headers. This fixed the issue for me.

Ping @ahesford WDYT?

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
