### PR TITLE
anki: fix 'distutils' not found in Python 3.12

### DIFF
--- a/srcpkgs/anki/patches/fix_distutils_not_found.patch
+++ b/srcpkgs/anki/patches/fix_distutils_not_found.patch
@@ -1,0 +1,8 @@
+--- a/anki/mpv.py
++++ b/anki/mpv.py
+@@ -39 +39 @@ import inspect
+-from distutils.spawn import find_executable # pylint: disable=import-error,no-name-in-module
++from shutil import which
+@@ -68 +68 @@ class MPVBase:
+-    executable = find_executable("mpv")
++    executable = which("mpv")

--- a/srcpkgs/anki/template
+++ b/srcpkgs/anki/template
@@ -1,7 +1,7 @@
 # Template file for 'anki'
 pkgname=anki
 version=2.1.15
-revision=6
+revision=7
 build_style=gnu-makefile
 depends="python3-PyQt5-webengine python3-requests python3-SQLAlchemy
  python3-PyAudio python3-mpv python3-Markdown python3-send2trash


### PR DESCRIPTION
Fixes #46613 
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [x] aarch64-musl
<!--
  - armv7l
  - armv6l-musl
-->
