### PR TITLE
avfs: update to 1.1.5.

### DIFF
--- a/srcpkgs/avfs/template
+++ b/srcpkgs/avfs/template
@@ -1,18 +1,18 @@
 # Template file for 'avfs'
 pkgname=avfs
-version=1.1.4
+version=1.1.5
 revision=1
 build_style=gnu-configure
 configure_args="--with-system-zlib --with-system-bzlib"
 hostmakedepends="pkg-config"
-makedepends="fuse-devel liblzma-devel libzstd-devel zlib-devel bzip2-devel"
+makedepends="fuse-devel liblzma-devel libzstd-devel zlib-devel bzip2-devel lzlib-devel"
 depends="perl"
 short_desc="Virtual filesystem that allows browsing compressed files"
 maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-only, LGPL-2.0-only"
 homepage="https://avf.sourceforge.net/"
 distfiles="$SOURCEFORGE_SITE/avf/avfs-${version}.tar.bz2"
-checksum=3a7981af8557f864ae10d4b204c29969588fdb526e117456e8efd54bf8faa12b
+checksum=ad9f3b64104d6009a058c70f67088f799309bf8519b14b154afad226a45272cf
 
 libavfs_package() {
 	short_desc+=" - library"
@@ -24,7 +24,7 @@ libavfs_package() {
 
 avfs-devel_package() {
 	short_desc+=" - development files"
-	depends="avfs>=${version}_${revision}"
+	depends="${makedepends} libavfs>=${version}_${revision}"
 	pkg_install() {
 		vmove usr/bin/avfs-config
 		vmove usr/lib/pkgconfig


### PR DESCRIPTION
...also enable lzip support and fix avfs-devel dependencies,

I noticed the issue with the avfs-devel dependencies when packaging worker: #45807 

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
