### PR TITLE
qca-qt5: update to 2.3.7.

### DIFF
--- a/srcpkgs/qca-qt5/template
+++ b/srcpkgs/qca-qt5/template
@@ -1,6 +1,6 @@
 # Template file for 'qca-qt5'
 pkgname=qca-qt5
-version=2.3.6
+version=2.3.7
 revision=1
 build_style=cmake
 configure_args="-DQCA_FEATURE_INSTALL_DIR=/usr/share/qca-qt5/mkspecs
@@ -13,7 +13,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://userbase.kde.org/QCA"
 distfiles="${KDE_SITE}/qca/${version}/qca-${version}.tar.xz"
-checksum=ee59d531d4b82fb1685f4d8d74c2caa0777f501800f7426eaa372109a4305249
+checksum=fee2343b54687d5be3e30fb33ce296ee50ac7ae5e23d7ab725f63ffdf7af3f43
 
 if [ "$CROSS_BUILD" ]; then
 	hostmakedepends+=" qt5-host-tools qt5-devel"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

@Johnnynator

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
