### PR TITLE
puzzles: update to 20231010.2d9e414.

### DIFF
--- a/srcpkgs/puzzles/template
+++ b/srcpkgs/puzzles/template
@@ -1,6 +1,6 @@
 # Template file for 'puzzles'
 pkgname=puzzles
-version=20230909.67496e7
+version=20231010.2d9e414
 revision=1
 build_style=cmake
 configure_args="-DNAME_PREFIX=puzzles-"
@@ -10,8 +10,8 @@ short_desc="Simon Tatham's Portable Puzzle Collection"
 maintainer="Leah Neukirchen <leah@vuxu.org>"
 license="MIT"
 homepage="https://www.chiark.greenend.org.uk/~sgtatham/puzzles/"
-distfiles="https://git.tartarus.org/?p=simon/puzzles.git;a=snapshot;h=67496e74f68db900d8117be6de3c75285c29c489;sf=tgz>${pkgname}-${version#*.}.tgz"
-checksum=88e05ac209a34afd74fafd34f2e31246725113f31ff8f478cfc454c3f2ee4a72
+distfiles="https://git.tartarus.org/?p=simon/puzzles.git;a=snapshot;h=2d9e414ee316b37143954150016e8f4f18358497;sf=tgz>${pkgname}-${version#*.}.tgz"
+checksum=cf2a20981de3eac20c4a44bcc53c1bc77fbd407f5fdc09d79b7eeda9d04ae384
 
 post_install() {
 	vlicense LICENCE LICENSE


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture: **x86_64**