### PR TITLE
python3-rapidfuzz: update to 3.5.2

### DIFF
--- a/srcpkgs/python3-rapidfuzz/template
+++ b/srcpkgs/python3-rapidfuzz/template
@@ -1,6 +1,6 @@
 # Template file for 'python3-rapidfuzz'
 pkgname=python3-rapidfuzz
-version=3.4.0
+version=3.5.2
 revision=1
 build_style=python3-pep517
 hostmakedepends="cmake python3-scikit-build"
@@ -12,7 +12,7 @@ maintainer="chrysos349 <chrysostom349@gmail.com>"
 license="MIT"
 homepage="https://github.com/maxbachmann/rapidfuzz"
 distfiles="${PYPI_SITE}/r/rapidfuzz/rapidfuzz-${version}.tar.gz"
-checksum=a74112e2126b428c77db5e96f7ce34e91e750552147305b2d361122cbede2955
+checksum=9e9b395743e12c36a3167a3a9fd1b4e11d92fb0aa21ec98017ee6df639ed385e
 
 export CMAKE_ARGS="-DPython_INCLUDE_DIR:PATH=${XBPS_CROSS_BASE}/${py3_inc}"
 

--- a/srcpkgs/rapidfuzz-cpp/template
+++ b/srcpkgs/rapidfuzz-cpp/template
@@ -1,6 +1,6 @@
 # Template file for 'rapidfuzz-cpp'
 pkgname=rapidfuzz-cpp
-version=2.1.1
+version=2.2.3
 revision=1
 build_style=cmake
 short_desc="Rapid fuzzy string matching in C++ using the Levenshtein Distance"
@@ -8,7 +8,7 @@ maintainer="chrysos349 <chrysostom349@gmail.com>"
 license="MIT"
 homepage="https://github.com/maxbachmann/rapidfuzz-cpp"
 distfiles="https://github.com/maxbachmann/rapidfuzz-cpp/archive/v${version}.tar.gz"
-checksum=1680c0dbf77d228ea81825c24755db99ee0e21a8db3663b5136741b3e108c3f2
+checksum=df4412e9593945782de2212095bd4b70a8f8e63ae8f313976c616809be124d2c
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl x
  - armv7l x
  - armv6l-musl x
