### PR TITLE
build-helper/rust.sh: prevent stripping by cargo

### DIFF
--- a/common/build-helper/rust.sh
+++ b/common/build-helper/rust.sh
@@ -30,6 +30,9 @@ else
 	unset CARGO_BUILD_TARGET
 fi
 
+# prevent cargo stripping debug symbols
+export CARGO_PROFILE_RELEASE_STRIP=false
+
 # For cross-compiling rust -sys crates
 export PKG_CONFIG_ALLOW_CROSS=1
 


### PR DESCRIPTION
Some rust pacakges (e.g. eza and bat) do set strip = true
in their release profile which removes the debug symbols
before xbps-src can split them.

closes #47459
