### PR TITLE
flake8: update to 6.1.0.

### DIFF
--- a/srcpkgs/flake8/template
+++ b/srcpkgs/flake8/template
@@ -1,9 +1,12 @@
 # Template file for 'flake8'
 pkgname=flake8
-version=6.0.0
+version=6.1.0
 revision=1
-build_style=python3-module
-hostmakedepends="python3-setuptools"
+build_style=python3-pep517
+make_check_target="tests/unit"
+make_check_args="--ignore=tests/unit/plugins/pycodestyle_test.py
+ --ignore=tests/unit/test_pyflakes_codes.py"
+hostmakedepends="python3-setuptools python3-wheel"
 depends="python3-pycodestyle python3-pyflakes python3-mccabe"
 checkdepends="$depends python3-mock python3-pytest"
 short_desc="Modular source code checker: pycodestyle, pyflakes, mccabe"
@@ -11,15 +14,8 @@ maintainer="Michal Vasilek <michal@vasilek.cz>"
 license="MIT"
 homepage="https://flake8.pycqa.org/"
 changelog="https://raw.githubusercontent.com/PyCQA/flake8/main/docs/source/release-notes/${version}.rst"
-distfiles="${PYPI_SITE}/f/flake8/flake8-${version}.tar.gz"
-checksum=c61007e76655af75e6785a931f452915b371dc48f56efd765247c8fe68f2b181
-
-do_check() {
-	local testdir="tmp/$(date +%s)"
-	python3 setup.py install --prefix=/usr --root=${testdir}
-	PATH="${testdir}/usr/bin:${PATH}" PYTHONPATH="${testdir}/${py3_sitelib}" pytest3 \
-		--ignore tests/unit/plugins/pycodestyle_test.py
-}
+distfiles="https://github.com/PyCQA/flake8/archive/refs/tags/${version}.tar.gz"
+checksum=bcb01efc0c83d3c9362e200b5359fe22e11b859962dd27e5bebf3ada7620ae2f
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
Switch `distfiles` to GH due to upstream changes.
Ref: https://github.com/PyCQA/flake8/pull/1761

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture: **x86_64**

cc @paper42 