### PR TITLE
nerd-fonts: split symbols font

### DIFF
--- a/srcpkgs/nerd-fonts-symbols-ttf
+++ b/srcpkgs/nerd-fonts-symbols-ttf
@@ -1,0 +1,1 @@
+nerd-fonts

--- a/srcpkgs/nerd-fonts/template
+++ b/srcpkgs/nerd-fonts/template
@@ -1,7 +1,7 @@
 # Template file for 'nerd-fonts'
 pkgname=nerd-fonts
 version=3.0.2
-revision=1
+revision=2
 depends="nerd-fonts-ttf nerd-fonts-otf"
 short_desc="Iconic font aggregator, collection and patcher"
 maintainer="cinerea0 <cinerea0@protonmail.com>"
@@ -17,19 +17,31 @@ do_install() {
 	vmkdir usr/lib/NerdFonts
 
 	# get all patched fonts
-	find patched-fonts -name '*.otf' -exec install -Dm644 '{}' ${DESTDIR}/usr/share/fonts/NerdFonts/otf \;
-	find patched-fonts -name '*.ttf' -exec install -Dm644 '{}' ${DESTDIR}/usr/share/fonts/NerdFonts/ttf \;
+	find patched-fonts -name '*.otf' -exec install -Dm644 '{}' "${DESTDIR}/usr/share/fonts/NerdFonts/otf" \;
+	find patched-fonts -name '*.ttf' -exec install -Dm644 '{}' "${DESTDIR}/usr/share/fonts/NerdFonts/ttf" \;
+	rm "${DESTDIR}"/usr/share/fonts/NerdFonts/ttf/SymbolsNerdFont*.ttf
 
 	# install patching scripts
 	for sh in bin/scripts/lib/i_*.sh; do
-		vinstall $sh 744 usr/lib/NerdFonts
+		vinstall "$sh" 744 usr/lib/NerdFonts
 	done
 
 	vlicense LICENSE
 }
 
+nerd-fonts-symbols-ttf_package() {
+	short_desc+=" - TTF symbols-only font"
+	font_dirs="/usr/share/fonts/NerdFonts/ttf/symbols"
+	depends="font-util"
+	pkg_install() {
+		vmkdir usr/share/fonts/NerdFonts/ttf/symbols
+		vcopy "patched-fonts/NerdFontsSymbolsOnly/*.ttf" usr/share/fonts/NerdFonts/ttf/symbols
+		vinstall 10-nerd-font-symbols.conf 644 usr/share/fontconfig/conf.avail
+	}
+}
+
 nerd-fonts-otf_package() {
-	short_desc="Iconic font aggregator, collection and patcher - otf fonts"
+	short_desc+=" - OTF fonts"
 	font_dirs="/usr/share/fonts/NerdFonts/otf"
 	depends="font-util"
 	pkg_install() {
@@ -38,9 +50,9 @@ nerd-fonts-otf_package() {
 }
 
 nerd-fonts-ttf_package() {
-	short_desc="Iconic font aggregator, collection and patcher - ttf fonts"
+	short_desc+=" - TTF fonts"
 	font_dirs="/usr/share/fonts/NerdFonts/ttf"
-	depends="font-util"
+	depends="font-util nerd-fonts-symbols-ttf"
 	pkg_install() {
 		vmove usr/share/fonts/NerdFonts/ttf
 	}


### PR DESCRIPTION
cc maintainer @cinerea0, interested party @chrysos349

- "gets rid of the bloat", if the user desires to only have the symbol font
- doesn't break existing installs (`-ttf` depends on `-symbols-ttf` to preserve continuity best, doesn't enable the fontconfig conf by default, doesn't remove other patched nerd-fonts)
- doesn't create more maintainer burden by having 2 templates

#### Testing the changes
- I tested the changes in this PR: **YES**
