### PR TITLE
python3-argcomplete: update to 3.1.2.

### DIFF
--- a/srcpkgs/python3-argcomplete/template
+++ b/srcpkgs/python3-argcomplete/template
@@ -1,7 +1,7 @@
 # Template file for 'python3-argcomplete'
 pkgname=python3-argcomplete
-version=3.1.1
-revision=2
+version=3.1.2
+revision=1
 build_style=python3-pep517
 hostmakedepends="python3-setuptools_scm python3-wheel"
 depends="python3"
@@ -12,7 +12,7 @@ license="Apache-2.0"
 homepage="https://github.com/kislyuk/argcomplete"
 changelog="https://raw.githubusercontent.com/kislyuk/argcomplete/develop/Changes.rst"
 distfiles="${PYPI_SITE}/a/argcomplete/argcomplete-${version}.tar.gz"
-checksum=6c4c563f14f01440aaffa3eae13441c5db2357b5eec639abe7c0b15334627dff
+checksum=d5d1e5efd41435260b8f85673b74ea2e883affcbec9f4230c582689e8e78251b
 
 do_check() {
 	# pytest is not supported


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **NO**

@leahneukirchen

Seems to include some kind of Python 3.12 fix (https://github.com/kislyuk/argcomplete/pull/448).

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
