### PR TITLE
virglrenderer: update to 0.10.4

### DIFF
--- a/srcpkgs/virglrenderer/template
+++ b/srcpkgs/virglrenderer/template
@@ -1,6 +1,6 @@
 # Template file for 'virglrenderer'
 pkgname=virglrenderer
-version=0.9.1
+version=0.10.4
 revision=1
 build_style=meson
 hostmakedepends="pkg-config"
@@ -10,7 +10,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
 homepage="https://gitlab.freedesktop.org/virgl/virglrenderer"
 distfiles="https://gitlab.freedesktop.org/virgl/virglrenderer/-/archive/virglrenderer-${version}/virglrenderer-virglrenderer-${version}.tar.gz"
-checksum=dd4a8008ca7bcaaf56666c94fcd738d705cdeda6313a82b3cea78bc3fb1b1ba5
+checksum=fd9a1b12473f4cda8d87e6ba1a6e5714a24355e16b69ed85df5c21bf48f797fa
 
 post_install() {
 	vlicense COPYING


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->
Adds support for H.264 video encoding and OpenGL 4.5/Vulkan 1.2

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
