### PR TITLE
element-desktop update to 1.11.49

### DIFF
--- a/srcpkgs/element-desktop/template
+++ b/srcpkgs/element-desktop/template
@@ -1,6 +1,6 @@
 # Template file for 'element-desktop'
 pkgname=element-desktop
-version=1.11.43
+version=1.11.49
 revision=1
 create_wrksrc=yes
 conf_files="/etc/${pkgname}/config.json"
@@ -9,7 +9,7 @@ hostmakedepends="git yarn nodejs rust cargo python3 curl
  app-builder jq moreutils"
 makedepends="libsecret-devel"
 depends="c-ares ffmpeg gtk+3 http-parser libevent
- libxslt minizip nss re2 snappy sqlcipher electron24"
+ libxslt minizip nss re2 snappy sqlcipher electron24 libflac"
 short_desc="Glossy Matrix collaboration client, desktop version"
 maintainer="Jan Christian Grünhage <jan.christian@gruenhage.xyz>"
 license="Apache-2.0"
@@ -17,8 +17,8 @@ homepage="https://element.io"
 changelog="https://raw.githubusercontent.com/vector-im/element-desktop/develop/CHANGELOG.md"
 distfiles="https://github.com/vector-im/element-desktop/archive/v${version}.tar.gz>element-desktop-v${version}.tar.gz
  https://github.com/vector-im/element-web/archive/v${version}.tar.gz>element-web-v${version}.tar.gz"
-checksum="9a090dad94096e57ceb6629f41650fbb70c3efb2d36a7354ec3902463495633e
- c7395f14a7747ece79ade9ab1133e95abf9c35c73fa430220e4a5d8868cd5028"
+checksum="a675717f5267907a5f4e2fa1746b35fdee30e09b8aa9a15253b8fcdc8f3b4434
+ 3d663c2bef164d284f2a7b29ec74b89b5a86063b85100089906708eb07b484e9"
 
 export USE_SYSTEM_APP_BUILDER=true
 


### PR DESCRIPTION
Fix LibFlac missing


<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-GLIBC)
