### PR TITLE
python3-pycodestyle: update to 2.11.0

### DIFF
--- a/srcpkgs/python3-pycodestyle/template
+++ b/srcpkgs/python3-pycodestyle/template
@@ -1,18 +1,17 @@
 # Template file for 'python3-pycodestyle'
 pkgname=python3-pycodestyle
-version=2.10.0
+version=2.11.0
 revision=1
 build_style=python3-module
 hostmakedepends="python3-setuptools"
 depends="python3"
-checkdepends="python3-pytest"
 short_desc="Python style guide checker (formerly called pep8)"
 maintainer="Michal Vasilek <michal@vasilek.cz>"
 license="MIT"
 homepage="https://github.com/PyCQA/pycodestyle"
 changelog="https://raw.githubusercontent.com/PyCQA/pycodestyle/main/CHANGES.txt"
 distfiles="${PYPI_SITE}/p/pycodestyle/pycodestyle-${version}.tar.gz"
-checksum=347187bdb476329d98f695c213d7295a846d1152ff4fe9bacb8a9590b8ee7053
+checksum=259bcc17857d8a8b3b4a2327324b79e5f020a13c16074670f9c8c8f872ea76d0
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

Fixes error with newer flake8

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
