### PR TITLE
kvantum: update to 1.0.10.

### DIFF
--- a/srcpkgs/kvantum/patches/lib32.patch
+++ b/srcpkgs/kvantum/patches/lib32.patch
@@ -1,0 +1,14 @@
+--- a/Kvantum/style/CMakeLists.txt	2023-12-09 19:15:19.658089615 -0500
++++ b/Kvantum/style/CMakeLists.txt	2023-12-09 19:15:31.014342407 -0500
+@@ -36,10 +36,7 @@
+ if(QT_VERSION_MAJOR EQUAL 6)
+   get_target_property(REAL_QMAKE_EXECUTABLE Qt6::qmake
+                       IMPORTED_LOCATION)
+-  execute_process(COMMAND "${REAL_QMAKE_EXECUTABLE}" -query QT_INSTALL_PLUGINS
+-                  OUTPUT_VARIABLE _Qt6_PLUGIN_INSTALL_DIR
+-                  ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
+-  set(KVANTUM_STYLE_DIR "${_Qt6_PLUGIN_INSTALL_DIR}/styles/")
++  set(KVANTUM_STYLE_DIR "${QT6_INSTALL_PLUGINS}/styles/")
+ 
+   include_directories(${CMAKE_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR}
+                       ${Qt6Core_INCLUDE_DIRS} ${Qt6Widgets_INCLUDE_DIRS}

--- a/srcpkgs/kvantum/template
+++ b/srcpkgs/kvantum/template
@@ -1,21 +1,35 @@
 # Template file for 'kvantum'
 pkgname=kvantum
-version=1.0.5
+version=1.0.10
 revision=1
 build_wrksrc=Kvantum
-build_style=qmake
-hostmakedepends="qt5-tools qt5-qmake qt5-host-tools"
-makedepends="qt5-devel qt5-svg-devel qt5-x11extras-devel
- kwindowsystem-devel"
-short_desc="SVG-based theme engine for Qt4/Qt5, KDE and LXQt"
+build_style=cmake
+hostmakedepends="qt5-tools-devel qt5-host-tools qt6-tools-devel"
+makedepends="qt5-devel qt6-base-devel qt5-svg-devel qt6-svg-devel
+ qt5-x11extras-devel kwindowsystem-devel"
+short_desc="SVG-based theme engine for Qt5/Qt6, KDE and LXQt"
 maintainer="Giuseppe Fierro <gspe@ae-design.ws>"
 license="GPL-3.0-or-later"
 homepage="https://github.com/tsujan/Kvantum"
 changelog="https://raw.githubusercontent.com/tsujan/Kvantum/master/Kvantum/ChangeLog"
 distfiles="https://github.com/tsujan/Kvantum/archive/V${version}.tar.gz"
-checksum=2284017dbe5b4b4b5f657215525ca1d1e30d702b28102067d4aa2ec1e764c6a6
+checksum=2ef368df6c54a3bde2097ed89341f188b6670d1b1f8d11bcb3a80138887aca12
+
+post_configure() {
+	mkdir build6
+	(
+		cd build6
+		configure_args="-DENABLE_QT5=OFF"
+		do_configure
+	)
+}
+
+post_build() {
+	(cd build6 && do_build)
+}
 
 post_install() {
+	(cd build6 && do_install)
 	vdoc doc/Theme-Config.pdf
 	vdoc doc/Theme-Making.pdf
 }


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, **x86_64**

#### Comments

Allows kvantum to handle qt5 and qt6 themes under qt5ct and qt6ct.
Their install guide says to 'disable' qt5 but it works fine for both.

Switches build to cmake over qmake

https://github.com/tsujan/Kvantum/blob/master/Kvantum/INSTALL.md#with-cmake