### PR TITLE
New package: pdfcpu-0.5.0

### DIFF
--- a/srcpkgs/pdfcpu/template
+++ b/srcpkgs/pdfcpu/template
@@ -1,0 +1,14 @@
+# Template file for 'pdfcpu'
+pkgname=pdfcpu
+version=0.5.0
+revision=1
+build_style=go
+go_import_path="github.com/pdfcpu/pdfcpu"
+go_package="${go_import_path}/cmd/pdfcpu"
+short_desc="PDF processor"
+maintainer="Andrew Benson <abenson+void@gmail.com>"
+license="Apache-2.0"
+homepage="http://pdfcpu.io/"
+changelog="https://github.com/pdfcpu/pdfcpu/releases"
+distfiles="https://github.com/pdfcpu/pdfcpu/archive/v${version}.tar.gz"
+checksum=d67529db954b4b8fd708ac984cf79a53baf57ab2d50ef9ee0f9188f7e4a83127


### PR DESCRIPTION

#### Testing the changes
- I tested the changes in this PR: **YES**


#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

#### Local build testing
```
pkg      host         target        cross  result
pdfcpu   x86_64       x86_64        n      OK
pdfcpu   x86_64-musl  x86_64-musl   n      OK
pdfcpu   i686         i686          n      OK
pdfcpu   x86_64       aarch64-musl  y      OK
pdfcpu   x86_64       aarch64       y      OK
pdfcpu   x86_64       armv7l-musl   y      OK
pdfcpu   x86_64       armv7l        y      OK
pdfcpu   x86_64       armv6l-musl   y      OK
pdfcpu   x86_64       armv6l        y      OK
```