### PR TITLE
bitcoin: update to 25.1

### DIFF
--- a/srcpkgs/bitcoin/template
+++ b/srcpkgs/bitcoin/template
@@ -1,6 +1,6 @@
 # Template file for 'bitcoin'
 pkgname=bitcoin
-version=25.0
+version=25.1
 revision=1
 build_style=gnu-configure
 configure_args="--with-incompatible-bdb --disable-ccache --disable-static
@@ -15,7 +15,7 @@ homepage="https://bitcoincore.org/"
 distfiles="https://bitcoincore.org/bin/bitcoin-core-${version}/bitcoin-${version}.tar.gz
  https://raw.githubusercontent.com/bitcoin-core/packaging/main/debian/bitcoin-qt.desktop
  https://raw.githubusercontent.com/bitcoin/bitcoin/v${version}/share/pixmaps/bitcoin128.png"
-checksum="5df67cf42ca3b9a0c38cdafec5bbb517da5b58d251f32c8d2a47511f9be1ebc2
+checksum="bec2a598d8dfa8c2365b77f13012a733ec84b8c30386343b7ac1996e901198c9
  0a46bbadda140599e807be38999e6848c89f9c3523d26fede02d34d62d50f632
  ad880c8459ecfdb96abe6a4689af06bdd27906e0edcd39d0915482f2da91e722"
 conflicts="litecoin" # Both provide libbitcoinconsensus.so.0

--- a/srcpkgs/bitcoin/update
+++ b/srcpkgs/bitcoin/update
@@ -1,2 +1,2 @@
-site="https://bitcoin.org/bin/"
+site="https://bitcoincore.org/bin/"
 pattern='bitcoin-core-\K[\d.]+'


### PR DESCRIPTION
Also changes update to point to bitcoincore.org, as that is the most regularly updated source of binaries/source code.

#### Testing the changes
- I tested the changes in this PR: **NO**