### PR TITLE
vale: update to 2.29.4.

### DIFF
--- a/srcpkgs/vale/template
+++ b/srcpkgs/vale/template
@@ -1,6 +1,6 @@
 # Template file for 'vale'
 pkgname=vale
-version=2.29.2
+version=2.29.4
 revision=1
 build_style=go
 go_import_path="github.com/errata-ai/vale/v2"
@@ -12,7 +12,7 @@ license="MIT"
 homepage="https://vale.sh"
 changelog="https://github.com/errata-ai/vale/releases"
 distfiles="https://github.com/errata-ai/vale/archive/refs/tags/v${version}.tar.gz"
-checksum=a30634199d01f9fbdbada000029e444bd54b0e3c0af6a9619e0b17abf7a63e31
+checksum=3dc463c6cb1432469b3d7f0876c68913133d9cf5c2d157a22efc8503f35a4315
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture: **x86_64**