### PR TITLE
gst-plugins-ugly1: enable GPL plugins, New package: photofilmstrip.

### DIFF
--- a/srcpkgs/gst-plugins-ugly1/template
+++ b/srcpkgs/gst-plugins-ugly1/template
@@ -1,9 +1,11 @@
 # Template file for 'gst-plugins-ugly1'
 pkgname=gst-plugins-ugly1
 version=1.22.2
-revision=1
+revision=2
 build_style=meson
-configure_args="-Damrnb=disabled -Damrwbdec=disabled -Dsidplay=disabled"
+configure_args="-Damrnb=disabled -Damrwbdec=disabled -Dsidplay=disabled
+ -Dgpl=enabled -Dx264=enabled -Da52dec=enabled -Dmpeg2dec=enabled
+ -Dcdio=enabled"
 # XXX add required pkgs for the amr, sid plugins.
 hostmakedepends="pkg-config intltool python3"
 makedepends="glib-devel libxml2-devel gst-plugins-base1-devel
@@ -12,7 +14,7 @@ makedepends="glib-devel libxml2-devel gst-plugins-base1-devel
 depends="orc>=0.4.18 gst-plugins-base1>=${version}"
 short_desc="GStreamer plugins from the ugly set (1.x)"
 maintainer="Orphaned <orphan@voidlinux.org>"
-license="LGPL-2.1-or-later"
+license="LGPL-2.1-or-later, GPL-2.0-or-later"
 homepage="https://gstreamer.freedesktop.org"
 distfiles="${homepage}/src/${pkgname/1/}/${pkgname/1/}-${version}.tar.xz"
 checksum=8f30f44db0bd063709bf6fbe55138e3a98af0abcb61c360f35582bbe10e80691

--- a/srcpkgs/photofilmstrip/patches/no-img2py.patch
+++ b/srcpkgs/photofilmstrip/patches/no-img2py.patch
@@ -1,0 +1,13 @@
+--- a/setup.py
++++ b/setup.py
+@@ -187,9 +187,7 @@ class pfs_build(build):
+         build.run(self)
+ 
+     def _make_resources(self):
+-        try:
+-            from wx.tools.img2py import img2py
+-        except ImportError:
++        if True:
+             log.warn("Cannot update image resources! Using images.py from source")
+             return
+ 

--- a/srcpkgs/photofilmstrip/template
+++ b/srcpkgs/photofilmstrip/template
@@ -1,0 +1,24 @@
+# Template file for 'photofilmstrip'
+pkgname=photofilmstrip
+version=4.0.0
+revision=1
+build_style=python3-module
+hostmakedepends="python3-setuptools gst1-python3 python3-Sphinx gettext"
+depends="python3 gst1-python3 gst1-editing-services python3-Pillow wxPython4"
+checkdepends="$depends"
+short_desc="Slideshow creator with Ken Burns effect"
+maintainer="Đoàn Trần Công Danh <congdanhqx@gmail.com>"
+license="GPL-2.0-or-later"
+homepage="https://www.photofilmstrip.org/"
+distfiles="https://github.com/PhotoFilmStrip/PFS/archive/refs/tags/v${version}.tar.gz"
+checksum=1e0ced0a25f752100a68286833d35fd976a59bafd927eb4eae54b837974578ee
+
+post_patch() {
+	vsed -i -e 's/gstreamer1.0-libav/gst-libav/' \
+		-e 's/gstreamer1.0-plugins-base/gst-plugins-base1/' \
+		-e 's/gstreamer1.0-plugins-good/gst-plugins-good1/' \
+		-e 's/gstreamer1.0-plugins-bad/gst-plugins-bad1/' \
+		-e 's/gstreamer1.0-plugins-ugly/gst-plugins-ugly1/' \
+		photofilmstrip/core/renderer/GStreamerRenderer.py \
+		po/*.po
+}


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
