### PR TITLE
variety: patch to fix for Python 3.12.

### DIFF
--- a/srcpkgs/variety/patches/Jumble_importlib_3.12_fix.patch
+++ b/srcpkgs/variety/patches/Jumble_importlib_3.12_fix.patch
@@ -1,0 +1,36 @@
+--- a/jumble/Jumble.py
++++ b/jumble/Jumble.py
+@@ -14,7 +14,8 @@
+ # with this program.  If not, see <http://www.gnu.org/licenses/>.
+ ### END LICENSE
+ 
+-import imp
++import importlib.util
++import sys
+ import inspect
+ import logging
+ import os
+@@ -39,13 +40,16 @@
+         for location, f in self._walk_python_files():
+             path = os.path.join(location, f)
+             name = os.path.splitext(f)[0]
+-            info = imp.find_module(name, [location])
+-            try:
+-                logger.info(lambda: "Jumble loading module in %s from %s" % (name, path))
+-                yield imp.load_module(name, *info), path
+-            except Exception:
+-                logger.exception("Could not load plugin module %s" % path)
+-                continue
++            if (spec := importlib.util.spec_from_file_location(name, path)) is not None:
++                try:
++                    module = importlib.util.module_from_spec(spec)
++                    logger.info(lambda: "Jumble loading module in %s from %s" % (name, path))
++                    sys.modules[name] = module
++                    spec.loader.exec_module(module)
++                    yield module, path
++                except Exception:
++                    logger.exception("Could not load plugin module %s" % path)
++                    continue
+ 
+     def _walk_plugin_classes(self):
+         for module, path in self._walk_modules():

--- a/srcpkgs/variety/template
+++ b/srcpkgs/variety/template
@@ -1,7 +1,7 @@
 # Template file for 'variety'
 pkgname=variety
 version=0.8.10
-revision=2
+revision=3
 build_style=python3-module
 pycompile_dirs="usr/share/variety/plugins"
 hostmakedepends="python3-setuptools python3-distutils-extra intltool"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->

`imp` is no longer available so I had to patch it to use `importlib`.