### PR TITLE
[WIP] New package: saturn-notebook-1.2.2

### DIFF
--- a/srcpkgs/python3-ptpython/template
+++ b/srcpkgs/python3-ptpython/template
@@ -1,0 +1,18 @@
+# Template file for 'python3-ptpython'
+pkgname=python3-ptpython
+version=3.0.23
+revision=1
+build_style=python3-module
+hostmakedepends="python3-setuptools"
+depends="python3"
+short_desc="Python REPL build on top of prompt_toolkit"
+maintainer="Eloi Torrents <eloitor@duck.com>"
+license="BSD-3-Clause"
+homepage="https://github.com/prompt-toolkit/ptpython"
+changelog="https://raw.githubusercontent.com/prompt-toolkit/ptpython/master/CHANGELOG"
+distfiles="${PYPI_SITE}/p/ptpython/ptpython-${version}.tar.gz"
+checksum=9fc9bec2cc51bc4000c1224d8c56241ce8a406b3d49ec8dc266f78cd3cd04ba4
+
+post_install() {
+	vlicense LICENSE
+}

--- a/srcpkgs/python3-wurlitzer/template
+++ b/srcpkgs/python3-wurlitzer/template
@@ -1,0 +1,23 @@
+# Template file for 'python3-wurlitzer'
+pkgname=python3-wurlitzer
+version=3.0.3
+revision=1
+build_style=python3-module
+hostmakedepends="python3-setuptools"
+depends="python3"
+checkdepends="python3-pytest"
+short_desc="Capture C-level stdout/stderr in Python"
+maintainer="Eloi Torrents <eloitor@duck.com>"
+license="MIT"
+homepage="https://github.com/minrk/wurlitzer"
+changelog="https://raw.githubusercontent.com/minrk/wurlitzer/main/CHANGELOG.md"
+distfiles="${PYPI_SITE}/w/wurlitzer/wurlitzer-${version}.tar.gz"
+checksum=224f5fe70618be3872c05dfddc8c457191ec1870654596279fcc1edadebe3e5b
+
+post_install() {
+	vlicense LICENSE
+}
+
+do_check() {
+	python3 test.py
+}

--- a/srcpkgs/saturn-notebook/files/saturn-notebook
+++ b/srcpkgs/saturn-notebook/files/saturn-notebook
@@ -1,0 +1,3 @@
+#! /bin/sh
+
+python3 -m saturn_notebook

--- a/srcpkgs/saturn-notebook/patches/remove_poetry-dynamic-versioning.patch
+++ b/srcpkgs/saturn-notebook/patches/remove_poetry-dynamic-versioning.patch
@@ -1,0 +1,25 @@
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -33,21 +33,5 @@
+ icecream = "^2.1.2"
+ mpi4py = "^3.1.3"
+ 
+-[tool.poetry-dynamic-versioning]
+-enable = true
+-vcs = "git"
+-pattern  = "^(?P<base>\\d+\\.\\d+\\.\\d+)(-?((?P<stage>[a-zA-Z]+)\\.?(?P<revision>\\d+)?))?"
+-format-jinja = """
+-    {%- if distance == 0 -%}
+-        {{- base -}}
+-    {%- else -%}
+-        {{- base }}.dev{{ distance }}+{{commit}}
+-    {%- endif -%}
+-"""
+-format-jinja-imports = [
+-    { module = "datetime", item = "datetime" }
+-]
+-
+ [build-system]
+-requires = ["poetry-core>=1.0.0", "poetry-dynamic-versioning"]
+-build-backend = "poetry_dynamic_versioning.backend"
++requires = ["poetry-core>=1.0.0"]

--- a/srcpkgs/saturn-notebook/template
+++ b/srcpkgs/saturn-notebook/template
@@ -1,0 +1,20 @@
+# Template file for 'saturn-notebook'
+pkgname=saturn-notebook
+version=1.2.2
+revision=1
+build_style=python3-pep517
+hostmakedepends="python3-poetry-core python3-setuptools"
+makedepends="python3-wheel"
+depends="python3-argh python3-atomicwrites python3-dill python3-more-itertools python3-wurlitzer"
+short_desc="Plain-text Python notebooks with checkpointing"
+maintainer="Eloi Torrents <eloitor@duck.com>"
+license="custom:Saturn"
+homepage="https://github.com/mrzv/saturn"
+changelog="https://raw.githubusercontent.com/mrzv/saturn/master/CHANGELOG.md"
+distfiles="${PYPI_SITE}/s/saturn_notebook/saturn_notebook-${version}.tar.gz"
+checksum=0fc8090e61bc8f9d33b542650d83115c094b90160cab04e797d552722360dd0c
+
+post_install() {
+	vbin ${FILESDIR}/saturn-notebook
+	vlicense LICENSE.txt
+}


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)

I don't know what I should do to get the binary in `/usr/bin/`

```
$ xls saturn-notebook  
/usr/lib/python3.12/site-packages/saturn_notebook/__init__.py
/usr/lib/python3.12/site-packages/saturn_notebook/__main__.py
/usr/lib/python3.12/site-packages/saturn_notebook/cells.py
/usr/lib/python3.12/site-packages/saturn_notebook/evaluate.py
/usr/lib/python3.12/site-packages/saturn_notebook/image.py
/usr/lib/python3.12/site-packages/saturn_notebook/mpl.py
/usr/lib/python3.12/site-packages/saturn_notebook/notebook.py
/usr/lib/python3.12/site-packages/saturn_notebook/repl.py
/usr/lib/python3.12/site-packages/saturn_notebook/theme.py
/usr/lib/python3.12/site-packages/saturn_notebook/traceback.py
/usr/lib/python3.12/site-packages/saturn_notebook/utils.py
/usr/lib/python3.12/site-packages/saturn_notebook-0.0.0.dist-info/LICENSE.txt
/usr/lib/python3.12/site-packages/saturn_notebook-0.0.0.dist-info/METADATA
/usr/lib/python3.12/site-packages/saturn_notebook-0.0.0.dist-info/RECORD
/usr/lib/python3.12/site-packages/saturn_notebook-0.0.0.dist-info/WHEEL
/usr/lib/python3.12/site-packages/saturn_notebook-0.0.0.dist-info/top_level.txt
/usr/share/licenses/saturn-notebook/LICENSE.txt
```