### PR TITLE
mhash: make boolean usage musl C++ portable.

### DIFF
--- a/srcpkgs/mhash/patches/fix-cpp-bools.patch
+++ b/srcpkgs/mhash/patches/fix-cpp-bools.patch
@@ -1,0 +1,21 @@
+--- a/include/mutils/mutils.h
++++ b/include/mutils/mutils.h
+@@ -21,6 +21,9 @@
+ #if !defined(__MUTILS_H)
+ #define __MUTILS_H
+ 
++#ifndef __cplusplus
++#include <stdbool.h>
++#endif
+ #include <mutils/mincludes.h>
+ 
+ #if defined(const)
+@@ -97,7 +100,7 @@ typedef unsigned char mutils_word8;
+  */
+ 
+ #if defined(HAVE__BOOL)
+-#define mutils_boolean _Bool
++#define mutils_boolean bool
+ #else
+ typedef char mutils_boolean;
+ #endif

--- a/srcpkgs/mhash/patches/fix-tests-use-after-free.patch
+++ b/srcpkgs/mhash/patches/fix-tests-use-after-free.patch
@@ -1,0 +1,22 @@
+--- a/src/hmac_test.c
++++ b/src/hmac_test.c
+@@ -76,8 +76,6 @@ int main()
+ 
+ 	/* Test No 2 */	
+ 	
+-	mutils_memset(tmp, 0, sizeof(tmp));
+-	
+ 	passlen=sizeof(KEY2) - 1;
+ 	password = (mutils_word8 *) mutils_malloc(passlen+1);
+ 	mutils_memcpy(password, KEY2, passlen);
+--- a/src/keygen_test.c
++++ b/src/keygen_test.c
+@@ -121,8 +121,6 @@ int main()
+ 	
+ 	mhash_keygen_ext(KEYGEN_S2K_SALTED, data, key, keysize, password, passlen);
+ 
+-	mutils_memset(tmp, 0, keysize * 2);
+-
+ 	tmp = mutils_asciify(key, keysize);
+ 
+ 	result = mutils_strcmp((mutils_word8 *) KEY2, tmp);

--- a/srcpkgs/mhash/template
+++ b/srcpkgs/mhash/template
@@ -1,8 +1,9 @@
 # Template file for 'mhash'
 pkgname=mhash
 version=0.9.9.9
-revision=1
+revision=2
 build_style=gnu-configure
+checkdepends="perl"
 short_desc="Uniform interface to a large number of hash algorithms"
 maintainer="Andrew Benson <abenson+void@gmail.com>"
 license="LGPL-2.1-or-later"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (`x86_64-glibc`)
- I built this PR locally for these architectures:
  - `x86_64-musl` (crossbuild)
  - `i686` (crossbuild)

mhash uses `_Bool` directly for `#define mhash_boolean _Bool`. [musl C++ doesn't define `_Bool`](https://www.openwall.com/lists/musl/2017/07/28/1), so any C++ projects that include it will fail to build on musl. This fixes that without impacting any C projects