### PR TITLE
SDL2: fix sigill on some i686

### DIFF
--- a/srcpkgs/SDL2/template
+++ b/srcpkgs/SDL2/template
@@ -1,7 +1,7 @@
 # Template file for 'SDL2'
 pkgname=SDL2
 version=2.28.2
-revision=1
+revision=2
 build_style=cmake
 configure_args="-DSDL_ALSA=ON -DSDL_ESD=OFF -DSDL_RPATH=OFF
  -DSDL_CLOCK_GETTIME=ON -DSDL_PULSEAUDIO_SHARED=OFF
@@ -32,9 +32,11 @@ case "$XBPS_TARGET_MACHINE" in
 	*) build_options_default+=" pipewire";;
 esac
 
-# SDL_cpuinfo includes altivec.h, which breaks C++ programs with vector keyword
 case "$XBPS_TARGET_MACHINE" in
+	# SDL_cpuinfo includes altivec.h, which breaks C++ programs with vector keyword
 	ppc*) configure_args+=" -DSDL_ALTIVEC=OFF";;
+	# SDL detects SSE3 on i686, which is above our support target
+	i686*) configure_args+=" -DSDL_SSE3=OFF";;
 	*) ;;
 esac
 


### PR DESCRIPTION
@devlocalhost please test

fixes #44829

#### Testing the changes
- I tested the changes in this PR: **NO** (but `-msse3` is no longer added to `EXTRA_CFLAGS` on i686)

