### PR TITLE
maxima: fix build with -o ~sbcl

### DIFF
--- a/srcpkgs/maxima/patches/use-shared-library.patch
+++ b/srcpkgs/maxima/patches/use-shared-library.patch
@@ -1,21 +1,20 @@
---- a/src/maxima.system	2021-12-02 00:26:23.955984864 -0300
-+++ b/src/maxima.system	2021-12-02 00:31:22.299541969 -0300
-@@ -87,13 +87,15 @@
-       (let ((obj (mapcar #'(lambda (p)
+--- a/src/maxima.system
++++ b/src/maxima.system
+@@ -88,12 +88,15 @@
  			     ;; Convert dir/foo.fas to dir/foo.o
  			     (make-pathname :type "o" :defaults p))
--			 files)))
+ 			 files)))
 -	(c::build-fasl "binary-ecl/maxima" :lisp-files obj
-+			 files))
-+			(lib '("binary-ecl/libmaxima-ecl.so")))
 +	(c::build-shared-library "binary-ecl/maxima-ecl" :lisp-files obj)
-+	(c::build-fasl "binary-ecl/maxima" :lisp-files lib
++	(si::chdir "binary-ecl")
++	(defparameter c::*ld-rpath* "-Wl,-rpath=$ORIGIN")
++	(c::build-fasl "maxima" :lisp-files '("libmaxima-ecl.so")
  			  :ld-flags
  			  (let ((x (symbol-value (find-symbol "*AUTOCONF-LD-FLAGS*"
  							      (find-package "MAXIMA")))))
  			    (if (and x (not (string= x ""))) (split-string x))))
 -	(c::build-program "binary-ecl/maxima" :lisp-files obj
-+	(c::build-program "binary-ecl/maxima" :lisp-files lib
++	(c::build-program "maxima" :lisp-files '("libmaxima-ecl.so")
  			  :ld-flags
  			  (let ((x (symbol-value (find-symbol "*AUTOCONF-LD-FLAGS*"
  							      (find-package "MAXIMA")))))

--- a/srcpkgs/maxima/template
+++ b/srcpkgs/maxima/template
@@ -3,8 +3,8 @@ pkgname=maxima
 version=5.47.0
 revision=3
 build_style=gnu-configure
-configure_args="$(vopt_enable clisp) $(vopt_enable sbcl sbcl-exec) $(vopt_enable ecl)"
-hostmakedepends="python3 perl texinfo patchelf $(vopt_if ecl ecl)"
+configure_args="$(vopt_enable clisp) $(vopt_enable sbcl) $(vopt_enable ecl)
+ makeinfo_found=true"
 makedepends="$(vopt_if clisp clisp) $(vopt_if sbcl sbcl) $(vopt_if ecl ecl)"
 depends="$(vopt_if clisp clisp) rlwrap"
 checkdepends="gnuplot"
@@ -41,24 +41,20 @@ esac
 
 vopt_conflict clisp sbcl
 
-post_configure() {
+pre_build() {
 	# do not rebuild these files if they exist
 	touch -c doc/info/*.html
 	touch -c doc/info/maxima.info*
 	touch -c doc/info/maxima_toc.html
+	touch -c doc/info/maxima-index.lisp
+	touch -c doc/info/maxima-index-html.lisp
+	touch -c interfaces/xmaxima/doc/xmaxima.info
 	touch -c interfaces/xmaxima/doc/xmaxima.html
 }
 
 post_build() {
-	if [ "$build_option_ecl" ]; then
-		# everything will go in the same directory, use rpath=$ORIGIN
-		patchelf --remove-rpath src/binary-ecl/libmaxima-ecl.so
-		patchelf --set-rpath \$ORIGIN \
-			src/binary-ecl/{maxima,maxima.fas}
-		patchelf \
-			--replace-needed  binary-ecl/libmaxima-ecl.so libmaxima-ecl.so \
-			src/binary-ecl/{maxima,maxima.fas}
-	fi
+	# this one needs to be done after building
+	touch -c interfaces/emacs/imaxima/imaxima.info
 }
 
 do_check() {
@@ -103,7 +99,7 @@ post_install() {
 
 	# info files are used for maxima help, and need to be uncompressed
 	# removing this file prevents compression of info files
-	rm ${DESTDIR}/usr/share/info/dir
+	rm -f ${DESTDIR}/usr/share/info/dir
 }
 
 maxima-src_package() {


### PR DESCRIPTION
This is the default for aarch64.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

Rework the patch `use-shared-library.patch` so the ecl binaries work as built, no need to use `patchelf` anymore. This way there should be no problem if maxima is needed to build the documentation.

OTOH, the documentation is currently shipped in the tarball, so we touch the correct files so that it won't be rebuilt.

This won't change the binary package, no need to revbump.

Cc: @dkwo 

Fixes: #46293

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
