### PR TITLE
Add meson awareness to `numpy` helper and `python3-pep517` style

### DIFF
--- a/Manual.md
+++ b/Manual.md
@@ -1083,6 +1083,11 @@ meson for cross builds. This is particularly useful for building packages that w
 invocations (e.g., `python3-pep517` packages that use a meson backend) and is added by default
 for packages that use the `meson` build style.
 
+- `numpy` configures the environment for cross-compilation of python packages that provide
+compiled extensions linking to NumPy C libraries. If the `meson` build helper is also
+configured, a secondary cross file, `${XBPS_WRAPPERDIR}/meson/xbps_numpy.cross`, will be
+written to inform meson where common NumPy components may be found.
+
 - `python3` configures the cross-build environment to use Python libraries, header files, and
 interpreter configurations in the target root. The `python3` helper is added by default for
 packages that use the `python3-module` or `python3-pep517` build styles.

--- a/common/build-helper/numpy.sh
+++ b/common/build-helper/numpy.sh
@@ -34,4 +34,14 @@ if [ "$CROSS_BUILD" ]; then
 		ln -sf "${_gfortran}" "${XBPS_WRAPPERDIR}/gfortran"
 	fi
 	unset _gfortran
+
+	# Write a secondary meson cross file for numpy configuration
+	if [[ "${build_helper}" = *meson* ]]; then
+		mkdir -p "${XBPS_WRAPPERDIR}/meson"
+		cat > "${XBPS_WRAPPERDIR}/meson/xbps_numpy.cross" <<-EOF
+			[properties]
+			numpy-include-dir = '${XBPS_CROSS_BASE}/${py3_sitelib}/numpy/core/include'
+			pythran-include-dir = '${XBPS_CROSS_BASE}/${py3_sitelib}/pythran'
+			EOF
+	fi
 fi

--- a/common/build-style/python3-pep517.sh
+++ b/common/build-style/python3-pep517.sh
@@ -4,8 +4,18 @@
 
 do_build() {
 	: ${make_build_target:=.}
-	: ${make_build_args:=--no-isolation  --wheel}
-	python3 -m build ${make_build_args} ${make_build_target}
+
+	if [ "${CROSS_BUILD}" ] && [[ "${build_helper}" = *meson* ]]; then
+		local mcross="-Csetup-args=--cross-file=${XBPS_WRAPPERDIR}/meson"
+		make_build_args+=" ${mcross}/xbps_meson.cross"
+
+		if [[ "${build_helper}" = *numpy* ]]; then
+			make_build_args+=" ${mcross}/xbps_numpy.cross"
+		fi
+	fi
+
+	python3 -m build --no-isolation --wheel \
+		${make_build_args} ${make_build_target}
 }
 
 do_check() {

--- a/srcpkgs/python3-scikit-image/template
+++ b/srcpkgs/python3-scikit-image/template
@@ -3,7 +3,7 @@ pkgname=python3-scikit-image
 version=0.21.0
 revision=1
 build_style=python3-pep517
-build_helper="meson"
+build_helper="meson numpy"
 hostmakedepends="python3-build python3-installer python3-meson-python
  python3-wheel python3-setuptools python3-packaging python3-Cython pythran
  python3-lazy_loader python3-numpy pkg-config"
@@ -19,23 +19,6 @@ distfiles="https://github.com/scikit-image/scikit-image/archive/v${version}.tar.
 checksum=53a82a9dbd3ed608d2ad3876269a271a7e922b12e228388eac996b508aadd652
 # Tests require data files and unpackaged dependencies
 make_check=no
-
-if [ "${CROSS_BUILD}" ]; then
-	make_build_args+=" --no-isolation --wheel
-	 -Csetup-args=--cross-file=${XBPS_WRAPPERDIR}/meson/xbps_meson.cross
-	 -Csetup-args=--cross-file=${XBPS_WRAPPERDIR}/meson/python.cross"
-fi
-
-post_patch() {
-	if [ "${CROSS_BUILD}" ]; then
-		local _xpy="${XBPS_CROSS_BASE}/${py3_sitelib}"
-		cat > "${XBPS_WRAPPERDIR}/meson/python.cross" <<-EOF
-		[properties]
-		numpy-include-dir = '${_xpy}/numpy/core/include'
-		pythran-include-dir = '${_xpy}/pythran'
-		EOF
-	fi
-}
 
 pre_build() {
 	if [ "${CROSS_BUILD}" ]; then

--- a/srcpkgs/python3-scipy/template
+++ b/srcpkgs/python3-scipy/template
@@ -3,9 +3,10 @@ pkgname=python3-scipy
 version=1.11.2
 revision=1
 build_style=python3-pep517
-build_helper="meson"
-make_build_args="--no-isolation --wheel
- $(vopt_if openblas "" "-Csetup-args=-Dblas=blas -Csetup-args=-Dlapack=lapack")"
+build_helper="meson numpy"
+make_build_args="
+ $(vopt_if openblas "" "-Csetup-args=-Dblas=blas -Csetup-args=-Dlapack=lapack")
+"
 hostmakedepends="python3-build python3-installer python3-meson-python
  python3-wheel python3-Cython python3-pybind11 pythran python3-numpy
  gcc-fortran pkg-config"
@@ -23,11 +24,6 @@ make_check="no" # Tests need an installed copy to run and meson makes this tough
 build_options="openblas"
 
 if [ "$CROSS_BUILD" ]; then
-	make_build_args+="
-	 -Csetup-args=--cross-file=${XBPS_WRAPPERDIR}/meson/xbps_meson.cross
-	 -Csetup-args=--cross-file=${XBPS_WRAPPERDIR}/meson/python.cross
-	"
-
 	_pybind11_dir="${py3_sitelib}/pybind11"
 	export PKG_CONFIG_PATH="${XBPS_CROSS_BASE}/${_pybind11_dir}/share/pkgconfig"
 	# pybind11 uses a path relative to the pkgconfig file to set $prefix,
@@ -50,17 +46,6 @@ if [ "$build_option_openblas" ]; then
 		ppc*) broken="numpy can't be built with openblas";;
 	esac
 fi
-
-post_patch() {
-	if [ "$CROSS_BUILD" ]; then
-		local _xpy="${XBPS_CROSS_BASE}/${py3_sitelib}"
-		cat > "${XBPS_WRAPPERDIR}/meson/python.cross" <<-EOF
-			[properties]
-			numpy-include-dir = '${_xpy}/numpy/core/include'
-			pythran-include-dir = '${_xpy}/pythran'
-			EOF
-	fi
-}
 
 pre_build() {
 	if [ "$CROSS_BUILD" ]; then


### PR DESCRIPTION
Now that a `meson` build helper exists, we can further remove redundancy in some numeric python packages. In addition to the two cleaned up here, I believe we have some pending PRs that would benefit from these changes.

While I'm touching the `numpy` helper, I might as well fix its missing documentation.

cc: @tornaria 

#### Testing the changes
- I tested the changes in this PR: **YES**