### PR TITLE
Qt 6.5.2

### DIFF
--- a/srcpkgs/python3-pyqt6-sip/template
+++ b/srcpkgs/python3-pyqt6-sip/template
@@ -1,6 +1,6 @@
 # Template file for 'python3-pyqt6-sip'
 pkgname=python3-pyqt6-sip
-version=13.5.1
+version=13.5.2
 revision=1
 build_style=python3-module
 hostmakedepends="python3-devel python3-setuptools sip"
@@ -11,7 +11,7 @@ maintainer="Đoàn Trần Công Danh <congdanhqx@gmail.com>"
 license="GPL-2.0-only, GPL-3.0-only, custom:SIP"
 homepage="https://www.riverbankcomputing.com/software/sip/"
 distfiles="${PYPI_SITE}/P/PyQt6_sip/PyQt6_sip-${version}.tar.gz"
-checksum=d1e9141752966669576d04b37ba0b122abbc41cc9c35493751028d7d91c4dd49
+checksum=ebf6264b6feda01ba37d3b60a4bb87493bdb87be70f7b2a5384a7acd4902d88d
 lib32disabled=yes
 
 post_extract() {

--- a/srcpkgs/python3-pyqt6/template
+++ b/srcpkgs/python3-pyqt6/template
@@ -1,6 +1,6 @@
 # Template file for 'python3-pyqt6'
 pkgname=python3-pyqt6
-version=6.5.0
+version=6.5.2
 revision=1
 build_style=sip-build
 build_helper=qemu
@@ -17,7 +17,7 @@ maintainer="Đoàn Trần Công Danh <congdanhqx@gmail.com>"
 license="GPL-3.0-only"
 homepage="https://www.riverbankcomputing.com/software/pyqt/"
 distfiles="$PYPI_SITE/P/PyQt6/PyQt6-$version.tar.gz"
-checksum=b97cb4be9b2c8997904ea668cf3b0a4ae5822196f7792590d05ecde6216a9fbc
+checksum=1487ee7350f9ffb66d60ab4176519252c2b371762cbe8f8340fd951f63801280
 lib32disabled=yes
 
 # Split like qt6, but keep qt6-core in main pkg

--- a/srcpkgs/qt6-3d/template
+++ b/srcpkgs/qt6-3d/template
@@ -1,6 +1,6 @@
 # Template file for 'qt6-3d'
 pkgname=qt6-3d
-version=6.5.0
+version=6.5.2
 revision=1
 build_style=cmake
 hostmakedepends="perl qt6-declarative-host-tools"
@@ -10,7 +10,7 @@ maintainer="John <me@johnnynator.dev>"
 license="(LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only) AND GPL-3.0-only with Qt-GPL-exception-1.0"
 homepage="https://qt.io/"
 distfiles="http://download.qt.io/official_releases/qt/${version%.*}/${version}/submodules/qt3d-everywhere-src-${version}.tar.xz"
-checksum=20b250023244f21dfbec5c007bac805d4494fa463a6dd27538afb1a81b230816
+checksum=21f064db21ad1bfc5547fd4e8cba09acc8c187de58d7eee206f6549ab9e2f910
 
 qt6-3d-devel_package() {
 	depends="${sourcepkg}>=${version}_${revision}"

--- a/srcpkgs/qt6-base/template
+++ b/srcpkgs/qt6-base/template
@@ -1,7 +1,7 @@
 # Template file for 'qt6-base'
 pkgname=qt6-base
-version=6.5.0
-revision=4
+version=6.5.2
+revision=1
 build_style=cmake
 configure_args="-DINSTALL_DATADIR=share/qt6
  -DINSTALL_ARCHDATADIR=lib${XBPS_TARGET_WORDSIZE}/qt6
@@ -32,7 +32,7 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-3.0-only WITH Qt-GPL-exception-1.0, LGPL-3.0-only, GPL-2.0-or-later"
 homepage="https://www.qt.io"
 distfiles="https://download.qt.io/official_releases/qt/${version%.*}/${version}/submodules/qtbase-everywhere-src-${version}.tar.xz"
-checksum=fde1aa7b4fbe64ec1b4fc576a57f4688ad1453d2fab59cbadd948a10a6eaf5ef
+checksum=3db4c729b4d80a9d8fda8dd77128406353baff4755ca619177eda4cddae71269
 python_version=3
 
 if [ "$CROSS_BUILD" ]; then

--- a/srcpkgs/qt6-charts/template
+++ b/srcpkgs/qt6-charts/template
@@ -1,6 +1,6 @@
 # Template file for 'qt6-charts'
 pkgname=qt6-charts
-version=6.5.0
+version=6.5.2
 revision=1
 build_style=cmake
 hostmakedepends="perl qt6-declarative-host-tools"
@@ -10,7 +10,7 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-3.0-only"
 homepage="https://qt.io/"
 distfiles="http://download.qt.io/official_releases/qt/${version%.*}/${version}/submodules/qtcharts-everywhere-src-${version}.tar.xz"
-checksum=fccd1d50a7f56de011f7668e0e90f022316bd4065fa7f91b078579403e2e26a8
+checksum=775af7be019cca698b27e5acffbc2def8f7a5b8f06f5c6db2a7015d578a6ad2d
 
 pre_check() {
 	export QML2_IMPORT_PATH="$wrksrc/build/lib/qt6/qml"

--- a/srcpkgs/qt6-connectivity/template
+++ b/srcpkgs/qt6-connectivity/template
@@ -1,6 +1,6 @@
 # Template file for 'qt6-connectivity'
 pkgname=qt6-connectivity
-version=6.5.0
+version=6.5.2
 revision=1
 build_style=cmake
 hostmakedepends="perl qt6-declarative-host-tools"
@@ -10,7 +10,7 @@ maintainer="Đoàn Trần Công Danh <congdanhqx@gmail.com>"
 license="GPL-3.0-only"
 homepage="https://qt.io/"
 distfiles="http://download.qt.io/official_releases/qt/${version%.*}/${version}/submodules/qtconnectivity-everywhere-src-${version}.tar.xz"
-checksum=e7636653bab986361a77b23451d966c85591428c0422741890ef0fb197698f06
+checksum=db2e4922352d253cafbb8f21eeca58da269c19e0e6d614420af19a7cd35fdc99
 
 qt6-connectivity-devel_package() {
 	depends="${sourcepkg}>=${version}_${revision}

--- a/srcpkgs/qt6-declarative/template
+++ b/srcpkgs/qt6-declarative/template
@@ -1,6 +1,6 @@
 # Template file for 'qt6-declarative'
 pkgname=qt6-declarative
-version=6.5.0
+version=6.5.2
 revision=1
 build_style=cmake
 configure_args="-DQT_BUILD_TESTS=ON"
@@ -11,7 +11,7 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-3.0-only with Qt-GPL-exception-1.0, LGPL-3.0-only, GPL-2.0-or-later"
 homepage="https://www.qt.io"
 distfiles="https://download.qt.io/official_releases/qt/${version%.*}/${version}/submodules/qtdeclarative-everywhere-src-${version}.tar.xz"
-checksum=f7d631cd8ebc1491dad0f30f1b5326ae812bee4ad706e61157816a82bf588c97
+checksum=f3a11fe54e9fac77c649e46e39f1cbe161e9efe89bad205115ba2861b1eb8719
 replaces="qt6-quickcontrols2>=0"
 
 if [ "$CROSS_BUILD" ]; then

--- a/srcpkgs/qt6-imageformats/template
+++ b/srcpkgs/qt6-imageformats/template
@@ -1,6 +1,6 @@
 # Template file for 'qt6-imageformats'
 pkgname=qt6-imageformats
-version=6.5.0
+version=6.5.2
 revision=1
 build_style=cmake
 hostmakedepends="perl qt6-base"
@@ -10,4 +10,4 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only"
 homepage="https://qt.io/"
 distfiles="http://download.qt.io/official_releases/qt/${version%.*}/${version}/submodules/qtimageformats-everywhere-src-${version}.tar.xz"
-checksum=f9f810cd3ac7e60132c0da33f34fcfce42e3e764d6cad3020c2f3b1b42046f78
+checksum=aae0c08924c6a5e47f9d57e031673d611ffff7aab2bee2e1cc460471ecac6743

--- a/srcpkgs/qt6-location/patches/no-cmake-test.patch
+++ b/srcpkgs/qt6-location/patches/no-cmake-test.patch
@@ -1,9 +1,9 @@
 --- qt6-location-6.4.2.orig/tests/auto/CMakeLists.txt
 +++ qt6-location-6.4.2/tests/auto/CMakeLists.txt
-@@ -14,7 +14,6 @@ add_subdirectory(qgeopositioninfo)
- add_subdirectory(qgeosatelliteinfo)
+@@ -18,7 +18,6 @@
  add_subdirectory(qgeosatelliteinfosource)
  add_subdirectory(qnmeasatelliteinfosource)
+ add_subdirectory(qwebmercator)
 -add_subdirectory(cmake)
  if (QT6_IS_SHARED_LIBS_BUILD)
      add_subdirectory(positionplugin)

--- a/srcpkgs/qt6-location/template
+++ b/srcpkgs/qt6-location/template
@@ -1,6 +1,6 @@
 # Template file for 'qt6-location'
 pkgname=qt6-location
-version=6.5.0
+version=6.5.2
 revision=1
 build_style=cmake
 hostmakedepends="perl qt6-base qt6-declarative-host-tools"
@@ -10,7 +10,7 @@ maintainer="John <me@johnnynator.dev>"
 license="(LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only) AND GPL-3.0-only with Qt-GPL-exception-1.0"
 homepage="https://qt.io/"
 distfiles="http://download.qt.io/official_releases/qt/${version%.*}/${version}/submodules/qtpositioning-everywhere-src-${version}.tar.xz"
-checksum=0da7121ebfd9d2ba985ab1f2c8a3af70027c35732177ec0fc72ff7e82835c886
+checksum=70493f03748d1c5b1577e4c011c0af9bcaffcdc6c5e519362605b01f917614fa
 
 pre_check() {
 	export QML2_IMPORT_PATH="$wrksrc/build/lib/qt6/qml"

--- a/srcpkgs/qt6-lottie/template
+++ b/srcpkgs/qt6-lottie/template
@@ -1,6 +1,6 @@
 # Template file for 'qt6-lottie'
 pkgname=qt6-lottie
-version=6.5.0
+version=6.5.2
 revision=1
 build_style=cmake
 hostmakedepends="perl qt6-base qt6-declarative-host-tools"
@@ -10,7 +10,7 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-3.0-only"
 homepage="https://qt.io/"
 distfiles="http://download.qt.io/official_releases/qt/${version%.*}/${version}/submodules/qtlottie-everywhere-src-${version}.tar.xz"
-checksum=8425ecdeb9286a6c51985bdaf3936026610d04dc31eec06fee79df6442b7e246
+checksum=003adc5cf0d50b32d00a09d66ba6332db22191fb0999f51e032f02a21474e89b
 
 if [ "$XBPS_CHECK_PKGS" ]; then
 	configure_args="-DQT_BUILD_TESTS=ON"

--- a/srcpkgs/qt6-multimedia/template
+++ b/srcpkgs/qt6-multimedia/template
@@ -1,7 +1,7 @@
 # Template file for 'qt6-multimedia'
 pkgname=qt6-multimedia
-version=6.5.0
-revision=2
+version=6.5.2
+revision=1
 build_style=cmake
 configure_args="-DQT_FEATURE_gstreamer=ON"
 hostmakedepends="perl qt6-declarative-host-tools pkg-config qt6-shadertools"
@@ -12,7 +12,7 @@ maintainer="John <me@johnnynator.dev>"
 license="(LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only) AND GPL-3.0-only with Qt-GPL-exception-1.0"
 homepage="https://qt.io/"
 distfiles="http://download.qt.io/official_releases/qt/${version%.*}/${version}/submodules/qtmultimedia-everywhere-src-${version}.tar.xz"
-checksum=9480d0c73abdd01aec4899e340938cec046a3f404b9f9ed945288be574dca146
+checksum=948f00aa679e92839a2a71bd07245a92cc849af486607417ee4c334b2b998975
 
 if [ "$XBPS_MACHINE" = "i686" ]; then
 	CXXFLAGS="-DPFFFT_SIMD_DISABLE=1"

--- a/srcpkgs/qt6-networkauth/template
+++ b/srcpkgs/qt6-networkauth/template
@@ -1,6 +1,6 @@
 # Template file for 'qt6-networkauth'
 pkgname=qt6-networkauth
-version=6.5.0
+version=6.5.2
 revision=1
 build_style=cmake
 hostmakedepends="perl qt6-base"
@@ -10,7 +10,7 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-3.0-only"
 homepage="https://qt.io/"
 distfiles="http://download.qt.io/official_releases/qt/${version%.*}/${version}/submodules/qtnetworkauth-everywhere-src-${version}.tar.xz"
-checksum=dbcc522ab2136ebe6c9be5c7f156a3bcefa92cd19a462e33a00e94068a24413e
+checksum=4ecc4b560ac24c29086550972d634a4e1a1a58936b6186a24dd131f8079c283c
 
 if [ "$XBPS_CHECK_PKGS" ]; then
 	configure_args="-DQT_BUILD_TESTS=ON"

--- a/srcpkgs/qt6-qt5compat/template
+++ b/srcpkgs/qt6-qt5compat/template
@@ -1,7 +1,7 @@
 # Template file for 'qt6-qt5compat'
 pkgname=qt6-qt5compat
-version=6.5.0
-revision=2
+version=6.5.2
+revision=1
 build_style=cmake
 configure_args="-DQT_FEATURE_textcodec=ON -DQT_FEATURE_codecs=ON
  -DQT_FEATURE_iconv=ON -DQT_FEATURE_big_codecs=ON"
@@ -12,7 +12,7 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-3.0-only with Qt-GPL-exception-1.0, LGPL-3.0-only, GPL-2.0-or-later"
 homepage="https://qt.io/"
 distfiles="http://download.qt.io/official_releases/qt/${version%.*}/${version}/submodules/qt5compat-everywhere-src-${version}.tar.xz"
-checksum=a9e2f53a193fc2e131b01a2f6e7a1fbfe31309c2413fdc213e5a81c558c21261
+checksum=b9abe42ee2055c27a8e7579c7816069e91aae1f9b10649bf572db8ba96fa91c4
 
 if [ "$XBPS_CHECK_PKGS" ]; then
 	configure_args="-DQT_BUILD_TESTS=ON"

--- a/srcpkgs/qt6-quick3d/template
+++ b/srcpkgs/qt6-quick3d/template
@@ -1,6 +1,6 @@
 # Template file for 'qt6-quick3d'
 pkgname=qt6-quick3d
-version=6.5.0
+version=6.5.2
 revision=1
 build_style=cmake
 hostmakedepends="perl qt6-declarative-host-tools qt6-shadertools"
@@ -11,7 +11,7 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-3.0-or-later"
 homepage="https://qt.io/"
 distfiles="http://download.qt.io/official_releases/qt/${version%.*}/${version}/submodules/qtquick3d-everywhere-src-${version}.tar.xz"
-checksum=9b590429ca98b5cc8cec4df2efa3775e9f11ed8260d123e95f3c0fc37f3772a5
+checksum=75e0a35d9419e8b2ae98c950056b55f2377e4b559aafbe00a9c8d150c5db00da
 
 subpackages="qt6-quick3d-tools qt6-quick3d-devel"
 if [ "$CROSS_BUILD" ]; then

--- a/srcpkgs/qt6-quicktimeline/template
+++ b/srcpkgs/qt6-quicktimeline/template
@@ -1,6 +1,6 @@
 # Template file for 'qt6-quicktimeline'
 pkgname=qt6-quicktimeline
-version=6.5.0
+version=6.5.2
 revision=1
 build_style=cmake
 hostmakedepends="perl qt6-base qt6-declarative-host-tools"
@@ -10,7 +10,7 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-3.0-or-later"
 homepage="https://qt.io/"
 distfiles="http://download.qt.io/official_releases/qt/${version%.*}/${version/rc/-rc}/submodules/qtquicktimeline-everywhere-src-${version/rc/-rc}.tar.xz"
-checksum=578b3e929662b443cd4e51cb0de71e91f4ff55a512d66e0b1ea2999b5657cfbf
+checksum=c945ae905dc1542967c7f9bea826022235bc179c2ed59142c029336c03f015ba
 
 if [ "$XBPS_CHECK_PKGS" ]; then
 	configure_args="-DQT_BUILD_TESTS=ON"

--- a/srcpkgs/qt6-remoteobjects/template
+++ b/srcpkgs/qt6-remoteobjects/template
@@ -1,7 +1,7 @@
 # Template file for 'qt6-remoteobjects'
 pkgname=qt6-remoteobjects
-version=6.5.0
-revision=2
+version=6.5.2
+revision=1
 build_style=cmake
 hostmakedepends="perl qt6-declarative-host-tools pkg-config"
 makedepends="qt6-declarative-devel"
@@ -13,7 +13,7 @@ maintainer="Đoàn Trần Công Danh <congdanhqx@gmail.com>"
 license="(LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only) AND GPL-3.0-only with Qt-GPL-exception-1.0"
 homepage="https://qt.io/"
 distfiles="http://download.qt.io/official_releases/qt/${version%.*}/${version}/submodules/qtremoteobjects-everywhere-src-${version}.tar.xz"
-checksum=ff40b6e7afa84e44190d3b6357462569525b1e1fb0e8bfd8de16a8680825c2ae
+checksum=c0f41f1f79eff28303ecd68dc064a4d8f92b35f3ddc06d78909b142bc0d4494c
 
 if [ "$CROSS_BUILD" ]; then
 	hostmakedepends+=" qt6-remoteobjects"

--- a/srcpkgs/qt6-scxml/template
+++ b/srcpkgs/qt6-scxml/template
@@ -1,6 +1,6 @@
 # Template file for 'qt6-scxml'
 pkgname=qt6-scxml
-version=6.5.0
+version=6.5.2
 revision=1
 build_style=cmake
 hostmakedepends="perl qt6-declarative-host-tools"
@@ -10,7 +10,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only"
 homepage="https://qt.io/"
 distfiles="http://download.qt.io/official_releases/qt/${version%.*}/${version}/submodules/qtscxml-everywhere-src-${version}.tar.xz"
-checksum=f121843cb8cf4a76d621be371e80265ac28254f3c4c123b051e907c1c915766e
+checksum=a830f2ec750913a70f854e487b1b44d1ec3a48eb21253f414a1990f8cf4dbdcb
 
 subpackages="qt6-scxml-tools qt6-scxml-devel"
 if [ "$CROSS_BUILD" ]; then

--- a/srcpkgs/qt6-sensors/template
+++ b/srcpkgs/qt6-sensors/template
@@ -1,7 +1,7 @@
 # Template file for 'qt6-sensors'
 pkgname=qt6-sensors
-version=6.5.0
-revision=2
+version=6.5.2
+revision=1
 build_style=cmake
 hostmakedepends="perl qt6-declarative-host-tools pkg-config"
 makedepends="qt6-declarative-devel qt6-svg-devel"
@@ -10,7 +10,7 @@ maintainer="Đoàn Trần Công Danh <congdanhqx@gmail.com>"
 license="(LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only) AND GPL-3.0-only with Qt-GPL-exception-1.0"
 homepage="https://qt.io/"
 distfiles="http://download.qt.io/official_releases/qt/${version%.*}/${version}/submodules/qtsensors-everywhere-src-${version}.tar.xz"
-checksum=5ee434e2f4917c2d2e9b1de6cb1347c644a8c92338284efeb96202a557e72ea6
+checksum=4006bd7cfbb4302a887bda82b7fe3c31633626363a5e6ba9730bdb4fa8ab2aa6
 
 post_install() {
 	rm -rf ${DESTDIR}/usr/tests

--- a/srcpkgs/qt6-serialport/template
+++ b/srcpkgs/qt6-serialport/template
@@ -1,6 +1,6 @@
 # Template file for 'qt6-serialport'
 pkgname=qt6-serialport
-version=6.5.0
+version=6.5.2
 revision=1
 build_style=cmake
 hostmakedepends="perl qt6-base pkg-config"
@@ -10,7 +10,7 @@ maintainer="John <me@johnnynator.dev>"
 license="(LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only) AND GPL-3.0-only with Qt-GPL-exception-1.0"
 homepage="https://qt.io/"
 distfiles="http://download.qt.io/official_releases/qt/${version%.*}/${version}/submodules/qtserialport-everywhere-src-${version}.tar.xz"
-checksum=9209a9f5978a4adf3a150582270432fe3b635d05513ad1a57bff5ca4954a4dff
+checksum=063c54169aea6b303183b434637ad050e9f67d7f22bb3eff1ede1905eb2ccc9e
 
 qt6-serialport-devel_package() {
 	depends="${sourcepkg}>=${version}_${revision} qt6-base-devel>=${version}_1"

--- a/srcpkgs/qt6-shadertools/template
+++ b/srcpkgs/qt6-shadertools/template
@@ -1,6 +1,6 @@
 # Template file for 'qt6-shadertools'
 pkgname=qt6-shadertools
-version=6.5.0
+version=6.5.2
 revision=1
 build_style=cmake
 hostmakedepends="perl qt6-base"
@@ -11,7 +11,7 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-3.0-or-later"
 homepage="https://qt.io/"
 distfiles="http://download.qt.io/official_releases/qt/${version%.*}/${version}/submodules/qtshadertools-everywhere-src-${version}.tar.xz"
-checksum=86618d037f3071f1f7ac5eb7ab76ae4e6f51cfddded0a402bb9aa7f3f79f5775
+checksum=ca3fb0db8576c59b9c38bb4b271cc6e10aebeb54e2121f429f4ee80671fc0a3d
 
 if [ "$CROSS_BUILD" ]; then
 	configure_args="-DQT_FORCE_BUILD_TOOLS=true"

--- a/srcpkgs/qt6-svg/template
+++ b/srcpkgs/qt6-svg/template
@@ -1,6 +1,6 @@
 # Template file for 'qt6-svg'
 pkgname=qt6-svg
-version=6.5.0
+version=6.5.2
 revision=1
 build_style=cmake
 hostmakedepends="qt6-base perl"
@@ -10,7 +10,7 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-3.0-only with Qt-GPL-exception-1.0, GPL-2.0-or-later, LGPL-3.0-only"
 homepage="https://qt.io/"
 distfiles="http://download.qt.io/official_releases/qt/${version%.*}/${version}/submodules/qtsvg-everywhere-src-${version}.tar.xz"
-checksum=64ca7e61f44d51e28bcbb4e0509299b53a9a7e38879e00a7fe91643196067a4f
+checksum=48b4cc1093af2e0ab3bea30f60651bddd877a2335d16e7207879a2e9e81963a3
 
 if [ "$XBPS_CHECK_PKGS" ]; then
 	configure_args="-DQT_BUILD_TESTS=ON"

--- a/srcpkgs/qt6-tools/template
+++ b/srcpkgs/qt6-tools/template
@@ -1,6 +1,6 @@
 # Template file for 'qt6-tools'
 pkgname=qt6-tools
-version=6.5.0
+version=6.5.2
 revision=1
 build_style=cmake
 configure_args="-DEXTERNAL_GUMBO=ON -DLITEHTML_UTF8=ON -DUSE_ICU=ON
@@ -16,7 +16,7 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-3.0-only with Qt-GPL-exception-1.0, LGPL-3.0-only, GPL-2.0-or-later"
 homepage="https://qt.io/"
 distfiles="http://download.qt.io/official_releases/qt/${version%.*}/${version}/submodules/qttools-everywhere-src-${version}.tar.xz"
-checksum=49c33d96b0a44988be954269b8ce3d1a495b439726e03a6be7c0d50a686369c4
+checksum=551ffb22751d8fd4d88e9ebd55b9131f4ca55341ee497fdbbba4da8d10d94341
 
 if [ "$CROSS_BUILD" ]; then
 	configure_args+=" -DQT_FORCE_BUILD_TOOLS=TRUE"

--- a/srcpkgs/qt6-translations/template
+++ b/srcpkgs/qt6-translations/template
@@ -1,6 +1,6 @@
 # Template file for 'qt6-translations'
 pkgname=qt6-translations
-version=6.5.0
+version=6.5.2
 revision=1
 build_style=cmake
 hostmakedepends="qt6-base qt6-tools perl"
@@ -10,4 +10,4 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-3.0-only with Qt-GPL-exception-1.0"
 homepage="https://qt.io/"
 distfiles="http://download.qt.io/official_releases/qt/${version%.*}/${version}/submodules/qttranslations-everywhere-src-${version}.tar.xz"
-checksum=fc85d0fd8393f518653ccada1014177a56df6e73f30f3b64eea0c2e4a0067a3d
+checksum=337c45637e757e754c2f0ea65c20de3e6e53a841dda1253db15baa622515beeb

--- a/srcpkgs/qt6-virtualkeyboard/template
+++ b/srcpkgs/qt6-virtualkeyboard/template
@@ -1,6 +1,6 @@
 # Template file for 'qt6-virtualkeyboard'
 pkgname=qt6-virtualkeyboard
-version=6.5.0
+version=6.5.2
 revision=1
 build_style=cmake
 hostmakedepends="perl pkg-config qt6-declarative-host-tools"
@@ -10,7 +10,7 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-3.0-only"
 homepage="https://qt.io/"
 distfiles="http://download.qt.io/official_releases/qt/${version%.*}/${version}/submodules/qtvirtualkeyboard-everywhere-src-${version}.tar.xz"
-checksum=7b45de78240817e9f4b57af821e4781655463a4f5f396bbc5df0580a7d2a0fa7
+checksum=0570e0387e22a526b8ff735355ca8f09347501b71f7ae2166b60a81a40626269
 
 if [ "$XBPS_CHECK_PKGS" ]; then
 	configure_args="-DQT_BUILD_TESTS=ON"

--- a/srcpkgs/qt6-wayland/template
+++ b/srcpkgs/qt6-wayland/template
@@ -1,6 +1,6 @@
 # Template file for 'qt6-wayland'
 pkgname=qt6-wayland
-version=6.5.0
+version=6.5.2
 revision=1
 build_style=cmake
 hostmakedepends="qt6-base perl pkg-config wayland-devel qt6-declarative-host-tools"
@@ -14,7 +14,7 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-3.0-only with Qt-GPL-exception-1.0, LGPL-3.0-only, GPL-2.0-or-later"
 homepage="https://www.qt.io"
 distfiles="https://download.qt.io/official_releases/qt/${version%.*}/${version}/submodules/qtwayland-everywhere-src-${version}.tar.xz"
-checksum=ccc57fa277fc5f1c1c2c4733eae80a60996b67a067233c47809e542aa31759a3
+checksum=3020be86fb7fd0abb8509906ca6583cadcaee168159abceaeb5b3e9d42563c9a
 
 subpackages="qt6-wayland-tools qt6-wayland-devel"
 

--- a/srcpkgs/qt6-webchannel/template
+++ b/srcpkgs/qt6-webchannel/template
@@ -1,7 +1,7 @@
 # Template file for 'qt6-webchannel'
 pkgname=qt6-webchannel
-version=6.5.0
-revision=2
+version=6.5.2
+revision=1
 build_style=cmake
 hostmakedepends="perl qt6-base qt6-declarative-host-tools"
 makedepends="qt6-base-devel qt6-declarative-devel qt6-websockets-devel"
@@ -10,7 +10,7 @@ maintainer="John <me@johnnynator.dev>"
 license="(LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only) AND GPL-3.0-only with Qt-GPL-exception-1.0"
 homepage="https://qt.io/"
 distfiles="http://download.qt.io/official_releases/qt/${version%.*}/${version}/submodules/qtwebchannel-everywhere-src-${version}.tar.xz"
-checksum=d9553d646df3681b8e09c7609bf7eda0cde69b562f180fa50451a987ed00f1bf
+checksum=c188d9fa6e535b850b574fa9e47c6089555b8df1fe041dcb13aeeca336b78e63
 
 pre_check() {
 	export QML2_IMPORT_PATH="$wrksrc/build/lib/qt6/qml"

--- a/srcpkgs/qt6-webengine/patches/0900-cross-build-examples.patch
+++ b/srcpkgs/qt6-webengine/patches/0900-cross-build-examples.patch
@@ -1,14 +1,14 @@
 --- qt6-webengine-6.4.2.orig/examples/CMakeLists.txt
 +++ qt6-webengine-6.4.2/examples/CMakeLists.txt
-@@ -1,7 +1,6 @@
+@@ -4,7 +4,6 @@
  cmake_minimum_required(VERSION 3.16)
  
  qt_examples_build_begin(EXTERNAL_BUILD)
--if(NOT CMAKE_CROSSCOMPILING) #QTBUG-86533
+-if(NOT CMAKE_CROSSCOMPILING AND Qt6Core_VERSION VERSION_GREATER_EQUAL "6.5") #QTBUG-86533
      if(TARGET Qt::WebEngineCore)
          add_subdirectory(webenginequick)
      endif()
-@@ -14,5 +13,4 @@ if(NOT CMAKE_CROSSCOMPILING) #QTBUG-8653
+@@ -17,5 +16,4 @@
      if(TARGET Qt::PdfWidgets)
          add_subdirectory(pdfwidgets)
      endif()

--- a/srcpkgs/qt6-webengine/template
+++ b/srcpkgs/qt6-webengine/template
@@ -1,7 +1,7 @@
 # Template file for 'qt6-webengine'
 pkgname=qt6-webengine
-version=6.5.0
-revision=2
+version=6.5.2
+revision=1
 build_style=cmake
 configure_args="
  -DQT_FEATURE_webengine_system_ffmpeg=ON
@@ -32,7 +32,7 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-3.0-only, GPL-2.0-only, LGPL-3.0-only, BSD-3-Clause"
 homepage="https://www.qt.io"
 distfiles="https://download.qt.io/official_releases/qt/${version%.*}/${version}/submodules/qtwebengine-everywhere-src-${version}.tar.xz"
-checksum=2a10da34a71b307e9ff11ec086455dd20b83d5b0ee6bda499c4ba9221e306f07
+checksum=e7c9438b56f502b44b4e376b92ed80f1db7c2c3881d68d319b0677afd5701d9f
 
 if [ "$XBPS_LIBC" = "musl" ]; then
 	hostmakedepends+=" musl-legacy-compat"

--- a/srcpkgs/qt6-websockets/template
+++ b/srcpkgs/qt6-websockets/template
@@ -1,6 +1,6 @@
 # Template file for 'qt6-websockets'
 pkgname=qt6-websockets
-version=6.5.0
+version=6.5.2
 revision=1
 build_style=cmake
 hostmakedepends="perl qt6-base qt6-declarative-host-tools"
@@ -12,7 +12,7 @@ maintainer="John <me@johnnynator.dev>"
 license="(LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only) AND GPL-3.0-only with Qt-GPL-exception-1.0"
 homepage="https://qt.io/"
 distfiles="http://download.qt.io/official_releases/qt/${version%.*}/${version}/submodules/qtwebsockets-everywhere-src-${version}.tar.xz"
-checksum=bc087bd656bb34da120ccab6e927036a219f75fd88f1543744c426bfca616308
+checksum=204bd7b0dffb54c934abc6cf0eb5e3016f11b3c9721a67b4875a6b21bb8b5c76
 
 pre_check() {
 	export QML2_IMPORT_PATH="$wrksrc/build/lib/qt6/qml"


### PR DESCRIPTION
`qt6-webengine` fixes an annoying bug that plagues `qutebrowser`, so we might as well bump everything.

I'm not sure if I'm missing anything and don't know whether `python3-pyqt6-{3d,chargts,networkauth,webengine}` can stay at 6.5.0 and still work with Qt 6.5.2.

#### Testing the changes
- I tested the changes in this PR: **working on it**

cc: @Johnnynator @sgn

[ci skip]