### PR TITLE
dbeaver: update to 23.2.5.

### DIFF
--- a/srcpkgs/dbeaver/template
+++ b/srcpkgs/dbeaver/template
@@ -1,6 +1,6 @@
 # Template file for 'dbeaver'
 pkgname=dbeaver
-version=23.2.2
+version=23.2.5
 revision=1
 # the build downloads binaries linked to glibc
 archs="x86_64 aarch64"
@@ -12,7 +12,7 @@ license="Apache-2.0"
 homepage="https://dbeaver.io"
 changelog="https://dbeaver.io/news/"
 distfiles="https://github.com/dbeaver/dbeaver/archive/${version}.tar.gz"
-checksum=7bea1833a26e928e43f8dc977b8a09949b7b1c63959723e5c26d87e24a26dbdb
+checksum=f2ae503a5bba9f41bd2d9a477e493da158b4d7c2c4d02ca0d9d46c62f0b7f755
 nopie=true
 
 do_build() {
@@ -22,6 +22,11 @@ do_build() {
 do_install() {
 	vmkdir /usr/lib
 	vcopy "product/community/target/products/org.jkiss.dbeaver.core.product/linux/gtk/${XBPS_TARGET_MACHINE}/dbeaver" /usr/lib/
+
+	# Delete folders with Java Native Access .so's for different architectures
+	jna_dir="${DESTDIR}/usr/lib/dbeaver/plugins/com.sun.jna_5.13.0.v20230812-1000/com/sun/jna"
+	jna_arch="linux-${XBPS_TARGET_MACHINE//_/-}"
+	find "$jna_dir" -depth -mindepth 1 -type d -not -name $jna_arch -exec rm -rf {} \;
 
 	vmkdir /usr/bin
 	ln -s /usr/lib/dbeaver/dbeaver ${DESTDIR}/usr/bin/dbeaver


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

Since v23.2.3 DBeaver contains a new JNA plugin with .so libs for many architectures; delete the non-applicable arches.

Also needed to fix `=> ERROR: dbeaver-23.2.3_1: failed to strip /usr/lib/dbeaver/plugins/com.sun.jna_5.13.0.v20230812-1000/com/sun/jna/sunos-sparc/libjnidispatch.so`.