### PR TITLE
singular: update to 4.3.2p7.

### DIFF
--- a/srcpkgs/singular/template
+++ b/srcpkgs/singular/template
@@ -1,6 +1,6 @@
 # Template file for 'singular'
 pkgname=singular
-version=4.3.2p3
+version=4.3.2p7
 revision=1
 _majver=${version%p*}
 build_style=gnu-configure
@@ -13,14 +13,14 @@ configure_args="--with-readline=ncurses
  --without-python
  --with-libparse
  ac_cv_lib_cddgmp_dd_free_global_constants=yes"
-hostmakedepends="perl tar doxygen automake"
-makedepends="flintlib-devel cddlib-devel readline-devel graphviz"
+hostmakedepends="perl tar"
+makedepends="flintlib-devel cddlib-devel readline-devel"
 short_desc="Computer algebra system for polynomial computations"
 maintainer="dkwo <npiazza@disroot.org>"
 license="GPL-2.0-or-later"
 homepage="https://www.singular.uni-kl.de"
 distfiles="https://www.singular.uni-kl.de/ftp/pub/Math/Singular/SOURCES/${_majver//./-}/singular-${version}.tar.gz"
-checksum=9f7cfc838eb16c976369e498845f69551a95c4bc9d6d6cfbb4657836aae5ff3e
+checksum=aad23c30066b7fbc011138a98d60532565d76a847eec6bf2938410d93b272ca3
 
 if [ -z "$CROSS_BUILD" ]; then
 	makedepends+=" ntl-devel"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

Works with sagemath. With the current version in repo (10.0_2) it gives a few doctest failures because output format changes. Not worth updating sagemath now IMO, since 10.1 will be coming out soon (if need arises, the relevant PR are https://github.com/sagemath/sage/pull/35977, https://github.com/sagemath/sage/pull/35980, https://github.com/sagemath/sage/pull/36018; also https://github.com/sagemath/sage/pull/36006 fixes a doctest after gmp 6.3.0 but it's not really necessary).

@dkwo 

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
