### PR TITLE
power-profiles-daemon: create /var/lib/power-profiles-daemon

### DIFF
--- a/srcpkgs/power-profiles-daemon/template
+++ b/srcpkgs/power-profiles-daemon/template
@@ -1,7 +1,7 @@
 # Template file for 'power-profiles-daemon'
 pkgname=power-profiles-daemon
 version=0.13
-revision=2
+revision=3
 build_style=meson
 configure_args="-Dsystemdsystemunitdir=/usr/lib/systemd/system/"
 hostmakedepends="pkg-config glib-devel"
@@ -15,6 +15,7 @@ homepage="https://gitlab.freedesktop.org/hadess/power-profiles-daemon"
 changelog="https://gitlab.freedesktop.org/hadess/power-profiles-daemon/-/raw/main/NEWS"
 distfiles="https://gitlab.freedesktop.org/hadess/power-profiles-daemon/-/archive/${version}/power-profiles-daemon-${version}.tar.gz"
 checksum=74aac43eb43ebe5a3255a00eb48d781a5acfba32e96ab85737e22205e045e581
+make_dirs="/var/lib/power-profiles-daemon 0755 root root"
 
 if [ "$XBPS_CHECK_PKGS" ]; then
 	configure_args+=" -Dtests=true"


### PR DESCRIPTION
@oreo639 
Fixes the following warning, that spams the log:

```
daemon.notice: Oct  8 17:58:12 power-profiles-daemon: ** (power-profiles-daemon:833): WARNING **: 17:58:12.124: Could not save configuration file '/var/lib/power-profiles-daemon/state.ini': Failed to create file ?/var/lib/power-profiles-daemon/state.ini.AKGIC2?: No such file or directory
```

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**