### PR TITLE
btrfs-progs: update to 6.5.1.

### DIFF
--- a/srcpkgs/btrfs-progs/template
+++ b/srcpkgs/btrfs-progs/template
@@ -1,6 +1,6 @@
 # Template file for 'btrfs-progs'
 pkgname=btrfs-progs
-version=6.3.3
+version=6.5.1
 revision=1
 build_style=gnu-configure
 make_check_target=test
@@ -15,7 +15,7 @@ license="GPL-2.0-only, LGPL-2.1-or-later"
 homepage="https://btrfs.wiki.kernel.org/index.php/Main_Page"
 changelog="https://raw.githubusercontent.com/kdave/btrfs-progs/master/CHANGES"
 distfiles="${KERNEL_SITE}/kernel/people/kdave/btrfs-progs/btrfs-progs-v${version}.tar.xz"
-checksum=4be30015760270d081642cc0023a8bfee7cb657a2aa055644e6a56d68695b96e
+checksum=dacbb28136e82586af802205263a428c3d1941778bc3fdc9b1b386ea12eb904e
 # Most of the tests depend on `mount` and `fallocate` commands, which are not
 # presented in chroot-util-linux
 make_check=no


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
I built this PR locally for these architectures (if supported. mark crossbuilds):
    - armv6l-musl (cross)


