### PR TITLE
hplip: update to 3.23.8.

### DIFF
--- a/srcpkgs/hplip/patches/python312.patch
+++ b/srcpkgs/hplip/patches/python312.patch
@@ -1,0 +1,57 @@
+diff -ur hplip-3.23.8.orig/base/g.py hplip-3.23.8/base/g.py
+--- hplip-3.23.8.orig/base/g.py	2023-10-15 16:09:06.390645895 -0400
++++ hplip-3.23.8/base/g.py	2023-10-15 16:10:55.225170318 -0400
+@@ -128,7 +128,7 @@
+             try:
+                 fp = open(self.filename, "r")
+                 try:
+-                    self.conf.readfp(fp)
++                    self.conf.read_file(fp)
+                 except configparser.MissingSectionHeaderError:
+                     print("")
+                     log.error("Found No Section in %s. Please set the http proxy for root and try again." % self.filename)
+diff -ur hplip-3.23.8.orig/ui/devmgr4.py hplip-3.23.8/ui/devmgr4.py
+--- hplip-3.23.8.orig/ui/devmgr4.py	2023-10-15 16:09:06.460646229 -0400
++++ hplip-3.23.8/ui/devmgr4.py	2023-10-15 16:10:31.857056822 -0400
+@@ -1226,9 +1226,8 @@
+             opt_plugin = d.plugin == PLUGIN_OPTIONAL
+ 
+             hplip_conf = ConfigParser.ConfigParser()
+-            fp = open("/etc/hp/hplip.conf", "r")
+-            hplip_conf.readfp(fp)
+-            fp.close()
++            with open("/etc/hp/hplip.conf", "r") as fp:
++                hplip_conf.read_file(fp)
+ 
+             try:
+                 plugin_installed = utils.to_bool(hplip_conf.get("hplip", "plugin"))
+diff -ur hplip-3.23.8.orig/ui4/devmgr5.py hplip-3.23.8/ui4/devmgr5.py
+--- hplip-3.23.8.orig/ui4/devmgr5.py	2023-10-15 16:09:06.475646300 -0400
++++ hplip-3.23.8/ui4/devmgr5.py	2023-10-15 16:10:13.125965849 -0400
+@@ -1023,9 +1023,8 @@
+                     return
+ 
+                 hplip_conf = configparser.ConfigParser()
+-                fp = open("/etc/hp/hplip.conf", "r")
+-                hplip_conf.readfp(fp)
+-                fp.close()
++                with open("/etc/hp/hplip.conf", "r") as fp:
++                    hplip_conf.read_file(fp)
+ 
+                 try:
+                     plugin_installed = utils.to_bool(hplip_conf.get("hplip", "plugin"))
+diff -ur hplip-3.23.8.orig/ui5/devmgr5.py hplip-3.23.8/ui5/devmgr5.py
+--- hplip-3.23.8.orig/ui5/devmgr5.py	2023-10-15 16:09:06.467646262 -0400
++++ hplip-3.23.8/ui5/devmgr5.py	2023-10-15 16:11:12.961256459 -0400
+@@ -1073,9 +1073,8 @@
+                     return
+ 
+                 hplip_conf = configparser.ConfigParser()
+-                fp = open("/etc/hp/hplip.conf", "r")
+-                hplip_conf.readfp(fp)
+-                fp.close()
++                with open("/etc/hp/hplip.conf", "r") as fp:
++                    hplip_conf.read_file(fp)
+ 
+                 try:
+                     plugin_installed = utils.to_bool(hplip_conf.get("hplip", "plugin"))

--- a/srcpkgs/hplip/template
+++ b/srcpkgs/hplip/template
@@ -1,8 +1,8 @@
 # Template file for 'hplip'
 # When possible, keep this package in sync with hplip-plugin
 pkgname=hplip
-version=3.23.3
-revision=3
+version=3.23.8
+revision=1
 build_style=gnu-configure
 pycompile_dirs="usr/share/hplip"
 configure_args="
@@ -34,7 +34,7 @@ license="GPL-2.0-only, BSD-3-Clause, MIT"
 homepage="https://developers.hp.com/hp-linux-imaging-and-printing"
 changelog="https://developers.hp.com/hp-linux-imaging-and-printing/release_notes"
 distfiles="${SOURCEFORGE_SITE}/hplip/hplip/${version}/hplip-${version}.tar.gz"
-checksum=e4260a98a2b1d88d21e82562de419aa21c95bc9e2ace3583346a80fd217e07b6
+checksum=f7cc05f628c0cfd750e54ae41431c1dfdd29e97682f18b5c5ba5cb2c5b4b1b46
 
 CFLAGS="-I${XBPS_CROSS_BASE}/usr/include/libusb-1.0 -I${XBPS_CROSS_BASE}/${py3_inc}"
 


### PR DESCRIPTION
Fixes: #46684.

This does not suppress syntax warnings, which are not a behavior change from prior Python versions. (The warnings are just more vocal.)

#### Testing the changes
- I tested the changes in this PR: **briefly**