### PR TITLE
cross-built kernel/dkms improvements

### DIFF
--- a/srcpkgs/dkms/files/dkms.default
+++ b/srcpkgs/dkms/files/dkms.default
@@ -1,0 +1,2 @@
+# number of parallel jobs to use for DKMS compilation (default: $(nproc))
+#DKMS_JOBS=

--- a/srcpkgs/dkms/files/kernel.d/dkms.postinst
+++ b/srcpkgs/dkms/files/kernel.d/dkms.postinst
@@ -17,10 +17,13 @@ if [ ! -e /lib/modules/${VERSION}/build/include ] ; then
 	exit 0
 fi
 
+[ -r /etc/default/dkms ] && . /etc/default/dkms
+: "${DKMS_JOBS:=$(nproc)}"
+
 export IGNORE_CC_MISMATCH=1
 
 if [ ! -f /lib/modules/${VERSION}/build/scripts/basic/fixdep ] || [ ! -f /lib/modules/${VERSION}/build/scripts/mod/modpost ]; then
-	yes "" | make -j $(nproc) -C /lib/modules/${VERSION}/build prepare0
+	yes "" | make -j "${DKMS_JOBS}" -C /lib/modules/${VERSION}/build prepare0
 fi
 
 # Check available DKMS modules
@@ -68,7 +71,7 @@ while [ $# -gt 1 ]; do
 		fi
 		# Build the module
 		echo -n "Building DKMS module: ${module}-${modulever}... "
-		/usr/bin/dkms build -q -m ${module} -v ${modulever} -k ${VERSION} -a ${ARCH}
+		/usr/bin/dkms build -j "${DKMS_JOBS}" -q -m ${module} -v ${modulever} -k ${VERSION} -a ${ARCH}
 		rval=$?
 		# If the module was skipped or failed, go to the next module.
 		if [ $rval -eq 0 ]; then
@@ -87,7 +90,7 @@ while [ $# -gt 1 ]; do
 	if [ $(echo "$status"|grep -c ": built") -eq 1 ] &&
 	   [ $(echo "$status"|grep -c ": installed") -eq 0 ]; then
 		echo -n "Installing DKMS module: ${module}-${modulever}... "
-		/usr/bin/dkms install --force -q -m ${module} -v ${modulever} -k ${VERSION} -a ${ARCH}
+		/usr/bin/dkms install --force -j "${DKMS_JOBS}" -q -m ${module} -v ${modulever} -k ${VERSION} -a ${ARCH}
 		rval=$?
 		# If the module failed installation, go to the next module.
 		if [ $rval -eq 0 ]; then

--- a/srcpkgs/dkms/template
+++ b/srcpkgs/dkms/template
@@ -1,9 +1,9 @@
 # Template file for 'dkms'
 pkgname=dkms
 version=3.0.10
-revision=2
-conf_files="/etc/dkms/framework.conf"
-depends="bash kmod gcc make coreutils xbps-triggers>=0.123_1"
+revision=3
+conf_files="/etc/dkms/framework.conf /etc/default/dkms"
+depends="bash kmod gcc bc make coreutils xbps-triggers>=0.123_1"
 short_desc="Dynamic Kernel Module Support"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later"
@@ -35,6 +35,7 @@ do_install() {
 	vcompletion dkms.bash-completion bash dkms
 	vinstall dkms_framework.conf 644 etc/dkms framework.conf
 	# Kernel hooks.
-	vinstall ${FILESDIR}/kernel.d/dkms.postinst 754 etc/kernel.d/post-install 10-dkms
-	vinstall ${FILESDIR}/kernel.d/dkms.prerm 754 etc/kernel.d/pre-remove 10-dkms
+	vinstall "${FILESDIR}/kernel.d/dkms.postinst" 754 etc/kernel.d/post-install 10-dkms
+	vinstall "${FILESDIR}/kernel.d/dkms.prerm" 754 etc/kernel.d/pre-remove 10-dkms
+	vinstall "${FILESDIR}/dkms.default" 644 etc/default dkms
 }

--- a/srcpkgs/linux6.1/template
+++ b/srcpkgs/linux6.1/template
@@ -1,7 +1,7 @@
 # Template file for 'linux6.1'
 pkgname=linux6.1
 version=6.1.55
-revision=1
+revision=2
 short_desc="Linux kernel and modules (${version%.*} series)"
 maintainer="Đoàn Trần Công Danh <congdanhqx@gmail.com>"
 license="GPL-2.0-only"
@@ -169,6 +169,7 @@ do_install() {
 	cd ${wrksrc}
 	# Install required headers to build external modules
 	install -Dm644 Makefile ${hdrdest}/Makefile
+	install -Dm644 Kbuild ${hdrdest}/Kbuild
 	install -Dm644 kernel/Makefile ${hdrdest}/kernel/Makefile
 	install -Dm644 .config ${hdrdest}/.config
 	for file in $(find . -name Kconfig\*); do
@@ -210,6 +211,13 @@ do_install() {
 	cp -a security/selinux/include ${hdrdest}/security/selinux
 	mkdir -p ${hdrdest}/tools/include
 	cp -a tools/include/tools ${hdrdest}/tools/include
+	if [ -d "arch/${arch}/tools" ]; then
+		cp -a "arch/${arch}/tools" "${hdrdest}/arch/${arch}"
+	fi
+	cp -a kernel/time/timeconst.bc "${hdrdest}/kernel/time"
+	cp -a kernel/bounds.c "${hdrdest}/kernel"
+	mkdir -p "${hdrdest}/arch/x86/entry/syscalls"
+	cp -a arch/x86/entry/syscalls/syscall_32.tbl "${hdrdest}/arch/x86/entry/syscalls"
 
 	mkdir -p ${hdrdest}/arch/${arch}/kernel
 	cp arch/${arch}/Makefile ${hdrdest}/arch/${arch}
@@ -222,6 +230,7 @@ do_install() {
 		cp arch/x86/kernel/asm-offsets.s ${hdrdest}/arch/x86/kernel
 	elif [ "$arch" = "arm64" ]; then
 		mkdir -p ${hdrdest}/arch/arm64/kernel
+		cp arch/arm64/kernel/asm-offsets.s ${hdrdest}/arch/arm64/kernel
 		cp -a arch/arm64/kernel/vdso ${hdrdest}/arch/arm64/kernel/
 	fi
 
@@ -282,21 +291,6 @@ do_install() {
 			cp tools/objtool/objtool ${hdrdest}/tools/objtool
 			;;
 	esac
-
-	# Remove unneeded architectures
-	case "$arch" in
-		i386|x86_64) _args="arm* m* p*";;
-		arm|arm64) _args="x86* m* p*";;
-		powerpc) _args="arm* m* x86* parisc";;
-		mips) _args="arm* x86* p*";;
-	esac
-	for arch in alpha avr32 blackfin cris frv h8300 \
-		ia64 s* um v850 xtensa ${_args}; do
-		rm -rf ${hdrdest}/arch/${arch}
-	done
-	# Keep arch/x86/ras/Kconfig as it is needed by drivers/ras/Kconfig
-	mkdir -p ${hdrdest}/arch/x86/ras
-	cp -a arch/x86/ras/Kconfig ${hdrdest}/arch/x86/ras/Kconfig
 
 	# Extract debugging symbols and compress modules
 	msg_normal "$pkgver: extracting debug info and compressing modules, please wait...\n"

--- a/srcpkgs/linux6.3/template
+++ b/srcpkgs/linux6.3/template
@@ -1,7 +1,7 @@
 # Template file for 'linux6.3'
 pkgname=linux6.3
 version=6.3.13
-revision=1
+revision=2
 short_desc="Linux kernel and modules (${version%.*} series)"
 maintainer="Đoàn Trần Công Danh <congdanhqx@gmail.com>"
 license="GPL-2.0-only"
@@ -177,6 +177,7 @@ do_install() {
 	cd ${wrksrc}
 	# Install required headers to build external modules
 	install -Dm644 Makefile ${hdrdest}/Makefile
+	install -Dm644 Kbuild ${hdrdest}/Kbuild
 	install -Dm644 kernel/Makefile ${hdrdest}/kernel/Makefile
 	install -Dm644 .config ${hdrdest}/.config
 	for file in $(find . -name Kconfig\*); do
@@ -218,6 +219,13 @@ do_install() {
 	cp -a security/selinux/include ${hdrdest}/security/selinux
 	mkdir -p ${hdrdest}/tools/include
 	cp -a tools/include/tools ${hdrdest}/tools/include
+	if [ -d "arch/${arch}/tools" ]; then
+		cp -a "arch/${arch}/tools" "${hdrdest}/arch/${arch}"
+	fi
+	cp -a kernel/time/timeconst.bc "${hdrdest}/kernel/time"
+	cp -a kernel/bounds.c "${hdrdest}/kernel"
+	mkdir -p "${hdrdest}/arch/x86/entry/syscalls"
+	cp -a arch/x86/entry/syscalls/syscall_32.tbl "${hdrdest}/arch/x86/entry/syscalls"
 
 	mkdir -p ${hdrdest}/arch/${arch}/kernel
 	cp arch/${arch}/Makefile ${hdrdest}/arch/${arch}
@@ -230,6 +238,7 @@ do_install() {
 		cp arch/x86/kernel/asm-offsets.s ${hdrdest}/arch/x86/kernel
 	elif [ "$arch" = "arm64" ]; then
 		mkdir -p ${hdrdest}/arch/arm64/kernel
+		cp arch/arm64/kernel/asm-offsets.s ${hdrdest}/arch/arm64/kernel
 		cp -a arch/arm64/kernel/vdso ${hdrdest}/arch/arm64/kernel/
 	fi
 
@@ -290,22 +299,6 @@ do_install() {
 			cp tools/objtool/objtool ${hdrdest}/tools/objtool
 			;;
 	esac
-
-	# Remove unneeded architectures
-	case "$arch" in
-		i386|x86_64) _args="arm* m* p*";;
-		arm|arm64) _args="x86* m* p*";;
-		powerpc) _args="arm* m* x86* parisc";;
-		mips) _args="arm* x86* p*";;
-		riscv) _args="arm* m* x86* p*";;
-	esac
-	for arch in alpha avr32 blackfin cris frv h8300 \
-		ia64 s* um v850 xtensa ${_args}; do
-		rm -rf ${hdrdest}/arch/${arch}
-	done
-	# Keep arch/x86/ras/Kconfig as it is needed by drivers/ras/Kconfig
-	mkdir -p ${hdrdest}/arch/x86/ras
-	cp -a arch/x86/ras/Kconfig ${hdrdest}/arch/x86/ras/Kconfig
 
 	# Extract debugging symbols and compress modules
 	msg_normal "$pkgver: extracting debug info and compressing modules, please wait...\n"

--- a/srcpkgs/linux6.5/template
+++ b/srcpkgs/linux6.5/template
@@ -1,7 +1,7 @@
 # Template file for 'linux6.5'
 pkgname=linux6.5
 version=6.5.5
-revision=1
+revision=2
 short_desc="Linux kernel and modules (${version%.*} series)"
 maintainer="Duncaen <duncaen@voidlinux.org>"
 license="GPL-2.0-only"
@@ -176,6 +176,7 @@ do_install() {
 	cd ${wrksrc}
 	# Install required headers to build external modules
 	install -Dm644 Makefile ${hdrdest}/Makefile
+	install -Dm644 Kbuild ${hdrdest}/Kbuild
 	install -Dm644 kernel/Makefile ${hdrdest}/kernel/Makefile
 	install -Dm644 .config ${hdrdest}/.config
 	for file in $(find . -name Kconfig\*); do
@@ -217,6 +218,13 @@ do_install() {
 	cp -a security/selinux/include ${hdrdest}/security/selinux
 	mkdir -p ${hdrdest}/tools/include
 	cp -a tools/include/tools ${hdrdest}/tools/include
+	if [ -d "arch/${arch}/tools" ]; then
+		cp -a "arch/${arch}/tools" "${hdrdest}/arch/${arch}"
+	fi
+	cp -a kernel/time/timeconst.bc "${hdrdest}/kernel/time"
+	cp -a kernel/bounds.c "${hdrdest}/kernel"
+	mkdir -p "${hdrdest}/arch/x86/entry/syscalls"
+	cp -a arch/x86/entry/syscalls/syscall_32.tbl "${hdrdest}/arch/x86/entry/syscalls"
 
 	mkdir -p ${hdrdest}/arch/${arch}/kernel
 	cp arch/${arch}/Makefile ${hdrdest}/arch/${arch}
@@ -229,6 +237,7 @@ do_install() {
 		cp arch/x86/kernel/asm-offsets.s ${hdrdest}/arch/x86/kernel
 	elif [ "$arch" = "arm64" ]; then
 		mkdir -p ${hdrdest}/arch/arm64/kernel
+		cp arch/arm64/kernel/asm-offsets.s ${hdrdest}/arch/arm64/kernel
 		cp -a arch/arm64/kernel/vdso ${hdrdest}/arch/arm64/kernel/
 	fi
 

--- a/srcpkgs/xbps-triggers/files/dkms
+++ b/srcpkgs/xbps-triggers/files/dkms
@@ -52,6 +52,9 @@ remove_modules() {
 add_modules() {
 	local rval=
 
+	[ -r /etc/default/dkms ] && . /etc/default/dkms
+	: "${DKMS_JOBS:=$(nproc)}"
+
 	# Add/build and install the specified modules for all kernels.
 	set -- ${dkms_modules}
 	while [ $# -gt 0 ]; do
@@ -77,7 +80,7 @@ add_modules() {
 		fi
 		if [ ! -f ${f}/build/scripts/basic/fixdep ] || [ ! -f ${f}/build/scripts/mod/modpost ] ; then
 			echo -n "Prepare to build modules for kernel-${_kver}... "
-			yes "" | make -j$(nproc) -C ${f}/build prepare0 > ${f}/build/make.log 2>&1
+			yes "" | make -j "$DKMS_JOBS" -C ${f}/build prepare0 > ${f}/build/make.log 2>&1
 			if [ $? -eq 0 ]; then
 				echo "done."
 			else
@@ -89,7 +92,7 @@ add_modules() {
 		set -- ${dkms_modules}
 		while [ $# -gt 0 ]; do
 			echo -n "Building DKMS module '$1-$2' for kernel-${_kver}... "
-			$DKMS build -q -m "$1" -v "$2" -k "${_kver}" >/dev/null 2>&1
+			$DKMS build -j "${DKMS_JOBS}" -q -m "$1" -v "$2" -k "${_kver}" >/dev/null 2>&1
 			if [ $? -eq 0 ]; then
 				echo "done."
 			else
@@ -99,7 +102,7 @@ add_modules() {
 				shift 2; continue
 			fi
 			echo -n "Installing DKMS module '$1-$2' for kernel-${_kver}... "
-			$DKMS install --force -q -m "$1" -v "$2" -k "${_kver}" >/dev/null 2>&1
+			$DKMS install --force -j "${DKMS_JOBS}" -q -m "$1" -v "$2" -k "${_kver}" >/dev/null 2>&1
 			if [ $? -eq 0 ]; then
 				echo "done."
 			else

--- a/srcpkgs/xbps-triggers/template
+++ b/srcpkgs/xbps-triggers/template
@@ -1,6 +1,6 @@
 # Template file for 'xbps-triggers'
 pkgname=xbps-triggers
-version=0.125
+version=0.126
 revision=1
 bootstrap=yes
 short_desc="XBPS triggers for Void Linux"


### PR DESCRIPTION
- dkms: allow limiting jobs, add missing dep
    - some less-powerful platforms may be overwhelmed by the default `-j$(nproc)`. Allow overriding this by setting `DKMS_JOBS` in `/etc/default/dkms`
    - `bc` is needed for `make prepare0` on kernel 6.1+, which is run on cross.
    - see also: https://github.com/void-linux/void-packages/pull/46152#issuecomment-1741479613
- linux6.1: include files necessary for dkms on cross
- linux6.5: include files necessary for dkms on cross

The same fix could be applied to linux6.3 and linux6.4, but with the impending zfs 2.1.13 bump (#46304), I don't see much point.

fixes #44807

#### Testing the changes
- I tested the changes in this PR: **YES** (tested in an aarch64-musl VM on 6.3 with several dkms modules)

@moabeat-berlin, @r-ricci, @Calandracas606: please test

[ci skip]