### PR TITLE
Rust 1.72

### DIFF
--- a/srcpkgs/cargo-bootstrap/template
+++ b/srcpkgs/cargo-bootstrap/template
@@ -1,6 +1,6 @@
 # Template file for 'cargo-bootstrap'
 pkgname=cargo-bootstrap
-version=1.71.1
+version=1.72.0
 revision=1
 short_desc="Bootstrap binaries of Rust package manager"
 maintainer="Orphaned <orphan@voidlinux.org>"
@@ -24,15 +24,15 @@ esac
 case "$XBPS_TARGET_MACHINE" in
 	i686)
 		distfiles="${_bootstrap_url}/cargo-${version}-i686-unknown-linux-gnu.tar.xz"
-		checksum="fca0d2e9a561a00eeacedbec15deed35e388d872282092257fe81c9b2467637d"
+		checksum="549eda5cda44750b0b2e6d3ce3f9c90c3a133b695e4882b4c6b93e54d6e8a73a"
 		;;
 	x86_64)
 		distfiles="${_bootstrap_url}/cargo-${version}-x86_64-unknown-linux-gnu.tar.xz"
-		checksum="55760c2f20356fe5cb2a4aa105e20693a573048f1dbc9daa41a0983fc0930b15"
+		checksum="4a401dfe7b3056dc0d42acbcd380b2b90f936577706ca74ef5327af0f5abd0a0"
 		;;
 	x86_64-musl)
 		distfiles="${_bootstrap_url}/cargo-${version}-x86_64-unknown-linux-musl.tar.xz"
-		checksum="865d33e427603db0a3514d58824ce51c0cf8a085b74ebd0d3d7bbf356f178279"
+		checksum="0edc4773dd9679904261d3a556306a0f152d229c21408622c892971da681cf01"
 		;;
 	# placeholders for user-supplied distfiles
 	ppc64le)

--- a/srcpkgs/cargo/template
+++ b/srcpkgs/cargo/template
@@ -1,8 +1,8 @@
 # Template file for 'cargo'
 pkgname=cargo
-version=1.71.1
-revision=2
-_cargo_revision=0.72.2
+version=1.72.0
+revision=1
+_cargo_revision=0.73.1
 build_helper=rust
 hostmakedepends="cargo-bootstrap rust python3 curl pkg-config zlib-devel"
 makedepends="rust libcurl-devel openssl-devel"
@@ -12,7 +12,7 @@ maintainer="Enno Boland <gottox@voidlinux.org>"
 license="MIT, Apache-2.0"
 homepage="https://crates.io/"
 distfiles="https://github.com/rust-lang/cargo/archive/refs/tags/${_cargo_revision}.tar.gz"
-checksum=479beb5858363209f789e0b5fa4b1fa3cdc3d31f819214b94a8d502ebaa1126a
+checksum=976fb6f3e773319e60875772478645297d9eacc852857e288e8cec65399d2c88
 replaces="cargo-tree>=0"
 
 build_options="static bindist"

--- a/srcpkgs/rust-bootstrap/template
+++ b/srcpkgs/rust-bootstrap/template
@@ -1,6 +1,6 @@
 # Template file for 'rust-bootstrap'
 pkgname=rust-bootstrap
-version=1.71.1
+version=1.72.0
 revision=1
 short_desc="Rust programming language bootstrap toolchain"
 maintainer="Orphaned <orphan@voidlinux.org>"
@@ -31,24 +31,24 @@ case "$XBPS_TARGET_MACHINE" in
 		 ${_bootstrap_url}/rustc-${version}-i686-unknown-linux-gnu.tar.xz
 		 ${_bootstrap_url}/rust-std-${version}-i686-unknown-linux-gnu.tar.xz"
 		checksum="
-		 33bc15de9f1d1cddbddf008f7f51a5af09867bc5fb40c65194a1f5f8b2972d40
-		 672811c88fd5ffc5185d40eeecc7d257aeff47c9b48e0ced70ccea1e2559b273"
+		 53c0e2045078326fd2ac9e77900a34b4ced1545a489b2a438deaebd2150cf543
+		 536c5ec1403b55045a502af1d6f8af192b560fbf9a24874bce6d59163fb8a38a"
 		;;
 	x86_64)
 		distfiles="
 		 ${_bootstrap_url}/rustc-${version}-x86_64-unknown-linux-gnu.tar.xz
 		 ${_bootstrap_url}/rust-std-${version}-x86_64-unknown-linux-gnu.tar.xz"
 		checksum="
