### PR TITLE
puzzles: update to 20230909.67496e7.

### DIFF
--- a/srcpkgs/puzzles/template
+++ b/srcpkgs/puzzles/template
@@ -1,6 +1,6 @@
 # Template file for 'puzzles'
 pkgname=puzzles
-version=20230707.ad7042d
+version=20230909.67496e7
 revision=1
 build_style=cmake
 configure_args="-DNAME_PREFIX=puzzles-"
@@ -10,8 +10,8 @@ short_desc="Simon Tatham's Portable Puzzle Collection"
 maintainer="Leah Neukirchen <leah@vuxu.org>"
 license="MIT"
 homepage="https://www.chiark.greenend.org.uk/~sgtatham/puzzles/"
-distfiles="https://git.tartarus.org/?p=simon/puzzles.git;a=snapshot;h=ad7042db989eb525defea9298b2b14d564498473;sf=tgz>${pkgname}-${version#*.}.tgz"
-checksum=748af7455723ba11152cf93f3df768759454ca0040f6aea3a6155dc977a596bd
+distfiles="https://git.tartarus.org/?p=simon/puzzles.git;a=snapshot;h=67496e74f68db900d8117be6de3c75285c29c489;sf=tgz>${pkgname}-${version#*.}.tgz"
+checksum=88e05ac209a34afd74fafd34f2e31246725113f31ff8f478cfc454c3f2ee4a72
 
 post_install() {
 	vlicense LICENCE LICENSE

--- a/srcpkgs/puzzles/update
+++ b/srcpkgs/puzzles/update
@@ -1,0 +1,1 @@
+disabled="ad-hoc updates from git commits"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture: **x86_64**