### PR TITLE
tuxpaint: remove python 2 scripts

### DIFF
--- a/srcpkgs/tuxpaint/template
+++ b/srcpkgs/tuxpaint/template
@@ -1,7 +1,7 @@
 # Template file for 'tuxpaint'
 pkgname=tuxpaint
 version=0.9.31
-revision=1
+revision=2
 build_style=gnu-makefile
 conf_files="/etc/tuxpaint/tuxpaint.conf"
 hostmakedepends="gettext gperf pkg-config ImageMagick"
@@ -15,7 +15,6 @@ homepage="https://www.tuxpaint.org/"
 distfiles="${SOURCEFORGE_SITE}/tuxpaint/${version}/tuxpaint-${version}.tar.gz"
 checksum=1a85c04fa5c9ae6b3ffd2ca8fa86a84c0c8b462b5059fa1fc2c445b5cfa857ee
 replaces="tuxpaint-data>=0"
-python_version=2
 CFLAGS="-D_GNU_SOURCE -D_POSIX_PRIORITY_SCHEDULING"
 
 pre_build() {
@@ -24,4 +23,7 @@ pre_build() {
 
 post_install() {
 	vinstall src/tuxpaint.desktop 644 usr/share/applications
+	# python 2
+	rm "${DESTDIR}/usr/share/doc/tuxpaint-${version}/outdated/zh_tw/mkTuxpaintIM.py" \
+		"${DESTDIR}/usr/share/tuxpaint/fonts/locale/zh_tw_docs/maketuxfont.py"
 }


### PR DESCRIPTION
- `maketuxfont.py` is impossible to easily port to python 3 because there is no equivalent to `string.letters` (set of all letters, locale-dependent). It is also probably not very useful in the modern era; it was created in 2005 when a "more then 13 MB" font file was considered huge.
- `mkTuxpaintIM.py` seems to be just for updating documentation (so probably not useful for users ever)

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

@Chocimier 
