### PR TITLE
Nim: update to v2.0.0, adopt

### DIFF
--- a/srcpkgs/nim/template
+++ b/srcpkgs/nim/template
@@ -1,24 +1,24 @@
 # Template file for 'nim'
 pkgname=nim
-version=1.6.14
+version=2.0.0
 revision=1
-_c1version=561b417c65791cd8356b5f73620914ceff845d10
-_nimbleversion=0.13.1
+_c2version=86742fb02c6606ab01a532a0085784effb2e753e
+_nimbleversion=0.14.2
 build_wrksrc="Nim-$version"
 depends="gcc openssl-devel"
 short_desc="Nim programming language"
-maintainer="Orphaned <orphan@voidlinux.org>"
+maintainer="Leon (adigitoleo) <adigitoleo@posteo.net>"
 license="MIT"
 homepage="https://nim-lang.org/"
 distfiles="https://github.com/nim-lang/Nim/archive/v${version}.tar.gz
- https://github.com/nim-lang/csources_v1/archive/${_c1version}.tar.gz>csources_v1-${_c1version}.tar.gz
+ https://github.com/nim-lang/csources_v2/archive/${_c2version}.tar.gz>csources_v2-${_c2version}.tar.gz
  https://github.com/nim-lang/nimble/archive/v${_nimbleversion}.tar.gz>nimble-${_nimbleversion}.tar.gz"
-checksum="0a31586a6194545be2cfb159189d0f39c8ced2ec134119f3d517dcada9b4aeea
- 71c823444c794a12da9027d19d6a717dd7759521ecbbe28190b08372142607ec
- e6aa8d9ee4b3ed0321dca329b4a38fa546771b9729984482fb50fe73d3777f5d"
+checksum="2d33e3a75fe6d26726de432eb236657b3eadef5727e9c08101a91e06cb0c2dc5
+	9c2be306011e0c953bd63a565a4bd6a094e22d3944ca201977c1d03560d0a25c
+	d94f11c592d49aed6c5a492289f187010eb8c103b2b653252763d2f65a82abac"
 
 post_extract() {
-	mv csources_v1-$_c1version $build_wrksrc/csources_v1
+	mv csources_v2-$_c2version $build_wrksrc/csources_v2
 	mkdir $build_wrksrc/dist
 	mv nimble-$_nimbleversion $build_wrksrc/dist/nimble
 }
@@ -27,17 +27,17 @@ do_build() {
 	case "$XBPS_TARGET_MACHINE" in
 		i686*)
 			CC=cc LD=cc CFLAGS="-Os -pipe" LDFLAGS= \
-			make -C csources_v1 ucpu=i686 ${makejobs};;
+			make -C csources_v2 ucpu=i686 ${makejobs};;
 		ppc|ppc-musl)
 			CC=cc LD=cc CFLAGS="-Os -pipe" LDFLAGS= \
-			make -C csources_v1 ucpu=powerpc ${makejobs};;
+			make -C csources_v2 ucpu=powerpc ${makejobs};;
 		*)
 			CC=cc LD=cc CFLAGS="-Os -pipe" LDFLAGS= \
-			make -C csources_v1 ${makejobs};;
+			make -C csources_v2 ${makejobs};;
 	esac
 
 	bin/nim c koch
-	./koch boot -d:release -d:danger
+	PATH=/usr/libexec/chroot-git:$PATH ./koch boot -d:release -d:danger
 
 	case "$XBPS_TARGET_MACHINE" in
 		aarch64*) _arch=arm64;;
@@ -56,10 +56,10 @@ do_build() {
 		$_arch.linux.gcc.linkerexe = "$CC"
 		EDIT
 		bin/nim c -d:release -d:danger --os:linux --cpu:$_arch --listCmd compiler/nim
-		./koch tools --os:linux --cpu:$_arch --listCmd
+		PATH=/usr/libexec/chroot-git:$PATH ./koch tools --os:linux --cpu:$_arch --listCmd
 		vsed -i config/nim.cfg -e '/^# VOIDLINUX TEMP$/,$d'
 	;; *)
-		./koch tools
+		PATH=/usr/libexec/chroot-git:$PATH ./koch tools
 	esac
 }
 


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64 glibc)
- I built this PR locally for these architectures:
  - aarch64
  - armv6l
  - x86_64-musl

#### Notes

Other than version bumps, the only change is adding `git` as hostmakedepends. The new version of `koch` (Nim build script) clones some extra dependencies for bootstrapping the Nim `libffi`. See <https://github.com/nim-lang/Nim/commit/14bc3f32683c87f971bf23ae30d500dc89cdebb8>.

I'm not sure if I should find a way to patch/disable it instead, or if that is OK.
