### PR TITLE
runc: update to 1.1.10.

### DIFF
--- a/srcpkgs/runc/template
+++ b/srcpkgs/runc/template
@@ -1,7 +1,7 @@
 # Template file for 'runc'
 pkgname=runc
-version=1.1.9
-revision=2
+version=1.1.10
+revision=1
 build_style=go
 go_import_path=github.com/opencontainers/runc
 go_build_tags="seccomp apparmor"
@@ -14,7 +14,7 @@ license="Apache-2.0"
 homepage="https://github.com/opencontainers/runc"
 changelog="https://github.com/opencontainers/runc/raw/main/CHANGELOG.md"
 distfiles="https://github.com/opencontainers/runc/releases/download/v${version}/runc.tar.xz"
-checksum=7695febe134e17559b26224821a2a123bc9e9a637ad4a8c47e99ae0a1ec71dc2
+checksum=bd3e89ae89319ef344e7e26f392b40e344bcd5bbdea84ca459a43189451615bf
 
 post_build() {
 	make man


### PR DESCRIPTION

#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc

