### PR TITLE
ecryptfs-utils: remove -python subpackage

### DIFF
--- a/srcpkgs/ecryptfs-utils-python
+++ b/srcpkgs/ecryptfs-utils-python
@@ -1,1 +1,0 @@
-ecryptfs-utils

--- a/srcpkgs/ecryptfs-utils/template
+++ b/srcpkgs/ecryptfs-utils/template
@@ -1,13 +1,13 @@
 # Template file for 'ecryptfs-utils'
 pkgname=ecryptfs-utils
 version=111
-revision=10
+revision=11
 build_style=gnu-configure
 configure_args="--sbindir=/usr/bin
  --with-pamdir=/usr/lib/security --enable-gpg --enable-gui
- --with-gpgme-prefix=${XBPS_CROSS_BASE}/usr"
-hostmakedepends="automake gettext-devel glib-devel libtool pkg-config intltool swig python"
-makedepends="python-devel pam-devel nss-devel openssl-devel keyutils-devel gpgme-devel gtk+-devel"
+ --with-gpgme-prefix=${XBPS_CROSS_BASE}/usr --disable-pywrap"
+hostmakedepends="automake gettext-devel glib-devel libtool pkg-config intltool swig"
+makedepends="pam-devel nss-devel openssl-devel keyutils-devel gpgme-devel gtk+-devel"
 depends="gettext"
 _desc="Ecryptfs cryptographic filesystem"
 short_desc="${_desc} - utilities"
@@ -18,12 +18,11 @@ distfiles="http://launchpad.net/ecryptfs/trunk/${version}/+download/${pkgname}_$
 checksum=112cb3e37e81a1ecd8e39516725dec0ce55c5f3df6284e0f4cc0f118750a987f
 lib32disabled=yes
 
-CPPFLAGS="-D_FILE_OFFSET_BITS=64 -I${XBPS_CROSS_BASE}/usr/include/python2.7"
+CPPFLAGS="-D_FILE_OFFSET_BITS=64"
 
 pre_configure() {
 	NOCONFIGURE=1 ./autogen.sh
 	sed -i 's/__SWORD_TYPE/unsigned long/g' src/utils/mount.ecryptfs_private.c
-	export PYTHON=python2
 }
 
 post_install() {
@@ -50,14 +49,5 @@ libecryptfs-devel_package() {
 		vmove usr/include
 		vmove usr/lib/pkgconfig
 		vmove "usr/lib/*.so"
-	}
-}
-
-ecryptfs-utils-python_package() {
-	lib32disabled=yes
-	depends="python"
-	short_desc="${_desc} - python bindings"
-	pkg_install() {
-		vmove usr/lib/python2.7
 	}
 }

--- a/srcpkgs/removed-packages/template
+++ b/srcpkgs/removed-packages/template
@@ -1,6 +1,6 @@
 # Template file for 'removed-packages'
 pkgname=removed-packages
-version=0.1.20230805
+version=0.1.20230813
 revision=1
 build_style=meta
 short_desc="Uninstalls packages removed from repository"
@@ -100,6 +100,7 @@ replaces="
  dtkwm<=2.0.12_1
  ebtables<=2.0.10.4_8
  eclipse-ecj<=4.9_3
+ ecryptfs-utils-python<=111_10
  elasticsearch<=5.1.2_2
  electron10<=10.4.7_2
  electron12<=12.0.14_1


### PR DESCRIPTION
python2, upstream is pretty dead so no chance of py3 update

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**
