### PR TITLE
carapace: update to 0.26.0.

### DIFF
--- a/srcpkgs/carapace/template
+++ b/srcpkgs/carapace/template
@@ -1,6 +1,6 @@
 # Template file for 'carapace'
 pkgname=carapace
-version=0.25.3
+version=0.26.0
 revision=1
 build_style=go
 go_import_path=github.com/rsteube/carapace-bin
@@ -12,7 +12,7 @@ maintainer="icp <pangolin@vivaldi.net>"
 license="MIT"
 homepage="https://github.com/rsteube/carapace-bin"
 distfiles="https://github.com/rsteube/carapace-bin/archive/refs/tags/v${version}.tar.gz"
-checksum=176f6ba1432e8cfeee3154bc527ff603d3a4d5a17d2195207c9e6fe9b8cfe6a4
+checksum=79ce389f1f7472f484ed0f7bd07befbbad33c5737f709bd75f8b868b301b751f
 
 pre_build() {
 	GOARCH= go generate ./cmd/...


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture: **x86_64**