### PR TITLE
mu4e: update to 1.10.8

### DIFF
--- a/srcpkgs/mu4e/template
+++ b/srcpkgs/mu4e/template
@@ -1,6 +1,6 @@
 # Template file for 'mu4e'
 pkgname=mu4e
-version=1.10.7
+version=1.10.8
 revision=1
 build_style=meson
 hostmakedepends="emacs libtool pkg-config texinfo glib-devel"
@@ -11,6 +11,6 @@ license="GPL-3.0-or-later"
 homepage="https://www.djcbsoftware.nl/code/mu/"
 changelog="https://github.com/djcb/mu/raw/master/NEWS.org"
 distfiles="https://github.com/djcb/mu/releases/download/v${version}/mu-${version}.tar.xz"
-checksum=eaaac9ba515da232295b03f2797eed13552fdd29a30122134dd382a64d0d3c21
+checksum=6b11d8add2a7eeb0ebc4a5c7a6b9a9b3e1be8c5175c0c1c019a7ad8d7e363589
 replaces="mu<${version}"
 provides="mu-${version}_${revision}"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
