### PR TITLE
New package: nxengine-evo-2.6.5

### DIFF
--- a/srcpkgs/nxengine-evo/template
+++ b/srcpkgs/nxengine-evo/template
@@ -1,0 +1,46 @@
+# Template file for 'nxengine-evo'
+pkgname=nxengine-evo
+version=2.6.5
+revision=1
+_rev=1
+_translation=1.14
+archs="x86_64* i686*"
+create_wrksrc=yes
+build_wrksrc="$pkgname-$version${_rev:+"-$_rev"}"
+build_style=cmake
+makedepends="SDL2-devel SDL2_mixer-devel SDL2_image-devel libpng-devel
+ libjpeg-turbo-devel"
+short_desc="Upgraded version of NXEngine, an open-source port of Cave Story"
+maintainer="Aicaya Maro <aicaya@posteo.net>"
+license="GPL-3.0-or-later"
+homepage="https://github.com/nxengine/nxengine-evo"
+distfiles="${homepage}/archive/refs/tags/v${version}${_rev:+"-$_rev"}.tar.gz
+ https://www.cavestory.org/downloads/cavestoryen.zip
+ ${homepage%/*}/translations/releases/download/v${_translation}/all.zip"
+checksum="db9b78b0c4005959ab8f3a6a05c02d86e764e6593cdd11a2178c581bb03a0699
+ aa87fa30bee9b4980640c7e104791354e0f1f6411ee0d45a70af70046aa0685f
+ 1dd85a8c230c5ebf23c6fd6283fe168d9bf4044339d1e93e324bd336165a4422"
+
+pre_install() {
+	cp -r "${wrksrc}/CaveStory/data" \
+		"${wrksrc}/CaveStory/Doukutsu.exe" \
+		"${wrksrc}/data" .
+	./build/nxextract
+}
+
+do_install() {
+	local _xdg_file="platform/xdg/org.nxengine.nxengine_evo"
+
+	vbin build/nxengine-evo
+	vmkdir usr/share/nxengine
+	vcopy data usr/share/nxengine
+
+	vinstall "${_xdg_file}.desktop" 644 usr/share/applications
+	vinstall "${_xdg_file}.png" 644 usr/share/pixmaps
+	vinstall "${_xdg_file}.appdata.xml" 644 usr/share/metainfo
+}
+
+post_install() {
+	vdoc "${wrksrc}/CaveStory/Manual.html"
+	vcopy "${wrksrc}/CaveStory/Manual" "usr/share/doc/${pkgname}"
+}


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl
  - i686

I tried cross-building, but it failed on account of `pre_install()` needing to use one of the built binaries (I assume).  If the github tests for the ARM builds fail, I'll force-push with `archs="x86_64* i686*"` added to the template.

**EDIT:** Tests here failed as well, so the line has been added.  Going to assume it just won't compile on ARM.