### PR TITLE
New package: cmakelang-0.6.13

### DIFF
--- a/srcpkgs/cmakelang/template
+++ b/srcpkgs/cmakelang/template
@@ -1,0 +1,17 @@
+# Template file for 'cmakelang'
+pkgname=cmakelang
+version=0.6.13
+revision=1
+build_style=python3-module
+hostmakedepends="python3-setuptools"
+depends="python3-six"
+checkdepends="$depends python3-pytest cmake git"
+short_desc="Source code formatter for cmake listfiles"
+maintainer="meator <meator.dev@gmail.com>"
+license="GPL-3.0-only"
+homepage="https://github.com/cheshirekow/cmake_format"
+distfiles="https://github.com/cheshirekow/cmake_format/archive/refs/tags/v${version}.tar.gz"
+checksum=b67dd150380d9223036a12f82126a7a9b18e77db4a8d7240f993ee090884e4bf
+# tests are broken, they also rely on git to pull a repo which requires
+# internet access
+make_check="no"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->
I've tried really hard but found no way to make tests work. I believe having a package without tests is better than having no package. I have tested `cmake-lint` and `cmake-format` and they work well.

#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
