### PR TITLE
Signal-Desktop: update to 6.27.0.

### DIFF
--- a/srcpkgs/Signal-Desktop/template
+++ b/srcpkgs/Signal-Desktop/template
@@ -1,6 +1,6 @@
 # Template file for 'Signal-Desktop'
 pkgname=Signal-Desktop
-version=6.26.0
+version=6.27.0
 revision=1
 # Signal officially only supports x86_64 
 # x86_64-musl could potentially work based on the Alpine port:
@@ -14,7 +14,7 @@ maintainer="anelki <akierig@fastmail.de>"
 license="AGPL-3.0-only"
 homepage="https://github.com/signalapp/Signal-Desktop"
 distfiles="https://github.com/signalapp/Signal-Desktop/archive/v${version}.tar.gz"
-checksum=4c9fbe43c4e6727dc4a4c10507346b4f210f3b70373cc2641617c09d7bc8bb15
+checksum=a93a364d31272896dd58c0dcfa6299d800121a611723d822fe38649021dbf40b
 nostrip_files="signal-desktop"
 
 post_extract() {


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**


#### Local build testing
- I built this PR locally for my native architecture, x86_64