### PR TITLE
gallery-dl: update to 1.26.0.

### DIFF
--- a/srcpkgs/gallery-dl/template
+++ b/srcpkgs/gallery-dl/template
@@ -1,7 +1,7 @@
 # Template file for 'gallery-dl'
 pkgname=gallery-dl
-version=1.25.8
-revision=2
+version=1.26.0
+revision=1
 build_style=python3-module
 make_check_args="--ignore test/test_results.py"
 hostmakedepends="python3-setuptools"
@@ -13,7 +13,7 @@ license="GPL-2.0-only"
 homepage="https://github.com/mikf/gallery-dl"
 changelog="https://raw.githubusercontent.com/mikf/gallery-dl/master/CHANGELOG.md"
 distfiles="https://github.com/mikf/gallery-dl/archive/refs/tags/v${version}.tar.gz"
-checksum=eb1c95b1a279a6254fee7966845de1404fc4a61f2d1aa591c6f069184d3518a7
+checksum=9dd03cdc193b2b20b5007e13cce73c5f0297efeae809619ce9342006fdf0f3cc
 
 pre_build() {
 	make man completion


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc

Was just bumping the macports port and was going to do this anyway so I though I'd submit the PR for it.