### PR TITLE
[RFC] do not install checkdepends when check is not going to run

### DIFF
--- a/common/xbps-src/shutils/build_dependencies.sh
+++ b/common/xbps-src/shutils/build_dependencies.sh
@@ -137,7 +137,11 @@ install_pkg_deps() {
     local -a host_missing_deps missing_deps missing_rdeps
 
     [ -z "$pkgname" ] && return 2
-    [ -z "$XBPS_CHECK_PKGS" ] && unset checkdepends
+    [ -z "$XBPS_CHECK_PKGS" ] ||
+        [ "$XBPS_CROSS_BUILD" ] ||
+        [ "$make_check" = ci-skip  -a "$XBPS_BUILD_ENVIRONMENT" = void-packages-ci ] ||
+        [ "$make_check" = extended -a "$XBPS_CHECK_PKGS" != full ] ||
+        [ "$make_check" = no ] && unset checkdepends
 
     if [[ $build_style ]] || [[ $build_helper ]]; then
         style=" with"
@@ -208,7 +212,7 @@ install_pkg_deps() {
     #
     # Host check dependencies.
     #
-    if [[ ${checkdepends} ]] && [[ $XBPS_CHECK_PKGS ]] && [ -z "$XBPS_CROSS_BUILD" ]; then
+    if [[ ${checkdepends} ]]; then
         templates=""
         # check validity
         for f in ${checkdepends}; do


### PR DESCRIPTION
This is useful e.g. to break build <-> check cycles.

For instance, one can set `make_check=extended` so check doesn't run on CI or -Q (maybe the check depencies are updated at the same time), but it's still easy to run check using -K after dependencies have been built.

I'm working on jupyter notebook packages, and there are a few build <-> check cycles. I want to try to arrange checks so that `-Q` will check as much as possible without cycles, and `-K` will do full check (assuming all dependencies are already packaged).

Without this patch one needs to add packages to `checkdepends` conditionally on `$XBPS_CHECK_PKGS`, but it seems simpler this way.


<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
