### PR TITLE
rio: update to 0.0.27

### DIFF
--- a/srcpkgs/rio/template
+++ b/srcpkgs/rio/template
@@ -1,6 +1,6 @@
 # Template file for 'rio'
 pkgname=rio
-version=0.0.26
+version=0.0.27
 revision=1
 build_style=cargo
 make_install_args="--path rio"
@@ -13,7 +13,7 @@ license="MIT"
 homepage="https://raphamorim.io/rio/"
 changelog="https://raw.githubusercontent.com/raphamorim/rio/main/CHANGELOG.md"
 distfiles="https://github.com/raphamorim/rio/archive/refs/tags/v${version}.tar.gz"
-checksum=d95a6f9c89d00da9723138a2ed7d970b1b3ffb6ab52d545984174a597b7bd961
+checksum=2338d679eaec987bd50ab12ca1e9b79853690899d2e8e70efa88315d0c626090
 
 do_install() {
 	# avoid doing a rebuild in install due to complex feature setup


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
