### PR TITLE
catch2: fix deceiving description

### DIFF
--- a/srcpkgs/catch2/template
+++ b/srcpkgs/catch2/template
@@ -8,7 +8,7 @@ configure_args="-DCATCH_USE_VALGRIND=OFF -DCATCH_BUILD_TESTING=ON
  -DCATCH_ENABLE_COVERAGE=OFF -DCATCH_ENABLE_WERROR=OFF
  -DCATCH_INSTALL_DOCS=ON -DCATCH_INSTALL_HELPERS=ON"
 hostmakedepends="python3"
-short_desc="C++ header-only test framework for unit-tests, TDD and BDD"
+short_desc="C++ test framework for unit-tests, TDD and BDD"
 maintainer="Louis Dupré Bertoni <contact@louisdb.xyz>"
 license="BSL-1.0"
 homepage="https://github.com/catchorg/Catch2"


### PR DESCRIPTION
The `catch2` package is really weird by the way. It ships a _static_ library. It also doesn't have `catch2-devel`
 because of this. I guess this is for developers only. I know Catch2 doesn't really like to be packaged, it prefers to be managed by the project's build system, but it still isn't standard to ship static libraries like this. Correct me if I'm wrong.
<!-- Uncomment relevant sections and delete options which are not applicable -->
ping @DBLouis 

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
