### PR TITLE
adguardian: update to 1.6.0

### DIFF
--- a/srcpkgs/adguardian/template
+++ b/srcpkgs/adguardian/template
@@ -1,6 +1,6 @@
 # Template file for 'adguardian'
 pkgname=adguardian
-version=1.3.0
+version=1.6.0
 revision=1
 build_style=cargo
 hostmakedepends="pkg-config"
@@ -9,7 +9,7 @@ maintainer="Alex Childs <misuchiru03+void@gmail.com>"
 license="MIT"
 homepage="https://github.com/Lissy93/AdGuardian-Term"
 distfiles="https://github.com/Lissy93/AdGuardian-Term/archive/${version}.tar.gz"
-checksum=44a2ee5cdd40341ea0ea2a6800797e4440393d5d10cf377ae84db22ba0563505
+checksum=0bc7671411372b7b1a4439ff8081c4ce28c4db2c32fe9fac38ae3177cd54fea4
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-GLIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
