### PR TITLE
New package: qtkeychain-qt6-0.14.1

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -2235,6 +2235,7 @@ libclamunrar_iface.so.9 clamav-0.103.1_2
 libfreshclam.so.2 clamav-0.103.1_2
 libqca-qt5.so.2 qca-qt5-2.1.3_1
 libqt5keychain.so.1 qtkeychain-qt5-0.7.0_1
+libqt6keychain.so.1 qtkeychain-qt6-0.14.0_1
 libphonon4qt5.so.4 phonon-qt5-4.8.3_1
 libphonon4qt5experimental.so.4 phonon-qt5-4.8.3_1
 libtelepathy-qt5.so.0 telepathy-qt5-0.9.5_1

--- a/srcpkgs/qtkeychain-qt6-devel
+++ b/srcpkgs/qtkeychain-qt6-devel
@@ -1,0 +1,1 @@
+qtkeychain-qt6

--- a/srcpkgs/qtkeychain-qt6/files/README.voidlinux
+++ b/srcpkgs/qtkeychain-qt6/files/README.voidlinux
@@ -1,0 +1,2 @@
+qtkeychain-qt6 is a supporting library, to use it you need to have a
+secret manager like 'kwallet' or 'gnome-keyring' installed.

--- a/srcpkgs/qtkeychain-qt6/template
+++ b/srcpkgs/qtkeychain-qt6/template
@@ -1,0 +1,34 @@
+# Template file for 'qtkeychain-qt6'
+pkgname=qtkeychain-qt6
+version=0.14.1
+revision=1
+build_style=cmake
+configure_args="-DBUILD_WITH_QT6=on"
+hostmakedepends="pkg-config"
+makedepends="libsecret-devel qt6-tools-devel"
+short_desc="Platform-independent Qt6 API for storing passwords securely"
+maintainer="Mazin Fadl <mazen@illumed.net>"
+license="BSD-2-Clause"
+homepage="https://github.com/frankosterfeld/qtkeychain"
+distfiles="https://github.com/frankosterfeld/${pkgname%-*}/archive/${version}.tar.gz"
+checksum=afb2d120722141aca85f8144c4ef017bd74977ed45b80e5d9e9614015dadd60c
+
+if [ "$CROSS_BUILD" ]; then
+	hostmakedepends+=" qt6-declarative-host-tools qt6-tools-devel"
+fi
+
+post_install() {
+	vlicense COPYING
+	vdoc "${FILESDIR}/README.voidlinux"
+}
+
+qtkeychain-qt6-devel_package() {
+	depends="${sourcepkg}>=${version}_${revision}"
+	short_desc+=" - development files"
+	pkg_install() {
+		vmove usr/include
+		vmove usr/lib/cmake
+		vmove usr/lib/*.so
+		vmove usr/lib/qt6/mkspecs
+	}
+}


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->

Will be used to update the `chatterino2` package to QT6.