### PR TITLE
zeek: update to 6.1.0.

### DIFF
--- a/srcpkgs/spicy/template
+++ b/srcpkgs/spicy/template
@@ -1,6 +1,6 @@
 # Template file for 'spicy'
 pkgname=spicy
-version=1.8.1
+version=1.9.0
 revision=1
 build_style=cmake
 build_helper=qemu
@@ -11,7 +11,7 @@ maintainer="Andrew Benson <abenson+void@gmail.com>"
 license="BSD-3-Clause"
 homepage="https://docs.zeek.org/projects/spicy/en/latest/"
 distfiles="https://github.com/zeek/spicy/releases/download/v${version}/spicy.tar.gz"
-checksum=016d2ba6dc7a35e007bc8519afd7dec4ede15a129ce7b268ebd90865d8da9fa8
+checksum=b2bc57fe43585746048497dd76cc2e1cb33633596f98d31c54fff22b52ca0b00
 
 if [ "$CROSS_BUILD" ]; then
 	export CROSSCOMPILE_EMULATOR="/usr/bin/qemu-${XBPS_TARGET_QEMU_MACHINE}-static"

--- a/srcpkgs/zeek/template
+++ b/srcpkgs/zeek/template
@@ -1,7 +1,7 @@
 # Template file for 'zeek'
 pkgname=zeek
-version=6.0.1
-revision=2
+version=6.1.0
+revision=1
 archs="x86_64* i686* aarch64* armv7* ppc64*"
 build_style=cmake
 build_helper=qemu
@@ -15,7 +15,7 @@ maintainer="Andrew Benson <abenson+void@gmail.com>"
 license="BSD-3-Clause"
 homepage="https://www.zeek.org"
 distfiles="https://download.zeek.org/zeek-${version}.tar.gz"
-checksum=cfc329a170439195d7070ec5387d95cdda7eb6b86ac85ec707b9ed0e9d576a29
+checksum=fb756f4b97809755b5dec38927c49477ff06aa647dfcd2b88025b1be1b6a358e
 make_check=no # checks are broken
 
 if [ "$XBPS_TARGET_LIBC" = "musl" ]; then


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing

```
pkg      host         target        cross  result
spicy    x86_64       x86_64        n      OK
zeek     x86_64       x86_64        n      OK
spicy    x86_64-musl  x86_64-musl   n      OK
zeek     x86_64-musl  x86_64-musl   n      OK
spicy    i686         i686          n      OK
zeek     i686         i686          n      OK
spicy    x86_64       aarch64-musl  y      OK
zeek     x86_64       aarch64-musl  y      OK
spicy    x86_64       aarch64       y      OK
zeek     x86_64       aarch64       y      OK
spicy    x86_64       armv7l-musl   y      OK
zeek     x86_64       armv7l-musl   y      OK
spicy    x86_64       armv7l        y      OK
zeek     x86_64       armv7l        y      OK
spicy    x86_64       armv6l-musl   y      OK
zeek     x86_64       armv6l-musl   y      SKIPPED
spicy    x86_64       armv6l        y      OK
zeek     x86_64       armv6l        y      SKIPPED
```