### PR TITLE
Texlive 2023

### DIFF
--- a/common/build-style/texmf.sh
+++ b/common/build-style/texmf.sh
@@ -3,14 +3,11 @@ do_build() {
 	# Extract the source files
 	mkdir -p "build/usr/share/texmf-dist"
 	find . -maxdepth 1 -print -name "*.tar.xz" \
-		-exec bsdtar -C "build/usr/share/texmf-dist" -xf {} \;
+		-exec bsdtar \
+		-s '|^texmf-dist/||' \
+		-C "build/usr/share/texmf-dist" \
+		-xf {} \;
 	cd "build/usr/share/texmf-dist/"
-	# Everything in usr/share/texmf-dist/texmf-dist should really be in
-	# usr/share/texmf-dist, so we move it
-	if [ -d "texmf-dist" ] ; then
-		rsync -ar texmf-dist/ ./
-		rm -rf texmf-dist/
-	fi
 	# LICENSEs are unneeded
 	rm -f LICENSE*
 

--- a/common/environment/build-style/texmf.sh
+++ b/common/environment/build-style/texmf.sh
@@ -1,4 +1,2 @@
-# rsync isn't needed for everything but it's far easier to just put it here
-hostmakedepends+=" rsync"
 # python_version isn't needed for everything either
 python_version=3

--- a/common/environment/build-style/texmf/ownership.txt
+++ b/common/environment/build-style/texmf/ownership.txt
@@ -37,13 +37,6 @@ scripts/cjk-gs-integrate/cjk-gs-integrate.pl texlive
 scripts/clojure-pamphlet/pamphletangler texlive
 scripts/cluttex/cluttex.lua texlive
 scripts/context/perl/mptopdf.pl texlive
-scripts/context/stubs/unix/contextjit texlive
-scripts/context/stubs/unix/context texlive
-scripts/context/stubs/unix/luatools texlive
-scripts/context/stubs/unix/mtxrunjit texlive
-scripts/context/stubs/unix/mtxrun texlive
-scripts/context/stubs/unix/texexec texlive
-scripts/context/stubs/unix/texmfstart texlive
 scripts/convbkmk/convbkmk.rb texlive-langjapanese
 scripts/crossrefware/bbl2bib.pl texlive
 scripts/crossrefware/bibdoiadd.pl texlive
@@ -185,8 +178,8 @@ scripts/texlive/mktexlsr texlive
 scripts/texlive/mktexmf texlive
 scripts/texlive/mktexpk texlive
 scripts/texlive/mktextfm texlive
+scripts/texlive/rungs.lua texlive
 scripts/texliveonfly/texliveonfly.py texlive
-scripts/texlive/rungs.tlu texlive
 scripts/texlive/tlmgr.pl texlive
 scripts/texlive/updmap.pl texlive
 scripts/texlive/updmap-sys.sh texlive

--- a/common/environment/build-style/texmf/ownership.txt
+++ b/common/environment/build-style/texmf/ownership.txt
@@ -26,6 +26,7 @@ scripts/attachfile2/pdfatfi.pl texlive
 scripts/authorindex/authorindex texlive
 scripts/bib2gls/bib2gls.sh texlive
 scripts/bib2gls/convertgls2bib.sh texlive
+scripts/bibcop/bibcop.pl texlive
 scripts/bibexport/bibexport.sh texlive
 scripts/bundledoc/arlatex texlive
 scripts/bundledoc/bundledoc texlive
@@ -33,6 +34,7 @@ scripts/cachepic/cachepic.tlu texlive-pictures
 scripts/checkcites/checkcites.lua texlive
 scripts/checklistings/checklistings.sh texlive
 scripts/chklref/chklref.pl texlive
+scripts/citation-style-language/citeproc-lua.lua texlive
 scripts/cjk-gs-integrate/cjk-gs-integrate.pl texlive
 scripts/clojure-pamphlet/pamphletangler texlive
 scripts/cluttex/cluttex.lua texlive

--- a/common/environment/build-style/texmf/ownership.txt
+++ b/common/environment/build-style/texmf/ownership.txt
@@ -52,6 +52,7 @@ scripts/ctan-o-mat/ctan-o-mat.pl texlive
 scripts/ctanupload/ctanupload.pl texlive
 scripts/de-macro/de-macro texlive
 scripts/diadia/diadia.lua texlive-humanities
+scripts/digestif/digestif.texlua texlive
 scripts/dosepsbin/dosepsbin.pl texlive
 scripts/dtxgen/dtxgen texlive
 scripts/dviasm/dviasm.py texlive
@@ -97,6 +98,7 @@ scripts/listbib/listbib texlive
 scripts/listings-ext/listings-ext.sh texlive
 scripts/ltxfileinfo/ltxfileinfo texlive
 scripts/ltximg/ltximg.pl texlive
+scripts/luafindfont/luafindfont.lua texlive
 scripts/luaotfload/luaotfload-tool.lua texlive
 scripts/lwarp/lwarpmk.lua texlive
 scripts/make4ht/make4ht texlive
@@ -111,6 +113,9 @@ scripts/m-tx/m-tx.lua texlive-music
 scripts/multibibliography/multibibliography.pl texlive
 scripts/musixtex/musixflx.lua texlive-music
 scripts/musixtex/musixtex.lua texlive-music
+scripts/optexcount/optexcount texlive
+scripts/pagelayout/pagelayoutapi texlive
+scripts/pagelayout/textestvis texlive
 scripts/pax/pdfannotextractor.pl texlive
 scripts/pdfbook2/pdfbook2 texlive
 scripts/pdfcrop/pdfcrop.pl texlive
@@ -150,6 +155,7 @@ scripts/srcredact/srcredact.pl texlive
 scripts/sty2dtx/sty2dtx.pl texlive
 scripts/svn-multi/svn-multi.pl texlive
 scripts/tex4ebook/tex4ebook texlive
+scripts/texaccents/texaccents.sno texlive
 scripts/texcount/texcount.pl texlive
 scripts/texdef/texdef.pl texlive
 scripts/texdiff/texdiff texlive
@@ -173,6 +179,8 @@ scripts/texlive-extra/texconfig-dialog.sh texlive
 scripts/texlive-extra/texconfig.sh texlive
 scripts/texlive-extra/texconfig-sys.sh texlive
 scripts/texlive-extra/texlinks.sh texlive
+scripts/texlive-extra/xelatex-unsafe.sh texlive
+scripts/texlive-extra/xetex-unsafe.sh texlive
 scripts/texlive/fmtutil.pl texlive
 scripts/texlive/fmtutil-sys.sh texlive
 scripts/texlive/fmtutil-user.sh texlive
@@ -187,6 +195,8 @@ scripts/texlive/updmap.pl texlive
 scripts/texlive/updmap-sys.sh texlive
 scripts/texlive/updmap-user.sh texlive
 scripts/texloganalyser/texloganalyser texlive
+scripts/texlogfilter/texlogfilter texlive
+scripts/texlogsieve/texlogsieve texlive
 scripts/texosquery/texosquery-jre5.sh texlive
 scripts/texosquery/texosquery-jre8.sh texlive
 scripts/texosquery/texosquery.sh texlive

--- a/srcpkgs/texlive-basic/template
+++ b/srcpkgs/texlive-basic/template
@@ -1,13 +1,13 @@
 # Template file for 'texlive-basic'
 pkgname=texlive-basic
-version=2021.0
+version=2023.0
 revision=1
 build_style=meta
 _year=${version%.*}
-depends="texlive>=20210325
- texlive-BibTeX>=20210325
- texlive-LuaTeX>=20210325
- texlive-dvi>=20210325
+depends="texlive>=20230313
+ texlive-BibTeX>=20230313
+ texlive-LuaTeX>=20230313
+ texlive-dvi>=20210313
  texlive-core>=${_year}
  texlive-latexextra>=${_year}
  texlive-pictures>=${_year}"

--- a/srcpkgs/texlive-bibtexextra/template
+++ b/srcpkgs/texlive-bibtexextra/template
@@ -1,6 +1,6 @@
 # Template file for 'texlive-bibtexextra'
 pkgname=texlive-bibtexextra
-version=2021.58697
+version=2023.66579
 revision=1
 build_style="texmf"
 depends="texlive-core"
@@ -9,4 +9,4 @@ maintainer="fosslinux <fosslinux@aussies.space>"
 license="GPL-2.0-or-later"
 homepage="https://tug.org/texlive/"
 distfiles="https://sources.archlinux.org/other/texlive/${pkgname}-${version}-src.zip"
-checksum=d65aa2a12df851e9ddca879f6502a15a52ece9d33c803d4c0d0227fcc785a1c9
+checksum=b2b0b90abb0c0a9eef5366cf0968f7e58ee84c1be688c36d751dd0577c872a3c

--- a/srcpkgs/texlive-core/template
+++ b/srcpkgs/texlive-core/template
@@ -1,6 +1,6 @@
 # Template file for 'texlive-core'
 pkgname=texlive-core
-version=2021.58710
+version=2023.66587
 revision=1
 build_style="texmf"
 short_desc="TeX Live - core texmf distribution"
@@ -8,4 +8,4 @@ maintainer="fosslinux <fosslinux@aussies.space>"
 license="GPL-2.0-or-later"
 homepage="https://tug.org/texlive"
 distfiles="https://sources.archlinux.org/other/texlive/${pkgname}-${version}-src.zip"
-checksum=ef11a19ca15f3e937733ed9e17cc024afaf525afdf3d649c9ae4261f1bfb4415
+checksum=2cdaf356d89351e61152243f1192a5e000a9586c67b873737f01878a3e5724ff

--- a/srcpkgs/texlive-fontsextra/template
+++ b/srcpkgs/texlive-fontsextra/template
@@ -1,6 +1,6 @@
 # Template file for 'texlive-fontsextra'
 pkgname=texlive-fontsextra
-version=2021.58704
+version=2023.66328
 revision=1
 build_style="texmf"
 depends="texlive-core"
@@ -9,4 +9,4 @@ maintainer="fosslinux <fosslinux@aussies.space>"
 license="GPL-2.0-or-later"
 homepage="https://tug.org/texlive/"
 distfiles="https://sources.archlinux.org/other/texlive/${pkgname}-${version}-src.zip"
-checksum=4e1647ea20536d336120c2885af3f7677d9e483ce7f397c1c4404e31fc5fc0aa
+checksum=c5e32f213ec81a5e85f36437d401331b49a1338dacdc2fe8bb27f9f0fbaf2e36

--- a/srcpkgs/texlive-formatsextra/template
+++ b/srcpkgs/texlive-formatsextra/template
@@ -1,6 +1,6 @@
 # Template file for 'texlive-formatsextra'
 pkgname=texlive-formatsextra
-version=2021.57972
+version=2023.66186
 revision=1
 build_style="texmf"
 depends="texlive-core"
@@ -9,4 +9,4 @@ maintainer="fosslinux <fosslinux@aussies.space>"
 license="GPL-2.0-or-later"
 homepage="https://tug.org/texlive/"
 distfiles="https://sources.archlinux.org/other/texlive/${pkgname}-${version}-src.zip"
-checksum=641660f85062d70d715b11e8bd404558d1618a02ce95e1d54792f01e3aa8b80a
+checksum=ffacdfacd9381cf3f21247d15cbd7b4e931855d9258edfe51fd23165cff30ca6

--- a/srcpkgs/texlive-full/template
+++ b/srcpkgs/texlive-full/template
@@ -1,6 +1,6 @@
 # Template file for 'texlive-full'
 pkgname=texlive-full
-version=2021.0
+version=2023.0
 revision=1
 build_style=meta
 _year=${version%.*}

--- a/srcpkgs/texlive-games/template
+++ b/srcpkgs/texlive-games/template
@@ -1,6 +1,6 @@
 # Template file for 'texlive-games'
 pkgname=texlive-games
-version=2021.56833
+version=2023.66190
 revision=1
 build_style="texmf"
 depends="texlive-core"
@@ -9,4 +9,4 @@ maintainer="fosslinux <fosslinux@aussies.space>"
 license="GPL-2.0-or-later"
 homepage="https://tug.org/texlive/"
 distfiles="https://sources.archlinux.org/other/texlive/${pkgname}-${version}-src.zip"
-checksum=9d808f5ecbc8a00d3b2fabef627e4ae0ac026c9eb54d6b02f2efeed486aea54b
+checksum=d5c87bdc6445260c947e1585f117efd6ef3c400af03af422939478c4237aee44

--- a/srcpkgs/texlive-humanities/template
+++ b/srcpkgs/texlive-humanities/template
@@ -1,6 +1,6 @@
 # Template file for 'texlive-humanities'
 pkgname=texlive-humanities
-version=2021.58589
+version=2023.65502
 revision=1
 build_style="texmf"
 depends="texlive-core texlive-latexextra texlive-pictures"
@@ -9,4 +9,4 @@ maintainer="fosslinux <fosslinux@aussies.space>"
 license="GPL-2.0-or-later"
 homepage="https://tug.org/texlive/"
 distfiles="https://sources.archlinux.org/other/texlive/${pkgname}-${version}-src.zip"
-checksum=a2688733e66ba324154ee9715327f4cdb26e7c19283a38d03f086e1b3f123e9f
+checksum=c0b0e4be08cc4fb46206e6769b48f9418ec73a11c556efb8249931d6222d94ef

--- a/srcpkgs/texlive-lang/template
+++ b/srcpkgs/texlive-lang/template
@@ -1,6 +1,6 @@
 # Template file for 'texlive-lang'
 pkgname=texlive-lang
-version=2021.0
+version=2023.0
 revision=1
 build_style=meta
 _year=${version%.*}

--- a/srcpkgs/texlive-langchinese/template
+++ b/srcpkgs/texlive-langchinese/template
@@ -1,6 +1,6 @@
 # Template file for 'texlive-langchinese'
 pkgname=texlive-langchinese
-version=2021.58583
+version=2023.66188
 revision=1
 build_style="texmf"
 depends="texlive-core"
@@ -9,4 +9,4 @@ maintainer="fosslinux <fosslinux@aussies.space>"
 license="GPL-2.0-or-later"
 homepage="https://tug.org/texlive/"
 distfiles="https://sources.archlinux.org/other/texlive/${pkgname}-${version}-src.zip"
-checksum=61c476961b3e4d2cc8e95fe68b8ade9a4e692abe644190c1b34adfb58c2f8f8b
+checksum=a08c5c2d7a2eaece4d8f68eedeec64eb44b70255c84087df66679f6a59f649a0

--- a/srcpkgs/texlive-langcyrillic/template
+++ b/srcpkgs/texlive-langcyrillic/template
@@ -1,6 +1,6 @@
 # Template file for 'texlive-langcyrillic'
 pkgname=texlive-langcyrillic
-version=2021.58426
+version=2023.64588
 revision=1
 build_style="texmf"
 depends="texlive-core"
@@ -9,4 +9,4 @@ maintainer="fosslinux <fosslinux@aussies.space>"
 license="GPL-2.0-or-later"
 homepage="https://tug.org/texlive/"
 distfiles="https://sources.archlinux.org/other/texlive/${pkgname}-${version}-src.zip"
-checksum=9dbab28a29c74164f336f38d735277b46ae837492a6fe417b96345620979db7f
+checksum=b22a0759b1e28fb0f9c2e155d9cecec23649d08e33f42adf52bc1efb04630336

--- a/srcpkgs/texlive-langextra/template
+++ b/srcpkgs/texlive-langextra/template
@@ -1,6 +1,6 @@
 # Template file for 'texlive-langextra'
 pkgname=texlive-langextra
-version=2021.58019
+version=2023.66225
 revision=1
 build_style="texmf"
 depends="texlive-core texlive-latexextra"
@@ -9,4 +9,4 @@ maintainer="fosslinux <fosslinux@aussies.space>"
 license="GPL-2.0-or-later"
 homepage="https://tug.org/texlive/"
 distfiles="https://sources.archlinux.org/other/texlive/${pkgname}-${version}-src.zip"
-checksum=3b4b6b09a67a33f2a327021ba39e32e746b9be602037c1f50f7e4ab64605bd47
+checksum=635a2a266c01b16660421bfd5dbf5e6f11ce40d0dd63c17e0a07a637f645c1ff

--- a/srcpkgs/texlive-langgreek/template
+++ b/srcpkgs/texlive-langgreek/template
@@ -1,6 +1,6 @@
 # Template file for 'texlive-langgreek'
 pkgname=texlive-langgreek
-version=2021.57684
+version=2023.66513
 revision=1
 build_style="texmf"
 depends="texlive-core"
@@ -9,4 +9,4 @@ maintainer="fosslinux <fosslinux@aussies.space>"
 license="GPL-2.0-or-later"
 homepage="https://tug.org/texlive/"
 distfiles="https://sources.archlinux.org/other/texlive/${pkgname}-${version}-src.zip"
-checksum=dc51d6c3b1ccf8ef95504f4d610759e465eb2703764d0a5bb6cc82790c831141
+checksum=fdf44664219be6288278466c927c8f0c8eec42c0a733555c2c56c34f890813a0

--- a/srcpkgs/texlive-langjapanese/template
+++ b/srcpkgs/texlive-langjapanese/template
@@ -1,6 +1,6 @@
 # Template file for 'texlive-langjapanese'
 pkgname=texlive-langjapanese
-version=2021.58632
+version=2023.66482
 revision=1
 build_style="texmf"
 depends="texlive-core"
@@ -9,4 +9,4 @@ maintainer="fosslinux <fosslinux@aussies.space>"
 license="GPL-2.0-or-later"
 homepage="https://tug.org/texlive/"
 distfiles="https://sources.archlinux.org/other/texlive/${pkgname}-${version}-src.zip"
-checksum=60f3306ab01d1e57720190c8f59d77e50784646a4050720ed0233deccf65871e
+checksum=f9c23022dfdecb662a2097cc6d495ad07b55e74adb9751e0f96d363b27eddc90

--- a/srcpkgs/texlive-langkorean/template
+++ b/srcpkgs/texlive-langkorean/template
@@ -1,6 +1,6 @@
 # Template file for 'texlive-langkorean'
 pkgname=texlive-langkorean
-version=2021.58468
+version=2023.66513
 revision=1
 build_style="texmf"
 depends="texlive-core"
@@ -9,4 +9,4 @@ maintainer="fosslinux <fosslinux@aussies.space>"
 license="GPL-2.0-or-later"
 homepage="https://tug.org/texlive/"
 distfiles="https://sources.archlinux.org/other/texlive/${pkgname}-${version}-src.zip"
-checksum=65da5065850e516840ade0522dca2fe0ecbbcabe38c68744372513943c6c61fc
+checksum=9837b0b47bf33d383247c1243f0e203753d0d20038cba5b5c071028af7b9af4d

--- a/srcpkgs/texlive-latexextra/template
+++ b/srcpkgs/texlive-latexextra/template
@@ -1,6 +1,6 @@
 # Template file for 'texlive-latexextra'
 pkgname=texlive-latexextra
-version=2021.58668
+version=2023.66551
 revision=1
 build_style="texmf"
 depends="perl-File-Which python3-Pygments texlive-core texlive-pictures"
@@ -9,4 +9,4 @@ maintainer="fosslinux <fosslinux@aussies.space>"
 license="GPL-2.0-or-later"
 homepage="https://tug.org/texlive/"
 distfiles="https://sources.archlinux.org/other/texlive/${pkgname}-${version}-src.zip"
-checksum=9c2ef3ce71ad656df7644770a2c4aec27c4ea9375421d0ab3b56cb5b25a06287
+checksum=6254daf3152e9f2a7fcf1084873ee9cab150a7f04b0696c327e31da49eae6a95

--- a/srcpkgs/texlive-minimal/template
+++ b/srcpkgs/texlive-minimal/template
@@ -1,10 +1,10 @@
 # Template file for 'texlive-minimal'
 pkgname=texlive-minimal
-version=2021.0
-revision=2
+version=2023.0
+revision=1
 build_style=meta
 _year=${version%.*}
-depends="texlive>=20210325
+depends="texlive>=20230313
  texlive-core>=${_year}"
 short_desc="TeX Live - Metapackage including minimal packages"
 maintainer="fosslinux <fosslinux@aussies.space>"

--- a/srcpkgs/texlive-most/template
+++ b/srcpkgs/texlive-most/template
@@ -1,17 +1,16 @@
 # Template file for 'texlive-most'
 pkgname=texlive-most
-version=2021.0
+version=2023.0
 revision=1
 build_style=meta
 _year=${version%.*}
-depends="texlive>=20210325
- texlive-BibTeX>=20210325
- texlive-ConTeXt>=20210325
- texlive-LuaTeX>=20210325
- texlive-PythonTeX>=20210325
- texlive-Xdvi>=20210325
- texlive-XeTeX>=20210325
- texlive-dvi>=20210325
+depends="texlive>=20230313
+ texlive-BibTeX>=20230313
+ texlive-LuaTeX>=20230313
+ texlive-PythonTeX>=20230313
+ texlive-Xdvi>=20230313
+ texlive-XeTeX>=20230313
+ texlive-dvi>=20230313
  texlive-core>=${_year}
  texlive-bibtexextra>=${_year}
  texlive-fontsextra>=${_year}

--- a/srcpkgs/texlive-music/template
+++ b/srcpkgs/texlive-music/template
@@ -1,6 +1,6 @@
 # Template file for 'texlive-music'
 pkgname=texlive-music
-version=2021.58331
+version=2023.66278
 revision=1
 build_style="texmf"
 depends="fontforge python3 texlive-core"
@@ -9,4 +9,4 @@ maintainer="fosslinux <fosslinux@aussies.space>"
 license="GPL-2.0-or-later"
 homepage="https://tug.org/texlive/"
 distfiles="https://sources.archlinux.org/other/texlive/${pkgname}-${version}-src.zip"
-checksum=6018606d59925c94a22aeaafbc1fc8e3fbfa78ce2c2f39a4494249e5a27cd984
+checksum=83df527875cd6bb77941868f35cdc0b7b7300f25c1644fe702ded855e7f492f9

--- a/srcpkgs/texlive-pictures/template
+++ b/srcpkgs/texlive-pictures/template
@@ -1,6 +1,6 @@
 # Template file for 'texlive-pictures'
 pkgname=texlive-pictures
-version=2021.58558
+version=2023.66549
 revision=1
 build_style="texmf"
 depends="texlive-core"
@@ -9,4 +9,4 @@ maintainer="fosslinux <fosslinux@aussies.space>"
 license="GPL-2.0-or-later"
 homepage="https://tug.org/texlive/"
 distfiles="https://sources.archlinux.org/other/texlive/${pkgname}-${version}-src.zip"
-checksum=3c4451eb8d81edadfb165233477835ec7dc8b6ba2ba636cc98204623e3f284d6
+checksum=63ff117823e8e9d23e456fc753343ca1a83224de4ad0481acf5be81e2888de0e

--- a/srcpkgs/texlive-pstricks/template
+++ b/srcpkgs/texlive-pstricks/template
@@ -1,6 +1,6 @@
 # Template file for 'texlive-pstricks'
 pkgname=texlive-pstricks
-version=2021.58293
+version=2023.66115
 revision=1
 build_style="texmf"
 depends="texlive-core"
@@ -9,4 +9,4 @@ maintainer="fosslinux <fosslinux@aussies.space>"
 license="GPL-2.0-or-later"
 homepage="https://tug.org/texlive/"
 distfiles="https://sources.archlinux.org/other/texlive/${pkgname}-${version}-src.zip"
-checksum=f35f6fa8b9686cfdf9a7a2bd43add9d193c1d28f67dd87acfe69765672930b7d
+checksum=3b0359f4e7f2efee4b96990813fe6b087f8178923e80fcb8c3d3eeaf5c8a7baf

--- a/srcpkgs/texlive-publishers/template
+++ b/srcpkgs/texlive-publishers/template
@@ -1,6 +1,6 @@
 # Template file for 'texlive-publishers'
 pkgname=texlive-publishers
-version=2021.58683
+version=2023.66550
 revision=1
 build_style="texmf"
 short_desc="TeX Live - Classes and packages for certain publishers"
@@ -8,4 +8,4 @@ maintainer="fosslinux <fosslinux@aussies.space>"
 license="GPL-2.0-or-later"
 homepage="https://tug.org/texlive/"
 distfiles="https://sources.archlinux.org/other/texlive/${pkgname}-${version}-src.zip"
-checksum=7ee1bdb92641601c285f972f1978b19adbcbb90f430ae38356bd2e5165506304
+checksum=52f9d38288dcaabfd67f0cb07fb8a48f2c709ff80e5085b298a2cedc9af88588

--- a/srcpkgs/texlive-science/template
+++ b/srcpkgs/texlive-science/template
@@ -1,6 +1,6 @@
 # Template file for 'texlive-science'
 pkgname=texlive-science
-version=2022.62977
+version=2023.66461
 revision=1
 build_style="texmf"
 depends="texlive-core"
@@ -9,4 +9,4 @@ maintainer="fosslinux <fosslinux@aussies.space>"
 license="GPL-2.0-or-later"
 homepage="https://tug.org/texlive/"
 distfiles="https://sources.archlinux.org/other/texlive/${pkgname}-${version}-src.zip"
-checksum=3e420b34fbc22c54cbbaeed1c377bbb80360cb162f1464547321114a08f214a3
+checksum=9c5e36cdc932007bb151bd61bacdc216d1d1d682758555a4d6e0e85c51005098

--- a/srcpkgs/texlive/files/remove-himktables.patch
+++ b/srcpkgs/texlive/files/remove-himktables.patch
@@ -1,0 +1,13 @@
+--- a/texk/web2c/Makefile.in	2023-12-19 16:13:41.579311491 +1100
++++ b/texk/web2c/Makefile.in	2023-12-19 16:14:01.587311491 +1100
+@@ -22095,10 +22095,6 @@
+ hitex-tangle: ctangle$(EXEEXT) hitexdir/hitex.w tangle-sh
+ 	$(hi_ctangle_sh) hitex
+ 
+-# Generating hitables.c using himktables.
+-hitables.c: himktables$(EXEEXT)
+-	./himktables$(EXEEXT) > $@ || { rm -f hitables.c; exit 1; }
+-
+ # hitex, histretch, and hishrink all need (at least) some 
+ # of the sources generated from hiformat.w.
+ #

--- a/srcpkgs/texlive/patches/luajit-arch-fixes.patch
+++ b/srcpkgs/texlive/patches/luajit-arch-fixes.patch
@@ -9,24 +9,25 @@ Author: q66 <daniel@octaforge.org>
 
 --- a/libs/luajit/configure
 +++ b/libs/luajit/configure
-@@ -14243,7 +14243,7 @@ else
- fi
- if grep 'LJ_ARCH_BITS 64' conftest.i >/dev/null 2>&1; then :
+@@ -15267,7 +15267,7 @@
+ if grep 'LJ_ARCH_BITS 64' conftest.i >/dev/null 2>&1
+ then :
    echo '-D P64' >>dynasm_flags
--         if test "x$LJHOST" = xLinux; then :
-+         if test "x$LJHOST" = xLinux -a "x$LJARCH" = xx64; then :
+-         if test "x$LJHOST" = xLinux
++         if test "x$LJHOST" = xLinux -a "x$LJARCH" = xx64
+ then :
    LUAJIT_DEFINES="$LUAJIT_DEFINES -DMAP_32BIT=0x40"
  fi
- fi
-@@ -14294,6 +14294,9 @@ fi
- fi
-                 if grep 'LJ_ARCH_PPC32ON64 1' conftest.i >/dev/null 2>&1; then :
+@@ -15331,6 +15331,10 @@
+ then :
    echo '-D GPR64' >>dynasm_flags
-+fi
-+                if grep 'LJ_ARCH_PPC_ELFV2 1' conftest.i >/dev/null 2>&1; then :
-+  echo '-D ELFV2' >>dynasm_flags
  fi
-                 if grep 'LJ_ARCH_PPC64 ' conftest.i >/dev/null 2>&1; then :
++                if grep 'LJ_ARCH_PPC_ELFV2 1' conftest.i >/dev/null 2>&1
++then :
++  echo '-D ELFV2' >>dynasm_flags
++fi
+                 if grep 'LJ_ARCH_PPC64 ' conftest.i >/dev/null 2>&1
+ then :
    DASM_ARCH=ppc64
 --- a/libs/luajit/m4/lj-system.m4
 +++ b/libs/luajit/m4/lj-system.m4

--- a/srcpkgs/texlive/patches/tlmgr.patch
+++ b/srcpkgs/texlive/patches/tlmgr.patch
@@ -1,31 +1,19 @@
-Modified from Debian's tlmgr patch.
-Src: https://raw.githubusercontent.com/debian-tex/texlive-nonbin/9767c8ba4ea64d671eb98ddff550498cd2ac3d51/texlive-base/debian/patches/debian-tlmgr-usermode.
-
-Modifications:
-
-* Drop Debian specific wording.
-* Drop unnessecary manpage changes.
-* Change /usr/share path to what we use.
-
-Modified by fosslinux.
-
---- a/texk/texlive/linked_scripts/texlive/tlmgr.pl
-+++ b/texk/texlive/linked_scripts/texlive/tlmgr.pl
-@@ -20,7 +20,7 @@ $datrev =~ s/^.*Date: //;
- $datrev =~ s/ \(.*$//;
- $tlmgrversion = "$tlmgrrevision ($datrev)";
- 
--our $Master;
-+our $Master = "/usr/share/texmf-dist";
- our $loadmediasrcerror;
- our $packagelogfile;
- our $packagelogged;
-@@ -39,38 +39,9 @@ END {
- }
+--- a/texk/texlive/linked_scripts/texlive/tlmgr.pl	2023-03-09 08:31:49.000000000 +1100
++++ b/texk/texlive/linked_scripts/texlive/tlmgr.pl	2023-12-18 22:20:18.634173357 +1100
+@@ -13,7 +13,7 @@
+ my $tlmgrrevision;
+ my $tlmgrversion;
+ my $prg;
+-my $bindir;
++my $bindir = '/usr/bin';
+ if ($svnrev =~ m/: ([0-9]+) /) {
+   $tlmgrrevision = $1;
+ } else {
+@@ -44,43 +44,12 @@
  
  BEGIN {
--  $^W = 1;
-   # make subprograms (including kpsewhich) have the right path:
+   $^W = 1;
+-  # make subprograms (including kpsewhich) have the right path:
 -  my $kpsewhichname;
 -  if ($^O =~ /^MSWin/i) {
 -    # on w32 $0 and __FILE__ point directly to tlmgr.pl; they can be relative
@@ -33,7 +21,7 @@ Modified by fosslinux.
 -    $Master =~ s!\\!/!g;
 -    $Master =~ s![^/]*$!../../..!
 -      unless ($Master =~ s!/texmf-dist/scripts/texlive/tlmgr\.pl$!!i);
--    $bindir = "$Master/bin/win32";
+-    $bindir = "$Master/bin/windows";
 -    $kpsewhichname = "kpsewhich.exe";
 -    # path already set by wrapper batchfile
 -  } else {
@@ -47,7 +35,7 @@ Modified by fosslinux.
 -  }
 -  if (-r "$bindir/$kpsewhichname") {
 -    # if not in bootstrapping mode => kpsewhich exists, so use it to get $Master
--    chomp($Master = `kpsewhich -var-value=SELFAUTOPARENT`);
+-    chomp($Master = `kpsewhich -var-value=TEXMFROOT`);
 -  }
 -
 -  # if we have no directory in which to find our modules,
@@ -56,43 +44,49 @@ Modified by fosslinux.
 -    die ("Could not determine directory of tlmgr executable, "
 -         . "maybe shared library woes?\nCheck for error messages above");
 -  }
-+  $bindir = $Master;
-+  $ENV{"PATH"} = "$bindir:$ENV{PATH}";
- 
+-
++  $Master = "/usr/share/texmf-dist";
    $::installerdir = $Master;  # for config.guess et al., see TLUtils.pm
  
-@@ -615,6 +586,13 @@ for the full story.\n";
+   # make Perl find our packages first:
+   unshift (@INC, "$Master/tlpkg");
+-  unshift (@INC, "$Master/texmf-dist/scripts/texlive");
++  unshift (@INC, "$Master/scripts/texlive");
+ }
+ 
+ use Cwd qw/abs_path/;
+@@ -622,6 +591,13 @@
      tldie("$prg: Try --help if you need it.\n");
    }
  
-+  # automatically switch to user mode on Void, and warn
++  # automatically switch to user mode, and warn
 +  if (!$opts{"usermode"} && $action ne "init-usertree") {
 +    $opts{"usermode"} = 1;
-+    print "WARNING: switching to user mode!\n";
-+    print "WARNING: normal mode unsupported on Void Linux.\n";
++    print "(running on Void Linux, switching to user mode!)\n";
++    print "(see https://docs.voidlinux.org/config/texlive.html)\n";
 +  }
 +
    #
    # the main tree we will be working on
    $::maintree = $Master;
-@@ -6118,7 +6096,9 @@ sub action_postaction {
+@@ -6260,7 +6236,9 @@
  # sets up the user tree for tlmgr in user mode
  sub action_init_usertree {
    # init_local_db but do not die if localtlpdb is not found!
 -  init_local_db(2);
-+  # we don't ship tlpdb in the system, so don't even
++  # we don't ship tlpdb for system files, so don't even
 +  # try to initialize it.
 +  # init_local_db(2);
    my $tlpdb = TeXLive::TLPDB->new;
    my $usertree;
    if ($opts{"usertree"}) {
-@@ -6758,7 +6738,11 @@ sub init_local_db {
+@@ -6900,7 +6878,11 @@
      if ($should_i_die == 2) {
        return undef;
      } else {
 -      die("cannot setup TLPDB in $::maintree");
 +      if ($opts{'usermode'}) {
-+        die("$prg: user mode not initialized, please run `tlmgr init-usertree`\n");
++        die("$prg: user mode not initialized, please read https://docs.voidlinux.org/config/texlive.html!\n");
 +      } else {
 +        die("cannot setup TLPDB in $::maintree");
 +      }

--- a/srcpkgs/texlive/template
+++ b/srcpkgs/texlive/template
@@ -1,7 +1,7 @@
 # Template file for 'texlive'
 pkgname=texlive
-version=20210325
-revision=8
+version=20230313
+revision=1
 build_wrksrc="build"
 build_style=gnu-configure
 configure_script="../configure"
@@ -64,7 +64,7 @@ configure_args="
  --with-system-zlib
  --with-system-zziplib
  --with-xdvi-x-toolkit=Xaw"
-hostmakedepends="pkg-config perl lua52-BitOp texinfo"
+hostmakedepends="pkg-config perl lua52-BitOp texinfo libXaw-devel"
 makedepends="cairo-devel freetype-devel gd-devel graphite-devel gmp-devel
  harfbuzz-devel icu-devel libpaper-devel libpng-devel mpfr-devel
  pixman-devel libteckit-devel zlib-devel zziplib-devel libXaw-devel"
@@ -73,8 +73,8 @@ short_desc="TeX Live"
 maintainer="fosslinux <fosslinux@aussies.space>"
 license="GPL-2.0-or-later"
 homepage="https://tug.org/texlive/"
-distfiles="ftp://tug.org/texlive/historic/2021/texlive-${version}-source.tar.xz"
-checksum=7aefd96608d72061970f2d73f275be5648ea8ae815af073016d3106acc0d584b
+distfiles="ftp://tug.org/texlive/historic/2023/texlive-${version}-source.tar.xz"
+checksum=3878aa0e1ed0301c053b0e2ee4e9ad999c441345f4882e79bdd1c8f4ce9e79b9
 python_version=3
 # Virtual package cares only about year part of version
 provides="tex-${version%${version#????}}_1"
@@ -207,6 +207,15 @@ EOF
 #!/bin/sh
 printf "already complete\\n"
 EOF
+
+	# himktables needs to be built on host
+	if [ -n "${CROSS_BUILD}" ]; then
+		cd "${wrksrc}/build/texk/web2c"
+		ctangle ../../../texk/web2c/hitexdir/hiformat.w
+		gcc -o himktables himktables.c
+		./himktables > hitables.c
+		patch -d "${wrksrc}" -Np1 -i ${FILESDIR}/remove-himktables.patch
+	fi
 }
 
 post_install() {
@@ -251,7 +260,9 @@ texlive-XeTeX_package() {
 	depends="${sourcepkg}>=${version}_${revision}"
 	short_desc+=" - engine supporting modern typography"
 	pkg_install() {
+		vmove usr/share/texmf-dist/scripts/texlive-extra/xe*.sh
 		vmove usr/bin/xetex
+		vmove usr/share/man/man1/xe*.1
 		ln -s xetex "${PKGDESTDIR}/usr/bin/xelatex"
 	}
 }
@@ -279,14 +290,14 @@ texlive-LuaTeX_package() {
 				vmove "usr/bin/${i}"
 			done
 		fi
-		for i in checkcites cllualatex cluttex diadia getmapdl l3build luahbtex \
-				 luaotfload-tool luatools luatex lwarpmk m-tx \
+		for i in checkcites cllualatex cluttex diadia digestif getmapdl l3build luafindfont luahbtex \
+				 luaotfload-tool luatex lwarpmk m-tx \
 				 makeglossaries-lite mflua mflua-nowin musixflx musixtex pmxchords \
 				 ptex2pdf texlua texluac xindex ; do
 			vmove "usr/bin/${i}"
 		done
-		for i in checkcites cluttex diadia getmap glossaries/makeglossaries-lite.lua \
-				 l3build luaotfload lwarp m-tx musixtex pmxchords ptex2pdf xindex ; do
+		for i in checkcites cluttex diadia digestif getmap glossaries/makeglossaries-lite.lua \
+				 l3build luafindfont luaotfload lwarp m-tx musixtex pmxchords ptex2pdf xindex ; do
 			vmove "usr/share/texmf-dist/scripts/${i}"
 		done
 		for i in luatex texlua texluac ; do
@@ -356,7 +367,7 @@ texlive-BibTeX_package() {
 		for i in bbl2bib ctanbib ; do
 			vmove "usr/bin/${i}"
 		done
-		for i in bib2gls bibexport ; do
+		for i in bib2gls bibcop bibexport ; do
 			vmove "usr/share/texmf-dist/scripts/${i}"
 		done
 		vmove usr/bin/bib*
@@ -365,21 +376,9 @@ texlive-BibTeX_package() {
 }
 
 texlive-ConTeXt_package() {
-	depends="${sourcepkg}>=${version}_${revision} perl ghostscript"
-	short_desc+=" - alternative general-purpose document processor"
-	pkg_install() {
-		for i in context contextjit mptopdf mtxrun mtxrunjit texexec \
-				 texmfstart dosepsbin epspdf epspdftk purifyeps repstopdf \
-				 ps2eps tl-epsffit ; do
-			vmove "usr/bin/${i}"
-		done
-		for i in context dosepsbin epspdf epstopdf ps2eps purifyeps ; do
-			vmove "usr/share/texmf-dist/scripts/${i}"
-		done
-		for i in tl-epsffit ps2eps ; do
-			vmove "usr/share/man/man1/${i}.1"
-		done
-	}
+	build_style=meta
+	short_desc+=" (transitional package)"
+	depends="texlive>=${version}_${revision}"
 }
 
 texlive-PythonTeX_package() {


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **yes**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, x86_64
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [x] aarch64-musl
  - [x] armv7l
  - [x] armv6l-musl


<strike>A few consideration's I'm 100% sure about.

1. I'm not certain about our current ownerships - a lot of things from `texmf-dist` come from the texlive package, whereas most other distributions appear to have the primary texlive package as compiled binaries-only and then place all the `texmf-dist` binaries symlinked to scripts in their texlive-core package (obviously different names but same idea). Should we be doing this?
2. What do I do about the ppc64 patches, should they be dropped or left?</strike>
*all considered now*