### PR TITLE
python3-httplib2: update to 0.22.0

### DIFF
--- a/srcpkgs/python3-httplib2/template
+++ b/srcpkgs/python3-httplib2/template
@@ -1,10 +1,8 @@
 # Template file for 'python3-httplib2'
 pkgname=python3-httplib2
-version=0.21.0
-revision=2
+version=0.22.0
+revision=1
 build_style=python3-module
-# https://github.com/httplib2/httplib2/issues/221
-make_check_args="-k not(test_client_cert_password_verified)"
 hostmakedepends="python3-setuptools"
 depends="python3 ca-certificates python3-parsing"
 checkdepends="python3-pytest python3-pytest-cov python3-pytest-timeout
@@ -15,7 +13,7 @@ license="MIT"
 homepage="https://github.com/httplib2/httplib2"
 changelog="https://raw.githubusercontent.com/httplib2/httplib2/master/CHANGELOG"
 distfiles="${PYPI_SITE}/h/httplib2/httplib2-${version}.tar.gz"
-checksum=fc144f091c7286b82bec71bdbd9b27323ba709cc612568d3000893bfd9cb4b34
+checksum=d7a10bc5ef5ab08322488bde8c726eeee5c8618723fdb399597ec58f3d82df81
 
 post_install() {
 	# use system ca certificates


### PR DESCRIPTION
@ahesford the previously failing test is now passing (at least locally on `x86_64`).