### PR TITLE
gwenhywfar: update to 5.10.2, remove -gtk; aqbanking: update to 6.5.4

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -1548,7 +1548,6 @@ libslang.so.2 slang-2.2.4_1
 libtre.so.5 tre-0.8.0_1
 libktoblzcheck.so.1 ktoblzcheck-1.43_2
 libgwenhywfar.so.79 gwenhywfar-5.4.0_2
-libgwengui-gtk2.so.79 gwenhywfar-gtk-5.4.0_2
 libgwengui-gtk3.so.79 gwenhywfar-gtk3-5.4.0_2
 libgwengui-cpp.so.79 gwenhywfar-5.4.0_2
 libgwengui-qt5.so.79 gwenhywfar-qt5-5.4.0_2

--- a/srcpkgs/aqbanking/template
+++ b/srcpkgs/aqbanking/template
@@ -1,22 +1,32 @@
 # Template file for 'aqbanking'
 pkgname=aqbanking
-version=6.3.2
+version=6.5.4
 revision=1
 build_style=gnu-configure
-hostmakedepends="pkg-config gwenhywfar tar"
-makedepends="gwenhywfar-devel xmlsec1-devel ktoblzcheck-devel gmp-devel"
+hostmakedepends="automake libtool pkg-config gwenhywfar gwenhywfar-devel tar"
+makedepends="gwenhywfar-devel xmlsec1-devel gmp-devel"
 short_desc="Library for online banking and financial applications"
 maintainer="Enno Boland <gottox@voidlinux.org>"
 license="GPL-2.0-only, GPL-3.0-only"
 homepage="https://www.aquamaniac.de/rdm/"
-distfiles="https://www.aquamaniac.de/rdm/attachments/download/386/${pkgname}-${version}.tar.gz"
-checksum=a97ab42f7298cbb2617b2bda53ca51a2b0fe5f780bde098a39a5f4a3243e3418
+distfiles="https://github.com/aqbanking/aqbanking/archive/refs/tags/${version}.tar.gz"
+checksum=66b13d7694c25d09511b77edc14262025a452dfd93359c7257826f0e4c60dc6b
 disable_parallel_build=yes
 
 if [ "$CROSS_BUILD" ]; then
 	export PKG_CONFIG_PATH=${XBPS_CROSS_BASE}/usr/lib/pkgconfig
 	configure_args+=" -with-xmlmerge=/usr/bin/xmlmerge"
 fi
