### PR TITLE
tvheadend: add service

### DIFF
--- a/srcpkgs/tvheadend/files/tvheadend/run
+++ b/srcpkgs/tvheadend/files/tvheadend/run
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+exec 2>&1
+exec env - HOME=/root /usr/bin/tvheadend

--- a/srcpkgs/tvheadend/template
+++ b/srcpkgs/tvheadend/template
@@ -1,7 +1,7 @@
 # Template file for 'tvheadend'
 pkgname=tvheadend
 version=4.2.8
-revision=6
+revision=7
 build_style=gnu-configure
 configure_args="--enable-dvbscan --disable-ffmpeg_static
 --disable-hdhomerun_static --disable-bintray_cache --disable-libx264_static
@@ -22,4 +22,5 @@ CFLAGS="-fcommon"
 pre_build() {
 	sed -i '/^${PROG}:/s/check_config//' Makefile
 	sed -i 's/-Werror//' Makefile
+	vsv tvheadend
 }


### PR DESCRIPTION
I installed tvheadend and had a frustrating time getting it to run as a system service. If $HOME isn't set then it will exit as it can't find its config files. $HOME isn't set for the system runsvdir as it is launched from runit but it is set if you just run runsv (or runsvdir) from a shell - so everything worked when testing but the service wouldn't work when linked into /var/service. It looks like tvheadend should output an error message when it hits this case but I couldn't see it in any log :(.

This is just what I came up with, I'm running it locally and have put it in the package for review. I haven't tried to build and install the modified package (yet). A possible alternative to setting $HOME in the service is to explicitly specify the config directory as an option. Setting $HOME has the advantage that it will use the same config files as running tvheadend from a shell, which can be useful for initial setup (-C).

Possibly the service should run with --firstrun

         -C, --firstrun
              If no user account exist then create one with no username and no
              password. Use with care as it will allow world-wide
              administrative access to your Tvheadend installation until you
              edit the access-control from within the Tvheadend UI."

That does mean the default is not very secure, but without it the default is to not be able to login (as far as I can tell anyway, I manually ran tvheadend --firstrun).

Another thing is whether the service should be run as a dedicated user (I don't bother running anything not as root on my media server). What is the void policy on that?

#### Testing the changes
- I tested the changes in this PR: **NO**

