### PR TITLE
swirc: update to 3.4.6.

### DIFF
--- a/srcpkgs/swirc/template
+++ b/srcpkgs/swirc/template
@@ -1,6 +1,6 @@
 # Template file for 'swirc'
 pkgname=swirc
-version=3.4.5
+version=3.4.6
 revision=1
 build_style=configure
 configure_args="$(vopt_with notify libnotify)"
@@ -17,7 +17,7 @@ license="BSD-3-Clause, ISC, MIT"
 homepage="https://www.nifty-networks.net/swirc"
 changelog="https://raw.githubusercontent.com/uhlin/swirc/master/CHANGELOG.md"
 distfiles="https://www.nifty-networks.net/swirc/releases/swirc-${version}.tgz"
-checksum=a25373e380140d519077ad15633fb9efb8493bf1575544d6c3a1164cbf00b48e
+checksum=b34b2fed727eb4ebd7f7fdd134e2466d70665e3fc397b1488bdb2c0f475da982
 
 build_options="notify"
 build_options_default="notify"
@@ -29,8 +29,8 @@ post_configure() {
 		msg_error "cannot find $_file\n"
 	fi
 
-	vsed -i "$_file" -e "s/CC=/CC?=/"
-	vsed -i "$_file" -e "s/CXX=/CXX?=/"
+	vsed -i "$_file" -e "s/CC =/CC ?=/"
+	vsed -i "$_file" -e "s/CXX =/CXX ?=/"
 }
 
 post_check() {


### PR DESCRIPTION
Swirc 3.4.6 out!

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, **x86_64-musl**
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - armv6l-musl **cross**
