### PR TITLE
rsClock: update to 0.1.10.

### DIFF
--- a/srcpkgs/rsClock/template
+++ b/srcpkgs/rsClock/template
@@ -1,6 +1,6 @@
 # Template file for 'rsClock'
 pkgname=rsClock
-version=0.1.9
+version=0.1.10
 revision=1
 build_style=cargo
 short_desc="Simple terminal clock written in Rust"
@@ -9,7 +9,7 @@ license="MIT"
 homepage="https://github.com/valebes/rsClock"
 changelog="https://github.com/valebes/rsClock/releases"
 distfiles="https://github.com/valebes/rsClock/archive/refs/tags/v${version}.tar.gz"
-checksum=1535a9e317e7434bae31ab526ccfa1086ae58fb395db799a3b414332ce08418c
+checksum=b4ce70801680fec5c80422b9f3367615c3a0ca96f620058f93f79a522b88a30e
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture: **x86_64**