### PR TITLE
zfs/zfs-lts: please do not eat my data

### DIFF
--- a/srcpkgs/zfs-lts/patches/default-zfs_dmu_offset_next_sync-to-off.patch
+++ b/srcpkgs/zfs-lts/patches/default-zfs_dmu_offset_next_sync-to-off.patch
@@ -1,0 +1,45 @@
+From 2b266bd36980caefe353411bd56b2487c44aeb6e Mon Sep 17 00:00:00 2001
+From: Sam James <sam@gentoo.org>
+Date: Fri, 24 Nov 2023 21:38:06 +0000
+Subject: [PATCH] Disable zfs_dmu_offset_next_sync tunable by default
+
+As a mitigation until more is understood and fixes are tested & reviewed, change
+the default of zfs_dmu_offset_next_sync from 1 to 0, as it was before
+05b3eb6d232009db247882a39d518e7282630753.
+
+There are no reported cases of The Bug being hit with zfs_dmu_offset_next_sync=1:
+that does not mean this is a cure or a real fix, but it _appears_ to be at least
+effective in reducing the chances of it happening. By itself, it's a safe change
+anyway, so it feels worth us doing while we wait.
+
+Bug: https://github.com/openzfs/zfs/issues/11900
+Bug: https://github.com/openzfs/zfs/issues/15526
+Bug: https://bugs.gentoo.org/917224
+Signed-off-by: Sam James <sam@gentoo.org>
+---
+diff --git a/man/man4/zfs.4 b/man/man4/zfs.4
+index 0c60a9c8e..8c14e670b 100644
+--- a/man/man4/zfs.4
++++ b/man/man4/zfs.4
+@@ -1646,7 +1646,7 @@ Allow no-operation writes.
+ The occurrence of nopwrites will further depend on other pool properties
+ .Pq i.a. the checksumming and compression algorithms .
+ .
+-.It Sy zfs_dmu_offset_next_sync Ns = Ns Sy 1 Ns | Ns 0 Pq int
++.It Sy zfs_dmu_offset_next_sync Ns = Ns Sy 0 Ns | Ns 1 Pq int
+ Enable forcing TXG sync to find holes.
+ When enabled forces ZFS to sync data when
+ .Sy SEEK_HOLE No or Sy SEEK_DATA
+diff --git a/module/zfs/dmu.c b/module/zfs/dmu.c
+index 96e98a42e..c1fd57c9e 100644
+--- a/module/zfs/dmu.c
++++ b/module/zfs/dmu.c
+@@ -80,7 +80,7 @@ unsigned long zfs_per_txg_dirty_frees_percent = 30;
+  * Disabling this option will result in holes never being reported in dirty
+  * files which is always safe.
+  */
+-int zfs_dmu_offset_next_sync = 1;
++int zfs_dmu_offset_next_sync = 0;
+ 
+ /*
+  * Limit the amount we can prefetch with one call to this amount.  This

--- a/srcpkgs/zfs-lts/template
+++ b/srcpkgs/zfs-lts/template
@@ -1,7 +1,7 @@
 # Template file for 'zfs-lts'
 pkgname=zfs-lts
 version=2.1.13
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--with-config=user --with-mounthelperdir=/usr/bin
  --with-udevdir=/usr/lib/udev --with-udevruledir=/usr/lib/udev/rules.d

--- a/srcpkgs/zfs/patches/default-zfs_dmu_offset_next_sync-to-off.patch
+++ b/srcpkgs/zfs/patches/default-zfs_dmu_offset_next_sync-to-off.patch
@@ -1,0 +1,51 @@
+From 2b266bd36980caefe353411bd56b2487c44aeb6e Mon Sep 17 00:00:00 2001
+From: Sam James <sam@gentoo.org>
+Date: Fri, 24 Nov 2023 21:38:06 +0000
+Subject: [PATCH] Disable zfs_dmu_offset_next_sync tunable by default
+
+As a mitigation until more is understood and fixes are tested & reviewed, change
+the default of zfs_dmu_offset_next_sync from 1 to 0, as it was before
+05b3eb6d232009db247882a39d518e7282630753.
+
+There are no reported cases of The Bug being hit with zfs_dmu_offset_next_sync=1:
+that does not mean this is a cure or a real fix, but it _appears_ to be at least
+effective in reducing the chances of it happening. By itself, it's a safe change
+anyway, so it feels worth us doing while we wait.
+
+Bug: https://github.com/openzfs/zfs/issues/11900
+Bug: https://github.com/openzfs/zfs/issues/15526
+Bug: https://bugs.gentoo.org/917224
+Signed-off-by: Sam James <sam@gentoo.org>
+---
+ man/man4/zfs.4   | 2 +-
+ module/zfs/dmu.c | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/man/man4/zfs.4 b/man/man4/zfs.4
+index 5daf27e9d..d70c8921c 100644
+--- a/man/man4/zfs.4
++++ b/man/man4/zfs.4
+@@ -1677,7 +1677,7 @@ Allow no-operation writes.
+ The occurrence of nopwrites will further depend on other pool properties
+ .Pq i.a. the checksumming and compression algorithms .
+ .
+-.It Sy zfs_dmu_offset_next_sync Ns = Ns Sy 1 Ns | Ns 0 Pq int
++.It Sy zfs_dmu_offset_next_sync Ns = Ns Sy 0 Ns | Ns 1 Pq int
+ Enable forcing TXG sync to find holes.
+ When enabled forces ZFS to sync data when
+ .Sy SEEK_HOLE No or Sy SEEK_DATA
+diff --git a/module/zfs/dmu.c b/module/zfs/dmu.c
+index a63aac51f..2cdbd4dc5 100644
+--- a/module/zfs/dmu.c
++++ b/module/zfs/dmu.c
+@@ -82,7 +82,7 @@ static uint_t zfs_per_txg_dirty_frees_percent = 30;
+  * Disabling this option will result in holes never being reported in dirty
+  * files which is always safe.
+  */
+-static int zfs_dmu_offset_next_sync = 1;
++static int zfs_dmu_offset_next_sync = 0;
+ 
+ /*
+  * Limit the amount we can prefetch with one call to this amount.  This
+-- 
+2.43.0

--- a/srcpkgs/zfs/template
+++ b/srcpkgs/zfs/template
@@ -1,7 +1,7 @@
 # Template file for 'zfs'
 pkgname=zfs
 version=2.2.1
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--with-config=user --with-mounthelperdir=/usr/bin
  --with-udevdir=/usr/lib/udev --with-udevruledir=/usr/lib/udev/rules.d


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

While OpenZFS tracks down providing files with a surplus of zeros, we should disable a relevant tunable by default that mitigates the damage.