### PR TITLE
tuxedo-keyboard: update to 3.2.10

### DIFF
--- a/srcpkgs/tuxedo-keyboard/template
+++ b/srcpkgs/tuxedo-keyboard/template
@@ -1,6 +1,6 @@
 # Template file for 'tuxedo-keyboard'
 pkgname=tuxedo-keyboard
-version=3.2.9
+version=3.2.10
 revision=1
 depends="dkms"
 short_desc="TUXEDO kernel module drivers for keyboard & general hardware I/O"
@@ -8,7 +8,7 @@ maintainer="newbluemoon <blaumolch@mailbox.org>"
 license="GPL-3.0-or-later"
 homepage="https://github.com/tuxedocomputers/tuxedo-keyboard"
 distfiles="https://github.com/tuxedocomputers/tuxedo-keyboard/archive/v${version}.tar.gz"
-checksum=fc317c6ca66ca5fa5c511b058d842837dc93cd1133e54b4931bebc909a872344
+checksum=b8584c865ad1d47bc35a0b78ad4cfc7cb8dac88bab8a8451360a1c7c3a210128
 
 dkms_modules="tuxedo-keyboard ${version}"
 


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**
<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)

