### PR TITLE
New package: cpupower-gui-1.0.0

### DIFF
--- a/srcpkgs/cpupower-gui/files/cpupower-gui/run
+++ b/srcpkgs/cpupower-gui/files/cpupower-gui/run
@@ -1,0 +1,3 @@
+#!/bin/sh
+/usr/bin/cpupower-gui config
+sv down cpupower-gui

--- a/srcpkgs/cpupower-gui/patches/meson.patch
+++ b/srcpkgs/cpupower-gui/patches/meson.patch
@@ -1,0 +1,12 @@
+diff --git a/data/meson.build b/data/meson.build
+index 4dbfe5c..3be1e44 100644
+--- a/data/meson.build
++++ b/data/meson.build
+@@ -12,7 +12,6 @@ desktop_conf = configuration_data()
+ desktop_conf.set('icon', application_id)
+ 
+ desktop_file = i18n.merge_file(
+-  'desktop',
+    input: configure_file(
+     input: files('org.rnd2.cpupower_gui.desktop.in.in'),
+     output: 'org.rnd2.cpupower_gui.desktop.in',

--- a/srcpkgs/cpupower-gui/template
+++ b/srcpkgs/cpupower-gui/template
@@ -1,0 +1,17 @@
+# Template file for 'cpupower-gui'
+pkgname=cpupower-gui
+version=1.0.0
+revision=1
+build_style=meson
+hostmakedepends="pkg-config glib-devel gettext"
+depends="glib python3 gtk+3 polkit python3-dbus python3-gobject python3-xdg libhandy1"
+short_desc="GUI for changing CPU frequency limits"
+maintainer="voidbert <humbertogilgomes@protonmail.com>"
+license="GPL-3.0-or-later"
+homepage="https://github.com/vagnum08/cpupower-gui"
+distfiles="https://github.com/vagnum08/cpupower-gui/archive/v${version}.tar.gz"
+checksum=09f8b9619e974abe00fc06c0d5528b6a36518f6b283b3db338349bada1d51492
+
+post_install() {
+	vsv cpupower-gui
+}


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

Addresses issue #45182.

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-musl)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64
  - i686
  - armv6l
  - armv6l-musl

#### Help wanted

##### Polkit testing

<details><summary>Previous problem - now fixed</summary>
<p>

I'm having lots of trouble getting an authentication agent working in my sway WM system. I would thank anyone that uses a DE (or got polkit working in a WM) to test if they can set CPU frequencies from a regular user, without having to launch the whole app as root.

</p></details>

I managed to test polkit authentication on a live VoidLinux xfce image.

##### Runit services

<details><summary>Previous problem - now fixed</summary>
<p>

I already wrote a runit service but I keep getting the following error:
```
# sv once cpupower-gui
warning: cpupower-gui: unable to open supervise/ok: file does not exist
```
I can confirm that `/var/service/cpupower-gui/supervise` is a broken symlink, even after rebooting the system. After a reboot, the service doesn't produce any effects on the CPU frequencies, so I think it's not being started.

However, `runsv` seems to work, after which I start getting a different error:
```
# sv once cpupower-gui
fail: cpupower-gui: runsv not running
```

Does anyone more knowledgeable in runit know how I can fix this? Also, I think there's no great way to port user services from systemd, but again, I'd be happy anyone more informed would be willing to help.

</p></details>

The previous problem, now fixed, happened because I accidentally messed up `/var/service`'s permissions and runit got confused. I still don't know if it is possible to **port over systemd's user services**.
