### PR TITLE
mupdf and zathura-mupdf-pdf: rebuild for jbig2dec

### DIFF
--- a/srcpkgs/fbpdf/template
+++ b/srcpkgs/fbpdf/template
@@ -1,7 +1,7 @@
 # Template file for 'fbpdf'
 pkgname=fbpdf
 version=0.0.20220624
-revision=1
+revision=2
 _githash=6276360f47edd71de736e153f5dcc82b6d60b3db
 _gitshort="${_githash:0:7}"
 build_style=gnu-makefile

--- a/srcpkgs/mupdf/template
+++ b/srcpkgs/mupdf/template
@@ -1,7 +1,7 @@
 # Template file for 'mupdf'
 pkgname=mupdf
 version=1.20.3
-revision=2
+revision=3
 hostmakedepends="pkg-config zlib-devel libcurl-devel freetype-devel
  libjpeg-turbo-devel jbig2dec-devel libXext-devel libXcursor-devel
  libXrandr-devel libXinerama-devel harfbuzz-devel readline-devel

--- a/srcpkgs/sioyek/template
+++ b/srcpkgs/sioyek/template
@@ -1,7 +1,7 @@
 # Template file for 'sioyek'
 pkgname=sioyek
 version=2.0.0
-revision=3
+revision=4
 build_style=qmake
 configure_args="pdf_viewer_build_config.pro"
 hostmakedepends="qt5-qmake qt5-host-tools

--- a/srcpkgs/zathura-pdf-mupdf/template
+++ b/srcpkgs/zathura-pdf-mupdf/template
@@ -1,7 +1,7 @@
 # Template file for 'zathura-pdf-mupdf'
 pkgname=zathura-pdf-mupdf
 version=0.4.1
-revision=1
+revision=2
 build_style=meson
 hostmakedepends="pkg-config"
 makedepends="mupdf-devel zathura-devel libopenjpeg2-devel tesseract-ocr-devel


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**
Fixes: #46184

I have a pdf that cannot be loaded before / can be loaded after.

Maybe sioyek and fbpdf also have to be rebuilt.

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
