### PR TITLE
nvidia-vaapi-driver: update to 0.0.11.

### DIFF
--- a/srcpkgs/nvidia-vaapi-driver/template
+++ b/srcpkgs/nvidia-vaapi-driver/template
@@ -1,6 +1,6 @@
 # Template file for 'nvidia-vaapi-driver'
 pkgname=nvidia-vaapi-driver
-version=0.0.10
+version=0.0.11
 revision=1
 archs="x86_64"
 build_style=meson
@@ -11,7 +11,7 @@ maintainer="Owen Law <owenlaw222@gmail.com>"
 license="MIT"
 homepage="https://github.com/elFarto/nvidia-vaapi-driver"
 distfiles="https://github.com/elFarto/nvidia-vaapi-driver/archive/refs/tags/v${version}.tar.gz"
-checksum=df63b0832ccf9f74a90ff8b26d8e069606e0614d1748e35a857d2e53745ab95c
+checksum=3e1ed95d7e2b2b1377c9cb59c3e7caaf960134694e9441e1d91c38f224d1d5d9
 conflicts="libva-vdpau-driver"
 
 post_install() {


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)

Also tested building with my current PR of [nv-codec-headers](https://github.com/void-linux/void-packages/pull/44781).
