### PR TITLE
libnotify: update to 0.8.3.

### DIFF
--- a/srcpkgs/libnotify/template
+++ b/srcpkgs/libnotify/template
@@ -1,6 +1,6 @@
 # Template file for 'libnotify'
 pkgname=libnotify
-version=0.8.2
+version=0.8.3
 revision=1
 build_style=meson
 build_helper=gir
@@ -14,7 +14,7 @@ license="LGPL-2.1-or-later"
 homepage="https://gitlab.gnome.org/GNOME/libnotify"
 changelog="https://gitlab.gnome.org/GNOME/libnotify/-/raw/master/NEWS"
 distfiles="https://gitlab.gnome.org/GNOME/libnotify/-/archive/${version}/libnotify-${version}.tar.gz"
-checksum=84d6bbcd633ff10eed25226730c52220cd41e362bb183513e5b6a5d1b3c0c12f
+checksum=5bcfeff21b6669c009c862e25c42556723f7a46c2c3454fce0fd532ebed715a0
 # https://gitlab.gnome.org/GNOME/libnotify/-/issues/30
 make_check=no
 


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->
>This release contains a critical stability/minor security update which affects
Electron applications that utilize Portal notifications (eg, through Flatpak).
It is highly recommended that all users of libnotify 0.8.x update to this
release.


#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc



