### PR TITLE
grafana: update to 10.0.3

### DIFF
--- a/srcpkgs/grafana/files/grafana/run
+++ b/srcpkgs/grafana/files/grafana/run
@@ -1,4 +1,3 @@
 #!/bin/sh
 exec 2>&1
-
-exec chpst -u _grafana:_grafana grafana-server -homepath /usr/share/grafana/ -config /etc/grafana/grafana.ini 2>&1
+exec chpst -u _grafana:_grafana grafana server -homepath /usr/share/grafana/ -config /etc/grafana/grafana.ini 2>&1

--- a/srcpkgs/grafana/template
+++ b/srcpkgs/grafana/template
@@ -1,10 +1,10 @@
 # Template file for 'grafana'
 pkgname=grafana
-version=8.5.24
+version=10.0.3
 revision=1
 build_style=go
 go_import_path=github.com/grafana/grafana
-go_package="${go_import_path}/pkg/cmd/grafana-cli ${go_import_path}/pkg/cmd/grafana-server"
+go_package="${go_import_path}/pkg/cmd/grafana-cli ${go_import_path}/pkg/cmd/grafana-server ${go_import_path}/pkg/cmd/grafana"
 hostmakedepends="tar make"
 short_desc="Open platform for beautiful analytics and monitoring"
 maintainer="Michael Aldridge <maldridge@voidlinux.org>"
@@ -12,8 +12,8 @@ license="Apache-2.0"
 homepage="https://grafana.com"
 distfiles="https://dl.grafana.com/oss/release/grafana-${version}.linux-amd64.tar.gz
 https://github.com/grafana/grafana/archive/v${version}.tar.gz"
-checksum="ff088012f356bcece24e5c89f924fed83a3b63736ec2cc9bc2a66341bf8fe00c
-9332fea516f617e6f9b418f28154f4f8f162c2abb3b739cc6ae7fedac21ddc41"
+checksum="daeb7eee1327b6d407cdaaf1a234ec9d8e2ae5a6d085e0fd3d8c606214eb6032
+9c1a1e3a9133abe4140aabad0d968f43ec2b3b14309f0dff80da367220bf58ff"
 
 system_accounts="_grafana"
 _grafana_homedir="/var/lib/grafana"
@@ -35,7 +35,7 @@ pre_build() {
 do_install() {
 	# only install grafana binaries - GOPATH/bin contains eg. wire used at
 	# buildtime, which we don't want in the package
-	for f in ${GOPATH}/bin/grafana-* ${GOPATH}/bin/*/grafana-*; do
+	for f in ${GOPATH}/bin/grafana* ${GOPATH}/bin/*/grafana*; do
 		if [ -f "$f" ] && [ -x "$f" ]; then
 			vbin "$f"
 		fi


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures:
   - armv6l-glibc

Grafana is on a rather old version on Void Linux - the 8 series.
Going to the 9 series has no breaking changes as far as I can see.
Going to the 10 series has some: https://grafana.com/docs/grafana/latest/breaking-changes/breaking-changes-v10-0/ but nothing too fancy imho.

One notable change is a new executable _grafana_ which will deprecate _grafana-cli_ **and** _grafana-server_. For now they are included all 3 for compatibility.
