### PR TITLE
owncloudclient: update to 5.2.1.

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -3533,6 +3533,7 @@ libwoff2common.so.1.0.2 libwoff2common1.0.2-1.0.2_1
 libwoff2enc.so.1.0.2 libwoff2enc1.0.2-1.0.2_1
 libwoff2dec.so.1.0.2 libwoff2dec1.0.2-1.0.2_1
 libcloudproviders.so.0 libcloudproviders-0.2.5_2
+libkdsingleapplication-qt6.so.1.1 KDSingleApplication-1.1.0_1
 libKF5KDEGames.so.7 libkdegames-18.08.3_1
 libKF5KDEGamesPrivate.so.7 libkdegames-21.04.0_1
 libidn2.so.0 libidn2-2.1.1_1

--- a/common/shlibs
+++ b/common/shlibs
@@ -2235,6 +2235,7 @@ libfreshclam.so.2 clamav-0.103.1_2
 libqca-qt5.so.2 qca-qt5-2.1.3_1
 libqca-qt6.so.2 qca-qt6-2.3.8_1
 libqt5keychain.so.1 qtkeychain-qt5-0.7.0_1
+libqt6keychain.so.1 qtkeychain-qt6-0.14.1_1
 libphonon4qt5.so.4 phonon-qt5-4.8.3_1
 libphonon4qt5experimental.so.4 phonon-qt5-4.8.3_1
 libphonon4qt6.so.4 phonon-4.12.0_1

--- a/srcpkgs/KDSingleApplication/template
+++ b/srcpkgs/KDSingleApplication/template
@@ -1,0 +1,20 @@
+# Template file for 'KDSingleApplication'
+pkgname=KDSingleApplication
+version=1.1.0
+revision=1
+build_style=cmake
+configure_args="-DKDSingleApplication_QT6=ON
+ -DECM_MKSPECS_INSTALL_DIR=/usr/lib/qt6/mkspecs"
+hostmakedepends="qt6-base"
+makedepends="qt6-base-devel"
+short_desc="KDAB's helper class for single-instance policy applications"
+maintainer="Gonzalo Tornaría <tornaria@cmat.edu.uy>"
+license="MIT"
+homepage="https://github.com/KDAB/KDSingleApplication"
+changelog="https://github.com/KDAB/KDSingleApplication/releases"
+distfiles="https://github.com/KDAB/KDSingleApplication/releases/download/v${version}/kdsingleapplication-${version}.tar.gz"
+checksum=31029fffa4873e2769c555668e8edaa6bd5721edbc445bff5e66cc6af3b9ed78
+
+post_install() {
+	vlicense LICENSE.txt
+}

--- a/srcpkgs/libre-graph-api-cpp-qt-client/template
+++ b/srcpkgs/libre-graph-api-cpp-qt-client/template
@@ -1,11 +1,11 @@
 # Template file for 'libre-graph-api-cpp-qt-client'
 pkgname=libre-graph-api-cpp-qt-client
 version=1.0.4
-revision=1
+revision=2
 build_wrksrc=client
 build_style=cmake
-hostmakedepends="qt5-qmake qt5-host-tools"
-makedepends="qt5-devel"
+hostmakedepends="qt6-base"
+makedepends="qt6-base-devel"
 short_desc="Libre Graph API for owncloudclient"
 maintainer="Gonzalo Tornaría <tornaria@cmat.edu.uy>"
 license="Apache-2.0"

--- a/srcpkgs/owncloudclient/patches/skip-root-test.patch
+++ b/srcpkgs/owncloudclient/patches/skip-root-test.patch
@@ -1,35 +1,19 @@
 Hardcode `getuid()` as `0` in tests, since inside xbps-src the
 filesystem is not restricted.
 
