### PR TITLE
setup/git.sh: fix non-portable sed invocation

### DIFF
--- a/common/environment/setup/git.sh
+++ b/common/environment/setup/git.sh
@@ -15,7 +15,7 @@ elif [ -z "${SOURCE_DATE_EPOCH}" ]; then
 	fi
 	# check if the template is under version control:
 	if [ -n "$basepkg" -a -z "$($XBPS_GIT_CMD -C ${XBPS_SRCPKGDIR}/${basepkg} ls-files template)" ]; then
-		export SOURCE_DATE_EPOCH="$(stat -c %Y ${XBPS_SRCPKGDIR}/${basepkg}/template)"
+		export SOURCE_DATE_EPOCH="$(stat_mtime ${XBPS_SRCPKGDIR}/${basepkg}/template)"
 	else
 		export SOURCE_DATE_EPOCH=$($XBPS_GIT_CMD -C ${XBPS_DISTDIR} cat-file commit HEAD |
 			sed -n '/^committer /{s/.*> \([0-9][0-9]*\) [-+][0-9].*/\1/p;q;}')

--- a/common/environment/setup/git.sh
+++ b/common/environment/setup/git.sh
@@ -18,7 +18,7 @@ elif [ -z "${SOURCE_DATE_EPOCH}" ]; then
 		export SOURCE_DATE_EPOCH="$(stat -c %Y ${XBPS_SRCPKGDIR}/${basepkg}/template)"
 	else
 		export SOURCE_DATE_EPOCH=$($XBPS_GIT_CMD -C ${XBPS_DISTDIR} cat-file commit HEAD |
-			sed -n '/^committer /{s/.*> \([0-9][0-9]*\) [-+][0-9].*/\1/p;q}')
+			sed -n '/^committer /{s/.*> \([0-9][0-9]*\) [-+][0-9].*/\1/p;q;}')
 	fi
 fi
 

--- a/common/hooks/do-fetch/00-distfiles.sh
+++ b/common/hooks/do-fetch/00-distfiles.sh
@@ -253,7 +253,7 @@ hook() {
 				if [[ $cksum = $filesum ]]; then
 					dfgood=$((dfgood + 1))
 				else
-					inode=$(stat "$distfile" --printf "%i")
+					inode=$(stat_inode "$distfile")
 					msg_warn "$pkgver: wrong checksum found for ${curfile} - purging\n"
 					find ${XBPS_SRCDISTDIR} -inum ${inode} -delete -print
 				fi

--- a/common/xbps-src/shutils/common.sh
+++ b/common/xbps-src/shutils/common.sh
@@ -1,5 +1,41 @@
 # vim: set ts=4 sw=4 et:
 
+# A portable abstraction for stat(1)
+#
+# The stat(1) command has different syntaxes between GNU flavor
+# and BSD flavor; implementations generally follow one or the other
+#
+if ! stat -c "%s" / > /dev/null 2>&1; then
+    # BSD stat
+
+    stat_size() {
+        stat -f %z "$1"
+    }
+
+    stat_inode() {
+        stat -f %i "$1"
+    }
+
+    stat_mtime() {
+        stat -f %m "$1"
+    }
+else
+    # GNU stat
+
+    stat_size() {
+        stat -c %s "$1"
+    }
+
+    stat_inode() {
+        stat -c %i "$1"
+    }
+
+    stat_mtime() {
+        stat -c %Y "$1"
+    }
+fi
+
+
 run_func() {
     local func="$1" desc="$2" funcname="$3" restoretrap= logpipe= logfile= teepid=
 

--- a/common/xbps-src/shutils/cross.sh
+++ b/common/xbps-src/shutils/cross.sh
@@ -16,7 +16,7 @@ remove_pkg_cross_deps() {
     $XBPS_REMOVE_XCMD -Ryo > $tmplogf 2>&1
     rval=$?
     while [ $rval -eq 0 ]; do
-        local curs=$(stat -c %s $tmplogf)
+        local curs=$(stat_size $tmplogf)
         if [ $curs -eq $prevs ]; then
             break
         fi

--- a/common/xbps-src/shutils/pkgtarget.sh
+++ b/common/xbps-src/shutils/pkgtarget.sh
@@ -65,11 +65,11 @@ remove_pkg_autodeps() {
 
     remove_pkg_cross_deps
     $XBPS_RECONFIGURE_CMD -a >> $tmplogf 2>&1
-    prevs=$(stat -c %s $tmplogf)
+    prevs=$(stat_size $tmplogf)
     echo yes | $XBPS_REMOVE_CMD -Ryod 2>> $errlogf 1>> $tmplogf
     rval=$?
     while [ $rval -eq 0 ]; do
-        local curs=$(stat -c %s $tmplogf)
+        local curs=$(stat_size $tmplogf)
         if [ $curs -eq $prevs ]; then
             break
         fi

--- a/common/xbps-src/shutils/purge_distfiles.sh
+++ b/common/xbps-src/shutils/purge_distfiles.sh
@@ -57,7 +57,7 @@ purge_distfiles() {
 	cur=0
 	percent=-1
 	for distfile in ${distfiles[@]}; do
-		inode=$(stat "$distfile" --printf "%i")
+		inode=$(stat_inode "$distfile")
 		if [ -z "${inodes[$inode]}" ]; then
 			inodes[$inode]="$distfile"
 		else
@@ -77,7 +77,7 @@ purge_distfiles() {
 		hash_distfile=${file##*/}
 		hash=${hash_distfile:0:$HASHLEN}
 		[ -n "${my_hashes[$hash]}" ] && continue
-		inode=$(stat "$file" --printf "%i")
+		inode=$(stat_inode "$file")
 		echo "Obsolete $hash (inode: $inode)"
 		( IFS="|"; for f in ${inodes[$inode]}; do rm -vf "$f"; rmdir "${f%/*}" 2>/dev/null; done )
 	done


### PR DESCRIPTION
This lets xbps-src work in non-GNU environments.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
