### PR TITLE
.github/workflows/cycles.yaml: run on PRs, don't run on forks

### DIFF
--- a/.github/workflows/cycles.yml
+++ b/.github/workflows/cycles.yml
@@ -43,26 +43,19 @@ jobs:
       - name: Restore dependency cache
         run: |
           set -x
-          mkdir -p /xbps-cycles
+          mkdir -p "$GITHUB_WORKSPACE/xbps-cycles"
 
           run="$(gh run list --status completed --event schedule --workflow cycles.yml --limit 1 --json databaseId --jq '.[].databaseId')"
           if [ -n "$run" ]; then
-            gh run download "$run" -D /xbps-cycles -n dependency-cache || true
+            gh run download "$run" -D "$GITHUB_WORKSPACE/xbps-cycles" -n dependency-cache || true
           fi
-          ls -l /xbps-cycles
+          ls -l "$GITHUB_WORKSPACE/xbps-cycles"
         env:
           GH_TOKEN: ${{ github.token }}
 
       - name: Find cycles
         run: |
-          common/scripts/xbps-cycles.py -c /xbps-cycles | tee cycles
-
-      - name: Save dependency cache
-        uses: actions/upload-artifact@v1
-        with:
-          name: dependency-cache
-          path: /xbps-cycles
-          retention-days: 5
+          common/scripts/xbps-cycles.py -c "$GITHUB_WORKSPACE/xbps-cycles" | tee cycles
 
       - name: Open issues
         if: ${{ github.event_name == 'schedule' }}
@@ -88,3 +81,9 @@ jobs:
           fi
           cat cycles
           exit $rv
+
+      - name: Save dependency cache
+        uses: actions/upload-artifact@v1
+        with:
+          name: dependency-cache
+          path: xbps-cycles

--- a/.github/workflows/cycles.yml
+++ b/.github/workflows/cycles.yml
@@ -43,7 +43,7 @@ jobs:
           common/travis/prepare.sh
       - name: Load cached dependencies
         id: cache-restore
-        uses: actions/cache/restore@v2
+        uses: actions/cache@v2
         with:
           key: xbps-cycles
           path: /xbps-cycles
@@ -51,12 +51,6 @@ jobs:
         run: |
           mkdir -p /xbps-cycles
           common/scripts/xbps-cycles.py -c /xbps-cycles | tee cycles
-      - name: Save cached dependencies
-        if: ${{ github.event_name == 'schedule' }}
-        uses: actions/cache/save@v2
-        with:
-          key: ${{ steps.cache-restore.outputs.cache-primary-key }}
-          path: /xbps-cycles
       - name: Open issues
         if: ${{ github.event_name == 'schedule' }}
         run: |

--- a/.github/workflows/cycles.yml
+++ b/.github/workflows/cycles.yml
@@ -42,11 +42,12 @@ jobs:
 
       - name: Restore dependency cache
         run: |
+          set -x
           mkdir -p /xbps-cycles
 
           run="$(gh run list --status completed --event schedule --workflow cycles.yml --limit 1 --json databaseId --jq '.[].databaseId')"
           if [ -n "$run" ]; then
-            gh run download "$run" -D /xbps-cycles -n dependency-cache
+            gh run download "$run" -D /xbps-cycles -n dependency-cache || true
           fi
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/cycles.yml
+++ b/.github/workflows/cycles.yml
@@ -45,7 +45,7 @@ jobs:
           set -x
           mkdir -p "$GITHUB_WORKSPACE/xbps-cycles"
 
-          run="$(gh run list --status completed --event schedule --workflow cycles.yml --limit 1 --json databaseId --jq '.[].databaseId')"
+          run="$(gh run list --status completed --workflow cycles.yml --limit 1 --json databaseId --jq '.[].databaseId')"
           if [ -n "$run" ]; then
             gh run download "$run" -D "$GITHUB_WORKSPACE/xbps-cycles" -n dependency-cache || true
           fi
@@ -83,6 +83,7 @@ jobs:
           exit $rv
 
       - name: Save dependency cache
+        # if: ${{ github.event_name == 'schedule' }}
         uses: actions/upload-artifact@v1
         with:
           name: dependency-cache

--- a/.github/workflows/cycles.yml
+++ b/.github/workflows/cycles.yml
@@ -3,11 +3,18 @@ name: 'Cycle Check'
 on:
   schedule:
     - cron: '0 18 * * *'
+  pull_request:
+    paths:
+      - 'srcpkgs/**'
 
 jobs:
   cycles:
     runs-on: ubuntu-latest
+    # run only if on the main repo or on pull requests
+    if: ${{ github.event_name == 'pull_request' || github.repository_owner == 'void-linux' }}
     permissions:
+      # this will only apply to scheduled runs
+      # https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token
       issues: write
     container:
       image: 'ghcr.io/void-linux/void-buildroot-musl:20230904R2'
@@ -24,7 +31,7 @@ jobs:
           # Upgrade again (in case there was a xbps update)
           xbps-install -yu
           # Install script dependencies
-          xbps-install -y python3-networkx github-cli
+          xbps-install -y python3-networkx nodejs
 
       - name: Clone and checkout
         uses: classabbyamp/treeless-checkout-action@v1
@@ -34,9 +41,26 @@ jobs:
           ln -s "$(pwd)" /hostrepo &&
           common/travis/set_mirror.sh &&
           common/travis/prepare.sh
-      - name: Find cycles and open issues
+      - name: Load cached dependencies
+        id: cache-restore
+        uses: actions/cache/restore@v2
+        with:
+          key: xbps-cycles
+          path: /xbps-cycles
+      - name: Find cycles
         run: |
