### PR TITLE
xbps-src/common: add riscv64 profiles

### DIFF
--- a/common/build-profiles/riscv64-musl.sh
+++ b/common/build-profiles/riscv64-musl.sh
@@ -1,0 +1,7 @@
+XBPS_TARGET_CFLAGS="-march=rv64imafdc"
+XBPS_TARGET_CXXFLAGS="$XBPS_TARGET_CFLAGS"
+XBPS_TARGET_FFLAGS="$XBPS_TARGET_CFLAGS"
+XBPS_TRIPLET="riscv64-unknown-linux-musl"
+XBPS_RUST_TARGET="riscv64gc-unknown-linux-musl"
+XBPS_ZIG_TARGET="riscv64-linux-musl"
+XBPS_ZIG_CPU="baseline"

--- a/common/build-style/cmake.sh
+++ b/common/build-style/cmake.sh
@@ -31,6 +31,7 @@ _EOF
 			ppc64*) _CMAKE_SYSTEM_PROCESSOR=ppc64 ;;
 			ppcle*) _CMAKE_SYSTEM_PROCESSOR=ppcle ;;
 			ppc*) _CMAKE_SYSTEM_PROCESSOR=ppc ;;
+			riscv64*) _CMAKE_SYSTEM_PROCESSOR=riscv64 ;;
 			*) _CMAKE_SYSTEM_PROCESSOR=generic ;;
 		esac
 		cat > cross_${XBPS_CROSS_TRIPLET}.cmake <<_EOF

--- a/common/cross-profiles/riscv64-musl.sh
+++ b/common/cross-profiles/riscv64-musl.sh
@@ -1,0 +1,12 @@
+# Cross build profile for riscv64 and Musl libc.
+
+XBPS_TARGET_MACHINE="riscv64-musl"
+XBPS_TARGET_QEMU_MACHINE="riscv64"
+XBPS_CROSS_TRIPLET="riscv64-linux-musl"
+XBPS_CROSS_CFLAGS="-march=rv64imafdc"
+XBPS_CROSS_CXXFLAGS="$XBPS_CROSS_CFLAGS"
+XBPS_CROSS_FFLAGS="$XBPS_CROSS_CFLAGS"
+XBPS_CROSS_RUSTFLAGS="--sysroot=${XBPS_CROSS_BASE}/usr"
+XBPS_CROSS_RUST_TARGET="riscv64gc-unknown-linux-musl"
+XBPS_CROSS_ZIG_TARGET="riscv64-linux-musl"
+XBPS_CROSS_ZIG_CPU="baseline"

--- a/common/environment/build-style/go.sh
+++ b/common/environment/build-style/go.sh
@@ -1,7 +1,7 @@
 if [ -z "$hostmakedepends" -o "${hostmakedepends##*gcc-go-tools*}" ]; then
 	# gc compiler
 	if [ -z "$archs" ]; then
-		archs="aarch64* armv[567]* i686* x86_64* ppc64le*"
+		archs="aarch64* armv[567]* i686* x86_64* ppc64le* riscv64*"
 	fi
 	hostmakedepends+=" go"
 	nopie=yes
@@ -9,7 +9,7 @@ else
 	# gccgo compiler
 	if [ -z "$archs" ]; then
 		# we have support for these in our gcc
-		archs="aarch64* armv[567]* i686* x86_64* ppc64*"
+		archs="aarch64* armv[567]* i686* x86_64* ppc64* riscv64*"
 	fi
 	if [ "$CROSS_BUILD" ]; then
 		# target compiler to use; otherwise it'll just call gccgo
@@ -29,6 +29,7 @@ case "$XBPS_TARGET_MACHINE" in
 	ppc*) export GOARCH=ppc;;
 	mipsel*) export GOARCH=mipsle;;
 	mips*) export GOARCH=mips;;
+	riscv64*) export GOARCH=riscv64;;
 esac
 
 export GOPATH="${wrksrc}/_build-${pkgname}-xbps"

