### PR TITLE
go: update to 1.21.4.

### DIFF
--- a/srcpkgs/go/template
+++ b/srcpkgs/go/template
@@ -1,6 +1,6 @@
 # Template file for 'go'
 pkgname=go
-version=1.21.3
+version=1.21.4
 revision=1
 create_wrksrc=yes
 build_wrksrc=go
@@ -12,7 +12,7 @@ license="BSD-3-Clause"
 homepage="https://go.dev/"
 changelog="https://go.dev/doc/devel/release.html"
 distfiles="https://go.dev/dl/go${version}.src.tar.gz"
-checksum=186f2b6f8c8b704e696821b09ab2041a5c1ee13dcbc3156a13adcf75931ee488
+checksum=47b26a83d2b65a3c1c1bcace273b69bee49a7a7b5168a7604ded3d26a37bd787
 nostrip=yes
 noverifyrdeps=yes
 # on CI it tries to use `git submodule`, which is not part of chroot-git


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (amd64)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - armv7l
  - i686
  - aarch64
