### PR TITLE
New package: OpenLoco-23.10

### DIFF
--- a/srcpkgs/OpenLoco/template
+++ b/srcpkgs/OpenLoco/template
@@ -1,0 +1,22 @@
+# Template file for 'OpenLoco'
+pkgname=OpenLoco
+version=23.10
+revision=1
+# OpenLoco can currently only be built as 32-bit x86 application
+archs="i686"
+build_style=cmake
+hostmakedepends="git pkg-config"
+makedepends="gtest-devel libopenal-devel libpng-devel libzip-devel SDL2-devel"
+short_desc="Open-source re-implementation of Chris Sawyer's Locomotion"
+maintainer="Matthew Beaudoin <m.beaudoin@mailbox.org>"
+license="MIT"
+homepage="https://openloco.io"
+changelog="https://raw.githubusercontent.com/OpenLoco/OpenLoco/master/CHANGELOG.md"
+distfiles="https://github.com/OpenLoco/OpenLoco/archive/refs/tags/v${version}.tar.gz"
+checksum=c7e592bec24136a100e180b58434542dc021a5501ba32189345ef2dca46a11bd
+lib32mode="full"
+nopie="yes"
+
+post_install() {
+	vlicense LICENSE
+}


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->
This PR completes the trilogy of open-source re-implementations of classic Chris Sawyer games in the Void package repository. It's less mature than both OpenTTD and OpenRCT2, but it's undergoing active development and is fully playable. Due to the project still relying on the original (32-bit) Chris Sawyer's Locomotion executable, it can currently only be built as a 32-bit binary.  

#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture: x86_64-glibc (multilib)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - i686-glibc (native 32-bit masterdir)
