### PR TITLE
python3-zope.interface: update to 6.1.

### DIFF
--- a/srcpkgs/python3-zope.interface/template
+++ b/srcpkgs/python3-zope.interface/template
@@ -1,7 +1,7 @@
 # Template file for 'python3-zope.interface'
 pkgname=python3-zope.interface
-version=5.5.2
-revision=2
+version=6.1
+revision=1
 build_style=python3-module
 hostmakedepends="python3-setuptools"
 makedepends="python3-devel"
@@ -12,7 +12,7 @@ license="ZPL-2.1"
 homepage="https://github.com/zopefoundation/zope.interface"
 changelog="https://raw.githubusercontent.com/zopefoundation/zope.interface/master/CHANGES.rst"
 distfiles="${PYPI_SITE}/z/zope.interface/zope.interface-${version}.tar.gz"
-checksum=bfee1f3ff62143819499e348f5b8a7f3aa0259f9aca5e0ddae7391d059dce671
+checksum=2fdc7ccbd6eb6b7df5353012fbed6c3c5d04ceaca0038f75e601060e95345309
 # Tests can't find the package they test
 make_check=no
 


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
