### PR TITLE
vale: update to 2.28.3.

### DIFF
--- a/srcpkgs/vale/template
+++ b/srcpkgs/vale/template
@@ -1,7 +1,7 @@
 # Template file for 'vale'
 pkgname=vale
-version=2.28.2
-revision=2
+version=2.28.3
+revision=1
 build_style=go
 go_import_path="github.com/errata-ai/vale/v2"
 go_package="${go_import_path}/cmd/vale"
@@ -12,7 +12,7 @@ license="MIT"
 homepage="https://vale.sh"
 changelog="https://github.com/errata-ai/vale/releases"
 distfiles="https://github.com/errata-ai/vale/archive/refs/tags/v${version}.tar.gz"
-checksum=642bd739da11273fc12db8660847899557cfc146e8e4d3a0de7e5d345fe173ff
+checksum=93224b7e587268a13698f135850144c2fee85cfda66d629f70678e73b7f75135
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture: **x86_64**