### PR TITLE
ncurses: reënable libtinfo 32bit pkgs

### DIFF
--- a/srcpkgs/ncurses/template
+++ b/srcpkgs/ncurses/template
@@ -1,7 +1,7 @@
 # Template file for 'ncurses'
 pkgname=ncurses
 version=6.4
-revision=1
+revision=2
 bootstrap=yes
 configure_args="--enable-big-core"
 short_desc="System V Release 4.0 curses emulation library"
@@ -154,7 +154,6 @@ ncurses-term_package() {
 }
 
 ncurses-libtinfo-libs_package() {
-	lib32disabled=yes
 	depends="ncurses-libs-${version}_${revision}"
 	short_desc+=" - libtinfo.so symlink"
 	pkg_install() {
@@ -163,7 +162,7 @@ ncurses-libtinfo-libs_package() {
 }
 
 ncurses-libtinfo-devel_package() {
-	lib32disabled=yes
+	lib32mode=full
 	depends="ncurses-devel-${version}_${revision}"
 	depends+=" ncurses-libtinfo-libs-${version}_${revision}"
 	short_desc+=" - libtinfo.so symlink - development files"


### PR DESCRIPTION
fixes #42007

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly** (generated package seems to be correct)
