### PR TITLE
python3-matplotlib: update to 3.8.1.

### DIFF
--- a/srcpkgs/python3-contourpy/template
+++ b/srcpkgs/python3-contourpy/template
@@ -1,7 +1,7 @@
 # Template file for 'python3-contourpy'
 pkgname=python3-contourpy
-version=1.1.1
-revision=2
+version=1.2.0
+revision=1
 build_style=python3-pep517
 build_helper=meson
 hostmakedepends="python3-meson-python python3-pybind11 pkg-config"
@@ -14,7 +14,7 @@ license="BSD-3-Clause"
 homepage="https://github.com/contourpy/contourpy"
 changelog="https://raw.githubusercontent.com/contourpy/contourpy/main/docs/changelog.rst"
 distfiles="${PYPI_SITE}/c/contourpy/contourpy-${version}.tar.gz"
-checksum=96ba37c2e24b7212a77da85004c38e7c4d155d3e72a45eeaf22c1f03f607e8ab
+checksum=171f311cb758de7da13fc53af221ae47a5877be5a0843a9fe150818c51ed276a
 
 # This test needs `wurlitzer`, not packaged
 make_check_args="--deselect=tests/test_internal.py::test_write_cache"

--- a/srcpkgs/python3-cycler/template
+++ b/srcpkgs/python3-cycler/template
@@ -1,17 +1,18 @@
 # Template file for 'python3-cycler'
 pkgname=python3-cycler
-version=0.11.0
-revision=2
-build_style=python3-module
-hostmakedepends="python3-setuptools"
+version=0.12.1
+revision=1
+build_style=python3-pep517
+hostmakedepends="python3-setuptools python3-wheel"
 depends="python3"
-checkdepends="python3-pytest-xdist $depends"
-short_desc="Composable style cycles (Python3)"
-maintainer="Orphaned <orphan@voidlinux.org>"
+checkdepends="python3-pytest"
+short_desc="Composable style cycles"
+maintainer="Gonzalo Tornaría <tornaria@cmat.edu.uy>"
 license="BSD-3-Clause"
 homepage="https://github.com/matplotlib/cycler"
-distfiles="${PYPI_SITE}/C/Cycler/cycler-${version}.tar.gz"
-checksum=9c87405839a19696e837b3b818fed3f5f69f16f1eec1a1ad77e043dcea9c772f
+changelog="https://github.com/matplotlib/cycler/releases"
+distfiles="https://github.com/matplotlib/cycler/archive/refs/tags/v${version}.tar.gz"
+checksum=e83c1956b154ceb252c32e079ac7a95860a76c9ce894858dd082cc881008cae0
 
 post_install() {
 	vlicense LICENSE

--- a/srcpkgs/python3-matplotlib/INSTALL.msg
+++ b/srcpkgs/python3-matplotlib/INSTALL.msg
@@ -1,1 +1,0 @@
-NOTICE: /etc/matplotlibrc is no longer supported as configuration file

--- a/srcpkgs/python3-matplotlib/template
+++ b/srcpkgs/python3-matplotlib/template
@@ -1,7 +1,7 @@
 # Template file for 'python3-matplotlib'
 pkgname=python3-matplotlib
-version=3.8.0
-revision=2
+version=3.8.1
+revision=1
 build_style=python3-pep517
 build_helper="numpy"
 hostmakedepends="pkg-config python3-setuptools_scm python3-certifi
@@ -16,7 +16,7 @@ license="custom:matplotlib, BSD-3-Clause, MIT"
 homepage="https://matplotlib.org/"
 changelog="https://github.com/matplotlib/matplotlib/releases"
 distfiles="${PYPI_SITE}/m/matplotlib/matplotlib-${version}.tar.gz"
-checksum=df8505e1c19d5c2c26aff3497a7cbd3ccfc2e97043d1e4db3e76afa399164b69
+checksum=044df81c1f6f3a8e52d70c4cfcb44e77ea9632a10929932870dfaa90de94365d
 replaces="python3-matplotlib-data>=0"
 # Comparison of images is too frail for validation
 make_check="no"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

Also included here a couple of dependencies:
 - python3-cycler: update to 0.12.1.
 - python3-contourpy: update to 1.2.0, adopt.

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
