### PR TITLE
aqbanking: update to 6.5.4

### DIFF
--- a/srcpkgs/aqbanking/template
+++ b/srcpkgs/aqbanking/template
@@ -1,22 +1,32 @@
 # Template file for 'aqbanking'
 pkgname=aqbanking
-version=6.3.2
+version=6.5.4
 revision=1
 build_style=gnu-configure
-hostmakedepends="pkg-config gwenhywfar tar"
-makedepends="gwenhywfar-devel xmlsec1-devel ktoblzcheck-devel gmp-devel"
+hostmakedepends="automake libtool pkg-config gwenhywfar tar"
+makedepends="gwenhywfar-devel xmlsec1-devel gmp-devel"
 short_desc="Library for online banking and financial applications"
 maintainer="Enno Boland <gottox@voidlinux.org>"
 license="GPL-2.0-only, GPL-3.0-only"
 homepage="https://www.aquamaniac.de/rdm/"
-distfiles="https://www.aquamaniac.de/rdm/attachments/download/386/${pkgname}-${version}.tar.gz"
-checksum=a97ab42f7298cbb2617b2bda53ca51a2b0fe5f780bde098a39a5f4a3243e3418
+distfiles="https://github.com/aqbanking/aqbanking/archive/refs/tags/${version}.tar.gz"
+checksum=66b13d7694c25d09511b77edc14262025a452dfd93359c7257826f0e4c60dc6b
 disable_parallel_build=yes
 
 if [ "$CROSS_BUILD" ]; then
 	export PKG_CONFIG_PATH=${XBPS_CROSS_BASE}/usr/lib/pkgconfig
 	configure_args+=" -with-xmlmerge=/usr/bin/xmlmerge"
 fi
+
+pre_configure() {
+	autoreconf -fi
+}
+
+pre_build() {
+	make -f Makefile.cvs
+	make typedefs
+	make types
+}
 
 aqbanking-devel_package() {
 	depends="${sourcepkg}>=${version}_${revision}"
@@ -25,6 +35,7 @@ aqbanking-devel_package() {
 		vmove usr/bin/aqbanking-config
 		vmove usr/include
 		vmove "usr/lib/*.so"
+		vmove usr/lib/cmake
 		vmove usr/lib/pkgconfig
 		vmove usr/share/aclocal
 	}


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

I tested this as part of the gnucash update, and everything seems to work. I did **not** test against the older version of gnucash or gwenhywfar, so this should only be merged after https://github.com/void-linux/void-packages/pull/43386 and #45360.