### PR TITLE
podman, buildah, and containers-dependency updates

### DIFF
--- a/srcpkgs/buildah/template
+++ b/srcpkgs/buildah/template
@@ -1,7 +1,7 @@
 # Template file for 'buildah'
 pkgname=buildah
-version=1.31.0
-revision=2
+version=1.32.2
+revision=1
 build_style=go
 go_import_path=github.com/containers/buildah
 go_package="${go_import_path}/cmd/buildah"
@@ -16,7 +16,7 @@ license="Apache-2.0"
 homepage="https://github.com/containers/buildah"
 changelog="https://github.com/containers/buildah/blob/master/CHANGELOG.md"
 distfiles="https://github.com/containers/buildah/archive/refs/tags/v${version}.tar.gz"
-checksum=c119921e8e4b2d7fd7e1041dfbcfdfac0882e3dea4f7dabdc5175f9bbc70d868
+checksum=4e6c4b2186d6ef5195334f6979d3f7484664a5a3df425b6524a19b14774efc20
 
 post_build() {
 	make -C docs GOMD2MAN=go-md2man

--- a/srcpkgs/cni-plugins/template
+++ b/srcpkgs/cni-plugins/template
@@ -1,7 +1,7 @@
 # Template file for 'cni-plugins'
 pkgname=cni-plugins
-version=1.2.0
-revision=3
+version=1.3.0
+revision=1
 build_style=go
 go_import_path="github.com/containernetworking/plugins"
 short_desc="Container Network Interface (plugins)"
@@ -9,7 +9,7 @@ maintainer="Cameron Nemo <cam@nohom.org>"
 license="Apache-2.0"
 homepage="https://github.com/containernetworking/plugins"
 distfiles="https://github.com/containernetworking/plugins/archive/v${version}.tar.gz"
-checksum=f3496ddda9c7770a0b695b67ae7ee80a4ee331ac2745af4830054b81627f79b7
+checksum=f9871b9f6ccb51d2b264532e96521e44f926928f91434b56ce135c95becf2901
 
 do_build() {
 	./build_linux.sh \

--- a/srcpkgs/conmon/template
+++ b/srcpkgs/conmon/template
@@ -1,6 +1,6 @@
 # Template file for 'conmon'
 pkgname=conmon
-version=2.1.7
+version=2.1.8
 revision=1
 build_style=gnu-makefile
 hostmakedepends="pkg-config"
@@ -10,7 +10,7 @@ maintainer="Cameron Nemo <cam@nohom.org>"
 license="Apache-2.0"
 homepage="https://github.com/containers/conmon"
 distfiles="https://github.com/containers/conmon/archive/v${version}.tar.gz"
-checksum=7d0f9a2f7cb8a76c51990128ac837aaf0cc89950b6ef9972e94417aa9cf901fe
+checksum=e72c090210a03ca3b43a0fad53f15bca90bbee65105c412468009cf3a5988325
 
 _have_docs=no
 

--- a/srcpkgs/containers-common/template
+++ b/srcpkgs/containers-common/template
@@ -1,6 +1,6 @@
 # Template file for 'containers-common'
 pkgname=containers-common
-version=0.55.2
+version=0.56.0
 revision=1
 build_style=gnu-makefile
 make_build_args="-C docs"
@@ -11,7 +11,7 @@ maintainer="Cameron Nemo <cam@nohom.org>"
 license="Apache-2.0"
 homepage="https://github.com/containers/common"
 distfiles="https://github.com/containers/common/archive/v${version}.tar.gz"
-checksum=997529c8aed1b6b71ff732d0cb75e67560222012402a3715ccab765b92ce0479
+checksum=a981ff8746cf193fda0caccb9cd0deac121e334dfa0de6f441ad7ebb267f1109
 
 post_install() {
 	vinstall pkg/seccomp/seccomp.json 0644 usr/share/containers

--- a/srcpkgs/containers.image/template
+++ b/srcpkgs/containers.image/template
@@ -1,6 +1,6 @@
 # Template file for 'containers.image'
 pkgname=containers.image
-version=5.24.2
+version=5.28.0
 revision=1
 conf_files="/etc/containers/registries.conf /etc/containers/policy.json"
 hostmakedepends="go-md2man"
@@ -9,7 +9,7 @@ maintainer="Cameron Nemo <cam@nohom.org>"
 license="Apache-2.0"
 homepage="https://github.com/containers/image"
 distfiles="https://github.com/containers/image/archive/v${version}.tar.gz"
-checksum=9ddc18a58bbec6de2854e858341c77aebf5a2afe49d00a7288d4e6cfe7732047
+checksum=89f0aa574f65b1849c57ed2be660fac2cbaec5f43e2e14cdfebb3ff15556fd78
 
 do_build() {
 	mkdir -p build

--- a/srcpkgs/containers.storage/template
+++ b/srcpkgs/containers.storage/template
@@ -1,6 +1,6 @@
 # Template file for 'containers.storage'
 pkgname=containers.storage
-version=1.45.4
+version=1.50.2
 revision=1
 hostmakedepends="go-md2man"
 depends="fuse-overlayfs"
@@ -9,7 +9,7 @@ maintainer="Cameron Nemo <cam@nohom.org>"
 license="Apache-2.0"
 homepage="https://github.com/containers/storage"
 distfiles="https://github.com/containers/storage/archive/refs/tags/v${version}.tar.gz"
-checksum=741860bc30574570db20446053575b748e54a299a806c18eebc224471cebcd0c
+checksum=8ed20cea8cd9bb6ecb63220a0b3f32df63445fe06fb8074c50e3c942e7d1ca0f
 _manpage="containers-storage.conf.5"
 
 do_build() {

--- a/srcpkgs/fuse-overlayfs/template
+++ b/srcpkgs/fuse-overlayfs/template
@@ -1,6 +1,6 @@
 # Template file for 'fuse-overlayfs'
 pkgname=fuse-overlayfs
-version=1.11
+version=1.13
 revision=1
 build_style=gnu-configure
 hostmakedepends="autoconf automake pkg-config"
@@ -11,7 +11,7 @@ license="GPL-3.0-or-later"
 homepage="https://github.com/containers/fuse-overlayfs"
 changelog="https://raw.githubusercontent.com/containers/fuse-overlayfs/main/NEWS"
 distfiles="https://github.com/containers/fuse-overlayfs/archive/v${version}.tar.gz"
-checksum=320a411425414679736dcb7f3b05146430ca4af20ded0096c69ac3c7540ebca2
+checksum=96d10344921d5796bcba7a38580ae14a53c4e60399bb90b238ac5a10b3bb65b2
 
 pre_configure() {
 	./autogen.sh

--- a/srcpkgs/podman/template
+++ b/srcpkgs/podman/template
@@ -1,7 +1,7 @@
 # Template file for 'podman'
 pkgname=podman
-version=4.5.1
-revision=2
+version=4.7.2
+revision=1
 build_style=go
 go_import_path="github.com/containers/podman/v4"
 go_package="${go_import_path}/cmd/podman ${go_import_path}/cmd/rootlessport"
@@ -16,7 +16,7 @@ license="Apache-2.0"
 homepage="https://podman.io/"
 changelog="https://raw.githubusercontent.com/containers/podman/main/RELEASE_NOTES.md"
 distfiles="https://github.com/containers/podman/archive/v${version}.tar.gz"
-checksum=ee2c8b02b7fe301057f0382637b995a9c6c74e8d530692d6918e4c509ade6e39
+checksum=10346c5603546427bd809b4d855d1e39b660183232309128ad17a64969a0193d
 
 if [ "$CROSS_BUILD" ]; then
 	go_build_tags+=" containers_image_openpgp"

--- a/srcpkgs/runc/template
+++ b/srcpkgs/runc/template
@@ -1,7 +1,7 @@
 # Template file for 'runc'
 pkgname=runc
-version=1.1.9
-revision=2
+version=1.1.10
+revision=1
 build_style=go
 go_import_path=github.com/opencontainers/runc
 go_build_tags="seccomp apparmor"
@@ -14,7 +14,7 @@ license="Apache-2.0"
 homepage="https://github.com/opencontainers/runc"
 changelog="https://github.com/opencontainers/runc/raw/main/CHANGELOG.md"
 distfiles="https://github.com/opencontainers/runc/releases/download/v${version}/runc.tar.xz"
-checksum=7695febe134e17559b26224821a2a123bc9e9a637ad4a8c47e99ae0a1ec71dc2
+checksum=bd3e89ae89319ef344e7e26f392b40e344bcd5bbdea84ca459a43189451615bf
 
 post_build() {
 	make man

--- a/srcpkgs/slirp4netns/template
+++ b/srcpkgs/slirp4netns/template
@@ -1,6 +1,6 @@
 # Template file for 'slirp4netns'
 pkgname=slirp4netns
-version=1.2.0
+version=1.2.2
 revision=1
 build_style=gnu-configure
 hostmakedepends="autoconf automake pkg-config"
@@ -10,7 +10,7 @@ maintainer="Cameron Nemo <cam@nohom.org>"
 license="GPL-2.0-only"
 homepage="https://github.com/rootless-containers/slirp4netns"
 distfiles="https://github.com/rootless-containers/slirp4netns/archive/v${version}.tar.gz"
-checksum=b584edde686d3cfbac210cbdb93c4b0ba5d8cc0a6a4d92b9dfc3c5baec99c727
+checksum=2450afb5730ee86a70f9c3f0d3fbc8981ab8e147246f4e0d354f0226a3a40b36
 # tests fail due to use of unshare (unavailable with chroot util-linux)
 make_check=no
 


### PR DESCRIPTION
- runc: update to 1.1.10
- conmon: update to 2.1.8
- cni-plugins: update to 1.3.0
- fuse-overlayfs: update to 1.13
- slirp4netns: update to 1.2.2
- containers.image: update to 5.28.0
- containers.storage: update to 1.50.2
- containers-common: update to 0.56.0
- podman: update to 4.7.2
- buildah: update to 1.32.2

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
