### PR TITLE
duperemove: update to 0.13.

### DIFF
--- a/srcpkgs/duperemove/patches/add_dev_t_include.patch
+++ b/srcpkgs/duperemove/patches/add_dev_t_include.patch
@@ -1,0 +1,11 @@
+--- a/dbfile.h
++++ b/dbfile.h
+@@ -7,6 +7,8 @@
+ #include <stdbool.h>
+ #include "util.h"
+ 
++#include <sys/types.h>
++
+ struct filerec;
+ struct block_csum;
+ struct extent_csum;

--- a/srcpkgs/duperemove/template
+++ b/srcpkgs/duperemove/template
@@ -1,7 +1,9 @@
 # Template file for 'duperemove'
 pkgname=duperemove
-version=0.11.2
+version=0.13
 revision=1
+build_style=gnu-makefile
+make_use_env=yes
 hostmakedepends="pkg-config"
 makedepends="sqlite-devel libglib-devel libgcrypt-devel"
 short_desc="Tools for deduping file systems"
@@ -9,11 +11,7 @@ maintainer="Enno Boland <gottox@voidlinux.org>"
 license="GPL-2.0-only"
 homepage="https://github.com/markfasheh/duperemove"
 distfiles="https://github.com/markfasheh/duperemove/archive/v${version}.tar.gz"
-checksum=e162c2cf99c9d1e1e111cf84fa2615490a7d654173a3719651a962257bf8179e
+checksum=65fc972339965976cf617ed430ece86dc64c2695b2017db058413aa098f1da89
 
-do_build() {
-	make CC=$CC CFLAGS="$CFLAGS $LDFLAGS -fcommon"
-}
-do_install() {
-	make PREFIX=/usr SBINDIR=/usr/bin DESTDIR=${DESTDIR} install
-}
+# The makefile tries to use git to guess if these aren't set.
+export VERSION="${version}" IS_RELEASE=1


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->
I have switched the template to `gnu-makefile` build style. The makefile looks well behaved regarding environmental variables, so I have set `make_use_env`. Hash files generated with the older release (most likely) won't be compatible with the new release. This is to be expected, the manpage and documentation say that the hash file format isn't stable.

#### Testing the changes
- I tested the changes in this PR: **YES**

ping mainainer: @Gottox 