### PR TITLE
nim: update to 2.0.0

### DIFF
--- a/srcpkgs/nim/template
+++ b/srcpkgs/nim/template
@@ -1,9 +1,11 @@
 # Template file for 'nim'
 pkgname=nim
-version=1.6.14
+version=2.0.0
 revision=1
-_c1version=561b417c65791cd8356b5f73620914ceff845d10
-_nimbleversion=0.13.1
+_c2version=86742fb02c6606ab01a532a0085784effb2e753e
+_nimbleversion=0.14.2
+_checksumsversion=b4c73320253f78e3a265aec6d9e8feb83f97c77b
+_atlasversion=3e3b4482f228df670626adbe29a7fc55d1a27177
 build_wrksrc="Nim-$version"
 depends="gcc openssl-devel"
 short_desc="Nim programming language"
@@ -11,29 +13,37 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
 homepage="https://nim-lang.org/"
 distfiles="https://github.com/nim-lang/Nim/archive/v${version}.tar.gz
- https://github.com/nim-lang/csources_v1/archive/${_c1version}.tar.gz>csources_v1-${_c1version}.tar.gz
- https://github.com/nim-lang/nimble/archive/v${_nimbleversion}.tar.gz>nimble-${_nimbleversion}.tar.gz"
-checksum="0a31586a6194545be2cfb159189d0f39c8ced2ec134119f3d517dcada9b4aeea
- 71c823444c794a12da9027d19d6a717dd7759521ecbbe28190b08372142607ec
- e6aa8d9ee4b3ed0321dca329b4a38fa546771b9729984482fb50fe73d3777f5d"
+ https://github.com/nim-lang/csources_v2/archive/${_c2version}.tar.gz>csources_v2-${_c2version}.tar.gz
+ https://github.com/nim-lang/nimble/archive/v${_nimbleversion}.tar.gz>nimble-${_nimbleversion}.tar.gz
+ https://github.com/nim-lang/checksums/archive/${_checksumsversion}.zip
+ https://github.com/nim-lang/atlas/archive/${_atlasversion}.zip"
+checksum="2d33e3a75fe6d26726de432eb236657b3eadef5727e9c08101a91e06cb0c2dc5
+ 9c2be306011e0c953bd63a565a4bd6a094e22d3944ca201977c1d03560d0a25c
+ d94f11c592d49aed6c5a492289f187010eb8c103b2b653252763d2f65a82abac
+ bf526adf906f826bc10e1a6f049193825ed8ff26d0b42f6d5ba14ac7b32bbc3c
+ 646aa1e2ef75fade7a0cabc8c938b2a99654acee6e9f186c184e3d3c776cebd4"
 
 post_extract() {
-	mv csources_v1-$_c1version $build_wrksrc/csources_v1
+	mv csources_v2-$_c2version $build_wrksrc/csources_v2
 	mkdir $build_wrksrc/dist
 	mv nimble-$_nimbleversion $build_wrksrc/dist/nimble
+	mv checksums-$_checksumsversion $build_wrksrc/dist/checksums
+	mkdir -p $build_wrksrc/dist/nimble/dist
+	cp -r $build_wrksrc/dist/checksums $build_wrksrc/dist/nimble/dist/checksums
+	mv atlas-$_atlasversion $build_wrksrc/dist/atlas
 }
 
 do_build() {
 	case "$XBPS_TARGET_MACHINE" in
 		i686*)
 			CC=cc LD=cc CFLAGS="-Os -pipe" LDFLAGS= \
-			make -C csources_v1 ucpu=i686 ${makejobs};;
+			make -C csources_v2 ucpu=i686 ${makejobs};;
 		ppc|ppc-musl)
 			CC=cc LD=cc CFLAGS="-Os -pipe" LDFLAGS= \
-			make -C csources_v1 ucpu=powerpc ${makejobs};;
+			make -C csources_v2 ucpu=powerpc ${makejobs};;
 		*)
 			CC=cc LD=cc CFLAGS="-Os -pipe" LDFLAGS= \
-			make -C csources_v1 ${makejobs};;
+			make -C csources_v2 ${makejobs};;
 	esac
 
 	bin/nim c koch
@@ -73,7 +83,7 @@ do_install() {
 	vmkdir usr/bin
 	vmkdir usr/share/nim
 	ln -sf /usr/lib/nim/bin/nim ${DESTDIR}/usr/bin/nim
-	for _f in nimble nimsuggest nimgrep nimpretty testament; do
+	for _f in nimble nimsuggest nimgrep nimpretty testament atlas; do
 		chmod 0755 bin/$_f
 		cp bin/$_f ${DESTDIR}/usr/lib/nim/bin
 		ln -sf /usr/lib/nim/bin/$_f ${DESTDIR}/usr/bin/$_f


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

Confirmed that compiler runs and used it to compile one of my projects.

#### Local build testing
- I built this PR locally for my native architecture, (amd64-glibc)

#### External dependencies
They are still trying to pull git repos from masters during a build--even in the stable release. I've patched around this by adding the latest checkout as of today (20230816) and the Github download links for those. This gets us what appears to be a working copy but I will need to bonk the devs up there to stop doing this.