### PR TITLE
mu4e: update to 1.10.6

### DIFF
--- a/srcpkgs/mu4e/template
+++ b/srcpkgs/mu4e/template
@@ -1,6 +1,6 @@
 # Template file for 'mu4e'
 pkgname=mu4e
-version=1.10.5
+version=1.10.6
 revision=1
 build_style=meson
 hostmakedepends="emacs libtool pkg-config texinfo glib-devel"
@@ -11,6 +11,6 @@ license="GPL-3.0-or-later"
 homepage="https://www.djcbsoftware.nl/code/mu/"
 changelog="https://github.com/djcb/mu/raw/master/NEWS.org"
 distfiles="https://github.com/djcb/mu/releases/download/v${version}/mu-${version}.tar.xz"
-checksum=1af693dc19d6980f743b98494ab6db97656b6954e7edff343ceb62e65ca5cc2d
+checksum=3c45b72ad5de350c8ff6e1ad19a3cb868719cfc3e65c3427797e757d6eff18d6
 replaces="mu<${version}"
 provides="mu-${version}_${revision}"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES, with emacs 28.2 and very briefly with 29.1**


#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc

