### PR TITLE
python3-bitstring: update to 4.1.4; python3-bitarray: update to 2.9.2.

### DIFF
--- a/srcpkgs/python3-bitarray/template
+++ b/srcpkgs/python3-bitarray/template
@@ -1,7 +1,7 @@
 # Template file for 'python3-bitarray'
 pkgname=python3-bitarray
-version=2.6.0
-revision=3
+version=2.9.2
+revision=1
 build_style=python3-module
 hostmakedepends="python3-setuptools"
 makedepends="python3-devel libcurl-devel"
@@ -11,7 +11,7 @@ maintainer="Toyam Cox <Vaelatern@voidlinux.org>"
 license="Python-2.0"
 homepage="https://github.com/ilanschnell/bitarray"
 distfiles="https://github.com/ilanschnell/bitarray/archive/${version}.tar.gz"
-checksum=32fc30c0ca8ae86bdbfbc0e77fb3c813695022a22cfea05f31c7af545fc15ff7
+checksum=33c5ff01fa0241d34dcea34efc7bbb86ebcb3ad28946e23fc4970642f4554ac5
 
 post_install() {
 	vlicense LICENSE

--- a/srcpkgs/python3-bitstring/template
+++ b/srcpkgs/python3-bitstring/template
@@ -1,16 +1,17 @@
 # Template file for 'python3-bitstring'
 pkgname=python3-bitstring
-version=4.0.2
-revision=2
+version=4.1.4
+revision=1
 build_style=python3-pep517
 hostmakedepends="python3-setuptools python3-wheel"
-depends="python3"
+depends="python3-bitarray"
+checkdepends="python3-bitarray"
 short_desc="Python module for creation and analysis of binary data"
 maintainer="Arjan Mossel <arjanmossel@gmail.com>"
 license="MIT"
 homepage="https://github.com/scott-griffiths/bitstring"
 distfiles="${PYPI_SITE}/b/bitstring/bitstring-${version}.tar.gz"
-checksum=a391db8828ac4485dd5ce72c80b27ebac3e7b989631359959e310cd9729723b2
+checksum=94f3f1c45383ebe8fd4a359424ffeb75c2f290760ae8fcac421b44f89ac85213
 
 do_check() {
 	python -m unittest


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Notes

- python3-bitstring >= 4.1.0 depends on python3-bitarray >= 2.8.0
