### PR TITLE
Berry: add patch

### DIFF
--- a/srcpkgs/berry/patches/no-zombies.patch
+++ b/srcpkgs/berry/patches/no-zombies.patch
@@ -1,0 +1,39 @@
+From 3501ee006ee9bdddc817fd71750e431b4186a0c7 Mon Sep 17 00:00:00 2001
+From: Joseph Eib <xealblade@example.com>
+Date: Wed, 30 Nov 2022 17:10:43 -0500
+Subject: [PATCH] Avoid creation of zombie process by load_config
+
+Previously, a zombie process was created when the process forked in
+load_config terminates because the parent does not call wait or waitpid.
+It is unreasonable to wait for the child because a user may exec their
+autostart script into a long-running process. Instead, the parent now
+simply ignores SIGCHLD which allows the child to be reaped immediately
+upon termination.
+---
+ wm.c | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/wm.c b/wm.c
+index f3a01b8..b863bea 100644
+--- a/wm.c
++++ b/wm.c
+@@ -4,6 +4,7 @@
+ #include "config.h"
+ 
+ #include <limits.h>
++#include <signal.h>
+ #include <stdbool.h>
+ #include <stdio.h>
+ #include <stdint.h>
+@@ -2536,8 +2537,10 @@ main(int argc, char *argv[])
+     LOGN("Successfully opened display");
+ 
+     setup();
+-    if (conf_found)
++    if (conf_found) {
++        signal(SIGCHLD, SIG_IGN);
+         load_config(conf_path);
++    }
+     run();
+     close_wm();
+     free(font_name);


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

I tested berrywm on a VM and it ran, however I'm stuck at a blank screen without any errors or warnings from Xorg - I'm not sure if this is normal behaviour with something I haven't configured.

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)

There's no new version of berry, but they provide a patch which I've imported that seems to fix the issue as mentioned in https://github.com/void-linux/void-packages/issues/46039