### PR TITLE
pango: update to 1.51.0

### DIFF
--- a/srcpkgs/pango/template
+++ b/srcpkgs/pango/template
@@ -1,6 +1,6 @@
 # Template file for 'pango'
 pkgname=pango
-version=1.50.14
+version=1.51.0
 revision=1
 build_style=meson
 build_helper=gir
@@ -14,17 +14,11 @@ license="LGPL-2.1-or-later"
 homepage="https://www.pango.org/"
 changelog="https://gitlab.gnome.org/GNOME/pango/-/raw/main/NEWS"
 distfiles="${GNOME_SITE}/pango/${version%.*}/pango-${version}.tar.xz"
-checksum=1d67f205bfc318c27a29cfdfb6828568df566795df0cb51d2189cde7f2d581e8
-make_check=no  # doesn't pass its own tests
+checksum=74efc109ae6f903bbe6af77eaa2ac6094b8ee245a2e23f132a7a8f0862d1a9f5
 
 # Package build options
 build_options="gir"
 build_options_default="gir"
-
-post_install() {
-	rm -rf -- ${DESTDIR}/usr/share/installed-tests
-	rm -rf -- ${DESTDIR}/usr/libexec/installed-tests
-}
 
 pango-xft_package() {
 	short_desc+=" - X font rendering"


### PR DESCRIPTION
@cinerea0 

required for newer gnome apps

#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl x
  - armv7l x
  - armv6l-musl x