### PR TITLE
opensmtpd-filter-rspamd: update to 0.1.8

### DIFF
--- a/srcpkgs/opensmtpd-filter-rspamd/template
+++ b/srcpkgs/opensmtpd-filter-rspamd/template
@@ -1,7 +1,7 @@
 # Template file for 'opensmtpd-filter-rspamd'
 pkgname=opensmtpd-filter-rspamd
-version=0.1.7
-revision=3
+version=0.1.8
+revision=1
 build_style=go
 go_import_path="github.com/poolpOrg/filter-rspamd"
 short_desc="Filter incoming mail based on sender reputation"
@@ -9,7 +9,7 @@ maintainer="Lucas L. Treffenstädt <lucas@treffenstaedt.de>"
 license="ISC"
 homepage="https://github.com/poolpOrg/filter-rspamd"
 distfiles="https://github.com/poolpOrg/filter-rspamd/archive/v${version}.tar.gz"
-checksum=734733c3b672b660bcfe8f0008b09c84469f051f7381230d332265981af6f287
+checksum=42b3e8d35feac813e695245b55c552126728de1a3219fb4dc64c62935f831f29
 
 do_install() {
 	vlicense LICENSE


### PR DESCRIPTION
- I tested the changes in this PR: **NO**
- I built this PR locally for my native architecture, (amd64-musl)

This brings in a rather important IMHO security fix: it's possible to crash filter-rspamd by attempting to log in as a user with a "|" character in it.  Doing so will also quit opensmtpd since it dies once a filter exits.

Furthermore, this update will also be needed for the next opensmtpd version since it'll bump the protocol version.

I haven't actually run this on void linux, but I'm using it on other systems and the [diff is quite small](https://github.com/poolpOrg/filter-rspamd/compare/v0.1.7...v0.1.8), I don't expect actual breakages.

(edit: I've mailed the maintainer since I don't know their github account)