### PR TITLE
openntpd: fix integer overflow on i686

### DIFF
--- a/srcpkgs/openntpd/patches/fix-time_t-overflow.patch
+++ b/srcpkgs/openntpd/patches/fix-time_t-overflow.patch
@@ -1,0 +1,12 @@
+--- a/src/constraint.c
++++ b/src/constraint.c
+@@ -842,7 +842,7 @@ constraint_update(void)
+ 	/* calculate median */
+ 	i = cnt / 2;
+ 	if (cnt % 2 == 0)
+-		conf->constraint_median = (values[i - 1] + values[i]) / 2;
++		conf->constraint_median = ((long long)values[i - 1] + values[i]) / 2;
+ 	else
+ 		conf->constraint_median = values[i];
+ 
+

--- a/srcpkgs/openntpd/template
+++ b/srcpkgs/openntpd/template
@@ -1,7 +1,7 @@
 # Template file for 'openntpd'
 pkgname=openntpd
 version=6.8p1
-revision=4
+revision=5
 build_style=gnu-configure
 configure_args="--with-privsep-user=openntpd --with-cacert=/etc/ssl/certs.pem"
 hostmakedepends="automake libtool"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
#### Local build testing
- I built this PR locally for my native architecture, (i686)

#### Change description
On i686, `time_t` is a 32 bit integer. In `openntpd`, an addition of two `time_t`s is performed, leading to an integer overflow. This code is part of the constraints logic of openntpd. When the bug triggers, all time sources will be marked invalid.

Upstream pull request: https://github.com/openntpd-portable/openntpd-portable/pull/74