### PR TITLE
badwolf: update to 1.3.0, adopt.

### DIFF
--- a/srcpkgs/badwolf/template
+++ b/srcpkgs/badwolf/template
@@ -1,24 +1,22 @@
 # Template file for 'badwolf'
 pkgname=badwolf
-version=1.2.2
+version=1.3.0
 revision=1
 build_style=configure
+configure_args="PREFIX=/usr WITH_WEBKITGTK=4.1 WITH_URI_PARSER=guri"
+make_cmd=ninja
 make_check_target=test
-hostmakedepends="pkg-config gettext"
-makedepends="webkit2gtk-devel libsoup-devel"
-checkdepends="mdocml"
+hostmakedepends="pkg-config gettext ninja ed"
+makedepends="libwebkit2gtk41-devel"
 short_desc="Minimalist and privacy-oriented WebKitGTK+ browser"
-maintainer="Orphaned <orphan@voidlinux.org>"
+maintainer="yosh <yosh-git@riseup.net>"
 license="BSD-3-Clause"
 homepage="https://hacktivis.me/projects/badwolf"
 changelog="https://hacktivis.me/releases/badwolf-${version}.txt"
 distfiles="https://hacktivis.me/releases/badwolf-${version}.tar.gz"
-checksum=fcdf1b0d7111071db53f785cd3cecfb4c7ba852403a5697037b281e7fe262a4b
+checksum=276dfccba8addfc205ceb10477668e4b2b6a4853f344c86d5c1e35b1c703459f
 
-pre_configure() {
-	export PREFIX=/usr
-}
-
-post_install() {
+do_install() {
+	DESTDIR=${DESTDIR} ninja install
 	vlicense COPYING
 }


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

- I built this PR locally for my native architecture, (`x86_64`)
Crossbuilt for: `armv6l`

~~GNOME [recommends using libsoup3](https://discourse.gnome.org/t/please-build-against-libsoup-3-by-default/10190) instead of libsoup2. build worked fine with 41.~~

what really should have been said above ^ is that GNOME is moving away from libsoup2 for their software. badwolf doesn't explicitly support libsoup3, but it does support `GUri`. it's probably better in the long term to use the compatible libwebkitgtk41+GUri build