### PR TITLE
tuigreet: add /var/cache/tuigreet to make_dirs

### DIFF
--- a/srcpkgs/tuigreet/template
+++ b/srcpkgs/tuigreet/template
@@ -1,7 +1,7 @@
 # Template file for 'tuigreet'
 pkgname=tuigreet
 version=0.8.0
-revision=2
+revision=3
 build_style=cargo
 hostmakedepends="scdoc"
 depends="greetd"
@@ -12,6 +12,7 @@ homepage="https://github.com/apognu/tuigreet"
 distfiles="https://github.com/apognu/tuigreet/archive/refs/tags/${version}.tar.gz"
 checksum=ed371ebe288a3e5782f01681c6c4ed4786b470184af286fa0e7b8898e47c154e
 tags="greeter"
+make_dirs="/var/cache/tuigreet 0755 _greeter _greeter"
 
 post_build() {
 	scdoc < contrib/man/tuigreet-1.scd > tuigreet.1


### PR DESCRIPTION
It's needed for `--remember*` options

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**|**briefly**|**NO**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
