### PR TITLE
openexr: update to 3.2.1.

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -1675,8 +1675,6 @@ libtcmalloc_minimal_debug.so.4 gperftools-2.1.90_1
 libtcmalloc_debug.so.4 gperftools-2.1.90_1
 libprofiler.so.0 gperftools-2.1.90_1
 libtcmalloc_and_profiler.so.4 gperftools-2.1.90_1
-libIlmImf-2_4.so.24 libopenexr-2.4.0_1
-libIlmImfUtil-2_4.so.24 libopenexr-2.4.0_1
 libGraphicsMagick.so.3 libgraphicsmagick-1.3.19_1
 libGraphicsMagick++.so.12 libgraphicsmagick-1.3.22_1
 libGraphicsMagickWand.so.2 libgraphicsmagick-1.3.19_1
@@ -4231,11 +4229,11 @@ libpanel-1.so.1 libpanel-1.0.1_1
 libqrtr.so.1 qrtr-ns-1.0_1
 libbpf.so.1 libbpf-1.0.0_1
 libImath-3_1.so.29 imath-3.1.9_1
-libIex-3_1.so.30 libopenexr-3.1.5_1
-libIlmThread-3_1.so.30 libopenexr-3.1.5_1
-libOpenEXR-3_1.so.30 libopenexr-3.1.5_1
-libOpenEXRCore-3_1.so.30 libopenexr-3.1.5_1
-libOpenEXRUtil-3_1.so.30 libopenexr-3.1.5_1
+libIex-3_2.so.31 libopenexr-3.2.1_1
+libIlmThread-3_2.so.31 libopenexr-3.2.1_1
+libOpenEXR-3_2.so.31 libopenexr-3.2.1_1
+libOpenEXRCore-3_2.so.31 libopenexr-3.2.1_1
+libOpenEXRUtil-3_2.so.31 libopenexr-3.2.1_1
 libdate-tz.so.3 chrono-date-3.0.1_1
 libayatana-ido3-0.4.so.0 ayatana-ido-0.9.2_1
 libayatana-indicator3.so.7 libayatana-indicator-0.9.3_1

--- a/srcpkgs/ImageMagick/template
+++ b/srcpkgs/ImageMagick/template
@@ -2,7 +2,7 @@
 pkgname=ImageMagick
 # Revbump php*-imagick with ImageMagick updates.
 version=7.1.1.18
-revision=1
+revision=2
 _upstream_version="${version/.${version##*.}/-${version##*.}}"
 build_style=gnu-configure
 configure_args="--disable-static --enable-opencl --with-modules --with-gslib

--- a/srcpkgs/blender/template
+++ b/srcpkgs/blender/template
@@ -1,7 +1,7 @@
 # Template file for 'blender'
 pkgname=blender
 version=3.6.5
-revision=1
+revision=2
 archs="x86_64* ppc64*"
 build_style="cmake"
 pycompile_dirs="/usr/share/blender/${version%.*}/scripts"

--- a/srcpkgs/darktable/template
+++ b/srcpkgs/darktable/template
@@ -1,7 +1,7 @@
 # Template file for 'darktable'
 pkgname=darktable
 version=4.4.2
-revision=2
+revision=3
 # upstream only supports these archs:
 archs="x86_64* aarch64* ppc64le*"
 build_style=cmake

--- a/srcpkgs/gimp/template
+++ b/srcpkgs/gimp/template
@@ -1,7 +1,7 @@
 # Template file for 'gimp'
 pkgname=gimp
 version=2.10.34
-revision=2
+revision=3
 build_style=gnu-configure
 configure_args="--disable-check-update --datadir=/usr/share --disable-python"
 hostmakedepends="automake gegl gettext-devel glib-devel gtk+-devel intltool

--- a/srcpkgs/gmic/template
+++ b/srcpkgs/gmic/template
@@ -1,7 +1,7 @@
 # Template file for 'gmic'
 pkgname=gmic
 version=3.1.6
-revision=4
+revision=5
 _zart_hash=34ebf6cce0bafb98abe57cec83c4a02cd1abeca0
 create_wrksrc=yes
 build_wrksrc="src"

--- a/srcpkgs/hugin/template
+++ b/srcpkgs/hugin/template
@@ -1,7 +1,7 @@
 # Template file for 'hugin'
 pkgname=hugin
 version=2022.0.0
-revision=10
+revision=11
 build_style=cmake
 build_helper=cmake-wxWidgets-gtk3
 pycompile_dirs="usr/share/hugin/data/plugins usr/share/hugin/data/plugins-templates"

--- a/srcpkgs/kimageformats/template
+++ b/srcpkgs/kimageformats/template
@@ -1,7 +1,7 @@
 # Template file for 'kimageformats'
 pkgname=kimageformats
 version=5.111.0
