### PR TITLE
vale: update to 2.29.0.

### DIFF
--- a/srcpkgs/vale/template
+++ b/srcpkgs/vale/template
@@ -1,6 +1,6 @@
 # Template file for 'vale'
 pkgname=vale
-version=2.28.3
+version=2.29.0
 revision=1
 build_style=go
 go_import_path="github.com/errata-ai/vale/v2"
@@ -12,7 +12,7 @@ license="MIT"
 homepage="https://vale.sh"
 changelog="https://github.com/errata-ai/vale/releases"
 distfiles="https://github.com/errata-ai/vale/archive/refs/tags/v${version}.tar.gz"
-checksum=93224b7e587268a13698f135850144c2fee85cfda66d629f70678e73b7f75135
+checksum=d94bb530ff4282f22adb9168dc619c4387e23902cbf88052772fb5cd8fdb3e64
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture: **x86_64**