### PR TITLE
netavark: update to 1.8.0, aardvark-dns: update to 1.8.0.

### DIFF
--- a/srcpkgs/aardvark-dns/template
+++ b/srcpkgs/aardvark-dns/template
@@ -1,6 +1,6 @@
 # Template file for 'aardvark-dns'
 pkgname=aardvark-dns
-version=1.7.0
+version=1.8.0
 revision=1
 build_style=cargo
 short_desc="Authoritative dns server for A/AAAA container records"
@@ -9,7 +9,7 @@ license="Apache-2.0"
 homepage="https://github.com/containers/aardvark-dns"
 changelog="https://raw.githubusercontent.com/containers/aardvark-dns/main/RELEASE_NOTES.md"
 distfiles="https://github.com/containers/aardvark-dns/archive/refs/tags/v${version}.tar.gz"
-checksum=6ee7dfa8bab8040b917959a2f57f25496ad036a2d933c6225114e2c1e68bab0b
+checksum=c9b818110e3d5d45f8bdb3c9ccc48c994aedb0b19fefcc7577fc1ef7ed294343
 
 post_install() {
 	vmkdir usr/libexec/podman

--- a/srcpkgs/netavark/template
+++ b/srcpkgs/netavark/template
@@ -1,6 +1,6 @@
 # Template file for 'netavark'
 pkgname=netavark
-version=1.7.0
+version=1.8.0
 revision=1
 build_style=cargo
 hostmakedepends="mandown protobuf"
@@ -10,7 +10,7 @@ license="Apache-2.0"
 homepage="https://github.com/containers/netavark"
 changelog="https://raw.githubusercontent.com/containers/netavark/main/RELEASE_NOTES.md"
 distfiles="https://github.com/containers/netavark/archive/refs/tags/v${version}.tar.gz"
-checksum=b0ed7d80fd96ef2af88e7a001d91024919125e5842d9772de94648044630e116
+checksum=b1422ef6927458e9f80f7d322b751e29ab5d04d8ed6cb065baa82fa4291af10f
 # needs unshare which cannot be used in CI
 make_check=ci-skip
 


### PR DESCRIPTION
- netavark: update to 1.8.0.
- aardvark-dns: update to 1.8.0.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
