### PR TITLE
openssh: enable gssapi build option by default

### DIFF
--- a/srcpkgs/openssh/template
+++ b/srcpkgs/openssh/template
@@ -1,7 +1,7 @@
 # Template file for 'openssh'
 pkgname=openssh
 version=9.3p2
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--datadir=/usr/share/openssh
  --sysconfdir=/etc/ssh --without-selinux --with-privsep-user=nobody
@@ -31,7 +31,7 @@ make_dirs="/var/chroot/ssh 0755 root root"
 
 # Package build options
 build_options="fido2 gssapi ldns ssl"
-build_options_default="fido2 ldns ssl"
+build_options_default="fido2 gssapi ldns ssl"
 desc_option_fido2="Enable support for FIDO2 USB tokens"
 
 if [ "$build_option_fido2" ]; then


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
#### Local build testing
- I built this PR locally for my native architecture, (x86_64-musl)
<!--
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->

---
I currently have a use for this feature so it would be helpful if it could be built by default.
