### PR TITLE
rootlesskit: update to 1.1.1.

### DIFF
--- a/srcpkgs/rootlesskit/template
+++ b/srcpkgs/rootlesskit/template
@@ -1,7 +1,7 @@
 # Template file for 'rootlesskit'
 pkgname=rootlesskit
-version=0.14.6
-revision=3
+version=1.1.1
+revision=1
 build_style=go
 go_import_path="github.com/rootless-containers/rootlesskit"
 go_package="${go_import_path}/cmd/rootlesskit ${go_import_path}/cmd/rootlessctl
@@ -11,4 +11,4 @@ maintainer="Piotr Wójcik <chocimier@tlen.pl>"
 license="Apache-2.0"
 homepage="https://github.com/rootless-containers/rootlesskit"
 distfiles="https://github.com/rootless-containers/rootlesskit/archive/v${version}.tar.gz"
-checksum=e27e4249f12cca44fc6e15a27f214f30fcb5f15646c813a90b6788bd9f0cfd4b
+checksum=6bc1c4b873bf66766174cbf37046fca67737405ccfb393c1469d6ef7383ab5e2


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
