### PR TITLE
python3-email-validator: update to 2.0.0.

### DIFF
--- a/srcpkgs/python3-email-validator/template
+++ b/srcpkgs/python3-email-validator/template
@@ -1,20 +1,19 @@
 # Template file for 'python3-email-validator'
 pkgname=python3-email-validator
-version=1.3.0
-revision=3
+version=2.0.0
+revision=1
 build_style=python3-module
 hostmakedepends="python3-setuptools"
 makedepends="python3"
 depends="python3-idna python3-dnspython"
-checkdepends="python3-pytest"
+checkdepends="python3-pytest $depends"
 short_desc="Robust email address syntax and deliverability validation library"
 maintainer="DragonGhost7 <darkiridiumghost@gmail.com>"
 license="CC0-1.0"
 homepage="https://github.com/JoshData/python-email-validator"
 changelog="https://raw.githubusercontent.com/JoshData/python-email-validator/main/CHANGELOG.md"
 distfiles="https://github.com/JoshData/python-email-validator/archive/refs/tags/v${version}.tar.gz"
-checksum=1f5b38b5f6b8455468f2c557e887c442d455931ee1523c6eb40c6f7ce119d99b
-make_check=no #no tests folder is present in archives
+checksum=0cd656b4c2cba10bcb518808f800bdde74af0c01a2522a9d475b3b1954d98f01
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**


#### Local build testing
- I built this PR locally for my native architecture, (x86_64-libc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - i686
  - x86_64-musl
  - armv6l-musl
