### PR TITLE
dooble: update to 2023.11.30 migrate to qt6

### DIFF
--- a/srcpkgs/dooble/template
+++ b/srcpkgs/dooble/template
@@ -1,22 +1,22 @@
 # Template file for 'dooble'
 pkgname=dooble
-version=2023.08.30
+version=2023.11.30
 revision=1
 build_style=qmake
 configure_args="dooble.pro"
-hostmakedepends="qt5-qmake qt5-host-tools qt5-webengine"
-makedepends="qt5-charts-devel qt5-webengine-devel qt5-webchannel-devel qt5-location-devel"
-depends="qt5-plugin-sqlite"
+hostmakedepends="qt6-webengine qt6-declarative-devel"
+makedepends="qt6-charts-devel qt6-webengine-devel qt6-webchannel-devel qt6-location-devel qt6-charts-devel qt6-wayland python3-QtPy"
+depends="glibc libgcc libstdc++ qt6-charts qt6-core qt6-declarative qt6-gui qt6-network qt6-plugin-sqlite qt6-printsupport qt6-sql qt6-webengine qt6-widgets"
 short_desc="Dooble, the scientific browser. Minimal, cute, and unusually stable"
 maintainer="Eloi Torrents <eloitor@disroot.org>"
 license="BSD-3-Clause"
 homepage="https://textbrowser.github.io/dooble/"
 distfiles="https://github.com/textbrowser/dooble/archive/refs/tags/${version}.tar.gz"
-checksum=d430cbc8fcbe7627d7494bd995d7e88beb728cd94bf4d3039cb3718e685391a7
+checksum=bc8d930f929111d8eb29e4d830b96ac9f2608be5d7a33e9a24d6efba637f213f
 
 do_install() {
 	vbin Dooble dooble
-	vinstall dooble.desktop 644 usr/share/applications
+	vinstall Distributions/dooble.desktop 644 usr/share/applications
 	vinstall Icons/Logo/dooble.png 644 usr/share/pixmaps
 	vmkdir usr/share/dooble/translations
 	vcopy "Translations/dooble_*.qm" usr/share/dooble/translations


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)

closes #45924 