### PR TITLE
New package: rust-bacon-3.15.0

### DIFF
--- a/srcpkgs/rust-bacon/template
+++ b/srcpkgs/rust-bacon/template
@@ -1,0 +1,17 @@
+# Template file for 'rust-bacon'
+pkgname=rust-bacon
+version=3.15.0
+revision=1
+build_style=cargo
+short_desc="Background rust code checker"
+maintainer="icp <pangolin@vivaldi.net>"
+license="AGPL-3.0-only"
+homepage="https://dystroy.org/bacon/"
+changelog="https://raw.githubusercontent.com/Canop/bacon/main/CHANGELOG.md"
+distfiles="https://github.com/Canop/bacon/archive/refs/tags/v${version}.tar.gz"
+checksum=b162a0e9f827d849c962a5a0623ba9435182e3bf6c8e3fe4630a2446a8326bc7
+conflicts="bacon"
+
+post_install() {
+	vlicense LICENSE
+}


### PR DESCRIPTION
#### Description
[bacon](https://dystroy.org/bacon/) is a background rust code checker designed for minimal interaction so that you can just let it run, alongside your editor, and be notified of warnings, errors, or test failures in your Rust code.

#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

#### Local build testing
- I built this PR locally for my native architecture: **x86_64**