### PR TITLE
rpi-kernel: update to 6.1.54 (and rpi-firmware, rpi-userland, rpi-eeprom)

### DIFF
--- a/srcpkgs/rpi-eeprom/template
+++ b/srcpkgs/rpi-eeprom/template
@@ -1,8 +1,8 @@
 # Template file for 'rpi-eeprom'
 pkgname=rpi-eeprom
-version=2022.05.20
+version=2023.09.29
 revision=1
-_githash="1c758a0904630da2ea905118bdf34fe2d8a6bb5e"
+_githash="4f2d676b4e2a9c2d9ee1ab42015ce711fde97afa"
 archs="armv7* aarch64*"
 conf_files="/etc/default/rpi-eeprom-update"
 depends="binutils pciutils python3 rpi-firmware rpi-userland"
@@ -11,7 +11,7 @@ maintainer="Leah Neukirchen <leah@vuxu.org>"
 license="BSD-3-Clause, custom:Proprietary"
 homepage="https://github.com/raspberrypi/rpi-eeprom/"
 distfiles="https://github.com/raspberrypi/rpi-eeprom/archive/${_githash}.tar.gz"
-checksum=ab4e20ef187f1583265c0face1d7d1597df2dc5d0fef697b459794924542388a
+checksum="189c5d37f3102247cec72619e3cb357d027ec526fa3c7373d3107bd6c9e30e29"
 python_version=3
 repository=nonfree
 
