### PR TITLE
[RFC] Fix alternatives for openjdk{11,17}

### DIFF
--- a/srcpkgs/jmol/template
+++ b/srcpkgs/jmol/template
@@ -2,7 +2,7 @@
 pkgname=jmol
 version=16.1.9
 revision=1
-depends="virtual?java-environment"
+depends="virtual?java-runtime"
 short_desc="Open-source Java/JavaScript-based molecule viewer"
 maintainer="Brenton Horne <brentonhorne77@gmail.com>"
 license="LGPL-2.1-or-later"

--- a/srcpkgs/openjdk11/template
+++ b/srcpkgs/openjdk11/template
@@ -77,7 +77,6 @@ alternatives="
  jdk:/usr/bin/jaotc:/${_jdk_home}/bin/jaotc
  jdk:/usr/bin/jar:/${_jdk_home}/bin/jar
  jdk:/usr/bin/jarsigner:/${_jdk_home}/bin/jarsigner
- jdk:/usr/bin/java:/${_jdk_home}/bin/java
  jdk:/usr/bin/javac:/${_jdk_home}/bin/javac
  jdk:/usr/bin/javadoc:/${_jdk_home}/bin/javadoc
  jdk:/usr/bin/javap:/${_jdk_home}/bin/javap
@@ -86,10 +85,10 @@ alternatives="
  jdk:/usr/bin/jdb:/${_jdk_home}/bin/jdb
  jdk:/usr/bin/jdeprscan:/${_jdk_home}/bin/jdeprscan
  jdk:/usr/bin/jdeps:/${_jdk_home}/bin/jdeps
+ jdk:/usr/bin/jfr:/${_jdk_home}/bin/jfr
  jdk:/usr/bin/jhsdb:/${_jdk_home}/bin/jhsdb
  jdk:/usr/bin/jimage:/${_jdk_home}/bin/jimage
  jdk:/usr/bin/jinfo:/${_jdk_home}/bin/jinfo
- jdk:/usr/bin/jjs:/${_jdk_home}/bin/jjs
  jdk:/usr/bin/jlink:/${_jdk_home}/bin/jlink
  jdk:/usr/bin/jmap:/${_jdk_home}/bin/jmap
  jdk:/usr/bin/jmod:/${_jdk_home}/bin/jmod
@@ -99,13 +98,8 @@ alternatives="
  jdk:/usr/bin/jstack:/${_jdk_home}/bin/jstack
  jdk:/usr/bin/jstat:/${_jdk_home}/bin/jstat
  jdk:/usr/bin/jstatd:/${_jdk_home}/bin/jstatd
- jdk:/usr/bin/keytool:/${_jdk_home}/bin/keytool
- jdk:/usr/bin/pack200:/${_jdk_home}/bin/pack200
  jdk:/usr/bin/rmic:/${_jdk_home}/bin/rmic
- jdk:/usr/bin/rmid:/${_jdk_home}/bin/rmid
- jdk:/usr/bin/rmiregistry:/${_jdk_home}/bin/rmiregistry
  jdk:/usr/bin/serialver:/${_jdk_home}/bin/serialver
- jdk:/usr/bin/unpack200:/${_jdk_home}/bin/unpack200
 "
 
 post_extract() {

--- a/srcpkgs/openjdk17/template
+++ b/srcpkgs/openjdk17/template
@@ -86,7 +86,6 @@ fi
 alternatives="
  jdk:/usr/bin/jar:/${_jdk_home}/bin/jar
  jdk:/usr/bin/jarsigner:/${_jdk_home}/bin/jarsigner
- jdk:/usr/bin/java:/${_jdk_home}/bin/java
  jdk:/usr/bin/javac:/${_jdk_home}/bin/javac
  jdk:/usr/bin/javadoc:/${_jdk_home}/bin/javadoc
  jdk:/usr/bin/javap:/${_jdk_home}/bin/javap
@@ -95,7 +94,6 @@ alternatives="
  jdk:/usr/bin/jdb:/${_jdk_home}/bin/jdb
  jdk:/usr/bin/jdeprscan:/${_jdk_home}/bin/jdeprscan
  jdk:/usr/bin/jdeps:/${_jdk_home}/bin/jdeps
- jdk:/usr/bin/jfr:/${_jdk_home}/bin/jfr
  jdk:/usr/bin/jhsdb:/${_jdk_home}/bin/jhsdb
  jdk:/usr/bin/jimage:/${_jdk_home}/bin/jimage
  jdk:/usr/bin/jinfo:/${_jdk_home}/bin/jinfo
@@ -109,8 +107,6 @@ alternatives="
  jdk:/usr/bin/jstack:/${_jdk_home}/bin/jstack
  jdk:/usr/bin/jstat:/${_jdk_home}/bin/jstat
  jdk:/usr/bin/jstatd:/${_jdk_home}/bin/jstatd
- jdk:/usr/bin/keytool:/${_jdk_home}/bin/keytool
- jdk:/usr/bin/rmiregistry:/${_jdk_home}/bin/rmiregistry
  jdk:/usr/bin/serialver:/${_jdk_home}/bin/serialver
 "
 


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

Make sure alternatives for openjdk match the files that are shipped, to fix an issue with disappearing `/usr/bin/java`.

Steps to reproduce:
 - install `openjdk11-jre` so there is a symlink `/usr/bin/java -> ../lib/jvm/openjdk11/bin/java`
 - install `openjdk11` so the alternative switches from `java` to `jdk`, which also makes a symlink `/usr/bin/java -> ../lib/jvm/openjdk11/bin/java`
 - uninstall `openjdk11` so the alternative switches back from `jdk` to `java`. The symlink will be removed for `jdk` but not added back for `java`.

Arguably this is a bug in `xbps-alternatives`, but it doesn't seem ok for a package to provide an alternative for a file it doesn't contain (or for two packages to provide the exact same alternative.

However, I'm not sure this is ok. What happens if one tries to use `jdk` alternative from one version and `java` alternative from a different version? Maybe that's the reason why this was set up this way. Thus the [RFC]. I also didn't bump the revision, let me know if I should do that or just fix it and wait for a next update.

I found this while installing and uninstalling `jmol` which depends on `java-environment`, thus `openjdk11` would be installed/uninstalled breaking `/bin/java` for me. I also think `jmol` should not depend on java-environment but that java-runtime should be good enough (it seems to run ok; I don't use it directly but only through sage which uses it sometimes to create png files). So I added a commit here to that effect, but of course I could move that to a separate PR.

Ping: @mhmdanas @classabbyamp since you often update these.

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
