### PR TITLE
New package: encrypted-dns

### DIFF
--- a/srcpkgs/encrypted-dns/files/README.voidlinux
+++ b/srcpkgs/encrypted-dns/files/README.voidlinux
@@ -1,0 +1,9 @@
+Before enabling / starting the service, you must install a
+configuration file in /etc/encrypted-dns/encrypted-dns.toml
+An example is in: /usr/share/examples/encrypted-dns/example-encrypted-dns.toml
+You can copy that file to /etc/encrypted-dns/encrypted-dns.toml and adjust it.
+
+Notes for /etc/encrypted-dns/encrypted-dns.toml
+- user/group for encrypted-dns is: _encrypted_dns/_encrypted_dns
+- The encrypted-dns.state file should be in /var/lib/encrypted-dns
+- Location for list of undelegated TLDs is /etc/encrypted-dns/undelegated.txt

--- a/srcpkgs/encrypted-dns/files/encrypted-dns/run
+++ b/srcpkgs/encrypted-dns/files/encrypted-dns/run
@@ -1,0 +1,3 @@
+#!/bin/sh
+exec 2>&1
+exec encrypted-dns -c /etc/encrypted-dns/encrypted-dns.toml

--- a/srcpkgs/encrypted-dns/patches/cargo-lock.patch
+++ b/srcpkgs/encrypted-dns/patches/cargo-lock.patch
@@ -1,0 +1,11 @@
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -226,7 +226,7 @@
+ 
+ [[package]]
+ name = "encrypted-dns"
+-version = "0.9.12"
++version = "0.9.13"
+ dependencies = [
+  "anyhow",
+  "byteorder",

--- a/srcpkgs/encrypted-dns/template
+++ b/srcpkgs/encrypted-dns/template
@@ -1,0 +1,27 @@
+# Template file for 'encrypted-dns'
+pkgname=encrypted-dns
+version=0.9.13
+revision=1
+build_style=cargo
+makedepends="libsodium-devel"
+short_desc="DNSCrypt v2 server with support for DNSSEC and DoH forwarding"
+maintainer="MeganerdNL <meganerd@meganerd.nl>"
+license="MIT"
+homepage="https://github.com/DNSCrypt/encrypted-dns-server"
+distfiles="https://github.com/DNSCrypt/encrypted-dns-server/archive/refs/tags/${version}.tar.gz"
+checksum=5e4f9143313bf58888c31ec4e220e9fb65b28b60fe5b6aff872f9f2ecb7537d5
+make_dirs="/var/lib/encrypted-dns 0750 _encrypted_dns _encrypted_dns"
+system_accounts="_encrypted_dns"
+_encrypted_dns_homedir="/var/lib/encrypted-dns"
+
+if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
+	XBPS_CROSS_RUSTFLAGS+=" -latomic"
+fi
+
+post_install() {
+	vlicense LICENSE
+	vinstall undelegated.txt 0644 etc/encrypted-dns
+	vsconf example-encrypted-dns.toml
+	vdoc "${FILESDIR}/README.voidlinux"
+	vsv encrypted-dns
+}


### PR DESCRIPTION
**DNSCrypt v2 server with support for DNSSEC, DoH forwarding and anonymized DNSCrypt**

#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl
  - i686-glibc
  - aarch64-glibc
  - aarch64-musl
  - armv7l-glibc
  - armv7l-musl
  - armv6l-glibc
  - armv6l-musl