### PR TITLE
Signal-Desktop: update to 6.39.0.

### DIFF
--- a/srcpkgs/Signal-Desktop/template
+++ b/srcpkgs/Signal-Desktop/template
@@ -1,6 +1,6 @@
 # Template file for 'Signal-Desktop'
 pkgname=Signal-Desktop
-version=6.38.0
+version=6.39.0
 revision=1
 # Signal officially only supports x86_64 
 # x86_64-musl could potentially work based on the Alpine port:
@@ -14,7 +14,7 @@ maintainer="anelki <akierig@fastmail.de>"
 license="AGPL-3.0-only"
 homepage="https://github.com/signalapp/Signal-Desktop"
 distfiles="https://github.com/signalapp/Signal-Desktop/archive/v${version}.tar.gz"
-checksum=f147de8752c05d235e866f7b5d5513365a7b6bd4ea5ccdeda254a2171dc2d1f3
+checksum=c448b5ae6ccca0ca44798a6c9dde66800198f1391618a7b9c14b5fdd9485a832
 nostrip_files="signal-desktop"
 
 post_extract() {


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64