### PR TITLE
got: update to 0.93.

### DIFF
--- a/srcpkgs/got/template
+++ b/srcpkgs/got/template
@@ -1,6 +1,6 @@
 # Template file for 'got'
 pkgname=got
-version=0.91
+version=0.93
 revision=1
 build_style=gnu-configure
 hostmakedepends="byacc pkg-config"
@@ -11,7 +11,7 @@ license="ISC"
 homepage="https://gameoftrees.org"
 changelog="https://gameoftrees.org/releases/CHANGES"
 distfiles="https://gameoftrees.org/releases/portable/got-portable-${version}.tar.gz"
-checksum=79b15eb508601018f2ddaab74df2bdbde79ebdb992004bfd91a52886c9ecae55
+checksum=c2572726bedfdc177d48482b2a23e5afba534a36918f8eeac24b48da37a920d1
 
 post_install() {
 	sed -n '/Copyright/,/PERFORMANCE/p' got/got.c > LICENSE


### PR DESCRIPTION
- I tested the changes in this PR: **YES**
- I built this PR locally for my native architecture, (amd64-musl)

for this time I've left gotd out.  I'd like to revisit it in the future, but I need to see how the alternatives works to provide a gotsh-backed `git-{upload,receive}-pack`.