-diff --git a/test/testdownload.cpp b/test/testdownload.cpp
-index b37cb807da..4af30ae72e 100644
---- a/test/testdownload.cpp
-+++ b/test/testdownload.cpp
-@@ -150,10 +150,10 @@ private slots:
-     void testMoveFailsInAConflict() {
- #ifdef Q_OS_WIN
-         QSKIP("Not run on windows because permission on directory does not do what is expected");
- #else
--        if (getuid() == 0) {
-+        if (0 == 0) {
-             QSKIP("The permissions have no effect on the root user");
-         }
- #endif
-         // Test for https://github.com/owncloud/client/issues/7015
-         // We want to test the case in which the renaming of the original to the conflict file succeeds,
 diff --git a/test/testfolderman.cpp b/test/testfolderman.cpp
 index 8fc2cc2627..47213ed6b9 100644
 --- a/test/testfolderman.cpp
 +++ b/test/testfolderman.cpp
-@@ -102,11 +102,11 @@ private slots:
-         QVERIFY(folderman->checkPathValidityForNewFolder(dirPath + "/link1/subfolder").isNull());
-         QVERIFY(folderman->checkPathValidityForNewFolder(dirPath + "/link2/free/subfolder").isNull());
+@@ -109,11 +109,11 @@ private slots:
+         QVERIFY(folderman->checkPathValidityForNewFolder(dirPath + QStringLiteral("/link1/subfolder")).isNull());
+         QVERIFY(folderman->checkPathValidityForNewFolder(dirPath + QStringLiteral("/link2/free/subfolder")).isNull());
  
 -        if (getuid() != 0) {
 +        if (0 != 0) {
              // Should not have the rights
-             QVERIFY(!folderman->checkPathValidityForNewFolder("/").isNull());
-             QVERIFY(!folderman->checkPathValidityForNewFolder("/usr/bin/somefolder").isNull());
+             QVERIFY(!folderman->checkPathValidityForNewFolder(QStringLiteral("/")).isNull());
+             QVERIFY(!folderman->checkPathValidityForNewFolder(QStringLiteral("/usr/bin/somefolder")).isNull());
          }
  #endif
  

--- a/srcpkgs/owncloudclient/template
+++ b/srcpkgs/owncloudclient/template
@@ -1,33 +1,30 @@
 # Template file for 'owncloudclient'
 pkgname=owncloudclient
-version=4.2.0
+version=5.2.1
 revision=1
 build_style=cmake
-configure_args="-Wno-dev -DWITH_AUTO_UPDATER=OFF"
-hostmakedepends="pkg-config extra-cmake-modules qt5-host-tools qt5-tools-devel
- kcoreaddons"
-makedepends="qtkeychain-qt5-devel sqlite-devel qt5-declarative-devel kio-devel
- qt5-tools-devel qt5-plugin-odbc qt5-plugin-tds qt5-plugin-pgsql qt5-plugin-mysql
- qt5-plugin-sqlite libre-graph-api-cpp-qt-client libcloudproviders-devel"
-depends="qt5-plugin-sqlite qt5-svg"
+configure_args="-Wno-dev -DWITH_AUTO_UPDATER=OFF
+ -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins"
+hostmakedepends="pkg-config extra-cmake-modules qt6-base qt6-tools"
+makedepends="qt6-base-devel qtkeychain-qt6-devel libre-graph-api-cpp-qt-client
+ KDSingleApplication"
+depends="qt6-plugin-sqlite qt6-plugin-tls-openssl qt6-svg"
 conf_files="/etc/ownCloud/sync-exclude.lst"
 short_desc="Connect to ownCloud servers"
 maintainer="Gonzalo Tornaría <tornaria@cmat.edu.uy>"
 license="GPL-2.0-or-later"
 homepage="https://www.owncloud.org"
 changelog="https://raw.githubusercontent.com/owncloud/client/master/CHANGELOG.md"
-distfiles="https://github.com/owncloud/client/archive/v${version/.rc/-rc}.tar.gz"
-checksum=e31402a922c63dd94975cb3d8b0a0952374891024daf8e08ce4442cfba0729b1
-subpackages="owncloudclient-kde5 owncloudclient-devel"
+distfiles="https://github.com/owncloud/client/archive/v${version}.tar.gz"
+checksum=f73afffc08a1788abbb7e8e66a3a2c39f638d1584402b0d04594c3bb99035ef1
 
 owncloudclient-kde5_package() {
+	# kde5 integration has been moved to:
+	# https://github.com/owncloud/client-desktop-shell-integration-dolphin
+	build_style=meta
 	short_desc+=" - KDE 5 integration"
 	depends="${sourcepkg}>=${version}_${revision}"
-	pkg_install() {
-		vmove "usr/lib/*dolphin*"
-		vmove "usr/lib/qt5/plugins/*dolphin*"
-		vmove "usr/lib/qt5/plugins/kf5"
-	}
+	short_desc+=" (transitional dummy package)"
 }
 
 owncloudclient-devel_package() {

--- a/srcpkgs/qtkeychain-qt6-devel
+++ b/srcpkgs/qtkeychain-qt6-devel
@@ -1,0 +1,1 @@
+qtkeychain-qt6

--- a/srcpkgs/qtkeychain-qt6/files/README.voidlinux
+++ b/srcpkgs/qtkeychain-qt6/files/README.voidlinux
@@ -1,0 +1,2 @@
+To actually use qtkeychain-qt6 you need to either have kwallet or
+gnome-keyring installed.

--- a/srcpkgs/qtkeychain-qt6/patches/fix-cross-qt6.patch
+++ b/srcpkgs/qtkeychain-qt6/patches/fix-cross-qt6.patch
@@ -1,0 +1,14 @@
+Cross build with Qt6 is broken without this, since host tools are not
+found (tries to use binaries from target dir instead)
+
+--- a/CMakeLists.txt	2023-06-01 08:38:35.000000000 -0300
++++ b/CMakeLists.txt	2023-11-02 22:41:50.717285646 -0300
+@@ -10,6 +10,8 @@
+ 
+ include(FindPkgConfig)
+ 
++find_package(Qt6 COMPONENTS Core REQUIRED)
++
+ ###
+ 
+ set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH}" "${PROJECT_SOURCE_DIR}/cmake/Modules")

--- a/srcpkgs/qtkeychain-qt6/patches/use-kwallet-dbus-def.patch
+++ b/srcpkgs/qtkeychain-qt6/patches/use-kwallet-dbus-def.patch
@@ -1,0 +1,15 @@
+Use kwallet interface definition from the kwallet package,
+instead of using the out-of-date provided in qtkeychain package
+see https://github.com/frankosterfeld/qtkeychain/issues/172
+
+--- a/CMakeLists.txt	2020-09-08 15:13:16.000000000 +0200
++++ b/CMakeLists.txt	2020-11-13 13:50:56.648621533 +0100
+@@ -169,7 +169,7 @@
+ 
+     add_definitions(-DKEYCHAIN_DBUS=1)
+     list(APPEND qtkeychain_SOURCES keychain_unix.cpp gnomekeyring.cpp libsecret.cpp plaintextstore.cpp)
+-    qt_add_dbus_interface(qtkeychain_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/org.kde.KWallet.xml kwallet_interface KWalletInterface)
++    qt_add_dbus_interface(qtkeychain_SOURCES /usr/share/dbus-1/interfaces/kf5_org.kde.KWallet.xml kwallet_interface KWalletInterface)
+     list(APPEND qtkeychain_LIBRARIES ${QTDBUS_LIBRARIES} )
+ endif()
+ 

--- a/srcpkgs/qtkeychain-qt6/template
+++ b/srcpkgs/qtkeychain-qt6/template
@@ -1,0 +1,36 @@
+# Template file for 'qtkeychain-qt6'
+pkgname=qtkeychain-qt6
+version=0.14.2
+revision=1
+build_style=cmake
+configure_args="-DBUILD_WITH_QT6=ON
+ -DECM_MKSPECS_INSTALL_DIR=/usr/lib/qt6/mkspecs"
+hostmakedepends="qt6-base qt6-tools pkg-config kwallet"
+makedepends="qt6-base-devel libsecret-devel"
+short_desc="Platform-independent Qt6 API for storing passwords securely"
+maintainer="Gonzalo Tornaría <tornaria@cmat.edu.uy>"
+license="BSD-2-Clause"
+homepage="https://github.com/frankosterfeld/qtkeychain"
+distfiles="https://github.com/frankosterfeld/${pkgname%-*}/archive/${version}.tar.gz"
+checksum=cf2e972b783ba66334a79a30f6b3a1ea794a1dc574d6c3bebae5ffd2f0399571
+
+post_patch() {
+	# ensure it's not used (see dedicated patch)
+	rm org.kde.KWallet.xml
+}
+
+post_install() {
+	vlicense COPYING
+	vdoc "${FILESDIR}/README.voidlinux"
+}
+
+qtkeychain-qt6-devel_package() {
+	depends="${sourcepkg}>=${version}_${revision} libsecret-devel"
+	short_desc+=" - development files"
+	pkg_install() {
+		vmove usr/include
+		vmove usr/lib/cmake
+		vmove usr/lib/*.so
+		vmove usr/lib/qt6/mkspecs
+	}
+}


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

I've been using 5.0.0 for a while, and now updated to 5.1.0.

Note that kde integration (#45352) has been removed.
There is an external project: https://github.com/owncloud/client-desktop-shell-integration-dolphin but I don't use kde and I wouldn't be able to test at all.

It was necessary to build `qtkeychain-qt6` which I copied with obvious changes from `qtkeychain-qt5`. Should this new pkg keep @yopito as maintainer?

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