--- a/common/environment/configure/autoconf_cache/riscv64-linux
+++ b/common/environment/configure/autoconf_cache/riscv64-linux
@@ -1,0 +1,148 @@
+
+## # general
+#ac_cv_va_val_copy=${ac_cv_va_val_copy=yes}
+#ac_cv_func_lstat_dereferences_slashed_symlink=${ac_cv_func_lstat_dereferences_slashed_symlink=yes}
+## ac_cv_func_lstat_empty_string_bug=${ac_cv_func_lstat_empty_string_bug=no}
+## ac_cv_func_posix_getpwnam_r=${ac_cv_func_posix_getpwnam_r=yes}
+## ac_cv_func_setvbuf_reversed=${ac_cv_func_setvbuf_reversed=no}
+## ac_cv_func_stat_empty_string_bug=${ac_cv_func_stat_empty_string_bug=no}
+## ac_cv_func_stat_ignores_trailing_slash=${ac_cv_func_stat_ignores_trailing_slash=no}
+## ac_libnet_have_packet_socket=${ac_libnet_have_packet_socket=yes}
+## ac_cv_linux_vers=${ac_cv_linux_vers=2}
+## ac_cv_need_trio=${ac_cv_need_trio=no}
+#ac_cv_sizeof___int64=0
+#ac_cv_sizeof_char=1
+c_cv_sizeof_int=${ac_cv_sizeof_int=4}
+ac_cv_sizeof_long=${ac_cv_sizeof_long=8}
+ac_cv_sizeof_off_t=${ac_cv_sizeof_off_t=8}
+ac_cv_sizeof_long_int=${ac_cv_sizeof_long_int=8}
+#ac_cv_sizeof_long_long=8
+#ac_cv_sizeof_short=2
+#ac_cv_sizeof_size_t=8
+#ac_cv_sizeof_ssize_t=8
+#ac_cv_sizeof_void_p=8
+#ac_cv_sizeof_unsigned_int=4
+#ac_cv_sizeof_unsigned_long=8
+ac_cv_sizeof_bool=1
+## ac_cv_sizeof_long_double=${ac_cv_sizeof_long_double=16}
+## ac_cv_sizeof_long_long=${ac_cv_sizeof_long_long=8}
+#ac_cv_sizeof_unsigned_short=2
+## ac_cv_sizeof_short_int=${ac_cv_sizeof_short_int=2}
+## ac_cv_sizeof_size_t=${ac_cv_sizeof_size_t=8}
+## ac_cv_sizeof_uid_t=${ac_cv_sizeof_uid_t=4}
+## ac_cv_sizeof_gid_t=${ac_cv_sizeof_gid_t=4}
+## ac_cv_sizeof_ino_t=${ac_cv_sizeof_ino_t=8}
+## ac_cv_sizeof_dev_t=${ac_cv_sizeof_dev_t=8}
+## ac_cv_sizeof_void_p=${ac_cv_sizeof_void_p=8}
+## ac_cv_strerror_r_SUSv3=${ac_cv_strerror_r_SUSv3=no}
+## db_cv_alignp_t=${db_cv_alignp_t='unsigned long long'}
+## db_cv_align_t=${db_cv_align_t='unsigned long long'}
+## db_cv_fcntl_f_setfd=${db_cv_fcntl_f_setfd=yes}
+## db_cv_sprintf_count=${db_cv_sprintf_count=yes}
+## ac_cv_sizeof_struct_iovec=16
+
+# glib
+#glib_cv_hasinline=${glib_cv_hasinline=yes}
+#glib_cv_has__inline=${glib_cv_has__inline=yes}
+#glib_cv_has__inline__=${glib_cv_has__inline__=yes}
+#glib_cv_long_long_format=${glib_cv_long_long_format=ll}
+#glib_cv_rtldglobal_broken=${glib_cv_rtldglobal_broken=no}
+glib_cv_stack_grows=${glib_cv_stack_grows=no}
+glib_cv_uscore=${glib_cv_uscore=no}
+#glib_cv_va_val_copy=${glib_cv_va_val_copy=yes}
+#ac_cv_alignof_guint32=4
+#ac_cv_alignof_guint64=8
+#ac_cv_alignof_unsigned_long=8
+#ac_cv_alignof_char=1
+#ac_cv_alignof_double=8
+
+## nano_cv_func_regexec_segv_emptystr=${nano_cv_func_regexec_segv_emptystr=no}
+## samba_cv_HAVE_VA_COPY=${samba_cv_HAVE_VA_COPY=yes}
+## utils_cv_sys_open_max=${utils_cv_sys_open_max=1015}
+
+# gettext
+am_cv_func_working_getline=${am_cv_func_working_getline=yes}
+
+#gcc
+#ac_cv_lib_m_sin=${ac_cv_lib_m_sin=yes}
+
+#orbit
+#libIDL_cv_long_long_format=ll
+
+## # ORBit2
+## ac_cv_alignof_CORBA_boolean=1
+## ac_cv_alignof_CORBA_char=1
+## ac_cv_alignof_CORBA_double=8
+## ac_cv_alignof_CORBA_float=4
+## ac_cv_alignof_CORBA_long=4
+## ac_cv_alignof_CORBA_long_double=8
+## ac_cv_alignof_CORBA_long_long=8
+## ac_cv_alignof_CORBA_octet=1
+## ac_cv_alignof_CORBA_pointer=8
+## ac_cv_alignof_CORBA_short=2
+## ac_cv_alignof_CORBA_struct=1
+## ac_cv_alignof_CORBA_wchar=2
+##
+## lf_cv_sane_realloc=yes
+as_cv_unaligned_access=${as_cv_unaligned_access=no}
+##
+## #unfs3
+## nfsd_cv_broken_setfsuid=${nfsd_cv_broken_setfsuid=0}
+## nfsd_cv_func_statfs=${nfsd_cv_func_statfs=statfs2_bsize}
+## nfsd_cv_bsd_signals=${nfsd_cv_bsd_signals=yes}
+
+#apr
+apr_cv_tcp_nodelay_with_cork=${apr_cv_tcp_nodelay_with_cork=yes}
+
+# lftp
+lftp_cv_va_val_copy=${lftp_cv_va_val_copy=yes}
+
+# slrn
+slrn_cv_va_val_copy=${slrn_cv_va_val_copy=yes}
+
+# cvs
+cvs_cv_func_printf_ptr=${cvs_cv_func_printf_ptr=yes}
+
+## # at-spi2-core
+#ac_cv_alignof_dbind_pointer=8
+#ac_cv_alignof_dbind_struct=1
+#ac_cv_alignof_dbus_bool_t=4
+#ac_cv_alignof_dbus_int16_t=2
+#ac_cv_alignof_dbus_int32_t=4
+#ac_cv_alignof_dbus_int64_t=8
+
+## # socat
+#sc_cv_type_dev_basic='6 /* unsigned long */'
+#sc_cv_type_gidt_basic='4 /* unsigned int */'
+#sc_cv_type_longlong=yes
+#sc_cv_type_modet_basic='4 /* unsigned int */'
+#sc_cv_type_off64=yes
+#sc_cv_type_off64_basic='5 /* long */'
+#sc_cv_type_off_basic='5 /* long */'
+#sc_cv_type_pidt_basic='3 /* int */'
+#sc_cv_type_rlimit_rlimmax_basic='6 /* unsigned long */'
+#sc_cv_type_sa_family_t=yes
+#sc_cv_type_sighandler=yes
+#sc_cv_type_sizet_basic='6 /* unsigned long */'
+#sc_cv_type_socklen=yes
+#sc_cv_type_socklent_basic='4 /* unsigned int */'
+#sc_cv_type_stat64=yes
+#sc_cv_type_stat64_stblksize_basic='3 /* int */'
+#sc_cv_type_stat64_stblocks_basic='5 /* long */'
+#sc_cv_type_stat64_stdev_basic='6 /* unsigned long */'
+#sc_cv_type_stat64_stino_basic='6 /* unsigned long */'
+#sc_cv_type_stat64_stnlink_basic='4 /* unsigned int */'
+#sc_cv_type_stat64_stsize_basic='5 /* long */'
+#sc_cv_type_stat_stblksize_basic='3 /* int */'
+#sc_cv_type_stat_stblocks_basic='5 /* long */'
+#sc_cv_type_stat_stino_basic='6 /* unsigned long */'
+#sc_cv_type_stat_stnlink_basic='4 /* unsigned int */'
+#sc_cv_type_stat_stsize_basic='5 /* long */'
+#sc_cv_type_struct_timeval_tv_usec='5 /* long */'
+#sc_cv_type_timet_basic='5 /* long */'
+#sc_cv_type_uidt_basic='4 /* unsigned int */'
+#sc_cv_type_uint16=yes
+#sc_cv_type_uint32=yes
+#sc_cv_type_uint64=yes
+#sc_cv_type_uint8=yes
+#sc_cv_typeof_struct_cmsghdr_cmsg_len='6 /* unsigned long */'

