### PR TITLE
common/container: move masterdir image building to void-packages

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+*
+!common/container/
+!common/repo-keys/

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -40,11 +40,12 @@ jobs:
     if: "!contains(github.event.pull_request.title, '[ci skip]') && !contains(github.event.pull_request.body, '[ci skip]')"
 
     container:
-      image: 'ghcr.io/void-linux/xbps-src-masterdir:20230708RC01-${{ matrix.config.bootstrap }}'
+      image: ghcr.io/void-linux/void-buildroot-${{ matrix.config.libc }}:20230818R1
+      options: --platform ${{ matrix.config.platform }}
       env:
         PATH: '/usr/libexec/chroot-git:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/sbin:/usr/local/bin:/tmp/bin'
         ARCH: '${{ matrix.config.arch }}'
-        BOOTSTRAP: '${{ matrix.config.bootstrap }}'
+        BOOTSTRAP: '${{ matrix.config.host }}'
         TEST: '${{ matrix.config.test }}'
         HOSTREPO: /hostrepo
 
@@ -52,13 +53,13 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - { arch: x86_64, bootstrap: x86_64, test: 1 }
-          - { arch: i686, bootstrap: i686, test: 1 }
-          - { arch: aarch64, bootstrap: x86_64, test: 0 }
-          - { arch: armv7l, bootstrap: x86_64, test: 0 }
-          - { arch: x86_64-musl, bootstrap: x86_64-musl, test: 1 }
-          - { arch: armv6l-musl, bootstrap: x86_64-musl, test: 0 }
-          - { arch: aarch64-musl, bootstrap: x86_64-musl, test: 0 }
+          - { arch: x86_64,       host: x86_64,      libc: glibc, platform: linux/amd64, test: 1 }
+          - { arch: i686,         host: i686,        libc: glibc, platform: linux/386,   test: 1 }
+          - { arch: aarch64,      host: x86_64,      libc: glibc, platform: linux/amd64, test: 0 }
+          - { arch: armv7l,       host: x86_64,      libc: glibc, platform: linux/amd64, test: 0 }
+          - { arch: x86_64-musl,  host: x86_64-musl, libc: musl,  platform: linux/amd64, test: 1 }
+          - { arch: armv6l-musl,  host: x86_64-musl, libc: musl,  platform: linux/amd64, test: 0 }
+          - { arch: aarch64-musl, host: x86_64-musl, libc: musl,  platform: linux/amd64, test: 0 }
 
     steps:
       - name: Prepare container