+
+pre_configure() {
+	autoreconf -fi
+}
+
+pre_build() {
+	make -f Makefile.cvs
+	make typedefs
+	make types
+}
 
 aqbanking-devel_package() {
 	depends="${sourcepkg}>=${version}_${revision}"
@@ -25,6 +35,7 @@ aqbanking-devel_package() {
 		vmove usr/bin/aqbanking-config
 		vmove usr/include
 		vmove "usr/lib/*.so"
+		vmove usr/lib/cmake
 		vmove usr/lib/pkgconfig
 		vmove usr/share/aclocal
 	}

--- a/srcpkgs/gwenhywfar-gtk
+++ b/srcpkgs/gwenhywfar-gtk
@@ -1,1 +1,0 @@
-gwenhywfar

--- a/srcpkgs/gwenhywfar/patches/qt5-cross.patch
+++ b/srcpkgs/gwenhywfar/patches/qt5-cross.patch
@@ -1,28 +1,31 @@
---- a/m4/ax_have_qt.m4	2020-01-16 19:40:22.927813462 +0100
-+++ b/m4/ax_have_qt.m4	2020-01-16 19:42:12.106436543 +0100
-@@ -74,6 +74,12 @@
+diff --git a/m4/ax_have_qt.m4 b/m4/ax_have_qt.m4
+index f035a81852..b43f8c2387 100644
+--- a/m4/ax_have_qt.m4
++++ b/m4/ax_have_qt.m4
+@@ -74,6 +74,13 @@ AC_DEFUN([AX_HAVE_QT],
+     [QT_QMAKE="$withval"],
      [QT_QMAKE="qmake"]
    )
- 
++
 +  AC_ARG_WITH(qt5-config,
 +    [  --with-qt5-config=FILE   uses given qt configuration],
-+    [QT_CONFIGURATION="$withval"],
++    [QT_CONFIGURATION="$withval"], 
 +    [QT_CONFIGURATION=""]
 +  )
-+
++  
    AC_MSG_CHECKING(for Qt)
    # If we have Qt5 or later in the path, we're golden
    ver=`$QT_QMAKE --version | grep -o "Qt version ."`
-@@ -122,7 +128,11 @@
+@@ -96,7 +103,11 @@ percent.target = %
  percent.commands = @echo -n "\$(\$(@))\ "
  QMAKE_EXTRA_TARGETS += percent
  EOF
 -    $QT_QMAKE $am_have_qt_pro -o $am_have_qt_makefile
 +    if test -z $QT_CONFIGURATION; then
-+        $QT_QMAKE $am_have_qt_pro -o $am_have_qt_makefile
++      $QT_QMAKE $am_have_qt_pro -o $am_have_qt_makefile
 +    else
-+        $QT_QMAKE $am_have_qt_pro -o $am_have_qt_makefile -qtconf $QT_CONFIGURATION
++      $QT_QMAKE $am_have_qt_pro -o $am_have_qt_makefile -qtconf $QT_CONFIGURATION
 +    fi
-     QT_CXXFLAGS=`make -s -f $am_have_qt_makefile CXXFLAGS INCPATH`
-     QT_LIBS=`make -s -f $am_have_qt_makefile LIBS`
+     QT_CXXFLAGS=`cd $am_have_qt_dir; make -s -f $am_have_qt_makefile CXXFLAGS INCPATH`
+     QT_LIBS=`cd $am_have_qt_dir; make -s -f $am_have_qt_makefile LIBS`
      rm $am_have_qt_pro $am_have_qt_makefile

--- a/srcpkgs/gwenhywfar/template
+++ b/srcpkgs/gwenhywfar/template
@@ -1,18 +1,19 @@
 # Template file for 'gwenhywfar'
 pkgname=gwenhywfar
-version=5.6.0
+version=5.10.2
 revision=1
 build_style=gnu-configure
-configure_args="--disable-binreloc
+configure_args="--disable-binreloc --disable-network-checks
  --with-qt5-moc=/usr/lib/qt5/bin/moc --with-qt5-uic=/usr/lib/qt5/bin/uic"
-hostmakedepends="automake pkg-config libgcrypt-devel libtool which"
+hostmakedepends="automake pkg-config libgcrypt-devel libtool which
+ gettext-devel"
 makedepends="libgcrypt-devel gnutls-devel gtk+-devel qt5-devel gtk+3-devel"
 short_desc="OS abstraction functions for various projects"
 maintainer="Enno Boland <gottox@voidlinux.org>"
 license="LGPL-2.1-or-later"
 homepage="https://github.com/aqbanking/gwenhywfar"
-distfiles="https://github.com/aqbanking/gwenhywfar/archive/${version}.tar.gz"
-checksum=9f2876770824a283d02fd730bb1f7a98970fa6f20121f4af433d6698831c3a84
+distfiles="https://github.com/aqbanking/gwenhywfar/archive/refs/tags/${version}.tar.gz"
+checksum=2b0b9dd49b95f025f4e0c0346ba88e20b893407c444fccf6403a4da349954f04
 
 if [ "$CROSS_BUILD" ]; then
 	hostmakedepends+=" qt5-host-tools qt5-devel"
@@ -20,44 +21,35 @@ fi
 
 pre_configure() {
 	export QT_SELECT=5
-	# Build all GUIs
-	vsed -i configure.ac -e's;"qt4 gtk2";"qt5 gtk2 gtk3";'
 	autoreconf -fi
 	if [ "$CROSS_BUILD" ]; then
-                cat > "${wrksrc}/qt.conf" <<_EOF
-[Paths]
-Sysroot=${XBPS_CROSS_BASE}
-Prefix=${XBPS_CROSS_BASE}/usr
-ArchData=${XBPS_CROSS_BASE}/usr/lib/qt5
-Data=${XBPS_CROSS_BASE}/usr/share/qt5
-Documentation=${XBPS_CROSS_BASE}/usr/share/doc/qt5
-Headers=${XBPS_CROSS_BASE}/usr/include/qt5
-Libraries=${XBPS_CROSS_BASE}/usr/lib
-LibraryExecutables=/usr/lib/qt5/libexec
-Binaries=/usr/lib/qt5/bin
-Tests=${XBPS_CROSS_BASE}/usr/tests
-Plugins=/usr/lib/qt5/plugins
-Imports=${XBPS_CROSS_BASE}/usr/lib/qt5/imports
-Qml2Imports=${XBPS_CROSS_BASE}/usr/lib/qt5/qml
-Translations=${XBPS_CROSS_BASE}/usr/share/qt5/translations
-Settings=${XBPS_CROSS_BASE}/etc/xdg
-Examples=${XBPS_CROSS_BASE}/usr/share/qt5/examples
-HostPrefix=/usr
-HostData=/usr/lib/qt5
-HostBinaries=/usr/lib/qt5/bin
-HostLibraries=/usr/lib
-Spec=linux-g++
-TargetSpec=linux-g++
-_EOF
-	configure_args+=" --with-qt5-config=${wrksrc}/qt.conf"
-        fi
-}
-
-gwenhywfar-gtk_package() {
-	short_desc+=" - gtk+2 bindings"
-	pkg_install() {
-		vmove usr/lib/*-gtk2*
-	}
+		cat > "${wrksrc}/qt.conf" <<- _EOF
+			[Paths]
+			Sysroot=${XBPS_CROSS_BASE}
+			Prefix=${XBPS_CROSS_BASE}/usr
+			ArchData=${XBPS_CROSS_BASE}/usr/lib/qt5
+			Data=${XBPS_CROSS_BASE}/usr/share/qt5
+			Documentation=${XBPS_CROSS_BASE}/usr/share/doc/qt5
+			Headers=${XBPS_CROSS_BASE}/usr/include/qt5
+			Libraries=${XBPS_CROSS_BASE}/usr/lib
+			LibraryExecutables=/usr/lib/qt5/libexec
+			Binaries=/usr/lib/qt5/bin
+			Tests=${XBPS_CROSS_BASE}/usr/tests
+			Plugins=/usr/lib/qt5/plugins
+			Imports=${XBPS_CROSS_BASE}/usr/lib/qt5/imports
+			Qml2Imports=${XBPS_CROSS_BASE}/usr/lib/qt5/qml
+			Translations=${XBPS_CROSS_BASE}/usr/share/qt5/translations
+			Settings=${XBPS_CROSS_BASE}/etc/xdg
+			Examples=${XBPS_CROSS_BASE}/usr/share/qt5/examples
+			HostPrefix=/usr
+			HostData=/usr/lib/qt5
+			HostBinaries=/usr/lib/qt5/bin
+			HostLibraries=/usr/lib
+			Spec=linux-g++
+			TargetSpec=linux-g++
+			_EOF
+		configure_args+=" --with-qt5-config=${wrksrc}/qt.conf"
+	fi
 }
 
 gwenhywfar-gtk3_package() {

--- a/srcpkgs/removed-packages/template
+++ b/srcpkgs/removed-packages/template
@@ -1,6 +1,6 @@
 # Template file for 'removed-packages'
 pkgname=removed-packages
-version=0.1.20230728
+version=0.1.20230805
 revision=1
 build_style=meta
 short_desc="Uninstalls packages removed from repository"
@@ -166,6 +166,7 @@ replaces="
  gtkhtml<=4.10.0_1
  guile1.8-devel<=1.8.8_3
  guile1.8<=1.8.8_3
+ gwenhywfar-gtk<=5.6.0_1
  gx-go<=1.9.0_1
  gx<=0.14.3_1
  hangups<=0.4.18_2


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

I tested this as part of the gnucash update, and everything seems to work fine. I did **not** test against the older version of gnucash, so this should only be merged after https://github.com/void-linux/void-packages/pull/43386.

Please let me know if I handled anything incorrectly with removing the `gwenhywfar-gtk` subpackage. Nothing depends on it and it's GTK2, so it should be fine to remove.