### PR TITLE
tigervnc: update to 1.13.1, add service directory

### DIFF
--- a/srcpkgs/tigervnc/files/README.voidlinux
+++ b/srcpkgs/tigervnc/files/README.voidlinux
@@ -1,0 +1,65 @@
+The system service /etc/sv/vncserver runs a TigerVNC server on DISPLAY :1
+
+A. Quick start
+
+1. Map a user to display :1 in /etc/tigervnc/vncserver.users
+2. Configure session, geometry, security, etc. - see man pages for details
+3. Enable the service: $ sudo ln -s /etc/sv/vncserver /var/service
+4. To use another display instead of :1, map the user to the alternate display
+   in /etc/tigervnc/vncserver.users and set DISPLAY to the alternate display
+   in /etc/sv/vncserver/conf
+
+B: Running multiple vncserver services
+
+The administrator can create multiple vncserver services. For example:
+
+$ sudo mkdir -p /etc/sv/vncserver-2/log
+$ sudo cp /etc/sv/vncserver/run /etc/sv/vncserver-2/run
+$ sudo cp /etc/sv/vncserver/log/run /etc/sv/vncserver-2/log/run
+$ echo DISPLAY=\":2\" > conf.tmp && sudo mv conf.tmp /etc/sv/vncserver-2/conf
+
+creates a system service named vncserver-2 that runs on display :2.
+
+C: Enabling services
+
+For example, to enable two vncserver services, vncserver and vncserver-2:
+
+$ sudo ln -s /etc/sv/vncserver /var/service
+$ sudo ln -s /etc/sv/vncserver-2 /var/service
+
+Do not enable a service for a display before that display is mapped
+to a user in /etc/tigervnc/vncserver.users.
+
+D. Security warning
+
+Upstream warns that vncserver should not be run on an untrusted LAN. Upstream
+has some suggestions for securing vncserver on an untrusted network at these links:
+
+https://github.com/TigerVNC/tigervnc/blob/master/unix/vncserver/vncserver%40.service.in
+
+https://github.com/TigerVNC/tigervnc/wiki/Secure-your-connection
+
+E: The Xsession wrapper script
+
+The upstream TigerVNC server requires a system-wide Xsession wrapper script at
+/etc/X11/xinit/Xsession or /etc/X11/Xsession, but not all Void systems have
+such a file.
+
+So the tigervnc package provides a minimal Xsession wrapper script
+in /etc/tigervnc/Xsession-fallback. It is only used if neither
+/etc/X11/xinit/Xsession nor /etc/X11/Xsession exists. Currently, this
+is the Xsession script provided by the lightdm display manager package.
+
+This way, if there is an Xsession wrapper script where upstream
+TigerVNC expects it to be, that script will be used instead of
+the minimal wrapper provided by the Void tigervnc package.
+
+As an alternative to the minimal Xsession wrapper script, one
+can use any other suitable Xsession script. For example, do:
+
+$ sudo ln -s /etc/lxdm/Xsession /etc/X11/xinit/Xsession
+
+and the TigerVNC server will use the lxdm Xsession script instead.
+
+The administrator can also write any suitable Xsession script for
+custom needs and install it under /etc/X11/xinit or /etc/X11.

--- a/srcpkgs/tigervnc/files/vncserver/run
+++ b/srcpkgs/tigervnc/files/vncserver/run
@@ -1,0 +1,5 @@
+#!/bin/sh
+sv check dbus >/dev/null || exit 1
+exec 2>&1
+[ -r ./conf ] && . ./conf
+exec /usr/libexec/vncsession-start "${DISPLAY:-:1}"

