### PR TITLE
osc: update to 1.5.0

### DIFF
--- a/srcpkgs/osc/template
+++ b/srcpkgs/osc/template
@@ -1,6 +1,6 @@
 # Template file for 'osc'
 pkgname=osc
-version=1.4.2
+version=1.5.0
 revision=1
 build_style=python3-module
 hostmakedepends="python3-setuptools python3-cryptography python3-devel
@@ -13,4 +13,4 @@ license="GPL-2.0-or-later"
 homepage="https://github.com/openSUSE/osc"
 changelog="https://raw.githubusercontent.com/openSUSE/osc/master/NEWS"
 distfiles="https://github.com/openSUSE/osc/archive/refs/tags/${version}.tar.gz"
-checksum=f5990b3f63fd085ff0d10af12581f8b37d65c3fdcdc56b9263fff85adaef2d33
+checksum=7d3be5b17338f11767441c451c50137356756b51786d0296e751f2fef1c87e27


### PR DESCRIPTION
- I tested the changes in this PR: **YES**
- I built this PR locally for my native architecture, (x86_64-glibc)