### PR TITLE
godot: add correct build name

### DIFF
--- a/srcpkgs/godot/template
+++ b/srcpkgs/godot/template
@@ -1,7 +1,7 @@
 # Template file for 'godot'
 pkgname=godot
 version=4.1.2
-revision=1
+revision=2
 archs="x86_64* i686* aarch64* armv7* ppc64*"
 build_style=scons
 # Build currently fails with embree-4.X
@@ -47,6 +47,7 @@ make_build_args+=" arch=$arch"
 
 pre_build() {
 	export CXXFLAGS=" $CXXFLAGS "
+	export BUILD_NAME="voidlinux"
 }
 
 post_patch() {


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)

It's a minor change that makes debugging and reporting issues for our package easier.
Instead of ".custom_build" the suffix is ".voidlinux".