### PR TITLE
python3-trove-classifiers: update to 2023.8.7.

### DIFF
--- a/srcpkgs/python3-trove-classifiers/template
+++ b/srcpkgs/python3-trove-classifiers/template
@@ -1,6 +1,6 @@
 # Template file for 'python3-trove-classifiers'
 pkgname=python3-trove-classifiers
-version=2023.7.6
+version=2023.8.7
 revision=1
 build_style=python3-pep517
 hostmakedepends="python3-setuptools python3-wheel python3-calver"
@@ -12,4 +12,4 @@ license="Apache-2.0"
 homepage="https://github.com/pypa/trove-classifiers"
 changelog="https://github.com/pypa/trove-classifiers/releases"
 distfiles="${PYPI_SITE}/t/trove-classifiers/trove-classifiers-${version}.tar.gz"
-checksum=8a8e168b51d20fed607043831d37632bb50919d1c80a64e0f1393744691a8b22
+checksum=c9f2a0a85d545e5362e967e4f069f56fddfd91215e22ffa48c66fb283521319a


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
