### PR TITLE
New package: neomutt-autocrypt-20230517

### DIFF
--- a/srcpkgs/neomutt-autocrypt/template
+++ b/srcpkgs/neomutt-autocrypt/template
@@ -1,0 +1,88 @@
+# Template file for 'neomutt-autocrypt'
+pkgname=neomutt-autocrypt
+version=20230517
+revision=1
+create_wrksrc=true
+build_wrksrc="neomutt-${version}"
+build_style=configure
+configure_args="--ssl --gpgme --notmuch --gdbm --lua --sasl --zlib --tdb
+ --rocksdb --autocrypt --sqlite"
+make_check_target=test
+conf_files="/etc/neomuttrc"
+# neomutt needs either w3m/lynx/elinks to build manual.html
+hostmakedepends="docbook-xsl gettext libxslt perl tcl w3m pkg-config"
+makedepends="aspell-devel gdbm-devel gettext-devel gpgme-devel
+ rocksdb-devel tdb-devel ncurses-devel libidn2-devel libnotmuch-devel
+ openssl-devel libsasl-devel lua54-devel zlib-devel sqlite-devel"
+depends="mime-types"
+short_desc="Mutt with misc fixes and feature patches with autocrypt"
+maintainer="Petr Cizmar <xxb0322@xpc.ovh>"
+license="GPL-2.0-or-later"
+homepage="https://neomutt.org/"
+_test_files_hash=34f79ee9d91863a97f6e18700aea51157b8610cf
+distfiles="https://github.com/neomutt/neomutt/archive/${version}.tar.gz
+ https://github.com/neomutt/neomutt-test-files/archive/${_test_files_hash}.tar.gz"
+checksum="4ac277b40e7ed5d67ba516338e2b26cc6810aa37564f6e9a2d45eb15b3a9213e
+ 4507e70e7c8512c993d9188cf320aea601580345ae9fb0c399ed1402d4e39b1f"
+conflicts=neomutt
+python_version=3
+
+# fix:
+if [ "${XBPS_CROSS_BASE}" ]; then
+	configure_args="${configure_args} --host=$XBPS_CROSS_TRIPLET"
+	configure_args="${configure_args} --build=$XBPS_TRIPLET"
+	configure_args="${configure_args} --with-sysroot=$XBPS_CROSS_BASE"
+fi
+
+case "${XBPS_TARGET_MACHINE}" in
+	x86_64-musl)
+		# FIXME: error: variable 'fp' has initializer but incomplete type
+		make_check=no # https://github.com/neomutt/neomutt/issues/3865
+		CFLAGS="-D_FILE_OFFSET_BITS=64 -DLARGEFILE_SOURCE=1"
+		;;
+	*-musl)
+		make_check=no # Same as in the x86_64-musl condition
+		;;
+	# Inquiry: Do we have largefile support on everywhere?
+esac
+
+post_install() {
+	# move dist to examples dir
+	vsconf contrib/oauth2/mutt_oauth2.py Muttrc.mutt_oauth2.dist
+	vsconf contrib/vim-keys/vim-keys.rc Muttrc.vim-keys.dist
+	vsconf contrib/smime_keys Muttrc.smime_keys.dist
+}
+
+pre_check() {
+	(
+	 cd ${wrksrc}/neomutt-test-files-${_test_files_hash}/
+	 ./setup.sh
+	)
+	export NEOMUTT_TEST_DIR=${wrksrc}/neomutt-test-files-${_test_files_hash}
+}
+
+post_check() {
+	# This is a file chmodded to 311 and can't be removed normally
+	chmod 777 ${wrksrc}/neomutt-test-files-${_test_files_hash}/maildir/damson
+}
+
+# REMARKS:
+# Conf file is in a --sysconfdir=/etc/$pkgname/Muttrc and then alternatives to
+# /etc/Muttrc. In addition, a dependency on mime-types is broken by having
+# /etc/dir/ because mutt probably expects the mime information in the same
+# dir as sysconfdir. Thus a symlink is created to deal with this.
+# /etc/Muttrc is not currently in alternatives to prevent inadvertently
+# overwriting configuration.
+# In version 20160808 keybase integration was added, and lots of new
+# documentation now gets installed. Rumors of an /etc/NeoMuttrc are in the
+# release notes but not currently installed for unknown reasons.
+# As of 20171013, neomutt has hard forked and no longer refers to itself as
+# "Mutt" anywhere in the codebase. https://www.neomutt.org/2017/10/13/release
+# /etc/neomuttrc now exists, and there are no conflicts with regular mutt.
+# Due to this, an install.msg was added and all alternatives were removed.
+# Cross compiling was fixed in 20180323
+# 20200417 had some build changes, none referenced explicitly by our templates.
+# It also added a need for a special directory for unit tests, refered here by
+# commit hash (due to a lack of versioning)
+# Currently a shebang for keybase is rewritten to python2. That should be
+# fixed. In fact, it turns out to be a py3 only file. Fixed as of 20200424.


### PR DESCRIPTION
It is just a slight modification of the neomutt package. I just added support for *autocrypt*. I don't know what the reaseons for not having autocrypt enabled in neomutt is, so I created this new package. However, maybe it would be better just to enable it.

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64
