### PR TITLE
Backblaze-b2: Patch TQDM version

### DIFF
--- a/srcpkgs/backblaze-b2/patches/tqdm_ver.patch
+++ b/srcpkgs/backblaze-b2/patches/tqdm_ver.patch
@@ -1,0 +1,10 @@
+Upstream builds with the newer version of tqdm, but upstream hasn't updated their requirements.txt
+
+--- a/requirements.txt
++++ b/requirements.txt
+@@ -7,4 +7,4 @@
+ phx-class-registry~=4.0
+ rst2ansi==0.1.5
+ tabulate==0.9.0
+-tqdm~=4.65.0
++tqdm>=4.65.0

--- a/srcpkgs/backblaze-b2/template
+++ b/srcpkgs/backblaze-b2/template
@@ -1,7 +1,7 @@
 # Template file for 'backblaze-b2'
 pkgname=backblaze-b2
 version=3.11.0
-revision=2
+revision=3
 build_style=python3-module
 hostmakedepends="python3-setuptools_scm python3-wheel"
 depends="python3-Arrow python3-b2sdk python3-docutils


### PR DESCRIPTION
Allows package to build with newer version of tqdm in void-packages. Upstream has a dependabot pull that passed all their tests, but is not merged yet.

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64 glibc)

Closes #47348 
