### PR TITLE
gedit: update to 46.1 and add new dependencies

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -3585,6 +3585,7 @@ libqmdnsengine.so.0 qmdnsengine-0.1.0_1
 libyang.so.1 libyang-1.0r5_1
 libhtp.so.2 libhtp-0.5.30_1
 libgedit-44.so gedit-44.0_1
+libgedit-amtk-5.so.0 libgedit-amtk-5.8.0_1
 libchewing.so.3 libchewing-0.5.1_1
 libdwarves.so.1 pahole-1.12_1
 libdwarves_emit.so.1 pahole-1.12_1

--- a/common/shlibs
+++ b/common/shlibs
@@ -3584,7 +3584,7 @@ libqhttpengine.so.1 qhttpengine-1.0.1_1
 libqmdnsengine.so.0 qmdnsengine-0.1.0_1
 libyang.so.1 libyang-1.0r5_1
 libhtp.so.2 libhtp-0.5.30_1
-libgedit-44.so gedit-44.0_1
+libgedit-46.so gedit-46.1_1
 libgedit-amtk-5.so.0 libgedit-amtk-5.8.0_1
 libgedit-gtksourceview-300.so.0 libgedit-gtksourceview-299.0.5_1
 libchewing.so.3 libchewing-0.5.1_1

--- a/common/shlibs
+++ b/common/shlibs
@@ -3467,7 +3467,7 @@ libwx_gtk3u_richtext-3.2.so.0 wxWidgets-gtk3-3.2.2.1_1
 libwx_gtk3u_stc-3.2.so.0 wxWidgets-gtk3-3.2.2.1_1
 libwx_gtk3u_webview-3.2.so.0 wxWidgets-gtk3-3.2.2.1_1
 libwx_gtk3u_xrc-3.2.so.0 wxWidgets-gtk3-3.2.2.1_1
-libtepl-6.so.2 tepl-6.4.0_1
+libtepl-6.so.4 tepl-6.8.0_1
 libnomacsCore.so.3 nomacs-3.10.2_4
 libaudit.so.1 libaudit-2.8.4_1
 libauparse.so.0 libauparse-2.8.4_1

--- a/common/shlibs
+++ b/common/shlibs
@@ -3586,6 +3586,7 @@ libyang.so.1 libyang-1.0r5_1
 libhtp.so.2 libhtp-0.5.30_1
 libgedit-44.so gedit-44.0_1
 libgedit-amtk-5.so.0 libgedit-amtk-5.8.0_1
+libgedit-gtksourceview-300.so.0 libgedit-gtksourceview-299.0.5_1
 libchewing.so.3 libchewing-0.5.1_1
 libdwarves.so.1 pahole-1.12_1
 libdwarves_emit.so.1 pahole-1.12_1

--- a/srcpkgs/gedit-plugins/template
+++ b/srcpkgs/gedit-plugins/template
@@ -1,15 +1,14 @@
 # Template file for 'gedit-plugins'
 # keep major version in sync with gedit
 pkgname=gedit-plugins
-version=44.1
-revision=2
+version=46.0
+revision=1
 build_style=meson
 pycompile_dirs="usr/lib/gedit/plugins"
 hostmakedepends="gettext glib-devel itstool pkg-config vala appstream-glib
  python3-gobject gucharmap-devel vte3-devel"
-makedepends="gedit-devel gtksourceview4-devel gtk+3-devel libgit2-glib-devel
- libglib-devel libpeas-devel python3-dbus-devel python3-devel zeitgeist-devel
- amtk-devel"
+makedepends="gedit-devel libgedit-gtksourceview-devel gtk+3-devel libgit2-glib-devel
+ libglib-devel libpeas-devel python3-dbus-devel python3-devel"
 depends="python3-gobject gucharmap vte3"
 short_desc="Set of plugins for Gedit"
 maintainer="Enno Boland <gottox@voidlinux.org>"
@@ -17,5 +16,5 @@ license="GPL-2.0-or-later"
 homepage="https://gitlab.gnome.org/GNOME/gedit-plugins"
 changelog="https://gitlab.gnome.org/GNOME/gedit-plugins/-/raw/master/NEWS"
 distfiles="${GNOME_SITE}/gedit-plugins/${version%.*}/gedit-plugins-${version}.tar.xz"
-checksum=1e56036e79d4425b5bfdf09dfd7d2892cfa01d025f7f33cdc48e1c569f2bba61
+checksum=db6b4aa72dac0190a8ae497f770f5a4ba66ae3cf1e03ea8b744e6101df09b251
 python_version=3

--- a/srcpkgs/gedit/template
+++ b/srcpkgs/gedit/template
@@ -1,34 +1,34 @@
 # Template file for 'gedit'
 # keep major version in sync with gedit-plugins
 pkgname=gedit
