### PR TITLE
canto-next: disable tests

### DIFF
--- a/srcpkgs/canto-next/template
+++ b/srcpkgs/canto-next/template
@@ -12,6 +12,7 @@ license="GPL-2.0-only"
 homepage="https://codezen.org/canto-ng/"
 distfiles="https://github.com/themoken/${pkgname}/archive/v${version}.tar.gz"
 checksum=647a6bc23423fcf465080f1c7e3c227c323c401447bd422ff01c1416c7e826ad
+make_check=no # tests are not compatible with setuptools
 
 post_install() {
 	rm -rf ${DESTDIR}/usr/lib/systemd


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**
#### Local build testing
- I built this PR locally for my native architecture, (x86_64-GLIBC)
