### PR TITLE
linux-firmware: update to 20231111.

### DIFF
--- a/srcpkgs/linux-firmware/template
+++ b/srcpkgs/linux-firmware/template
@@ -1,14 +1,15 @@
 # Template file for 'linux-firmware'
 pkgname=linux-firmware
-version=20230804
+version=20231111
 revision=1
+hostmakedepends="rdfind which"
 depends="linux-firmware-amd>=${version}_${revision} linux-firmware-network>=${version}_${revision}"
 short_desc="Binary firmware blobs for the Linux kernel"
 maintainer="Érico Nogueira <ericonr@disroot.org>"
 license="custom:see /usr/share/licenses/linux-firmware"
 homepage="https://www.kernel.org/"
 distfiles="https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git/snapshot/linux-firmware-${version}.tar.gz"
-checksum=c09913f675bea9623798eebf8b238cda49b62dfa1729cc7c2c17193b0ab22ff7
+checksum=80bfc46e3fc43820331a965354f5a3a9b478df90b07e2f39d9ddebc67ae0b23a
 python_version=3
 nostrip=yes
 


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

The next tagged version of linux-firmware can do away with `rdfind` and `which` as makedepends - https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git/log/copy-firmware.sh . 