### PR TITLE
New package: python3-dbus-next-0.2.3

### DIFF
--- a/srcpkgs/python3-dbus-next/template
+++ b/srcpkgs/python3-dbus-next/template
@@ -1,0 +1,20 @@
+# Template file for 'python3-dbus-next'
+pkgname=python3-dbus-next
+version=0.2.3
+revision=1
+build_style=python3-module
+hostmakedepends="python3-setuptools"
+depends="python3"
+short_desc="Next great DBus library"
+maintainer="Bartek Stalewski <ftpd@insomniac.pl>"
+license="MIT"
+homepage="https://github.com/altdesktop/python-dbus-next"
+changelog="https://github.com/altdesktop/python-dbus-next/raw/master/CHANGELOG.md"
+distfiles="${PYPI_SITE}/d/dbus-next/dbus_next-${version}.tar.gz"
+checksum=f4eae26909332ada528c0a3549dda8d4f088f9b365153952a408e28023a626a5
+# Tests are not provided in source tarball
+make_check=no
+
+post_install() {
+	vlicense LICENSE
+}


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64.
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - armv6l

closes #46495