### PR TITLE
gzdoom: add patch for correct pk3 file search location by default.

### DIFF
--- a/srcpkgs/gzdoom/patches/pk3location.patch
+++ b/srcpkgs/gzdoom/patches/pk3location.patch
@@ -1,0 +1,22 @@
+diff --git a/src/gameconfigfile.cpp b/src/gameconfigfile.cpp
+index 0b3931e..c6856cc 100644
+--- a/src/gameconfigfile.cpp
++++ b/src/gameconfigfile.cpp
+@@ -124,6 +124,8 @@ FGameConfigFile::FGameConfigFile ()
+ 		SetValueForKey ("Path", "/usr/local/share/doom", true);
+ 		SetValueForKey ("Path", "/usr/local/share/games/doom", true);
+ 		SetValueForKey ("Path", "/usr/share/doom", true);
++                // Adds the correct locations of the pk3file for Voidlinux
++		SetValueForKey ("Path", "/usr/share/gzdoom", true);
+ 		SetValueForKey ("Path", "/usr/share/games/doom", true);
+ #endif
+ 	}
+@@ -146,6 +148,8 @@ FGameConfigFile::FGameConfigFile ()
+ 		SetValueForKey ("Path", "/usr/local/share/doom", true);
+ 		SetValueForKey ("Path", "/usr/local/share/games/doom", true);
+ 		SetValueForKey ("Path", "/usr/share/doom", true);
++                // Adds the correct locations of the pk3file for Voidlinux
++		SetValueForKey ("Path", "/usr/share/gzdoom", true);
+ 		SetValueForKey ("Path", "/usr/share/games/doom", true);
+ #endif
+ 		SetValueForKey ("Path", "$DOOMWADDIR", true);

--- a/srcpkgs/gzdoom/template
+++ b/srcpkgs/gzdoom/template
@@ -1,7 +1,7 @@
 # Template file for 'gzdoom'
 pkgname=gzdoom
 version=4.11.0
-revision=1
+revision=2
 archs="~i686* ~arm*"
 build_style=cmake
 configure_args="-DINSTALL_PK3_PATH=share/gzdoom -DDYN_GTK=OFF -DDYN_OPENAL=OFF"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (GlibC)


Heya guys ! As promised [here](https://github.com/void-linux/void-packages/issues/46386#issuecomment-1743488596), i made a tiny patch for GZDoom to search it's own `.pk3` files by default.

This should solve the issue for anyone having this issue !


