### PR TITLE
gimp: applying gtk patch to stop crash when using with wacom tablet

### DIFF
--- a/srcpkgs/gimp/patches/gtk-workaround.patch
+++ b/srcpkgs/gimp/patches/gtk-workaround.patch
@@ -1,0 +1,63 @@
+Source: https://gitlab.gnome.org/GNOME/gimp/-/merge_requests/935.patch
+
+From 4c54950219fc1dcebafd734645ec3b9d31c7fe64 Mon Sep 17 00:00:00 2001
+From: Gabriel Scherer <gabriel.scherer@gmail.com>
+Date: Thu, 1 Jun 2023 16:23:22 +0200
+Subject: [PATCH] a workaround fix for a gdk_device_get_state bug
+
+See https://gitlab.gnome.org/GNOME/gtk/-/merge_requests/6045
+
+This is an alternative, quick&dirty approach to the nicer but more
+invasive workaround:
+  https://gitlab.gnome.org/GNOME/gimp/-/merge_requests/934
+
+Suggested-by: Peter Hutterer <peter.hutterer@who-t.net>
+---
+ app/widgets/gimpdeviceinfo-coords.c | 27 ++++++++++++++++++++++++++-
+ 1 file changed, 26 insertions(+), 1 deletion(-)
+
+diff --git a/app/widgets/gimpdeviceinfo-coords.c b/app/widgets/gimpdeviceinfo-coords.c
+index 93c1d90beae..024cd5b1b4d 100644
+--- a/app/widgets/gimpdeviceinfo-coords.c
++++ b/app/widgets/gimpdeviceinfo-coords.c
+@@ -121,12 +121,37 @@ gimp_device_info_get_event_coords (GimpDeviceInfo *info,
+   return FALSE;
+ }
+ 
++#define GIMP_AXIS_HOPEFULLY_LAST 36
++/* gtk2 has a bug where gdk_device_get_state may write
++   more coordinates than GDK_AXIS_LAST in a caller-provided
++   array, resulting in a buffer overflow.
++
++   This happens when the underlying X device supports more axes -- as
++   of 2023, the Wacom tablet driver 1.20 supports 8 axes when
++   GDK_AXIS_LAST is 7.
++
++   To be safe we over-estimate the maximum number of axes that any
++   driver may provide to gtk, to avoid buffer overflows. It would be nicer
++   to fix gdk upstream (to never write more than GDK_AXIS_LAST - GDK_AXIS_X
++   coordinates), but the proper upstream fix was rejected as gtk2 is EOL:
++    https://gitlab.gnome.org/GNOME/gtk/-/merge_requests/6045
++
++   Our constant might in theory become wrong if new device drivers
++   start returning much more axes than they do today -- more than 32,
++   when the current maximum is 8. Hopefully, by the time this happens,
++   users have migrated to gtk3 versions of gimp that use a different
++   API and do not suffer from this bug.
++
++   We chose 36 as it is also the internal limit MAX_VALUATORS on the
++   number of 'valuators' used by current X server implementations.
++*/
++
+ void
+ gimp_device_info_get_device_coords (GimpDeviceInfo *info,
+                                     GdkWindow      *window,
+                                     GimpCoords     *coords)
+ {
+-  gdouble axes[GDK_AXIS_LAST] = { 0, };
++  gdouble axes[GIMP_AXIS_HOPEFULLY_LAST] = { 0, };
+ 
+   *coords = default_coords;
+ 
+-- 
+GitLab

--- a/srcpkgs/gimp/template
+++ b/srcpkgs/gimp/template
@@ -1,7 +1,7 @@
 # Template file for 'gimp'
 pkgname=gimp
 version=2.10.34
-revision=2
+revision=3
 build_style=gnu-configure
 configure_args="--disable-check-update --datadir=/usr/share --disable-python"
 hostmakedepends="automake gegl gettext-devel glib-devel gtk+-devel intltool


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
YES

GIMP (in combination with xf86-input-wacom v1.2.0_1) doesn't crash anymore when performing actions that make it reliably crash with GIMP v2.10.34_2.

#### Local build testing
- I built this PR locally for my native architecture, (x86_64, glibc 2.36_2)
