### PR TITLE
libjpeg-turbo: update to 3.0.1.

### DIFF
--- a/srcpkgs/libjpeg-turbo/template
+++ b/srcpkgs/libjpeg-turbo/template
@@ -1,7 +1,7 @@
 # Template file for 'libjpeg-turbo'
 pkgname=libjpeg-turbo
-version=2.1.5.1
-revision=2
+version=3.0.1
+revision=1
 build_style=cmake
 configure_args="-DWITH_JPEG8=1"
 hostmakedepends="yasm"
@@ -11,7 +11,7 @@ license="IJG, BSD-3-Clause, Zlib"
 homepage="https://libjpeg-turbo.org/"
 changelog="https://raw.githubusercontent.com/libjpeg-turbo/libjpeg-turbo/main/ChangeLog.md"
 distfiles="${SOURCEFORGE_SITE}/libjpeg-turbo/libjpeg-turbo-${version}.tar.gz"
-checksum=2fdc3feb6e9deb17adec9bafa3321419aa19f8f4e5dea7bf8486844ca22207bf
+checksum=22429507714ae147b3acacd299e82099fce5d9f456882fc28e252e4579ba2a75
 
 provides="jpeg-8_1"
 replaces="jpeg>=0"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