-revision=1
+revision=2
 build_style=cmake
 configure_args="-DKIMAGEFORMATS_HEIF=ON"
 hostmakedepends="kcoreaddons extra-cmake-modules qt5-qmake qt5-host-tools

--- a/srcpkgs/kio-extras/template
+++ b/srcpkgs/kio-extras/template
@@ -1,7 +1,7 @@
 # Template file for 'kio-extras'
 pkgname=kio-extras
 version=23.04.0
-revision=1
+revision=2
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF -DKDSOAP_KDWSDL2CPP_COMPILER=/usr/bin/kdwsdl2cpp"
 hostmakedepends="extra-cmake-modules pkg-config gperf qt5-qmake qt5-host-tools

--- a/srcpkgs/krita/template
+++ b/srcpkgs/krita/template
@@ -1,7 +1,7 @@
 # Template file for 'krita'
 pkgname=krita
 version=5.2.1
-revision=1
+revision=2
 build_style=cmake
 configure_args="-Wno-dev -DBUILD_TESTING=OFF"
 hostmakedepends="extra-cmake-modules gettext pkg-config python3

--- a/srcpkgs/libgdal/template
+++ b/srcpkgs/libgdal/template
@@ -1,7 +1,7 @@
 # Template file for 'libgdal'
 pkgname=libgdal
 version=3.5.3
-revision=11
+revision=12
 build_style=cmake
 build_helper=python3
 configure_args="-DGDAL_USE_OPENCL=ON

--- a/srcpkgs/libjxl/template
+++ b/srcpkgs/libjxl/template
@@ -1,7 +1,7 @@
 # Template file for 'libjxl'
 pkgname=libjxl
 version=0.8.2
-revision=1
+revision=2
 _testdata_hash=d6168ffb9e1cc24007e64b65dd84d822ad1fc759
 _skcms_hash=b25b07b4b07990811de121c0356155b2ba0f4318
 build_style=cmake

--- a/srcpkgs/opencv/template
+++ b/srcpkgs/opencv/template
@@ -1,7 +1,7 @@
 # Template file for 'opencv'
 pkgname=opencv
 version=4.6.0
-revision=5
+revision=6
 create_wrksrc=yes
 build_wrksrc=${pkgname}-${version}
 build_style=cmake

--- a/srcpkgs/openexr/template
+++ b/srcpkgs/openexr/template
@@ -1,18 +1,18 @@
 # Template file for 'openexr'
 pkgname=openexr
-version=3.1.11
+version=3.2.1
 revision=1
 build_style=cmake
 build_helper="qemu"
 hostmakedepends="pkg-config"
-makedepends="zlib-devel imath-devel"
+makedepends="imath-devel libdeflate-devel"
 short_desc="High dynamic-range (HDR) image file format"
 maintainer="André Cerqueira <acerqueira021@gmail.com>"
 license="BSD-3-Clause"
 homepage="https://www.openexr.com/"
 changelog="https://raw.githubusercontent.com/AcademySoftwareFoundation/openexr/main/CHANGES.md"
 distfiles="https://github.com/openexr/openexr/archive/v${version}.tar.gz>openexr-${version}.tar.gz"
-checksum=06b4a20d0791b5ec0f804c855d320a0615ce8445124f293616a086e093f1f1e1
+checksum=61e175aa2203399fb3c8c2288752fbea3c2637680d50b6e306ea5f8ffdd46a9b
 
 if [ "$XBPS_CHECK_PKGS" ]; then
 	configure_args+=" -DBUILD_TESTING=ON"
@@ -20,10 +20,11 @@ else
 	configure_args+=" -DBUILD_TESTING=OFF"
 fi
 
-if [ "$XBPS_MACHINE" = "i686" ]; then
-	make_check=no # Test Fails in i686
+if [ "$XBPS_MACHINE" = "i686" ] || [ "$XBPS_LIBC" = "musl" ]; then
 	# See upstream:
