### PR TITLE
bfs: add to find alternatives group.

### DIFF
--- a/srcpkgs/bfs/template
+++ b/srcpkgs/bfs/template
@@ -1,7 +1,7 @@
 # Template file for 'bfs'
 pkgname=bfs
 version=3.0.1
-revision=1
+revision=2
 build_style=gnu-makefile
 makedepends="acl-devel libcap-devel oniguruma-devel"
 checkdepends="acl-progs libcap-progs"
@@ -12,6 +12,11 @@ homepage="https://github.com/tavianator/bfs"
 changelog="https://raw.githubusercontent.com/tavianator/bfs/main/docs/CHANGELOG.md"
 distfiles="https://github.com/tavianator/bfs/archive/${version}.tar.gz"
 checksum=a38bb704201ed29f4e0b989fb2ab3791ca51c3eff90acfc31fff424579bbf962
+
+alternatives="
+ find:find:/usr/bin/bfs
+ find:find.1:/usr/share/man/man1/bfs.1
+"
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
- I tested the changes in this PR: **YES**
- I built this PR locally for my native architecture, `x86_64`

`bfs` is 100% compatible with POSIX `find` by default (all valid POSIX `find` commands are valid and follow POSIX guidelines in `bfs`, though it does have its own extensions)

disregard the mentioned issue--it was made without entirely knowing that `bfs`'s `POSIXLY_CORRECT` follows the same rationale as `gfind`'s