### PR TITLE
yggdrasil: update to 0.5.2.

### DIFF
--- a/srcpkgs/yggdrasil/INSTALL.msg
+++ b/srcpkgs/yggdrasil/INSTALL.msg
@@ -1,2 +1,2 @@
-NOTICE: Yggdrasil 0.4 contains breaking changes. For more information, see
-https://yggdrasil-network.github.io/2021/06/19/preparing-for-v0-4.html
+NOTICE: Yggdrasil 0.5 contains breaking changes. For more information, see
+https://yggdrasil-network.github.io/2023/10/22/upcoming-v05-release.html

--- a/srcpkgs/yggdrasil/template
+++ b/srcpkgs/yggdrasil/template
@@ -1,7 +1,7 @@
 # Template file for 'yggdrasil'
 pkgname=yggdrasil
-version=0.4.7
-revision=3
+version=0.5.2
+revision=1
 build_style=go
 go_import_path=github.com/yggdrasil-network/yggdrasil-go
 short_desc="Experiment in scalable routing as an encrypted IPv6 overlay network"
@@ -10,7 +10,7 @@ license="LGPL-3.0-only"
 homepage="https://yggdrasil-network.github.io/"
 changelog="https://raw.githubusercontent.com/yggdrasil-network/yggdrasil-go/develop/CHANGELOG.md"
 distfiles="https://github.com/yggdrasil-network/yggdrasil-go/archive/v${version}.tar.gz"
-checksum=47429f75b87d9b2450108471991e84c90d748606642e8778e9f578485b05a56f
+checksum=ed908594ab687e141dd2202e1b360e5bd93f910de1fd1f737d210cc784cf2470
 
 do_build() {
 	PKGNAME=${pkgname} PKGVER=${version} ./build


### PR DESCRIPTION
Yggdrasil is now on v0.5, a breaking change from v0.4.

https://yggdrasil-network.github.io/2023/10/22/upcoming-v05-release.html


#### Testing the changes
- I tested the changes in this PR: **YES**
