### PR TITLE
xdg-desktop-portal: include a default portals.conf

### DIFF
--- a/srcpkgs/xdg-desktop-portal/files/portals.conf
+++ b/srcpkgs/xdg-desktop-portal/files/portals.conf
@@ -1,0 +1,2 @@
+[preferred]
+default=*

--- a/srcpkgs/xdg-desktop-portal/template
+++ b/srcpkgs/xdg-desktop-portal/template
@@ -1,11 +1,11 @@
 # Template file for 'xdg-desktop-portal'
 pkgname=xdg-desktop-portal
 version=1.18.0
-revision=1
+revision=2
 build_style=meson
 configure_args="-Dgeoclue=enabled -Dlibportal=enabled
  -Dsystemd=disabled"
-hostmakedepends="pkg-config gettext glib-devel bubblewrap flatpak"
+hostmakedepends="pkg-config gettext glib-devel bubblewrap flatpak python3-docutils"
 makedepends="flatpak-devel fuse3-devel pipewire-devel geoclue2-devel
  libportal-devel polkit-devel"
 checkdepends="dbus python3-dbusmock"
@@ -20,3 +20,7 @@ checksum=4c8a017fb3c894ec46c03d08e6b6c3d31259707bdb3c7ee8aedb3a0cc0b4d707
 if [ "$XBPS_BUILD_ENVIRONMENT" = "void-packages-ci" ]; then
 	export TEST_IN_CI="true"
 fi
+
+post_install() {
+	vinstall "${FILESDIR}"/portals.conf 644 usr/share/xdg-desktop-portal
+}


### PR DESCRIPTION
Without this, `xdg-desktop-portal` cannot do anything as of 1.18.0. DEs and WMs should probably ship their own if they want to use a specific frontend, but this should be good enough for now.

This conf file is put in the lowest precedence location, and generic `portals.conf` is overriden if `XDG_CURRENT_DESKTOP-portals.conf` is found, so this should be fairly safe.

Additionally, this `portals.conf` does not require any specific frontend, just the special value `*`, which means the first one found in lexicographical order.

See [portals.conf(5)](https://github.com/flatpak/xdg-desktop-portal/blob/main/doc/portals-conf.rst) for more details. This manpage is also installed now by adding `python3-docutils` to `hostmakedepends`.

fixes #46317

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

