### PR TITLE
New package: ymir-0.0.5

### DIFF
--- a/srcpkgs/ymir/template
+++ b/srcpkgs/ymir/template
@@ -1,0 +1,22 @@
+# Template file for 'ymir'
+pkgname=ymir
+version=0.0.5
+revision=1
+build_style=cargo
+build_helper=qemu
+short_desc="Tool for doing bulk test builds of Void Linux packages"
+maintainer="Marcin Puc <tranzystorek.io@protonmail.com>"
+license="MIT"
+homepage="https://codeberg.org/tranzystorek-io/ymir"
+changelog="https://codeberg.org/tranzystorek-io/ymir/raw/branch/main/CHANGELOG.md"
+distfiles="https://codeberg.org/tranzystorek-io/ymir/archive/v${version}.tar.gz"
+checksum=6af91fdbe20dd615269a98571302372b0245f0b99f2e4533fc8688e79bc1604d
+
+post_install() {
+	for shell in bash fish zsh; do
+		vtargetrun ${DESTDIR}/usr/bin/ymir completion ${shell} > ymir.${shell}
+		vcompletion ymir.${shell} ${shell}
+	done
+
+	vlicense LICENSE
+}


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

This is a void-centric tool for large bulk package builds. I've used it to do `build_style=cargo` rebuilds for Rust PRs.

Disclaimer: I am the author of this project.

#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
