### PR TITLE
rpi-kernel: update to 6.1.58 + eeprom + firmware

### DIFF
--- a/srcpkgs/rpi-eeprom/template
+++ b/srcpkgs/rpi-eeprom/template
@@ -1,8 +1,8 @@
 # Template file for 'rpi-eeprom'
 pkgname=rpi-eeprom
-version=2023.09.29
+version=2023.10.20
 revision=1
-_githash="4f2d676b4e2a9c2d9ee1ab42015ce711fde97afa"
+_githash="fdff8e81f0202c2a8538218e54488b14af2a719e"
 archs="armv7* aarch64*"
 conf_files="/etc/default/rpi-eeprom-update"
 depends="binutils pciutils python3 rpi-firmware rpi-userland"
@@ -11,7 +11,7 @@ maintainer="Leah Neukirchen <leah@vuxu.org>"
 license="BSD-3-Clause, custom:Proprietary"
 homepage="https://github.com/raspberrypi/rpi-eeprom/"
 distfiles="https://github.com/raspberrypi/rpi-eeprom/archive/${_githash}.tar.gz"
-checksum="189c5d37f3102247cec72619e3cb357d027ec526fa3c7373d3107bd6c9e30e29"
+checksum="3fbb9e6e51acb1e3ea2d28428ed14dfe11f3a722e92c8e972b5eb19edb70fe7f"
 python_version=3
 repository=nonfree
 

--- a/srcpkgs/rpi-firmware/template
+++ b/srcpkgs/rpi-firmware/template
@@ -1,8 +1,8 @@
 # Template file for 'rpi-firmware'
 pkgname=rpi-firmware
-version=20230925
+version=20231020
 revision=1
-_rpi_fw=6b37a457122714aa14b2c7df0926455173fd04f1
+_rpi_fw=ce3a0b4197eaf311ba0734efdb9f5bdedefe5e27
 _rpi_bt=9556b08ace2a1735127894642cc8ea6529c04c90
 _rpi_brcm=2c3a8701193ba23d0ef85cdf0d0c9e47baf03dfc
 create_wrksrc=yes
@@ -21,7 +21,7 @@ distfiles="
  https://github.com/RPi-Distro/bluez-firmware/raw/${_rpi_bt}/synaptics/SYN43430A1.hcd>BCM43430A1.raspberrypi,model-zero-2-w.hcd
  https://github.com/RPi-Distro/bluez-firmware/raw/${_rpi_bt}/synaptics/SYN43430B0.hcd>BCM43430B0.raspberrypi,model-zero-2-w.hcd
  https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git/plain/LICENCE.cypress>LICENCE.cypress"
-checksum="913986b1be22b8dc30a3e6a9b5a28316b1bbee7bec90040ddefff0d7512560f4
+checksum="7d876e60d7389d89edd5e41f58076e09cbdf5cfe81e8013204dd13a86fceb114
  9156d90116b921d2e7938b52fad84fbe1d96df622a66c5db09569c735832387a
  c096ad4a5c3f06ed7d69eba246bf89ada9acba64a5b6f51b1e9c12f99bb1e1a7
  51c45e77ddad91a19e96dc8fb75295b2087c279940df2634b23baf71b6dea42c

--- a/srcpkgs/rpi-kernel/template
+++ b/srcpkgs/rpi-kernel/template
@@ -12,9 +12,9 @@
 #
 # Upstream documentation: https://www.raspberrypi.com/documentation/computers/linux_kernel.html
 pkgname=rpi-kernel
-version=6.1.54
+version=6.1.58
 revision=1
-_githash=fad58933544bb2a7b7db92847c25c79a83171fa6
+_githash=0f51aa6afb5d8dba6022184f144786774e20b43b
 archs="armv6l* armv7l* aarch64*"
 hostmakedepends="perl kmod uboot-mkimage openssl-devel bc bison flex xz"
 makedepends="ncurses-devel"
@@ -23,7 +23,7 @@ maintainer="Piraty <mail@piraty.dev>"
 license="GPL-2.0-only"
 homepage="http://www.kernel.org"
 distfiles="https://github.com/raspberrypi/linux/archive/${_githash}.tar.gz"
-checksum=1bd02902fae49351fb16ac0d5ccc3bf4d67aa0640006dbbf8846963519b01ab8
+checksum=30c22e415c4ebb776d0b88f803231ccaa4b653fa180b263a5b3470afb584d76e
 python_version=3
 
 _kernver="${version}_${revision}"


### PR DESCRIPTION
- rpi-kernel: update to 6.1.58.
- rpi-firmware: update to 20231020.
- rpi-eeprom: update to 2023.10.20.

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for these architectures:
  - aarch64 (cross)
  - aarch64-musl (cross)

builds for testing available at: https://barrens.de/repo and https://barrens.de/repo/nonfree

Also tested dkms. It's working fine.

[ci skip]