### PR TITLE
openssl: update to 3.1.3.

### DIFF
--- a/srcpkgs/nginx/template
+++ b/srcpkgs/nginx/template
@@ -4,7 +4,7 @@
 # See comments in mime-types template
 pkgname=nginx
 version=1.24.0
-revision=3
+revision=4
 _tests_commit=36a4563f7f00
 _njs_version=0.7.12
 create_wrksrc=yes
@@ -42,6 +42,7 @@ configure_args="--prefix=${_cfgdir}
  --with-http_xslt_module=dynamic
  --with-http_geoip_module=dynamic
  --with-http_perl_module=dynamic
+ --with-openssl-opt=enable-ktls
  --with-stream=dynamic
  --with-stream_geoip_module=dynamic
  --with-stream_realip_module

--- a/srcpkgs/openssl/template
+++ b/srcpkgs/openssl/template
@@ -1,12 +1,12 @@
 # Template file for 'openssl'
 pkgname=openssl
-version=3.1.2
+version=3.1.4
 revision=1
 bootstrap=yes
 build_style=configure
 configure_script="./Configure"
 configure_args="--prefix=/usr --openssldir=/etc/ssl --libdir=lib
- shared no-ssl3-method $(vopt_if asm ' ' 'no-asm')
+ shared enable-ktls $(vopt_if asm ' ' 'no-asm')
  -Wa,--noexecstack"
 make_cmd=make
 make_build_args='MAKEDEPPROG="$(CC)'
@@ -17,7 +17,7 @@ maintainer="John <me@johnnynator.dev>"
 license="Apache-2.0"
 homepage="https://www.openssl.org"
 distfiles="https://www.openssl.org/source/openssl-${version}.tar.gz"
-checksum=a0ce69b8b97ea6a35b96875235aa453b966ba3cba8af2de23657d8b6767d6539
+checksum=840af5366ab9b522bde525826be3ef0fb0af81c6a9ebd84caa600fea1731eee3
 conf_files="/etc/ssl/openssl.cnf"
 replaces="libressl>=0"
 


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**
    - tested nginx with the new openssl version and confirmed ktls works
    - still testing openssl itself (seems fine, only thing in the changelog affects windows)

cc @duncaen (nginx maintainer), @Johnnynator (openssl maintainer)
