### PR TITLE
osc: update to 1.3.0

### DIFF
--- a/srcpkgs/osc/template
+++ b/srcpkgs/osc/template
@@ -1,6 +1,6 @@
 # Template file for 'osc'
 pkgname=osc
-version=1.2.0
+version=1.3.0
 revision=1
 build_style=python3-module
 hostmakedepends="python3-setuptools python3-cryptography python3-devel
@@ -13,4 +13,4 @@ license="GPL-2.0-or-later"
 homepage="https://github.com/openSUSE/osc"
 changelog="https://raw.githubusercontent.com/openSUSE/osc/master/NEWS"
 distfiles="https://github.com/openSUSE/osc/archive/refs/tags/${version}.tar.gz"
-checksum=0b2b094a515b340f859b417016def33f9b33a47abe4c3fad66c5dbc8b8447a7d
+checksum=77653f92555a644f436570f9d45ea97eec63d76c0a173a154ec4232e05d11d69


### PR DESCRIPTION
Simple version bump.

- I tested the changes in this PR: **briefly**
- I built this PR locally for my native architecture, (x86_64)
