### PR TITLE
python3-pikepdf: update to 8.5.1.

### DIFF
--- a/srcpkgs/python3-pikepdf/template
+++ b/srcpkgs/python3-pikepdf/template
@@ -1,7 +1,7 @@
 # Template file for 'python3-pikepdf'
 pkgname=python3-pikepdf
-version=8.2.1
-revision=2
+version=8.5.1
+revision=1
 build_style=python3-module
 hostmakedepends="python3-pybind11 python3-wheel"
 makedepends="libqpdf-devel python3-pybind11"
@@ -15,7 +15,7 @@ license="MPL-2.0"
 homepage="https://github.com/pikepdf/pikepdf"
 changelog="https://raw.githubusercontent.com/pikepdf/pikepdf/master/docs/releasenotes/version${version%%.*}.rst"
 distfiles="${PYPI_SITE}/p/pikepdf/pikepdf-${version}.tar.gz"
-checksum=ec6fb1bc37d1bd4c4f70ab13fc685787f21b498b92ae93215df23471c55401de
+checksum=f1a1de1a241912f96cb202b7ac28b4bc229d66c8bdf08d8dc25144f155adf653
 
 pre_check() {
 	cp -r src/pikepdf.egg-info "$(cd build/lib* && pwd)"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->

Fixes a new test failure with python 3.12, among other things.