### PR TITLE
New package: virtiofsd-1.8.0 (QEMU regression fix)

### DIFF
--- a/srcpkgs/virtiofsd/template
+++ b/srcpkgs/virtiofsd/template
@@ -1,0 +1,27 @@
+# Template file for 'virtiofsd'
+pkgname=virtiofsd
+version=1.8.0
+revision=1
+build_style=cargo
+makedepends="libcap-ng-devel libseccomp-devel"
+short_desc="Virtio-fs vhost-user device daemon"
+maintainer="Matthias von Faber <mvf@gmx.eu>"
+license="Apache-2.0, BSD-3-Clause"
+homepage="https://gitlab.com/virtio-fs/virtiofsd"
+distfiles="https://gitlab.com/virtio-fs/virtiofsd/-/archive/v${version}/virtiofsd-v${version}.tar.gz"
+checksum=35a59628c44da64d72b25cbdea54fe2fa68ecd42482f34c4755f4020e6dc280b
+
+if [ "$XBPS_TARGET_WORDSIZE" = 32 ]; then
+	broken="https://gitlab.com/virtio-fs/virtiofsd/-/issues/114"
+fi
+
+do_install() {
+	vinstall "target/${RUST_TARGET}/release/virtiofsd" 755 usr/libexec
+	vinstall 50-qemu-virtiofsd.json 644 usr/share/qemu/vhost-user
+
+	vdoc README.md
+	vdoc doc/xattr-mapping.md
+
+	vlicense LICENSE-APACHE
+	vlicense LICENSE-BSD-3-Clause
+}


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES** (x86_64 glibc host, Windows 11 guest)

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures (note: this package is 64-bit only):
  - aarch64 (cross)
  - aarch64-musl (cross)
  - x86_64-musl

---

QEMU 8 dropped its `virtiofsd` in favor of the package in this PR ([ChangeLog](https://wiki.qemu.org/ChangeLog/8.0#Removed_features_and_incompatible_changes)). Just installing it fixes Virt Manager VMs with `virtiofs` shares. Since #44822 these don't power on due to:

```
Error starting domain: operation failed: Unable to find a satisfying virtiofsd
```