### PR TITLE
qflipper: fix for qt6 svg rendering

### DIFF
--- a/srcpkgs/qflipper/template
+++ b/srcpkgs/qflipper/template
@@ -1,7 +1,7 @@
 # Template file for 'qflipper'
 pkgname=qflipper
 version=1.3.2
-revision=1
+revision=2
 _nanopb_version=0.4.6
 build_style=qmake
 configure_args="CONFIG+=qtquickcompiler DEFINES+=DISABLE_APPLICATION_UPDATES"

--- a/srcpkgs/qflipper/template
+++ b/srcpkgs/qflipper/template
@@ -8,7 +8,7 @@ configure_args="CONFIG+=qtquickcompiler DEFINES+=DISABLE_APPLICATION_UPDATES"
 hostmakedepends="pkg-config qt6-tools-devel"
 makedepends="qt6-serialport-devel qt6-declarative-devel qt6-wayland-devel
  qt6-qt5compat-devel qt6-svg-devel libusb-devel"
-depends="qt6-plugin-tls-openssl"
+depends="qt6-plugin-tls-openssl qt6-svg"
 short_desc="Desktop application for updating Flipper Zero firmware via PC"
 maintainer="Toyam Cox <Vaelatern@voidlinux.org>"
 license="GPL-3.0-only"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

WIthout installing qt6-svg, icons and art were not rendered.

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
