### PR TITLE
pgmetrics: update to 1.16.0.

### DIFF
--- a/srcpkgs/pgmetrics/template
+++ b/srcpkgs/pgmetrics/template
@@ -1,10 +1,11 @@
 # Template file for 'pgmetrics'
 pkgname=pgmetrics
 version=1.16.0
-revision=1
+revision=2
 build_style=go
 go_import_path="github.com/rapidloop/pgmetrics"
 go_package="./cmd/pgmetrics"
+go_ldflags="-X main.version=${version} -extldflags '-static'"
 short_desc="Collect and display statistics from running Postgresql"
 maintainer="Gerardo Di iorio <arete74@gmail.com>"
 license="Apache-2.0"


### PR DESCRIPTION
I changed the template so now pgmetrics shows the version string.
```
$ pgmetrics -V
pgmetrics 1.16.0
```
Instead of
```
$ pgmetrics -V
pgmetrics devel
```

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
