### PR TITLE
python3-ffmpeg-python: fix for py3.12

### DIFF
--- a/srcpkgs/python3-ffmpeg-python/patches/remove-future.patch
+++ b/srcpkgs/python3-ffmpeg-python/patches/remove-future.patch
@@ -1,0 +1,155 @@
+--- a/ffmpeg/_ffmpeg.py
++++ b/ffmpeg/_ffmpeg.py
+@@ -1,8 +1,5 @@
+ from __future__ import unicode_literals
+ 
+-from past.builtins import basestring
+-from ._utils import basestring
+-
+ from .nodes import (
+     filter_operator,
+     GlobalNode,
+@@ -81,7 +78,7 @@
+     """
+     streams_and_filename = list(streams_and_filename)
+     if 'filename' not in kwargs:
+-        if not isinstance(streams_and_filename[-1], basestring):
++        if not isinstance(streams_and_filename[-1], str):
+             raise ValueError('A filename must be provided')
+         kwargs['filename'] = streams_and_filename.pop(-1)
+     streams = streams_and_filename
+--- a/ffmpeg/_run.py
++++ b/ffmpeg/_run.py
+@@ -1,6 +1,6 @@
+ from __future__ import unicode_literals
+ from .dag import get_outgoing_edges, topo_sort
+-from ._utils import basestring, convert_kwargs_to_cmd_line_args
++from ._utils import convert_kwargs_to_cmd_line_args
+ from builtins import str
+ from functools import reduce
+ import collections
+@@ -136,7 +136,7 @@
+         args += ['-b:a', str(kwargs.pop('audio_bitrate'))]
+     if 'video_size' in kwargs:
+         video_size = kwargs.pop('video_size')
+-        if not isinstance(video_size, basestring) and isinstance(
++        if not isinstance(video_size, str) and isinstance(
+             video_size, collections.Iterable
+         ):
+             video_size = '{}x{}'.format(video_size[0], video_size[1])
+@@ -183,7 +183,7 @@
+     This is the same as calling :meth:`get_args` except that it also
+     includes the ``ffmpeg`` command as the first argument.
+     """
+-    if isinstance(cmd, basestring):
++    if isinstance(cmd, str):
+         cmd = [cmd]
+     elif type(cmd) != list:
+         cmd = list(cmd)
+--- a/ffmpeg/_utils.py
++++ b/ffmpeg/_utils.py
+@@ -1,25 +1,8 @@
+ from __future__ import unicode_literals
+ from builtins import str
+-from past.builtins import basestring
+ import hashlib
+ import sys
+ 
+-if sys.version_info.major == 2:
+-    # noinspection PyUnresolvedReferences,PyShadowingBuiltins
+-    str = str
+-
+-
+-# `past.builtins.basestring` module can't be imported on Python3 in some environments (Ubuntu).
+-# This code is copy-pasted from it to avoid crashes.
+-class BaseBaseString(type):
+-    def __instancecheck__(cls, instance):
+-        return isinstance(instance, (bytes, str))
+-
+-    def __subclasshook__(cls, thing):
+-        # TODO: What should go here?
+-        raise NotImplemented
+-
+-
+ def with_metaclass(meta, *bases):
+     class metaclass(meta):
+         __call__ = type.__call__
+@@ -33,26 +16,13 @@
+     return metaclass('temporary_class', None, {})
+ 
+ 
+-if sys.version_info.major >= 3:
+-
+-    class basestring(with_metaclass(BaseBaseString)):
+-        pass
+-
+-
+-else:
+-    # noinspection PyUnresolvedReferences,PyCompatibility
+-    from builtins import basestring
+-
+-
+ def _recursive_repr(item):
+     """Hack around python `repr` to deterministically represent dictionaries.
+ 
+     This is able to represent more things than json.dumps, since it does not require things to be JSON serializable
+     (e.g. datetimes).
+     """
+-    if isinstance(item, basestring):
+-        result = str(item)
+-    elif isinstance(item, list):
++    if isinstance(item, list):
+         result = '[{}]'.format(', '.join([_recursive_repr(x) for x in item]))
+     elif isinstance(item, dict):
+         kv_pairs = [
+--- a/ffmpeg/nodes.py
++++ b/ffmpeg/nodes.py
+@@ -1,6 +1,5 @@
+ from __future__ import unicode_literals
+ 
+-from past.builtins import basestring
+ from .dag import KwargReprNode
+ from ._utils import escape_chars, get_hash_int
+ from builtins import object
+@@ -66,7 +65,7 @@
+         """
+         if self.selector is not None:
+             raise ValueError('Stream already has a selector: {}'.format(self))
+-        elif not isinstance(index, basestring):
++        elif not isinstance(index, str):
+             raise TypeError("Expected string index (e.g. 'a'); got {!r}".format(index))
+         return self.node.stream(label=self.label, selector=index)
+ 
+--- a/ffmpeg/_run.py
++++ b/ffmpeg/_run.py
+@@ -3,7 +3,6 @@
+ from ._utils import convert_kwargs_to_cmd_line_args
+ from builtins import str
+ from functools import reduce
+-import collections
+ import copy
+ import operator
+ import subprocess
+@@ -18,6 +17,11 @@
+     output_operator,
+ )
+ 
++try:
++    from collections.abc import Iterable
++except ImportError:
++    from collections import Iterable
++
+ 
+ class Error(Exception):
+     def __init__(self, cmd, stdout, stderr):
+@@ -136,9 +140,7 @@
+         args += ['-b:a', str(kwargs.pop('audio_bitrate'))]
+     if 'video_size' in kwargs:
+         video_size = kwargs.pop('video_size')
+-        if not isinstance(video_size, str) and isinstance(
+-            video_size, collections.Iterable
+-        ):
++        if not isinstance(video_size, str) and isinstance(video_size, Iterable):
+             video_size = '{}x{}'.format(video_size[0], video_size[1])
+         args += ['-video_size', video_size]
+     args += convert_kwargs_to_cmd_line_args(kwargs)

--- a/srcpkgs/python3-ffmpeg-python/template
+++ b/srcpkgs/python3-ffmpeg-python/template
@@ -1,7 +1,7 @@
 # Template file for 'python3-ffmpeg-python'
 pkgname=python3-ffmpeg-python
 version=0.2.0
-revision=6
+revision=7
 build_style=python3-module
 hostmakedepends="python3-setuptools"
 depends="ffmpeg python3-future"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing

```
pkg                    host         target        cross  result
python3-ffmpeg-python  x86_64       x86_64        n      OK
python3-ffmpeg-python  x86_64-musl  x86_64-musl   n      OK
python3-ffmpeg-python  i686         i686          n      OK
python3-ffmpeg-python  x86_64       aarch64-musl  y      OK
python3-ffmpeg-python  x86_64       aarch64       y      OK
python3-ffmpeg-python  x86_64       armv7l-musl   y      OK
python3-ffmpeg-python  x86_64       armv7l        y      OK
python3-ffmpeg-python  x86_64       armv6l-musl   y      OK
python3-ffmpeg-python  x86_64       armv6l        y      OK
```

This fixes `ytmdl`.