### PR TITLE
runc: update to 1.1.8.

### DIFF
--- a/srcpkgs/runc/template
+++ b/srcpkgs/runc/template
@@ -1,6 +1,6 @@
 # Template file for 'runc'
 pkgname=runc
-version=1.1.6
+version=1.1.8
 revision=1
 build_style=go
 go_import_path=github.com/opencontainers/runc
@@ -14,7 +14,7 @@ license="Apache-2.0"
 homepage="https://github.com/opencontainers/runc"
 changelog="https://github.com/opencontainers/runc/raw/main/CHANGELOG.md"
 distfiles="https://github.com/opencontainers/runc/releases/download/v${version}/runc.tar.xz"
-checksum=548506fc1de8f0a4790d8e937eeede17db4beb79c53d66acb4f7ec3edbc31668
+checksum=fac4b055f56a326bb422f6397ef27b109b87e2063c54c158766f82a5f315cdf0
 
 post_build() {
 	make man


### PR DESCRIPTION

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc

