### PR TITLE
yasm: migrate to `python3`.

### DIFF
--- a/srcpkgs/yasm/template
+++ b/srcpkgs/yasm/template
@@ -3,12 +3,12 @@ pkgname=yasm
 version=1.3.0
 revision=2
 build_style=gnu-configure
-hostmakedepends="xmlto python"
+hostmakedepends="xmlto python3"
 short_desc="Complete rewrite of the NASM assembler"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="BSD-3-Clause, Artistic-1.0, GPL-2.0-or-later, LGPL-2.1-or-later"
 homepage="http://www.tortall.net/projects/yasm/"
-distfiles="http://www.tortall.net/projects/yasm/releases/yasm-$version.tar.gz"
+distfiles="http://www.tortall.net/projects/yasm/releases/yasm-${version}.tar.gz"
 checksum=3dce6601b495f5b3d45b59f7d2492a340ee7e84b5beca17e48f862502bd5603f
 
 post_install() {


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES** (compiled `libvpx`)

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
