### PR TITLE
New package: python3-pulsectl-asyncio-1.1.1

### DIFF
--- a/srcpkgs/python3-pulsectl-asyncio/template
+++ b/srcpkgs/python3-pulsectl-asyncio/template
@@ -1,0 +1,17 @@
+# Template file for 'python3-pulsectl-asyncio'
+pkgname=python3-pulsectl-asyncio
+version=1.1.1
+revision=1
+build_style=python3-pep517
+hostmakedepends="python3-setuptools python3-wheel"
+depends="python3-pulsectl libpulseaudio"
+short_desc="Asyncio frontend for pulsectl, a Python bindings library for PulseAudio"
+maintainer="Kai Stian Olstad <void@olstad.com>"
+license="MIT"
+homepage="https://github.com/mhthies/pulsectl-asyncio"
+distfiles="${PYPI_SITE}/p/pulsectl-asyncio/pulsectl-asyncio-${version}.tar.gz"
+checksum=b5976b0ddd235d9ccc3455a03be664f7cb2201c942993b03ceb6b39d9cea8ad0
+
+post_install() {
+	vlicense LICENSE
+}


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

Required by built in optional widget [PulseVolume](https://docs.qtile.org/en/latest/manual/ref/widgets.html#pulsevolume) in [Qtile](https://github.com/void-linux/void-packages/blob/master/srcpkgs/qtile/template)

#### Local build testing
- I built this PR locally for my native architecture, (x86-64-LIBC)