### PR TITLE
procps-ng: update to 4.0.4.

### DIFF
--- a/srcpkgs/procps-ng/template
+++ b/srcpkgs/procps-ng/template
@@ -1,6 +1,6 @@
 # Template file for 'procps-ng'
 pkgname=procps-ng
-version=4.0.3
+version=4.0.4
 revision=1
 build_style=gnu-configure
 configure_args="--exec-prefix=/ --bindir=/usr/bin --sbindir=/usr/bin
@@ -15,7 +15,7 @@ license="GPL-2.0-or-later, LGPL-2.1-or-later"
 homepage="https://gitlab.com/procps-ng/procps"
 changelog="https://gitlab.com/procps-ng/procps/raw/master/NEWS"
 distfiles="${SOURCEFORGE_SITE}/procps-ng/Production/procps-ng-${version}.tar.xz"
-checksum=303c8ec4f96ae18d8eaef86c2bd0986938764a45dc505fe0a0af868c674dba92
+checksum=22870d6feb2478adb617ce4f09a787addaf2d260c5a8aa7b17d889a962c5e42e
 # "pmap X with unreachable process" and "pmap XX with unreachable process" fail
 # in the CI.
 make_check=ci-skip


### PR DESCRIPTION

#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc

