### PR TITLE
ardour: fix build with Python 3.12.

### DIFF
--- a/srcpkgs/ardour/patches/fix-build-with-python-3.12.diff
+++ b/srcpkgs/ardour/patches/fix-build-with-python-3.12.diff
@@ -1,0 +1,17 @@
+At the moment, running `itstool` with Python 3.12 spews out a bunch of
+`SyntaxWarning`s, polluting the command's stderr (which the code in `ardour`'s
+`wscript` captures) and causing a configure failure.
+
+diff --git a/wscript b/wscript
+index 39761da5f..b72e2ab75 100644
+--- a/wscript
++++ b/wscript
+@@ -973,7 +973,7 @@ def configure(conf):
+ 
+     # freedesktop translations needs itstool > 1.0.3 (-j option)
+     if Options.options.freedesktop:
+-        output = subprocess.Popen("itstool --version", shell=True, stderr=subprocess.STDOUT, stdout=subprocess.PIPE).communicate()[0].splitlines()
++        output = subprocess.Popen("itstool --version", shell=True, stderr=subprocess.DEVNULL, stdout=subprocess.PIPE).communicate()[0].splitlines()
+         o = output[0].decode('utf-8')
+         itstool = o.split(' ')[0]
+         version = o.split(' ')[1].split('.')


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**|**briefly**|**NO**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
