### PR TITLE
gcc6: remove python 2 scripts, move to bootstrap

### DIFF
--- a/srcpkgs/gcc6/template
+++ b/srcpkgs/gcc6/template
@@ -3,7 +3,7 @@
 _isl_version=0.16
 pkgname=gcc6
 version=6.5.0
-revision=1
+revision=2
 _majorver="${version%%.*}"
 _minorver="${version%.*}"
 create_wrksrc=yes
@@ -26,7 +26,7 @@ skip_extraction="ecj-4.9.jar"
 nopie=yes
 lib32disabled=yes
 nocross=yes
-python_version=2 #unverified
+repository=bootstrap
 
 subpackages="gcc6-gcj gcc6-gcj-ecj libgcj-devel libgcj gcc6-gcj-jdk-compat"
 
@@ -206,6 +206,9 @@ do_install() {
 
 	# Remove python stuff
 	rm -rf ${DESTDIR}/usr/share/gcc-${version}/python
+	rm -f ${DESTDIR}/usr/lib/gcc/${_triplet}/${_minorver}/*.py
+	rm -f ${DESTDIR}/usr/bin/aot-compile-6
+	rm -f ${DESTDIR}/usr/share/man/man1/aot-compile-6.1
 
 	# Avoid conflict with gcc
 	mv ${DESTDIR}/usr/lib/libcc1* ${DESTDIR}/usr/lib/gcc/${_triplet}/${_minorver}
@@ -251,13 +254,13 @@ gcc6-gcj_package() {
 		for f in gcj jv-convert gjarsigner gjar grmic jcf-dump \
 			gtnameserv gcjh gnative2ascii gserialver gkeytool \
 			gij grmiregistry grmid gorbd gcj-dbtool gjavah \
-			gc-analyze gappletviewer rebuild-gcj-db aot-compile; do
+			gc-analyze gappletviewer rebuild-gcj-db; do
 			vmove usr/bin/${f}-${_majorver}
 		done
 		for f in gcj jv-convert gjarsigner gjar grmic jcf-dump gjdoc \
 			gtnameserv gcjh gnative2ascii gserialver gkeytool \
 			gij grmiregistry grmid gorbd gcj-dbtool gjavah \
-			gc-analyze gappletviewer rebuild-gcj-db aot-compile; do
+			gc-analyze gappletviewer rebuild-gcj-db; do
 			if [ -f ${DESTDIR}/usr/share/man/man1/${f}-${_majorver}.1 ]; then
 				vmove usr/share/man/man1/${f}-${_majorver}.1
 			fi

--- a/srcpkgs/pdftk/template
+++ b/srcpkgs/pdftk/template
@@ -14,9 +14,11 @@ checksum=118f6a25fd3acaafb58824dce6f97cdc07e56050e666b90e4c4ef426ea37b8c1
 nocross=yes
 
 do_build() {
+	_cxxflags="${CXXFLAGS//-fstack-clash-protection}"
+	_cxxflags="${_cxxflags//-ffile-prefix-map=\/builddir\/${pkgname}-${version}\/${build_wrksrc}=.}"
 	sed -e "s;@CXX@;g++-6;" \
 		-e "s;@AR@;$AR;" \
-		-e "s;@CXXFLAGS@;${CXXFLAGS//-fstack-clash-protection};" \
+		-e "s;@CXXFLAGS@;${_cxxflags};" \
 		-e "s;@LDFLAGS@;$LDFLAGS;" \
 		${FILESDIR}/Makefile > Makefile
 	make ${makejobs} || make ${makjobs}


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES** (built revdeps)

this will require removing `*gcc6*` from the main repos after merge