-		 9a8a12b6c2a6f67d75ead0f343f891b78672c59387d1be28b46f3161ec2b251d
-		 31f392df564850d78be80adc625b06a3964a49ef5c519075b930f2042a422264"
+		 5b5d7854a0d73368f15146c1aa47e4dbccf12762c93282f410a09a605929ce09
+		 36f27513a6e4381f15b0cd14097c885af537f990cb6193cec3337c429367bf23"
 		;;
 	x86_64-musl)
 		distfiles="
 		 ${_bootstrap_url}/rustc-${version}-x86_64-unknown-linux-musl.tar.xz
 		 ${_bootstrap_url}/rust-std-${version}-x86_64-unknown-linux-musl.tar.xz"
 		checksum="
-		 725d2cf0004ecc51e9c3b7949624744df28f74fbfbe53d742104c6a4e2121cef
-		 20667738a9005dda0386c8b6e59d55ce3044be11f78002f6640ca874d6911483"
+		 1f02cd6f6ed66f09ffa49a3dac139542e5f2a8f120cc150f4edf8833c7b2929d
+		 4df4dc1fd057ddf222c300d6c929f2850889511f3749f3d0da413e8536f8c006"
 		;;
 	# placeholders for user-supplied distfiles
 	ppc64le)

--- a/srcpkgs/rust/patches/0002-Remove-nostdlib-and-musl_root-from-musl-targets.patch
+++ b/srcpkgs/rust/patches/0002-Remove-nostdlib-and-musl_root-from-musl-targets.patch
@@ -60,10 +60,10 @@ index 61553e71b..88f807a58 100644
      base
  }
 diff --git a/config.example.toml b/config.example.toml
-index d0eaa9fd7..b92f9488e 100644
+index 0c65b25fe..3030f1a92 100644
 --- a/config.example.toml
 +++ b/config.example.toml
-@@ -556,14 +556,6 @@ changelog-seen = 2
+@@ -563,14 +563,6 @@ changelog-seen = 2
  # behavior -- this may lead to miscompilations or other bugs.
  #description = ""
  
@@ -79,28 +79,28 @@ index d0eaa9fd7..b92f9488e 100644
  # platforms to ensure that the compiler is usable by default from the build
  # directory (as it links to a number of dynamic libraries). This may not be
 diff --git a/src/bootstrap/cc_detect.rs b/src/bootstrap/cc_detect.rs
-index 65c882fb8..f35a92821 100644
+index ade3bfed1..66d2f549a 100644
 --- a/src/bootstrap/cc_detect.rs
 +++ b/src/bootstrap/cc_detect.rs
