### PR TITLE
brltty: fix segfault when built with Cython 3

### DIFF
--- a/srcpkgs/brltty/patches/cython3.patch
+++ b/srcpkgs/brltty/patches/cython3.patch
@@ -1,0 +1,44 @@
+From e6707d5e094dc36db4319ce4d052a6ad568a5d26 Mon Sep 17 00:00:00 2001
+From: Samuel Thibault <samuel.thibault@ens-lyon.org>
+Date: Tue, 15 Aug 2023 16:29:13 +0200
+Subject: [PATCH] brlapi: Fix python crash on connection error
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+From Lukáš Tyrychtr:
+“
+Cython 3.0 started using the new Python object finalization APIs from PEP 442
+”
+
+This means that __del__ gets called even when raising an exception from
+__init__, while it was not before. To cope with both behaviors, we can
+set self.h to NULL to determine whether it still exists or not.
+
+Thanks Lukáš Tyrychtr for the investigation and patch draft!
+---
+ Bindings/Python/brlapi.pyx | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/Bindings/Python/brlapi.pyx b/Bindings/Python/brlapi.pyx
+index 0136895eaf..af62cc9be0 100644
+--- a/Bindings/Python/brlapi.pyx
++++ b/Bindings/Python/brlapi.pyx
+@@ -453,6 +453,7 @@ cdef class Connection:
+ 		c_brlapi.brlapi_protocolExceptionInit(self.h)
+ 		if self.fd == -1:
+ 			c_brlapi.free(self.h)
++			self.h = NULL
+ 			raise ConnectionError(self.settings.host, self.settings.auth)
+ 
+ 	def closeConnection(self):
+@@ -465,7 +466,8 @@ cdef class Connection:
+ 		"""Release resources used by the connection"""
+ 		if self.fd != -1:
+ 			c_brlapi.brlapi__closeConnection(self.h)
+-		c_brlapi.free(self.h)
++		if self.h != NULL:
++			c_brlapi.free(self.h)
+ 
+ 	property host:
+ 		"""To get authorized to connect, libbrlapi has to tell the BrlAPI server a secret key, for security reasons. This is the path to the file which holds it; it will hence have to be readable by the application."""

--- a/srcpkgs/brltty/template
+++ b/srcpkgs/brltty/template
@@ -1,7 +1,7 @@
 # Template file for 'brltty'
 pkgname=brltty
 version=6.4
-revision=10
+revision=11
 build_style=gnu-configure
 build_helper=python3
 configure_args="--enable-gpm --with-screen-driver=lx,sc


### PR DESCRIPTION
https://discourse.gnome.org/t/psa-for-distros-brltty-should-be-built-using-cython-0-29-x-not-cython-3/16715/3i

this isn't an issue with brltty currently in repositories because it was not rebuilt with cython3, but a simple rebuild reveals the segfault when doing `python3 -c "import brlapi; brlapi.Connection()"`, it will be an issue when the python 3.12 rebuilds finish because they include a revbump to this package

@ahesford do you want to merge this now or after the 3.12 builds are done?

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