-	# https://github.com/AcademySoftwareFoundation/openexr/issues/1281
+	# https://github.com/AcademySoftwareFoundation/openexr/issues/1281 (i686)
+	# https://github.com/AcademySoftwareFoundation/openexr/issues/1556 (musl)
+	make_check=no
 fi
 
 post_install() {

--- a/srcpkgs/openimageio/template
+++ b/srcpkgs/openimageio/template
@@ -1,7 +1,7 @@
 # Template file for 'openimageio'
 pkgname=openimageio
 version=2.4.9.0
-revision=6
+revision=7
 build_style=cmake
 build_helper=qemu
 configure_args="-DUSE_QT=0 -DUSE_PYTHON=0 -DOIIO_BUILD_TESTS=0
@@ -18,7 +18,7 @@ license="BSD-3-Clause"
 homepage="https://sites.google.com/site/openimageio/home"
 changelog="https://raw.githubusercontent.com/OpenImageIO/oiio/release/CHANGES.md"
 distfiles="https://github.com/OpenImageIO/oiio/archive/v${version}.tar.gz"
-checksum=d04c12575d63d13ed64fc037ea37da616224736213d785de9f50337f6eb5a9ed
+checksum=00381cabc97e164541e9e555420be5fc5af3696d0f815514dc45666f9c5bcef7
 # Runs checks even for features we disabled.
 make_check=no
 

--- a/srcpkgs/swayimg/template
+++ b/srcpkgs/swayimg/template
@@ -1,7 +1,7 @@
 # Template file for 'swayimg'
 pkgname=swayimg
 version=1.12
-revision=1
+revision=2
 build_style=meson
 hostmakedepends="pkg-config wayland-devel"
 makedepends="wayland-devel cairo-devel json-c-devel libxkbcommon-devel

--- a/srcpkgs/synfig/template
+++ b/srcpkgs/synfig/template
@@ -2,7 +2,7 @@
 # Should be kept in sync with 'synfigstudio' and 'ETL'
 pkgname=synfig
 version=1.4.4
-revision=3
+revision=4
 build_style=gnu-configure
 configure_args="--with-boost-libdir=${XBPS_CROSS_BASE}/usr/lib"
 hostmakedepends="boost-build ImageMagick pkg-config intltool"

--- a/srcpkgs/synfigstudio/template
+++ b/srcpkgs/synfigstudio/template
@@ -2,7 +2,7 @@
 # Should be kept in sync with 'synfig' and 'ETL'
 pkgname=synfigstudio
 version=1.4.4
-revision=3
+revision=4
 build_style=gnu-configure
 configure_args="--disable-update-mimedb"
 hostmakedepends="pkg-config intltool gettext synfig"

--- a/srcpkgs/vigra/template
+++ b/srcpkgs/vigra/template
@@ -1,7 +1,7 @@
 # Template file for 'vigra'
 pkgname=vigra
 version=1.11.2
-revision=1
+revision=2
 build_style=cmake
 configure_args="-DWITH_OPENEXR=1"
 hostmakedepends="python3"

--- a/srcpkgs/vips/template
+++ b/srcpkgs/vips/template
@@ -1,7 +1,7 @@
 # Template file for 'vips'
 pkgname=vips
 version=8.14.4
-revision=1
+revision=2
 build_style=meson
 build_helper=gir
 # TODO: As of version 8.11 vips supports loading its support for OpenSlide,


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
-  Cross build - aarch64

Disabling the tests for *-musl (https://github.com/AcademySoftwareFoundation/openexr/issues/1556)

Currently failing, because this templates are broken: 

- [x] hugin (fails because it needs vigra)
- [x] openimageio (checksum wrong, fixed)
- [x] vigra #46829 

<details>
  <summary>Build Status</summary>

```
SUMMARY
pkg            host    target  cross  result
openexr        x86_64  x86_64  n      OK
ImageMagick    x86_64  x86_64  n      OK
gimp           x86_64  x86_64  n      OK
opencv         x86_64  x86_64  n      OK
synfig         x86_64  x86_64  n      OK
libjxl         x86_64  x86_64  n      OK
vigra          x86_64  x86_64  n      OK
gmic           x86_64  x86_64  n      OK
openimageio    x86_64  x86_64  n      OK
vips           x86_64  x86_64  n      OK
synfigstudio   x86_64  x86_64  n      OK
swayimg        x86_64  x86_64  n      OK
libgdal        x86_64  x86_64  n      OK
krita          x86_64  x86_64  n      OK
kio-extras     x86_64  x86_64  n      OK
kimageformats  x86_64  x86_64  n      OK
hugin          x86_64  x86_64  n      OK
darktable      x86_64  x86_64  n      OK
blender        x86_64  x86_64  n      OK
```

```
SUMMARY
pkg            host    target   cross  result
openexr        x86_64  aarch64  y      OK
ImageMagick    x86_64  aarch64  y      OK
gimp           x86_64  aarch64  y      OK
opencv         x86_64  aarch64  y      OK
synfig         x86_64  aarch64  y      OK
libjxl         x86_64  aarch64  y      OK
vigra          x86_64  aarch64  y      OK
gmic           x86_64  aarch64  y      OK
openimageio    x86_64  aarch64  y      OK
vips           x86_64  aarch64  y      OK
synfigstudio   x86_64  aarch64  y      OK
swayimg        x86_64  aarch64  y      OK
libgdal        x86_64  aarch64  y      OK
krita          x86_64  aarch64  y      OK
kio-extras     x86_64  aarch64  y      OK
kimageformats  x86_64  aarch64  y      OK
hugin          x86_64  aarch64  y      OK
darktable      x86_64  aarch64  y      OK
blender        x86_64  aarch64  y      SKIPPED
```

</details>

[ci skip]