### PR TITLE
system-monitoring-center: update to 2.22.1

### DIFF
--- a/srcpkgs/system-monitoring-center/template
+++ b/srcpkgs/system-monitoring-center/template
@@ -1,6 +1,6 @@
 # Template file for 'system-monitoring-center'
 pkgname=system-monitoring-center
-version=2.21.2
+version=2.22.1
 revision=1
 build_style=meson
 hostmakedepends="kdelibs4support-devel gettext"
@@ -12,4 +12,4 @@ license="GPL-3.0-only"
 homepage="https://github.com/hakandundar34coding/system-monitoring-center"
 changelog="https://raw.githubusercontent.com/hakandundar34coding/system-monitoring-center/master/Changes.md"
 distfiles="https://github.com/hakandundar34coding/system-monitoring-center/archive/refs/tags/v${version}.tar.gz"
-checksum=0e3a97db5654ce23bf26da85b6376ddec76bddd361151ece26fa2d58c23d822a
+checksum=c4ed7e6c3ac403b4a44d05d8fb10fce0c6761631f7e3423eb67038c1fd7afeee


### PR DESCRIPTION

#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, (x64 glibc)
