### PR TITLE
maxima: unbreak ecl build

### DIFF
--- a/srcpkgs/maxima/template
+++ b/srcpkgs/maxima/template
@@ -1,7 +1,7 @@
 # Template file for 'maxima'
 pkgname=maxima
 version=5.47.0
-revision=3
+revision=4
 build_style=gnu-configure
 configure_args="$(vopt_enable clisp) $(vopt_enable sbcl sbcl-exec) $(vopt_enable ecl)"
 hostmakedepends="python3 perl texinfo patchelf $(vopt_if ecl ecl)"
@@ -46,6 +46,8 @@ post_configure() {
 	touch -c doc/info/*.html
 	touch -c doc/info/maxima.info*
 	touch -c doc/info/maxima_toc.html
+	touch -c doc/info/maxima-index.lisp
+	touch -c doc/info/maxima-index-html.lisp
 	touch -c interfaces/xmaxima/doc/xmaxima.html
 }
 


### PR DESCRIPTION
Fixes the (currently failing, native) build `./xbps-src pkg -o ecl,~sbcl maxima` #46293 
Passes local tests with `./xbps-src pkg -f -Q -o ecl,~sbcl maxima` on `x86_64`.

cc @tornaria 