### PR TITLE
qutebrowser: update to 3.0.0, use Qt6 by default

### DIFF
--- a/srcpkgs/qutebrowser/template
+++ b/srcpkgs/qutebrowser/template
@@ -1,37 +1,47 @@
 # Template file for 'qutebrowser'
 pkgname=qutebrowser
-version=2.5.4
+version=3.0.0
 revision=1
 build_style=python3-module
 hostmakedepends="python3-setuptools asciidoc"
-depends="python3-PyQt5-quick python3-Jinja2 python3-yaml
- python3-PyQt5-opengl python3-PyQt5-sql qt5-plugin-sqlite"
+depends="python3-Jinja2 python3-yaml"
 short_desc="Keyboard-focused browser with a minimal GUI"
 maintainer="Daniel Eyßer <daniel.eysser@gmail.com>"
 license="GPL-3.0-or-later"
 homepage="https://qutebrowser.org/"
 changelog="https://raw.githubusercontent.com/qutebrowser/qutebrowser/master/doc/changelog.asciidoc"
 distfiles="https://github.com/qutebrowser/qutebrowser/releases/download/v${version}/qutebrowser-${version}.tar.gz"
-checksum=a460b2202527e42a670c26d225d9fa6417d092cc1f16f3a95e7bc95dd89c1ab1
+checksum=39eaf4a7f0f051f39e8d40a04824a432f2cb023372271e75aa037b6dc410d8fc
 nostrip=yes
 # testing requires unpackaged plugins:
 # pytest-bdd, pytest-benchmark, pytest-instafail, pytest-rerunfailures
 make_check=no
 
-build_options="webengine"
-desc_option_webengine="Build Qt5 WebEngine support"
+build_options="qt6 webkit"
+desc_option_qt6="Use Qt6 GUI and WebEngine backend"
+desc_option_webkit="Use Qt5 WebKit backend"
 
-if [ "$XBPS_TARGET_ENDIAN" = "le" ]; then
-	# qt5-webengine is only available for little-endian systems
-	if [ "$XBPS_WORDSIZE" = "$XBPS_TARGET_WORDSIZE" ]; then
-		build_options_default="webengine"
-	fi
+vopt_conflict qt6 webkit
+
+# WebEngine is unavailable on BE systems or when host & target word sizes differ
+if [ "$XBPS_TARGET_ENDIAN" != "le" ]; then
+	build_options_default="webkit"
+elif [ "$XBPS_WORDSIZE" != "$XBPS_TARGET_WORDSIZE" ]; then
+	build_options_default="webkit"
+elif [ "$XBPS_WORDSIZE" != 32 ]; then
+	# qt6-webengine is broken on 32-bit systems
+	build_options_default="qt6"
 fi
 
-if [ "$build_option_webengine" ]; then
-	depends+=" python3-PyQt5-webengine"
+if [ "$build_option_qt6" ]; then
+	depends+=" python3-pyqt6-declarative python3-pyqt6-gui
+	 python3-pyqt6-sql python3-pyqt6-webengine python3-pyqt6-webchannel
+	 python3-pyqt6-widgets python3-pyqt6-network python3-pyqt6-dbus
+	 python3-pyqt6-printsupport qt6-plugin-sqlite"
 else
-	depends+=" python3-PyQt5-webkit"
+	depends+=" python3-PyQt5-quick python3-PyQt5-opengl
+	 python3-PyQt5-sql qt5-plugin-sqlite
+	 $(vopt_if webkit python3-PyQt5-webkit python3-PyQt5-webengine)"
 fi
 
 pre_build() {
@@ -48,10 +58,10 @@ post_install() {
 
 	local dim
 	for dim in 16 24 32 48 64 96 128 256 512; do
-		vinstall icons/qutebrowser-${dim}x${dim}.png 644 \
+		vinstall qutebrowser/icons/qutebrowser-${dim}x${dim}.png 644 \
 			usr/share/icons/hicolor/${dim}x${dim}/apps qutebrowser.png
 	done
 
-	vinstall icons/qutebrowser.svg 644 \
+	vinstall qutebrowser/icons/qutebrowser.svg 644 \
 		usr/share/icons/hicolor/scalable/apps qutebrowser.svg
 }


### PR DESCRIPTION
We can make Qt6 a (default, when possible) build option to allow people to build Qt5 versions if desired, and also force the WebKit backend (which implies Qt5) when WebEngine is unavailable.

#### Testing the changes
- I tested the changes in this PR: **briefly** (I'm using it now)

cc: @daniel-eys