### PR TITLE
fdm: add MANUAL file.

### DIFF
--- a/srcpkgs/fdm/template
+++ b/srcpkgs/fdm/template
@@ -1,7 +1,7 @@
 # Template file for 'fdm'
 pkgname=fdm
 version=2.2
-revision=2
+revision=3
 build_style=gnu-configure
 configure_args="ac_cv_func_strlcpy=no ac_cv_func_strlcat=no --enable-pcre2"
 hostmakedepends="automake bison"
@@ -20,6 +20,7 @@ fi
 post_install() {
 	vmkdir usr/share/doc/${pkgname}
 	cp -r examples ${DESTDIR}/usr/share/doc/${pkgname}
+	vdoc MANUAL
 	sed 17q fdm.c >LICENSE
 	vlicense LICENSE
 }


### PR DESCRIPTION
Most of the documentation for this program are in the plaintext MANUAL file. If we're including the examples, the MANUAL is just as helpful to have around if not more so.

#### Testing the changes
- I tested the changes in this PR: **YES**


#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc

