### PR TITLE
vlc: update to 3.0.19.

### DIFF
--- a/srcpkgs/vlc/template
+++ b/srcpkgs/vlc/template
@@ -1,7 +1,7 @@
 # Template file for 'vlc'
 pkgname=vlc
-version=3.0.18
-revision=9
+version=3.0.19
+revision=1
 build_style=gnu-configure
 configure_args="--disable-gme --disable-libtar --enable-jack
  --enable-live555 --disable-fluidsynth --enable-dvdread
@@ -17,7 +17,7 @@ license="GPL-2.0-only, LGPL-2.1-only"
 homepage="https://www.videolan.org/vlc/"
 changelog="https://www.videolan.org/developers/vlc-branch/NEWS"
 distfiles="${VIDEOLAN_SITE}/vlc/${version}/vlc-${version}.tar.xz"
-checksum=57094439c365d8aa8b9b41fa3080cc0eef2befe6025bb5cef722accc625aedec
+checksum=643e3294bafe922324663ca499515b7564f2794575fd7d2b7992d20896381745
 
 lib32disabled=yes
 


### PR DESCRIPTION
vlc: update to 3.0.19

#### Testing the changes
- I tested the changes in this PR: **YES** -- vlc runs and I can confirm that FLAC playback is fixed (the main reason I sought this update)

#### Local build testing
- I built this PR locally for my native architecture, x86_64
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl (crossbuild)
  - aarch64 (crossbuild)
  - aarch64-musl (crossbuild)
