### PR TITLE
Update python3-pytest-timeout and python3-pytest-aiohttp pytest modules

### DIFF
--- a/srcpkgs/python3-pytest-aiohttp/template
+++ b/srcpkgs/python3-pytest-aiohttp/template
@@ -1,7 +1,7 @@
 # Template file for 'python3-pytest-aiohttp'
 pkgname=python3-pytest-aiohttp
-version=1.0.4
-revision=3
+version=1.0.5
+revision=1
 build_style=python3-module
 hostmakedepends="python3-setuptools_scm python3-wheel"
 depends="python3-pytest python3-aiohttp python3-pytest-asyncio"
@@ -11,6 +11,6 @@ maintainer="Tim Sandquist <tim.sandquist@gmail.com>"
 license="Apache-2.0"
 homepage="https://github.com/aio-libs/pytest-aiohttp/"
 distfiles="${PYPI_SITE}/p/pytest-aiohttp/pytest-aiohttp-${version}.tar.gz"
-checksum=39ff3a0d15484c01d1436cbedad575c6eafbf0f57cdf76fb94994c97b5b8c5a4
+checksum=880262bc5951e934463b15e3af8bb298f11f7d4d3ebac970aab425aff10a780a
 # Tests require package be installed (but they succeed in that case)
 make_check=no

--- a/srcpkgs/python3-pytest-timeout/template
+++ b/srcpkgs/python3-pytest-timeout/template
@@ -1,7 +1,7 @@
 # Template file for 'python3-pytest-timeout'
 pkgname=python3-pytest-timeout
-version=2.1.0
-revision=3
+version=2.2.0
+revision=1
 build_style=python3-module
 hostmakedepends="python3-setuptools"
 depends="python3-pytest"
@@ -11,7 +11,7 @@ maintainer="Tim Sandquist <tim.sandquist@gmail.com>"
 license="MIT"
 homepage="https://github.com/pytest-dev/pytest-timeout/"
 distfiles="${PYPI_SITE}/p/pytest-timeout/pytest-timeout-${version}.tar.gz"
-checksum=c07ca07404c612f8abbe22294b23c368e2e5104b521c1790195561f37e1ac3d9
+checksum=3b0b95dabf3cb50bac9ef5ca912fa0cfc286526af17afc806824df20c2f72c90
 # Tests require package to be installed
 make_check=no
 


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**
- Since these are pytest modules I ran the gns3-server tests to verify these versions work.

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
