### PR TITLE
python3-Cheroot: update to 9.0.0, new package dependency for tests

### DIFF
--- a/srcpkgs/python3-Cheroot/template
+++ b/srcpkgs/python3-Cheroot/template
@@ -1,18 +1,21 @@
 # Template file for 'python3-Cheroot'
 pkgname=python3-Cheroot
-version=8.4.5
-revision=4
+version=9.0.0
+revision=1
 build_style=python3-module
-hostmakedepends="python3-setuptools_scm"
-depends="python3-setuptools python3-six
- python3-more-itertools python3-jaraco.functools"
+make_check_args="--ignore cheroot/test/test_server.py" # requires pypy
+hostmakedepends="python3-setuptools python3-setuptools_scm"
+depends="python3-six python3-more-itertools python3-jaraco.functools"
+checkdepends="${depends} python3-jaraco.context python3-jaraco.text python3-pytest python3-pytest-forked
+ python3-pytest-mock python3-pytest-cov python3-pytest-sugar python3-pytest-xdist python3-pytest-rerunfailures
+ python3-watchdog python3-trustme python3-requests-toolbelt python3-requests-unixsocket python3-urllib3 python3-openssl python3-portend"
 short_desc="High-performance, pure-Python HTTP server (Python3)"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="BSD-3-Clause"
 homepage="https://github.com/cherrypy/cheroot"
 changelog="https://github.com/cherrypy/cheroot/blob/master/CHANGES.rst"
 distfiles="${PYPI_SITE}/c/cheroot/cheroot-${version}.tar.gz"
-checksum=b6c18caf5f79cdae668c35fc8309fc88ea4a964cce9e2ca8504fab13bcf57301
+checksum=3d47ad9ee19ecbec144b4758399036692fdbf67a40b96eef1fb1454367b3d338
 alternatives="cheroot:cheroot:/usr/bin/cheroot3"
 
 post_patch() {

--- a/srcpkgs/python3-pytest-rerunfailures/template
+++ b/srcpkgs/python3-pytest-rerunfailures/template
@@ -1,0 +1,19 @@
+# Template file for 'python3-pytest-rerunfailures'
+pkgname=python3-pytest-rerunfailures
+version=12.0
+revision=1
+build_style=python3-pep517
+hostmakedepends="python3-setuptools python3-wheel"
+depends="python3-pytest python3-packaging python3-importlib_metadata"
+checkdepends="python3-pytest-flake8 python3-pytest-black flake8"
+short_desc="Pytest plugin to re-run tests to eliminate intermittent failures"
+maintainer="Luciogi <lucigithubcommit@skiff.com>"
+license="MPL-2.0"
+homepage="https://github.com/pytest-dev/pytest-rerunfailures"
+changelog="https://raw.githubusercontent.com/pytest-dev/pytest-rerunfailures/master/CHANGES.rst"
+distfiles="${PYPI_SITE}/p/pytest-rerunfailures/pytest-rerunfailures-${version}.tar.gz"
+checksum=784f462fa87fe9bdf781d0027d856b47a4bfe6c12af108f6bd887057a917b48e
+
+post_install() {
+	vlicense LICENSE
+}


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**
#### Local build testing
- I built this PR locally for my native architecture, (x86_64-GLIBC)

## new dependency 
- `pytest-rerunfailures` for tests