### PR TITLE
android-udev-rules: depend on libmtp, as suggested by upstream

### DIFF
--- a/srcpkgs/android-udev-rules/template
+++ b/srcpkgs/android-udev-rules/template
@@ -1,7 +1,8 @@
 # Template file for 'android-udev-rules'
 pkgname=android-udev-rules
 version=20231104
-revision=1
+revision=2
+depends="libmtp"
 short_desc="Android udev rules list aimed to be the most comprehensive on the net"
 maintainer="Mohammed Anas <triallax@tutanota.com>"
 license="GPL-3.0-or-later"


### PR DESCRIPTION
- I tested the changes in this PR: yes

This was suggested by upstream in discussion https://github.com/M0Rf30/android-udev-rules/issues/295