### PR TITLE
New package: python3-lsp-ruff

### DIFF
--- a/srcpkgs/python3-cattrs/template
+++ b/srcpkgs/python3-cattrs/template
@@ -1,0 +1,17 @@
+# Template file for 'python3-cattrs'
+pkgname=python3-cattrs
+version=23.1.2
+revision=1
+build_style=python3-pep517
+hostmakedepends="python3-poetry-core"
+depends="python3-attrs"
+short_desc="Composable complex class support for attrs and dataclasses"
+maintainer="Cameron Nemo <cam@nohom.org>"
+license="MIT"
+homepage="https://github.com/python-attrs/cattrs"
+distfiles="${PYPI_SITE}/c/cattrs/cattrs-${version}.tar.gz"
+checksum=db1c821b8c537382b2c7c66678c3790091ca0275ac486c76f3c8f3920e83c657
+
+post_install() {
+	vlicense LICENSE
+}

--- a/srcpkgs/python3-lsp-ruff/template
+++ b/srcpkgs/python3-lsp-ruff/template
@@ -1,0 +1,22 @@
+# Template file for 'python3-lsp-ruff'
+pkgname=python3-lsp-ruff
+version=1.6.0
+revision=1
+build_style=python3-module
+hostmakedepends="python3-setuptools python3-setuptools_scm python3-wheel"
+depends="python3-lsp-server python3-lsprotocol python3-cattrs ruff"
+checkdepends="${depends} python3-pytest"
+short_desc="Python implementation of the Language Server Protocol"
+maintainer="Cameron Nemo <cam@nohom.org>"
+license="MIT"
+homepage="https://github.com/python-lsp/python-lsp-ruff"
+distfiles="${PYPI_SITE}/p/python-lsp-ruff/python-lsp-ruff-${version}.tar.gz"
+checksum=bdfdd9359c9e9f55b6f6a938493d6cbace554dccacf45df4ebb36552be34e9b8
+
+do_check() {
+	python3 -m pytest
+}
+
+post_install() {
+	vlicense LICENSE
+}

--- a/srcpkgs/python3-lsp-server/template
+++ b/srcpkgs/python3-lsp-server/template
@@ -1,7 +1,7 @@
 # Template file for 'python3-lsp-server'
 pkgname=python3-lsp-server
-version=1.8.0
-revision=2
+version=1.8.2
+revision=1
 build_style=python3-module
 hostmakedepends="python3-setuptools python3-setuptools_scm python3-wheel"
 depends="python3-jedi python3-pluggy python3-lsp-jsonrpc python3-ultrajson
@@ -16,7 +16,7 @@ license="MIT"
 homepage="https://github.com/python-lsp/python-lsp-server"
 changelog="https://raw.githubusercontent.com/python-lsp/python-lsp-server/develop/CHANGELOG.md"
 distfiles="${PYPI_SITE}/p/python-lsp-server/python-lsp-server-${version}.tar.gz"
-checksum=807b0347cf83f02cbd9113a68624ac5dbf8b01854a3b11dd03c3bbbdff4e5d89
+checksum=fd85e1c6ad95c1d276c82a33c2c85898f110afc3c7bfeaced79c0df095076fd1
 
 do_check() {
 	python3 -m pytest \

--- a/srcpkgs/python3-lsprotocol/template
+++ b/srcpkgs/python3-lsprotocol/template
@@ -1,0 +1,17 @@
+# Template file for 'python3-lsprotocol'
+pkgname=python3-lsprotocol
+version=0.0.0.20230918
+revision=1
+_version=2023.0.0b1
+build_style=python3-pep517
+hostmakedepends="python3-setuptools python3-wheel python3-flit_core"
+short_desc="Python implementation of the Language Server Protocol"
+maintainer="Cameron Nemo <cam@nohom.org>"
+license="MIT"
+homepage="https://github.com/microsoft/lsprotocol"
+distfiles="${PYPI_SITE}/l/lsprotocol/lsprotocol-${_version}.tar.gz"
+checksum=f7a2d4655cbd5639f373ddd1789807450c543341fa0a32b064ad30dbb9f510d4
+
+post_install() {
+	vlicense LICENSE
+}


### PR DESCRIPTION
- python3-lsp-server: update to 1.8.2
- New package: python3-cattrs-23.1.2
- New package: python3-lsprotocol-0.0.0.20230918
- New package: python3-lsp-ruff-1.6.0

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**, system-level

Closes: #46560
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
