### PR TITLE
R-cran-svglite: rebuild to fix error

### DIFF
--- a/srcpkgs/R-cran-svglite/template
+++ b/srcpkgs/R-cran-svglite/template
@@ -1,7 +1,7 @@
 # Template file for 'R-cran-svglite'
 pkgname=R-cran-svglite
 version=2.1.0
-revision=1
+revision=2
 build_style=R-cran
 makedepends="R-cran-systemfonts R-cran-cpp11 libpng-devel"
 depends="R-cran-systemfonts"


### PR DESCRIPTION
Saw the following error while using an R script:

```
> ggsave('bones_line.svg', plot=pt_line, width=24, height=12, units='cm')
Error in svglite_(filename, bg, width, height, pointsize, standalone,  :
  Versión API gráfica incompatible
Calls: ggsave -> dev -> <Anonymous> -> svglite_
Ejecución interrumpida
```

Rebuilt and updated the package, and the error went away.

Not sure what triggered it. I run updates not so often, and this script less often.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
