### PR TITLE
libQuotient 0.8.1.2 and client updates

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -3595,7 +3595,7 @@ libgaminggearwidget.so.0 libgaminggear-0.15.1_1
 libopkg.so.1 libopkg-0.4.4_2
 libpkgconf.so.4 libpkgconf-1.9.3_1
 libkodiplatform.so.19.0 kodi-platform-20180302_1
-libQuotient.so.0.6 libQuotient-0.6.11_1
+libQuotient.so.0.8 libQuotient-0.8.1.2_1
 libipset.so.13 libipset-7.9_1
 libmp3splt.so.0 libmp3splt-0.9.2_1
 libliquid.so.1 liquid-dsp-1.4.0_1

--- a/srcpkgs/Quaternion/template
+++ b/srcpkgs/Quaternion/template
@@ -1,21 +1,21 @@
 # Template file for 'Quaternion'
 pkgname=Quaternion
-version=0.0.95.1
+version=0.0.96.beta4
 revision=1
+_gitversion=0.0.96-beta4
 build_style=cmake
+configure_args="-DBUILD_WITH_QT6=OFF"
 hostmakedepends="qt5-qmake qt5-host-tools"
 makedepends="qt5-declarative-devel qt5-quickcontrols qt5-tools-devel
  qt5-multimedia-devel qt5-quickcontrols2-devel libQuotient-devel
- $(vopt_if qtkeychain qtkeychain-qt5-devel)"
+ qtkeychain-qt5-devel olm-devel qt5-plugin-mysql qt5-plugin-odbc
+ qt5-plugin-pgsql qt5-plugin-sqlite qt5-plugin-tds"
 depends="qt5-quickcontrols qt5-graphicaleffects"
-short_desc="Qt5-based IM client for the Matrix protocol"
+short_desc="Qt-based IM client for the Matrix protocol"
 maintainer="Julio Galvan <juliogalvan@protonmail.com>"
 license="GPL-3.0-or-later"
 homepage="https://github.com/quotient-im/Quaternion"
-distfiles="https://github.com/quotient-im/Quaternion/archive/${version}.tar.gz"
-checksum=69f034241dddc8d9436a895bb76b022e492e61e2f49d9a80ed8d79ab12b63a0e
-
-build_options="qtkeychain"
-build_options_default="qtkeychain"
+distfiles="https://github.com/quotient-im/Quaternion/archive/${_gitversion}.tar.gz"
+checksum=c3a49ea5af3800528690c827dd3bf266d04ad165561807e9a117c8718769deeb
 
 CXXFLAGS="-Wno-deprecated-declarations"

--- a/srcpkgs/libQuotient/patches/testolmaccount.patch
+++ b/srcpkgs/libQuotient/patches/testolmaccount.patch
@@ -1,0 +1,12 @@
+diff --git a/autotests/CMakeLists.txt b/autotests/CMakeLists.txt
+index f2c7287..460e741 100644
+--- a/autotests/CMakeLists.txt
++++ b/autotests/CMakeLists.txt
+@@ -17,7 +17,6 @@ endfunction()
+ quotient_add_test(NAME callcandidateseventtest)
+ quotient_add_test(NAME utiltests)
+ if(${PROJECT_NAME}_ENABLE_E2EE)
+-    quotient_add_test(NAME testolmaccount)
+     quotient_add_test(NAME testgroupsession)
+     quotient_add_test(NAME testolmsession)
+     if (NOT MSVC)

--- a/srcpkgs/libQuotient/template
+++ b/srcpkgs/libQuotient/template
@@ -1,17 +1,23 @@
 # Template file for 'libQuotient'
 pkgname=libQuotient
-version=0.6.11
+version=0.8.1.2
 revision=1
 build_style=cmake
-configure_args="-DBUILD_SHARED_LIBS=1 -DQuotient_INSTALL_TESTS=0"
+configure_args="-DBUILD_SHARED_LIBS=1 -DQuotient_INSTALL_TESTS=0
+ $(vopt_bool e2ee Quotient_ENABLE_E2EE)"
 hostmakedepends="qt5-qmake qt5-host-tools"