--- a/srcpkgs/tigervnc/files/xsession
+++ b/srcpkgs/tigervnc/files/xsession
@@ -1,0 +1,58 @@
+#!/bin/sh
+#
+# Fallback TigerVNC wrapper to run around X sessions.
+# Used on systems that do not have /etc/X11/xinit/Xsession or /etc/X11/Xsession
+
+echo "Running X session wrapper"
+
+# Load profile
+for file in "/etc/profile" "$HOME/.profile" "/etc/xprofile" "$HOME/.xprofile"; do
+    if [ -f "$file" ]; then
+        echo "Loading profile from $file";
+        . "$file"
+    fi
+done
+
+# Load resources
+for file in "/etc/X11/Xresources" "$HOME/.Xresources"; do
+    if [ -f "$file" ]; then
+        echo "Loading resource: $file"
+        xrdb -nocpp -merge "$file"
+    fi
+done
+
+# Load keymaps
+for file in "/etc/X11/Xkbmap" "$HOME/.Xkbmap"; do
+    if [ -f "$file" ]; then
+        echo "Loading keymap: $file"
+        setxkbmap `cat "$file"`
+        XKB_IN_USE=yes
+    fi
+done
+
+# Load xmodmap if not using XKB
+if [ -z "$XKB_IN_USE" ]; then
+    for file in "/etc/X11/Xmodmap" "$HOME/.Xmodmap"; do
+        if [ -f "$file" ]; then
+           echo "Loading modmap: $file"
+           xmodmap "$file"
+        fi
+    done
+fi
+
+unset XKB_IN_USE
+
+# Run all system xinitrc shell scripts.
+xinitdir="/etc/X11/xinit/xinitrc.d"
+if [ -d "$xinitdir" ]; then
+    for script in $xinitdir/*; do
+        echo "Loading xinit script $script"
+        if [ -x "$script" -a ! -d "$script" ]; then
+            . "$script"
+        fi
+    done
+fi
+
+echo "X session wrapper complete, running session $@"
+
+exec $@

--- a/srcpkgs/tigervnc/patches/Xsession-fallback.patch
+++ b/srcpkgs/tigervnc/patches/Xsession-fallback.patch
@@ -1,0 +1,15 @@
+Some Void systems, inluding an installation from the live image, do not have an
+Xsession script where upstream expects it to be, so use the fallback Xsession
+script provided by the Void tigervnc package.
+
+--- a/unix/vncserver/vncserver.in	2023-02-28 10:11:20.000000000 -0500
++++ b/unix/vncserver/vncserver.in	2023-07-30 17:55:47.604000000 -0400
+@@ -439,7 +439,7 @@
+ 	die "$prog: couldn't find \"$cmd\" on your PATH.\n";
+     }
+ 
+-    foreach $cmd ("/etc/X11/xinit/Xsession", "/etc/X11/Xsession") {
++    foreach $cmd ("/etc/X11/xinit/Xsession", "/etc/X11/Xsession", "/etc/tigervnc/Xsession-fallback") {
+         if (-x "$cmd") {
+             $Xsession = $cmd;
+             last;

--- a/srcpkgs/tigervnc/patches/pam-configuration.patch
+++ b/srcpkgs/tigervnc/patches/pam-configuration.patch
@@ -1,0 +1,19 @@
+Void requires some tweaks to the default upstream PAM configuration.
+
+--- a/unix/vncserver/tigervnc.pam	2023-02-28 10:11:20.000000000 -0500
++++ b/unix/vncserver/tigervnc.pam	2023-07-30 17:54:21.281000000 -0400
+@@ -1,11 +1,11 @@
+ #%PAM-1.0
+ # pam_selinux.so close should be the first session rule
+--session   required     pam_selinux.so close
++-session   optional     pam_selinux.so close
+ session    required     pam_loginuid.so
+--session   required     pam_selinux.so open
++-session   optional     pam_selinux.so open
+ session    required     pam_namespace.so
+ session    optional     pam_keyinit.so force revoke
+ session    required     pam_limits.so
+--session   optional     pam_systemd.so
++-session   optional     pam_elogind.so
+ session    required     pam_unix.so
+ -session   optional     pam_reauthorize.so prepare

--- a/srcpkgs/tigervnc/patches/use-no-fork-vncsession.patch
+++ b/srcpkgs/tigervnc/patches/use-no-fork-vncsession.patch
@@ -1,0 +1,10 @@
+On Void, use the non-forking option -D when starting vncsession
+
+--- a/unix/vncserver/vncsession-start.in	2023-02-28 10:11:20.000000000 -0500
++++ b/unix/vncserver/vncsession-start.in	2023-07-30 17:53:09.330000000 -0400
+@@ -40,4 +40,4 @@
+ 	exit 1
+ fi
+ 
+-exec "@CMAKE_INSTALL_FULL_SBINDIR@/vncsession" "${USER}" "${DISPLAY}"
++exec "@CMAKE_INSTALL_FULL_SBINDIR@/vncsession" -D "${USER}" "${DISPLAY}"

--- a/srcpkgs/tigervnc/patches/vncsession-no-fork.patch
+++ b/srcpkgs/tigervnc/patches/vncsession-no-fork.patch
@@ -1,0 +1,82 @@
+Add option to run as a non-forking daemon
+
+See upstream issue: https://github.com/TigerVNC/tigervnc/issues/1649
+
+--- a/unix/vncserver/vncsession.c	2021-11-09 02:51:28.000000000 -0500
++++ b/unix/vncserver/vncsession.c	2023-07-27 17:43:26.711000000 -0400
+@@ -506,14 +506,23 @@
+ 
+     const char *username, *display;
+ 
+-    if ((argc != 3) || (argv[2][0] != ':')) {
++    int forking = 1;
++    if (argc == 4) {
++        if ((getopt(argc, argv, "D") == 'D') && (argv[3][0] == ':'))
++            forking = 0;
++        else {
++            fprintf(stderr, "Syntax:\n");
++            fprintf(stderr, "    %s [-D] <username> <display>\n", argv[0]);
++            return EX_USAGE;
++        }
++    } else if ((argc != 3) || (argv[2][0] != ':')) {
+         fprintf(stderr, "Syntax:\n");
+-        fprintf(stderr, "    %s <username> <display>\n", argv[0]);
++        fprintf(stderr, "    %s [-D] <username> <display>\n", argv[0]);
+         return EX_USAGE;
+     }
+ 
+-    username = argv[1];
+-    display = argv[2];
++    username = argv[argc - 2];
++    display = argv[argc - 1];
+ 
+     if (geteuid() != 0) {
+         fprintf(stderr, "This program needs to be run as root!\n");
+@@ -529,8 +538,10 @@
+         return EX_OSERR;
+     }
+ 
+-    if (begin_daemon() == -1)
+-        return EX_OSERR;
++    if (forking) {
++        if (begin_daemon() == -1)
++            return EX_OSERR;
++    }
+ 
+     openlog("vncsession", LOG_PID, LOG_AUTH);
+ 
+@@ -581,7 +592,8 @@
+         fclose(f);
+     }
+ 
+-    finish_daemon();
++    if (forking)
++        finish_daemon();
+ 
+     while (1) {
+         int status;
+--- a/unix/vncserver/vncsession.man.in	2023-07-27 22:03:56.095000000 -0400
++++ b/unix/vncserver/vncsession.man.in	2023-07-27 22:11:53.605000000 -0400
+@@ -3,6 +3,7 @@
+ vncsession \- start a VNC server
+ .SH SYNOPSIS
+ .B vncsession
++.RI [-D]
+ .RI < username >
+ .RI <: display# >
+ .SH DESCRIPTION
+@@ -16,6 +17,14 @@
+ is rarely called directly and is normally started by the system service
+ manager.
+ 
++.SH -D OPTION
++.B vncsession
++by default forks and detaches so it normally is a systemd Type=forking service.
++If the -D option is used, it does not fork and detach. This option is provided
++for use with other types of systemd services such as Type=simple and Type=exec
++and for use with non-systemd system service managers that are not compatible
++with Type=forking services.
++
+ .SH FILES
+ Several VNC-related files are found in the directory $HOME/.vnc:
+ .TP

--- a/srcpkgs/tigervnc/template
+++ b/srcpkgs/tigervnc/template
@@ -1,6 +1,6 @@
 # Template file for 'tigervnc'
 pkgname=tigervnc
-version=1.12.0
+version=1.13.1
 revision=1
 _xorg_version=1.20.0
 create_wrksrc=yes
@@ -16,10 +16,14 @@ license="GPL-2.0-or-later"
 homepage="https://www.tigervnc.org"
 distfiles="https://github.com/TigerVNC/tigervnc/archive/v${version}.tar.gz
  ${XORG_SITE}/xserver/xorg-server-${_xorg_version}.tar.bz2"
-checksum="9ff3f3948f2a4e8cc06ee598ee4b1096beb62094c13e0b1462bff78587bed789
+checksum="b7c5b8ed9e4e2c2f48c7b2c9f21927db345e542243b4be88e066b2daa3d1ae25
  9d967d185f05709274ee0c4f861a4672463986e550ca05725ce27974f550d3e6"
 conflicts="turbovnc>=0"
 skip_extraction="xorg-server-${_xorg_version}.tar.gz"
+conf_files="
+	/etc/tigervnc/vncserver-config-defaults
+	/etc/tigervnc/vncserver-config-mandatory
+	/etc/tigervnc/vncserver.users"
 
 post_extract() {
 	mv tigervnc-${version}/* .
@@ -58,6 +62,9 @@ post_build() {
 }
 
 post_install() {
+	vinstall ${FILESDIR}/xsession 755 etc/tigervnc Xsession-fallback
+	vsv vncserver
+	vdoc "${FILESDIR}/README.voidlinux"
 	cd ${wrksrc}/unix/xserver/hw/vnc
 	make TIGERVNC_BUILDDIR=${wrksrc}/build DESTDIR=${DESTDIR} install
 }


### PR DESCRIPTION
In addition to updating to the latest version, this commit also fixes multiple issues with this package:

- Upstream only provides a systemd service, but Void needs a runit service
- Upstream presumes a system with SELinux and systemd, but Void does not have SELinux and uses elogind, not systemd
- Upstream requires an Xsession script that is not always present on Void systems
- Upstream only provides a forking and detaching vncsession daemon which is not very compatible with runit

This PR addresses all of the above issues by adding the necessary tweaks for Void:

- Void-compatible PAM configuration for systems without SELinux and elogind instead of systemd
- a fallback Xsession wrapper script
- define conf_files that should not be overwritten on upgrades
- add a README.voidlinux file
- patch vncsession.c to provide an option to prevent it from forking
- patch vncsession-start.in to use the option to prevent vncsession from forking

The patch to vncsession.c hopefully will be accepted upstream to fix upstream issue: https://github.com/TigerVNC/tigervnc/issues/1649. The patch has been submitted to upstream as https://github.com/TigerVNC/tigervnc/pull/1651

Closes https://github.com/void-linux/void-packages/issues/45522

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES** Tested on x86_64-musl, also built for x86_64, checked xlint which passed