### PR TITLE
platformio: update to 6.1.1, adopt, add new dependencies

### DIFF
--- a/srcpkgs/platformio/template
+++ b/srcpkgs/platformio/template
@@ -1,23 +1,25 @@
 # Template file for 'platformio'
 pkgname=platformio
-version=5.2.5
-revision=3
+version=6.1.1
+revision=1
 build_style=python3-module
 # According to https://github.com/platformio/platformio-core/blob/9c20ab81cb68f1ffb7a8cac22ce95c4c797643ec/Makefile#L13
 make_check_target="tests/test_examples.py"
 hostmakedepends="python3-setuptools"
-depends="python3-bottle python3-click python3-colorama python3-marshmallow
- python3-pyelftools python3-pyserial python3-requests
- python3-semanticversion python3-setuptools python3-tabulate"
+depends="python3-aiofiles python3-ajsonrpc python3-anyio python3-bottle
+ python3-click python3-colorama  python3-marshmallow python3-pyelftools
+ python3-pyserial python3-requests python3-semanticversion python3-setuptools
+ python3-starlette python3-tabulate python3-uvicorn python3-wsproto
+ python3-zeroconf"
 checkdepends="python3-pytest python3-jsondiff python3-wheel python3-pip
  python3-Twisted python3-certifi git python3-zeroconf $depends"
 short_desc="Ecosystem for embedded development"
-maintainer="Orphaned <orphan@voidlinux.org>"
+maintainer="Emil Miler <em@0x45.cz>"
 license="Apache-2.0"
 homepage="https://github.com/platformio/platformio-core"
 changelog="https://raw.githubusercontent.com/platformio/platformio-core/develop/HISTORY.rst"
-distfiles="${homepage}/archive/v${version}.tar.gz"
-checksum=26cc5b61d113250519257c156ae693ab8f6aea891283b28f1c4c67ffc81fb574
+distfiles="https://github.com/platformio/platformio-core/archive/refs/tags/v${version}.tar.gz"
+checksum=44e66d216f3925fe0ee5d830ec4d569c57e3407aeafedb277ce71f69d9027acc
 
 post_install() {
 	vinstall scripts/99-platformio-udev.rules 644 usr/lib/udev/rules.d

--- a/srcpkgs/python3-ajsonrpc/template
+++ b/srcpkgs/python3-ajsonrpc/template
@@ -1,0 +1,18 @@
+# Template file for 'python3-ajsonrpc'
+pkgname=python3-ajsonrpc
+version=1.2.0
+revision=1
+build_style=python3-module
+hostmakedepends="python3-setuptools"
+depends="python3"
+checkdepends="python3-pytest"
+short_desc="Async JSON-RPC 2.0 protocol and server"
+maintainer="Emil Miler <em@0x45.cz>"
+license="MIT"
+homepage="https://github.com/pavlov99/ajsonrpc"
+distfiles="${PYPI_SITE}/a/ajsonrpc/ajsonrpc-${version}.tar.gz"
+checksum=791bac18f0bf0dee109194644f151cf8b7ff529c4b8d6239ac48104a3251a19f
+
+post_install() {
+	vlicense LICENSE.txt
+}

--- a/srcpkgs/python3-starlette/template
+++ b/srcpkgs/python3-starlette/template
@@ -1,0 +1,19 @@
+# Template file for 'python3-starlette'
+pkgname=python3-starlette
+version=0.32.0
+revision=1
+build_style=python3-pep517
+hostmakedepends="hatchling"
+depends="python3"
+short_desc="Lightweight ASGI framework for building async web services"
+maintainer="Emil Miler <em@0x45.cz>"
+license="BSD-3-Clause"
+homepage="https://github.com/encode/starlette"
+distfiles="${PYPI_SITE}/s/starlette/starlette-${version}.tar.gz"
+checksum=87c899fe3aee6a42f711380b03e1d244a21079529cb3dbe1a5109e60915e0bbb
+# Many modules needed for testing are not available
+make_check=no
+
+post_install() {
+	vlicense LICENSE.md
+}

--- a/srcpkgs/python3-uvicorn/template
+++ b/srcpkgs/python3-uvicorn/template
@@ -1,0 +1,18 @@
+# Template file for 'python3-uvicorn'
+pkgname=python3-uvicorn
+version=0.24.0
+revision=1
+build_style=python3-pep517
+hostmakedepends="hatchling"
+depends="python3-asgiref python3-uvloop python3-click python3-h11"
+short_desc="ASGI web server"
+maintainer="Emil Miler <em@0x45.cz>"
+license="BSD-3-Clause"
+homepage="https://www.uvicorn.org/"
+changelog="https://github.com/encode/uvicorn/blob/master/CHANGELOG.md"
+distfiles="${PYPI_SITE}/u/uvicorn/uvicorn-${version}.tar.gz"
+checksum=368d5d81520a51be96431845169c225d771c9dd22a58613e1a181e6c4512ac33
+
+post_install() {
+	vlicense LICENSE.md
+}


### PR DESCRIPTION
This is a rather large PR which updates `platformio` to the latest version and adds new python3 modules as dependencies.

#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)
