### PR TITLE
lapack: update to 3.12.0.

### DIFF
--- a/srcpkgs/lapack/template
+++ b/srcpkgs/lapack/template
@@ -1,6 +1,6 @@
 # Template file for 'lapack'
 pkgname=lapack
-version=3.11
+version=3.12.0
 revision=1
 build_style=cmake
 configure_args="-DCMAKE_SKIP_RPATH=ON -DCMAKE_VERBOSE_MAKEFILE=ON
@@ -12,7 +12,7 @@ license="BSD-3-Clause"
 homepage="https://netlib.org/lapack/"
 changelog="https://netlib.org/lapack/release_notes.html"
 distfiles="https://github.com/Reference-LAPACK/lapack/archive/v${version}.tar.gz"
-checksum=5a5b3bac27709d8c66286b7a0d1d7bf2d7170ec189a1a756fdf812c97aa7fd10
+checksum=eac9570f8e0ad6f30ce4b963f4f033f0f643e7c3912fc9ee6cd99120675ad48b
 
 if [ "$CROSS_BUILD" ]; then
 	configure_args+=" -DTEST_FORTRAN_COMPILER=OFF"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
