### PR TITLE
libmateweather: update to 1.26.2.

### DIFF
--- a/srcpkgs/libmateweather/template
+++ b/srcpkgs/libmateweather/template
@@ -1,6 +1,6 @@
 # Template file for 'libmateweather'
 pkgname=libmateweather
-version=1.26.1
+version=1.26.2
 revision=1
 build_style=gnu-configure
 configure_args="--disable-static --enable-locations-compression
@@ -14,7 +14,7 @@ license="GPL-2.0-or-later"
 homepage="https://mate-desktop.org"
 changelog="https://raw.githubusercontent.com/mate-desktop/libmateweather/master/NEWS"
 distfiles="https://pub.mate-desktop.org/releases/${version%.*}/libmateweather-${version}.tar.xz"
-checksum=c200990f4b8e9d4d0e2c6f7d31a5876374c3d2a36c6b8cb590440043a860ef3a
+checksum=ca50a81586655cf53a8f96766b9ce90a4d07ed0fe162bd5e15dadadd0060c7f6
 
 libmateweather-devel_package() {
 	short_desc+=" - development files"


### PR DESCRIPTION
This update fixes the weather widget not working.

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, `Void 6.1.43-xanmod1_1 x86_64 AuthenticAMD uptodate hold rrmFFFFFFFFFFFFFFFFF`
