### PR TITLE
gopass{,-jsonapi}: update to 1.15.8.

### DIFF
--- a/srcpkgs/gopass-jsonapi/template
+++ b/srcpkgs/gopass-jsonapi/template
@@ -1,6 +1,6 @@
 # Template file for 'gopass-jsonapi'
 pkgname=gopass-jsonapi
-version=1.15.7
+version=1.15.8
 revision=1
 build_style=go
 go_import_path=github.com/gopasspw/gopass-jsonapi
@@ -12,7 +12,7 @@ license="MIT"
 homepage="https://www.gopass.pw/"
 changelog="https://raw.githubusercontent.com/gopasspw/gopass-jsonapi/master/CHANGELOG.md"
 distfiles="https://github.com/gopasspw/gopass-jsonapi/archive/refs/tags/v${version}.tar.gz"
-checksum=08ec445cc6929c7887caa3c631ab1aa73def89ca35f16160e5ff2ce535a0370b
+checksum=753b1628ab379dea0cd4b599939fb46b11fdc46af76d049e7addc46477bf593c
 
 post_install() {
 	vlicense LICENSE

--- a/srcpkgs/gopass/template
+++ b/srcpkgs/gopass/template
@@ -1,6 +1,6 @@
 # Template file for 'gopass'
 pkgname=gopass
-version=1.15.7
+version=1.15.8
 revision=1
 build_style=go
 build_helper=qemu
@@ -14,7 +14,7 @@ license="MIT"
 homepage="https://www.gopass.pw/"
 changelog="https://raw.githubusercontent.com/gopasspw/gopass/master/CHANGELOG.md"
 distfiles="https://github.com/gopasspw/gopass/archive/v${version}.tar.gz"
-checksum=35d1af333de479e429da31427b70b2043e20ef9a7ab0f8b816867ffc6f44927b
+checksum=20f21e78036fe3b962eee45058ef83f062f0cd21d8155b64e9eaefb96423806e
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture: **x86_64**