### PR TITLE
gbinder-python: update to 1.1.2.

### DIFF
--- a/srcpkgs/gbinder-python/template
+++ b/srcpkgs/gbinder-python/template
@@ -1,10 +1,10 @@
 # Template file for 'gbinder-python'
 pkgname=gbinder-python
-version=1.1.1
-revision=2
+version=1.1.2
+revision=1
 build_style=python3-module
 make_build_args="--cython"
-hostmakedepends="python3-Cython0.29 pkg-config"
+hostmakedepends="python3-Cython pkg-config"
 makedepends="libgbinder-devel python3-devel"
 depends="python3"
 short_desc="Python bindings for libgbinder"
@@ -12,4 +12,4 @@ maintainer="Jami Kettunen <jami.kettunen@protonmail.com>"
 license="GPL-3.0-or-later"
 homepage="https://github.com/erfanoabdi/gbinder-python"
 distfiles="https://github.com/erfanoabdi/gbinder-python/archive/refs/tags/${version}.tar.gz"
-checksum=64ef246a7c538105d92350c88fe8634b4d64e04b45dce95b76abc0d2f3376246
+checksum=2dc424d5c2594146612e4bd752964f8928a62eec7c5ce6046f4c582079d0b537


### PR DESCRIPTION
Also switch to Cython 3.x

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
