### PR TITLE
eludris: fix fetch

### DIFF
--- a/srcpkgs/eludris/template
+++ b/srcpkgs/eludris/template
@@ -11,8 +11,10 @@ makedepends="openssl-devel"
 short_desc="Simple CLI to help with setting up and managing your Eludris instance"
 maintainer="Oliver Wilkes <oliverwilkes2006@icloud.com>"
 license="MIT"
-homepage="https://github.com/eludris/eludris/tree/main/cli"
-distfiles="https://github.com/eludris/eludris/archive/refs/tags/v${version}.tar.gz"
+homepage="https://eludris.com/"
+# distfiles="https://github.com/eludris/eludris/archive/refs/tags/v${version}.tar.gz"
+# Upstream repo is gone, project is now proprietary
+distfiles="https://sources.voidlinux.org/eludris-${version}/v${version}.tar.gz"
 checksum=e204969d056e147a97cb8d1b2a0c16b7e4d06c5895ef9bb939884ddc0ecdb3c2
 
 post_install() {


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: N/A

---

Upstream repo has disappeared. From the devs:
> Unfortunately there will not be any tool for managing Eludris
> instances in the near future until Eludris potentially sorts out its
> business model, to avoid a continuous net financial loss. For now
> Eludris has become proprietary and will not be self-hostable.