### PR TITLE
mit-krb5: update to 1.21.2

### DIFF
--- a/srcpkgs/mit-krb5/template
+++ b/srcpkgs/mit-krb5/template
@@ -2,7 +2,7 @@
 # if there is a bump in .so version,
 # also update srcpkgs/libgssglue/files/gssapi_mech.conf
 pkgname=mit-krb5
-version=1.21.1
+version=1.21.2
 revision=1
 _distver=$(echo $version | cut -d. -f-2)
 build_style=gnu-configure
@@ -17,7 +17,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
 homepage="http://web.mit.edu/kerberos"
 distfiles="http://kerberos.org/dist/krb5/${_distver}/krb5-${version}.tar.gz"
-checksum=7881c3aaaa1b329bd27dbc6bf2bf1c85c5d0b6c7358aff2b35d513ec2d50fa1f
+checksum=9560941a9d843c0243a71b17a7ac6fe31c7cebb5bce3983db79e52ae7e850491
 build_options="ldap lmdb"
 build_options_default="ldap"
 desc_option_lmdb="Enable LMDB database backend"


### PR DESCRIPTION
Changes from previous release:
- Fix double-free in KDC TGS processing [CVE-2023-39975]

#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)