### PR TITLE
rust-bindgen: update to 0.69.4.

### DIFF
--- a/srcpkgs/rust-bindgen/template
+++ b/srcpkgs/rust-bindgen/template
@@ -1,6 +1,6 @@
 # Template file for 'rust-bindgen'
 pkgname=rust-bindgen
-version=0.66.1
+version=0.69.4
 revision=1
 build_style="cargo"
 configure_args="--bins"
@@ -13,7 +13,7 @@ license="BSD-3-Clause"
 homepage="https://rust-lang.github.io/rust-bindgen/"
 changelog="https://raw.githubusercontent.com/rust-lang/rust-bindgen/master/CHANGELOG.md"
 distfiles="https://github.com/rust-lang/rust-bindgen/archive/refs/tags/v${version}.tar.gz"
-checksum=adedec96f2a00ce835a7c31656e09d6aae6ef55df9ca3d8d65d995f8f2542388
+checksum=c02ce18b95c4e5021b95b8b461e5dbe6178edffc52a5f555cbca35b910559b5e
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-gnu)
- I built this PR locally for these architectures (crossbuilds):
   - aarch64
   - aarch64-musl
   - armv7l
   - armv7l-musl
   - armv6l
   - armv6l-musl
   - i686
   - x86_64-musl
