### PR TITLE
dnscrypt-proxy: update to 2.1.5.

### DIFF
--- a/srcpkgs/dnscrypt-proxy/template
+++ b/srcpkgs/dnscrypt-proxy/template
@@ -1,7 +1,7 @@
 # Template file for 'dnscrypt-proxy'
 pkgname=dnscrypt-proxy
-version=2.1.4
-revision=5
+version=2.1.5
+revision=1
 build_style=go
 go_import_path=github.com/dnscrypt/dnscrypt-proxy
 go_package="${go_import_path}/dnscrypt-proxy"
@@ -12,12 +12,10 @@ license="ISC"
 homepage="https://github.com/DNSCrypt/dnscrypt-proxy"
 changelog="https://raw.githubusercontent.com/DNSCrypt/dnscrypt-proxy/master/ChangeLog"
 distfiles="https://github.com/DNSCrypt/dnscrypt-proxy/archive/refs/tags/${version}.tar.gz"
-checksum=05f0a3e8c8f489caf95919e2a75a1ec4598edd3428d2b9dd357caba6adb2607d
+checksum=044c4db9a3c7bdcf886ff8f83c4b137d2fd37a65477a92bfe86bf69587ea7355
 conf_files="/etc/dnscrypt-proxy.toml"
 system_accounts="dnscrypt_proxy"
 make_dirs="/var/log/dnscrypt-proxy 0750 dnscrypt_proxy dnscrypt_proxy"
-
-export GOTOOLCHAIN=go1.20
 
 post_install() {
 	vconf dnscrypt-proxy/example-dnscrypt-proxy.toml dnscrypt-proxy.toml


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - i686
  - aarch64
  - armv7l

The new version 2.1.5 fixes go1.21.0 version support, see [changelog](https://github.com/DNSCrypt/dnscrypt-proxy/blob/master/ChangeLog):
# Version 2.1.5
 - dnscrypt-proxy can be compiled with Go 1.21.0+
 - Responses to blocked queries now include extended error codes
 - Reliability of connections using HTTP/3 has been improved
 - New configuration directive: `tls_key_log_file`. When defined, this
is the path to a file where TLS secret keys will be written to, so
that DoH traffic can be locally inspected.