@@ -22,7 +22,8 @@ do_install() {
 	vinstall rpi-eeprom-update-default 644 etc/default rpi-eeprom-update
 
 	vmkdir usr/lib/firmware/raspberrypi/bootloader
-	vcopy firmware/* usr/lib/firmware/raspberrypi/bootloader/
+	# need to figure out how to package both pi4 (2711) and pi5 (2712) fw
+	vcopy firmware-2711/* usr/lib/firmware/raspberrypi/bootloader/
 
 	vlicense LICENSE
 }

--- a/srcpkgs/rpi-firmware/template
+++ b/srcpkgs/rpi-firmware/template
@@ -1,82 +1,78 @@
 # Template file for 'rpi-firmware'
-_githash="62efc6a69d4e717bf2833c649d622c8298a37e9c"
-_gitshort="${_githash:0:7}"
-
 pkgname=rpi-firmware
-version=20220823
-revision=2
+version=20230925
+revision=1
+_rpi_fw=6b37a457122714aa14b2c7df0926455173fd04f1
+_rpi_bt=9556b08ace2a1735127894642cc8ea6529c04c90
+_rpi_brcm=2c3a8701193ba23d0ef85cdf0d0c9e47baf03dfc
+create_wrksrc=yes
 archs="armv6l* armv7l* aarch64*"
-provides="linux-firmware-broadcom-${version}_${revision}"
-replaces="linux-firmware-broadcom>=0"
-short_desc="Firmware files for the Raspberry Pi (git ${_gitshort})"
+short_desc="Firmware files for the Raspberry Pi"
 maintainer="Piraty <mail@piraty.dev>"
 license="BSD-3-Clause, custom:Cypress"
 homepage="https://github.com/raspberrypi/firmware"
-distfiles="https://github.com/raspberrypi/firmware/archive/${_githash}.tar.gz"
-checksum=3fc5ab7155bde7221245f439971217558300dcbc988ade861cfef4e737de9909
+distfiles="
+ https://github.com/raspberrypi/firmware/archive/${_rpi_fw}.tar.gz
+ https://github.com/RPi-Distro/firmware-nonfree/archive/${_rpi_brcm}.tar.gz
+ https://github.com/RPi-Distro/bluez-firmware/raw/${_rpi_bt}/broadcom/BCM43430A1.hcd
+ https://github.com/RPi-Distro/bluez-firmware/raw/${_rpi_bt}/broadcom/BCM4345C0.hcd
+ https://github.com/RPi-Distro/bluez-firmware/raw/${_rpi_bt}/broadcom/BCM43430B0.hcd
+ https://github.com/RPi-Distro/bluez-firmware/raw/${_rpi_bt}/broadcom/BCM4345C5.hcd
+ https://github.com/RPi-Distro/bluez-firmware/raw/${_rpi_bt}/synaptics/SYN43430A1.hcd>BCM43430A1.raspberrypi,model-zero-2-w.hcd
+ https://github.com/RPi-Distro/bluez-firmware/raw/${_rpi_bt}/synaptics/SYN43430B0.hcd>BCM43430B0.raspberrypi,model-zero-2-w.hcd
+ https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git/plain/LICENCE.cypress>LICENCE.cypress"
+checksum="913986b1be22b8dc30a3e6a9b5a28316b1bbee7bec90040ddefff0d7512560f4
+ 9156d90116b921d2e7938b52fad84fbe1d96df622a66c5db09569c735832387a
+ c096ad4a5c3f06ed7d69eba246bf89ada9acba64a5b6f51b1e9c12f99bb1e1a7
+ 51c45e77ddad91a19e96dc8fb75295b2087c279940df2634b23baf71b6dea42c
+ 338c2c6631131f516bfc7e64ef0872bd0402e1f98ef9d0c900eef0c814d90a25
+ fb9f4ec2df5301bd35f416384e103c012c5983024c49aa72fbbaf90177512caa
+ 55071227c94d86369d04f9aff3bbfd4197a78a53dc350295123e1a8b048bba8f
+ 338c2c6631131f516bfc7e64ef0872bd0402e1f98ef9d0c900eef0c814d90a25
+ ae0db6cc4db33941148df0f67de53e76a77b1b5a46b3165edb7040aa2750015f"
+
+skip_extraction="BCM43430A1.hcd BCM4345C0.hcd BCM43430B0.hcd BCM4345C5.hcd
+ BCM43430A1.raspberrypi,model-zero-2-w.hcd BCM43430B0.raspberrypi,model-zero-2-w.hcd
+ LICENCE.cypress"
+
+provides="linux-firmware-broadcom-${version}_${revision}"
+replaces="linux-firmware-broadcom>=0"
 
 conf_files="/boot/cmdline.txt /boot/config.txt"
 nostrip=yes
 
 do_install() {
-	rm -f boot/*.img
-	rm -rf boot/overlays
-	rm -f boot/*.dtb
-	rm -f boot/COPYING.linux
-
-	vlicense boot/LICENCE.broadcom
-	rm -f boot/LICENCE.broadcom
+	# bootloader
+	vlicense "firmware-${_rpi_fw}/boot/LICENCE.broadcom"
+	rm -rf "firmware-${_rpi_fw}/boot/"*.img \
+		"firmware-${_rpi_fw}/boot/overlays" \
+		"firmware-${_rpi_fw}/boot/"*.dtb \
+		"firmware-${_rpi_fw}/boot/COPYING.linux" \
+		"firmware-${_rpi_fw}/boot/LICENCE.broadcom"
 
 	vmkdir boot
-	cp -R boot/* ${DESTDIR}/boot
+	vcopy "firmware-${_rpi_fw}/boot/*" boot
 
 	# Install configuration files.
-	vinstall ${FILESDIR}/cmdline.txt 644 boot
-	vinstall ${FILESDIR}/config.txt 644 boot
+	vinstall "${FILESDIR}/cmdline.txt" 644 boot
+	vinstall "${FILESDIR}/config.txt" 644 boot
 
-	$XBPS_FETCH_CMD https://raw.githubusercontent.com/RPi-Distro/firmware-nonfree/buster/LICENCE.cypress
-	vlicense LICENCE.cypress
+	# firmware
+	# we can use either the -standard or -minimal 43455 file so use standard by default
+	ln -sfv cyfmac43455-sdio-standard.bin "firmware-nonfree-${_rpi_brcm}/debian/config/brcm80211/cypress/cyfmac43455-sdio.bin"
+	vlicense "${XBPS_SRCDISTDIR}/${pkgname}-${version}/LICENCE.cypress"
 
-	# Firmware for rpi3 b and zero wifi chip
-	for f in bin txt; do
-		$XBPS_FETCH_CMD https://raw.githubusercontent.com/RPi-Distro/firmware-nonfree/buster/brcm/brcmfmac43430-sdio.${f}
-		vinstall brcmfmac43430-sdio.${f} 0644 usr/lib/firmware/brcm
+	# add original Pi Foundation firmware files
+	# install deref's symlinks and copies a whole file, which makes rpi use duplicated variants specifically from downstream firmware
+	install -Dm644 \
+		"firmware-nonfree-${_rpi_brcm}/debian/config/brcm80211/brcm/"brcmfmac*raspberrypi* \
+		-t "${DESTDIR}/usr/lib/firmware/brcm"
+
+	# but 43436/43436s/43456 is not in linux-firmware, so copy it normally
+	vcopy "firmware-nonfree-${_rpi_brcm}/debian/config/brcm80211/brcm/brcmfmac43456"* usr/lib/firmware/brcm
+	vcopy "firmware-nonfree-${_rpi_brcm}/debian/config/brcm80211/brcm/brcmfmac43436"* usr/lib/firmware/brcm
+
+	for file in "${XBPS_SRCDISTDIR}/${pkgname}-${version}/"*.hcd; do
+		vinstall "$file" 0644 usr/lib/firmware/brcm
 	done
-
-	# Firmware for rpi3 b and zero bluetooth chip
-	$XBPS_FETCH_CMD https://raw.githubusercontent.com/RPi-Distro/bluez-firmware/master/broadcom/BCM43430A1.hcd
-	vinstall BCM43430A1.hcd 0644 usr/lib/firmware/brcm
-
-	# Firmware for rpi3 b+ wifi chip
-	for f in bin txt clm_blob; do
-		$XBPS_FETCH_CMD https://raw.githubusercontent.com/RPi-Distro/firmware-nonfree/buster/brcm/brcmfmac43455-sdio.${f}
-		vinstall brcmfmac43455-sdio.${f} 0644 usr/lib/firmware/brcm
-	done
-
-	# Firmware for rpi3 b+ bluetooth chip
-	$XBPS_FETCH_CMD https://raw.githubusercontent.com/RPi-Distro/bluez-firmware/master/broadcom/BCM4345C0.hcd
-	vinstall BCM4345C0.hcd 0644 usr/lib/firmware/brcm
-
-	# Firmware for rpi zero 2w wifi chip
-	for f in bin txt clm_blob; do
-		$XBPS_FETCH_CMD https://raw.githubusercontent.com/RPi-Distro/firmware-nonfree/buster/brcm/brcmfmac43436-sdio.${f}
-		vinstall brcmfmac43436-sdio.${f} 0644 usr/lib/firmware/brcm
-	done
-	for f in bin txt; do
-		$XBPS_FETCH_CMD https://raw.githubusercontent.com/RPi-Distro/firmware-nonfree/buster/brcm/brcmfmac43436s-sdio.${f}
-		vinstall brcmfmac43436s-sdio.${f} 0644 usr/lib/firmware/brcm
-	done
-
-	# Firmware for rpi4/rpi400 wifi chip
-	for f in bin txt clm_blob; do
-		$XBPS_FETCH_CMD https://raw.githubusercontent.com/RPi-Distro/firmware-nonfree/buster/brcm/brcmfmac43456-sdio.${f}
-		vinstall brcmfmac43456-sdio.${f} 0644 usr/lib/firmware/brcm
-	done
-
-	# Firmware for rpi4/rpi400 bluetooth chip
-	$XBPS_FETCH_CMD https://raw.githubusercontent.com/RPi-Distro/bluez-firmware/master/broadcom/BCM4345C5.hcd
-	vinstall BCM4345C5.hcd 0644 usr/lib/firmware/brcm
-
-	$XBPS_FETCH_CMD https://raw.githubusercontent.com/RPi-Distro/bluez-firmware/master/broadcom/BCM43430B0.hcd
-	vinstall BCM43430B0.hcd 0644 usr/lib/firmware/brcm
 }

--- a/srcpkgs/rpi-kernel/template
+++ b/srcpkgs/rpi-kernel/template
@@ -1,30 +1,29 @@
 # Template file for 'rpi-kernel'
 #
 # We track the latest Raspberry Pi LTS kernel as that is what is used in the
-# official Raspberry Pi OS distribution. This is currently 5.15:
+# official Raspberry Pi OS distribution. This is currently 6.1:
 #
-# https://forums.raspberrypi.com/viewtopic.php?t=322879
+# https://forums.raspberrypi.com/viewtopic.php?t=344246
 #
 # Commit hash is picked from latest tag [1], if appropriate, or from latest
-# "Merge remote-tracking branch 'stable/linux-5.x.y' into rpi-5.x.y" commit.
+# "Merge remote-tracking branch 'stable/linux-6.x.y' into rpi-6.x.y" commit.
 #
 # [1] https://github.com/raspberrypi/linux/tags
 #
 # Upstream documentation: https://www.raspberrypi.com/documentation/computers/linux_kernel.html
-
 pkgname=rpi-kernel
-version=5.15.72
+version=6.1.54
 revision=1
-_githash="3b98eb7a4aeaecd5274108dc1be7a5df94253500"
+_githash=fad58933544bb2a7b7db92847c25c79a83171fa6
 archs="armv6l* armv7l* aarch64*"
 hostmakedepends="perl kmod uboot-mkimage openssl-devel bc bison flex xz"
 makedepends="ncurses-devel"
+short_desc="Linux kernel for Raspberry Pi (${version%.*} series)"
 maintainer="Piraty <mail@piraty.dev>"
-homepage="http://www.kernel.org"
 license="GPL-2.0-only"
-short_desc="Linux kernel for Raspberry Pi (${version%.*} series [git ${_githash:0:7}])"
+homepage="http://www.kernel.org"
 distfiles="https://github.com/raspberrypi/linux/archive/${_githash}.tar.gz"
-checksum=5cad1fd22f309ddd7b996df748aa21ced72f88d47fdbb8d4bfd9ef3a8a9b6ce9
+checksum=1bd02902fae49351fb16ac0d5ccc3bf4d67aa0640006dbbf8846963519b01ab8
 python_version=3
 
 _kernver="${version}_${revision}"
@@ -45,18 +44,17 @@ mutable_files="
  /usr/lib/modules/${_kernver}/modules.alias.bin
  /usr/lib/modules/${_kernver}/modules.devname"
 
-_arch=
-_image_target=
-_image_name=
 case "$XBPS_TARGET_MACHINE" in
 	armv6l*) _arch=arm; _image_target=zImage; _image_name=kernel.img ;;
 	armv7l*) _arch=arm; _image_target=zImage; _image_name=kernel7.img ;;
 	aarch64*) _arch=arm64; _image_target=Image.gz; _image_name=kernel8.img ;;
+	*) broken="No Raspberry Pi exists for this arch" ;;
 esac
 
-_cross=
 if [ "$CROSS_BUILD" ]; then
 	_cross="CROSS_COMPILE=${XBPS_CROSS_TRIPLET}-"
+else
+	_cross=
 fi
 
 do_configure() {
@@ -72,27 +70,79 @@ do_configure() {
 	esac
 
 	defconfig="arch/${_arch}/configs/${target}"
-	echo "CONFIG_CONNECTOR=y" >> "$defconfig"
-	echo "CONFIG_PROC_EVENTS=y" >> "$defconfig"
+	cp "$defconfig" .config
 
-	# HID Controllers
-	echo "CONFIG_HID_STEAM=y" >> "$defconfig"
+	cat <<-! > "foo"
+	CONFIG_CONNECTOR=y
+	CONFIG_HID_STEAM=y
+	CONFIG_PROC_EVENTS=y
+	CONFIG_GCC_PLUGINS=n
+	CONFIG_BRIDGE_VLAN_FILTERING=y
+	CONFIG_FUNCTION_TRACER=n
+	CONFIG_STACK_TRACER=n
+	CONFIG_ATM=n
+	CONFIG_SLAB_FREELIST_RANDOM=y
+	CONFIG_CGROUP_PIDS=y
+	CONFIG_SLAB_FREELIST_HARDENED=y
+	CONFIG_PACKET=m
+	CONFIG_NF_CT_PROTO_DCCP=y
+	CONFIG_NF_CT_PROTO_SCTP=y
+	CONFIG_NF_CT_PROTO_UDPLITE=y
+	CONFIG_BATMAN_ADV=n
+	CONFIG_INPUT_LEDS=m
+	CONFIG_SQUASHFS_LZ4=y
+	CONFIG_STRICT_DEVMEM=y
+	CONFIG_IO_STRICT_DEVMEM=y
+	CONFIG_ENCRYPTED_KEYS=m
+	CONFIG_KEY_DH_OPERATIONS=y
+	CONFIG_HARDENED_USERCOPY=y
+	CONFIG_LOCALVERSION="_${revision}"
+	CONFIG_IP_PNP=n
+	CONFIG_USB_DWC2=m
+	CONFIG_USB_ETH=m
+	CONFIG_RTC_HCTOSYS=y
+	CONFIG_RTC_HCTOSYS_DEVICE="rtc0"
+	CONFIG_RTC_DRV_DS1307=y
+	CONFIG_I2C_BCM2835=y
+	CONFIG_MEMCG=y
+	CONFIG_CGROUP_PIDS=y
+	CONFIG_CGROUP_DEVICE=y
+	CONFIG_CPU_FREQ_DEFAULT_GOV_SCHEDUTIL=y
+	CONFIG_PSI=y
+	CONFIG_ZSTD_COMPRESS=y
+	CONFIG_LZ4_COMPRESS=y
+	CONFIG_CRYPTO_RNG=y
+	CONFIG_CRYPTO_RNG_DEFAULT=y
+	!
 
-	# Disable GCC plugins
-	echo "# CONFIG_GCC_PLUGINS is not set" >> "$defconfig"
+	while read -r line; do
+		# skip comments
+		case "$line" in
+			"#"*) continue;;
+		esac
+		local option=${line%%=*} str=
+		local cmd="$(echo "$line" | cut -d= -f2)"
+		case "$cmd" in
+			y) cmd="enable";;
+			n) cmd="disable";;
+			m) cmd="module";;
+			'"'*) cmd="set-str"; str="${line#*=}";;
+			[0-9]*) cmd="set-val"; str="${line#*=}";;
+			'') continue ;;
+			*) msg_error "Command $cmd not accepted\n" ;;
+		esac
+		msg_normal "config: $cmd: $option $str\n"
+		./scripts/config \
+			--file .config \
+			"--$cmd" "$option" "${str//\"/}"
+	done < foo
 
-	# LXD 4.2+ support
-	echo "CONFIG_BRIDGE_VLAN_FILTERING=y" >> "$defconfig"
-
-	make ${makejobs} ${_cross} ARCH=${_arch} ${target}
-
-	# Always use our revision to CONFIG_LOCALVERSION to match our pkg version.
-	vsed -i -e "s|^\(CONFIG_LOCALVERSION=\).*|\1\"_${revision}\"|" .config
+	make "${makejobs}" "${_cross}" ARCH="${_arch}" olddefconfig
 }
 
 do_build() {
-	make ${makejobs} ${_cross} ARCH=${_arch} prepare
-	make ${makejobs} ${_cross} ARCH=${_arch} ${_image_target} modules dtbs
+	make "${makejobs}" "${_cross}" ARCH="${_arch}" prepare
+	make "${makejobs}" "${_cross}" ARCH="${_arch}" "${_image_target}" modules dtbs
 }
 
 do_install() {
@@ -102,110 +152,104 @@ do_install() {
 	vsed -i -e '2iexit 0' scripts/depmod.sh
 
 	# Install kernel, firmware and modules
-	make ${makejobs} ARCH=${_arch} INSTALL_MOD_PATH=${DESTDIR} modules_install
+	make "${makejobs}" ARCH="${_arch}" INSTALL_MOD_PATH="${DESTDIR}" modules_install
 
 	# Install device tree blobs
-	make ${makejobs} ARCH=${_arch} INSTALL_DTBS_PATH=${DESTDIR}/boot dtbs_install
+	make "${makejobs}" "ARCH=${_arch}" INSTALL_DTBS_PATH="${DESTDIR}/boot" dtbs_install
 
 	# move dtbs that ended up in /boot/broadcom
 	if [ -d "${DESTDIR}/boot/broadcom" ]; then
-		mv ${DESTDIR}/boot/broadcom/*dtb ${DESTDIR}/boot
+		mv "${DESTDIR}"/boot/broadcom/*dtb "${DESTDIR}/boot"
 	fi
 
 	# Install kernel image
-	vinstall arch/${_arch}/boot/${_image_target} 644 boot ${_image_name}
+	vinstall "arch/${_arch}/boot/${_image_target}" 644 boot "${_image_name}"
 
 	# Switch to /usr.
 	vmkdir usr
-	mv ${DESTDIR}/lib ${DESTDIR}/usr
+	mv "${DESTDIR}/lib" "${DESTDIR}/usr"
 
-	cd ${DESTDIR}/usr/lib/modules/${_kernver}
+	pushd "${DESTDIR}/usr/lib/modules/${_kernver}"
 	rm -f source build
-	ln -sf ../../../src/${sourcepkg}-headers-${_kernver} build
+	ln -sf "../../../src/${sourcepkg}-headers-${_kernver}" build
+	popd
 
-	cd ${wrksrc}
 	# Install required headers to build external modules
-	install -Dm644 Makefile ${hdrdest}/Makefile
-	install -Dm644 kernel/Makefile ${hdrdest}/kernel/Makefile
-	install -Dm644 .config ${hdrdest}/.config
-	for file in $(find . -name Kconfig\*); do
-		mkdir -p ${hdrdest}/$(dirname $file)
-		install -Dm644 $file ${hdrdest}/${file}
-	done
-	for file in $(find arch/${_arch} scripts -name module.lds -o -name Kbuild.platforms -o -name Platform); do
-		mkdir -p ${hdrdest}/$(dirname $file)
-		install -Dm644 $file ${hdrdest}/${file}
-	done
-	mkdir -p ${hdrdest}/include
+	install -Dm644 Makefile "${hdrdest}/Makefile"
+	install -Dm644 Kbuild "${hdrdest}/Kbuild"
+	install -Dm644 kernel/Makefile "${hdrdest}/kernel/Makefile"
+	install -Dm644 .config "${hdrdest}/.config"
+	while read -r file; do
+		mkdir -p "${hdrdest}/$(dirname "$file")"
+		install -Dm644 "$file" "${hdrdest}/${file}"
+	done < <(find . -name 'Kconfig*')
+	while read -r file; do
+		mkdir -p "${hdrdest}/$(dirname $file)"
+		install -Dm644 "$file" "${hdrdest}/${file}"
+	done < <(find "arch/${_arch}" scripts -name module.lds -o -name Kbuild.platforms -o -name Platform)
+	mkdir -p "${hdrdest}/include"
 
 	# Remove firmware stuff provided by the "linux-firmware" pkg.
-	rm -rf ${DESTDIR}/usr/lib/firmware
+	rm -rf "${DESTDIR}/usr/lib/firmware"
 
 	for i in acpi asm-generic clocksource config crypto drm dt-bindings generated linux \
 		math-emu media net pcmcia scsi sound trace uapi vdso video xen; do
-		[ -d include/$i ] && cp -a include/$i ${hdrdest}/include
+		[ -d include/$i ] && cp -a "include/$i" "${hdrdest}/include"
 	done
 
-	cd ${wrksrc}
 	# Remove helper binaries built for host,
 	# if generated files from the scripts/ directory need to be included,
 	# they need to be copied to ${hdrdest} before this step
 	if [ "$CROSS_BUILD" ]; then
-		make ${makejobs} ARCH=${_arch} _mrproper_scripts
+		make "${makejobs}" ARCH="${_arch}" _mrproper_scripts
 		# remove host specific objects as well
 		find scripts -name '*.o' -delete
 	fi
 
 	# Copy files necessary for later builds.
-	cp Module.symvers ${hdrdest}
-	cp -a scripts ${hdrdest}
-	mkdir -p ${hdrdest}/security/selinux
-	cp -a security/selinux/include ${hdrdest}/security/selinux
-	mkdir -p ${hdrdest}/tools/include
-	cp -a tools/include/tools ${hdrdest}/tools/include
+	cp Module.symvers "${hdrdest}"
+	cp -a scripts "${hdrdest}"
+	mkdir -p "${hdrdest}/security/selinux"
+	cp -a security/selinux/include "${hdrdest}/security/selinux"
+	mkdir -p "${hdrdest}/tools/include"
+	cp -a tools/include/tools "${hdrdest}/tools/include"
 	if [ -d "arch/${_arch}/tools" ]; then
-		cp -a arch/${_arch}/tools ${hdrdest}/arch/${_arch}
+		cp -a "arch/${_arch}/tools" "${hdrdest}/arch/${_arch}"
 	fi
+	cp -a kernel/time/timeconst.bc "${hdrdest}/kernel/time"
+	cp -a kernel/bounds.c "${hdrdest}/kernel"
+	mkdir -p "${hdrdest}/arch/x86/entry/syscalls"
+	cp -a arch/x86/entry/syscalls/syscall_32.tbl "${hdrdest}/arch/x86/entry/syscalls"
 
 	# copy arch includes for external modules
-	mkdir -p ${hdrdest}/arch/${_arch}
-	cp -a arch/${_arch}/include ${hdrdest}/arch/${_arch}
+	mkdir -p "${hdrdest}/arch/${_arch}"
+	cp -a "arch/${_arch}/include" "${hdrdest}/arch/${_arch}"
 
-	mkdir -p ${hdrdest}/arch/${_arch}/kernel
-	cp arch/${_arch}/Makefile ${hdrdest}/arch/${_arch}
-	cp arch/${_arch}/kernel/asm-offsets.s ${hdrdest}/arch/${_arch}/kernel
+	mkdir -p "${hdrdest}/arch/${_arch}/kernel"
+	cp "arch/${_arch}/Makefile" "${hdrdest}/arch/${_arch}"
+	cp "arch/${_arch}/kernel/asm-offsets.s" "${hdrdest}/arch/${_arch}/kernel"
 	if [ "$_arch" = "arm64" ] ; then
-		cp -a arch/${_arch}/kernel/vdso ${hdrdest}/arch/${_arch}/kernel/
+		cp -a "arch/${_arch}/kernel/vdso" "${hdrdest}/arch/${_arch}/kernel/"
 	fi
 
 	# Add md headers
-	mkdir -p ${hdrdest}/drivers/md
-	cp drivers/md/*.h ${hdrdest}/drivers/md
+	mkdir -p "${hdrdest}/drivers/md"
+	cp drivers/md/*.h "${hdrdest}/drivers/md"
 
 	# Add inotify.h
-	mkdir -p ${hdrdest}/include/linux
-	cp include/linux/inotify.h ${hdrdest}/include/linux
+	mkdir -p "${hdrdest}/include/linux"
+	cp include/linux/inotify.h "${hdrdest}/include/linux"
 
 	# Add wireless headers
-	mkdir -p ${hdrdest}/net/mac80211/
-	cp net/mac80211/*.h ${hdrdest}/net/mac80211
-
-	# Remove unneeded architectures
-	# (save the correct one + Kconfig and delete all others)
-	mkdir -p arch-backup
-	cp -r ${hdrdest}/arch/${_arch} ${hdrdest}/arch/Kconfig arch-backup/
-	rm -rf ${hdrdest}/arch
-	mv arch-backup ${hdrdest}/arch
-	# Keep arch/x86/ras/Kconfig as it is needed by drivers/ras/Kconfig
-	mkdir -p ${hdrdest}/arch/x86/ras
-	cp -a arch/x86/ras/Kconfig ${hdrdest}/arch/x86/ras/Kconfig
+	mkdir -p "${hdrdest}/net/mac80211/"
+	cp net/mac80211/*.h "${hdrdest}/net/mac80211"
 
 	# Compress all modules with xz to save a few MBs.
 	msg_normal "$pkgver: compressing kernel modules with gzip, please wait...\n"
-	find ${DESTDIR} -name '*.ko' | xargs -n1 -P0 gzip -9
+	find "${DESTDIR}" -name '*.ko' | xargs -n1 -P0 gzip -9
 
 	# ... and run depmod again.
-	depmod -b ${DESTDIR}/usr -F System.map ${_kernver}
+	depmod -b "${DESTDIR}/usr" -F System.map "${_kernver}"
 }
 
 subpackages="rpi-kernel-headers"

--- a/srcpkgs/rpi-userland/template
+++ b/srcpkgs/rpi-userland/template
@@ -1,19 +1,17 @@
 # Template file for 'rpi-userland'
-_githash="97bc8180ad682b004ea224d1db7b8e108eda4397"
-_gitshort="${_githash:0:7}"
-
 pkgname=rpi-userland
-version=20210623
+version=20230920
 revision=1
+_githash="44a3953fd13d5f0b9b0cd120b904aa7db370244e"
 build_style=cmake
-hostmakedepends="pkg-config"
 configure_args="-DCMAKE_INSTALL_RPATH=\$ORIGIN/../lib"
-short_desc="Raspberry Pi GPU userland libraries and utilities (git ${_gitshort})"
+hostmakedepends="pkg-config"
+short_desc="Raspberry Pi GPU userland libraries and utilities"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="BSD-3-Clause"
 homepage="https://github.com/raspberrypi/userland"
 distfiles="https://github.com/raspberrypi/userland/archive/${_githash}.tar.gz"
-checksum=d67def03931215f41b741aed5a3a1bc2bd62fa33f5cc14692e9a4d65f2e0ea27
+checksum=981c376a110f78fe579a72e218888646ccd5d71ab82d04bb1a8d7be1487b45f0
 
 LDFLAGS="-Wl,--no-as-needed"
 archs="armv6l* armv7l* aarch64*"


### PR DESCRIPTION
- rpi-kernel: update to 6.1.54.
- rpi-firmware: update to 20230920.
- rpi-userland: update to 20230920.

continuation of #43600, made a new PR to clean things up

builds for testing: https://devspace.voidlinux.org/abby/updates/rpi/

#### Testing the changes
- I tested the changes in this PR: **YES**

Still getting the DKMS/headers issue:

When building `fixdep` and `modpost` in `/etc/kernel.d/post-install/10-dkms`, it gets stuck in an infinite makefile loop:

https://github.com/void-linux/void-packages/blob/5b18878cc72b410bc076ac15218f4c5fa0c3fcbf/srcpkgs/dkms/files/kernel.d/dkms.postinst#L22-L24

```
# xbps-reconfigure -f rpi-kernel
rpi-kernel: configuring ...
Executing post-install kernel hook: 10-dkms ...
  SYNC    include/config/auto.conf
  HOSTCC  scripts/basic/fixdep
  HOSTCC  scripts/kconfig/conf.o
  HOSTCC  scripts/kconfig/confdata.o
  HOSTCC  scripts/kconfig/expr.o
  HOSTCC  scripts/kconfig/lexer.lex.o
  HOSTCC  scripts/kconfig/menu.o
  HOSTCC  scripts/kconfig/parser.tab.o
  HOSTCC  scripts/kconfig/preprocess.o
  HOSTCC  scripts/kconfig/symbol.o
  HOSTCC  scripts/kconfig/util.o
  HOSTLD  scripts/kconfig/conf
  HOSTCC  scripts/dtc/dtc.o
  HOSTCC  scripts/dtc/flattree.o
  HOSTCC  scripts/dtc/fstree.o
  HOSTCC  scripts/dtc/data.o
  HOSTCC  scripts/dtc/livetree.o
  HOSTCC  scripts/dtc/treesource.o
  HOSTCC  scripts/dtc/srcpos.o
  HOSTCC  scripts/dtc/checks.o
  HOSTCC  scripts/dtc/util.o
  HOSTCC  scripts/dtc/dtc-lexer.lex.o
  HOSTCC  scripts/dtc/dtc-parser.tab.o
  HOSTLD  scripts/dtc/dtc
  HOSTCC  scripts/dtc/libfdt/fdt.o
  HOSTCC  scripts/dtc/libfdt/fdt_ro.o
  HOSTCC  scripts/dtc/libfdt/fdt_wip.o
  HOSTCC  scripts/dtc/libfdt/fdt_sw.o
  HOSTCC  scripts/dtc/libfdt/fdt_rw.o
  HOSTCC  scripts/dtc/libfdt/fdt_strerror.o
  HOSTCC  scripts/dtc/libfdt/fdt_empty_tree.o
  HOSTCC  scripts/dtc/libfdt/fdt_addresses.o
  HOSTCC  scripts/dtc/libfdt/fdt_overlay.o
  HOSTCC  scripts/dtc/fdtoverlay.o
  HOSTLD  scripts/dtc/fdtoverlay
  HOSTCC  scripts/genksyms/genksyms.o
  HOSTCC  scripts/genksyms/parse.tab.o
  HOSTCC  scripts/genksyms/lex.lex.o
  HOSTLD  scripts/genksyms/genksyms
  HOSTCC  scripts/kallsyms
  HOSTCC  scripts/sorttable
  HOSTCC  scripts/asn1_compiler
  UPD     include/generated/compile.h
  CC      scripts/mod/empty.o
  HOSTCC  scripts/mod/mk_elfconfig
  MKELF   scripts/mod/elfconfig.h
  HOSTCC  scripts/mod/modpost.o
  CC      scripts/mod/devicetable-offsets.s
  UPD     scripts/mod/devicetable-offsets.h
  HOSTCC  scripts/mod/file2alias.o
  HOSTCC  scripts/mod/sumversion.o
  HOSTLD  scripts/mod/modpost
scripts/Makefile.build:425: warning: overriding recipe for target 'built-in.a'
Makefile:1259: warning: ignoring old recipe for target 'built-in.a'
scripts/Makefile.build:440: warning: overriding recipe for target 'modules.order'
Makefile:1923: warning: ignoring old recipe for target 'modules.order'
scripts/Makefile.build:425: warning: overriding recipe for target 'built-in.a'
Makefile:1259: warning: ignoring old recipe for target 'built-in.a'
scripts/Makefile.build:440: warning: overriding recipe for target 'modules.order'
Makefile:1923: warning: ignoring old recipe for target 'modules.order'
scripts/Makefile.build:425: warning: overriding recipe for target 'built-in.a'
Makefile:1259: warning: ignoring old recipe for target 'built-in.a'
scripts/Makefile.build:440: warning: overriding recipe for target 'modules.order'
Makefile:1923: warning: ignoring old recipe for target 'modules.order'
scripts/Makefile.build:425: warning: overriding recipe for target 'built-in.a'
Makefile:1259: warning: ignoring old recipe for target 'built-in.a'
scripts/Makefile.build:440: warning: overriding recipe for target 'modules.order'
Makefile:1923: warning: ignoring old recipe for target 'modules.order'
^Cmake[4]: *** [Makefile:1307: asm-generic] Interrupt
Interrupt
make[3]: *** [Makefile:1289: prepare0] Interrupt
make[2]: *** [Makefile:1289: prepare0] Interrupt
make[1]: *** [Makefile:1289: prepare0] Interrupt
make: *** [Makefile:1289: prepare0] Interrupt
```

However, `^C`ing out of that and re-running it succeeds, because `fixdep` and `modpost` were build before the infinite loop:

```
# xbps-reconfigure -f rpi-kernel
rpi-kernel: configuring ...
Executing post-install kernel hook: 10-dkms ...
rpi-kernel: configured successfully.
```

And dkms works after that:

```
Building DKMS module 'rtl8821cu-5.12.0.4' for kernel-6.1.54_1... done.
Installing DKMS module 'rtl8821cu-5.12.0.4' for kernel-6.1.54_1... done.
rtl8821cu-dkms-20210916_2: installed successfully.
```

So the issue left to figure out is: why does it infinite loop?
