### PR TITLE
New package: TheForceEngine-1.09.530

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -2978,7 +2978,7 @@ libPocoCrypto.so.94 poco-1.12.4_1
 libPtex.so ptex-2.3.2_1
 libopenblas.so.0 openblas-0.2.19_1
 librtaudio.so.6 rtaudio-5.1.0_1
-librtmidi.so.5 rtmidi-4.0.0_1
+librtmidi.so.7 rtmidi-6.0.0_1
 libbiblesync.so.2.1.0 biblesync-2.1.0_1
 libbac-9.4.2.so bacula-common-9.4.2_4
 libbaccfg-9.4.2.so bacula-common-9.4.2_4

--- a/srcpkgs/TheForceEngine/patches/musl.patch
+++ b/srcpkgs/TheForceEngine/patches/musl.patch
@@ -1,0 +1,10 @@
+--- a/TheForceEngine/TFE_FileSystem/fileutil-posix.cpp  2023-09-28 06:00:17.000000000 +0200
++++ -   2023-09-28 09:33:09.076014188 +0200
+@@ -2,6 +2,7 @@
+ #include <errno.h>
+ #include <fcntl.h>
+ #include <libgen.h>
++#include <limits.h>
+ #include <stdio.h>
+ #include <stdlib.h>
+ #include <string.h>

--- a/srcpkgs/TheForceEngine/template
+++ b/srcpkgs/TheForceEngine/template
@@ -1,0 +1,28 @@
+# Template file for 'TheForceEngine'
+pkgname=TheForceEngine
+version=1.09.530
+revision=1
+build_style=cmake
+hostmakedepends="pkg-config"
+makedepends="SDL2-devel devil-devel rtmidi-devel jack-devel glew-devel MesaLib-devel"
+depends="zenity"
+short_desc="Modern \"Jedi Engine\" replacement supporting Dark Forces and mods"
+maintainer="Kenneth Dodrill <hello@kennydodrill.com>"
+license="GPL-2.0-only"
+homepage="https://theforceengine.github.io"
+distfiles="https://github.com/luciusDXL/TheForceEngine/archive/v${version}.tar.gz"
+checksum=6b4649fe219ec0678888e7b2076017cda545f97218d5d05f29cb7604bf45097e
+
+if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
+	makedepends+=" libexecinfo-devel"
+	configure_args="-DCMAKE_CXX_STANDARD_LIBRARIES=-lexecinfo"
+fi
+
+if [ "$XBPS_TARGET_WORDSIZE" == "32" ]; then
+	broken="Minimum requirements state 64-bit for GPU renderer"
+fi
+
+post_install() {
+	vinstall "${pkgname}/${pkgname}.desktop" 644 usr/share/applications
+	vinstall "${pkgname}/${pkgname}.png" 644 usr/share/icons/hicolor/256x256/apps/ ${pkgname}.png
+}

--- a/srcpkgs/furnace/template
+++ b/srcpkgs/furnace/template
@@ -1,7 +1,7 @@
 # Template file for 'furnace'
 pkgname=furnace
 version=0.6pre12
-revision=1
+revision=2
 _adpcm_commit="ef7a217154badc3b99978ac481b268c8aab67bd8"
 build_wrksrc=${pkgname}-${version}
 build_style=cmake

--- a/srcpkgs/giada/template
+++ b/srcpkgs/giada/template
@@ -1,7 +1,7 @@
 # Template file for 'giada'
 pkgname=giada
 version=0.17.0
-revision=1
+revision=2
 build_style=cmake
 # configure_args="--target=linux"
 hostmakedepends="cmake"

--- a/srcpkgs/milkytracker/template
+++ b/srcpkgs/milkytracker/template
@@ -1,8 +1,9 @@
 # Template file for 'milkytracker'
 pkgname=milkytracker
 version=1.02.00
-revision=2
+revision=3
 build_style=cmake
+hostmakedepends="pkg-config"
 makedepends="SDL2-devel zlib-devel jack-devel alsa-lib-devel rtmidi-devel"
 depends="libjack rtmidi"
 short_desc="Fast Tracker II inspired music tracker"

--- a/srcpkgs/rtmidi/template
+++ b/srcpkgs/rtmidi/template
@@ -1,17 +1,17 @@
 # Template file for 'rtmidi'
 pkgname=rtmidi
-version=4.0.0
-revision=2
+version=6.0.0
+revision=1
 build_style=gnu-configure
 configure_args="--with-alsa --with-jack"
 hostmakedepends="automake libtool"
 makedepends="alsa-lib-devel jack-devel"
 short_desc="C++ classes for realtime MIDI input/output"
 maintainer="Duncaen <duncaen@voidlinux.org>"
-license="MIT"
+license="custom:RtMidi"
 homepage="http://www.music.mcgill.ca/~gary/rtmidi/"
 distfiles="https://github.com/thestk/rtmidi/archive/${version}.tar.gz"
-checksum=d32de9ceebf6d969537e9a9720925a1ac7f6a8bc4ac4ce7c58c01434f4e54f44
+checksum=ef7bcda27fee6936b651c29ebe9544c74959d0b1583b716ce80a1c6fea7617f0
 
 pre_configure() {
 	sed -n '/Copyright (c)/,$ p' < README.md > LICENSE


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

https://github.com/luciusDXL/TheForceEngine

* Requires `rtmidi` to get bumped to `5.0.0`, but I went ahead and bumped it to `6.0.0`. The license changed, but I think most of the other changes are features.

* I revbumped the other packages that require `rtmidi`. `milkytracker` needed `pkg-config` added to `hostmakedepends`, otherwise it would fail. I packaged all of them, but I only installed milkytracker and played around with it a little.

* 32bit seems to not be available for now for this package. According to some github issues, ARM support may be possible with some patches. I also tested musl x86_64 and it failed, but possibly would work with some patches.

* Notably during testing the shareware version of Dark Forces will not work with TheForceEngine, you must use the full game.

#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, x86_64
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - i686 (failed)
  - x86_64-musl (failed)
