### PR TITLE
hikari: add xwayland restacking patch, adopt

### DIFF
--- a/srcpkgs/hikari/patches/restack_xwayland_windows.patch
+++ b/srcpkgs/hikari/patches/restack_xwayland_windows.patch
@@ -1,0 +1,10 @@
+--- a/src/xwayland_view.c	2023-10-02 23:25:53.794255011 -0400
++++ b/src/xwayland_view.c	2023-10-02 23:26:17.173265450 -0400
+@@ -304,6 +304,7 @@
+   struct wlr_xwayland_surface *xwayland_surface = xwayland_view->surface;
+ 
+   wlr_xwayland_surface_activate(xwayland_surface, active);
++  wlr_xwayland_surface_restack(xwayland_surface, NULL, XCB_STACK_MODE_ABOVE);
+   wlr_xwayland_set_seat(hikari_server.xwayland, hikari_server.seat);
+ }
+ 

--- a/srcpkgs/hikari/template
+++ b/srcpkgs/hikari/template
@@ -1,7 +1,7 @@
 # Template file for 'hikari'
 pkgname=hikari
 version=2.3.3
-revision=2
+revision=3
 build_style=gnu-makefile
 make_cmd=bmake
 make_use_env=yes
@@ -11,7 +11,7 @@ make_install_args="ETC_PREFIX= WITHOUT_SUID=YES"
 hostmakedepends="bmake pkg-config wayland-devel"
 makedepends="wlroots0.15-devel pango-devel cairo-devel pam-devel glib-devel libucl-devel"
 short_desc="Stacking Wayland compositor with tiling features"
-maintainer="Andrew J. Hesford <ajh@sideband.org>"
+maintainer="yosh <yosh-git@riseup.net>"
 license="BSD-2-Clause"
 homepage="https://hikari.acmelabs.space"
 changelog="https://hub.darcs.net/raichoo/hikari/browse/CHANGELOG.md"


### PR DESCRIPTION
- I tested the changes in this PR: **YES**

#### Local Build Testing
- I built this PR locally for my native architecture, (`x86_64-glibc`)

hikari currently doesn't restack xwayland windows when a new one is focused, which can cause dialog boxes in xwayland applications to not accept mouse input. this patch comes from [a fork of hikari](https://hub.darcs.net/holycow/hikari/patch/de3817572a6c3ba5b51614fe31151d2c63fe1fd4), and it seems that unfortunately [the origin repo](https://hub.darcs.net/raichoo/hikari/changes) isn't quite updated anymore. [I've reported it there as well nonetheless](https://hub.darcs.net/raichoo/hikari/issue/48)