### PR TITLE
New package: xdeb-install-1.0.0

### DIFF
--- a/srcpkgs/xdeb-install/template
+++ b/srcpkgs/xdeb-install/template
@@ -1,0 +1,26 @@
+# Template file for 'xdeb-install'
+pkgname=xdeb-install
+version=1.0.0
+revision=1
+archs="x86_64"
+create_wrksrc=required
+short_desc="Simple tool to automate the awesome xdeb tool"
+maintainer="Timo Reichl <thetredev@gmail.com>"
+license="MIT"
+homepage="https://github.com/thetredev/xdeb-install"
+distfiles="${homepage}/releases/download/v${version}/xdeb-install-linux-${XBPS_TARGET_MACHINE} https://raw.githubusercontent.com/thetredev/xdeb-install/v${version}/LICENSE"
+checksum="dc4d6db5afc8cfbc6b6d5a746edc77e7adb33c2107211f6af2bed4249f736baf 78dc220b8c0cb8341a9da3efaa33ff87483b81db5f9e0b94c81241a15582bc11"
+
+do_extract() {
+	# nothing to do here, it's a prebuilt go binary
+	# satisfy xbps-src using 'true'
+	true
+}
+
+do_install() {
+	bindir="${XBPS_SRCDISTDIR}/${pkgname}-${version}"
+	mv ${bindir}/xdeb-install-linux-${XBPS_TARGET_MACHINE} ${bindir}/xdeb-install
+
+	vbin ${bindir}/xdeb-install
+	vlicense ${bindir}/LICENSE
+}


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES** (also using `./xbps-src pkg -Q`)

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

#### Local build testing
- I built this PR locally for my native architecture, `x86_64-glibc`

#### Other notes

I doubt the underlying third party script `xdeb` works for `musl`, since most DEB packages are built for `glibc` as far as I'm aware. I could add support for more host architectures in the future, but that wasn't a priority for the first release of `xdeb-install`.

See https://github.com/toluschr/xdeb, https://github.com/thetredev/xdeb-install and https://github.com/thetredev/xdeb-install-repositories for more details.