### PR TITLE
nerdctl: update to 1.5.0.

### DIFF
--- a/srcpkgs/nerdctl/template
+++ b/srcpkgs/nerdctl/template
@@ -1,13 +1,14 @@
 # Template file for 'nerdctl'
 pkgname=nerdctl
-version=0.18.0
-revision=3
+version=1.5.0
+revision=1
 build_style=go
 go_import_path=github.com/containerd/nerdctl
+go_ldflags="-X ${go_import_path}/pkg/version.Version=${version}"
 go_package=$go_import_path/cmd/nerdctl
 short_desc="Docker-compatible CLI for containerd"
 maintainer="Michael Aldridge <maldridge@VoidLinux.org>"
 license="Apache-2.0"
 homepage="https://github.com/containerd/nerdctl"
 distfiles="https://github.com/containerd/nerdctl/archive/refs/tags/v$version.tar.gz"
-checksum=d6f858d649271b323a42dcf876b1d80f262416aa03236e30ca9d648cd80536bf
+checksum=3b9ae94124adb5105241c3d5070b8dc0c184e454a7a349f1b56c12d415ee7ce3


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
