### PR TITLE
linux: update to 6.4

### DIFF
--- a/srcpkgs/linux/template
+++ b/srcpkgs/linux/template
@@ -1,6 +1,6 @@
 # Template file for 'linux'
 pkgname=linux
-version=6.3
+version=6.4
 revision=1
 build_style=meta
 depends="linux${version} linux-base"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

Noticed the meta package not being on 6.4 yet, but 6.3 is already out of End of Life