### PR TITLE
New package: srb2kart-1.6

### DIFF
--- a/srcpkgs/srb2kart/template
+++ b/srcpkgs/srb2kart/template
@@ -1,0 +1,57 @@
+# Template file for 'srb2kart'
+pkgname=srb2kart
+version=1.6
+revision=1
+create_wrksrc=true
+build_wrksrc="Kart-Public-${version}"
+build_style=gnu-makefile
+make_use_env=yes
+make_build_args="-C src/ ECHO=1 LINUX=1 EXENAME=${pkgname}
+ NOOBJDUMP=1 NOUPX=1 DBGNAME=${pkgname}-debug PREFIX="
+hostmakedepends="pkg-config gettext"
+makedepends="SDL2-devel SDL2_mixer-devel libpng-devel libupnp-devel
+ libcurl-devel libgme-devel"
+short_desc="Kart racing game based off Sonic Robo Blast 2"
+maintainer="yosh <yosh-git@riseup.net>"
+license="GPL-2.0-or-later"
+homepage="https://mb.srb2.org/addons/srb2kart.2435/"
+distfiles="https://github.com/STJr/Kart-Public/archive/refs/tags/v${version}.tar.gz
+ https://github.com/STJr/Kart-Public/releases/download/v${version}/AssetsLinuxOnly.zip"
+checksum="924489e33ebb7e41bae3b84a65be2aae2ca01e2050938bff1e702b39848958d6
+ 7a384fb99d42f0cf41d12e3ed873754f9a5ba2b993d5e54bde7962bea3accdd1"
+restricted=yes
+
+case "$XBPS_TARGET_MACHINE" in
+	x86_64*|aarch64*) make_build_args+=" LINUX64=1 NONX86=1" ;;
+	*)
+		make_build_args+=" NONX86=1"
+		hostmakedepends+=" nasm"
+		;;
+esac
+
+if [ "$XBPS_TARGET_LIBC" = musl ]; then
+	makedepends+=" libexecinfo-devel"
+	export LDFLAGS="-lexecinfo"
+fi
+
+if [ -n "$CROSS_BUILD" ]; then
+	make_build_args+=" OBJCOPY=${XBPS_CROSS_TRIPLET}-objcopy"
+fi
+
+do_install() {
+	case "$XBPS_TARGET_MACHINE" in
+		x86_64*|aarch64*) vbin bin/Linux64/Release/srb2kart ;;
+		*) vbin bin/Linux/Release/srb2kart ;;
+	esac
+
+	PROGRAM_NAME="${pkgname}" PROGRAM_DESCRIPTION="${short_desc}" \
+		PACKAGE_INSTALL_PATH="/usr/bin" PROGRAM_FILENAME="${pkgname}" \
+		envsubst < debian-template/srb2.desktop > srb2.desktop
+
+	vinstall srb2.png 644 /usr/share/pixmaps/ srb2kart.png
+	vinstall srb2.desktop 644 /usr/share/applications/ srb2kart.desktop
+	vmkdir /usr/share/games/SRB2Kart
+	for f in {bonuschars,chars,gfx,maps,music,sounds,textures}.kart srb2.srb mdls{.dat,}; do
+		vcopy ../${f} /usr/share/games/SRB2Kart
+	done
+}


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl (crossbuild)
  - armv6l (crossbuild)
  - i686 (crossbuild)
  - aarch64 (crossbuild)

Closes #19355

most of srb2kart follows the same build style as srb2 with some tiny differences, so I used srb2's template as a base. there's some funkiness with where the result of the build is placed (`bin/Linux64` seems to be used exclusively for `x86_64`, since `aarch64` didn't get output there), but I think this covers all bases (I made sure to cross compile lots). this package is restricted because srb2 is restricted.