### PR TITLE
libdisplay-info: add missing shlib

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -4275,3 +4275,4 @@ libgeotiff.so.5 libgeotiff-1.7.1_1
 libdraco.so.8 draco-1.5.6_1
 libpdal_base.so.15 libpdal-2.5.6_1
 libpdal_util.so.15 libpdal-2.5.6_1
+libdisplay-info.so.1 libdisplay-info-0.1.1_1


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

Found when testing wlroots 0.17

#### Testing the changes
- I tested the changes in this PR: **YES**

cc @Johnnynator 

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
