### PR TITLE
schilytools: fix cross

### DIFF
--- a/srcpkgs/schilytools/template
+++ b/srcpkgs/schilytools/template
@@ -1,63 +1,102 @@
 # Template file for 'schilytools'
 pkgname=schilytools
 version=2023.09.28
-revision=2
+revision=3
+build_style=meta
+build_helper="qemu"
 makedepends="acl-devel attr-devel e2fsprogs-devel libcap-progs m4"
-depends="sccs sdd sfind smake star ved"
+depends="sccs sdd sfind smake star ved cdrtools"
 short_desc="Schily's portable tools"
 maintainer="Leah Neukirchen <leah@vuxu.org>"
 license="CDDL-1.0"
 homepage="https://codeberg.org/schilytools/schilytools"
 distfiles="https://codeberg.org/schilytools/schilytools/archive/${version//./-}.tar.gz"
-checksum=564ea2365876a53eba02f184c565016399aee188c26d862589906cf3f92198e6
-nocross=yes  # configure + re-builds with itself
+checksum=c813cc19a320f8d3b5d82f5b1ca6a93ab1bb5f4c50f86fdac58101fe472d2143
 
-do_build() {
-	make ${makejobs} CC="$CC" COPTX="$CFLAGS" LDOPTX="$LDFLAGS" INS_BASE=/usr
-	make ${makejobs} -C ved CC="$CC" COPTX="$CFLAGS" LDOPTX="$LDFLAGS" INS_BASE=/usr
-	make -C sccs clean
-	make -C sccs CC="$CC" COPTX="$CFLAGS" LDOPTX="$LDFLAGS" INS_BASE=/usr/libexec/sccs
+_common_flags=(ARCH="${XBPS_TARGET_MACHINE%-musl}" GMAKE_NOWARN=true INS_BASE=/usr)
+
+post_patch() {
+	vsed -i 's|INSDIR=.*|INSDIR=bin|' rscsi/Makefile
 }
 
-do_install() {
-	make install -C libsiconv/tables DESTDIR="$DESTDIR" INS_BASE=/usr
-	vlicense CDDL.Schily.txt
+do_build() {
+	local _flags=("${makejobs}" "${_common_flags[@]}" CC="$CC" CCC="$CXX" COPTX="$CFLAGS" LDOPTX="$LDFLAGS")
+
+	# build the bootstrap smake for host always
+	( cd psmake && CC="gcc" CC_OPT="-O2" CFLAGS="" LDFLAGS="" sh ./MAKE-all )
+
+	if [ "$CROSS_BUILD" ]; then
+		export CONFIG_RMTCALL="/usr/bin/qemu-${XBPS_TARGET_QEMU_MACHINE}-static"
+		export CONFIG_RMTHOST=dummy
+	fi
+
+	make "${_flags[@]}"
+
+	# sccs has a special INS_BASE
+	make -C sccs clean "${_flags[@]}"
+	make -C sccs "${_flags[@]}" INS_BASE=/usr/libexec/sccs
+
+	for d in ved sdd sfind smake star btcflash cdda2wav cdrecord mkisofs mkisofs/diag \
+	 readcd rscsi scgcheck scgskeleton; do
+		make -C "$d" clean "${_flags[@]}"
+		make -C "$d" "${_flags[@]}"
+	done
+}
+
+cdrtools_package() {
+	depends="libcap-progs"
+	short_desc+=" - cdrtools"
+	conf_files="/etc/default/rscsi /etc/default/cdrecord"
+	pkg_install() {
+		for d in btcflash cdda2wav cdrecord libsiconv/tables mkisofs mkisofs/diag readcd rscsi \
+		 scgcheck scgskeleton; do
+			make install -C "$d" DESTDIR="$PKGDESTDIR" "${_common_flags[@]}"
+		done
+		rm -rf "${PKGDESTDIR}"/usr/lib/profiled
+		vmkdir usr/lib/modules-load.d
+		echo sg > "${PKGDESTDIR}"/usr/lib/modules-load.d/cdrtools.conf
+		vlicense CDDL.Schily.txt
+	}
 }
 
 sccs_package() {
 	short_desc+=" - SCCS"
 	pkg_install() {
-		make install -C sccs DESTDIR="$PKGDESTDIR" INS_BASE=/usr/libexec/sccs
+		make install -C sccs DESTDIR="$PKGDESTDIR" "${_common_flags[@]}" INS_BASE=/usr/libexec/sccs
 		vmkdir usr/bin
 		vmkdir usr/share
-		rm -f ${PKGDESTDIR}/usr/libexec/sccs/share/man/man?/[!s]*
-		mv ${PKGDESTDIR}/usr/libexec/sccs/share/man ${PKGDESTDIR}/usr/share
-		rm -rf ${PKGDESTDIR}/usr/libexec/sccs/bin
-		ln -sfr ${PKGDESTDIR}/usr/libexec/sccs/ccs/bin/sccs ${PKGDESTDIR}/usr/bin/sccs
+		rm -f "${PKGDESTDIR}"/usr/libexec/sccs/share/man/man?/[!s]*
+		mv "${PKGDESTDIR}"/usr/libexec/sccs/share/man "${PKGDESTDIR}"/usr/share
+		rm -rf "${PKGDESTDIR}"/usr/libexec/sccs/bin
+		ln -sfr "${PKGDESTDIR}"/usr/libexec/sccs/ccs/bin/sccs "${PKGDESTDIR}"/usr/bin/sccs
 		vlicense CDDL.Schily.txt
 	}
 }
+
 sdd_package() {
 	short_desc+=" - sdd"
 	pkg_install() {
-		make install -C sdd DESTDIR="$PKGDESTDIR" INS_BASE=/usr
+		make install -C sdd DESTDIR="$PKGDESTDIR" "${_common_flags[@]}"
 		vlicense CDDL.Schily.txt
 	}
 }
+
 sfind_package() {
 	short_desc+=" - sfind"
 	pkg_install() {
-		make install -C sfind DESTDIR="$PKGDESTDIR" INS_BASE=/usr
+		make install -C sfind DESTDIR="$PKGDESTDIR" "${_common_flags[@]}"
 		vlicense CDDL.Schily.txt
 	}
 }
+
 smake_package() {
 	short_desc+=" - smake"
 	pkg_install() {
-		make install -C smake DESTDIR="$PKGDESTDIR" INS_BASE=/usr
+		make install -C smake DESTDIR="$PKGDESTDIR" "${_common_flags[@]}"
 		vlicense CDDL.Schily.txt
 	}
 }
+
 star_package() {
 	short_desc+=" - star"
 	conf_files="/etc/default/star"
@@ -66,38 +105,21 @@ star_package() {
 	 pax:pax.1:/usr/share/man/man1/spax.1
 	"
 	pkg_install() {
-		make install -C star DESTDIR="$PKGDESTDIR" INS_BASE=/usr SYMLINKS='suntar scpio spax'
-		rm -f ${PKGDESTDIR}/usr/share/man/man1/gnutar.1
-		rm -f ${PKGDESTDIR}/usr/share/man/man1/ustar.1
-		rm -f ${PKGDESTDIR}/usr/share/man/man1/gnutar.1
-		rm -f ${PKGDESTDIR}/usr/share/man/man1/*[!1]
-		rm -f ${PKGDESTDIR}/usr/share/man/man5/*[!5]
-		rm -rf ${PKGDESTDIR}/usr/share/doc/
-		vlicense CDDL.Schily.txt
-	}
-}
-ved_package() {
-	short_desc+=" - ved"
-	pkg_install() {
-		make install -C ved DESTDIR="$PKGDESTDIR" INS_BASE=/usr
+		make install -C star DESTDIR="$PKGDESTDIR" SYMLINKS='suntar scpio spax' "${_common_flags[@]}"
+		rm -f "${PKGDESTDIR}"/usr/share/man/man1/gnutar.1
+		rm -f "${PKGDESTDIR}"/usr/share/man/man1/ustar.1
+		rm -f "${PKGDESTDIR}"/usr/share/man/man1/gnutar.1
+		rm -f "${PKGDESTDIR}"/usr/share/man/man1/*[!1]
+		rm -f "${PKGDESTDIR}"/usr/share/man/man5/*[!5]
+		rm -rf "${PKGDESTDIR}"/usr/share/doc/
 		vlicense CDDL.Schily.txt
 	}
 }
 
-cdrtools_package() {
-	depends="schilytools libcap-progs"
-	short_desc+=" - cdrtools"
-	conf_files="/etc/default/rscsi /etc/default/cdrecord"
+ved_package() {
+	short_desc+=" - ved"
 	pkg_install() {
-		vsed -i 's|INSDIR=.*|INSDIR=bin|' rscsi/Makefile
-		for d in btcflash cdda2wav cdrecord mkisofs mkisofs/diag readcd rscsi \
-			scgcheck scgskeleton; do
-			make install -C "$d" DESTDIR="$PKGDESTDIR" INS_BASE=/usr \
-				CC="$CC" COPTX="$CFLAGS" LDOPTX="$LDFLAGS" LDPATH= RUNPATH=
-		done
-		rm -rf "${PKGDESTDIR}"/usr/lib/profiled
-		vmkdir usr/lib/modules-load.d
-		echo sg > "${PKGDESTDIR}"/usr/lib/modules-load.d/cdrtools.conf
+		make install -C ved DESTDIR="$PKGDESTDIR" "${_common_flags[@]}"
 		vlicense CDDL.Schily.txt
 	}
 }


### PR DESCRIPTION
also clean up template and move siconv tables back into cdrtools, as they are only used there

#### Testing the changes
- I tested the changes in this PR: **YES** (on aarch64-musl)
