### PR TITLE
New package: jellyfin-media-player-1.9.1

### DIFF
--- a/srcpkgs/jellyfin-media-player/patches/disable-auto-update.patch
+++ b/srcpkgs/jellyfin-media-player/patches/disable-auto-update.patch
@@ -1,0 +1,13 @@
+diff --git a/resources/settings/settings_description.json b/resources/settings/settings_description.json
+index 20fff81..9979de5 100644
+--- a/resources/settings/settings_description.json
++++ b/resources/settings/settings_description.json
+@@ -118,7 +118,7 @@
+       },
+       {
+         "value": "checkForUpdates",
+-        "default": true
++        "default": false
+       },
+       {
+         "value": "enableInputRepeat",

--- a/srcpkgs/jellyfin-media-player/template
+++ b/srcpkgs/jellyfin-media-player/template
@@ -1,0 +1,27 @@
+# Template file for 'jellyfin-media-player'
+pkgname=jellyfin-media-player
+version=1.9.1
+_ver=10.8.11
+revision=1
+build_style=cmake
+configure_args="-DCMAKE_BUILD_TYPE=Release -DLINUX_X11POWER=ON
+ -DOpenGL_GL_PREFERENCE=GLVND"
+hostmakedepends="pkg-config python3 qt5-host-tools qt5-qmake"
+makedepends="SDL2-devel libcec-devel mpv-devel qt5-declarative-devel
+ qt5-location-devel qt5-webchannel-devel qt5-webengine-devel qt5-x11extras-devel
+ zlib-devel"
+depends="qt5-quickcontrols"
+short_desc="Desktop media client for Jellyfin"
+maintainer="inalone <me@inal.one>"
+license="GPL-2.0-only"
+homepage="https://github.com/jellyfin/jellyfin-media-player"
+distfiles="https://github.com/jellyfin/jellyfin-media-player/archive/v${version}.tar.gz
+ https://repo.jellyfin.org/releases/server/portable/versions/stable/web/${_ver}/jellyfin-web_${_ver}_portable.tar.gz"
+checksum="8d119bb78e897ace3041cf332114a79c51be4d8e0cc8c68f5745fd588c2b9bde
+ e78dd5c14e7929193478a350a79d5e9d52a27b0405b6080a7e556f608b89d764"
+
+post_extract() {
+	mv ${pkgname}-${version}/* .
+	mkdir -p build/dist
+	mv jellyfin-web_*/* build/dist
+}


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
#### Local build testing
- I built this PR locally for my native architecture, x86_64 glibc

This PR is largely a revival of https://github.com/void-linux/void-packages/pull/33199 .