### PR TITLE
giac: fix `#include <giac/giac.h>` in musl

### DIFF
--- a/srcpkgs/giac/patches/fix-fgamma.patch
+++ b/srcpkgs/giac/patches/fix-fgamma.patch
@@ -1,0 +1,40 @@
+Adapted from
+https://github.com/geogebra/giac/commit/618a5de3349f8def5bdb909fea42fb447b6aad4a
+
+--- a/src/usual.cc
++++ b/src/usual.cc
+@@ -81,6 +81,16 @@ using namespace std;
+ #define sprintf256 sprintf
+ #endif
+ 
++#if defined HAVE_TGAMMAF || defined __APPLE__ || defined EMCC || defined EMCC2 || defined NO_BSD 
++inline float fgamma(float f1){ return tgammaf(f1); }
++#else
++#if defined(__MINGW_H) || defined(VISUALC) || defined(FXCG)// FIXME gamma, not used
++inline float fgamma(float f1){ return f1; }
++#else
++inline float fgamma(float f1){ return gammaf(f1); } // or tgammaf(f1) on some versions of emscripten
++#endif
++#endif
++
+ #ifndef NO_NAMESPACE_GIAC
+ namespace giac {
+ #endif // ndef NO_NAMESPACE_GIAC
+--- a/src/first.h
++++ b/src/first.h
+@@ -578,15 +578,6 @@ inline float ffloor(float f1){
+ #endif
+ }
+ inline float finv(float f1){ return 1/f1; }
+-#if defined HAVE_TGAMMAF || defined __APPLE__ || defined EMCC || defined EMCC2 || defined NO_BSD 
+-inline float fgamma(float f1){ return tgammaf(f1); }
+-#else
+-#if defined(__MINGW_H) || defined(VISUALC) || defined(FXCG)// FIXME gamma, not used
+-inline float fgamma(float f1){ return f1; }
+-#else
+-inline float fgamma(float f1){ return gammaf(f1); } // or tgammaf(f1) on some versions of emscripten
+-#endif
+-#endif
+ #ifdef FXCG
+ inline float atan2f(float f1,float f2,int rad){ if (rad) return std::atan2(f1,f2); else return std::atan2(f1,f2)*180/3.14159265358979323846;}
+ #else

--- a/srcpkgs/giac/template
+++ b/srcpkgs/giac/template
@@ -1,7 +1,7 @@
 # Template file for 'giac'
 pkgname=giac
 version=1.9.0.57
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--disable-micropy --disable-quickjs"
 hostmakedepends="automake gettext-devel libtool"
@@ -56,6 +56,10 @@ pre_configure() {
 post_install() {
 	# remove duplicates
 	rm -r ${DESTDIR}/usr/share/doc
+
+	echo "giac: check that '#include <giac/giac.h>' works (see #45708)"
+	echo '#include <giac/giac.h>' |
+		${CC} -c -isystem "${DESTDIR}/usr/include" -xc++ - -o /dev/null
 }
 
 libgiac_package() {


### PR DESCRIPTION
As reported in https://github.com/void-linux/void-packages/pull/45708#issuecomment-1688333569, including <giac/giac.h> fails in musl because the HAVE_TGAMMAF macro from autotools is not available at this time.

Here we include a patch adapted from https://github.com/geogebra/giac/commit/618a5de3349f8def5bdb909fea42fb447b6aad4a which is the solution upstream will include in next release of giac.

We need to fix this now so we can build sagemath in musl!

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
