### PR TITLE
Update: bCNC to 0.9.15, add  python3-shxparser-0.0.2, python3-svgelements-1.9.6 as dependency

### DIFF
--- a/srcpkgs/bCNC/template
+++ b/srcpkgs/bCNC/template
@@ -1,7 +1,7 @@
 # Template file for 'bCNC'
 pkgname=bCNC
-version=0.9.14.307
-revision=4
+version=0.9.15
+revision=1
 build_style=python3-module
 hostmakedepends="python3-setuptools"
 depends="python3-pyserial python3-Pillow python3-tkinter python3-numpy python3-scipy"
@@ -10,7 +10,8 @@ maintainer="Urs Schulz <voidpkgs@ursschulz.de>"
 license="GPL-2.0-only"
 homepage="https://github.com/vlachoudis/bCNC"
 distfiles="${PYPI_SITE}/b/${pkgname}/${pkgname}-${version}.tar.gz"
-checksum=005c3f2a0b244abab81dc3f6df2001f530db655165611165e7009e28b94cda5f
+checksum=7ca77f8914d2da51b4a2bf5db1fe48f52037e59e972769bf48c932fbee2d5ff3
+make_check=no # all tests require pyautogui, which is not packaged
 
 post_install() {
 	vmkdir usr/share/applications

--- a/srcpkgs/python3-shxparser/template
+++ b/srcpkgs/python3-shxparser/template
@@ -1,0 +1,21 @@
+# Template file for 'python3-shxparser'
+pkgname=python3-shxparser
+version=0.0.2
+revision=1
+build_style=python3-module
+hostmakedepends="python3-setuptools"
+checkdepends="python3-svgelements"
+short_desc="Pure Python Parser for SHX Hershey font files"
+maintainer="Luciogi <lucigithubcommit@skiff.com>"
+license="MIT"
+homepage="https://github.com/tatarize/shxparser"
+distfiles="${PYPI_SITE}/s/shxparser/shxparser-${version}.tar.gz"
+checksum=8541e4bce62876822c93f3959e7f6909ef1bf8352691b343bacdaaa9b92ff270
+
+pre_install() {
+	rm -r build/lib/test test
+}
+
+post_install() {
+	vlicense LICENSE
+}

--- a/srcpkgs/python3-svgelements/patches/fix_assert.patch
+++ b/srcpkgs/python3-svgelements/patches/fix_assert.patch
@@ -1,0 +1,23 @@
+diff --git a/test/test_cubic_bezier.py b/test/test_cubic_bezier.py
+index a7283e5..50148c2 100644
+--- a/test/test_cubic_bezier.py
++++ b/test/test_cubic_bezier.py
+@@ -79,4 +79,4 @@ class TestElementCubicBezierPoint(unittest.TestCase):
+         p = Path(transform=Matrix(682.657124793113, 0.000000000003, -0.000000000003, 682.657124793113, 257913.248909660178, -507946.354527872754))
+         p += CubicBezier(start=Point(-117.139521365,1480.99923469), control1=Point(-41.342266634,1505.62725567), control2=Point(40.3422666342,1505.62725567), end=Point(116.139521365,1480.99923469))
+         bounds = p.bbox()
+-        self.assertNotAlmostEquals(bounds[1], bounds[3], delta=100)
++        self.assertNotAlmostEqual(bounds[1], bounds[3], delta=100)
+diff --git a/test/test_write.py b/test/test_write.py
+index 85e5bb5..33c94a6 100644
+--- a/test/test_write.py
++++ b/test/test_write.py
+@@ -24,7 +24,7 @@ class TestElementWrite(unittest.TestCase):
+ 
+     def test_write_group(self):
+         g = Group()
+-        self.assertEquals(g.string_xml(), "<g />")
++        self.assertEqual(g.string_xml(), "<g />")
+ 
+     def test_write_rect(self):
+         r = Rect("1in", "1in", "3in", "3in", rx="5%")

--- a/srcpkgs/python3-svgelements/template
+++ b/srcpkgs/python3-svgelements/template
@@ -1,0 +1,21 @@
+# Template file for 'python3-svgelements'
+pkgname=python3-svgelements
+version=1.9.6
+revision=1
+build_style=python3-module
+hostmakedepends="python3-setuptools"
+checkdepends="python3-numpy python3-scipy python3-Pillow"
+short_desc="SVG Parsing for Elements, Paths, and other SVG Objects"
+maintainer="Luciogi <lucigithubcommit@skiff.com>"
+license="MIT"
+homepage="https://github.com/meerk40t/svgelements"
+distfiles="${PYPI_SITE}/s/svgelements/svgelements-${version}.tar.gz"
+checksum=7c02ad6404cd3d1771fd50e40fbfc0550b0893933466f86a6eb815f3ba3f37f7
+
+pre_install() {
+	rm -r build/lib/test test
+}
+
+post_install() {
+	vlicense LICENSE
+}


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64_glibc)

###  bCNC 0.9.15 requires new depends
- python3-shxparser
- python3-svgelements