### PR TITLE
docker: Parameterize loading the loop kernel module

### DIFF
--- a/srcpkgs/moby/files/docker/run
+++ b/srcpkgs/moby/files/docker/run
@@ -1,7 +1,10 @@
 #!/bin/sh
 exec 2>&1
 [ -r conf ] && . ./conf
-modprobe -q loop || exit 1
+case "${LOAD_LOOP_MODULE:-yes}" in
+    no) ;;
+    *) modprobe -q loop || exit 1 ;;
+esac
 mountpoint -q /sys/fs/cgroup/systemd || {
     mkdir -p /sys/fs/cgroup/systemd;
     mount -t cgroup -o none,name=systemd cgroup /sys/fs/cgroup/systemd;

--- a/srcpkgs/moby/template
+++ b/srcpkgs/moby/template
@@ -2,7 +2,7 @@
 # should be kept in sync with docker-cli
 pkgname=moby
 version=27.3.1
-revision=1
+revision=2
 # libnetwork commit is mentioned in vendor.conf
 _libnetwork_commit=05b93e0d3a95952f70c113b0bc5bdb538d7afdd7
 create_wrksrc=yes


### PR DESCRIPTION
These changes introduce a config variable `LOAD_LOOP_MODULE` which can be set to `yes` (default) or `no` within the `/etc/docker/sv/conf` file.

#### Testing the changes
- I tested the changes in this PR: **YES** (`xlint docker` + `./xbps-src pkg -Q docker`)
- I tested that the Docker service is working when the `loop` kernel module is not required (e.g. under WSL): **YES** (see below)

```
PS C:\Users\Cheeba> wsl -u root bash -ic "cat /etc/sv/docker/conf"
cat: /etc/sv/docker/conf: No such file or directory
PS C:\Users\Cheeba> wsl -u root bash -ic "sv status docker"
down: docker: 1s, normally up, want up; run: log: (pid 170) 3s
PS C:\Users\Cheeba> wsl -u root bash -ic "sv restart docker"
timeout: down: docker: 1s, normally up, want up
PS C:\Users\Cheeba> wsl -u root bash -ic "vim /etc/sv/docker/conf"
PS C:\Users\Cheeba> wsl -u root bash -ic "cat /etc/sv/docker/conf"
LOAD_LOOP_MODULE=yes
PS C:\Users\Cheeba> wsl -u root bash -ic "sv restart docker"
timeout: down: docker: 1s, normally up, want up
PS C:\Users\Cheeba> wsl -u root bash -ic "sv status docker"
down: docker: 0s, normally up, want up; run: log: (pid 170) 35s
PS C:\Users\Cheeba> wsl -u root bash -ic "vim /etc/sv/docker/conf"
PS C:\Users\Cheeba> wsl -u root bash -ic "cat /etc/sv/docker/conf"
LOAD_LOOP_MODULE=no
PS C:\Users\Cheeba> wsl -u root bash -ic "sv restart docker"
ok: run: docker: (pid 479) 1s
PS C:\Users\Cheeba> wsl -u root bash -ic "sv status docker"
run: docker: (pid 479) 2s; run: log: (pid 170) 45s
PS C:\Users\Cheeba> wsl -u root bash -ic "docker ps"
CONTAINER ID   IMAGE     COMMAND   CREATED   STATUS    PORTS     NAMES
PS C:\Users\Cheeba> wsl -u root bash -ic "docker version"
Client:
 Version:           24.0.6
 API version:       1.43
 Go version:        go1.21.0
 Git commit:        tag v24.0.6
 Built:             Wed Sep  6 13:42:27 2023
 OS/Arch:           linux/amd64
 Context:           default

Server:
 Engine:
  Version:          24.0.6
  API version:      1.43 (minimum version 1.12)
  Go version:       go1.21.0
  Git commit:       tag v24.0.6
  Built:            Wed Sep  6 13:42:27 2023
  OS/Arch:          linux/amd64
  Experimental:     false
 containerd:
  Version:          1.7.7
  GitCommit:        UNSET
 runc:
  Version:          1.1.9
  GitCommit:
 docker-init:
  Version:          0.19.0
  GitCommit:
PS C:\Users\Cheeba>
```

#### Motivation behind the changes

I played around with using Void Linux under WSL2 and struggled to get the Docker service started up. Eventually I realized that the `modprobe -q loop` command would *always* fail under WSL2, because there is no directory `/lib/modules`, so `modprobe` is essentially useless under WSL2. I think there are other mechanisms involved when loading the WSL2 kernel and modules. Either way, Docker runs very well with these changes.

I understand that Void Linux is not officially supported by Microsoft (and probably vice-versa), and there's manual steps involved installing it, but I thought why not make Docker run for everybody nonetheless?

These changes should make the Docker service run both when the `loop` module is available and has to be loaded (default), as well as in systems where it's not available or not required, like WSL2.