### PR TITLE
common/xbps-src/shutils/chroot.sh: support importing other keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ etc/conf
 etc/conf.*
 etc/virtual
 etc/xbps.d/custom
+etc/repo-keys

--- a/README.md
+++ b/README.md
@@ -340,6 +340,9 @@ Each time a binary package is created, a package signature must be created with 
 
 > It is not possible to sign a repository with multiple RSA keys.
 
+If packages in `hostdir/binpkgs` are signed, the key in `.plist` format (as imported by xbps) can be placed
+in `etc/repo-keys/` to prevent xbps-src from prompting to import that key.
+
 <a name="rebuilding"></a>
 ### Rebuilding and overwriting existing local packages
 

--- a/common/xbps-src/shutils/chroot.sh
+++ b/common/xbps-src/shutils/chroot.sh
@@ -309,6 +309,9 @@ chroot_sync_repodata() {
     # Copy xbps repository keys to the masterdir.
     mkdir -p $XBPS_MASTERDIR/var/db/xbps/keys
     cp -f $XBPS_COMMONDIR/repo-keys/*.plist $XBPS_MASTERDIR/var/db/xbps/keys
+    if [ -n "$(shopt -s nullglob; echo "$XBPS_DISTDIR"/etc/repo-keys/*.plist)" ]; then
+        cp -f "$XBPS_DISTDIR"/etc/repo-keys/*.plist "$XBPS_MASTERDIR"/var/db/xbps/keys
+    fi
 
     # Make sure to sync index for remote repositories.
     if [ -z "$XBPS_SKIP_REMOTEREPOS" ]; then


### PR DESCRIPTION
When packages in `hostdir/binpkgs` are signed, it causes `xbps-src` to annoyingly request to import the associated key (every time, in the case of automation tools like `xxbuild` or `ymir`). This allows the user to add their personal public key `.plist` to `etc/repo-keys/` so this prompting does not happen.

#### Testing the changes
- I tested the changes in this PR: **YES**
