### PR TITLE
libgssglue: update source mirror

### DIFF
--- a/srcpkgs/libgssglue/template
+++ b/srcpkgs/libgssglue/template
@@ -8,8 +8,8 @@ conf_files="/etc/gssapi_mech.conf"
 short_desc="Mechanism-switch gssapi library"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="BSD-3-Clause"
-homepage="http://www.citi.umich.edu/projects/nfsv4/linux/"
-distfiles="$homepage/$pkgname/$pkgname-$version.tar.gz"
+homepage="https://gitlab.com/gsasl/libgssglue"
+distfiles="$homepage/uploads/0e74f2717456bcfdf55e95a632c2acbf/$pkgname-$version.tar.gz"
 checksum=3f791a75502ba723e5e85e41e5e0c711bb89e2716b7c0ec6e74bd1df6739043a
 
 post_install() {


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc

Mirror for this package is down, has been changed to the current one on Gitlab.