### PR TITLE
alsa-lib: fix for segfault on 32-bit

### DIFF
--- a/srcpkgs/alsa-lib/patches/fix-segfault-32bit.patch
+++ b/srcpkgs/alsa-lib/patches/fix-segfault-32bit.patch
@@ -1,0 +1,110 @@
+From 0e3dfb9f705ca78be34cd70fd59d67c431e29cc7 Mon Sep 17 00:00:00 2001
+From: Takashi Iwai <tiwai@suse.de>
+Date: Sat, 9 Sep 2023 17:42:03 +0200
+Subject: [PATCH] pcm: Fix segfault with 32bit libs
+
+The recent rearrangement of header inclusion order caused a regression
+showing segfaults on 32bit Arm.  The primary reason is the
+inconsistent compile condition depending on the inclusion of config.h;
+while most of other code include pcm_local.h (that implicitly includes
+config.h) at first, pcm_direct.c doesn't do it, hence the access with
+direct plugins crashes.
+
+For fixing it, we need to include config.h at the beginning.  But,
+it's better to include pcm_local.h for all relevant code for
+consistency.  The patch does it, and also it adds the guard in
+pcm_local.h for double inclusions.
+
+Fixes: ad3a8b8b314e ("reshuffle included files to include config.h as first")
+Link: https://github.com/alsa-project/alsa-lib/issues/352
+Signed-off-by: Takashi Iwai <tiwai@suse.de>
+---
+ src/pcm/pcm_direct.c | 1 +
+ src/pcm/pcm_dmix.c   | 2 +-
+ src/pcm/pcm_dshare.c | 1 +
+ src/pcm/pcm_dsnoop.c | 1 +
+ src/pcm/pcm_local.h  | 5 +++++
+ src/pcm/pcm_shm.c    | 1 +
+ 6 files changed, 10 insertions(+), 1 deletion(-)
+
+diff --git a/src/pcm/pcm_direct.c b/src/pcm/pcm_direct.c
+index 040fc160..e53e5923 100644
+--- a/src/pcm/pcm_direct.c
++++ b/src/pcm/pcm_direct.c
+@@ -19,6 +19,7 @@
+  *
+  */
+   
++#include "pcm_local.h"
+ #include <stdio.h>
+ #include <stdlib.h>
+ #include <stddef.h>
+diff --git a/src/pcm/pcm_dmix.c b/src/pcm/pcm_dmix.c
+index 7cd3c508..55cae3e7 100644
+--- a/src/pcm/pcm_dmix.c
++++ b/src/pcm/pcm_dmix.c
+@@ -26,7 +26,7 @@
+  *
+  */
+   
+-#include "config.h"
++#include "pcm_local.h"
+ #include <stdio.h>
+ #include <stdlib.h>
+ #include <stddef.h>
+diff --git a/src/pcm/pcm_dshare.c b/src/pcm/pcm_dshare.c
+index 454b39a9..c0329098 100644
+--- a/src/pcm/pcm_dshare.c
++++ b/src/pcm/pcm_dshare.c
+@@ -26,6 +26,7 @@
+  *
+  */
+   
++#include "pcm_local.h"
+ #include <stdio.h>
+ #include <stdlib.h>
+ #include <stddef.h>
+diff --git a/src/pcm/pcm_dsnoop.c b/src/pcm/pcm_dsnoop.c
+index d3ce300c..bf67c68a 100644
+--- a/src/pcm/pcm_dsnoop.c
++++ b/src/pcm/pcm_dsnoop.c
+@@ -26,6 +26,7 @@
+  *
+  */
+   
++#include "pcm_local.h"
+ #include <stdio.h>
+ #include <stdlib.h>
+ #include <stddef.h>
+diff --git a/src/pcm/pcm_local.h b/src/pcm/pcm_local.h
+index 6a0e71e7..152c92c3 100644
+--- a/src/pcm/pcm_local.h
++++ b/src/pcm/pcm_local.h
+@@ -20,6 +20,9 @@
+  *
+  */
+ 
++#ifndef __PCM_LOCAL_H
++#define __PCM_LOCAL_H
++
+ #include "config.h"
+ 
+ #include <stdio.h>
+@@ -1223,3 +1226,5 @@ static inline void snd_pcm_unlock(snd_pcm_t *pcm)
+ #define snd_pcm_lock(pcm)		do {} while (0)
+ #define snd_pcm_unlock(pcm)		do {} while (0)
+ #endif /* THREAD_SAFE_API */
++
++#endif /* __PCM_LOCAL_H */
+diff --git a/src/pcm/pcm_shm.c b/src/pcm/pcm_shm.c
+index f0bfd934..d9596547 100644
+--- a/src/pcm/pcm_shm.c
++++ b/src/pcm/pcm_shm.c
+@@ -26,6 +26,7 @@
+  *
+  */
+   
++#include "pcm_local.h"
+ #include <stdio.h>
+ #include <stdlib.h>
+ #include <stddef.h>

--- a/srcpkgs/alsa-lib/template
+++ b/srcpkgs/alsa-lib/template
@@ -1,7 +1,7 @@
 # Template file for 'alsa-lib'
 pkgname=alsa-lib
 version=1.2.10
-revision=1
+revision=2
 build_style=gnu-configure
 hostmakedepends="pkg-config libtool"
 short_desc="Advanced Linux Sound Architecture (ALSA) library"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

I did experience segfault in some programs on i686 after upgrading to 1.2.10.  This patch from upstream addresses the issue.

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
