### PR TITLE
gzdoom: update to version 4.11.0.

### DIFF
--- a/srcpkgs/gzdoom/template
+++ b/srcpkgs/gzdoom/template
@@ -1,12 +1,12 @@
 # Template file for 'gzdoom'
 pkgname=gzdoom
-version=4.10.0
-revision=2
+version=4.11.0
+revision=1
 archs="~i686* ~arm*"
 build_style=cmake
 configure_args="-DINSTALL_PK3_PATH=share/gzdoom -DDYN_GTK=OFF -DDYN_OPENAL=OFF"
 hostmakedepends="pkg-config tar xz"
-makedepends="SDL2-devel gtk+3-devel libgomp-devel ZMusic-devel libopenal-devel libvpx-devel"
+makedepends="SDL2-devel gtk+3-devel libgomp-devel ZMusic-devel libopenal-devel libvpx-devel libwebp-devel"
 short_desc="Advanced Doom source port with OpenGL support"
 maintainer="Érico Nogueira <ericonr@disroot.org>"
 license="GPL-3.0-or-later"
@@ -14,8 +14,8 @@ homepage="https://www.zdoom.org"
 # WARNING: watch out for new submodules
 distfiles="https://github.com/ZDoom/gzdoom/archive/g${version}.tar.gz
  https://github.com/ZDoom/gzdoom/releases/download/g${version}/gzdoom_${version}_amd64.deb"
-checksum="8702522c05048dfd4a765c6ac82a270d8bd0942e813d5bc6f4b69795a5d23a20
- 1baf9f577839daff89073768eeccf561dd330eabec65217ba67eba799a4dfcab"
+checksum="44a0aee6fa6b9cc2f5956bb98252708720b03ddf264821c487ce6af07cb204d7
+ 23cec6b75612e106aa32dbf1e44dcddb5cce73d7476ab58da1af9429bcafeed4"
 skip_extraction="${pkgname}_${version}_amd64.deb"
 nocross=yes
 


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**


#### Local build testing
- I built this PR locally for my native architecture, (x64-GlibC)


Addendum:

Hey guys !
Just a pull request to update GZdoom to its latest release.
I added `libwebp-devel` as a make dependency as it makes an error without it, it is a new requirement since this release.

That's about it tho, have a nice day ! 👋

