### PR TITLE
libofx: update to 0.10.9

### DIFF
--- a/srcpkgs/libofx/template
+++ b/srcpkgs/libofx/template
@@ -1,28 +1,25 @@
 # Template file for 'libofx'
 pkgname=libofx
-version=0.10.1
+version=0.10.9
 revision=1
-build_style="gnu-configure"
-configure_args="--with-opensp-includes=${XBPS_CROSS_BASE}/usr/include/OpenSP
- --with-opensp-libs=${XBPS_CROSS_BASE}/usr/lib"
+build_style=cmake
 hostmakedepends="pkg-config"
 makedepends="opensp-devel libcurl-devel libxml++-devel"
 short_desc="OFX banking protocol abstraction library"
 maintainer="Enno Boland <gottox@voidlinux.org>"
 license="GPL-2.0-or-later"
-homepage="http://libofx.sourceforge.net"
+homepage="https://github.com/libofx/libofx"
 changelog="https://raw.githubusercontent.com/libofx/libofx/master/NEWS"
-distfiles="${SOURCEFORGE_SITE}/$pkgname/$pkgname/$pkgname-$version.tar.gz"
-checksum=3bcc2c86b23dc11315a8ce0c9f20cc504fdc6147ea3a0385cb3e05768279c64d
+distfiles="https://github.com/libofx/libofx/archive/refs/tags/${version}.tar.gz"
+checksum=ea9fa07759622ecc7f25b637fa8fb34d587af80607ca4389d25966a6a4f94ab9
 
 libofx-devel_package() {
 	depends="${sourcepkg}>=${version}_${revision}"
 	short_desc+=" - development files"
 	pkg_install() {
 		vmove usr/include
+		vmove usr/lib/cmake
 		vmove usr/lib/pkgconfig
-		vmove "usr/lib/*.a"
 		vmove "usr/lib/*.so"
-		vmove usr/share/doc
 	}
 }


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

I tested this as part of the gnucash update, and everything seems to work. I did **not** test against the older version of gnucash, so this should only be merged after #43386.