### PR TITLE
newsboat: update to 2.33

### DIFF
--- a/srcpkgs/newsboat/template
+++ b/srcpkgs/newsboat/template
@@ -1,6 +1,6 @@
 # Template file for 'newsboat'
 pkgname=newsboat
-version=2.32
+version=2.33
 revision=1
 build_style=configure
 build_helper="rust"
@@ -17,7 +17,7 @@ license="MIT"
 homepage="https://newsboat.org/"
 changelog="https://raw.githubusercontent.com/newsboat/newsboat/master/CHANGELOG.md"
 distfiles="https://newsboat.org/releases/${version}/newsboat-${version}.tar.xz"
-checksum=5b63514572a21e93f4dd3dd6c58f44fdbd9c9e6c6f978329a4766aabb13be6e6
+checksum=179d0d5e608337f14e5e670c0a6b144129ed4e504621ca2a117d188894cb34fa
 python_version=3
 
 # tests fail when run by superuser


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)