### PR TITLE
containerd: update to 1.7.8, adopt.

### DIFF
--- a/srcpkgs/containerd/template
+++ b/srcpkgs/containerd/template
@@ -1,6 +1,6 @@
 # Template file for 'containerd'
 pkgname=containerd
-version=1.7.7
+version=1.7.8
 revision=1
 build_style=go
 go_import_path=github.com/containerd/containerd
@@ -16,11 +16,11 @@ hostmakedepends="pkg-config go-md2man"
 makedepends="libbtrfs-devel libseccomp-devel"
 depends="runc"
 short_desc="Open and reliable container runtime"
-maintainer="Orphaned <orphan@voidlinux.org>"
+maintainer="Bnyro <bnyro@tutanota.com>"
 license="Apache-2.0"
 homepage="https://github.com/containerd/containerd"
 distfiles="https://github.com/containerd/containerd/archive/v${version}.tar.gz"
-checksum=4c6042b13746a803766d76b07f756d03678a33a944b52c0b832c238609db1b2e
+checksum=891b84e614b491ab1d3bd5c8f4fb119e4929c24762e149e83e181e72d687f706
 make_dirs="/var/lib/containerd 0755 root root"
 
 post_build() {


### PR DESCRIPTION

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc

