### PR TITLE
python3-janus: update to 1.0.0.

### DIFF
--- a/srcpkgs/python3-janus/template
+++ b/srcpkgs/python3-janus/template
@@ -1,13 +1,14 @@
 # Template file for 'python3-janus'
 pkgname=python3-janus
-version=0.5.0
-revision=6
+version=1.0.0
+revision=1
 build_style=python3-module
 hostmakedepends="python3-setuptools"
-depends="python3"
+depends="python3-typing_extensions"
+checkdepends="${depends} python3-pytest-asyncio"
 short_desc="Thread-safe asyncio-aware queue"
 maintainer="Adam Beckmeyer <adam_gpg@thebeckmeyers.xyz>"
 license="Apache-2.0"
 homepage="https://github.com/aio-libs/janus"
-distfiles="${homepage}/archive/v${version}.tar.gz"
-checksum=b2360921f1c30da53ef8a40a3e90824164cd592373434a1e0c7203a058ca09c0
+distfiles="https://github.com/aio-libs/janus/archive/refs/tags/v${version}.tar.gz"
+checksum=7795be8173faf473bbf0139e398bd0756b24e0f3fa3f11db729efc23f9032cfb


### PR DESCRIPTION
Tested locally on x86_64-glibc. All tests pass. Also briefly tested dependent pantalaimon and didn't find any issues. Tests passed.

#### Testing the changes
- I tested the changes in this PR: **YES**


#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
