### PR TITLE
[rfc] build-style: go: set buildmode=pie globally

### DIFF
--- a/common/build-style/go.sh
+++ b/common/build-style/go.sh
@@ -5,7 +5,7 @@
 do_configure() {
 	# $go_import_path must be set, or we can't link $PWD into $GOSRCPATH
 	# nor build from modules
-	if [ -z "$go_import_path" ]; then
+	if [ -z "${go_import_path}" ]; then
 		msg_error "\"\$go_import_path\" not set on $pkgname template.\n"
 	fi
 
@@ -23,13 +23,26 @@ do_configure() {
 
 do_build() {
 	# remove -s and -w from go_ldflags, we should let xbps-src strip binaries itself
-	for wd in $go_ldflags; do
-		if [ "$wd" == "-s" ] || [ "$wd" == "-w" ]; then
-			msg_error "$pkgname: remove -s and -w from go_ldflags\n"
+	for wd in ${go_ldflags}; do
+		if [ "${wd}" == "-s" ] || [ "$wd" == "-w" ]; then
+			msg_error "${pkgname}: remove -s and -w from go_ldflags\n"
 		fi
 	done
 
 	: ${go_package:=$go_import_path}
+	local buildmode
+	if [ -z "${nopie}" ]; then
+		buildmode=-buildmode=pie
+
+		# The linker checks the host sysroot, breaking static PIE musl cross builds
+		if [ -n "${CROSS_BUILD}" ] && [ "${XBPS_TARGET_LIBC}" = "musl" ]; then
+			case "${XBPS_TARGET_MACHINE}" in
+				aarch64*)
+					go_ldflags+=" -I /lib/ld-musl-aarch64.so.1"
+					;;
+			esac
+		fi
+	fi
 	# Build using Go modules if there's a go.mod file
 	if [ "${go_mod_mode}" != "off" ] && [ -f go.mod ]; then
 
@@ -38,7 +51,7 @@ do_build() {
 		fi
 
 		# Check if go_import_path matches module
-		if [ "module $go_import_path" != "$(grep '^module' go.mod | head -n1)" ]; then
+		if [ "module ${go_import_path}" != "$(grep '^module' go.mod | head -n1)" ]; then
 			msg_error "\"\$go_import_path\" doesn't match the one defined in go.mod!\n"
 		fi
 
@@ -50,20 +63,20 @@ do_build() {
 			# default behavior.
 			go_mod_mode=
 		fi
-		go install -p "$XBPS_MAKEJOBS" -mod="${go_mod_mode}" -modcacherw -v -tags "${go_build_tags}" -ldflags "${go_ldflags}" ${go_package}
+		go install -p "${XBPS_MAKEJOBS}" -mod="${go_mod_mode}" ${buildmode} -trimpath -modcacherw -v -tags "${go_build_tags}" -ldflags "${go_ldflags}" ${go_package}
 		if [[ -n "${_go_mod_path}" ]]; then
 			popd
 		fi
 	else
 		# Otherwise, build using GOPATH
-		go install -p "$XBPS_MAKEJOBS" -v -tags "${go_build_tags}" -ldflags "${go_ldflags}" ${go_package}
+		go install -p "${XBPS_MAKEJOBS}" ${buildmode} -trimpath -v -tags "${go_build_tags}" -ldflags "${go_ldflags}" ${go_package}
 	fi
 }
 
 do_check() {
 	: ${make_check_target:=./...}
 
-	${make_check_pre} go test -p "$XBPS_MAKEJOBS" -tags "${go_build_tags}" -ldflags "${go_ldflags}" ${make_check_args} ${make_check_target}
+	${make_check_pre} go test -p "${XBPS_MAKEJOBS}" -tags "${go_build_tags}" -ldflags "${go_ldflags}" ${make_check_args} ${make_check_target}
 }
 
 do_install() {

--- a/common/environment/build-style/go.sh
+++ b/common/environment/build-style/go.sh
@@ -4,7 +4,6 @@ if [ -z "$hostmakedepends" -o "${hostmakedepends##*gcc-go-tools*}" ]; then
 		archs="aarch64* armv[567]* i686* x86_64* ppc64le* riscv64*"
 	fi
 	hostmakedepends+=" go"
-	nopie=yes
 else
 	# gccgo compiler
 	if [ -z "$archs" ]; then

--- a/srcpkgs/booster/template
+++ b/srcpkgs/booster/template
@@ -18,7 +18,6 @@ alternatives="
  initramfs:/etc/kernel.d/post-install/20-initramfs:/usr/libexec/booster/kernel-hook-postinst
  initramfs:/etc/kernel.d/post-remove/20-initramfs:/usr/libexec/booster/kernel-hook-postrm
 "
-export GOFLAGS="-buildmode=pie"
 
 post_build() {
 	( cd init && CGO_ENABLED=0 go install -p "${XBPS_MAKEJOBS}" -mod=readonly -v -buildmode=default )

--- a/srcpkgs/cni-plugins/template
+++ b/srcpkgs/cni-plugins/template
@@ -11,6 +11,7 @@ homepage="https://github.com/containernetworking/plugins"
 changelog="https://github.com/containernetworking/plugins/releases"
 distfiles="https://github.com/containernetworking/plugins/archive/refs/tags/v${version}.tar.gz"
 checksum=95b639f8ccbb714da98e331ef8813f790d447fce5417f2f8a575f3c62bfb1474
+nopie=unverified
 
 do_build() {
 	./build_linux.sh \

--- a/srcpkgs/containerd/template
+++ b/srcpkgs/containerd/template
@@ -26,7 +26,6 @@ make_dirs="/var/lib/containerd 0755 root root"
 
 # Cross builds fail with -fuse-ld=gold
 LDFLAGS="-fuse-ld=bfd"
-export GOFLAGS="-buildmode=pie"
 
 post_build() {
 	# Build the man pages

--- a/srcpkgs/coyim/template
+++ b/srcpkgs/coyim/template
@@ -12,6 +12,7 @@ license="GPL-3.0-only"
 homepage="https://coy.im"
 distfiles="https://github.com/coyim/coyim/archive/v${version}.tar.gz"
 checksum=f2bf1e73562fbcc3a0b264a30f92dfe427dffe2046e9f44459087ecac5890098
+nopie=unverified
 
 case "$XBPS_TARGET_MACHINE" in
 	x86_64*) ;;

--- a/srcpkgs/cri-tools/template
+++ b/srcpkgs/cri-tools/template
@@ -11,6 +11,7 @@ license="Apache-2.0"
 homepage="https://github.com/kubernetes-sigs/cri-tools"
 distfiles="https://github.com/kubernetes-sigs/cri-tools/archive/v${version}.tar.gz"
 checksum=2d48319be933df77c660fbfe7efef8c3d61bbde6787e2f33725bcc519858b287
+nopie=unverified
 
 do_build() {
 	make ${makejobs}

--- a/srcpkgs/docker-machine/template
+++ b/srcpkgs/docker-machine/template
@@ -10,4 +10,4 @@ maintainer="Sergi Alvarez <pancake@nopcode.org>"
 license="Apache-2.0"
 homepage="https://github.com/docker/machine/"
 distfiles="https://github.com/docker/machine/archive/v${version}.tar.gz"
-checksum=af8bff768cd1746c787e2f118a3a8af45ed11679404b6e45d5199e343e550059
+checksum=f333d6dc8976d2c5b0c5e62fb46bce50423e72e3c9210aa77dd6363683db24bf

--- a/srcpkgs/eduvpn-common/template
+++ b/srcpkgs/eduvpn-common/template
@@ -11,7 +11,7 @@ license="MIT"
 homepage="https://www.eduvpn.org/"
 distfiles="https://codeberg.org/eduVPN/eduvpn-common/releases/download/${version}/eduvpn-common-${version}.tar.xz"
 checksum=5b97feaaf14456ee3eb30853c1c78c2b166de541d8f8ee1db7ea0d0ccfc812c3
-
+nopie=unverified
 subpackages="eduvpn-cli"
 
 if [ "$XBPS_TARGET_LIBC" = "glibc" ]; then

--- a/srcpkgs/gofumpt/template
+++ b/srcpkgs/gofumpt/template
@@ -10,7 +10,7 @@ license="BSD-3-Clause"
 homepage="https://github.com/mvdan/gofumpt"
 distfiles="https://github.com/mvdan/gofumpt/archive/refs/tags/v${version}.tar.gz"
 checksum=acff9518cf4ad3550ca910b9254fc8a706494d6a105fe2e92948fedc52a42a5b
-
+nopie=unverified
 export CGO_ENABLED=0
 
 post_install() {

--- a/srcpkgs/gopass/template
+++ b/srcpkgs/gopass/template
@@ -17,8 +17,6 @@ distfiles="https://github.com/gopasspw/gopass/archive/refs/tags/v${version}.tar.
 checksum=33451a782b66266c59560a5ec7f4e34c104c501a36b445fc574fad71e3b3d884
 make_check_pre="env GOPASS_BINARY=${GOPATH}/bin/gopass"
 
-export GOFLAGS="-buildmode=pie"
-
 post_install() {
 	vlicense LICENSE
 	vman gopass.1

--- a/srcpkgs/grafana/template
+++ b/srcpkgs/grafana/template
@@ -29,6 +29,7 @@ make_dirs="/var/log/grafana 0755 _grafana _grafana
 conf_files="/etc/grafana/grafana.ini"
 
 go_ldflags="-X main.version=${version}"
+nopie=unverified
 
 post_extract() {
 	# remove prebuilt binaries

--- a/srcpkgs/incus/template
+++ b/srcpkgs/incus/template
@@ -25,7 +25,6 @@ make_dirs="
  /var/log/incus 0755 root root"
 
 export CGO_LDFLAGS_ALLOW="(-Wl,-wrap,pthread_create)|(-Wl,-z,now)"
-export GOFLAGS="-buildmode=pie"
 
 post_build() {
 	CGO_ENABLED=0 go install -p "${XBPS_MAKEJOBS}" -v -tags netgo -buildmode=default "${go_import_path}/cmd/incus-migrate"

--- a/srcpkgs/kubernetes/template
+++ b/srcpkgs/kubernetes/template
@@ -17,6 +17,7 @@ nocross=yes
 system_accounts="kube"
 make_dirs="/var/lib/kubelet 0755 kube kube"
 conf_files="/etc/kubernetes/*"
+nopie=unverified
 
 do_build() {
 	export GOLDFLAGS=""

--- a/srcpkgs/kubo/template
+++ b/srcpkgs/kubo/template
@@ -22,6 +22,10 @@ system_accounts="_ipfs"
 make_dirs="/var/lib/ipfs 0700 _ipfs _ipfs"
 _ipfs_homedir="/var/lib/ipfs"
 
+if [ "$CROSS_BUILD" ]; then
+	nopie=unverified
+fi
+
 pre_build() {
 	export CGO_ENABLED=0
 }

--- a/srcpkgs/moby/template
+++ b/srcpkgs/moby/template
@@ -17,6 +17,7 @@ distfiles="https://github.com/moby/moby/archive/docker-v${version}.tar.gz"
 checksum=89ef4a0f681ae2c9f7449591243e1e932d86e6086ac3392a47da80c10b1a3d58
 system_groups="docker"
 make_check=no # no other tests are available
+nopie=unverified
 
 do_build() {
 	export AUTO_GOPATH=1

--- a/srcpkgs/nncp/template
+++ b/srcpkgs/nncp/template
@@ -10,7 +10,8 @@ license="GPL-3.0-only"
 homepage="http://www.nncpgo.org/"
 distfiles="http://www.nncpgo.org/download/${pkgname}-${version}.tar.xz"
 checksum=8ce3680e98005198d8975e031760b3a9b33be6d2d61844c799f778ca233d05f4
-make_check=no
+make_check=no # cannot find packages
+nopie=unverified
 
 do_build() {
 	./build

--- a/srcpkgs/podman/template
+++ b/srcpkgs/podman/template
@@ -22,6 +22,7 @@ distfiles="https://github.com/containers/podman/archive/v${version}.tar.gz
  https://github.com/containers/container-libs/archive/refs/tags/common/v${_container_libs_common}.tar.gz"
 checksum="b20ea65afc5a58ea1cea019bd51a5d84eb9042d25d3eb82c55010c8815732d84
  5438aa7763acd6d0ddb39426bec20bc344c53161716d88a9d75ac1fed0172b64"
+nopie=unverified
 
 case $XBPS_TARGET_MACHINE in
 	aarch64* | x86_64*) ;;

--- a/srcpkgs/rclone/template
+++ b/srcpkgs/rclone/template
@@ -17,6 +17,7 @@ changelog="https://raw.githubusercontent.com/rclone/rclone/master/docs/content/c
 distfiles="https://downloads.rclone.org/v${version}/rclone-v${version}.tar.gz"
 checksum=6834040157185e6ae38a6d6d673d63342d6c0f5ed2b244e5235a54d531330297
 make_check_pre="env RCLONE_CONFIG=/notfound CI=1"
+nopie=unverified
 
 pre_build() {
 	if [ "$CROSS_BUILD" ] && [ "$XBPS_TARGET_LIBC" = musl ]; then

--- a/srcpkgs/sbctl/template
+++ b/srcpkgs/sbctl/template
@@ -17,7 +17,6 @@ homepage="https://github.com/Foxboron/sbctl"
 distfiles="https://github.com/Foxboron/sbctl/archive/${version}.tar.gz"
 checksum=7aa2af7b50d42abe39eb4875069ae5cd3fb8406d067d7a58b029c8270bacd14d
 make_dirs="/var/lib/sbctl 0700 root root"
-export GOFLAGS="-buildmode=pie"
 
 post_install() {
 	make man

--- a/srcpkgs/walker/template
+++ b/srcpkgs/walker/template
@@ -17,6 +17,7 @@ changelog="https://github.com/abenz1267/walker/releases"
 distfiles="https://github.com/abenz1267/walker/archive/v${version}.tar.gz"
 checksum=ad8f3570b67bf27ecb42e647f65715ffda2212db58870e6b23ea206d209859d8
 make_check=no # no tests and slog warnings make it fail
+nopie=unverified
 
 do_build() {
 	# build_style=go uses "go install" which has no -o flag and the


### PR DESCRIPTION
Packages that fail to build with `pie` (due to not using the go build style) or set `CGO_ENABLED=0` have `nopie` set.

Results of `build_style=go` rebuild for `aarch64-glibc` with go 1.26.1:

- `lxd{,-lts}`: remove?
- depends on #60519 

[ci skip]