### PR TITLE
python3-jq: update to 1.5.0

### DIFF
--- a/srcpkgs/python3-jq/template
+++ b/srcpkgs/python3-jq/template
@@ -1,6 +1,6 @@
 # Template file for 'python3-jq'
 pkgname=python3-jq
-version=1.4.1
+version=1.5.0
 revision=1
 build_style=python3-module
 hostmakedepends="python3-setuptools python3-Cython0.29"
@@ -12,7 +12,7 @@ license="BSD-2-Clause"
 homepage="https://pypi.org/project/jq/"
 changelog="https://raw.githubusercontent.com/mwilliamson/jq.py/master/CHANGELOG.rst"
 distfiles="https://github.com/mwilliamson/jq.py/archive/${version}.tar.gz"
-checksum=24239bd49a01a91ee313bf805c3bc7eb0ecfd71ca1bd4b94a73bd00585d79349
+checksum=d8ef4b16bc9c48f2d257c419454feb3ba629e2d34a9a288270d4c8aad38b8d83
 
 pre_build() {
 	cython -X language_level=3 jq.pyx


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

I ran the tests but the computer that has the urlwatch config I use to test updates is offline for a while (the CPU cooked itself somehow.)

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
