### PR TITLE
libuecc: use SPDX identifier for license

### DIFF
--- a/srcpkgs/libuecc/template
+++ b/srcpkgs/libuecc/template
@@ -1,11 +1,11 @@
 # Template file for 'libuecc'
 pkgname=libuecc
 version=7
-revision=1
+revision=2
 build_style=cmake
 short_desc="Very small Elliptic Curve Cryptography library"
 maintainer="Enno Boland <gottox@voidlinux.org>"
-license="BSD"
+license="BSD-2-Clause"
 homepage="https://git.universe-factory.net/libuecc"
 distfiles="https://git.universe-factory.net/libuecc/snapshot/libuecc-${version}.tar"
 checksum=0120aee869f56289204255ba81535369816655264dd018c63969bf35b71fd707
@@ -19,4 +19,8 @@ libuecc-devel_package() {
 		vmove "usr/lib/*.a"
 		vmove "usr/lib/*.so"
 	}
+}
+
+post_install() {
+	vlicense COPYRIGHT
 }


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

Only a minor edit of the template file is included in this pull request.