### PR TITLE
ibus-hangul: update to 1.5.5

### DIFF
--- a/srcpkgs/ibus-hangul/template
+++ b/srcpkgs/ibus-hangul/template
@@ -1,19 +1,24 @@
 # Template file for 'ibus-hangul'
 pkgname=ibus-hangul
-version=1.5.3
+version=1.5.5
 revision=1
 build_style=gnu-configure
 configure_args="--libexec=/usr/lib/ibus --with-python=/usr/bin/python3"
 hostmakedepends="gettext libtool pkg-config swig"
-makedepends="ibus-devel libhangul-devel"
+makedepends="gtk+3-devel ibus-devel libhangul-devel"
 depends="ibus librsvg python3-gobject"
 short_desc="Korean input engine for IBus"
 maintainer="Michael Aldridge <maldridge@voidlinux.org>"
 license="GPL-2.0-or-later"
-homepage="https://github.com/choehwanjin/ibus-hangul"
-distfiles="${homepage}/releases/download/${version}/${pkgname}-${version}.tar.gz"
-checksum=5e661cd77a327b1eafacd537f7d839a61a374e951bd382044e799371855a0090
+homepage="https://github.com/libhangul/ibus-hangul"
+distfiles="${homepage}/releases/download/${version}/${pkgname}-${version}.tar.xz"
+checksum=a5aac88286cd18960229860e3e1a778978a7aeaa484ad9acfa48284b87fdc3bb
 
 if [ "$CROSS_BUILD" ]; then
 	hostmakedepends+=" python3"
 fi
+
+pre_configure() {
+	# tests directory contains interactive tests
+	vsed -e '/tests/d' -i Makefile.in
+}

--- a/srcpkgs/ibus-hangul/update
+++ b/srcpkgs/ibus-hangul/update
@@ -1,1 +1,2 @@
-site="https://github.com/choehwanjin/ibus-hangul/releases"
+site="https://github.com/libhangul/ibus-hangul/releases"
+pattern='Version \K[\d.]+(?=</a>)'


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures:   armv6l (cross-build)

#### Notes

Apparently, [recent versions of Python no longer have `gettext.bind_textdomain_codeset`](https://docs.python.org/3.10/library/gettext.html#gettext.bind_textdomain_codeset).

For recent Pythons, ibus-hangul 1.5.3's `ibus-setup-hangul` can crash with:

```
$ ibus-setup-hangul 
Traceback (most recent call last):
  File "/usr/share/ibus-hangul/setup/main.py", line 298, in <module>
    gettext.bind_textdomain_codeset(config.gettext_package, "UTF-8")
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: module 'gettext' has no attribute 'bind_textdomain_codeset'
```

A [PR for ibus-hangul to address this](https://github.com/libhangul/ibus-hangul/issues/93) was merged some time back and [the 1.5.4 release included the relevant code](https://github.com/libhangul/ibus-hangul/releases/tag/1.5.4).

There was [another release (1.5.5)](https://github.com/libhangul/ibus-hangul/releases/tag/1.5.5) since then and this PR is an update to that one.

---

#### Summary of Changes

* `template`
  * Update `version` and `checksum`
  * Update `makedepends` to include `gtk+3-devel`
  * Update `homepage`
  * Update `distfiles` to use `.xz`
  * Add `pre_configure` to skip the interactive tests in `tests` directory

* `update`
  * Update `site`
  * Add `pattern`