-version=44.2
-revision=2
+version=46.1
+revision=1
 build_helper="gir"
 build_style=meson
 pycompile_dirs="usr/lib/gedit/plugins"
 configure_args="-Dgtk_doc=false"
-hostmakedepends="itstool pkg-config glib-devel gdk-pixbuf perl gettext vala"
-makedepends="gsettings-desktop-schemas-devel gspell-devel gtksourceview4-devel
- libpeas-devel python3-gobject-devel amtk-devel tepl-devel"
+hostmakedepends="itstool pkg-config glib-devel gdk-pixbuf perl gettext
+ gtk-update-icon-cache desktop-file-utils"
+makedepends="gsettings-desktop-schemas-devel gspell-devel libgedit-gtksourceview-devel
+ libpeas-devel python3-gobject-devel libgedit-amtk-devel tepl-devel"
 depends="desktop-file-utils gsettings-desktop-schemas iso-codes"
 short_desc="Text editor for GNOME"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="https://wiki.gnome.org/Apps/Gedit"
-changelog="https://gitlab.gnome.org/GNOME/gedit/-/raw/gedit-44/NEWS"
+changelog="https://gitlab.gnome.org/GNOME/gedit/-/raw/${version}/NEWS"
 distfiles="${GNOME_SITE}/gedit/${version%.*}/gedit-${version}.tar.xz"
-checksum=3bbb1b3775d4c277daf54aaab44b0eb83a4eb1f09f0391800041c9e56893ec11
+checksum=a1a6e37f041765dff7227a1f5578b6f49faaf016b1e17e869caf5bfb94c6aa4e
 python_version=3
-shlib_provides="libgedit-44.so"
+shlib_provides="libgedit-46.so"
 
 gedit-devel_package() {
 	depends="${sourcepkg}>=${version}_${revision} gtk+3-devel libglib-devel
-	 gtksourceview4-devel libpeas-devel amtk-devel tepl-devel"
+	 libgedit-gtksourceview-devel libpeas-devel libgedit-amtk-devel tepl-devel"
 	short_desc+=" - development files"
 	pkg_install() {
 		vmove usr/include
 		vmove usr/lib/pkgconfig
 		vmove usr/share/gedit/gir-1.0
-		vmove usr/share/vala
 	}
 }

--- a/srcpkgs/gnome-latex/template
+++ b/srcpkgs/gnome-latex/template
@@ -1,6 +1,6 @@
 # Template file for 'gnome-latex'
 pkgname=gnome-latex
-version=3.44.0
+version=3.46.0
 revision=1
 build_helper="gir"
 build_style=gnu-configure
@@ -8,7 +8,7 @@ configure_args="--disable-appstream-util --disable-dconf-migration
  $(vopt_enable gir introspection)"
 hostmakedepends="glib-devel intltool itstool pkg-config vala yelp
  $(vopt_if gir gobject-introspection) gtk-doc"
-makedepends="gsettings-desktop-schemas-devel gspell-devel gtksourceview4-devel
+makedepends="gsettings-desktop-schemas-devel gspell-devel libgedit-gtksourceview-devel
  gtk+3-devel libgee-devel libglib-devel tepl-devel"
 short_desc="LaTeX editor for the GNOME desktop"
 maintainer="Enno Boland <gottox@voidlinux.org>"
@@ -16,7 +16,7 @@ license="GPL-3.0-or-later"
 homepage="https://wiki.gnome.org/Apps/GNOME-LaTeX"
 changelog="https://gitlab.gnome.org/swilmet/gnome-latex/-/raw/main/NEWS"
 distfiles="${GNOME_SITE}/gnome-latex/${version%.*}/gnome-latex-${version}.tar.xz"
-checksum=88bd5340bd28c7ed01c7966a3a00732bbd902773df5ac659be6ad11806a9e744
+checksum=d67555639b2a15a8aebd54f335354e44fe3433143ae3cb3cca7a8e26f8112ada
 
 build_options="gir"
 build_options_default="gir"

--- a/srcpkgs/libgedit-amtk-devel
+++ b/srcpkgs/libgedit-amtk-devel
@@ -1,0 +1,1 @@
+libgedit-amtk

