### PR TITLE
common/build-helper/rust.sh: link to libgit2 and libsqlite3 dynamically

### DIFF
--- a/common/build-helper/rust.sh
+++ b/common/build-helper/rust.sh
@@ -61,3 +61,9 @@ export ZSTD_SYS_USE_PKG_CONFIG=1
 
 # onig-sys
 export RUSTONIG_SYSTEM_LIBONIG=1
+
+# libsqlite3-sys
+export LIBSQLITE3_SYS_USE_PKG_CONFIG=1
+
+# libgit2-sys
+export LIBGIT2_NO_VENDOR=1


### PR DESCRIPTION
libgit2 upstream: https://github.com/rust-lang/git2-rs/commit/59a81cac9ada22b5ea6ca2841f5bd1229f1dd659
libsqlite3 upstream: https://github.com/rusqlite/rusqlite/commit/b4604f2421315040133717f48f616200e10507a8

#### Testing the changes
- I tested the changes in this PR: **NO**

#### Local build testing
- I built this PR locally for my native architecture: **x86_64**

Neither crates has a release since inclusion of these overrides so don't know what the testing strategy here. Probably one or two packages will have broken builds which needs the respective `-devel` packages in the `makedepends`.