### PR TITLE
maxima-emacs: remove package

### DIFF
--- a/srcpkgs/maxima/template
+++ b/srcpkgs/maxima/template
@@ -1,7 +1,7 @@
 # Template file for 'maxima'
 pkgname=maxima
 version=5.47.0
-revision=2
+revision=3
 build_style=gnu-configure
 configure_args="$(vopt_enable clisp) $(vopt_enable sbcl sbcl-exec) $(vopt_enable ecl)"
 hostmakedepends="python3 perl texinfo patchelf $(vopt_if ecl ecl)"
@@ -114,12 +114,6 @@ maxima-src_package() {
 	}
 }
 
-maxima-emacs_package() {
-	short_desc+=" - transitional dummy package"
-	depends="${sourcepkg}-${version}_${revision} virtual?emacs"
-	build_style=meta
-}
-
 xmaxima_package() {
 	short_desc+=" - Tk interface"
 	depends="${sourcepkg}-${version}_${revision} tk"
@@ -151,4 +145,4 @@ maxima-ecl_package() {
 	}
 }
 
-subpackages="maxima-src maxima-emacs xmaxima $(vopt_if ecl maxima-ecl)"
+subpackages="maxima-src xmaxima $(vopt_if ecl maxima-ecl)"

--- a/srcpkgs/removed-packages/template
+++ b/srcpkgs/removed-packages/template
@@ -395,6 +395,7 @@ replaces="
  mailpile<=0.5.2_4
  masterpassword-cli<=2.6_5
  mattermost-desktop<=4.6.0_1
+ maxima-emacs<=5.47.0_2
  mdds0<=0.12.1_3
  mesa-XvMC<=22.2.4_2
  mimms<=3.2.1_4


### PR DESCRIPTION
- I tested the changes in this PR: yes
- I built this PR locally for my native architecture, (x86_64)

remove the dummy package, as discussed, cc @tornaria , so we can build maxima on aarch64 without emacs.