### PR TITLE
zfs: update to 2.2.1.

### DIFF
--- a/srcpkgs/zfs/template
+++ b/srcpkgs/zfs/template
@@ -1,6 +1,6 @@
 # Template file for 'zfs'
 pkgname=zfs
-version=2.2.0
+version=2.2.1
 revision=1
 build_style=gnu-configure
 configure_args="--with-config=user --with-mounthelperdir=/usr/bin
@@ -16,7 +16,7 @@ maintainer="Toyam Cox <Vaelatern@voidlinux.org>"
 license="CDDL-1.0"
 homepage="https://openzfs.github.io/openzfs-docs/"
 distfiles="https://github.com/openzfs/zfs/releases/download/zfs-${version}/zfs-${version}.tar.gz"
-checksum=42035fd059faa25a09cd511b24a57b8ad1285cb69127f2a0043b98562c5ec690
+checksum=4ff2de43d39710283ae8ff1744aa96e6cdc83c8efe86a715294d4f6bc34a8e8e
 # dkms must be before initramfs-regenerate to build modules before images
 triggers="dkms initramfs-regenerate"
 dkms_modules="zfs ${version}"


### PR DESCRIPTION
Adds linux6.6 support, disables block cloning by default until the issues are fixed. It would be a good idea to get this merged quickly.

#### Testing the changes
- I tested the changes in this PR: **YES** (zfs on root with zfsbootmenu, linux6.1, pool fully upgraded, x86_64-glibc)

cc: @Vaelatern @zdykstra
