### PR TITLE
imlib2: update to 1.12.1.

### DIFF
--- a/srcpkgs/imlib2/template
+++ b/srcpkgs/imlib2/template
@@ -1,6 +1,6 @@
 # Template file for 'imlib2'
 pkgname=imlib2
-version=1.12.0
+version=1.12.1
 revision=1
 build_style=gnu-configure
 configure_args="--disable-static --sysconfdir=/etc/imlib2 --enable-visibility-hiding"
@@ -13,7 +13,7 @@ maintainer="tibequadorian <tibequadorian@posteo.de>"
 license="Imlib2"
 homepage="https://sourceforge.net/projects/enlightenment/"
 distfiles="${SOURCEFORGE_SITE}/enlightenment/imlib2-src/imlib2-${version}.tar.xz"
-checksum=95ff5d4cc17dd9f934c2e7ad151c360f308880a0a7849a6ca43b7c7b9a4bb216
+checksum=8c24d2d189c4d5ae602dbf2fc0fbb117aa923eab6c883041f0feeca4e8c6774e
 
 post_install() {
 	vlicense COPYING


### PR DESCRIPTION
This release fixes a segfault on i686 introduced in 1.12.0.

Tested with nsxiv

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