--- a/.github/workflows/container.yaml
+++ b/.github/workflows/container.yaml
@@ -1,0 +1,98 @@
+---
+name: 'Build buildroot containers'
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - master
+    paths:
+      - common/container/**
+  push:
+    branches:
+      - master
+    paths:
+      - common/container/**
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+
+    strategy:
+      matrix:
+        libc:
+          - glibc
+          - musl
+
+    steps:
+      - name: Checkout
+        uses: classabbyamp/treeless-checkout-action@v1
+
+      - name: Get image release
+        id: release
+        run: |
+          # gets the list of all date-shaped tags for the image, finds the most recent one
+          tag="$(skopeo list-tags "docker://ghcr.io/${{ github.repository_owner }}/void-buildroot-${{ matrix.libc }}" | \
+            jq -r '.Tags | sort | reverse | map(select(test("^[0-9]{8}(R[0-9]+)?$")))[0]')"
+          # tags from a different day or pre-YYYYMMDDRN
+          if [ "${tag%R*}" != "$(date -u +%Y%m%d)" ] || [ "${tag%R*}" = "${tag}" ]; then
+            rel=1
+          else
+            rel=$(( ${tag##*R} + 1 ))
+          fi
+          echo "rel=${rel}" >> "${GITHUB_OUTPUT}"
+
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            ghcr.io/${{ github.repository_owner }}/void-buildroot-${{ matrix.libc }}
+          tags: |
+            type=sha,prefix=
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value={{date 'YYYYMMDD'}}R${{ steps.release.outputs.rel }},enable={{is_default_branch}},priority=1000
+          flavor: latest=false
+          labels: |
+            org.opencontainers.image.authors=Void Linux team and contributors
+            org.opencontainers.image.url=https://voidlinux.org
+            org.opencontainers.image.documentation=https://github.com/${{ github.repository }}
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.vendor=Void Linux
+            org.opencontainers.image.title=Void Linux build root
+            org.opencontainers.image.description=Image for building packages with xbps-src on Void Linux
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to GCHR
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push images
+        id: build_and_push
+        uses: docker/bake-action@v3
+        with:
+          push: ${{ github.event_name != 'pull_request' }}
+          targets: void-buildroot-${{ matrix.libc }}
+          files: |
+            common/container/docker-bake.hcl
+            ${{ steps.meta.outputs.bake-file }}
+          set: |
+            _common.cache-to=type=gha
+            _common.cache-from=type=gha

--- a/.github/workflows/cycles.yml
+++ b/.github/workflows/cycles.yml
@@ -10,7 +10,7 @@ jobs:
     permissions:
       issues: write
     container:
-      image: 'ghcr.io/void-linux/xbps-src-masterdir:20230708RC01-x86_64-musl'
+      image: 'ghcr.io/void-linux/void-buildroot-musl:20230818R1'
       env:
         PATH: '/usr/libexec/chroot-git:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/sbin:/usr/local/bin:/tmp/bin'
     steps:

--- a/common/container/Containerfile
+++ b/common/container/Containerfile
@@ -1,0 +1,35 @@
+# syntax=docker/dockerfile:1
+FROM --platform=${BUILDPLATFORM} alpine:3.18 AS bootstrap
+ARG TARGETPLATFORM
+ARG MIRROR=https://repo-ci.voidlinux.org
+ARG LIBC
+RUN apk add ca-certificates curl && \
+  curl "${MIRROR}/static/xbps-static-static-0.59_5.$(uname -m)-musl.tar.xz" | tar vJx
+COPY common/repo-keys/* /target/var/db/xbps/keys/
+COPY common/container/setup.sh /bootstrap/setup.sh
+RUN --mount=type=cache,sharing=locked,target=/target/var/cache/xbps,id=repocache-${LIBC} \
+  . /bootstrap/setup.sh; \
+  XBPS_TARGET_ARCH=${ARCH} xbps-install -S \
+    -R "${REPO}" -R "${REPO}/bootstrap" \
+    -r /target
+
+FROM --platform=${BUILDPLATFORM} bootstrap AS install
+ARG TARGETPLATFORM
+ARG MIRROR
+ARG LIBC
+COPY --from=bootstrap /target /target
+COPY common/container/noextract.conf /target/etc/xbps.d/noextract.conf
+RUN --mount=type=cache,sharing=locked,target=/target/var/cache/xbps,id=repocache-${LIBC} \
+  . /bootstrap/setup.sh; \
+  XBPS_TARGET_ARCH=${ARCH} xbps-install -y \
+    -R "${REPO}" -R "${REPO}/bootstrap" \
+    -r /target \
+    base-chroot void-repo-bootstrap
+
+FROM scratch AS image
+COPY --link --from=install /target /
+RUN \
+  install -dm1777 tmp; \
+  xbps-reconfigure -fa; \
+  rm -rf /var/cache/xbps/*
+CMD ["/bin/sh"]

--- a/common/container/docker-bake.hcl
+++ b/common/container/docker-bake.hcl
@@ -1,0 +1,29 @@
+variable "MIRROR" {
+  default = "https://repo-ci.voidlinux.org/"
+}
+
+target "docker-metadata-action" {}
+
+target "_common" {
+  inherits = ["docker-metadata-action"]
+  dockerfile = "common/container/Containerfile"
+  no-cache-filter = ["bootstrap"]
+  cache-to = ["type=local,dest=/tmp/buildx-cache"]
+  cache-from = ["type=local,src=/tmp/buildx-cache"]
+  target = "image"
+  args = {
+    "MIRROR" = "${MIRROR}"
+  }
+}
+
+target "void-buildroot-glibc" {
+  inherits = ["_common"]
+  platforms = ["linux/amd64", "linux/386", "linux/arm64", "linux/arm/v7", "linux/arm/v6"]
+  args = { "LIBC" = "glibc" }
+}
+
+target "void-buildroot-musl" {
+  inherits = ["_common"]
+  platforms = ["linux/amd64", "linux/arm64", "linux/arm/v7", "linux/arm/v6"]
+  args = { "LIBC" = "musl" }
+}

--- a/common/container/noextract.conf
+++ b/common/container/noextract.conf
@@ -1,0 +1,13 @@
+noextract=/etc/sv*
+noextract=/usr/share/man*
+noextract=/usr/lib/dracut*
+noextract=/etc/skel*
+noextract=/usr/lib/modprobe.d*
+noextract=/usr/lib/sysctl.d*
+noextract=/usr/lib/udev*
+noextract=/usr/share/bash-completion*
+noextract=/usr/share/fish/vendor-completions.d*
+noextract=/usr/share/zsh/site-functions*
+noextract=/usr/share/info*
+noextract=/usr/share/locale*
+noextract=/usr/lib/gconv*

--- a/common/container/setup.sh
+++ b/common/container/setup.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+
+: "${MIRROR:=https://repo-default.voidlinux.org/}"
+
+suffix() {
+	case "${LIBC:?}" in
+	musl) echo "-musl" ;;
+	esac
+}
+
+repo() {
+	case "${ARCH:?}" in
+	aarch64*) echo "${MIRROR}/current/aarch64" ;;
+	*-musl)   echo "${MIRROR}/current/musl"    ;;
+	*)        echo "${MIRROR}/current"         ;;
+	esac
+}
+
+case "${TARGETPLATFORM:?}" in
+linux/arm/v6) ARCH="armv6l$(suffix)"  ;;
+linux/arm/v7) ARCH="armv7l$(suffix)"  ;;
+linux/arm64)  ARCH="aarch64$(suffix)" ;;
+linux/amd64)  ARCH="x86_64$(suffix)"  ;;
+linux/386)    ARCH="i686$(suffix)"    ;;
+esac
+
+REPO="$(repo)"
+
+export ARCH REPO


### PR DESCRIPTION
see void-linux/void-docker#11

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**
- example CI run with the new image: https://github.com/classabbyamp/void-packages/actions/runs/5843401357

before:
```
ghcr.io/void-linux/xbps-src-masterdir   latest-x86_64        607MB
ghcr.io/void-linux/xbps-src-masterdir   latest-x86_64-musl   522MB
```
after:
```
localhost:5000/void-buildroot-glibc    latest   438MB
localhost:5000/void-buildroot-musl     latest   383MB
```

