### PR TITLE
WindowMaker: update 0.96.0

### DIFF
--- a/srcpkgs/WindowMaker/template
+++ b/srcpkgs/WindowMaker/template
@@ -1,7 +1,7 @@
 # Template file for 'WindowMaker'
 pkgname=WindowMaker
-version=0.95.9
-revision=2
+version=0.96.0
+revision=1
 build_style=gnu-configure
 configure_args="--enable-xinerama --localedir=/usr/share/locale
  --enable-usermenu --enable-modelock --enable-xrandr --enable-wmreplace
@@ -19,9 +19,12 @@ conf_files="
 short_desc="X11 window manager with a NEXTSTEP look and feel"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later, WTFPL"
-homepage="http://www.windowmaker.org/"
-distfiles="http://windowmaker.org/pub/source/release/${pkgname}-${version}.tar.gz"
-checksum=f22358ff60301670e1e2b502faad0f2da7ff8976632d538f95fe4638e9c6b714
+homepage="https://www.windowmaker.org/"
+changelog="http://www.windowmaker.org/news/"
+distfiles="https://github.com/window-maker/wmaker/releases/download/wmaker-${version}/WindowMaker-${version}.tar.gz"
+checksum=4fe130ba23cf4aa21c156ec8f01f748df537d0604ec06c6bbcec896df1926f6d
+# tests various things against documentation, doesn't make sense to run
+make_check=no
 
 pre_configure() {
 	autoreconf -fi


### PR DESCRIPTION
Updated WindowMaker to 0.96.0. It required the distfiles url, version, revision, and checksum to be changed.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)

