### PR TITLE
python3-pyserial: update to 3.5.

### DIFF
--- a/srcpkgs/python3-pyserial/template
+++ b/srcpkgs/python3-pyserial/template
@@ -1,7 +1,7 @@
 # Template file for 'python3-pyserial'
 pkgname=python3-pyserial
-version=3.4
-revision=8
+version=3.5
+revision=1
 build_style=python3-module
 hostmakedepends="python3-setuptools"
 depends="python3"
@@ -10,11 +10,11 @@ short_desc="Python3 module providing access for the serial port"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="BSD-3-Clause"
 homepage="https://github.com/pyserial/pyserial"
+changelog="https://raw.githubusercontent.com/pyserial/pyserial/master/CHANGES.rst"
 distfiles="${PYPI_SITE}/p/pyserial/pyserial-${version}.tar.gz"
-checksum=6e2d401fdee0eab996cf734e67773a0143b932772ca8b42451440cfed942c627
+checksum=3c77e014170dfffbd816e6ffc205e9842efb10be9f58ec16d3e8675b4925cddb
 alternatives="pyserial:miniterm:/usr/bin/miniterm.py3"
 
 post_install() {
-	mv ${DESTDIR}/usr/bin/miniterm.py{,3}
 	vlicense LICENSE.txt LICENSE
 }


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
