### PR TITLE
PolyMC: drop package

### DIFF
--- a/srcpkgs/PolyMC
+++ b/srcpkgs/PolyMC
@@ -1,1 +1,0 @@
-PrismLauncher

--- a/srcpkgs/PrismLauncher/template
+++ b/srcpkgs/PrismLauncher/template
@@ -41,9 +41,3 @@ pre_configure() {
 post_install() {
 	vdoc ${FILESDIR}/README.voidlinux
 }
-
-PolyMC_package() {
-	depends="${sourcepkg}>=${version}_${revision}"
-	short_desc+=" (transitional dummy package)"
-	build_style=meta
-}

--- a/srcpkgs/removed-packages/template
+++ b/srcpkgs/removed-packages/template
@@ -1,6 +1,6 @@
 # Template file for 'removed-packages'
 pkgname=removed-packages
-version=0.1.20230709
+version=0.1.20230728
 revision=1
 build_style=meta
 short_desc="Uninstalls packages removed from repository"
@@ -18,6 +18,7 @@ replaces="
  MonkeysAudio<=5.28_3
  MultiMC<=0.6.13_1
  Platinum9-theme<=0.0.0.20170720_3
+ PolyMC<=7.2_1
  Pyrex<=0.9.9_5
  SMC<=1.9_9
  Venom<=0.5.5_1


### PR DESCRIPTION
It's a year since we removed it.
Let's be honest and declare that we don't have PolyMC.

Close: #45292

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
