### PR TITLE
blueprint-compiler: update to 0.10.0

### DIFF
--- a/srcpkgs/blueprint-compiler/template
+++ b/srcpkgs/blueprint-compiler/template
@@ -1,14 +1,15 @@
 # Template file for 'blueprint-compiler'
 pkgname=blueprint-compiler
-version=0.6.0
+version=0.10.0
 revision=1
 build_style=meson
-depends="python3-gobject gobject-introspection"
-checkdepends="${depends} gtk4-devel"
-short_desc="Blueprint is a markup language and compiler for GTK 4 user interfaces"
+depends="python3-gobject"
+checkdepends="${depends} libadwaita-devel xvfb-run"
+short_desc="Markup language and compiler for GTK 4 user interfaces"
 maintainer="Jan Christian Grünhage <jan.christian@gruenhage.xyz>"
 license="LGPL-3.0-or-later"
 homepage="https://jwestman.pages.gitlab.gnome.org/blueprint-compiler/"
 changelog="https://gitlab.gnome.org/jwestman/blueprint-compiler/-/raw/main/NEWS.md"
 distfiles="https://gitlab.gnome.org/jwestman/blueprint-compiler/-/archive/v${version}/blueprint-compiler-v${version}.tar.gz"
-checksum=c9e3652b66803c1de6a24b71f4fa4638b32260b4b04b93c2f3d958e1ce2a175e
+checksum=2bc729b36897d0959a9890fb0997c9847aa9d2fc9356520bd8a46ed0b51ff4c0
+make_check_pre="xvfb-run"


### PR DESCRIPTION
@jcgruenhage 

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl

Newer `libadwaita` apps require the updated `blueprint-compiler` due to the new syntax in blueprints.