### PR TITLE
cups: update to 2.4.7.

### DIFF
--- a/srcpkgs/cups/template
+++ b/srcpkgs/cups/template
@@ -1,6 +1,6 @@
 # Template file for 'cups'
 pkgname=cups
-version=2.4.6
+version=2.4.7
 revision=1
 build_style=gnu-configure
 make_install_args="BUILDROOT=${DESTDIR}"
@@ -14,7 +14,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="Apache-2.0"
 homepage="https://github.com/OpenPrinting/cups"
 distfiles="https://github.com/OpenPrinting/cups/releases/download/v${version}/cups-${version}-source.tar.gz"
-checksum=58e970cf1955e1cc87d0847c32526d9c2ccee335e5f0e3882b283138ba0e7262
+checksum=dd54228dd903526428ce7e37961afaed230ad310788141da75cebaa08362cf6c
 
 conf_files="/etc/pam.d/cups /etc/cups/*.conf /etc/xinetd.d/cups-lpd"
 make_dirs="


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

Fixes CVE-2023-4504.

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
