### PR TITLE
foobillard++: fix segfault on musl

### DIFF
--- a/srcpkgs/foobillard++/patches/strsound.patch
+++ b/srcpkgs/foobillard++/patches/strsound.patch
@@ -1,0 +1,19 @@
+diff --git a/src/sound_stuff.c b/src/sound_stuff.c
+index 32ffed7..7ed946e 100644
+--- a/src/sound_stuff.c
++++ b/src/sound_stuff.c
+@@ -96,12 +96,12 @@ int strsound ( char s1[] )
+    int i = 0;
+    char s[10];
+    if(strlen(s1) > 4) {
+-      strcpy(s,&s[strlen(s)-4]);
++      strcpy(s,&s1[strlen(s1)-4]);
+       while (s[i]) {
+          s[i] = toupper(s[i]);
+          ++i;
+       }
+- 	    if(strcmp(s,".MP3") || strcmp(s,".OGG")) {
++ 	    if(!strcmp(s,".MP3") || !strcmp(s,".OGG")) {
+          return(1);
+  	    }
+    }

--- a/srcpkgs/foobillard++/template
+++ b/srcpkgs/foobillard++/template
@@ -1,8 +1,7 @@
 # Template file for 'foobillard++'
-# often segfaults at launch on musl, but not marking broken yet
 pkgname=foobillard++
 version=3.42beta
-revision=4
+revision=5
 build_style=gnu-configure
 configure_args="--enable-standard"
 hostmakedepends="automake pkg-config"


### PR DESCRIPTION
fixes #43236

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
#### Local build testing
- I built this PR locally for my native architecture, (x86_64-musl)
