### PR TITLE
ansible: update to 8.5.0.

### DIFF
--- a/srcpkgs/ansible-core/patches/0001-add-Python-3.12-support-to-ansible-test-80834.patch
+++ b/srcpkgs/ansible-core/patches/0001-add-Python-3.12-support-to-ansible-test-80834.patch
@@ -1,0 +1,174 @@
+From 3cf88028e64ce275118f8071fde2baa5a2a0ccf9 Mon Sep 17 00:00:00 2001
+From: Sloane Hertel <19572925+s-hertel@users.noreply.github.com>
+Date: Fri, 21 Jul 2023 13:23:14 -0400
+Subject: [PATCH 1/2] add Python 3.12 support to ansible-test (#80834)
+
+* update docker containers versions to use newer ansible-test ref in the pre-built venvs
+
+* Allow invoking ansible-test with Python 3.12
+
+* Add python3.12 to the INTERPRETER_PYTHON_FALLBACK
+
+* changelog
+
+* add Python 3.12 as a non-default Python version for the test containers
+
+* Update mypy ignores for Python 3.12
+
+* Add Python 3.12 to CI matrix for unit tests, generic tests, and galaxy
+
+* Update unit test for using the Python 2 collection loader path with Python 3.
+
+Skip the existing test on Python 3.12, since find_module is removed.
+
+Suppress the pre-existing deprecation warnings using the Python 2
+codepath with Python 3.
+
+Add a test for Python >= 3.12, which doesn't call find_module.
+
+* Ignore sanity test errors on systems without libselinux present.
+---
+ lib/ansible/config/base.yml                   |  1 +
+ .../ansible_test/_data/completion/docker.txt  |  6 ++---
+ .../_internal/python_requirements.py          |  4 ++--
+ .../_util/target/common/constants.py          |  1 +
+ .../_util/target/setup/bootstrap.sh           |  2 +-
+ test/sanity/ignore.txt                        |  6 +++--
+ .../test_collection_loader.py                 | 22 +++++++++++++++++--
+ 7 files changed, 32 insertions(+), 10 deletions(-)
+
+diff --git a/lib/ansible/config/base.yml b/lib/ansible/config/base.yml
+index 052a8f0834..64e1099059 100644
+--- a/lib/ansible/config/base.yml
++++ b/lib/ansible/config/base.yml
+@@ -1548,6 +1548,7 @@ _INTERPRETER_PYTHON_DISTRO_MAP:
+ INTERPRETER_PYTHON_FALLBACK:
+   name: Ordered list of Python interpreters to check for in discovery
+   default:
++  - python3.12
+   - python3.11
+   - python3.10
+   - python3.9
+diff --git a/test/lib/ansible_test/_data/completion/docker.txt b/test/lib/ansible_test/_data/completion/docker.txt
+index ee3f082c1f..f73fdb408e 100644
+--- a/test/lib/ansible_test/_data/completion/docker.txt
++++ b/test/lib/ansible_test/_data/completion/docker.txt
+@@ -1,6 +1,6 @@
+-base image=quay.io/ansible/base-test-container:4.1.0 python=3.11,2.7,3.5,3.6,3.7,3.8,3.9,3.10
+-default image=quay.io/ansible/default-test-container:7.14.0 python=3.11,2.7,3.5,3.6,3.7,3.8,3.9,3.10 context=collection
+-default image=quay.io/ansible/ansible-core-test-container:7.14.0 python=3.11,2.7,3.5,3.6,3.7,3.8,3.9,3.10 context=ansible-core
++base image=quay.io/ansible/base-test-container:5.0.0 python=3.11,2.7,3.6,3.7,3.8,3.9,3.10,3.12
++default image=quay.io/ansible/default-test-container:8.3.0 python=3.11,2.7,3.6,3.7,3.8,3.9,3.10,3.12 context=collection
++default image=quay.io/ansible/ansible-core-test-container:8.3.0 python=3.11,2.7,3.6,3.7,3.8,3.9,3.10,3.12 context=ansible-core
+ alpine3 image=quay.io/ansible/alpine3-test-container:5.0.0 python=3.10 cgroup=none audit=none
+ centos7 image=quay.io/ansible/centos7-test-container:5.0.0 python=2.7 cgroup=v1-only
+ fedora37 image=quay.io/ansible/fedora37-test-container:5.0.0 python=3.11
+diff --git a/test/lib/ansible_test/_internal/python_requirements.py b/test/lib/ansible_test/_internal/python_requirements.py
+index 506b802c52..adf9445161 100644
+--- a/test/lib/ansible_test/_internal/python_requirements.py
++++ b/test/lib/ansible_test/_internal/python_requirements.py
+@@ -441,8 +441,8 @@ def get_venv_packages(python: PythonConfig) -> dict[str, str]:
+     #       See: https://github.com/ansible/base-test-container/blob/main/files/installer.py
+ 
+     default_packages = dict(
+-        pip='21.3.1',
+-        setuptools='60.8.2',
++        pip='23.1.2',
++        setuptools='67.7.2',
+         wheel='0.37.1',
+     )
+ 
+diff --git a/test/lib/ansible_test/_util/target/common/constants.py b/test/lib/ansible_test/_util/target/common/constants.py
+index 9bddfaf439..f3c3857ef9 100644
+--- a/test/lib/ansible_test/_util/target/common/constants.py
++++ b/test/lib/ansible_test/_util/target/common/constants.py
+@@ -17,4 +17,5 @@ CONTROLLER_PYTHON_VERSIONS = (
+     '3.9',
+     '3.10',
+     '3.11',
++    '3.12',
+ )
+diff --git a/test/lib/ansible_test/_util/target/setup/bootstrap.sh b/test/lib/ansible_test/_util/target/setup/bootstrap.sh
+index ea17dad387..367dcfcb4c 100644
+--- a/test/lib/ansible_test/_util/target/setup/bootstrap.sh
++++ b/test/lib/ansible_test/_util/target/setup/bootstrap.sh
+@@ -53,7 +53,7 @@ install_pip() {
+                 pip_bootstrap_url="https://ci-files.testing.ansible.com/ansible-test/get-pip-20.3.4.py"
+                 ;;
+             *)
+-                pip_bootstrap_url="https://ci-files.testing.ansible.com/ansible-test/get-pip-21.3.1.py"
++                pip_bootstrap_url="https://ci-files.testing.ansible.com/ansible-test/get-pip-23.1.2.py"
+                 ;;
+         esac
+ 
+diff --git a/test/sanity/ignore.txt b/test/sanity/ignore.txt
+index f62fcbfc09..4d3ffc04b9 100644
+--- a/test/sanity/ignore.txt
++++ b/test/sanity/ignore.txt
+@@ -9,12 +9,13 @@ lib/ansible/executor/task_queue_manager.py pylint:disallowed-name
+ lib/ansible/galaxy/collection/__init__.py mypy-3.9:attr-defined  # inline ignore has no effect
+ lib/ansible/galaxy/collection/__init__.py mypy-3.10:attr-defined  # inline ignore has no effect
+ lib/ansible/galaxy/collection/__init__.py mypy-3.11:attr-defined  # inline ignore has no effect
+-lib/ansible/galaxy/collection/gpg.py mypy-3.9:arg-type
++lib/ansible/galaxy/collection/__init__.py mypy-3.12:attr-defined  # inline ignore has no effect
+ lib/ansible/galaxy/collection/gpg.py mypy-3.10:arg-type
+ lib/ansible/galaxy/collection/gpg.py mypy-3.11:arg-type
+-lib/ansible/parsing/yaml/constructor.py mypy-3.9:type-var  # too many occurrences to ignore inline
++lib/ansible/galaxy/collection/gpg.py mypy-3.12:arg-type
+ lib/ansible/parsing/yaml/constructor.py mypy-3.10:type-var  # too many occurrences to ignore inline
+ lib/ansible/parsing/yaml/constructor.py mypy-3.11:type-var  # too many occurrences to ignore inline
++lib/ansible/parsing/yaml/constructor.py mypy-3.12:type-var  # too many occurrences to ignore inline
+ lib/ansible/keyword_desc.yml no-unwanted-files
+ lib/ansible/modules/apt.py validate-modules:parameter-invalid
+ lib/ansible/modules/apt_repository.py validate-modules:parameter-invalid
+@@ -77,6 +78,7 @@ lib/ansible/module_utils/compat/selinux.py import-3.8!skip # pass/fail depends o
+ lib/ansible/module_utils/compat/selinux.py import-3.9!skip # pass/fail depends on presence of libselinux.so
+ lib/ansible/module_utils/compat/selinux.py import-3.10!skip # pass/fail depends on presence of libselinux.so
+ lib/ansible/module_utils/compat/selinux.py import-3.11!skip # pass/fail depends on presence of libselinux.so
++lib/ansible/module_utils/compat/selinux.py import-3.12!skip # pass/fail depends on presence of libselinux.so
+ lib/ansible/module_utils/distro/_distro.py future-import-boilerplate # ignore bundled
+ lib/ansible/module_utils/distro/_distro.py metaclass-boilerplate # ignore bundled
+ lib/ansible/module_utils/distro/_distro.py no-assert
+diff --git a/test/units/utils/collection_loader/test_collection_loader.py b/test/units/utils/collection_loader/test_collection_loader.py
+index 9be59307a9..feaaf97a9c 100644
+--- a/test/units/utils/collection_loader/test_collection_loader.py
++++ b/test/units/utils/collection_loader/test_collection_loader.py
+@@ -29,8 +29,16 @@ def teardown(*args, **kwargs):
+ # BEGIN STANDALONE TESTS - these exercise behaviors of the individual components without the import machinery
+ 
+ 
+-@pytest.mark.skipif(not PY3, reason='Testing Python 2 codepath (find_module) on Python 3')
+-def test_find_module_py3():
++@pytest.mark.filterwarnings(
++    'ignore:'
++    r'find_module\(\) is deprecated and slated for removal in Python 3\.12; use find_spec\(\) instead'
++    ':DeprecationWarning',
++    'ignore:'
++    r'FileFinder\.find_loader\(\) is deprecated and slated for removal in Python 3\.12; use find_spec\(\) instead'
++    ':DeprecationWarning',
++)
++@pytest.mark.skipif(not PY3 or sys.version_info >= (3, 12), reason='Testing Python 2 codepath (find_module) on Python 3, <= 3.11')
++def test_find_module_py3_lt_312():
+     dir_to_a_file = os.path.dirname(ping_module.__file__)
+     path_hook_finder = _AnsiblePathHookFinder(_AnsibleCollectionFinder(), dir_to_a_file)
+ 
+@@ -40,6 +48,16 @@ def test_find_module_py3():
+     assert path_hook_finder.find_module('missing') is None
+ 
+ 
++@pytest.mark.skipif(sys.version_info < (3, 12), reason='Testing Python 2 codepath (find_module) on Python >= 3.12')
++def test_find_module_py3_gt_311():
++    dir_to_a_file = os.path.dirname(ping_module.__file__)
++    path_hook_finder = _AnsiblePathHookFinder(_AnsibleCollectionFinder(), dir_to_a_file)
++
++    # setuptools may fall back to find_module on Python 3 if find_spec returns None
++    # see https://github.com/pypa/setuptools/pull/2918
++    assert path_hook_finder.find_spec('missing') is None
++
++
+ def test_finder_setup():
+     # ensure scalar path is listified
+     f = _AnsibleCollectionFinder(paths='/bogus/bogus')
+-- 
+2.42.0
+

--- a/srcpkgs/ansible-core/patches/0002-add-coverage-for-Python-3.12-81125.patch
+++ b/srcpkgs/ansible-core/patches/0002-add-coverage-for-Python-3.12-81125.patch
@@ -1,0 +1,36 @@
+From 57da749403f117f37761ec0a2ad80a8d933315ee Mon Sep 17 00:00:00 2001
+From: Sloane Hertel <19572925+s-hertel@users.noreply.github.com>
+Date: Mon, 26 Jun 2023 13:38:22 -0400
+Subject: [PATCH 2/2] add coverage for Python 3.12 (#81125)
+
+---
+ test/lib/ansible_test/_data/requirements/ansible-test.txt | 2 +-
+ test/lib/ansible_test/_internal/coverage_util.py          | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/test/lib/ansible_test/_data/requirements/ansible-test.txt b/test/lib/ansible_test/_data/requirements/ansible-test.txt
+index f7cb9c2778..8b1772fb91 100644
+--- a/test/lib/ansible_test/_data/requirements/ansible-test.txt
++++ b/test/lib/ansible_test/_data/requirements/ansible-test.txt
+@@ -1,4 +1,4 @@
+ # The test-constraints sanity test verifies this file, but changes must be made manually to keep it in up-to-date.
+ virtualenv == 16.7.12 ; python_version < '3'
+-coverage == 6.5.0 ; python_version >= '3.7' and python_version <= '3.11'
++coverage == 6.5.0 ; python_version >= '3.7' and python_version <= '3.12'
+ coverage == 4.5.4 ; python_version >= '2.6' and python_version <= '3.6'
+diff --git a/test/lib/ansible_test/_internal/coverage_util.py b/test/lib/ansible_test/_internal/coverage_util.py
+index ae64024939..f2c35e3947 100644
+--- a/test/lib/ansible_test/_internal/coverage_util.py
++++ b/test/lib/ansible_test/_internal/coverage_util.py
+@@ -69,7 +69,7 @@ class CoverageVersion:
+ 
+ COVERAGE_VERSIONS = (
+     # IMPORTANT: Keep this in sync with the ansible-test.txt requirements file.
+-    CoverageVersion('6.5.0', 7, (3, 7), (3, 11)),
++    CoverageVersion('6.5.0', 7, (3, 7), (3, 12)),
+     CoverageVersion('4.5.4', 0, (2, 6), (3, 6)),
+ )
+ """
+-- 
+2.42.0
+

--- a/srcpkgs/ansible-core/template
+++ b/srcpkgs/ansible-core/template
@@ -1,7 +1,7 @@
 # Template file for 'ansible-core'
 pkgname=ansible-core
-version=2.15.0
-revision=2
+version=2.15.5
+revision=1
 hostmakedepends="python3-setuptools python3-wheel python3-packaging
  python3-straight.plugin python3-docutils python3-Jinja2 python3-yaml"
 depends="python3-cryptography python3-Jinja2 python3-paramiko python3-yaml
@@ -15,7 +15,7 @@ license="GPL-3.0-or-later"
 homepage="https://www.ansible.com/"
 changelog="https://raw.githubusercontent.com/ansible/ansible/stable-${version%.*}/changelogs/CHANGELOG-v${version%.*}.rst"
 distfiles="${PYPI_SITE}/a/ansible-core/ansible-core-${version}.tar.gz"
-checksum=cf690fd4ebb40590e00c5acdc0624758ca4c58d1e4b2b02ec026a034070ebf4d
+checksum=8cc539cb8d4349af3ffd901c70722f7a7a203ae6427ddac95ffdf546a6e41602
 conflicts="ansible<2.10.1_1"
 replaces="ansible-base<2.11.0_1"
 
@@ -30,13 +30,11 @@ do_check() {
 do_install() {
 	python setup.py install --root="${DESTDIR}"
 
-	make docs
-	for page in docs/man/man1/*.1; do
+	mkdir man
+	./packaging/cli-doc/build.py man --output-dir man
+	for page in man/*.1; do
 		vman ${page}
 	done
-
-	vsconf examples/ansible.cfg
-	vsconf examples/hosts
 }
 
 ansible-base_package() {

--- a/srcpkgs/ansible/template
+++ b/srcpkgs/ansible/template
@@ -1,7 +1,7 @@
 # Template file for 'ansible'
 pkgname=ansible
-version=8.0.0
-revision=2
+version=8.5.0
+revision=1
 build_style="python3-pep517"
 hostmakedepends="python3-setuptools python3-wheel"
 depends="ansible-core"
@@ -10,6 +10,6 @@ maintainer="Jan Christian Grünhage <jan.christian@gruenhage.xyz>"
 license="GPL-3.0-or-later"
 homepage="https://www.ansible.com/"
 distfiles="${PYPI_SITE}/a/ansible/ansible-${version}.tar.gz"
-checksum=8670c7c46021c188cac235e9fde7adadbb3c380c2436a3b0c1c493c4ba10bcab
+checksum=327c509bdaf5cdb2489d85c09d2c107e9432f9874c8bb5c0702a731160915f2d
 # Relevant tests happen in ansible-core
 make_check=no


### PR DESCRIPTION
- ansible-core: update to 2.15.5.
- ansible: update to 8.5.0.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

Since the Python 3.12 update was merged, the tests aren't passing anymore and need further adjustment.

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
