### PR TITLE
awsume: fix tests ; python3-boto3: update to1.29.6, fix tests ; python3-botocore: update to 1.32.6 

### DIFF
--- a/srcpkgs/awsume/template
+++ b/srcpkgs/awsume/template
@@ -4,9 +4,9 @@ version=4.5.3
 revision=4
 build_style=python3-module
 hostmakedepends="python3 python3-setuptools"
-makedepends="python3-argcomplete python3-boto3 python3-colorama python3-coverage
- python3-pluggy python3-psutil python3-xmltodict python3-yaml"
+makedepends="python3-boto3 python3-botocore python3-colorama python3-pluggy python3-psutil python3-xmltodict python3-yaml python-dateutil"
 depends="${makedepends}"
+checkdepends="${makedepends} python3-pytest"
 short_desc="Utility for easily assuming AWS IAM roles from the command line"
 maintainer="Leah Neukirchen <leah@vuxu.org>"
 license="MIT"

--- a/srcpkgs/python3-boto3/template
+++ b/srcpkgs/python3-boto3/template
@@ -1,16 +1,18 @@
 # Template file for 'python3-boto3'
 pkgname=python3-boto3
-version=1.28.20
-revision=2
+version=1.29.6
+revision=1
 build_style=python3-module
+make_check_args="--ignore=tests/integration" # These tests require aws credentials
 hostmakedepends="python3-setuptools"
-depends="python3"
+depends="python3-botocore python3-jmespath python3-s3transfer"
+checkdepends="${depends} python3-pytest python3-pytest-xdist"
 short_desc="Python interface to Amazon Web Services"
 maintainer="Leah Neukirchen <leah@vuxu.org>"
 license="MIT"
 homepage="https://github.com/boto/boto3"
 distfiles="https://github.com/boto/boto3/archive/${version}.tar.gz"
-checksum=aa4a8eb9735431a961f63928fb86fd36736c3fd01c77de7b1f1237328158aba4
+checksum=261957684a6f37ae227be7d38130aa3cbf2ae5e1cde9e39d856e58ff2310a854
 
 post_install() {
 	vlicense LICENSE

--- a/srcpkgs/python3-botocore/template
+++ b/srcpkgs/python3-botocore/template
@@ -1,7 +1,7 @@
 # Template file for 'python3-botocore'
 pkgname=python3-botocore
-version=1.24.33
-revision=3
+version=1.32.6
+revision=1
 build_style=python3-module
 # integration tests want aws credentials
 make_check_target="tests/functional tests/unit"
@@ -13,7 +13,7 @@ maintainer="Robert Lowry <bobertlo@gmail.com>"
 license="Apache-2.0"
 homepage="https://github.com/boto/botocore"
 distfiles="https://github.com/boto/botocore/archive/${version}.tar.gz"
-checksum=df97ad5dd13847d2684597798214bc35603c1bd9df7fef04ba5d583cb4229629
+checksum=f8526ef334400586bf5082573924f05fbc8f69b5ae00c4012a72cb84158414c5
 
 pre_check() {
 	rm -r tests/functional/leak # these 6 tests fail, probably fixable


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-GLIBC)

Note: awsume test requires, update for both `python3-boto3` and `python3-botocore`