### PR TITLE
spotify-adblock: upgrade to 1.0.3

### DIFF
--- a/srcpkgs/spotify-adblock/template
+++ b/srcpkgs/spotify-adblock/template
@@ -1,7 +1,7 @@
 # Template file for 'spotify-adblock'
 pkgname=spotify-adblock
-version=1.0.2
-revision=2
+version=1.0.3
+revision=1
 build_style=cargo
 conf_files="/etc/spotify-adblock/config.toml"
 short_desc="Adblocker for Spotify"
@@ -9,7 +9,7 @@ maintainer="Subhaditya Nath <sn03.general@gmail.com>"
 license="GPL-3.0-or-later"
 homepage="https://github.com/abba23/spotify-adblock"
 distfiles="https://github.com/abba23/spotify-adblock/archive/refs/tags/v${version}.tar.gz"
-checksum=a0b5124573b95548e2f5ae36fc74fdab4fab9282d755affba754641e561aeac6
+checksum=8141c2433dbb6a6c693e95856c0e2e4b22b5a9da81f70589cd07b9e058d8b3c5
 
 pre_install() {
 	{


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
<!--
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
