### PR TITLE
google-chrome: don't depend on qt6-{core,gui,widgets}

### DIFF
--- a/srcpkgs/google-chrome/template
+++ b/srcpkgs/google-chrome/template
@@ -1,7 +1,7 @@
 # Template file for 'google-chrome'
 pkgname=google-chrome
 version=116.0.5845.96
-revision=1
+revision=2
 _channel=stable
 archs="x86_64"
 hostmakedepends="python3-html2text python3-setuptools"
@@ -14,7 +14,7 @@ distfiles="https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stab
 checksum=b429124b27f9b5ff3a63229823af0d4200020698eb58b75027897ba5b5e327eb
 _license_checksum=8023b18fb5118ef65d586363e53909861bd1a9676e5eb83c20fd3ac6e33ea0be
 
-skiprdeps="/opt/google/chrome/libqt5_shim.so"
+skiprdeps="/opt/google/chrome/libqt5_shim.so /opt/google/chrome/libqt6_shim.so"
 repository=nonfree
 restricted=yes
 nostrip=yes


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES** (on a machine without any `qt*` packages)

---
Same as #40239, just for Qt6.

This disables rdep scanning for `libqt6_shim.so`, as does upstream:

https://chromium.googlesource.com/chromium/src/+/75f4b48eb71d4872ba3ac6c9fc3662a60eb4175d/chrome/installer/linux/BUILD.gn#106

Otherwise it pulls in `qt6-widgets`, etc.:

```
# xbps-install -R . google-chrome

Name                Action    Version           New version            Download size
double-conversion   install   -                 3.3.0_1                31KB
libb2               install   -                 0.98.1_1               16KB
qt6-core            install   -                 6.5.0_3                2200KB
libevdev            install   -                 1.13.0_1               36KB
libwacom            install   -                 2.7.0_1                102KB
mtdev               install   -                 1.1.6_1                12KB
libinput            install   -                 1.23.0_1               261KB
libmd4c             install   -                 0.4.8_1                36KB
libxkbcommon-x11    install   -                 1.5.0_1                13KB
qt6-dbus            install   -                 6.5.0_3                269KB
libproxy            install   -                 0.4.18_2               64KB
qt6-network         install   -                 6.5.0_3                640KB
tslib               install   -                 1.22_1                 50KB
xcb-util-image      install   -                 0.4.1_1                9382B
xcb-util-renderutil install   -                 0.3.10_1               7750B
xcb-util-cursor     install   -                 0.1.4_1                9.8KB
qt6-gui             install   -                 6.5.0_3                3962KB
qt6-widgets         install   -                 6.5.0_3                2783KB
google-chrome       update    114.0.5735.198_1  116.0.5845.96_1        -

Size to download:               10MB
Size required on disk:         342MB
Space available on disk:        86GB
```

Maintainer ping: @atk