### PR TITLE
reuse: update to 2.1.0, fix tests

### DIFF
--- a/srcpkgs/reuse/template
+++ b/srcpkgs/reuse/template
@@ -1,20 +1,21 @@
 # Template file for 'reuse'
 pkgname=reuse
-version=1.0.0
-revision=3
-build_style=python3-module
+version=2.1.0
+revision=1
+build_style=python3-pep517
 # These tests pass on local machine but don't pass in CI.
 make_check_args="--deselect tests/test_lint.py::test_lint_read_errors
  --deselect tests/test_main_addheader.py::test_addheader_to_read_only_file_does_not_traceback
- --deselect tests/test_report.py::test_generate_project_report_read_error"
-hostmakedepends="python3-setuptools python3-setuptools_scm gettext"
-depends="python3-binaryornot python3-boolean.py python3-debian python3-Jinja2
- python3-license-expression python3-requests python3-setuptools"
-checkdepends="python3-pytest $depends git mercurial"
+ --deselect tests/test_report.py::test_generate_project_report_read_error
+ --deselect tests/test_main_annotate.py::test_annotate_to_read_only_file_does_not_traceback"
+make_check_target="tests"
+hostmakedepends="python3-poetry-core"
+depends="python3-binaryornot python3-boolean.py python3-debian python3-Jinja2 python3-license-expression"
+checkdepends="${depends} python3-pytest git mercurial"
 short_desc="Helper tool for compliance with REUSE Specification"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-3.0-or-later, CC0-1.0, Apache-2.0, CC-BY-SA-4.0"
 homepage="https://reuse.software"
 changelog="https://raw.githubusercontent.com/fsfe/reuse-tool/master/CHANGELOG.md"
 distfiles="${PYPI_SITE}/r/reuse/reuse-${version}.tar.gz"
-checksum=db3022be2d87f69c8f508b928023de3026f454ce17d01e22f770f7147ac1e8d4
+checksum=4211e91caa4c9e433802618a89a2d49a67e2bf76a8029d6708090892f0cdebec


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-GLIBC)

## Changes
- Switched to `pep517`
- Removed dependency `setuptools`
- All tests are passing