### PR TITLE
fotoxx: update to 23.70.

### DIFF
--- a/srcpkgs/fotoxx/template
+++ b/srcpkgs/fotoxx/template
@@ -1,6 +1,6 @@
 # Template file for 'fotoxx'
 pkgname=fotoxx
-version=23.60
+version=23.70
 revision=1
 build_style=gnu-makefile
 make_use_env=yes
@@ -13,7 +13,7 @@ license="GPL-3.0-or-later"
 homepage="https://www.kornelix.net/fotoxx/fotoxx.html"
 changelog="https://www.kornelix.net/downloads/recent_changes.txt"
 distfiles="https://www.kornelix.net/downloads/downloads/fotoxx-${version}-source.tar.gz"
-checksum=ce7eff3682ce8355c5d1f692abe1583dba2c2c7059d47a2a3c341b90051f1a8c
+checksum=9eea1a0a81d5860d4f8444f78880b93aa082594dfd2e99a137865cad6174daf4
 
 CXXFLAGS="-I${XBPS_CROSS_BASE}/usr/include/champlain-0.12"
 


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (X86_64-LIBC)

