### PR TITLE
ccache: update to 4.8.3, add more compiler symlinks

### DIFF
--- a/srcpkgs/ccache/template
+++ b/srcpkgs/ccache/template
@@ -1,6 +1,6 @@
 # Template file for 'ccache'
 pkgname=ccache
-version=4.8.2
+version=4.8.3
 revision=1
 build_style=cmake
 configure_args="-DENABLE_TESTING=OFF -DREDIS_STORAGE_BACKEND=OFF
@@ -13,8 +13,8 @@ homepage="https://ccache.dev"
 changelog="https://ccache.dev/releasenotes.html"
 distfiles="https://github.com/ccache/ccache/releases/download/v${version}/ccache-${version}.tar.xz
  https://github.com/ccache/ccache/releases/download/v${version}/ccache-${version}-linux-x86_64.tar.xz"
-checksum="3d3fb3f888a5b16c4fa7ee5214cca76348afd6130e8443de5f6f2424f2076a49
- 0b33f39766fe9db67f40418aed6a5b3d7b2f4f7fab025a8213264b77a2d0e1b1"
+checksum="e47374c810b248cfca3665ee1d86c7c763ffd68d9944bc422d9c1872611f2b11
+ 1021f6dc9641447524cc7bceb72f807f2d6502df118d69dc3f0f86cacf048e79"
 
 if [ -n "$XBPS_CHECK_PKGS" ]; then
 	configure_args+=" -DENABLE_TESTING=ON"
@@ -33,14 +33,17 @@ post_install() {
 	# gcc
 	for f in gcc cc c++ g++; do
 		ln -sfr ${DESTDIR}/usr/bin/ccache ${DESTDIR}/usr/lib/ccache/bin/${f}
-		for x in arm-linux-gnueabi arm-linux-gnueabihf armv7l-linux-gnueabihf \
-			arm-linux-musleabihf armv7l-linux-musleabihf aarch64-linux-gnu \
-			i686-pc-linux-gnu aarch64-linux-musl i686-linux-musl \
-			mips-linux-musl mips-linux-muslhf mipsel-linux-musl mipsel-linux-muslhf \
-			powerpc-linux-gnu powerpc-linux-musl \
-			powerpcle-linux-gnu powerpcle-linux-musl \
-			powerpc64-linux-gnu powerpc64-linux-musl \
-			powerpc64le-linux-musl powerpc64le-linux-gnu; do
+		# cross compilers
+		for x in aarch64-linux-gnu aarch64-linux-musl arm-linux-gnueabi \
+			arm-linux-gnueabihf arm-linux-musleabi arm-linux-musleabihf \
+			arm-none-eabi armv7l-linux-gnueabihf armv7l-linux-musleabihf \
+			avr i686-linux-musl i686-pc-linux-gnu mips-linux-musl \
+			mips-linux-muslhf mipsel-linux-musl mipsel-linux-muslhf musl-gcc \
+			or1k-none-elf powerpc-linux-gnu powerpc-linux-musl \
+			powerpc64-linux-gnu powerpc64-linux-musl powerpc64le-linux-gnu \
+			powerpc64le-linux-musl powerpcle-linux-gnu powerpcle-linux-musl \
+			riscv64-linux-gnu riscv64-linux-musl x86_64-linux-gnu \
+			x86_64-linux-musl ; do
 			ln -sfr ${DESTDIR}/usr/bin/ccache ${DESTDIR}/usr/lib/ccache/bin/${x}-${f}
 		done
 	done


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

#### TODO
- [ ] winegcc ?
- [ ] afl-gcc ?
- [ ] msp430-gcc ?

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
