### PR TITLE
python3-stevedore: update to 5.1.0.

### DIFF
--- a/srcpkgs/python3-stevedore/template
+++ b/srcpkgs/python3-stevedore/template
@@ -1,16 +1,16 @@
 # Template file for 'python3-stevedore'
 pkgname=python3-stevedore
-version=3.2.0
-revision=5
-build_style=python3-module
-hostmakedepends="python3-setuptools python3-pbr"
+version=5.1.0
+revision=1
+build_style=python3-pep517
+hostmakedepends="python3-setuptools python3-wheel python3-pbr"
 depends="python3-six"
 short_desc="Manage dynamic plugins for Python3 applications"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="Apache-2.0"
-homepage="https://git.openstack.org/cgit/openstack/stevedore"
+homepage="https://docs.openstack.org/stevedore/latest/"
 distfiles="${PYPI_SITE}/s/stevedore/stevedore-${version}.tar.gz"
-checksum=38791aa5bed922b0a844513c5f9ed37774b68edc609e5ab8ab8d8fe0ce4315e5
+checksum=a54534acf9b89bc7ed264807013b505bf07f74dbe4bcfa37d32bd063870b087c
 
 pre_build() {
 	# remove dependency on pbr; it's not a runtime dependency


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
Fixes subliminal on python3.12