### PR TITLE
wpa_supplicant: log to stdout instead of syslog

### DIFF
--- a/srcpkgs/wpa_supplicant/files/wpa_supplicant/run
+++ b/srcpkgs/wpa_supplicant/files/wpa_supplicant/run
@@ -1,10 +1,10 @@
 #!/bin/sh
 if [ -r ./conf ]; then
 	. ./conf
-	: ${OPTS:=-M -c ${CONF_FILE:-/etc/wpa_supplicant/wpa_supplicant.conf} ${WPA_INTERFACE:+-i ${WPA_INTERFACE}} ${DRIVER:+-D ${DRIVER}} -s}
+	: ${OPTS:=-M -c ${CONF_FILE:-/etc/wpa_supplicant/wpa_supplicant.conf} ${WPA_INTERFACE:+-i ${WPA_INTERFACE}} ${DRIVER:+-D ${DRIVER}} }
 else
 	. ./auto
-	OPTS="${AUTO} -s"
+	OPTS="${AUTO}"
 fi
 
 exec 2>&1

--- a/srcpkgs/wpa_supplicant/template
+++ b/srcpkgs/wpa_supplicant/template
@@ -1,7 +1,7 @@
 # Template file for 'wpa_supplicant'
 pkgname=wpa_supplicant
 version=2.10
-revision=3
+revision=4
 build_wrksrc="$pkgname"
 short_desc="WPA/WPA2/IEEE 802.1X Supplicant"
 maintainer="Enno Boland <gottox@voidlinux.org>"


### PR DESCRIPTION
A long time ago the wpa_supplicant service was changed[0] to log to syslog by default instead of the stdout.  This setting was carrier through a number of changes and persists to this day.  As such, wpa_supplicant will not log via the log/run mechanism as expected by default.

Remove the -s flag from the default and auto options so wpa_supplicant logs to stdout (and hence log/run) as expected for runit services.

[0] 62ae6738b59 (wpa_supplicant: log to syslog by default)



#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architectures, (x86_64-musl, armv6l-musl)

