### PR TITLE
libjpeg-turbo: ensure that libjpeg-turboTargets-none.cmake is relocatable

### DIFF
--- a/common/build-style/cmake.sh
+++ b/common/build-style/cmake.sh
@@ -52,10 +52,10 @@ SET(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
 _EOF
 		cmake_args+=" -DCMAKE_TOOLCHAIN_FILE=${wrksrc}/${build_wrksrc}/${cmake_builddir}/cross_${XBPS_CROSS_TRIPLET}.cmake"
 	fi
-	cmake_args+=" -DCMAKE_INSTALL_PREFIX=/usr"
+	cmake_args+=" -DCMAKE_INSTALL_PREFIX:PATH=/usr"
 	cmake_args+=" -DCMAKE_BUILD_TYPE=None"
-	cmake_args+=" -DCMAKE_INSTALL_LIBDIR=lib${XBPS_TARGET_WORDSIZE}"
-	cmake_args+=" -DCMAKE_INSTALL_SYSCONFDIR=/etc"
+	cmake_args+=" -DCMAKE_INSTALL_LIBDIR:PATH=lib${XBPS_TARGET_WORDSIZE}"
+	cmake_args+=" -DCMAKE_INSTALL_SYSCONFDIR:PATH=/etc"
 
 	if [ "$CROSS_BUILD" ]; then
 		cmake_args+=" -DQT_HOST_PATH=/usr"
@@ -69,7 +69,7 @@ _EOF
 			>> cross_${XBPS_CROSS_TRIPLET}.cmake
 	fi
 
-	cmake_args+=" -DCMAKE_INSTALL_SBINDIR=bin"
+	cmake_args+=" -DCMAKE_INSTALL_SBINDIR:PATH=bin"
 
 	export CMAKE_GENERATOR="${CMAKE_GENERATOR:-Ninja}"
 	# Remove -pipe: https://gitlab.kitware.com/cmake/cmake/issues/19590

--- a/srcpkgs/VirtualGL/template
+++ b/srcpkgs/VirtualGL/template
@@ -4,7 +4,7 @@ version=2.6.2
 revision=4
 build_style=cmake
 configure_args="-DTJPEG_INCLUDE_DIR=/usr/include -DVGL_SYSTEMGLX=ON
- -DTJPEG_LIBRARY=/usr/lib/libturbojpeg.so -DCMAKE_INSTALL_LIBDIR=/usr/lib
+ -DTJPEG_LIBRARY=/usr/lib/libturbojpeg.so
  -DVGL_SYSTEMFLTK=ON -DVGL_USESSL=ON"
 makedepends="libXv-devel glu-devel libjpeg-turbo-devel MesaLib-devel
  libXtst-devel fltk-devel openssl-devel"

--- a/srcpkgs/kodi-platform/template
+++ b/srcpkgs/kodi-platform/template
@@ -3,7 +3,6 @@ pkgname=kodi-platform
 version=20180302
 revision=1
 build_style=cmake
-configure_args="-DCMAKE_INSTALL_LIBDIR=/usr/lib"
 makedepends="kodi-devel tinyxml-devel p8-platform-devel"
 short_desc="Kodi platform support library"
 maintainer="Orphaned <orphan@voidlinux.org>"
@@ -13,7 +12,7 @@ distfiles="https://github.com/xbmc/kodi-platform/archive/kodiplatform-${version}
 checksum=1d8ddbe444bd42f4b6f2babb9f78d6c1e152d828eff90b07308febf883c05b38
 
 if [ -n "${CROSS_BUILD}" ]; then
-	configure_args+=" -DCMAKE_MODULE_PATH=${XBPS_CROSS_BASE}/usr/share/kodi/cmake"
+	configure_args="-DCMAKE_MODULE_PATH=${XBPS_CROSS_BASE}/usr/share/kodi/cmake"
 fi
 
 kodi-platform-devel_package() {

--- a/srcpkgs/libjpeg-turbo/template
+++ b/srcpkgs/libjpeg-turbo/template
@@ -1,9 +1,9 @@
 # Template file for 'libjpeg-turbo'
 pkgname=libjpeg-turbo
 version=2.1.5.1
-revision=1
+revision=2
 build_style=cmake
-configure_args="-DWITH_JPEG8=1 -DCMAKE_INSTALL_LIBDIR=/usr/lib"
+configure_args="-DWITH_JPEG8=1"
 hostmakedepends="yasm"
 short_desc="Derivative of libjpeg which uses SIMD instructions"
 maintainer="Orphaned <orphan@voidlinux.org>"


### PR DESCRIPTION
specifying the full path in INSTALL_LIBDIR will result in it being
hardcoded in the Targets-none.cmake instead of being repalce with
_IMPORT_PREFIX
