### PR TITLE
grafana: update to 10.1.1

### DIFF
--- a/srcpkgs/grafana/template
+++ b/srcpkgs/grafana/template
@@ -1,7 +1,7 @@
 # Template file for 'grafana'
 pkgname=grafana
-version=10.0.3
-revision=2
+version=10.1.1
+revision=1
 build_style=go
 go_import_path=github.com/grafana/grafana
 go_package="${go_import_path}/pkg/cmd/grafana-cli ${go_import_path}/pkg/cmd/grafana-server ${go_import_path}/pkg/cmd/grafana"
@@ -12,8 +12,8 @@ license="Apache-2.0"
 homepage="https://grafana.com"
 distfiles="https://dl.grafana.com/oss/release/grafana-${version}.linux-amd64.tar.gz
 https://github.com/grafana/grafana/archive/v${version}.tar.gz"
-checksum="daeb7eee1327b6d407cdaaf1a234ec9d8e2ae5a6d085e0fd3d8c606214eb6032
-9c1a1e3a9133abe4140aabad0d968f43ec2b3b14309f0dff80da367220bf58ff"
+checksum="9a3168007cc5cdd26c56d6121c4c163f9b6012435c87dacf3d3fa7914f9768f6
+55f8822105d15fcb6e8dbfb16c3636dfa6e08f8fc6cd1f98700adbb6ba28bbb4"
 
 system_accounts="_grafana"
 _grafana_homedir="/var/lib/grafana"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture: **x86_64-glibc**

No breaking changes compared to v10.0.3 (previous in repos).