### PR TITLE
cherrytree: update to 1.0.0; gtksourceviewmm: enable deprecated API

### DIFF
--- a/srcpkgs/cherrytree/template
+++ b/srcpkgs/cherrytree/template
@@ -1,6 +1,6 @@
 # Template file for 'cherrytree'
 pkgname=cherrytree
-version=0.99.55
+version=1.0.0
 revision=1
 build_style=cmake
 # Tests are built during the normal build process and require access to X server
@@ -16,5 +16,5 @@ license="GPL-3.0-or-later"
 homepage="https://www.giuspen.com/cherrytree/"
 changelog="https://raw.githubusercontent.com/giuspen/cherrytree/master/changelog.txt"
 distfiles="https://github.com/giuspen/cherrytree/archive/refs/tags/${version}.tar.gz"
-checksum=c7e6393af6a7e82e02692faf06e62b3214c147818de1c3bbe809fa4113854215
+checksum=b0e814c97bb8f655c54f0d9c52c3afa839685bc95b101a40a9e73229abbee76c
 make_check=no  # Tests are run during build step

--- a/srcpkgs/gtksourceviewmm/template
+++ b/srcpkgs/gtksourceviewmm/template
@@ -1,16 +1,16 @@
 # Template file for 'gtksourceviewmm'
 pkgname=gtksourceviewmm
 version=3.18.0
-revision=4
+revision=5
 build_style=gnu-configure
-configure_args="--disable-deprecated-api --enable-documentation"
+configure_args="--enable-documentation"
 hostmakedepends="doxygen graphviz libxslt perl pkg-config"
 makedepends="glibmm-devel gtkmm-devel gtksourceview-devel"
 short_desc="GtkSourceview C++ bindings"
 maintainer="Enno Boland <gottox@voidlinux.org>"
-homepage="https://developer.gnome.org/gtksourceviewmm/"
 license="GPL-2.0-or-later"
-distfiles="${GNOME_SITE}/${pkgname}/${version%.*}/${pkgname}-${version}.tar.xz"
+homepage="https://developer.gnome.org/gtksourceviewmm/"
+distfiles="${GNOME_SITE}/gtksourceviewmm/${version%.*}/gtksourceviewmm-${version}.tar.xz"
 checksum=51081ae3d37975dae33d3f6a40621d85cb68f4b36ae3835eec1513482aacfb39
 
 gtksourceviewmm-devel_package() {


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**
