### PR TITLE
libtls: update to 3.8.1.

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -3529,7 +3529,7 @@ libmanette-0.2.so.0 libmanette-0.2.1_1
 libfmt.so.9 fmt-9.0.0_1
 libelementary-calendar.so.0 libio.elementary.calendar-4.2.3_1
 libolm.so.3 olm-3.0.0_1
-libtls.so.26 libtls-3.6.1_1
+libtls.so.28 libtls-3.8.1_1
 libxmlb.so.2 libxmlb-0.2.1_1
 libvoikko.so.1 libvoikko-4.2_1
 libfstrcmp.so.0 libfstrcmp-0.7.D001_1

--- a/srcpkgs/catgirl/template
+++ b/srcpkgs/catgirl/template
@@ -1,7 +1,7 @@
 # Template file for 'catgirl'
 pkgname=catgirl
 version=2.2
-revision=1
+revision=2
 build_style=gnu-configure
 make_build_target="all"
 hostmakedepends="pkg-config"

--- a/srcpkgs/libtls/template
+++ b/srcpkgs/libtls/template
@@ -1,6 +1,6 @@
 # Template file for 'libtls'
 pkgname=libtls
-version=3.7.3
+version=3.8.1
 revision=1
 create_wrksrc=yes
 build_wrksrc="libressl-${version}"
@@ -14,7 +14,7 @@ license="OpenSSL, ISC"
 homepage="http://www.libressl.org/"
 changelog="https://raw.githubusercontent.com/libressl/portable/master/ChangeLog"
 distfiles="http://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-${version}.tar.gz"
-checksum=7948c856a90c825bd7268b6f85674a8dcd254bae42e221781b24e3f8dc335db3
+checksum=c29bd6d9522746773cb9e4126d5a9a2c35ea5505f6fd49b679173f2b46e57372
 _lssl_asm_ver="1.2.0"
 replaces="libtls20>0"
 patch_args="-Np1 --directory=${build_wrksrc}"
@@ -75,7 +75,7 @@ libressl-netcat_package() {
 	 nc:nc:/usr/bin/libressl-nc
 	 nc:nc.1:/usr/share/man/man1/libressl-nc.1"
 	pkg_install() {
-		vbin apps/nc/.libs/nc libressl-nc
+		vbin apps/nc/nc libressl-nc
 		vman apps/nc/nc.1 libressl-nc.1
 	}
 }

--- a/srcpkgs/litterbox/template
+++ b/srcpkgs/litterbox/template
@@ -1,7 +1,7 @@
 # Template file for 'litterbox'
 pkgname=litterbox
 version=1.9
-revision=1
+revision=2
 build_style=gnu-configure
 make_build_target="all"
 hostmakedepends="pkg-config"

--- a/srcpkgs/openntpd/template
+++ b/srcpkgs/openntpd/template
@@ -1,7 +1,7 @@
 # Template file for 'openntpd'
 pkgname=openntpd
 version=6.8p1
-revision=5
+revision=6
 build_style=gnu-configure
 configure_args="--with-privsep-user=openntpd --with-cacert=/etc/ssl/certs.pem"
 hostmakedepends="automake libtool"

--- a/srcpkgs/pounce/template
+++ b/srcpkgs/pounce/template
@@ -1,7 +1,7 @@
 # Template file for 'pounce'
 pkgname=pounce
 version=3.1
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--enable-notify --enable-palaver"
 make_build_target="all"

--- a/srcpkgs/sacc/template
+++ b/srcpkgs/sacc/template
@@ -1,7 +1,7 @@
 # Template file for 'sacc'
 pkgname=sacc
 version=1.05
-revision=3
+revision=4
 build_style="gnu-makefile"
 makedepends="ncurses-devel libtls-devel"
 short_desc="Terminal gopher client"


### PR DESCRIPTION
- libtls: update to 3.8.1..
- catgirl: rebuild against libtls.so.28
- litterbox: rebuild against libtls.so.28
- openntpd: rebuild against libtls.so.28
- pounce: rebuild against libtls.so.28
- sacc: rebuild against libtls.so.28
