### PR TITLE
qtile: update to 0.23.0, python3-xcffib: update to 1.5.0, python3-cairocffi: update to 1.6.1 and new package: python3-pywlroots-0.16-0.16.5

### DIFF
--- a/srcpkgs/python3-cairocffi/template
+++ b/srcpkgs/python3-cairocffi/template
@@ -1,34 +1,25 @@
 # Template file for 'python3-cairocffi'
 pkgname=python3-cairocffi
-version=1.3.0
-revision=2
-build_style=python3-module
-hostmakedepends="python3-setuptools python3-cffi python3-wheel $(vopt_if xcb python3-xcffib)"
+version=1.6.1
+revision=1
+build_style=python3-pep517
+make_check_args="--pyargs cairocffi"
+hostmakedepends="python3-setuptools python3-cffi python3-wheel python3-flit_core $(vopt_if xcb python3-xcffib)"
 depends="python3-cffi cairo"
-checkdepends="python3-pytest python3-numpy gdk-pixbuf $depends"
+checkdepends="python3-pytest python3-numpy gdk-pixbuf python3-pikepdf $depends"
 short_desc="CFFI-based cairo bindings for Python3"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="BSD-3-Clause"
 homepage="https://github.com/Kozea/cairocffi"
 changelog="https://raw.githubusercontent.com/Kozea/cairocffi/master/NEWS.rst"
 distfiles="${PYPI_SITE}/c/cairocffi/cairocffi-${version}.tar.gz"
-checksum=108a3a7cb09e203bdd8501d9baad91d786d204561bd71e9364e8b34897c47b91
+checksum=78e6bbe47357640c453d0be929fa49cd05cce2e1286f3d2a1ca9cbda7efdb8b7
 
 build_options=xcb
 case "$XBPS_MACHINE" in
 x86_64*|i686|ppc64le*|ppc64)
 	build_options_default="xcb"
 esac
-
-post_patch() {
-	vsed -e '/pytest-runner/d' -i setup.cfg
-}
-
-do_check() {
-	vsed -e '/addopts/d' -i setup.cfg
-	# Copy in $wrksrc lacks generated module; run against built copy
-	( cd build/lib* && python3 -m pytest )
-}
 
 post_install() {
 	vlicense LICENSE

--- a/srcpkgs/python3-pywlroots-0.16/template
+++ b/srcpkgs/python3-pywlroots-0.16/template
@@ -1,0 +1,37 @@
+# Template file for 'python3-pywlroots-0.16'
+pkgname=python3-pywlroots-0.16
+version=0.16.5
+revision=1
+build_style=python3-pep517
+hostmakedepends="python3-setuptools python3-cffi python3-pywayland python3-xkbcommon
+ python3-wheel python3-devel wlroots${pkgname##*-}-devel"
+makedepends="python3-devel python3-cffi wlroots${pkgname##*-}-devel"
+depends="python3-pywayland python3-xkbcommon python3-cffi"
+short_desc="Python binding to the wlroots ${pkgname##*-} using cffi"
+maintainer="Orphaned <orphan@voidlinux.org>"
+license="MIT"
+homepage="https://github.com/flacjacket/pywlroots"
+distfiles="${PYPI_SITE}/p/pywlroots/pywlroots-${version}.tar.gz"
+checksum=5b8dd10897a4b6e9a0bcef4adcade61d1d418b2657b078f87cdd849069490a14
+conflicts="python3-pywlroots-0.15"
+
+pre_build() {
+	[ "$CROSS_BUILD" ] || return 0
+	(
+		rm -rf wlroots/__pycache__
+		CC="$BUILD_CC"
+		CFLAGS="$BUILD_CFLAGS"
+		LDFLAGS="$BUILD_LDFLAGS"
+		unset LDSHARED
+		unset PYTHON_CONFIG
+		unset PYTHONPATH
+		unset PYPREFIX
+		unset _PYTHON_SYSCONFIGDATA_NAME
+		python3 wlroots/ffi_build.py
+		rm -f wlroots/_ffi.o wlroots/_ffi.cpython.*.so
+	)
+}
+
+post_install() {
+	vlicense LICENSE
+}

--- a/srcpkgs/python3-pywlroots-0.16/update
+++ b/srcpkgs/python3-pywlroots-0.16/update
@@ -1,0 +1,1 @@
+pattern="[v_-]\K\Q${pkgname##*-}.\E.*(?=\.tar\.gz)"

--- a/srcpkgs/python3-xcffib/template
+++ b/srcpkgs/python3-xcffib/template
@@ -1,17 +1,18 @@
 # Template file for 'python3-xcffib'
 pkgname=python3-xcffib
-version=1.3.0
+version=1.5.0
 revision=1
 build_style=python3-pep517
 hostmakedepends="python3-setuptools pkg-config cabal-install parallel xcb-proto python3-cffi python3-wheel"
 makedepends="python3-devel libffi-devel libxcb-devel python3-six"
 depends="python3-six python3-cffi libxcb"
+checkdepends="python3-pytest xvfb-run xeyes"
 short_desc="Drop-in replacement for xpyb based on cffi"
 maintainer="Kai Stian Olstad <void@olstad.com>"
 license="Apache-2.0"
 homepage="https://github.com/tych0/xcffib"
 distfiles="${homepage}/archive/v${version}.tar.gz"
-checksum=e0819e9cf56d47839a58755728af22eee02cad3b8b57157f8f682f187da96013
+checksum=3bf9ce88b8a343a12eb1fc72a7b3e6091f8b65e682354510261b0a2cae1b00c5
 nocross="Cannot yet cross compile with Haskell"
 
 pre_build() {

--- a/srcpkgs/qtile/INSTALL.msg
+++ b/srcpkgs/qtile/INSTALL.msg
@@ -1,9 +1,0 @@
-!!! Config breakage !!!
-    - lazy.qtile.display_kb() no longer receives any arguments. If you passed
-      it any arguments (which were ignored previously), remove them.
-    - If you have a custom startup Python script that you use instead of
-      "qtile start" and run init_log manually, the signature has changed.
-      Please check the source for the updated arguments.
-    - "KeyChord"'s signature has changed. "mode" is now a boolean to indicate
-       whether the mode should persist. The "name" parameter should be used
-       to name the chord (e.g. for the ``Chord`` widget).

--- a/srcpkgs/qtile/template
+++ b/srcpkgs/qtile/template
@@ -1,9 +1,9 @@
 # Template file for 'qtile'
 pkgname=qtile
-version=0.22.0
-revision=3
+version=0.23.0
+revision=1
 build_style=python3-pep517
-_wlroots=0.15
+_wlroots=0.16
 hostmakedepends="python3-setuptools_scm python3-cairocffi python3-xcffib python3-wheel
  pkg-config python3-pywlroots-${_wlroots} python3-pywayland python3-xkbcommon"
 makedepends="python3-devel libffi-devel pulseaudio-devel wlroots${_wlroots}-devel"
@@ -14,7 +14,7 @@ license="MIT"
 homepage="http://www.qtile.org/"
 changelog="https://raw.githubusercontent.com/qtile/qtile/master/CHANGELOG"
 distfiles="${PYPI_SITE}/q/qtile/qtile-${version}.tar.gz"
-checksum=ecec16cf41b6bbbc1847d0cd3f7dba68eb16fa175fbe856a229817297f605f6e
+checksum=eae63f7a939d9deac86d7251f75cafddbddf67e6e828feccee2f8ad745ed19ed
 
 post_install() {
 	vinstall resources/qtile.desktop 644 usr/share/xsessions


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**, expect the Wayland part since I run X11.

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86-64-LIBC