--- a/srcpkgs/libgedit-amtk/template
+++ b/srcpkgs/libgedit-amtk/template
@@ -1,0 +1,29 @@
+# Template file for 'libgedit-amtk'
+pkgname=libgedit-amtk
+version=5.8.0
+revision=1
+build_helper="gir"
+build_style=meson
+configure_args="-Dgtk_doc=false"
+hostmakedepends="pkg-config glib-devel gettext"
+makedepends="gtk+3-devel"
+short_desc="Actions, Menus, and Toolbars Kit for GTK applications"
+maintainer="Matt Boehlke <mtboehlke@gmail.com>"
+license="LGPL-3.0-or-later"
+homepage="https://gedit-technology.net"
+changelog="https://raw.githubusercontent.com/gedit-technology/libgedit-amtk/main/NEWS"
+distfiles="https://gedit-technology.net/tarballs/libgedit-amtk/${pkgname}-${version}.tar.xz"
+checksum=64017ae100ef588e01ef54d79c13c4b9767fd37e4365d7e4afd924f751460ecc
+conflicts="amtk"
+
+libgedit-amtk-devel_package() {
+	depends="${sourcepkg}>=${version}_${revision} gtk+3-devel libglib-devel"
+	short_desc+=" - development files"
+	conflicts="amtk-devel"
+	pkg_install() {
+		vmove usr/include
+		vmove usr/lib/pkgconfig
+		vmove "usr/lib/*.so"
+		vmove usr/share/gir-1.0
+	}
+}

--- a/srcpkgs/libgedit-gtksourceview-devel
+++ b/srcpkgs/libgedit-gtksourceview-devel
@@ -1,0 +1,1 @@
+libgedit-gtksourceview

--- a/srcpkgs/libgedit-gtksourceview/template
+++ b/srcpkgs/libgedit-gtksourceview/template
@@ -1,0 +1,29 @@
+# Template file for 'libgedit-gtksourceview'
+pkgname=libgedit-gtksourceview
+version=299.0.5
+revision=1
+build_helper="gir"
+build_style=meson
+configure_args="-Dgtk_doc=false"
+hostmakedepends="pkg-config glib-devel gettext"
+makedepends="gtk+3-devel libxml2-devel"
+checkdepends="xvfb-run"
+short_desc="Source code editing widget"
+maintainer="Matt Boehlke <mtboehlke@gmail.com>"
+license="LGPL-2.1-or-later"
+homepage="https://gedit-technology.github.io"
+changelog="https://raw.githubusercontent.com/gedit-technology/libgedit-gtksourceview/main/NEWS"
+distfiles="https://github.com/gedit-technology/libgedit-gtksourceview/releases/download/${version}/libgedit-gtksourceview-${version}.tar.xz"
+checksum=4bdac3c6dd885a2af8064a7265618ff8505b2324ab02fb00b0ce55e02978d3d6
+make_check_pre="xvfb-run"
+
+libgedit-gtksourceview-devel_package() {
+	depends="${sourcepkg}>=${version}_${revision} libglib-devel gtk+3-devel libxml2-devel"
+	short_desc+=" - development files"
+	pkg_install() {
+		vmove usr/include
+		vmove usr/lib/pkgconfig
+		vmove "usr/lib/*.so"
+		vmove usr/share/gir-1.0
+	}
+}

--- a/srcpkgs/tepl/template
+++ b/srcpkgs/tepl/template
@@ -1,21 +1,21 @@
 # Template file for 'tepl'
 pkgname=tepl
-version=6.4.0
-revision=3
+version=6.8.0
+revision=1
 build_style=meson
 build_helper=gir
 configure_args="$(vopt_bool gir gobject_introspection) $(vopt_bool gtk_doc gtk_doc)"
 hostmakedepends="glib-devel pkg-config gettext $(vopt_if gtk_doc gtk-doc)"
-makedepends="amtk-devel libglib-devel gtksourceview4-devel gtk+3-devel
+makedepends="libgedit-amtk-devel libglib-devel libgedit-gtksourceview-devel gtk+3-devel
  libxml2-devel uchardet-devel gsettings-desktop-schemas-devel"
 checkdepends="xvfb-run"
 short_desc="Text editor product line"
 maintainer="Enno Boland <gottox@voidlinux.org>"
-license="GPL-3.0-or-later"
+license="LGPL-3.0-or-later"
 homepage="https://wiki.gnome.org/Projects/Tepl"
 changelog="https://gitlab.gnome.org/swilmet/tepl/-/raw/main/NEWS"
 distfiles="${GNOME_SITE}/tepl/${version%.*}/tepl-${version}.tar.xz"
-checksum=5e56b20669d0cf05fa1d64b58c8c342c59158122dc518100d093d59df9b87321
+checksum=46e6e5f1bfdbc52e5956f06add575e9c7697c673d53d3803dfe768f490b560f0
 make_check_pre="xvfb-run"
 
 build_options="gir gtk_doc"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

- New package: libgedit-amtk-5.8.0
- New package: libgedit-gtksourceview-299.0.5

These versions depend on the new packages:
- tepl: update to 6.8.0.
- gedit: update to 46.1.
- gedit-plugins: update to 46.0.
- gnome-latex: update to 3.46.0.

#### Testing the changes
- I tested the changes in this PR: **YES**

gedit-plugins no longer carries the zeitgeist plugin.

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

Gedit and friends now depend on new packages libgedit-amtk and libgedit-gtksourceview: https://gedit-technology.net/

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