-@@ -103,7 +103,7 @@ pub fn find(build: &mut Build) {
-         if let Some(cc) = config.and_then(|c| c.cc.as_ref()) {
-             cfg.compiler(cc);
-         } else {
--            set_compiler(&mut cfg, Language::C, target, config, build);
-+            set_compiler(&mut cfg, Language::C, target, config);
-         }
+@@ -110,7 +110,7 @@ pub fn find_target(build: &Build, target: TargetSelection) {
+     if let Some(cc) = config.and_then(|c| c.cc.as_ref()) {
+         cfg.compiler(cc);
+     } else {
+-        set_compiler(&mut cfg, Language::C, target, config, build);
++        set_compiler(&mut cfg, Language::C, target, config);
+     }
  
-         let compiler = cfg.get_compiler();
-@@ -124,7 +124,7 @@ pub fn find(build: &mut Build) {
-             cfg.compiler(cxx);
-             true
-         } else if build.hosts.contains(&target) || build.build == target {
--            set_compiler(&mut cfg, Language::CPlusPlus, target, config, build);
-+            set_compiler(&mut cfg, Language::CPlusPlus, target, config);
-             true
-         } else {
-             // Use an auto-detected compiler (or one configured via `CXX_target_triple` env vars).
-@@ -160,7 +160,6 @@ fn set_compiler(
+     let compiler = cfg.get_compiler();
+@@ -131,7 +131,7 @@ pub fn find_target(build: &Build, target: TargetSelection) {
+         cfg.compiler(cxx);
+         true
+     } else if build.hosts.contains(&target) || build.build == target {
+-        set_compiler(&mut cfg, Language::CPlusPlus, target, config, build);
++        set_compiler(&mut cfg, Language::CPlusPlus, target, config);
+         true
+     } else {
+         // Use an auto-detected compiler (or one configured via `CXX_target_triple` env vars).
+@@ -166,7 +166,6 @@ fn set_compiler(
      compiler: Language,
      target: TargetSelection,
      config: Option<&Target>,
@@ -108,7 +108,7 @@ index 65c882fb8..f35a92821 100644
  ) {
      match &*target.triple {
          // When compiling for android we may have the NDK configured in the
-@@ -196,26 +195,6 @@ fn set_compiler(
+@@ -202,26 +201,6 @@ fn set_compiler(
              }
          }
  
@@ -136,10 +136,10 @@ index 65c882fb8..f35a92821 100644
      }
  }
 diff --git a/src/bootstrap/compile.rs b/src/bootstrap/compile.rs
-index 33addb90d..fb6c97d82 100644
+index 14c3ef79a..c525031d1 100644
 --- a/src/bootstrap/compile.rs
 +++ b/src/bootstrap/compile.rs
-@@ -237,39 +237,7 @@ fn copy_self_contained_objects(
+@@ -268,39 +268,7 @@ fn copy_self_contained_objects(
      let mut target_deps = vec![];
  
      // Copies the libc and CRT objects.
@@ -180,7 +180,7 @@ index 33addb90d..fb6c97d82 100644
          let srcdir = builder
              .wasi_root(target)
              .unwrap_or_else(|| {
-@@ -366,15 +334,6 @@ pub fn std_cargo(builder: &Builder<'_>, target: TargetSelection, stage: u32, car
+@@ -397,15 +365,6 @@ pub fn std_cargo(builder: &Builder<'_>, target: TargetSelection, stage: u32, car
              .arg("--manifest-path")
              .arg(builder.src.join("library/sysroot/Cargo.toml"));
  
@@ -197,10 +197,10 @@ index 33addb90d..fb6c97d82 100644
              if let Some(p) = builder.wasi_root(target) {
                  let root = format!("native={}/lib/wasm32-wasi", p.to_str().unwrap());
 diff --git a/src/bootstrap/config.rs b/src/bootstrap/config.rs
-index e192cda9a..a7c39c40e 100644
+index fe932fd6b..937801cea 100644
 --- a/src/bootstrap/config.rs
 +++ b/src/bootstrap/config.rs
-@@ -211,7 +211,6 @@ pub struct Config {
+@@ -263,7 +263,6 @@ pub struct Config {
      pub missing_tools: bool,
  
      // Fallback musl-root for all targets
@@ -208,7 +208,7 @@ index e192cda9a..a7c39c40e 100644
      pub prefix: Option<PathBuf>,
      pub sysconfdir: Option<PathBuf>,
      pub datadir: Option<PathBuf>,
-@@ -470,8 +469,6 @@ pub struct Target {
+@@ -536,8 +535,6 @@ pub struct Target {
      pub profiler: Option<bool>,
      pub rpath: Option<bool>,
      pub crt_static: Option<bool>,
@@ -217,7 +217,7 @@ index e192cda9a..a7c39c40e 100644
      pub wasi_root: Option<PathBuf>,
      pub qemu_rootfs: Option<PathBuf>,
      pub no_std: bool,
-@@ -834,7 +831,6 @@ define_config! {
+@@ -945,7 +942,6 @@ define_config! {
          default_linker: Option<String> = "default-linker",
          channel: Option<String> = "channel",
          description: Option<String> = "description",
@@ -225,7 +225,7 @@ index e192cda9a..a7c39c40e 100644
          rpath: Option<bool> = "rpath",
          verbose_tests: Option<bool> = "verbose-tests",
          optimize_tests: Option<bool> = "optimize-tests",
-@@ -883,8 +879,6 @@ define_config! {
+@@ -994,8 +990,6 @@ define_config! {
          profiler: Option<bool> = "profiler",
          rpath: Option<bool> = "rpath",
          crt_static: Option<bool> = "crt-static",
@@ -234,7 +234,7 @@ index e192cda9a..a7c39c40e 100644
          wasi_root: Option<String> = "wasi-root",
          qemu_rootfs: Option<String> = "qemu-rootfs",
          no_std: Option<bool> = "no-std",
-@@ -1247,7 +1241,6 @@ impl Config {
+@@ -1367,7 +1361,6 @@ impl Config {
              set(&mut config.llvm_tools_enabled, rust.llvm_tools);
              config.rustc_parallel = rust.parallel_compiler.unwrap_or(false);
              config.rustc_default_linker = rust.default_linker;
@@ -242,7 +242,7 @@ index e192cda9a..a7c39c40e 100644
              config.save_toolstates = rust.save_toolstates.map(PathBuf::from);
              set(
                  &mut config.deny_warnings,
-@@ -1414,8 +1407,6 @@ impl Config {
+@@ -1534,8 +1527,6 @@ impl Config {
                  target.ranlib = cfg.ranlib.map(PathBuf::from);
                  target.linker = cfg.linker.map(PathBuf::from);
                  target.crt_static = cfg.crt_static;
@@ -252,10 +252,10 @@ index e192cda9a..a7c39c40e 100644
                  target.qemu_rootfs = cfg.qemu_rootfs.map(PathBuf::from);
                  target.sanitizers = cfg.sanitizers;
 diff --git a/src/bootstrap/configure.py b/src/bootstrap/configure.py
-index 571062a3a..a6fe35975 100755
+index e8eebdfb5..8e1b4ec98 100755
 --- a/src/bootstrap/configure.py
 +++ b/src/bootstrap/configure.py
-@@ -111,34 +111,6 @@ v("aarch64-linux-android-ndk", "target.aarch64-linux-android.android-ndk",
+@@ -110,34 +110,6 @@ v("aarch64-linux-android-ndk", "target.aarch64-linux-android.android-ndk",
    "aarch64-linux-android NDK standalone path")
  v("x86_64-linux-android-ndk", "target.x86_64-linux-android.android-ndk",
    "x86_64-linux-android NDK standalone path")
@@ -291,10 +291,10 @@ index 571062a3a..a6fe35975 100755
    "riscv32gc-unknown-linux-musl install directory")
  v("musl-root-riscv64gc", "target.riscv64gc-unknown-linux-musl.musl-root",
 diff --git a/src/bootstrap/lib.rs b/src/bootstrap/lib.rs
-index 943f51341..688e64296 100644
+index 0a7aff622..8f06a1b51 100644
 --- a/src/bootstrap/lib.rs
 +++ b/src/bootstrap/lib.rs
-@@ -1219,25 +1219,6 @@ impl Build {
+@@ -1256,25 +1256,6 @@ impl Build {
          }
      }
  
@@ -321,7 +321,7 @@ index 943f51341..688e64296 100644
      fn wasi_root(&self, target: TargetSelection) -> Option<&Path> {
          self.config.target_config.get(&target).and_then(|t| t.wasi_root.as_ref()).map(|p| &**p)
 diff --git a/src/bootstrap/sanity.rs b/src/bootstrap/sanity.rs
-index 140259b02..24bfb6019 100644
+index 8f5ba4273..73192fef2 100644
 --- a/src/bootstrap/sanity.rs
 +++ b/src/bootstrap/sanity.rs
 @@ -11,7 +11,6 @@

--- a/srcpkgs/rust/template
+++ b/srcpkgs/rust/template
@@ -8,7 +8,7 @@
 # uploaded to https://repo-default.voidlinux.org/distfiles/
 #
 pkgname=rust
-version=1.71.1
+version=1.72.0
 revision=1
 hostmakedepends="curl pkg-config python3 tar cargo-bootstrap"
 makedepends="libffi-devel ncurses-devel libxml2-devel zlib-devel llvm15"
@@ -18,7 +18,7 @@ maintainer="Enno Boland <gottox@voidlinux.org>"
 license="MIT, Apache-2.0"
 homepage="https://www.rust-lang.org/"
 distfiles="https://static.rust-lang.org/dist/rustc-${version}-src.tar.gz"
-checksum=6fa90d50d1d529a75f6cc349784de57d7ec0ba2419b09bde7d335c25bd4e472e
+checksum=ea9d61bbb51d76b6ea681156f69f0e0596b59722f04414b01c6e100b4b5be3a1
 lib32disabled=yes
 make_check=no # CBA for now
 python_version=3 # needed for python files in rust-src
@@ -114,7 +114,7 @@ do_configure() {
 		--enable-locked-deps \
 		--enable-verbose-tests \
 		--disable-full-bootstrap \
-		--disable-extended \
+		--enable-extended \
 		--disable-codegen-tests \
 		--disable-dist-src \
 		--${_llvm_shared}-llvm-link-shared \
@@ -128,6 +128,7 @@ do_configure() {
 		--release-description="Void Linux" \
 		--llvm-libunwind=no \
 		--llvm-config=/usr/bin/llvm-config \
+		--tools=clippy,rustdoc,rustfmt \
 		--set="rust.optimize=true" \
 		--set="rust.debug=false" \
 		--set="rust.codegen-units=1" \
@@ -198,6 +199,10 @@ do_install() {
 	tar xf build/dist/rust-docs-${version}-${RUST_TARGET}.tar.gz \
 	 -C "$DESTDIR/usr" --strip-components=2 --exclude=manifest.in
 	tar xf build/dist/rust-src-${version}.tar.gz \
+	 -C "$DESTDIR/usr" --strip-components=2 --exclude=manifest.in
+	tar xf build/dist/rustfmt-${version}-${RUST_TARGET}.tar.gz \
+	 -C "$DESTDIR/usr" --strip-components=2 --exclude=manifest.in
+	tar xf build/dist/clippy-${version}-${RUST_TARGET}.tar.gz \
 	 -C "$DESTDIR/usr" --strip-components=2 --exclude=manifest.in
 
 	vlicense COPYRIGHT


### PR DESCRIPTION
- rust-bootstrap: update to 1.72.0
- cargo-bootstrap: update to 1.72.0
- rust: update to 1.72.0
- cargo: update to 1.72.0

<!-- Uncomment relevant sections and delete options which are not applicable -->

This PR also adds common developer tools: rustfmt and clippy.

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
