### PR TITLE
New package: f3d-2.1.1

### DIFF
--- a/srcpkgs/f3d/template
+++ b/srcpkgs/f3d/template
@@ -1,6 +1,6 @@
 # Template file for 'f3d'
 pkgname=f3d
-version=2.2.1
+version=2.4.0
 revision=1
 build_style=cmake
 makedepends="vtk-devel"
@@ -11,7 +11,7 @@ license="BSD-3-Clause"
 homepage="https://f3d.app"
 changelog="https://f3d.app/doc/CHANGELOG.html"
 distfiles="https://github.com/f3d-app/f3d/archive/refs/tags/v${version}.tar.gz"
-checksum=4d3a73b0107c8db7f0556107c74087d3748232a73981f65f7c5186ac1003ec8d
+checksum=3286ad1b324b995fd95818679b4ced80ebc3cc3b4bd4c8e6964695c05c934c8f
 
 post_install() {
 	vlicense LICENSE.md

--- a/srcpkgs/f3d/template
+++ b/srcpkgs/f3d/template
@@ -1,0 +1,18 @@
+# Template file for 'f3d'
+pkgname=f3d
+version=2.1.0
+revision=1
+build_style=cmake
+makedepends="vtk-devel"
+depends="vtk"
+short_desc="Fast and minimalist 3D viewer"
+maintainer="Jipok <void@jipok.ru>"
+license="BSD-3-Clause"
+homepage="https://f3d.app"
+changelog="https://f3d.app/doc/CHANGELOG.html"
+distfiles="https://github.com/f3d-app/f3d/archive/refs/tags/v${version}.tar.gz"
+checksum=3e5e6c2c16da4d7ccce8b6e316ab8007592a2bc0fc11a513f1ebac8c7f0f95d2
+
+post_install() {
+	vlicense LICENSE.md
+}

--- a/srcpkgs/f3d/template
+++ b/srcpkgs/f3d/template
@@ -1,6 +1,6 @@
 # Template file for 'f3d'
 pkgname=f3d
-version=2.1.0
+version=2.2.1
 revision=1
 build_style=cmake
 makedepends="vtk-devel"
@@ -11,7 +11,7 @@ license="BSD-3-Clause"
 homepage="https://f3d.app"
 changelog="https://f3d.app/doc/CHANGELOG.html"
 distfiles="https://github.com/f3d-app/f3d/archive/refs/tags/v${version}.tar.gz"
-checksum=3e5e6c2c16da4d7ccce8b6e316ab8007592a2bc0fc11a513f1ebac8c7f0f95d2
+checksum=4d3a73b0107c8db7f0556107c74087d3748232a73981f65f7c5186ac1003ec8d
 
 post_install() {
 	vlicense LICENSE.md


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I cant built this PR locally for armv6l,aarch64-musl architectures:
```
=> ERROR: hdf5-devel-1.10.5_2: cannot be cross compiled...
=> ERROR: hdf5-devel-1.10.5_2: https://portal.hdfgroup.org/pages/viewpage.action?pageId=48808266
```

f3d is like feh but for 3d models. Very convenient for quickly viewing models. Especially if you have never worked with such programs before.