### PR TITLE
Fix handling of symlinked pkg-config files when purging $XBPS_CROSS_BASE refs

### DIFF
--- a/common/hooks/post-install/13-pkg-config-clean-xbps-cross-base-ref.sh
+++ b/common/hooks/post-install/13-pkg-config-clean-xbps-cross-base-ref.sh
@@ -16,7 +16,8 @@ hook() {
 			# s,/usr/armv7l-linux-musleabihf/usr,/usr,g
 			# trailing /usr to avoid clashing with
 			# other $XBPS_CROSS_BASE and $XBPS_CROSS_TRIPLET.
-			sed -i -e "s,$XBPS_CROSS_BASE/usr,/usr,g" "$f"
+			sed -i --follow-symlinks \
+				-e "s,$XBPS_CROSS_BASE/usr,/usr,g" "$f"
 		fi
 	done
 }

--- a/srcpkgs/python3-pybind11/template
+++ b/srcpkgs/python3-pybind11/template
@@ -1,7 +1,7 @@
 # Template file for 'python3-pybind11'
 pkgname=python3-pybind11
 version=2.11.1
-revision=2
+revision=3
 build_style=python3-module
 hostmakedepends="cmake python3-setuptools
  python3-pytest python3-sphinx_rtd_theme python3-breathe"


### PR DESCRIPTION
Packages (e.g., `python3-pybind11`) that symlink to `*.pc` files in `/usr/{lib,share}/pkgconfig` will have those links overwritten with actual copies of the files after the hook

    common/hooks/post-install/13-pkg-config-clean-xbps-cross-base-ref.sh

attempts to remove `$XBPS_CROSS_BASE` from paths. This will result in the new copy containing corrected paths, but the original file remaining uncorrected.

This was stolen fro @tornaria.

#### Testing the changes
- I tested the changes in this PR: **YES**|**briefly**|**NO**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
