### PR TITLE
qmk: depend on python3-pyserial

### DIFF
--- a/srcpkgs/qmk/template
+++ b/srcpkgs/qmk/template
@@ -1,7 +1,7 @@
 # Template file for 'qmk'
 pkgname=qmk
 version=1.1.2
-revision=1
+revision=2
 build_style=python3-pep517
 hostmakedepends="python3-wheel"
 # This includes the requirements from requirements.txt in the qmk_firmware
@@ -9,7 +9,7 @@ hostmakedepends="python3-wheel"
 depends="avr-gcc avrdude cross-arm-none-eabi dfu-programmer dfu-util
  python3-Pygments python3-appdirs python3-argcomplete python3-colorama
  python3-dotty-dict python3-hid python3-hjson python3-jsonschema python3-milc
- python3-nose2 python3-usb python3-yapf"
+ python3-nose2 python3-pyserial python3-usb python3-yapf"
 short_desc="Program to help users work with QMK Firmware"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->

```
# Context: have qmk-1.1.2_1 installed, plus all of its deps

(woods) qmk_firmware  » klardotsh/main » qmk compile -kb boardsource/unicorne -km default
Could not find module pyserial!
Would you like to install the required Python modules? [y/n] n

Please run `/usr/bin/python3 -m pip install -r /home/j/src/mine/qmk_firmware/requirements.txt` to install required python dependencies.

# Installed python3-pyserial in another window...

(woods) qmk_firmware  » klardotsh/main » qmk compile -kb boardsource/unicorne -km default
Ψ Compiling keymap with make --jobs=1 boardsource/unicorne:default
...
```