### PR TITLE
qutebrowser: work around drag-and-drop crash on wayland-egl.

### DIFF
--- a/srcpkgs/qutebrowser/patches/fix-wayland-egl-drag-and-drop.patch
+++ b/srcpkgs/qutebrowser/patches/fix-wayland-egl-drag-and-drop.patch
@@ -1,0 +1,23 @@
+From b317038a01094136d06d4cb769b7755450b94f61 Mon Sep 17 00:00:00 2001
+From: Florian Bruhin <me@the-compiler.org>
+Date: Mon, 18 Sep 2023 18:03:21 +0200
+Subject: [PATCH] eventfilter: Also enable workaround on wayland-egl
+
+Will be fixed nicely on main, this is a more minimal fix
+---
+ qutebrowser/keyinput/eventfilter.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/qutebrowser/keyinput/eventfilter.py b/qutebrowser/keyinput/eventfilter.py
+index 306d4405b6d..ce9959bd4e3 100644
+--- a/qutebrowser/keyinput/eventfilter.py
++++ b/qutebrowser/keyinput/eventfilter.py
+@@ -86,7 +86,7 @@ def eventFilter(self, obj: Optional[QObject], event: Optional[QEvent]) -> bool:
+ 
+         if (
+             ev_type == QEvent.Type.DragEnter and
+-            objects.qapp.platformName() == "wayland" and
++            objects.qapp.platformName() in ["wayland", "wayland-egl"] and
+             qVersion() == "6.5.2"
+         ):
+             # WORKAROUND for https://bugreports.qt.io/browse/QTBUG-115757

--- a/srcpkgs/qutebrowser/template
+++ b/srcpkgs/qutebrowser/template
@@ -1,7 +1,7 @@
 # Template file for 'qutebrowser'
 pkgname=qutebrowser
 version=3.0.0
-revision=1
+revision=2
 build_style=python3-module
 hostmakedepends="python3-setuptools asciidoc"
 depends="python3-Jinja2 python3-yaml"


### PR DESCRIPTION
Proper fix coming in Qt 6.5.3.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

@daniel-eys

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
