### PR TITLE
rpi-kernel: make btrfs built-in module

### DIFF
--- a/srcpkgs/rpi-kernel/template
+++ b/srcpkgs/rpi-kernel/template
@@ -13,7 +13,7 @@
 # Upstream documentation: https://www.raspberrypi.com/documentation/computers/linux_kernel.html
 pkgname=rpi-kernel
 version=6.1.54
-revision=1
+revision=2
 _githash=fad58933544bb2a7b7db92847c25c79a83171fa6
 archs="armv6l* armv7l* aarch64*"
 hostmakedepends="perl kmod uboot-mkimage openssl-devel bc bison flex xz"
@@ -113,6 +113,8 @@ do_configure() {
 	CONFIG_LZ4_COMPRESS=y
 	CONFIG_CRYPTO_RNG=y
 	CONFIG_CRYPTO_RNG_DEFAULT=y
+	CONFIG_BTRFS_FS=y
+	CONFIG_BTRFS_POSIX_ACL=y
 	!
 
 	while read -r line; do


### PR DESCRIPTION
This allows booting from btrfs partitions. Adds around 120kB to the uncompressed package size.

#### Testing the changes
- I tested the changes in this PR: **briefly**


- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl (Raspberry PI 3 Model A+) 

