### PR TITLE
gzdoom: update to version 4.11.3 + patch fixing missing pk3files.

### DIFF
--- a/srcpkgs/gzdoom/patches/pk3location.patch
+++ b/srcpkgs/gzdoom/patches/pk3location.patch
@@ -1,0 +1,22 @@
+diff --git a/src/gameconfigfile.cpp b/src/gameconfigfile.cpp
+index 0b3931e..c6856cc 100644
+--- a/src/gameconfigfile.cpp
++++ b/src/gameconfigfile.cpp
+@@ -124,6 +124,8 @@ FGameConfigFile::FGameConfigFile ()
+ 		SetValueForKey ("Path", "/usr/local/share/doom", true);
+ 		SetValueForKey ("Path", "/usr/local/share/games/doom", true);
+ 		SetValueForKey ("Path", "/usr/share/doom", true);
++                // Adds the correct locations of the pk3file for Voidlinux
++		SetValueForKey ("Path", "/usr/share/gzdoom", true);
+ 		SetValueForKey ("Path", "/usr/share/games/doom", true);
+ #endif
+ 	}
+@@ -146,6 +148,8 @@ FGameConfigFile::FGameConfigFile ()
+ 		SetValueForKey ("Path", "/usr/local/share/doom", true);
+ 		SetValueForKey ("Path", "/usr/local/share/games/doom", true);
+ 		SetValueForKey ("Path", "/usr/share/doom", true);
++                // Adds the correct locations of the pk3file for Voidlinux
++		SetValueForKey ("Path", "/usr/share/gzdoom", true);
+ 		SetValueForKey ("Path", "/usr/share/games/doom", true);
+ #endif
+ 		SetValueForKey ("Path", "$DOOMWADDIR", true);

--- a/srcpkgs/gzdoom/template
+++ b/srcpkgs/gzdoom/template
@@ -1,6 +1,6 @@
 # Template file for 'gzdoom'
 pkgname=gzdoom
-version=4.11.0
+version=4.11.3
 revision=1
 archs="~i686* ~arm*"
 build_style=cmake
@@ -14,8 +14,8 @@ homepage="https://www.zdoom.org"
 # WARNING: watch out for new submodules
 distfiles="https://github.com/ZDoom/gzdoom/archive/g${version}.tar.gz
  https://github.com/ZDoom/gzdoom/releases/download/g${version}/gzdoom_${version}_amd64.deb"
-checksum="44a0aee6fa6b9cc2f5956bb98252708720b03ddf264821c487ce6af07cb204d7
- 23cec6b75612e106aa32dbf1e44dcddb5cce73d7476ab58da1af9429bcafeed4"
+checksum="5943dba50da20ff94f1fcc415132672d42a15917c571b1c2b7ceefe14935f5d5
+ 4c544d243dc15fc22000a3b6eabd83fd70f87ea63205a14ff04254c092f74642"
 skip_extraction="${pkgname}_${version}_amd64.deb"
 nocross=yes
 


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**


#### Local build testing
- I built this PR locally for my native architecture, (x64-GlibC)


Hey everyone!

This PR focuses on updating GZDoom, to v4.11.3, but it also brings a patch to fix gzdoom not being able to find pk3 files.