### PR TITLE
[RFC] common/build-style/go: use -x -> -v so go build logs are readable

### DIFF
--- a/common/build-style/go.sh
+++ b/common/build-style/go.sh
@@ -45,10 +45,10 @@ do_build() {
 			# default behavior.
 			go_mod_mode=
 		fi
-		go install -p "$XBPS_MAKEJOBS" -mod="${go_mod_mode}" -modcacherw -x -tags "${go_build_tags}" -ldflags "${go_ldflags}" ${go_package}
+		go install -p "$XBPS_MAKEJOBS" -mod="${go_mod_mode}" -modcacherw -v -tags "${go_build_tags}" -ldflags "${go_ldflags}" ${go_package}
 	else
 		# Otherwise, build using GOPATH
-		go get -p "$XBPS_MAKEJOBS" -x -tags "${go_build_tags}" -ldflags "${go_ldflags}" ${go_package}
+		go get -p "$XBPS_MAKEJOBS" -v -tags "${go_build_tags}" -ldflags "${go_ldflags}" ${go_package}
 	fi
 }
 

--- a/srcpkgs/chezmoi/template
+++ b/srcpkgs/chezmoi/template
@@ -1,6 +1,6 @@
 # Template file for 'chezmoi'
 pkgname=chezmoi
-version=2.36.1
+version=2.37.0
 revision=1
 build_style=go
 go_import_path="github.com/twpayne/chezmoi/v2"
@@ -13,7 +13,7 @@ license="MIT"
 homepage="https://chezmoi.io/"
 changelog="https://github.com/twpayne/chezmoi/releases"
 distfiles="https://github.com/twpayne/chezmoi/archive/v${version}.tar.gz"
-checksum=771e848deed1134a9f8065b5de7ae8a885e51b7dc8dab1db2aa94ec44ab1a247
+checksum=c9c37268e437c28b8da93f48fcfdffc8586136a09f95910a06baa94bc4562667
 
 pre_build() {
 	local _date


### PR DESCRIPTION
this is still verbose (prints each module being compiled), but build logs should be more readable (for finding things like errors) now

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

