### PR TITLE
guake: backport fix for double click opens new tab from 3.8.5

### DIFF
--- a/srcpkgs/guake/patches/0001-Fix-double-click-opens-new-tab.patch
+++ b/srcpkgs/guake/patches/0001-Fix-double-click-opens-new-tab.patch
@@ -1,0 +1,30 @@
+From 9e6cd487b5acc66c4a7d36df4bb1e202f93990a0 Mon Sep 17 00:00:00 2001
+From: hrzlgnm <hrzlgnm@users.noreply.github.com>
+Date: Sun, 5 Nov 2023 14:37:31 +0100
+Subject: [PATCH] Fix double click opens new tab
+
+---
+ guake/notebook.py | 7 ++++++-
+ 1 file changed, 6 insertions(+), 1 deletion(-)
+
+diff --git a/guake/notebook.py b/guake/notebook.py
+index eb1fd5e..447588f 100644
+--- a/guake/notebook.py
++++ b/guake/notebook.py
+@@ -115,7 +115,12 @@ class TerminalNotebook(Gtk.Notebook):
+                 # Gtk 3.18 fallback ("'Menu' object has no attribute 'popup_at_pointer'")
+                 menu.popup(None, None, None, None, event.button, event.time)
+ 
+-        elif event.type == Gdk.EventType.DOUBLE_BUTTON_PRESS and event.button == 1:
++        elif (
++            event.type == Gdk.EventType.DOUBLE_BUTTON_PRESS
++            and event.button == 1
++            and event.window.get_height() < 60
++        ):
++            # event.window.get_height() reports the height of the clicked frame
+             self.new_page_with_focus()
+ 
+         return False
+-- 
+2.42.0
+

--- a/srcpkgs/guake/template
+++ b/srcpkgs/guake/template
@@ -1,7 +1,7 @@
 # Template file for 'guake'
 pkgname=guake
 version=3.7.0
-revision=4
+revision=5
 build_style=python3-module
 hostmakedepends="gettext python3-setuptools python3-pbr"
 makedepends="python3-devel python3-pbr"


### PR DESCRIPTION
The issue has been fixed in upstream with 3.8.5

See upstream changes for more details :
* https://github.com/Guake/guake/pull/1721/files
* https://github.com/Guake/guake/pull/2010/files


#### Testing the changes
- I tested the changes in this PR: YES

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-libc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
