### PR TITLE
New package: rapidcheck

### DIFF
--- a/srcpkgs/rapidcheck/template
+++ b/srcpkgs/rapidcheck/template
@@ -1,0 +1,32 @@
+# Template file for 'rapidcheck'
+
+# Upstream has no tags or release versioning, see:
+# https://github.com/emil-e/rapidcheck/issues/255
+# Commit here was picked based on what works to build nix.
+# https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/libraries/rapidcheck/default.nix
+pkgname=rapidcheck
+version=r1010.b78f892
+_commit=b78f89288c7e086d06e2a1e10b605d8375517a8a
+revision=1
+build_style=cmake
+configure_args="-DCMAKE_POSITION_INDEPENDENT_CODE=True -DRC_ENABLE_EXAMPLES=Off -DRC_ENABLE_TESTS=Off -DRC_INSTALL_ALL_EXTRAS=On"
+short_desc="QuickCheck clone for C++"
+maintainer="Vladimir Krivopalov <vladimir.krivopalov@gmail.com>"
+license="BSD-2-Clause"
+homepage="https://github.com/emil-e/rapidcheck"
+hostmakedepends="git cmake"
+
+do_fetch() {
+    rm -rf ${wrksrc}
+    git clone \
+    --filter=blob:none \
+    https://github.com/emil-e/rapidcheck ${wrksrc}
+    cd ${wrksrc}
+    git checkout ${_commit}
+}
+
+post_install() {
+    cd ${wrksrc}
+    cmake -P "build/cmake_install.cmake"
+    install -Dm0644 -t "$pkgdir/usr/share/licenses/$pkgname" LICENSE.md
+}


### PR DESCRIPTION
Rapidcheck is a QuickCheck clone for C++.
This package is used by newer versions of the Nix package manager and so it needs to be introduced for the 'nix' package to be updated.

Rapidcheck has no versioning or tags, the revision supported and used by Nix is currently being used when building this package.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