--- a/common/environment/configure/gnu-configure-args.sh
+++ b/common/environment/configure/gnu-configure-args.sh
@@ -123,6 +123,10 @@ case "$XBPS_TARGET_MACHINE" in
 		. ${_AUTOCONFCACHEDIR}/powerpc-linux
 		. ${_AUTOCONFCACHEDIR}/powerpc32-linux
 		;;
+	riscv*)
+		. ${_AUTOCONFCACHEDIR}/endian-little
+		. ${_AUTOCONFCACHEDIR}/riscv64-linux
+		;;
 
 	*) ;;
 esac

--- a/common/xbps-src/shutils/common.sh
+++ b/common/xbps-src/shutils/common.sh
@@ -289,6 +289,7 @@ get_endian() {
         ppc*le)   echo "le";;
         ppc*)     echo "be";;
         x86_64)   echo "le";;
+        riscv64)   echo "le";;
     esac
 }
 
@@ -316,6 +317,7 @@ get_wordsize() {
         ppc64*)   echo "64";;
         ppc*)     echo "32";;
         x86_64)   echo "64";;
+        riscv64)   echo "64";;
     esac
 }
 

--- a/srcpkgs/go/template
+++ b/srcpkgs/go/template
@@ -25,6 +25,7 @@ case "${XBPS_TARGET_MACHINE}" in
 	x86_64*) _goarch=amd64 ;;
 	ppc64le*) _goarch=ppc64le ;;
 	mips*) _goarch=mips ;;
+	riscv64*) _goarch=riscv64 ;;
 	*) broken="Unsupported architecture ${XBPS_TARGET_MACHINE}" ;;
 esac
 


### PR DESCRIPTION
- go: add riscv64
- build-style/cmake.sh: add riscv64 arch
- [WIP] add configure/autoconf_cache/riscv64-linux
- add riscv64 profiles

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**|**briefly**|**NO**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
