### PR TITLE
osc: update to 1.2.0

### DIFF
--- a/srcpkgs/osc/template
+++ b/srcpkgs/osc/template
@@ -1,15 +1,16 @@
 # Template file for 'osc'
 pkgname=osc
-version=1.1.4
+version=1.2.0
 revision=1
 build_style=python3-module
 hostmakedepends="python3-setuptools python3-cryptography python3-devel
  rpm-python3 python3-urllib3"
 depends="python3-cryptography rpm-python3 python3-urllib3"
-checkdepends="diffstat"
+checkdepends="python3-pytest diffstat"
 short_desc="Command Line Interface for Open Build Service"
 maintainer="Emil Miler <em@0x45.cz>"
 license="GPL-2.0-or-later"
 homepage="https://github.com/openSUSE/osc"
+changelog="https://raw.githubusercontent.com/openSUSE/osc/master/NEWS"
 distfiles="https://github.com/openSUSE/osc/archive/refs/tags/${version}.tar.gz"
-checksum=8407ccdcaa6089601e3b9f42c03c015d938ba756b1553f65e2eb122ff00b83e5
+checksum=0b2b094a515b340f859b417016def33f9b33a47abe4c3fad66c5dbc8b8447a7d


### PR DESCRIPTION
Simple version bump.

- I tested the changes in this PR: YES
- I built this PR locally for my native architecture, (x86_64-glibc)