### PR TITLE
go: update to 1.21.1.

### DIFF
--- a/srcpkgs/go/template
+++ b/srcpkgs/go/template
@@ -1,7 +1,7 @@
 # Template file for 'go'
 pkgname=go
-version=1.21.0
-revision=2
+version=1.21.1
+revision=1
 create_wrksrc=yes
 build_wrksrc=go
 hostmakedepends="go1.17-bootstrap"
@@ -12,7 +12,7 @@ license="BSD-3-Clause"
 homepage="https://go.dev/"
 changelog="https://go.dev/doc/devel/release.html"
 distfiles="https://go.dev/dl/go${version}.src.tar.gz"
-checksum=818d46ede85682dd551ad378ef37a4d247006f12ec59b5b755601d2ce114369a
+checksum=bfa36bf75e9a1e9cbbdb9abcf9d1707e479bd3a07880a8ae3564caee5711cb99
 nostrip=yes
 noverifyrdeps=yes
 # on CI it tries to use `git submodule`, which is not part of chroot-git


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - i686
  - aarch64
  - armv7l
