### PR TITLE
libblockdev: update to 3.0.4.

### DIFF
--- a/srcpkgs/libblockdev/template
+++ b/srcpkgs/libblockdev/template
@@ -1,7 +1,7 @@
 # Template file for 'libblockdev'
 pkgname=libblockdev
-version=3.0.3
-revision=2
+version=3.0.4
+revision=1
 build_style=gnu-configure
 make_check_target="test"
 hostmakedepends="pkg-config python3-setuptools"
@@ -16,7 +16,7 @@ homepage="https://github.com/storaged-project/libblockdev"
 # changelog needs to be adjusted on major version changes
 changelog="https://raw.githubusercontent.com/storaged-project/libblockdev/master/NEWS.rst"
 distfiles="https://github.com/storaged-project/libblockdev/releases/download/${version}-1/libblockdev-${version}.tar.gz"
-checksum=0f2872830293f3e222832903d80de4c38e06a9c3ea18915b3263272a72095ea8
+checksum=49841ff92db0ab032931e6f2b5eab63e5969b0ddc14b067b60e46a6eb6c60e47
 conf_files="/etc/libblockdev/3/conf.d/10-lvm-dbus.cfg
  /etc/libblockdev/3/conf.d/00-default.cfg"
 # Requires root.


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
