### PR TITLE
gocryptfs: switch dependency to fuse3

### DIFF
--- a/srcpkgs/gocryptfs/template
+++ b/srcpkgs/gocryptfs/template
@@ -1,12 +1,12 @@
 # Template file for 'gocryptfs'
 pkgname=gocryptfs
 version=2.3.1
-revision=3
+revision=4
 build_style=go
 go_import_path="github.com/rfjakob/gocryptfs/v2"
 go_build_tags="without_openssl"
 go_ldflags="-X main.GitVersion=v${version} -X main.GitVersionFuse="[vendored]" -X main.BuildDate=$(date +%Y-%m-%d)"
-depends="fuse"
+depends="fuse3"
 short_desc="Encrypted overlay filesystem written in Go"
 maintainer="Felipe Nogueira <contato.fnog@gmail.com>"
 license="MIT"


### PR DESCRIPTION
go-fuse supports both `fusermount` and `fusermount3` ([relevant code](https://github.com/hanwen/go-fuse/blob/22567ce3f39cc9dd6b30249282227d4c41f9a193/fuse/mount_linux.go#L248))

Tested by adding `ignorepkg=fuse` to xbps.conf, removing it and mounting a directory with `gocryptfs`.

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)

