### PR TITLE
python3-dnsrecon: update to 1.1.5.

### DIFF
--- a/srcpkgs/python3-dnsrecon/patches/requirements.txt.diff
+++ b/srcpkgs/python3-dnsrecon/patches/requirements.txt.diff
@@ -1,0 +1,9 @@
+--- a/requirements.txt	2023-11-19 15:38:53.078304888 -0600
++++ b/requirements.txt	2023-11-19 16:00:30.710566194 -0600
+@@ -1,6 +1,3 @@
+ dnspython>=2.0.0
+ netaddr
+ lxml
+-flake8
+-pytest
+-

--- a/srcpkgs/python3-dnsrecon/template
+++ b/srcpkgs/python3-dnsrecon/template
@@ -1,14 +1,15 @@
 # Template file for 'python3-dnsrecon'
 pkgname=python3-dnsrecon
-version=1.1.4
-revision=2
+version=1.1.5
+revision=1
 build_style=python3-module
+make_check_args="-k not(test_zone_transfer)"
 hostmakedepends="python3-setuptools"
-depends="python3 python3-netaddr python3-dnspython python3-lxml python3-flake8 python3-setuptools"
-checkdepends="${depends} python3-pytest"
+depends="python3 python3-netaddr python3-dnspython python3-lxml"
+checkdepends="${depends} python3-flake8 python3-pyflakes python3-pytest"
 short_desc="DNS enumeration script"
 maintainer="Jason Elswick <jason@jasondavid.tv>"
 license="GPL-2.0-only"
 homepage="https://github.com/darkoperator/dnsrecon"
 distfiles="https://github.com/darkoperator/dnsrecon/archive/refs/tags/${version}.tar.gz"
-checksum=ef3a7969b2cf25d1a65a62043a8dbede73103920e2c17c72e8c1aa7c1cc467b2
+checksum=528881c6f2cf759ce91c895c19345768902c3fd811b05dbdfba864f5980aef9c

--- a/srcpkgs/python3-pyflakes/template
+++ b/srcpkgs/python3-pyflakes/template
@@ -1,7 +1,7 @@
 # Template file for 'python3-pyflakes'
 pkgname=python3-pyflakes
-version=3.0.1
-revision=2
+version=3.1.0
+revision=1
 build_style=python3-module
 hostmakedepends="python3-setuptools"
 depends="python3"
@@ -12,7 +12,7 @@ license="MIT"
 homepage="https://github.com/PyCQA/pyflakes"
 changelog="https://raw.githubusercontent.com/PyCQA/pyflakes/master/NEWS.rst"
 distfiles="${PYPI_SITE}/p/pyflakes/pyflakes-${version}.tar.gz"
-checksum=ec8b276a6b60bd80defed25add7e439881c19e64850afd9b346283d4165fd0fd
+checksum=a0aae034c444db0071aa077972ba4768d40c830d9539fd45bf4cd3f8f6992efc
 conflicts="python-pyflakes>=0"
 
 post_install() {


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: YES

Testing zone transfer in some cases fails. Runs when packaged without tests and other tests pass. Zone transfer is disabled for tests in this template.