### PR TITLE
mesa: update to version 23.1.6.

### DIFF
--- a/srcpkgs/mesa/template
+++ b/srcpkgs/mesa/template
@@ -1,6 +1,6 @@
 # Template file for 'mesa'
 pkgname=mesa
-version=23.1.3
+version=23.1.6
 revision=1
 build_style=meson
 #Disable LTO flag should be present, see https://gitlab.freedesktop.org/mesa/mesa/-/issues/6911
@@ -23,7 +23,7 @@ license="MIT, LGPL-2.1-or-later"
 homepage="https://www.mesa3d.org/"
 changelog="https://docs.mesa3d.org/relnotes.html"
 distfiles="https://mesa.freedesktop.org/archive/mesa-${version}.tar.xz"
-checksum=2f6d7381bc10fbd2d6263ad1022785b8b511046c1a904162f8f7da18eea8aed9
+checksum=f4c7fd8e7b472a88da7d83e9a48f6f3bd17d4ea2cc4386f7231b796f3964157a
 
 build_options="wayland"
 build_options_default="wayland"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **NO**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->


Hey guys , it's me again. A little PR that will be replacing the first one i made for mesa 23.1.5.
This one is for mesa 23.1.6, this version will be - according to the [calendar](https://docs.mesa3d.org/release-calendar.html) - the latest version of mesa for the 23.1.X series.

Meaning, mesa 23.2 will be the next mesa release and should be coming soon. As always I'll keep an eye out for this to happen in order for us to have this version ASAP. In the meantime, enjoy mesa 23.1.6 !

Take care lads.
Best regards - Spid. :smile: 