### PR TITLE
New package: efm-langserver-0.0.52

### DIFF
--- a/srcpkgs/efm-langserver/template
+++ b/srcpkgs/efm-langserver/template
@@ -1,0 +1,16 @@
+# Template file for 'efm-langserver'
+pkgname=efm-langserver
+version=0.0.52
+revision=1
+build_style=go
+go_import_path=github.com/mattn/efm-langserver
+short_desc="General purpose language server"
+maintainer="icp <pangolin@vivaldi.net>"
+license="MIT"
+homepage="https://github.com/mattn/efm-langserver"
+distfiles="https://github.com/mattn/efm-langserver/archive/refs/tags/v${version}.tar.gz"
+checksum=8a61b2da781835da2d54786bd985f548beaf4b9ce9d003f806f198cb0ab51078
+
+post_install() {
+	vlicense LICENSE
+}


### PR DESCRIPTION
#### Description
[efm-langserver](https://github.com/mattn/efm-langserver) is a general purpose Language Server that can use specified error message format generated from specified command.

#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

#### Local build testing
- I built this PR locally for my native architecture: **x86_64**