### PR TITLE
AusweisApp2: update to 1.26.7

### DIFF
--- a/srcpkgs/AusweisApp2/template
+++ b/srcpkgs/AusweisApp2/template
@@ -1,7 +1,7 @@
 # Template file for 'AusweisApp2'
 pkgname=AusweisApp2
-version=1.24.1
-revision=2
+version=1.26.7
+revision=1
 build_style=cmake
 build_helper=qemu
 hostmakedepends="pkg-config qt5-qmake qt5-host-tools"
@@ -13,4 +13,4 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="EUPL-1.2"
 homepage="https://www.ausweisapp.bund.de"
 distfiles="https://github.com/Governikus/AusweisApp2/releases/download/${version}/AusweisApp2-${version}.tar.gz"
-checksum=ff3672db30a5156031b7bf85fd272f2aadc2d3458963c8dcead2c00f6da42042
+checksum=8062fe04332e9a7bee4c75fe3ef3efda6748c1a19a6fda8770f7914939c7bd28


### PR DESCRIPTION
- I tested the changes in this PR: yes
- I built this PR locally for my native architecture, x86_64

update for openssl3 #37681 