### PR TITLE
New package: chirp and dependencies

### DIFF
--- a/srcpkgs/chirp/template
+++ b/srcpkgs/chirp/template
@@ -1,0 +1,14 @@
+# Template file for 'chirp'
+pkgname=chirp
+version=20230814
+revision=1
+build_style=python3-pep517
+hostmakedepends="python3-setuptools python3-wheel"
+depends="python3-six wxPython4 python3-pyserial python3-future python3-requests
+ python3-suds python3-yattag"
+short_desc="Open-source tool for programming amateur radios"
+maintainer="Emil Miler <em@0x45.cz>"
+license="GPL-3.0-or-later"
+homepage="https://chirp.danplanet.com/projects/chirp/wiki/Home"
+distfiles="https://trac.chirp.danplanet.com/chirp_next/next-${version}/chirp-${version}.tar.gz"
+checksum=0e1e4726da8d7c360ea79948898f3aeb4221eecd22b546f69d51e47d24b7c599

--- a/srcpkgs/python3-suds/template
+++ b/srcpkgs/python3-suds/template
@@ -1,0 +1,13 @@
+# Template file for 'python3-suds'
+pkgname=python3-suds
+version=1.1.2
+revision=1
+build_style=python3-pep517
+hostmakedepends="python3-setuptools python3-wheel"
+depends="python3"
+short_desc="Lightweight SOAP-based web service client for Python"
+maintainer="Emil Miler <em@0x45.cz>"
+license="LGPL-3.0-or-later"
+homepage="https://github.com/suds-community/suds/"
+distfiles="${PYPI_SITE}/s/suds/suds-${version}.tar.gz"
+checksum=1d5cfa74117193b244a4233f246c483d9f41198b448c5f14a8bad11c4f649f2b

--- a/srcpkgs/python3-yattag/template
+++ b/srcpkgs/python3-yattag/template
@@ -1,0 +1,13 @@
+# Template file for 'python3-yattag'
+pkgname=python3-yattag
+version=1.15.1
+revision=1
+build_style=python3-module
+hostmakedepends="python3-setuptools"
+depends="python3"
+short_desc="Generate HTML or XML in a pythonic way"
+maintainer="Emil Miler <em@0x45.cz>"
+license="LGPL-2.1-only"
+homepage="https://www.yattag.org/"
+distfiles="${PYPI_SITE}/y/yattag/yattag-${version}.tar.gz"
+checksum=960fa54be1229d96f43178133e0b195c003391fdc49ecdb6b69b7374db6be416


### PR DESCRIPTION
This PR adds CHIRP, utility for programming amateur radios, and needed python3 dependencies. This package has been requested and packaged in the past, but was rejected due to upstream not supporting python3 and was postponed until then. The software is now running well on python3.

Related: #14681, #9018, #12072

#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)