### PR TITLE
refind: convert scripts to python3

### DIFF
--- a/srcpkgs/refind/patches/python3.patch
+++ b/srcpkgs/refind/patches/python3.patch
@@ -1,0 +1,296 @@
+--- a/filesystems/mk_fsw_strfunc.py
++++ b/filesystems/mk_fsw_strfunc.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/python3
+ 
+ #
+ # Copyright (c) 2006 Christoph Pfisterer
+@@ -201,7 +201,7 @@
+ 
+ # write output file
+ 
+-f = file("fsw_strfunc.h", "w")
++f = open("fsw_strfunc.h", "w")
+ f.write(output)
+ f.close()
+ 
+--- a/images/imgprepare.py
++++ b/images/imgprepare.py
+@@ -1,7 +1,7 @@
+-#!/usr/bin/python
++#!/usr/bin/python3
+ 
+ import sys
+-import Image
++from PIL import Image
+ 
+ def enc_backbuffer(backbuffer):
+     compdata = []
+@@ -52,7 +52,7 @@
+     mode = origimage.mode
+     data = origimage.getdata()
+ 
+-    print "%s: %d x %d %s" % (filename, width, height, mode)
++    print("%s: %d x %d %s" % (filename, width, height, mode))
+ 
+     basename = filename[:-4]
+     identname = basename.replace("-", "_")
+@@ -70,31 +70,31 @@
+             planes[2].append(pixeldata[0])
+ 
+         if planes[0] == planes[1] and planes[0] == planes[2]:
+-            print " encoding as greyscale"
++            print(" encoding as greyscale")
+             planecount = 1
+             rawdata.extend(planes[0])
+ 
+             if basename[0:4] == "font":
+-                print " font detected, using alpha-only mode"
++                print(" font detected, using alpha-only mode")
+                 imgmode = 1
+                 # invert all values
+                 rawdata = map(lambda x: 255-x, rawdata)
+ 
+         else:
+-            print " encoding as true color"
++            print(" encoding as true color")
+             planecount = 3
+             rawdata.extend(planes[0])
+             rawdata.extend(planes[1])
+             rawdata.extend(planes[2])
+ 
+     else:
+-        print " Mode not supported!"
++        print(" Mode not supported!")
+         continue
+ 
+     rawlen = len(rawdata)
+     compdata = packbits(rawdata)
+     complen = len(compdata)
+-    print " compressed %d to %d" % (rawlen, complen)
++    print(" compressed %d to %d" % (rawlen, complen))
+ 
+     output = """static UINT8 image_%s_compdata[] = {
+ """ % identname
+@@ -107,8 +107,8 @@
+ static BUILTIN_IMAGE image_%s = { NULL, %d, %d, %d, %d, image_%s_compdata, %d };
+ """ % (identname, width, height, imgmode, planecount, identname, len(compdata))
+ 
+-    f = file("image_%s.h" % identname, "w")
++    f = open("image_%s.h" % identname, "w")
+     f.write(output)
+     f.close()
+ 
+-print "Done!"
++print("Done!")
+--- a/images/mkeei.py
++++ b/images/mkeei.py
+@@ -1,7 +1,8 @@
+-#!/usr/bin/python
++#!/usr/bin/python3
+ 
+ import sys
+-import Image
++from functools import reduce
++from PIL import Image
+ 
+ def enc_backbuffer(backbuffer):
+     """Helper function for RLE compression, encodes a string of uncompressable data."""
+@@ -51,7 +52,7 @@
+     rawlen = len(rawdata)
+     compdata = compress_rle(rawdata)
+     complen = len(compdata)
+-    print "  plane %s: compressed %d to %d (%.1f%%)" % (planename, rawlen, complen, float(complen) / float(rawlen) * 100.0)
++    print("  plane %s: compressed %d to %d (%.1f%%)" % (planename, rawlen, complen, float(complen) / float(rawlen) * 100.0))
+ 
+     output = """static const UINT8 eei_%s_planedata_%s[%d] = {
+ """ % (identname, planename, complen)
+@@ -67,7 +68,7 @@
+ 
+ ### main loop
+ 
+-print "mkeei 0.1, Copyright (c) 2006 Christoph Pfisterer"
++print("mkeei 0.1, Copyright (c) 2006 Christoph Pfisterer")
+ 
+ planenames = ( "blue", "green", "red", "alpha", "grey" )
+ 
+@@ -79,7 +80,7 @@
+     mode = origimage.mode
+     data = origimage.getdata()
+ 
+-    print "%s: %d x %d %s" % (filename, width, height, mode)
++    print("%s: %d x %d %s" % (filename, width, height, mode))
+ 
+     basename = filename[:-4]   # TODO!!!!!!
+     identname = basename.replace("-", "_")
+@@ -109,16 +110,16 @@
+             planes[2].append(pixeldata)
+ 
+     else:
+-        print " Error: Mode not supported!"
++        print(" Error: Mode not supported!")
+         continue
+ 
+     # special treatment for fonts
+ 
+     if basename[0:4] == "font":
+         if planes[0] != planes[1] or planes[0] != planes[2]:
+-            print " Error: Font detected, but it is not greyscale!"
++            print(" Error: Font detected, but it is not greyscale!")
+             continue
+-        print " font detected, encoding as alpha-only"
++        print(" font detected, encoding as alpha-only")
+         # invert greyscale values for use as alpha
+         planes[3] = map(lambda x: 255-x, planes[0])
+         planes[0] = []
+@@ -131,30 +132,30 @@
+     planeinfo = [ "NULL, 0", "NULL, 0", "NULL, 0", "NULL, 0" ]
+ 
+     if len(planes[0]) > 0 and planes[0] == planes[1] and planes[0] == planes[2]:
+-        print " encoding as greyscale"
++        print(" encoding as greyscale")
+         (output_part, planeinfo[0]) = encode_plane(planes[0], identname, planenames[4])
+         output = output + output_part
+         planeinfo[1] = planeinfo[0]
+         planeinfo[2] = planeinfo[0]
+ 
+     elif len(planes[0]) > 0:
+-        print " encoding as true color"
++        print(" encoding as true color")
+ 
+         (output_part, planeinfo[0]) = encode_plane(planes[0], identname, planenames[0])
+         output = output + output_part
+ 
+         if planes[1] == planes[0]:
+-            print " encoding plane 1 is a copy of plane 0"
++            print(" encoding plane 1 is a copy of plane 0")
+             planeinfo[1] = planeinfo[0]
+         else:
+             (output_part, planeinfo[1]) = encode_plane(planes[1], identname, planenames[1])
+             output = output + output_part
+ 
+         if planes[2] == planes[0]:
+-            print " encoding plane 2 is a copy of plane 0"
++            print(" encoding plane 2 is a copy of plane 0")
+             planeinfo[2] = planeinfo[0]
+         elif planes[2] == planes[1]:
+-            print " encoding plane 2 is a copy of plane 1"
++            print(" encoding plane 2 is a copy of plane 1")
+             planeinfo[2] = planeinfo[1]
+         else:
+             (output_part, planeinfo[2]) = encode_plane(planes[2], identname, planenames[2])
+@@ -162,7 +163,7 @@
+ 
+     if len(planes[3]) > 0:
+         if reduce(lambda x,y: x+y, planes[3]) == 0:
+-            print " skipping alpha plane because it is empty"
++            print(" skipping alpha plane because it is empty")
+         else:
+             (output_part, planeinfo[3]) = encode_plane(planes[3], identname, planenames[3])
+             output = output + output_part
+@@ -172,8 +173,8 @@
+         output = output + "    { %s },\n" % planeinfo[i]
+     output = output + "} };\n"
+ 
+-    f = file("eei_%s.h" % identname, "w")
++    f = open("eei_%s.h" % identname, "w")
+     f.write(output)
+     f.close()
+ 
+-print "Done!"
++print("Done!")
+--- a/images/mkegemb.py
++++ b/images/mkegemb.py
+@@ -1,7 +1,8 @@
+-#!/usr/bin/env python
++#!/usr/bin/python3
+ 
+ import sys, os.path
+-import Image
++from functools import reduce
++from PIL import Image
+ 
+ def enc_backbuffer(backbuffer):
+     """Helper function for RLE compression, encodes a string of uncompressable data."""
+@@ -51,14 +52,14 @@
+     rawlen = len(rawdata)
+     compdata = compress_rle(rawdata)
+     complen = len(compdata)
+-    print "  plane %s: compressed %d to %d (%.1f%%)" % (planename, rawlen, complen, float(complen) / float(rawlen) * 100.0)
++    print("  plane %s: compressed %d to %d (%.1f%%)" % (planename, rawlen, complen, float(complen) / float(rawlen) * 100.0))
+     
+     return compdata
+ 
+ 
+ ### main loop
+ 
+-print "mkegemb 0.1, Copyright (c) 2006 Christoph Pfisterer"
++print("mkegemb 0.1, Copyright (c) 2006 Christoph Pfisterer")
+ 
+ planenames = ( "blue", "green", "red", "alpha", "grey" )
+ 
+@@ -70,7 +71,7 @@
+     mode = origimage.mode
+     data = origimage.getdata()
+     
+-    print "%s: %d x %d %s" % (filename, width, height, mode)
++    print("%s: %d x %d %s" % (filename, width, height, mode))
+     
+     (basename, extension) = os.path.splitext(filename)
+     identname = basename.replace("-", "_")
+@@ -102,16 +103,16 @@
+             planes[2].append(pixeldata)
+     
+     else:
+-        print " Error: Mode not supported!"
++        print(" Error: Mode not supported!")
+         continue
+     
+     # special treatment for fonts
+     
+     if basename[0:4] == "font":
+         if planes[0] != planes[1] or planes[0] != planes[2]:
+-            print " Error: Font detected, but it is not greyscale!"
++            print(" Error: Font detected, but it is not greyscale!")
+             continue
+-        print " font detected, encoding as alpha-only"
++        print(" font detected, encoding as alpha-only")
+         # invert greyscale values for use as alpha
+         planes[3] = map(lambda x: 255-x, planes[0])
+         planes[0] = []
+@@ -124,12 +125,12 @@
+     pixelformat = "EG_EIPIXELMODE"
+     
+     if len(planes[0]) > 0 and planes[0] == planes[1] and planes[0] == planes[2]:
+-        print " encoding as greyscale"
++        print(" encoding as greyscale")
+         imagedata.extend(encode_plane(planes[0], planenames[4]))
+         pixelformat = pixelformat + "_GRAY"
+     
+     elif len(planes[0]) > 0:
+-        print " encoding as true color"
++        print(" encoding as true color")
+         imagedata.extend(encode_plane(planes[0], planenames[0]))
+         imagedata.extend(encode_plane(planes[1], planenames[1]))
+         imagedata.extend(encode_plane(planes[2], planenames[2]))
+@@ -137,7 +138,7 @@
+     
+     if len(planes[3]) > 0:
+         if reduce(lambda x,y: x+y, planes[3]) == 0:
+-            print " skipping alpha plane because it is empty"
++            print(" skipping alpha plane because it is empty")
+         else:
+             imagedata.extend(encode_plane(planes[3], planenames[3]))
+             pixelformat = pixelformat + "_ALPHA"
+@@ -152,8 +153,8 @@
+     output = output + "\n};\n"
+     output = output + "static EG_EMBEDDED_IMAGE egemb_%s = { %d, %d, %s, EG_EICOMPMODE_RLE, egemb_%s_data, %d };\n" % (identname, width, height, pixelformat, identname, len(imagedata))
+     
+-    f = file("egemb_%s.h" % identname, "w")
++    f = open("egemb_%s.h" % identname, "w")
+     f.write(output)
+     f.close()
+ 
+-print "Done!"
++print("Done!")

--- a/srcpkgs/refind/template
+++ b/srcpkgs/refind/template
@@ -1,7 +1,7 @@
 # Template file for 'refind'
 pkgname=refind
 version=0.14.0.2
-revision=1
+revision=2
 archs="x86_64* i686* aarch64*"
 makedepends="gnu-efi-libs"
 depends="bash dosfstools efibootmgr"
@@ -11,7 +11,6 @@ license="GPL-3.0-only, BSD-3-Clause, BSD-2-Clause, GPL-2.0-only, LGPL-2.1-only"
 homepage="https://sourceforge.net/projects/refind/"
 distfiles="${SOURCEFORGE_SITE}/refind/refind-src-${version}.tar.gz"
 checksum=26a0c55dfd3565499e1f82d8fe57464dbef19ca886ce6d01a815228b8efc8b0f
-python_version=2
 conf_files="/etc/default/refind-kernel-hook.conf"
 make_dirs="/etc/refind.d/keys 0755 root root"
 


### PR DESCRIPTION
@sgn

compared the output and generated files of each script before with python 2 to after with python 3, all were identical except for a missing copyright notice in the generated header file.

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
