### PR TITLE
Signal-Desktop: update to 6.34.0.

### DIFF
--- a/srcpkgs/Signal-Desktop/template
+++ b/srcpkgs/Signal-Desktop/template
@@ -1,20 +1,20 @@
 # Template file for 'Signal-Desktop'
 pkgname=Signal-Desktop
-version=6.33.0
+version=6.34.0
 revision=1
 # Signal officially only supports x86_64 
 # x86_64-musl could potentially work based on the Alpine port:
 # https://git.alpinelinux.org/aports/tree/testing/signal-desktop
 # ARM: https://github.com/signalapp/Signal-Desktop/issues/3410
 archs="x86_64"
-hostmakedepends="git git-lfs nodejs-lts python3 tar"
+hostmakedepends="git git-lfs nodejs-lts python3 python3-distutils-extra tar"
 depends="cairo gtk+3 libvips pango"
 short_desc="Signal Private Messenger for Linux"
 maintainer="anelki <akierig@fastmail.de>"
 license="AGPL-3.0-only"
 homepage="https://github.com/signalapp/Signal-Desktop"
 distfiles="https://github.com/signalapp/Signal-Desktop/archive/v${version}.tar.gz"
-checksum=49865345fdf2e668666e7368ceee882d78492132bcf436d32830889bdae0cf99
+checksum=62cb1f6a3c835eca3a23fe379b43f93576e7d9a0e4d6098e8edab948fb671c10
 nostrip_files="signal-desktop"
 
 post_extract() {


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64
