### PR TITLE
python3-niapy: use official homepage url

### DIFF
--- a/srcpkgs/python3-niapy/template
+++ b/srcpkgs/python3-niapy/template
@@ -1,7 +1,7 @@
 # Template file for 'python3-niapy'
 pkgname=python3-niapy
 version=2.0.5
-revision=2
+revision=3
 build_style=python3-module
 hostmakedepends="python3-setuptools"
 depends="python3-numpy python3-openpyxl python3-pandas python3-matplotlib"
@@ -9,7 +9,7 @@ checkdepends="python3-pytest $depends"
 short_desc="Python microframework for building nature-inspired algorithms"
 maintainer="firefly-cpp <iztok@iztok-jr-fister.eu>"
 license="MIT"
-homepage="https://github.com/NiaOrg/NiaPy"
+homepage="https://niapy.org"
 distfiles="https://github.com/NiaOrg/NiaPy/archive/${version}.tar.gz"
 checksum=965b2ef884a24bbd17c3f1218a1ffc9b052c0201638dafb12a9e6452d99057c2
 


### PR DESCRIPTION
Minor edit: replace GitHub URL with official URL of NiaPy project.