### PR TITLE
tor: update to 0.4.8.7.

### DIFF
--- a/srcpkgs/tor/template
+++ b/srcpkgs/tor/template
@@ -1,9 +1,8 @@
 # Template file for 'tor'
 pkgname=tor
-version=0.4.7.14
-revision=2
+version=0.4.8.7
+revision=1
 build_style=gnu-configure
-configure_args="--enable-zstd"
 hostmakedepends="pkg-config"
 makedepends="libcap-devel libevent-devel libscrypt-devel libseccomp-devel liblzma-devel zlib-devel libzstd-devel"
 depends="ca-certificates torsocks"
@@ -14,7 +13,7 @@ license="BSD-3-Clause"
 homepage="https://www.torproject.org/"
 changelog="https://gitlab.torproject.org/tpo/core/tor/-/raw/main/ChangeLog"
 distfiles="https://dist.torproject.org/tor-${version}.tar.gz"
-checksum=a5ac67f6466380fc05e8043d01c581e4e8a2b22fe09430013473e71065e65df8
+checksum=b20d2b9c74db28a00c07f090ee5b0241b2b684f3afdecccc6b8008931c557491
 
 case "${XBPS_TARGET_MACHINE}" in
 	# Tests just don't work here


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

zstd is autodetected, configure_args not necessary

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
