### PR TITLE
pipewire: remove INSTALL.msg

### DIFF
--- a/srcpkgs/pipewire/INSTALL.msg
+++ b/srcpkgs/pipewire/INSTALL.msg
@@ -1,2 +1,0 @@
-The pipewire-media-session session manager has been removed from Void.
-All users must transition to wireplumber to avoid loss of functionality.


### PR DESCRIPTION
It's been quite some time since pipewire-media-session manager has been removed from void, is it safe to assume that users have transitioned by now?