-makedepends="qt5-devel qt5-multimedia-devel"
+makedepends="qt5-devel qt5-multimedia-devel qtkeychain-qt5-devel
+ $(vopt_if e2ee 'olm-devel openssl-devel qt5-plugin-mysql qt5-plugin-odbc
+ qt5-plugin-pgsql qt5-plugin-sqlite qt5-plugin-tds')"
 short_desc="Qt5 library to write cross-platform clients for Matrix"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="LGPL-2.1-or-later"
 homepage="https://matrix.org/docs/projects/sdk/quotient"
 distfiles="https://github.com/quotient-im/libQuotient/archive/${version}.tar.gz"
-checksum=12b15d1296e630477d5e8f4d32c821dc724b3c5b99d15d383417ba7d88f03c46
+checksum=5e5539fe9616c9f63985b0aabfab1858f1626e3d71a14709eeedd85af0471c7c
+
+build_options="e2ee"
+build_options_default="e2ee"
 
 libQuotient-devel_package() {
 	depends="${sourcepkg}>=${version}_${revision}"

--- a/srcpkgs/neochat/patches/delegatesizehelpertest_fix.patch
+++ b/srcpkgs/neochat/patches/delegatesizehelpertest_fix.patch
@@ -1,0 +1,38 @@
+From 6305359b3c515e030c2bfd35b6ee62ad36ebe497 Mon Sep 17 00:00:00 2001
+From: Tobias Fella <tobias.fella@kde.org>
+Date: Sun, 27 Aug 2023 01:46:50 +0200
+Subject: [PATCH] Use round instead of ceil in delegatesizehelper
+
+Fixes #592
+---
+ src/delegatesizehelper.cpp | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/src/delegatesizehelper.cpp b/src/delegatesizehelper.cpp
+index 7c4d6dec0..aae61fa06 100644
+--- a/src/delegatesizehelper.cpp
++++ b/src/delegatesizehelper.cpp
+@@ -124,7 +124,7 @@ int DelegateSizeHelper::calculateCurrentPercentageWidth() const
+     int maxPercentWidth = endPercentBigger ? m_endPercentWidth : m_startPercentWidth;
+     int minPercentWidth = endPercentBigger ? m_startPercentWidth : m_endPercentWidth;
+ 
+-    int calcPercentWidth = std::ceil(m * m_parentWidth + c);
++    int calcPercentWidth = std::round(m * m_parentWidth + c);
+     return std::clamp(calcPercentWidth, minPercentWidth, maxPercentWidth);
+ }
+ 
+@@ -146,9 +146,9 @@ qreal DelegateSizeHelper::currentWidth() const
+ 
+     qreal absoluteWidth = m_parentWidth * percentWidth * 0.01;
+     if (m_maxWidth < 0.0) {
+-        return std::ceil(absoluteWidth);
++        return std::round(absoluteWidth);
+     } else {
+-        return std::ceil(std::min(absoluteWidth, m_maxWidth));
++        return std::round(std::min(absoluteWidth, m_maxWidth));
+     }
+ }
+ 
+-- 
+GitLab
+

--- a/srcpkgs/neochat/patches/empty_image.source_crash.patch
+++ b/srcpkgs/neochat/patches/empty_image.source_crash.patch
@@ -1,0 +1,25 @@
+From 0d5929b4bc3ca8c55a9e27121782efb19e4d829e Mon Sep 17 00:00:00 2001
+From: Laurent Montel <montel@kde.org>
+Date: Mon, 4 Sep 2023 19:03:06 +0000
+Subject: [PATCH] Fix enable/disable save button when image.source is empty.
+ Otherwise it will crash
+
+---
+ src/qml/Settings/EmoticonEditorPage.qml | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/qml/Settings/EmoticonEditorPage.qml b/src/qml/Settings/EmoticonEditorPage.qml
+index c55e9178e..1f003d24e 100644
+--- a/src/qml/Settings/EmoticonEditorPage.qml
++++ b/src/qml/Settings/EmoticonEditorPage.qml
+@@ -119,8 +119,8 @@
+                 MobileForm.FormButtonDelegate {
+                     id: save
+                     text: i18n("Save")
+-                    icon.name: "document-save"
+-                    enabled: !root.newEmoticon || (image.source && shortcode.text && description.text)
++		    icon.name: "document-save"
++		    enabled: !root.newEmoticon || (image.source.toString().length > 0 && shortcode.text && description.text)
+                     onClicked: {
+                         if (root.newEmoticon) {
+                             model.addEmoticon(image.source, shortcode.text, description.text, emoticonType === EmoticonFormCard.Stickers ? "sticker" : "emoticon")

--- a/srcpkgs/neochat/template
+++ b/srcpkgs/neochat/template
@@ -1,7 +1,7 @@
 # Template file for 'neochat'
 pkgname=neochat
-version=23.04.3
-revision=2
+version=23.08.0
+revision=1
 build_style=cmake
 hostmakedepends="extra-cmake-modules gettext pkg-config qt5-qmake
  qt5-host-tools kcoreaddons kconfig AppStream"
@@ -9,14 +9,16 @@ makedepends="kquickimageeditor-devel libQuotient-devel qtkeychain-qt5-devel
  qt5-multimedia-devel kirigami2-devel ki18n-devel cmark-devel
  knotifications-devel kconfig-devel kcoreaddons-devel qqc2-desktop-style-devel
  sonnet-devel kitemmodels-devel kirigami-addons kconfigwidgets-devel kio-devel
- qcoro-qt5-devel"
-depends="kquickimageeditor kitemmodels"
+ qcoro-qt5-devel olm-devel qt5-plugin-mysql qt5-plugin-odbc qt5-plugin-pgsql
+ qt5-plugin-sqlite qt5-plugin-tds"
+depends="kquickimageeditor kitemmodels kirigami2 kirigami-addons kquickcharts
+ qt5-location"
 short_desc="Client for matrix from KDE"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-3.0-only, GPL-3.0-or-later, GPL-2.0-or-later, BSD-2-Clause"
 homepage="https://apps.kde.org/en/neochat"
 distfiles="${KDE_SITE}/release-service/${version}/src/neochat-${version}.tar.xz"
-checksum=2e7a006e24eea80049a0213897048291d1ddb52d484aae8d2d0f48bbb020af04
+checksum=4ead1a9fa308e53173229a744075c59580ed3364bd206a08c07d9db163758bfb
 
 if [ "$CROSS_BUILD" ]; then
 	hostmakedepends+=" kdoctools"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

This version of neochat requires libQuotient >=0.7, and the only versions of Quaternion that support libQuotient >=0.7 are the 0.0.96 beta versions.

neochat also requires libQuotient to be built with E2EE enabled now.

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
