### PR TITLE
dnscrypt-proxy: update to 2.1.5, move config file

### DIFF
--- a/srcpkgs/dnscrypt-proxy/INSTALL.msg
+++ b/srcpkgs/dnscrypt-proxy/INSTALL.msg
@@ -1,0 +1,3 @@
+The dnscrypt-proxy service now installs and looks for the config file at
+/etc/dnscrypt-proxy/dnscrypt-proxy.toml. Any previous configuration will
+need to be moved into this directory manually.

--- a/srcpkgs/dnscrypt-proxy/files/dnscrypt-proxy/run
+++ b/srcpkgs/dnscrypt-proxy/files/dnscrypt-proxy/run
@@ -1,3 +1,3 @@
 #!/bin/sh
 exec 2>&1
-exec dnscrypt-proxy -config /etc/dnscrypt-proxy.toml
+exec dnscrypt-proxy -config /etc/dnscrypt-proxy/dnscrypt-proxy.toml

--- a/srcpkgs/dnscrypt-proxy/template
+++ b/srcpkgs/dnscrypt-proxy/template
@@ -1,29 +1,30 @@
 # Template file for 'dnscrypt-proxy'
 pkgname=dnscrypt-proxy
-version=2.1.4
-revision=5
+version=2.1.5
+revision=1
 build_style=go
 go_import_path=github.com/dnscrypt/dnscrypt-proxy
 go_package="${go_import_path}/dnscrypt-proxy"
-hostmakedepends="go1.20"
+depends="python3-urllib3"
 short_desc="DNS proxy that encrypts queries"
 maintainer="cinerea0 <cinerea0@protonmail.com>"
 license="ISC"
 homepage="https://github.com/DNSCrypt/dnscrypt-proxy"
 changelog="https://raw.githubusercontent.com/DNSCrypt/dnscrypt-proxy/master/ChangeLog"
 distfiles="https://github.com/DNSCrypt/dnscrypt-proxy/archive/refs/tags/${version}.tar.gz"
-checksum=05f0a3e8c8f489caf95919e2a75a1ec4598edd3428d2b9dd357caba6adb2607d
-conf_files="/etc/dnscrypt-proxy.toml"
+checksum=044c4db9a3c7bdcf886ff8f83c4b137d2fd37a65477a92bfe86bf69587ea7355
+conf_files="/etc/dnscrypt-proxy/dnscrypt-proxy.toml"
 system_accounts="dnscrypt_proxy"
-make_dirs="/var/log/dnscrypt-proxy 0750 dnscrypt_proxy dnscrypt_proxy"
-
-export GOTOOLCHAIN=go1.20
 
 post_install() {
-	vconf dnscrypt-proxy/example-dnscrypt-proxy.toml dnscrypt-proxy.toml
+	vinstall dnscrypt-proxy/example-dnscrypt-proxy.toml 644 /etc/dnscrypt-proxy dnscrypt-proxy.toml
 	vlicense LICENSE
 	vsv dnscrypt-proxy
 	for example in dnscrypt-proxy/example*txt; do
-		vdoc $example
+		vsconf "${example}"
+	done
+	vbin utils/generate-domains-blocklist/generate-domains-blocklist.py
+	for f in utils/generate-domains-blocklist/*.{conf,txt}; do
+		vinstall "${f}" 644 /usr/share/dnscrypt-proxy
 	done
 }


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

---

I'm using this as an opportunity to pick up where #34517 left off. `dnscrypt-proxy` installs all of its supplemental files (that it periodically refreshes from upstream) into the same directory as its main config file. Currently this is `/etc`, which means we get a bunch of ambiguously-named files like "relays.md" polluting that directory. This change would group all those files together, at the expense of users having to move their config files to the new location.

Other changes:
* The files previously being installed as documentation were actually examples, so they are now installed with `vsconf`.
* The `generate-domains-blocklist` python helper script is now installed.
* The log directory is no longer needed after the mass switch to vlogger (#42026), so it has been removed.