### PR TITLE
New package: distrobox-1.6.0.1-1

### DIFF
--- a/srcpkgs/distrobox/INSTALL.msg
+++ b/srcpkgs/distrobox/INSTALL.msg
@@ -1,0 +1,1 @@
+Distrobox requires one of 'docker' or 'podman' to be installed.

--- a/srcpkgs/distrobox/template
+++ b/srcpkgs/distrobox/template
@@ -1,0 +1,23 @@
+# Template file for 'distrobox'
+pkgname=distrobox
+version=1.6.0.1
+revision=1
+short_desc="Podman/Docker wrapper to use any linux distribution in your terminal"
+maintainer="klardotsh <josh@klar.sh>"
+license="GPL-3.0-or-later"
+homepage="https://distrobox.it"
+distfiles="https://github.com/89luca89/${pkgname}/archive/${version}.tar.gz"
+checksum=d6b1330b56f6a1bf844c26a27d87f39efd8ae088ed3063f6513d48cf9c18f57e
+
+do_install() {
+	./install --prefix "${DESTDIR}/usr"
+	vdoc docs/README.md
+	vdoc docs/compatibility.md
+	vdoc docs/featured_articles.md
+	vdoc docs/useful_tips.md
+	vdoc docs/posts/distrobox_custom.md
+	vdoc docs/posts/execute_commands_on_host.md
+	vdoc docs/posts/integrate_vscode_distrobox.md
+	vdoc docs/posts/run_latest_gnome_kde_on_distrobox.md
+	vdoc docs/posts/run_libvirt_in_distrobox.md
+}


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES** (I am currently using this `distrobox` package to manage my Discord, Zoom, and Steam containers on x86_64-musl)

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

Rationale for inclusion despite being all shell scripts:

- A reasonable, casual bystander would expect to be able to "just install distrobox", it's not intuitive to require someone who wants their container management to Just Work to have to clone a Git repo that runs a shell script to install to sometimes the homedir, sometimes `/usr/local`
- This project updates at a reasonable cadence with real version numbers and is not just a "toss it in a contrib folder in your `PATH` and forget about it" type of script
- With some USE flag tinkering, we could make this auto-depend on `docker` or `podman` (or the recently supported [`lilipod`](https://github.com/89luca89/lilipod) written by the same author), perhaps with subpackages to create the dependency links

I very much don't like the `short_desc` here but it's what upstream provides for a description, and I can't think of a clearer, short/terse wording right now to encompass the broader usecase for the tool (for example, I don't really use any CLI tools with this thing: I'm managing Steam and Discord through it, which I launch via exported `.desktop` files and my launcher...)

---

This is a continuation of work done by another packager in #42123 earlier this year.

Resolves #36341.