### PR TITLE
tor: update to 0.4.8.9, torsocks: depends on tor, adopt.

### DIFF
--- a/srcpkgs/tor/template
+++ b/srcpkgs/tor/template
@@ -1,19 +1,20 @@
 # Template file for 'tor'
 pkgname=tor
-version=0.4.8.7
+version=0.4.8.9
 revision=1
 build_style=gnu-configure
+configure_args="--enable-gpl"
 hostmakedepends="pkg-config"
 makedepends="libcap-devel libevent-devel libscrypt-devel libseccomp-devel liblzma-devel zlib-devel libzstd-devel"
-depends="ca-certificates torsocks"
+depends="ca-certificates"
 checkdepends="coccinelle python3"
 short_desc="Anonymizing overlay network"
 maintainer="Daniel Eyßer <daniel.eysser@gmail.com>"
-license="BSD-3-Clause"
+license="BSD-3-Clause, GPL-3.0-only"
 homepage="https://www.torproject.org/"
 changelog="https://gitlab.torproject.org/tpo/core/tor/-/raw/main/ChangeLog"
 distfiles="https://dist.torproject.org/tor-${version}.tar.gz"
-checksum=b20d2b9c74db28a00c07f090ee5b0241b2b684f3afdecccc6b8008931c557491
+checksum=59bb7d8890f6131b4ce5344f3dcea5deb2182b7f4f10ff0cb4e4d81f11b2cf65
 
 case "${XBPS_TARGET_MACHINE}" in
 	# Tests just don't work here

--- a/srcpkgs/torsocks/template
+++ b/srcpkgs/torsocks/template
@@ -1,15 +1,17 @@
 # Template file for 'torsocks'
 pkgname=torsocks
 version=2.4.0
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--disable-static"
 hostmakedepends="automake libtool pkg-config"
+depends="tor"
 conf_files="/etc/tor/torsocks.conf"
 short_desc="Transparent socks proxy for use with tor"
-maintainer="Orphaned <orphan@voidlinux.org>"
+maintainer="Daniel Eyßer <daniel.eysser@gmail.com>"
 license="GPL-2.0-only"
 homepage="https://gitlab.torproject.org/tpo/core/torsocks"
+changelog="https://gitlab.torproject.org/tpo/core/torsocks/-/raw/main/ChangeLog"
 distfiles="https://gitlab.torproject.org/tpo/core/torsocks/-/archive/v${version}/torsocks-v${version}.tar.bz2"
 checksum=54b2e3255b697fb69bb92388376419bcef1f94d511da3980f9ed5cd8a41df3a8
 


### PR DESCRIPTION
- tor: update to 0.4.8.9.
- torsocks: depends on tor, adopt.

Enable Proof of Work DoS mitigation module, this needs `--enable-gpl`.
More information here: https://blog.torproject.org/introducing-proof-of-work-defense-for-onion-services/

Also make `torsocks` depend on `tor` and not the other way round.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
