### PR TITLE
SDL2: update to 2.28.3.

### DIFF
--- a/srcpkgs/SDL2/template
+++ b/srcpkgs/SDL2/template
@@ -1,7 +1,7 @@
 # Template file for 'SDL2'
 pkgname=SDL2
-version=2.28.2
-revision=2
+version=2.28.3
+revision=1
 build_style=cmake
 configure_args="-DSDL_ALSA=ON -DSDL_ESD=OFF -DSDL_RPATH=OFF
  -DSDL_CLOCK_GETTIME=ON -DSDL_PULSEAUDIO_SHARED=OFF
@@ -15,7 +15,7 @@ license="Zlib"
 homepage="https://www.libsdl.org/"
 changelog="https://raw.githubusercontent.com/libsdl-org/SDL/SDL2/WhatsNew.txt"
 distfiles="https://www.libsdl.org/release/SDL2-${version}.tar.gz"
-checksum=64b1102fa22093515b02ef33dd8739dee1ba57e9dbba6a092942b8bbed1a1c5e
+checksum=7acb8679652701a2504d734e2ba7543ec1a83e310498ddd22fd44bf965eb5518
 
 # Package build options
 build_options="gles opengl pulseaudio pipewire sndio vulkan wayland x11"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl (cross)
