### PR TITLE
VeraCrypt: update to 1.25.9.

### DIFF
--- a/srcpkgs/VeraCrypt/template
+++ b/srcpkgs/VeraCrypt/template
@@ -1,7 +1,7 @@
 # Template file for 'VeraCrypt'
 pkgname=VeraCrypt
-version=1.25.7
-revision=3
+version=1.25.9
+revision=1
 build_wrksrc=src
 build_style=gnu-makefile
 make_build_args="WX_CONFIG=wx-config-gtk3"
@@ -13,7 +13,7 @@ maintainer="Gustavo Heinz <gustavoheinz95@gmail.com>"
 license="Apache-2.0, custom:TrueCrypt-3.0"
 homepage="https://www.veracrypt.fr"
 distfiles="https://www.veracrypt.fr/code/VeraCrypt/snapshot/VeraCrypt_${version}.tar.gz"
-checksum=623006ed61d081f4fd25151c148437471a6552e44e96814c196079ad679a4ba1
+checksum=66f2195f126df53f1037cc4b81ea4b9eaa5cd6aaa351f5cfe324760fdefab0d0
 
 # license is Apache-2.0 AND TrueCrypt-3.0
 # TrueCrypt-3.0 is non-free, VI.4 disallow distributing


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, x86_64
- I built this PR locally for these architectures (if supported. mark crossbuilds):

```
pkg        host         target        cross  result
VeraCrypt  x86_64       x86_64        n      OK
VeraCrypt  x86_64-musl  x86_64-musl   n      OK
VeraCrypt  i686         i686          n      OK
VeraCrypt  x86_64       aarch64-musl  y      OK
VeraCrypt  x86_64       aarch64       y      OK
VeraCrypt  x86_64       armv7l-musl   y      OK
VeraCrypt  x86_64       armv7l        y      OK
VeraCrypt  x86_64       armv6l-musl   y      OK
VeraCrypt  x86_64       armv6l        y      OK
```
