### PR TITLE
eyeD3: update to 0.9.7

### DIFF
--- a/srcpkgs/eyeD3/template
+++ b/srcpkgs/eyeD3/template
@@ -1,7 +1,7 @@
 # Template file for 'eyeD3'
 pkgname=eyeD3
-version=0.9.6
-revision=3
+version=0.9.7
+revision=1
 build_style=python3-module
 hostmakedepends="python3-setuptools"
 depends="python3-pylast python3-setuptools python3-deprecation python3-filetype"
@@ -11,4 +11,4 @@ license="GPL-3.0-or-later"
 homepage="https://eyed3.readthedocs.io/en/latest/"
 changelog="https://raw.githubusercontent.com/nicfit/eyeD3/master/HISTORY.rst"
 distfiles="https://github.com/nicfit/eyeD3/archive/v${version}.tar.gz"
-checksum=7120ebc014cf3004984be39a08ff7ac0377c212d578cafb77be982e835ebfd5c
+checksum=808f2d376b585ff13c35f614b970f3392c0f15de191c5a96c6b04532bf2217ec


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for these architectures:
  - aarch64
  - aarch64-musl
  - armv6l
  - armv6l-musl
  - armv7l
  - armv7l-musl
  - x86_64
  - x86_64-musl

x86_64 was native; all others were crossbuilt.