### PR TITLE
musl: backport patch to fix fgetws

### DIFF
--- a/srcpkgs/musl/patches/fgetws.patch
+++ b/srcpkgs/musl/patches/fgetws.patch
@@ -1,0 +1,61 @@
+From f8bdc3048216f41eaaf655524fa286cfb1184a70 Mon Sep 17 00:00:00 2001
+From: Rich Felker <dalias@aerifal.cx>
+Date: Sun, 20 Feb 2022 20:11:14 -0500
+Subject: [PATCH] fix spurious failures by fgetws when buffer ends with partial
+ character
+
+commit a90d9da1d1b14d81c4f93e1a6d1a686c3312e4ba made fgetws look for
+changes to errno by fgetwc to detect encoding errors, since ISO C did
+not allow the implementation to set the stream's error flag in this
+case, and the fgetwc interface did not admit any other way to detect
+the error. however, the possibility of fgetwc setting errno to EILSEQ
+in the success path was overlooked, and in fact this can happen if the
+buffer ends with a partial character, causing mbtowc to be called with
+only part of the character available.
+
+since that change was made, the C standard was amended to specify that
+fgetwc set the stream error flag on encoding errors, and commit
+511d70738bce11a67219d0132ce725c323d00e4e made it do so. thus, there is
+no longer any need for fgetws to poke at errno to handle encoding
+errors.
+
+this commit reverts commit a90d9da1d1b14d81c4f93e1a6d1a686c3312e4ba
+and thereby fixes the problem.
+---
+ src/stdio/fgetws.c | 7 +------
+ 1 file changed, 1 insertion(+), 6 deletions(-)
+
+diff --git a/src/stdio/fgetws.c b/src/stdio/fgetws.c
+index b08b3049..195cb435 100644
+--- a/src/stdio/fgetws.c
++++ b/src/stdio/fgetws.c
+@@ -1,6 +1,5 @@
+ #include "stdio_impl.h"
+ #include <wchar.h>
+-#include <errno.h>
+ 
+ wint_t __fgetwc_unlocked(FILE *);
+ 
+@@ -12,10 +11,6 @@ wchar_t *fgetws(wchar_t *restrict s, int n, FILE *restrict f)
+ 
+ 	FLOCK(f);
+ 
+-	/* Setup a dummy errno so we can detect EILSEQ. This is
+-	 * the only way to catch encoding errors in the form of a
+-	 * partial character just before EOF. */
+-	errno = EAGAIN;
+ 	for (; n; n--) {
+ 		wint_t c = __fgetwc_unlocked(f);
+ 		if (c == WEOF) break;
+@@ -23,7 +18,7 @@ wchar_t *fgetws(wchar_t *restrict s, int n, FILE *restrict f)
+ 		if (c == '\n') break;
+ 	}
+ 	*p = 0;
+-	if (ferror(f) || errno==EILSEQ) p = s;
++	if (ferror(f)) p = s;
+ 
+ 	FUNLOCK(f);
+ 
+-- 
+2.41.0
+

--- a/srcpkgs/musl/template
+++ b/srcpkgs/musl/template
@@ -2,7 +2,7 @@
 pkgname=musl
 reverts="1.2.0_1"
 version=1.1.24
-revision=20
+revision=21
 archs="*-musl"
 bootstrap=yes
 build_style=gnu-configure


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
#### Local build testing
- I built this PR locally for my native architecture, (x86_64-musl)
<!--
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
