### PR TITLE
kodi-addon-inputstream-adaptive: update to 19.0.7

### DIFF
--- a/srcpkgs/kodi-addon-inputstream-adaptive/template
+++ b/srcpkgs/kodi-addon-inputstream-adaptive/template
@@ -1,17 +1,17 @@
 # Template file for 'kodi-addon-inputstream-adaptive'
 pkgname=kodi-addon-inputstream-adaptive
-version=2.6.7
-revision=2
+version=19.0.7
+revision=1
 _kodi_release=Matrix
 build_style=cmake
 makedepends="kodi-devel kodi-platform-devel p8-platform-devel tinyxml-devel
- expat-devel"
+ expat-devel gtest-devel"
 short_desc="Kodi inputstream addon for several manifest types"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later"
-homepage="https://github.com/peak3d/inputstream.adaptive"
-distfiles="https://github.com/peak3d/inputstream.adaptive/archive/${version}-${_kodi_release}.tar.gz"
-checksum=353207f5f98bf81ce8d79cec903c28da8c0227d7c7a632692c910d81e59c2dbe
+homepage="https://github.com/xbmc/inputstream.adaptive"
+distfiles="https://github.com/xbmc/inputstream.adaptive/archive/refs/tags/${version}-${_kodi_release}.tar.gz"
+checksum=b208313fd50442cabd339a16a3beec8cfa41c1b6bf19617ffeb269144c5f65fe
 
 if [ -n "${CROSS_BUILD}" ]; then
 	configure_args+=" -DCMAKE_MODULE_PATH=${XBPS_CROSS_BASE}/usr/share/kodi/cmake"

--- a/srcpkgs/kodi-addon-inputstream-adaptive/update
+++ b/srcpkgs/kodi-addon-inputstream-adaptive/update
@@ -1,0 +1,2 @@
+#pattern='/archive/refs/tags/(v?|\Q'"${pkgname}"'\E[-_])?\K[\d.]+\Q'"-${_kodi_release}"'\E(?=\.tar\.gz")'
+disabled='Default check is broken and there will be no more updates for Matrix'


### PR DESCRIPTION
Bump version to 19.0.7 (latest one supported by Matrix).

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64