### PR TITLE
New package: vscode-official-1.81.1

### DIFF
--- a/srcpkgs/vscode-official/files/code-url-handler.desktop
+++ b/srcpkgs/vscode-official/files/code-url-handler.desktop
@@ -1,0 +1,12 @@
+[Desktop Entry]
+Name=Visual Studio Code - URL Handler
+Comment=Code Editing. Redefined.
+GenericName=Text Editor
+Exec=/opt/code/code --open-url %U
+Icon=com.visualstudio.code
+Type=Application
+NoDisplay=true
+StartupNotify=true
+Categories=Utility;TextEditor;Development;IDE;
+MimeType=x-scheme-handler/vscode;
+Keywords=vscode;

--- a/srcpkgs/vscode-official/files/code-workspace.xml
+++ b/srcpkgs/vscode-official/files/code-workspace.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mime-info xmlns="http://www.freedesktop.org/standards/shared-mime-info">
+	<mime-type type="application/x-code-workspace">
+		<comment>Visual Studio Code Workspace</comment>
+		<glob pattern="*.code-workspace"/>
+	</mime-type>
+</mime-info>

--- a/srcpkgs/vscode-official/files/code.desktop
+++ b/srcpkgs/vscode-official/files/code.desktop
@@ -1,0 +1,18 @@
+[Desktop Entry]
+Name=Visual Studio Code
+Comment=Code Editing. Redefined.
+GenericName=Text Editor
+Exec=/opt/code/code %F
+Icon=com.visualstudio.code
+Type=Application
+StartupNotify=false
+StartupWMClass=Code
+Categories=Utility;TextEditor;Development;IDE;
+MimeType=text/plain;inode/directory;application/x-code-workspace;
+Actions=new-empty-window;
+Keywords=vscode;
+
+[Desktop Action new-empty-window]
+Name=New Empty Window
+Exec=/usr/share/code/code --new-window %F
+Icon=com.visualstudio.code

--- a/srcpkgs/vscode-official/template
+++ b/srcpkgs/vscode-official/template
@@ -1,0 +1,38 @@
+# Template file for 'vscode-official'
+pkgname=vscode-official
+version=1.81.1
+revision=1
+makedepends="tar"
+short_desc="Microsoft Visual Studio Code for Linux"
+maintainer="endigma <endigma@mailcat.ca>"
+license="custom:Proprietary"
+homepage="https://code.visualstudio.com/"
+distfiles="https://update.code.visualstudio.com/${version}/linux-x64/stable>vscode-${version}.tar.gz"
+repository=nonfree
+restricted=yes
+nopie=yes
+nostrip=yes
+
+checksum=4ea6b0aaed22474027dc2678c774461b4bc3df1fcfbd0c918554e173a4af7448
+
+do_install() {
+	vmkdir opt/code
+
+	vcopy * opt/code/
+
+	vmkdir usr/bin
+
+	vmkdir usr/share/applications
+
+	vinstall ${FILESDIR}/code.desktop 755 usr/share/applications/
+	vinstall ${FILESDIR}/code-url-handler.desktop 755 usr/share/applications/
+
+	# No plaintext licenses in tarball
+	# vlicense ${FILESDIR}/LICENSE
+
+	chmod -R o-w ${DESTDIR}/opt/code/resources/app/
+}
+
+post_install() {
+	ln -sf /opt/code/bin/code $DESTDIR/usr/bin/code
+}


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

#### Local build testing
- I built this PR locally for my native architecture, (linux-x64-glibc)

#### Notes

This PR differs from `vscode` in that it isn't Code-OSS, which is required for some extensions and by extension workplaces and users. It is structured similarly to the `spotify`, `discord`, `teamspeak3` packages and is marked as `nonfree` and `restricted`.
