### PR TITLE
chatty: update to 0.26.

### DIFF
--- a/srcpkgs/chatty/files/chatty
+++ b/srcpkgs/chatty/files/chatty
@@ -1,4 +1,4 @@
 #!/bin/sh
+
 cd /usr/share/chatty
-export PATH=/usr/lib/jvm/java-8-openjdk/jre/bin/:$PATH
-java -jar Chatty.jar "$@"
+exec java -jar Chatty.jar "$@"

--- a/srcpkgs/chatty/patches/config_dir.patch
+++ b/srcpkgs/chatty/patches/config_dir.patch
@@ -1,19 +1,11 @@
-*** a/src/chatty/Chatty.java	2017-12-26 11:56:51.000000000 -0500
---- a/src/chatty/Chatty.java	2018-02-19 04:41:33.348588121 -0500
-***************
-*** 91,97 ****
-       * Custom Settings directory, either the current working directory if the
-       * -cd parameter was used, or the directory specified with the -d parameter.
-       */
-!     private static String settingsDir = null;
-      
-      /**
-       * Parse the commandline arguments and start the actual chat client.
---- 91,97 ----
-       * Custom Settings directory, either the current working directory if the
-       * -cd parameter was used, or the directory specified with the -d parameter.
-       */
-!     private static String settingsDir = System.getProperty("user.home") + File.separator + ".config" + File.separator + "chatty";
-      
-      /**
-       * Parse the commandline arguments and start the actual chat client.
+--- a/src/chatty/Chatty.java
++++ b/src/chatty/Chatty.java
+@@ -212,7 +212,7 @@ public class Chatty {
+     // Paths
+     //--------------------------
+     public enum PathType {
+-        SETTINGS(() -> Paths.get(System.getProperty("user.home"), ".chatty"), null),
++        SETTINGS(() -> Paths.get(System.getProperty("user.home"), ".config/chatty"), null),
+         WORKING(() -> Paths.get(System.getProperty("user.dir")), null),
+         BACKUP(() -> getUserDataDirectory().resolve("backup"), null),
+         IMAGE(() -> getWorkingDirectory().resolve("img"), "imgPath"),

--- a/srcpkgs/chatty/patches/disable_version_check.patch
+++ b/srcpkgs/chatty/patches/disable_version_check.patch
@@ -1,19 +1,11 @@
-*** a/src/chatty/Chatty.java	2018-02-19 04:22:40.961744905 -0500
---- a/src/chatty/Chatty.java	2018-02-19 04:24:16.080555756 -0500
-***************
-*** 60,66 ****
-       * Enable Version Checker (if you compile and distribute this yourself, you
-       * may want to disable this)
-       */
-!     public static final boolean VERSION_CHECK_ENABLED = true;
-      
-      /**
-       * The regular URL of the textfile where the most recent version is stored.
---- 60,66 ----
-       * Enable Version Checker (if you compile and distribute this yourself, you
-       * may want to disable this)
-       */
-!     public static final boolean VERSION_CHECK_ENABLED = false;
-      
-      /**
-       * The regular URL of the textfile where the most recent version is stored.
+--- a/src/chatty/Chatty.java
++++ b/src/chatty/Chatty.java
+@@ -63,7 +63,7 @@ public class Chatty {
+      * Enable Version Checker (if you compile and distribute this yourself, you
+      * may want to disable this)
+      */
+-    public static final boolean VERSION_CHECK_ENABLED = true;
++    public static final boolean VERSION_CHECK_ENABLED = false;
+     
+     /**
+      * The regular URL of the textfile where the most recent version is stored.

--- a/srcpkgs/chatty/template
+++ b/srcpkgs/chatty/template
@@ -1,6 +1,6 @@
 # Template file for 'chatty'
 pkgname=chatty
-version=0.22
+version=0.26
 revision=1
 hostmakedepends="gradle openjdk8"
 depends="virtual?java-runtime"
@@ -8,11 +8,11 @@ short_desc="Twitch Chat Client for Desktop"
 maintainer="Frank Steinborn <steinex@nognu.de>"
 license="GPL-3.0-or-later"
 homepage="https://chatty.github.io/"
-distfiles="https://github.com/chatty/chatty/archive/v${version}.tar.gz"
-checksum=4d5f4236bba0190608e825fa5baf11d718650bf83e6571ab83dd9457af9f888c
+distfiles="https://github.com/chatty/chatty/archive/refs/tags/v${version}.tar.gz"
+checksum=f9b6287a257fa50d757128af116ee29cf4c8d29e96e09616857017b859aa43f5
 
 do_build() {
-	gradle shadowJar
+	gradle --no-daemon shadowJar
 }
 
 do_install() {


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)

#### Comments
- with the existence of the `java` alternatives group, I removed the setting of `$PATH` in the binary script. I tested that chatty works and runs on both jre8 and jre17.
- updated the patches to work on latest. the rationale for keeping the `config_dir` patch despite it not being required for the software to work is due to existing setups already using `.config/chatty` as the config dir from previous updates (as the patch has existed since this package's inception), thus preserving compatibility with them. if this is undesirable, let me know