### PR TITLE
[RFC] common/build-helper/meson.sh: new build helper, used by meson build style

### DIFF
--- a/Manual.md
+++ b/Manual.md
@@ -1079,6 +1079,11 @@ additional paths to be searched when linking target binaries to be introspected.
 `qemu-<target_arch>-static` when running the target binary. You can for example specify
 `GIR_EXTRA_OPTIONS="-strace"` to see a trace of what happens when running that binary.
 
+- `meson` creates a cross file, `${XBPS_WRAPPERDIR}/meson/xbps_meson.cross`, which configures
+meson for cross builds. This is particularly useful for building packages that wrap meson
+invocations (e.g., `python3-pep517` packages that use a meson backend) and is added by default
+for packages that use the `meson` build style.
+
 - `qemu` sets additional variables for the `cmake` and `meson` build styles to allow
 executing cross-compiled binaries inside qemu.
 It sets `CMAKE_CROSSCOMPILING_EMULATOR` for cmake and `exe_wrapper` for meson

--- a/common/build-helper/meson.sh
+++ b/common/build-helper/meson.sh
@@ -1,0 +1,82 @@
+# This build helper writes a Meson cross-file, allowing other build styles
+# to properly drive cross-builds in Meson when appropriate
+
+if [ -n "$CROSS_BUILD" ]; then
+	mkdir -p "${XBPS_WRAPPERDIR}/meson"
+
+	_MESON_TARGET_ENDIAN=little
+	# drop the -musl suffix to the target cpu, meson doesn't recognize it
+	_MESON_TARGET_CPU=${XBPS_TARGET_MACHINE/-musl/}
+	case "$XBPS_TARGET_MACHINE" in
+		mips|mips-musl|mipshf-musl)
+			_MESON_TARGET_ENDIAN=big
+			_MESON_CPU_FAMILY=mips
+			;;
+		armv*)
+			_MESON_CPU_FAMILY=arm
+			;;
+		i686*)
+			_MESON_CPU_FAMILY=x86
+			;;
+		ppc64le*)
+			_MESON_CPU_FAMILY=ppc64
+			;;
+		ppc64*)
+			_MESON_TARGET_ENDIAN=big
+			_MESON_CPU_FAMILY=ppc64
+			;;
+		ppcle*)
+			_MESON_CPU_FAMILY=ppc
+			;;
+		ppc*)
+			_MESON_TARGET_ENDIAN=big
+			_MESON_CPU_FAMILY=ppc
+			;;
+		*)
+			# if we reached here that means that the cpu and cpu_family
+			# are the same like 'x86_64' and 'aarch64'
+			_MESON_CPU_FAMILY=${_MESON_TARGET_CPU}
+			;;
+	esac
+
+	# Tell meson to run binaries with qemu if desired
+	_MESON_EXE_WRAPPER=""
+	if [[ "${build_helper}" = *qemu* ]]; then
+		_MESON_EXE_WRAPPER="exe_wrapper = '/usr/bin/qemu-${XBPS_TARGET_QEMU_MACHINE}-static'"
+	fi
+
+	# Record cross-compiling information in cross file.
+	#
+	# CFLAGS, CXXFLAGS and LDFLAGS are not yet available and
+	# will be taken from the environment at configure time.
+	cat > "${XBPS_WRAPPERDIR}/meson/xbps_meson.cross" <<-EOF
+		[binaries]
+		${_MESON_EXE_WRAPPER:-# exe_wrapper is not set}
+		c = '${CC}'
+		cpp = '${CXX}'
+		ar = '${XBPS_CROSS_TRIPLET}-gcc-ar'
+		nm = '${NM}'
+		ld = '${LD}'
+		strip = '${STRIP}'
+		readelf = '${READELF}'
+		objcopy = '${OBJCOPY}'
+		pkgconfig = '${PKG_CONFIG}'
+		rust = ['rustc', '--target', '${RUST_TARGET}' ,'--sysroot', '${XBPS_CROSS_BASE}/usr']
+		g-ir-scanner = '${XBPS_CROSS_BASE}/usr/bin/g-ir-scanner'
+		g-ir-compiler = '${XBPS_CROSS_BASE}/usr/bin/g-ir-compiler'
+		g-ir-generate = '${XBPS_CROSS_BASE}/usr/bin/g-ir-generate'
+		llvm-config = '/usr/bin/llvm-config'
+		cups-config = '${XBPS_CROSS_BASE}/usr/bin/cups-config'
+		
+		[properties]
+		needs_exe_wrapper = true
+		
+		[host_machine]
+		system = 'linux'
+		cpu_family = '${_MESON_CPU_FAMILY}'
+		cpu = '${_MESON_TARGET_CPU}'
+		endian = '${_MESON_TARGET_ENDIAN}'
+		EOF
+
+	unset _MESON_CPU_FAMILY _MESON_TARGET_CPU _MESON_TARGET_ENDIAN _MESON_EXE_WRAPPER
+fi

--- a/common/environment/build-style/meson.sh
+++ b/common/environment/build-style/meson.sh
@@ -1,1 +1,2 @@
 hostmakedepends+=" meson"
+build_helper+=" meson"

--- a/srcpkgs/python3-scikit-image/template
+++ b/srcpkgs/python3-scikit-image/template
@@ -2,8 +2,8 @@
 pkgname=python3-scikit-image
 version=0.21.0
 revision=1
-build_style=meson
-build_helper="python3"
+build_style=python3-pep517
+build_helper="meson"
 hostmakedepends="python3-build python3-installer python3-meson-python
  python3-wheel python3-setuptools python3-packaging python3-Cython pythran
  python3-lazy_loader python3-numpy pkg-config"
@@ -21,10 +21,23 @@ checksum=53a82a9dbd3ed608d2ad3876269a271a7e922b12e228388eac996b508aadd652
 make_check=no
 
 if [ "${CROSS_BUILD}" ]; then
-	configure_args="--cross-file=python.cross"
+	make_build_args+=" --no-isolation --wheel
+	 -Csetup-args=--cross-file=${XBPS_WRAPPERDIR}/meson/xbps_meson.cross
+	 -Csetup-args=--cross-file=${XBPS_WRAPPERDIR}/meson/python.cross"
 fi
 
-pre_patch() {
+post_patch() {
+	if [ "${CROSS_BUILD}" ]; then
+		local _xpy="${XBPS_CROSS_BASE}/${py3_sitelib}"
+		cat > "${XBPS_WRAPPERDIR}/meson/python.cross" <<-EOF
+		[properties]
+		numpy-include-dir = '${_xpy}/numpy/core/include'
+		pythran-include-dir = '${_xpy}/pythran'
+		EOF
+	fi
+}
+
+pre_build() {
 	if [ "${CROSS_BUILD}" ]; then
 		# Meson can't tolerate $CC with arguments as set by build helper
 		CC="${XBPS_CROSS_TRIPLET}-gcc"
@@ -33,25 +46,6 @@ pre_patch() {
 	fi
 }
 
-post_patch() {
-	if [ "${CROSS_BUILD}" ]; then
-		local _xpy="${XBPS_CROSS_BASE}/${py3_sitelib}"
-		cat > python.cross <<-EOF
-		[properties]
-		numpy-include-dir = '${_xpy}/numpy/core/include'
-		pythran-include-dir = '${_xpy}/pythran'
-		EOF
-	fi
-}
-
-do_build() {
-	# Use the build directory already configured by xbps-src for meson
-	python3 -m build --no-isolation --wheel \
-		-Cbuilddir="./build" -Ccompile-args="${makejobs}" .
-}
-
-do_install() {
-	python3 -m installer --destdir "${DESTDIR}" \
-		--no-compile-bytecode dist/*.whl
+post_install() {
 	vlicense LICENSE.txt
 }

--- a/srcpkgs/python3-scipy/template
+++ b/srcpkgs/python3-scipy/template
@@ -2,9 +2,10 @@
 pkgname=python3-scipy
 version=1.11.2
 revision=1
-build_style=meson
-build_helper="python3"
-configure_args="$(vopt_if openblas "" "-Dblas=blas -Dlapack=lapack")"
+build_style=python3-pep517
+build_helper="meson"
+make_build_args="--no-isolation --wheel
+ $(vopt_if openblas "" "-Csetup-args=-Dblas=blas -Csetup-args=-Dlapack=lapack")"
 hostmakedepends="python3-build python3-installer python3-meson-python
  python3-wheel python3-Cython python3-pybind11 pythran python3-numpy
  gcc-fortran pkg-config"
@@ -22,8 +23,12 @@ make_check="no" # Tests need an installed copy to run and meson makes this tough
 build_options="openblas"
 
 if [ "$CROSS_BUILD" ]; then
+	make_build_args+="
+	 -Csetup-args=--cross-file=${XBPS_WRAPPERDIR}/meson/xbps_meson.cross
+	 -Csetup-args=--cross-file=${XBPS_WRAPPERDIR}/meson/python.cross
+	"
+
 	_pybind11_dir="${py3_sitelib}/pybind11"
-	configure_args+=" --cross-file=python.cross"
 	export PKG_CONFIG_PATH="${XBPS_CROSS_BASE}/${_pybind11_dir}/share/pkgconfig"
 	# pybind11 uses a path relative to the pkgconfig file to set $prefix,
 	# which causes the wrapper to double-include $XBPS_CROSS_BASE; override
@@ -46,8 +51,19 @@ if [ "$build_option_openblas" ]; then
 	esac
 fi
 
-pre_patch() {
-	if [ "${CROSS_BUILD}" ]; then
+post_patch() {
+	if [ "$CROSS_BUILD" ]; then
+		local _xpy="${XBPS_CROSS_BASE}/${py3_sitelib}"
+		cat > "${XBPS_WRAPPERDIR}/meson/python.cross" <<-EOF
+			[properties]
+			numpy-include-dir = '${_xpy}/numpy/core/include'
+			pythran-include-dir = '${_xpy}/pythran'
+			EOF
+	fi
+}
+
+pre_build() {
+	if [ "$CROSS_BUILD" ]; then
 		# Meson can't tolerate $CC with arguments as set by the build helper
 		CC="${XBPS_CROSS_TRIPLET}-gcc"
 		# CXX needs to know where to find Python headers
@@ -55,25 +71,6 @@ pre_patch() {
 	fi
 }
 
-post_patch() {
-	if [ "$CROSS_BUILD" ]; then
-		local _xpy="${XBPS_CROSS_BASE}/${py3_sitelib}"
-		cat > python.cross <<-EOF
-		[properties]
-		numpy-include-dir = '${_xpy}/numpy/core/include'
-		pythran-include-dir = '${_xpy}/pythran'
-		EOF
-	fi
-}
-
-do_build() {
-	# Use the build directory already configured by xbps-src for meson
-	python3 -m build --no-isolation --wheel \
-		-Cbuilddir="./build" -Ccompile-args="${makejobs}" .
-}
-
-do_install() {
-	python3 -m installer --destdir "${DESTDIR}" \
-		--no-compile-bytecode dist/*.whl
+post_install() {
 	vlicense LICENSE.txt
 }


### PR DESCRIPTION
The `python3-scipy` package now builds with `python3-meson-python`, with some more coming down the pike. The Python build process is necessary to include Python package metadata. For SciPy, this is accomplished by using the `meson` build style to configure a build directory, then overriding `do_build` and `do_install` to build things the PEP517 way (using the pre-configured build directory).

It might be helpful to define a `meson` build helper that can write out the standard cross file for builds, allowing packages like SciPy to use the `python3-pep517` build style with the `meson` helper. There are some issues to be worked out:
1. It seems like the `xbps_meson.cross` is written before `CFLAGS`, *et al.* are properly defined, so this cross file is actually broken. (This is the process by which the `qmake` helper writes its configurations, and they reference `CFLAGS` and others; is the `qmake` helper writing broken configs?)
2. The meson configuration (which would need to happen even with `python3-pep517` plus a `meson` helper) still includes a lot of magic that would have to be brought over to templates. This isn't really easier than the current practice of overriding the one-line `do_build` and `do_install`.

A possible solution would be to define a special-purpose function in the helper, called `vmesoncross` or somesuch, that will only write the configured when called---from a build function where these are properly defined (*e.g.*, `pre_configure`, `do_configure`). We could also define a special `do_configure`-like function in the helper that can be used by the `meson` style to actually do the configuration. This might be a bit ugly, but avoids repetition or violating the typical practice that the actual build functions are only defined in templates or build styles.

A third option is just defining a new `python3-meson` build style that mashes the meson `do_configure` bits from the `meson` style with the `do_build` and `do_install` bits from the `python3-pep517` style.

All of these options are sub-optimal, but I'm not sure which one is least offsensive.