### PR TITLE
go: update to 1.21.3.

### DIFF
--- a/srcpkgs/go/template
+++ b/srcpkgs/go/template
@@ -1,6 +1,6 @@
 # Template file for 'go'
 pkgname=go
-version=1.21.1
+version=1.21.3
 revision=1
 create_wrksrc=yes
 build_wrksrc=go
@@ -12,7 +12,7 @@ license="BSD-3-Clause"
 homepage="https://go.dev/"
 changelog="https://go.dev/doc/devel/release.html"
 distfiles="https://go.dev/dl/go${version}.src.tar.gz"
-checksum=bfa36bf75e9a1e9cbbdb9abcf9d1707e479bd3a07880a8ae3564caee5711cb99
+checksum=186f2b6f8c8b704e696821b09ab2041a5c1ee13dcbc3156a13adcf75931ee488
 nostrip=yes
 noverifyrdeps=yes
 # on CI it tries to use `git submodule`, which is not part of chroot-git


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (amd64)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - armv7l
  - aarch64
  - i686

Changes, see https://go.dev/doc/devel/release#go1.21.minor
 - go1.21.2 (released 2023-10-05) includes one security fixes to the cmd/go package, as well as bug fixes to the compiler, the go command, the linker, the runtime, and the runtime/metrics package. See the [Go 1.21.2 milestone](https://github.com/golang/go/issues?q=milestone%3AGo1.21.2+label%3ACherryPickApproved) on our issue tracker for details.
 - go1.21.3 (released 2023-10-10) includes a security fix to the net/http package. See the [Go 1.21.3 milestone](https://github.com/golang/go/issues?q=milestone%3AGo1.21.3+label%3ACherryPickApproved) on our issue tracker for details.
