### PR TITLE
syncplay: backport fix for Python 3.12 support

### DIFF
--- a/srcpkgs/syncplay/patches/python3-12-compatibility.patch
+++ b/srcpkgs/syncplay/patches/python3-12-compatibility.patch
@@ -1,0 +1,86 @@
+From a637befbdebd7f8e834ccd782f09823bf04146a8 Mon Sep 17 00:00:00 2001
+From: Floris Vastenhout <kilmanio@mailfence.com>
+Date: Tue, 10 Oct 2023 19:20:26 +0200
+Subject: Update to python 3.12
+
+Backport of fix to make Syncplay work on Python 3.12.
+
+Source: https://github.com/Syncplay/syncplay/pull/636
+
+---
+ syncplay/ui/ConfigurationGetter.py | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/syncplay/ui/ConfigurationGetter.py b/syncplay/ui/ConfigurationGetter.py
+index 22525922..4b36ca4f 100755
+--- a/syncplay/ui/ConfigurationGetter.py
++++ b/syncplay/ui/ConfigurationGetter.py
+@@ -5,7 +5,7 @@
+ import re
+ import os
+ import sys
+-from configparser import SafeConfigParser, DEFAULTSECT
++from configparser import ConfigParser, DEFAULTSECT
+ 
+ from syncplay import constants, utils, version, milestone
+ from syncplay.messages import getMessage, setLanguage, isValidLanguage
+@@ -389,7 +389,7 @@ def _parseConfigFile(self, iniPath, createConfig=True):
+                 open(iniPath, 'w').close()
+             else:
+                 return
+-        parser.readfp(codecs.open(iniPath, "r", "utf_8_sig"))
++        parser.read(codecs.open(iniPath, "r", "utf_8_sig"))
+         for section, options in list(self._iniStructure.items()):
+             if parser.has_section(section):
+                 for option in options:
+@@ -432,7 +432,7 @@ def _saveConfig(self, iniPath):
+         if self._config['noStore']:
+             return
+         parser = SafeConfigParserUnicode(strict=False)
+-        parser.readfp(codecs.open(iniPath, "r", "utf_8_sig"))
++        parser.read(codecs.open(iniPath, "r", "utf_8_sig"))
+         for section, options in list(self._iniStructure.items()):
+             if not parser.has_section(section):
+                 parser.add_section(section)
+@@ -593,7 +593,7 @@ def setConfigOption(self, option, value):
+         self._config = backup
+ 
+ 
+-class SafeConfigParserUnicode(SafeConfigParser):
++class SafeConfigParserUnicode(ConfigParser):
+     def write(self, fp):
+         """Write an .ini-format representation of the configuration state."""
+         if self._defaults:
+
+From cc5a389faeb0a7edb9e6358400d6a37507e26dd4 Mon Sep 17 00:00:00 2001
+From: Floris Vastenhout <kilmanio@mailfence.com>
+Date: Tue, 10 Oct 2023 19:43:36 +0200
+Subject: [PATCH 2/2] Use read_file instead of read
+
+---
+ syncplay/ui/ConfigurationGetter.py | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/syncplay/ui/ConfigurationGetter.py b/syncplay/ui/ConfigurationGetter.py
+index 4b36ca4f..f0a7f32a 100755
+--- a/syncplay/ui/ConfigurationGetter.py
++++ b/syncplay/ui/ConfigurationGetter.py
+@@ -389,7 +389,7 @@ def _parseConfigFile(self, iniPath, createConfig=True):
+                 open(iniPath, 'w').close()
+             else:
+                 return
+-        parser.read(codecs.open(iniPath, "r", "utf_8_sig"))
++        parser.read_file(codecs.open(iniPath, "r", "utf_8_sig"))
+         for section, options in list(self._iniStructure.items()):
+             if parser.has_section(section):
+                 for option in options:
+@@ -432,7 +432,7 @@ def _saveConfig(self, iniPath):
+         if self._config['noStore']:
+             return
+         parser = SafeConfigParserUnicode(strict=False)
+-        parser.read(codecs.open(iniPath, "r", "utf_8_sig"))
++        parser.read_file(codecs.open(iniPath, "r", "utf_8_sig"))
+         for section, options in list(self._iniStructure.items()):
+             if not parser.has_section(section):
+                 parser.add_section(section)
+

--- a/srcpkgs/syncplay/template
+++ b/srcpkgs/syncplay/template
@@ -1,7 +1,7 @@
 # Template file for 'syncplay'
 pkgname=syncplay
 version=1.7.0
-revision=2
+revision=3
 build_style=gnu-makefile
 pycompile_dirs="usr/lib/syncplay/syncplay"
 depends="desktop-file-utils python3-pyside2 python3-Twisted


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

Since Void Linux now uses Python 3.12 as default, Syncplay broke. This backports the fix to make it work under Python 3.12.

Source: https://github.com/Syncplay/syncplay/pull/636

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, x86_64
-->
