### PR TITLE
New package: perl-IO-Compress-Brotli-0.004001

### DIFF
--- a/srcpkgs/perl-IO-Compress-Brotli/patches/no-bundled-brotli.patch
+++ b/srcpkgs/perl-IO-Compress-Brotli/patches/no-bundled-brotli.patch
@@ -1,0 +1,50 @@
+--- IO-Compress-Brotli-0.004001/Makefile.PL.orig	2022-08-02 09:39:14.249801914 +0200
++++ IO-Compress-Brotli-0.004001/Makefile.PL	2022-08-02 09:39:03.236639950 +0200
+@@ -1,5 +1,23 @@
+ use 5.014000;
+ use ExtUtils::MakeMaker;
++use ExtUtils::PkgConfig;
++
++my @requirements = qw(libbrotlidec libbrotlienc);
++my $libs = '';
++my $inc  = '';
++
++my %pkgcfg;
++foreach my $req (@requirements) {
++	eval{
++		%pkgcfg = ExtUtils::PkgConfig->find($req);
++	};
++	if ($@) {
++		die "Could not determine location of library $req.";
++	}
++	$libs .= $pkgcfg{libs}.' ';
++	$inc  .= $pkgcfg{cflags}.' ';
++}
++
+ 
+ WriteMakefile(
+ 	NAME             => 'IO::Compress::Brotli',
+@@ -16,20 +34,12 @@ WriteMakefile(
+ 		'Time::HiRes'   => '0',
+ 	},
+ 	BUILD_REQUIRES   => {},
+-	INC              => '-Ibrotli/c/include',
+-	MYEXTLIB         => 'brotli/libbrotli$(LIB_EXT)',
+-	clean            => { FILES => 'brotli/libbrotli$(LIB_EXT)' },
+ 	META_ADD         => {
+ 		dynamic_config => 0,
+ 		resources      => {
+ 			repository   => 'https://git.ieval.ro/?p=io-compress-brotli.git',
+ 		},
+-	}
++	},
++	LIBS		=> $libs,
++	INC		=> $inc,
+ );
+-
+-sub MY::postamble {
+-'
+-$(MYEXTLIB): brotli/Makefile
+-	cd brotli && CFLAGS=-fPIC `which gmake || echo $(MAKE)` lib
+-'
+-}

--- a/srcpkgs/perl-IO-Compress-Brotli/template
+++ b/srcpkgs/perl-IO-Compress-Brotli/template
@@ -1,0 +1,15 @@
+# Template file for 'perl-IO-Compress-Brotli'
+pkgname=perl-IO-Compress-Brotli
+version=0.004001
+revision=1
+build_style=perl-module
+hostmakedepends="perl perl-ExtUtils-PkgConfig"
+makedepends="perl-File-Slurper brotli-devel"
+depends="perl-File-Slurper"
+short_desc="Modules for compressing and uncompressing Brotli data"
+maintainer="yosh <yosh-git@riseup.net>"
+license="Artistic-1.0-Perl, GPL-1.0-or-later"
+homepage="https://metacpan.org/dist/IO-Compress-Brotli"
+changelog="https://fastapi.metacpan.org/source/MGV/IO-Compress-Brotli-0.004001/Changes"
+distfiles="https://search.cpan.org/CPAN/authors/id/M/MG/MGV/IO-Compress-Brotli-$version.tar.gz"
+checksum=8ba5c0167e966f487bde159c18bc1b3486528013b3235d39f2fcb375ca4bf410


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

#### Local build testing
- I built this PR locally for my native architecture, `x86_64-glibc`
- I built this PR locally for these architectures:
  - `x86_64-musl`
  - `i686-glibc`

noticed that this package is required for viewing jpeg xl brotli-compressed exif data using `exiftool`

I include the `no-bundled-brotli.patch` from [fedora](https://src.fedoraproject.org/rpms/perl-IO-Compress-Brotli/blob/rawhide/f/IO-Compress-Brotli-0.004001-Use-pkgconfig-instead-of-bundled-libbrotli.patch) since the old bundled brotli has a security vulnerability