### PR TITLE
metalog: fix bleeding logs onto tty1

### DIFF
--- a/srcpkgs/metalog/files/metalog/run
+++ b/srcpkgs/metalog/files/metalog/run
@@ -1,5 +1,3 @@
 #!/bin/sh
-exec 2>&1
-exec 1>&2
 [ -r conf ] && . ./conf
-exec metalog ${OPTS=-v}
+exec metalog ${OPTS} >/dev/null

--- a/srcpkgs/metalog/template
+++ b/srcpkgs/metalog/template
@@ -1,7 +1,7 @@
 # Template file for 'metalog'
 pkgname=metalog
 version=20230719
-revision=1
+revision=2
 build_style=gnu-configure
 conf_files="/etc/metalog.conf"
 hostmakedepends="autoconf autoconf-archive automake pkg-config"


### PR DESCRIPTION
This fixes issue #45653 [1].

[1]
https://github.com/void-linux/void-packages/issues/45653

#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture: x86_64-glibc