-          common/scripts/xbps-cycles.py | tee cycles
+          mkdir -p /xbps-cycles
+          common/scripts/xbps-cycles.py -c /xbps-cycles | tee cycles
+      - name: Save cached dependencies
+        if: ${{ github.event_name == 'schedule' }}
+        uses: actions/cache/save@v2
+        with:
+          key: ${{ steps.cache-restore.outputs.cache-primary-key }}
+          path: /xbps-cycles
+      - name: Open issues
+        if: ${{ github.event_name == 'schedule' }}
+        run: |
+          xbps-install -y github-cli
           grep 'Cycle:' cycles | while read -r line; do
               if gh issue list -R "$GITHUB_REPOSITORY" -S "$line" | grep .; then
                   printf "Issue on '%s' already exists.\n" "$line"
@@ -46,3 +70,14 @@ jobs:
           done
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN }}
+      - name: Summary
+        run: |
+          if grep -q '^Cycle:' cycles; then
+            echo "Build cycles found:"
+            rv=1
+          else
+            echo "No cycles found:"
+            rv=0
+          fi
+          cat cycles
+          exit $rv

--- a/.github/workflows/cycles.yml
+++ b/.github/workflows/cycles.yml
@@ -3,6 +3,7 @@ name: 'Cycle Check'
 on:
   schedule:
     - cron: '0 18 * * *'
+  workflow_dispatch:
   pull_request:
     paths:
       - 'srcpkgs/**'
@@ -10,11 +11,8 @@ on:
 jobs:
   cycles:
     runs-on: ubuntu-latest
-    # run only if on the main repo or on pull requests
-    if: ${{ github.event_name == 'pull_request' || github.repository_owner == 'void-linux' }}
+    if: ${{ github.event_name == 'pull_request' || ( github.event_name == 'schedule' && github.repository_owner == 'void-linux' ) }}
     permissions:
-      # this will only apply to scheduled runs
-      # https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token
       issues: write
     container:
       image: 'ghcr.io/void-linux/void-buildroot-musl:20230904R2'
@@ -31,7 +29,7 @@ jobs:
           # Upgrade again (in case there was a xbps update)
           xbps-install -yu
           # Install script dependencies
-          xbps-install -y python3-networkx nodejs
+          xbps-install -y python3-networkx github-cli
 
       - name: Clone and checkout
         uses: classabbyamp/treeless-checkout-action@v1
@@ -41,20 +39,30 @@ jobs:
           ln -s "$(pwd)" /hostrepo &&
           common/travis/set_mirror.sh &&
           common/travis/prepare.sh
-      - name: Load cached dependencies
-        id: cache-restore
-        uses: actions/cache@v2
-        with:
-          key: xbps-cycles
-          path: /xbps-cycles
-      - name: Find cycles
+
+      - name: Restore dependency cache
         run: |
           mkdir -p /xbps-cycles
+
+          run="$(gh run list --status completed --event schedule --workflow cycles.yml --limit 1 --json databaseId --jq '.[].databaseId')"
+          if [ -n "$run" ]; then
+            gh run download "$run" -D /xbps-cycles -n dependency-cache
+          fi
+
+      - name: Find cycles
+        run: |
           common/scripts/xbps-cycles.py -c /xbps-cycles | tee cycles
+
+      - name: Save dependency cache
+        uses: actions/upload-artifact@v3
+        with:
+          name: dependency-cache
+          path: /xbps-cycles
+          retention-days: 5
+
       - name: Open issues
         if: ${{ github.event_name == 'schedule' }}
         run: |
-          xbps-install -y github-cli
           grep 'Cycle:' cycles | while read -r line; do
               if gh issue list -R "$GITHUB_REPOSITORY" -S "$line" | grep .; then
                   printf "Issue on '%s' already exists.\n" "$line"
@@ -64,6 +72,7 @@ jobs:
           done
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN }}
+
       - name: Summary
         run: |
           if grep -q '^Cycle:' cycles; then

--- a/.github/workflows/cycles.yml
+++ b/.github/workflows/cycles.yml
@@ -48,6 +48,8 @@ jobs:
           if [ -n "$run" ]; then
             gh run download "$run" -D /xbps-cycles -n dependency-cache
           fi
+        env:
+          GH_TOKEN: ${{ github.token }}
 
       - name: Find cycles
         run: |

--- a/.github/workflows/cycles.yml
+++ b/.github/workflows/cycles.yml
@@ -49,6 +49,7 @@ jobs:
           if [ -n "$run" ]; then
             gh run download "$run" -D /xbps-cycles -n dependency-cache || true
           fi
+          ls -l /xbps-cycles
         env:
           GH_TOKEN: ${{ github.token }}
 
@@ -57,7 +58,7 @@ jobs:
           common/scripts/xbps-cycles.py -c /xbps-cycles | tee cycles
 
       - name: Save dependency cache
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v1
         with:
           name: dependency-cache
           path: /xbps-cycles

--- a/srcpkgs/chezmoi/template
+++ b/srcpkgs/chezmoi/template
@@ -1,7 +1,7 @@
 # Template file for 'chezmoi'
 pkgname=chezmoi
 version=2.39.1
-revision=1
+revision=2
 build_style=go
 go_import_path="github.com/twpayne/chezmoi/v2"
 go_build_tags="noembeddocs noupgrade"


### PR DESCRIPTION
- running on forks is kinda useless and just gives people useless error messages if they sync their master branch at the wrong time
- run cycle check on PRs to catch cycles before they happen. this makes the cron cycle check more of a backup/just-in-case for things that slip past the CI

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**|**briefly**|**NO**

