### PR TITLE
seatd: update to 0.8

### DIFF
--- a/srcpkgs/seatd/template
+++ b/srcpkgs/seatd/template
@@ -1,6 +1,6 @@
 # Template file for 'seatd'
 pkgname=seatd
-version=0.7.0
+version=0.8.0
 revision=1
 build_style=meson
 configure_args="-Dexamples=disabled $(vopt_if elogind -Dlibseat-logind=elogind)
@@ -12,7 +12,7 @@ maintainer="Isaac Freund <mail@isaacfreund.com>"
 license="MIT"
 homepage="https://sr.ht/~kennylevinsen/seatd/"
 distfiles="https://git.sr.ht/~kennylevinsen/seatd/archive/${version}.tar.gz"
-checksum=210ddf8efa1149cde4dd35908bef8e9e63c2edaa0cdb5435f2e6db277fafff3c
+checksum=a562a44ee33ccb20954a1c1ec9a90ecb2db7a07ad6b18d0ac904328efbcf65a0
 system_groups=_seatd
 
 build_options="elogind"


### PR DESCRIPTION
- I tested the changes in this PR: yes
- I built this PR locally for my native architecture, (x86_64-glibc)

cc maintainer @ifreund (seems a pretty standard update)