### PR TITLE
gmp: update to 6.3.0.

### DIFF
--- a/srcpkgs/gmp/template
+++ b/srcpkgs/gmp/template
@@ -1,6 +1,6 @@
 # Template file for 'gmp'
 pkgname=gmp
-version=6.2.1
+version=6.3.0
 revision=1
 bootstrap=yes
 build_style=gnu-configure
@@ -8,11 +8,12 @@ configure_args="--enable-cxx"
 hostmakedepends="m4"
 makedepends="zlib-devel"
 short_desc="Library for arbitrary precision arithmetic"
-maintainer="Orphaned <orphan@voidlinux.org>"
+maintainer="Gonzalo Tornaría <tornaria@cmat.edu.uy>"
 license="LGPL-3.0-or-later"
 homepage="http://gmplib.org/"
+changelog="https://gmplib.org/repo/gmp/raw-file/tip/NEWS"
 distfiles="${GNU_SITE}/gmp/gmp-${version}.tar.xz"
-checksum=fd4829912cddd12f84181c3451cc752be224643e87fac497b69edddadc49b4f2
+checksum=a3c2b80201b89e68616f4ad30bc66aee4927c3ce50e33929ca819d5c43538898
 
 subpackages="gmpxx gmpxx-devel gmp-devel"
 


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

It doesn't seem to have any breaking change (see https://gmplib.org/repo/gmp/file/tip/NEWS) but maybe wise to check more. I'm installing it locally (x86_64) and testing with sagemath.

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
