### PR TITLE
postgresql14: Fix postgresql14-libs-devel dependencies

### DIFF
--- a/srcpkgs/postgresql14/template
+++ b/srcpkgs/postgresql14/template
@@ -1,7 +1,7 @@
 # Template file for 'postgresql14'
 pkgname=postgresql14
 version=14.8
-revision=4
+revision=5
 build_style=gnu-configure
 make_build_target=world
 _major="${version%%.*}"
@@ -124,7 +124,7 @@ postgresql14-libs_package() {
 }
 
 postgresql14-libs-devel_package() {
-	depends="postgresql-libs>=${version}_${revision} openssl-devel"
+	depends="postgresql14-libs>=${version}_${revision} openssl-devel"
 	short_desc="PostgreSQL shared libraries (development files)"
 	conflicts="postgresql9.6-libs-devel>=0 postgresql12-libs-devel>=0 postgresql13-libs-devel>=0"
 	pkg_install() {


### PR DESCRIPTION
I think this change will resolve the failing tests in https://github.com/void-linux/void-packages/pull/45532

#### Testing the changes
- I tested the changes in this PR: **NO**

