### PR TITLE
Update tracker and libcue for CVE-2023-43641.

### DIFF
--- a/srcpkgs/libcue/patches/fdf72c8bded8d24cfa0608b8e97f2eed210a920e.patch
+++ b/srcpkgs/libcue/patches/fdf72c8bded8d24cfa0608b8e97f2eed210a920e.patch
@@ -1,0 +1,24 @@
+From fdf72c8bded8d24cfa0608b8e97f2eed210a920e Mon Sep 17 00:00:00 2001
+From: Kevin Backhouse <kevinbackhouse@github.com>
+Date: Wed, 27 Sep 2023 20:22:43 +0100
+Subject: [PATCH] Check that the array index isn't negative. This fixes
+ CVE-2023-43641.
+
+Signed-off-by: Kevin Backhouse <kevinbackhouse@github.com>
+---
+ cd.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/cd.c b/cd.c
+index cf77a18..4bbea19 100644
+--- a/cd.c
++++ b/cd.c
+@@ -339,7 +339,7 @@ track_get_rem(const Track* track)
+ 
+ void track_set_index(Track *track, int i, long ind)
+ {
+-	if (i > MAXINDEX) {
++	if (i < 0 || i > MAXINDEX) {
+ 		fprintf(stderr, "too many indexes\n");
+                 return;
+         }

--- a/srcpkgs/libcue/template
+++ b/srcpkgs/libcue/template
@@ -1,7 +1,7 @@
 # Template file for 'libcue'
 pkgname=libcue
 version=2.2.1
-revision=1
+revision=2
 build_style=cmake
 configure_args="-DBUILD_SHARED_LIBS=ON"
 hostmakedepends="bison flex"

--- a/srcpkgs/tracker-miners/template
+++ b/srcpkgs/tracker-miners/template
@@ -1,7 +1,7 @@
 # Template file for 'tracker-miners'
 pkgname=tracker-miners
-version=3.5.0
-revision=4
+version=3.6.1
+revision=1
 build_style=meson
 build_helper=qemu
 # missing libgrss for miner_rss
@@ -27,7 +27,7 @@ license="GPL-2.0-or-later"
 homepage="https://tracker.gnome.org/"
 changelog="https://gitlab.gnome.org/GNOME/tracker-miners/-/raw/master/NEWS"
 distfiles="${GNOME_SITE}/tracker-miners/${version%.*}/tracker-miners-${version}.tar.xz"
-checksum=17966603dc432a98526b490586a48acd7f9f59935f7895dfc51729a46a6901a3
+checksum=eef0e8d4aaca78feffb97d2f0957361869f53ea7768d1991385be51c17e8928e
 make_check=no # relies on unsupported ops in chroot
 
 tracker3-miners_package() {

--- a/srcpkgs/tracker/template
+++ b/srcpkgs/tracker/template
@@ -1,9 +1,9 @@
 # Template file for 'tracker'
 pkgname=tracker
-version=3.5.0
-revision=3
+version=3.6.0
+revision=1
 build_style=meson
-build_helper="gir"
+build_helper="gir qemu"
 configure_args="-Ddocs=false -Dman=true -Dstemmer=disabled
  -Dsystemd_user_services=false"
 hostmakedepends="gettext pkg-config glib-devel vala asciidoc
@@ -17,11 +17,12 @@ license="GPL-2.0-or-later, LGPL-2.1-or-later"
 homepage="https://wiki.gnome.org/Projects/Tracker"
 changelog="https://gitlab.gnome.org/GNOME/tracker/-/raw/master/NEWS"
 distfiles="${GNOME_SITE}/tracker/${version%.*}/tracker-${version}.tar.xz"
-checksum=13294275dbbbad9634b3a8390c08e6f12bebfe84f6ccafb72b27b0c23ba8da2f
+checksum=52592cfe19baffd16dbe47475be7da750dbd0b6333fd7acb60faa9da5bc40df2
 make_check_pre="dbus-run-session"
 
 if [ "$CROSS_BUILD" ]; then
 	hostmakedepends+=" dbus"
+	configure_args+=" --cross-file=${XBPS_WRAPPERDIR}/meson/xbps_sqlite.cross"
 fi
 
 if [ "${XBPS_TARGET_WORDSIZE}" = "32" ]; then
@@ -31,7 +32,15 @@ fi
 post_patch() {
 	if [ "$CROSS_BUILD" ]; then
 		# Tell the build system that we have internal fts5 in sqlite3
-		vsed -i "/\[properties\]/a sqlite3_has_fts5 = 'true'" xbps_meson.cross
+		cat > "${XBPS_WRAPPERDIR}/meson/xbps_sqlite.cross" <<-EOF
+			[properties]
+			sqlite3_has_fts5 = 'true'
+			EOF
+	fi
+
+	# Patch out error due to y2k38 on musl
+	if [ "$XBPS_TARGET_LIBC" = "musl" ] && [ "$XBPS_TARGET_WORDSIZE" = "32" ]; then
+		vsed -e "s/error('Libc implementation has broken 4-digit years implementation.')/year_modifier = '%2C%y'/" -i meson.build
 	fi
 }
 


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

See here for more details: https://github.blog/2023-10-09-coordinated-disclosure-1-click-rce-on-gnome-cve-2023-43641/
The public example file only tests libcue, so that was all I could test, but the tracker update should also fix the sandbox escape issue.

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
