### PR TITLE
chrony: update to 4.4

### DIFF
--- a/srcpkgs/chrony/template
+++ b/srcpkgs/chrony/template
@@ -1,8 +1,8 @@
 # Template file for 'chrony'
 # When Updating: Please confirm the upstream config still refers to make_dirs
 pkgname=chrony
-version=4.3
-revision=2
+version=4.4
+revision=1
 build_style=gnu-configure
 configure_args="--without-nss --enable-scfilter
  --with-sendmail=/usr/bin/sendmail"
@@ -15,7 +15,7 @@ license="GPL-2.0-only"
 homepage="https://chrony.tuxfamily.org/"
 changelog="https://chrony.tuxfamily.org/news.html"
 distfiles="https://download.tuxfamily.org/chrony/${pkgname}-${version}.tar.gz"
-checksum=9d0da889a865f089a5a21610ffb6713e3c9438ce303a63b49c2fb6eaff5b8804
+checksum=eafb07e6daf92b142200f478856dfed6efc9ea2d146eeded5edcb09b93127088
 system_accounts="chrony"
 chrony_homedir="/var/lib/chrony"
 


### PR DESCRIPTION
tagging the maintainer @paper42 
It's just a version bump
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures:
  - x86_64-musl

