### PR TITLE
salt: update dependencies

### DIFF
--- a/srcpkgs/salt/patches/requirements.patch
+++ b/srcpkgs/salt/patches/requirements.patch
@@ -1,0 +1,10 @@
+diff --git a/requirements/base.txt b/requirements/base.txt
+index c19d8804a2b..62244c35152 100644
+--- a/requirements/base.txt
++++ b/requirements/base.txt
+@@ -9,4 +9,4 @@ psutil>=5.0.0
+ packaging>=21.3
+ looseversion
+ # We need contextvars for salt-ssh
+-contextvars
++contextvars; python_version < "3.7"

--- a/srcpkgs/salt/template
+++ b/srcpkgs/salt/template
@@ -1,12 +1,13 @@
 # Template file for 'salt'
 pkgname=salt
 version=3006.3
-revision=1
+revision=2
 build_style=python3-module
 hostmakedepends="python3-setuptools"
 depends="python3-yaml python3-Jinja2 python3-requests python3-pyzmq
  python3-M2Crypto python3-tornado python3-msgpack dmidecode pciutils
- python3-psutil python3-distro python3-pycryptodomex python3-looseversion"
+ python3-psutil python3-distro python3-pycryptodomex python3-looseversion
+ python3-jmespath python3-packaging"
 short_desc="Remote execution system, and configuration manager"
 maintainer="Toyam Cox <Vaelatern@voidlinux.org>"
 license="Apache-2.0"


### PR DESCRIPTION
Update to fix `contextvars` version issue again.  See https://github.com/saltstack/salt/issues/60483 and https://github.com/void-linux/void-packages/pull/33331

This also adds a couple dependencies I found.

#### Testing the changes
- I tested the changes in this PR: **YES**

Salt runs now but I am having problems with connectivity between the master and minions.  I am not sure if it's caused by the upgrade or not.
