### PR TITLE
connman: build with iwd support

### DIFF
--- a/srcpkgs/connman/INSTALL.msg
+++ b/srcpkgs/connman/INSTALL.msg
@@ -1,0 +1,3 @@
+ConnMan's dependency on 'wpa_supplicant' will be removed in a future
+version. If you would like to keep using 'wpa_supplicant' as a Wi-Fi
+backend, please manually install it.

--- a/srcpkgs/connman/template
+++ b/srcpkgs/connman/template
@@ -1,13 +1,14 @@
 # Template file for 'connman'
 pkgname=connman
 version=1.42
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--enable-polkit --enable-client --enable-pie --enable-ethernet
  --enable-wifi --enable-bluetooth --enable-loopback --enable-nmcompat
  --enable-openvpn --with-openvpn=/usr/bin/openvpn --enable-openconnect
- --disable-tools --disable-wispr --with-openconnect=/usr/bin/openconnect"
-hostmakedepends="automake iptables libtool pkg-config wpa_supplicant"
+ --enable-iwd --disable-tools --disable-wispr
+ --with-openconnect=/usr/bin/openconnect"
+hostmakedepends="automake iptables libtool pkg-config"
 makedepends="gnutls-devel iptables-devel libglib-devel libmnl-devel
  openconnect-devel readline-devel"
 depends="dbus wpa_supplicant"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->

Allows using `iwd` instead of `wpa_supplicant` for wireless connections.
