### PR TITLE
New package: libdisplay-info-0.1.1

### DIFF
--- a/srcpkgs/libdisplay-info-devel
+++ b/srcpkgs/libdisplay-info-devel
@@ -1,0 +1,1 @@
+libdisplay-info

--- a/srcpkgs/libdisplay-info/template
+++ b/srcpkgs/libdisplay-info/template
@@ -1,0 +1,27 @@
+# Template file for 'libdisplay-info'
+pkgname=libdisplay-info
+version=0.1.1
+revision=1
+build_style=meson
+hostmakedepends="hwids"
+short_desc="EDID and DisplayID library"
+maintainer="John <me@johnnynator.dev>"
+license="MIT"
+homepage="https://gitlab.freedesktop.org/emersion/libdisplay-info/"
+distfiles="https://gitlab.freedesktop.org/emersion/libdisplay-info/-/archive/${version}/libdisplay-info-${version}.tar.gz"
+checksum=a5aeef57817916286526292ec816a5338c4d3c0094ce91e584fc82b57070a44f
+# tests require currently unpacakged edid-decode
+make_check=no
+
+post_install() {
+	vlicense LICENSE
+}
+
+libdisplay-info-devel_package() {
+	depends="${sourcepkg}>=${version}_${revision}"
+	pkg_install() {
+		vmove usr/include
+		vmove "usr/lib/*.so"
+		vmove usr/lib/pkgconfig
+	}
+}


### PR DESCRIPTION
Will be used by `kwin` in the future.

closes #43888

#### Testing the changes
- I tested the changes in this PR: **YES**|**briefly**|**NO**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
