### PR TITLE
chirp: update to 20230816

### DIFF
--- a/srcpkgs/chirp/template
+++ b/srcpkgs/chirp/template
@@ -1,6 +1,6 @@
 # Template file for 'chirp'
 pkgname=chirp
-version=20230814
+version=20230816
 revision=1
 build_style=python3-pep517
 hostmakedepends="python3-setuptools python3-wheel"
@@ -11,4 +11,4 @@ maintainer="Emil Miler <em@0x45.cz>"
 license="GPL-3.0-or-later"
 homepage="https://chirp.danplanet.com/projects/chirp/wiki/Home"
 distfiles="https://trac.chirp.danplanet.com/chirp_next/next-${version}/chirp-${version}.tar.gz"
-checksum=0e1e4726da8d7c360ea79948898f3aeb4221eecd22b546f69d51e47d24b7c599
+checksum=31269f3e4d31142380eebfe2dd846a01d0460a516f6b72661dd7bfc295544a49


### PR DESCRIPTION
Simple version bump.

- I tested the changes in this PR: **briefly**
- I built this PR locally for my native architecture, (x86_64)