### PR TITLE
zstd: clean up template.

### DIFF
--- a/srcpkgs/zstd/patches/dynamic-pzstd.patch
+++ b/srcpkgs/zstd/patches/dynamic-pzstd.patch
@@ -1,0 +1,15 @@
+Dynamically link pzstd against libzstd.so.
+
+--- a/contrib/pzstd/Makefile
++++ b/contrib/pzstd/Makefile
+@@ -167,8 +167,8 @@
+ 	$(TESTPROG) ./test/RoundTripTest$(EXT) $(TESTFLAGS)
+ 
+ # Build the main binary
+-pzstd$(EXT): main.o $(PROGDIR)/util.o Options.o Pzstd.o SkippableFrame.o $(ZSTDDIR)/libzstd.a
+-	$(LD_COMMAND)
++pzstd$(EXT): main.o $(PROGDIR)/util.o Options.o Pzstd.o SkippableFrame.o
++	$(LD_COMMAND) -L../../lib -lzstd
+ 
+ # Target that depends on all the tests
+ .PHONY: tests

--- a/srcpkgs/zstd/template
+++ b/srcpkgs/zstd/template
@@ -1,7 +1,7 @@
 # Template file for 'zstd'
 pkgname=zstd
 version=1.5.5
-revision=1
+revision=2
 bootstrap=yes
 makedepends="zlib-devel liblzma-devel liblz4-devel"
 checkdepends="gtest-devel tar"
@@ -15,6 +15,7 @@ checksum=9c4396cc829cfae319a6e2615202e82aad41372073482fce286fac78646d3ee4
 
 do_build() {
 	make ${makejobs} PREFIX=/usr lib-mt
+	make ${makejobs} PREFIX=/usr -C programs zstd-dll
 	make ${makejobs} PREFIX=/usr -C contrib/pzstd
 }
 


### PR DESCRIPTION
The zstd template had multiple issues:

- Since not all targets where built in do_build, compilation happened in do_install.
- Both zstd(1) and pzstd(1) statically linked libzstd.
- The libzstd.a library was meant to have multi-threading support, but was overwritten by a single-threaded version as a side-effect.

We patch pzstd to use dynamic linking and use "zstd-dll" for zstd.



In the future we may want to consider using cmake or ninja, but as it's a bootstrap package I've kept it on make.