### PR TITLE
New package: grandorgue-3.13.0

### DIFF
--- a/srcpkgs/grandorgue/template
+++ b/srcpkgs/grandorgue/template
@@ -1,0 +1,21 @@
+# Template file for 'grandorgue'
+pkgname=grandorgue
+version=3.13.0
+revision=1
+archs="x86_64"
+build_style="cmake"
+configure_args="-DCMAKE_BUILD_TYPE=Release -G Ninja"
+hostmakedepends="pkg-config git ImageMagick"
+makedepends="jack-devel eudev-libudev-devel zlib-devel yaml-cpp-devel wxWidgets-devel wxWidgets-common-devel wxWidgets-gtk3-devel fftw-devel wavpack-devel alsa-lib-devel"
+depends="gettext po4a zip"
+short_desc="Pipe Organ Simulator"
+maintainer="Nicolo Davis <nicolodavis@gmail.com>"
+license="GPL-2.0-or-later"
+homepage="https://github.com/GrandOrgue/grandorgue"
+
+export WX_CONFIG=wx-config-gtk3
+
+do_fetch() {
+	git clone --recurse-submodules --depth 1 --branch ${version}-${revision} https://github.com/GrandOrgue/grandorgue.git ${wrksrc}
+	cd ${wrksrc}
+}


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: YES

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): YES

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (x86_64 glibc)
