### PR TITLE
system-monitoring-center: update to 2.25.0

### DIFF
--- a/srcpkgs/system-monitoring-center/template
+++ b/srcpkgs/system-monitoring-center/template
@@ -1,6 +1,6 @@
 # Template file for 'system-monitoring-center'
 pkgname=system-monitoring-center
-version=2.22.1
+version=2.25.0
 revision=1
 build_style=meson
 hostmakedepends="kdelibs4support-devel gettext"
@@ -12,4 +12,4 @@ license="GPL-3.0-only"
 homepage="https://github.com/hakandundar34coding/system-monitoring-center"
 changelog="https://raw.githubusercontent.com/hakandundar34coding/system-monitoring-center/master/Changes.md"
 distfiles="https://github.com/hakandundar34coding/system-monitoring-center/archive/refs/tags/v${version}.tar.gz"
-checksum=c4ed7e6c3ac403b4a44d05d8fb10fce0c6761631f7e3423eb67038c1fd7afeee
+checksum=1af73b361cce6f7d5701d0fc6a11645555ebc4a5dc539f5a7054505b4834c410


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, (x64 glibc)