### PR TITLE
aria2: update to 1.37.0, adopt.

### DIFF
--- a/srcpkgs/aria2/template
+++ b/srcpkgs/aria2/template
@@ -1,7 +1,7 @@
 # Template file for 'aria2'
 pkgname=aria2
-version=1.36.0
-revision=2
+version=1.37.0
+revision=1
 build_style=gnu-configure
 configure_args="--with-openssl --with-libexpat --without-gnutls
  --with-ca-bundle=/etc/ssl/certs/ca-certificates.crt
@@ -13,12 +13,12 @@ makedepends="c-ares-devel expat-devel gmp-devel openssl-devel sqlite-devel
 depends="ca-certificates"
 checkdepends="libcppunit-devel"
 short_desc="Lightweight multi-protocol/multi-source command-line download utility"
-maintainer="Orphaned <orphan@voidlinux.org>"
+maintainer="yosh <yosh-git@riseup.net>"
 license="GPL-2.0-or-later"
 homepage="https://aria2.github.io/"
 changelog="https://raw.githubusercontent.com/aria2/aria2/master/NEWS"
 distfiles="https://github.com/aria2/aria2/releases/download/release-${version}/aria2-${version}.tar.xz"
-checksum=58d1e7608c12404f0229a3d9a4953d0d00c18040504498b483305bcb3de907a5
+checksum=60a420ad7085eb616cb6e2bdf0a7206d68ff3d37fb5a956dc44242eb2f79b66b
 
 libaria2_package() {
 	short_desc="Multi-Protocol/multi-source download library"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, `x86_64-glibc`
- I built this PR locally for these architectures:
  - `x86_64-musl`
  - `i686-glibc`