### PR TITLE
python3-prompt_toolkit: disable workaround for ipython 8.18

### DIFF
--- a/srcpkgs/python3-prompt_toolkit/patches/1821-disable_workaround_for_ipython_8.18.patch
+++ b/srcpkgs/python3-prompt_toolkit/patches/1821-disable_workaround_for_ipython_8.18.patch
@@ -1,0 +1,23 @@
+From 55a45b1d19330a939d5df5a33671c10d52e11477 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Gonzalo=20Tornar=C3=ADa?= <tornaria@cmat.edu.uy>
+Date: Mon, 27 Nov 2023 11:10:21 -0300
+Subject: [PATCH] Disable workaround for ipython >= 8.18
+
+---
+ src/prompt_toolkit/application/application.py | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/src/prompt_toolkit/application/application.py b/src/prompt_toolkit/application/application.py
+index 726fc0a06..c07ea4e94 100644
+--- a/src/prompt_toolkit/application/application.py
++++ b/src/prompt_toolkit/application/application.py
+@@ -960,7 +960,8 @@ def run_in_thread() -> None:
+         def _called_from_ipython() -> bool:
+             try:
+                 return (
+-                    "IPython/terminal/interactiveshell.py"
++                    sys.modules["IPython"].version_info < (8, 18, 0, "")
++                    and "IPython/terminal/interactiveshell.py"
+                     in sys._getframe(3).f_code.co_filename
+                 )
+             except BaseException:

--- a/srcpkgs/python3-prompt_toolkit/template
+++ b/srcpkgs/python3-prompt_toolkit/template
@@ -1,7 +1,7 @@
 # Template file for 'python3-prompt_toolkit'
 pkgname=python3-prompt_toolkit
 version=3.0.41
-revision=1
+revision=2
 build_style=python3-module
 hostmakedepends="python3-setuptools"
 depends="python3-wcwidth"


### PR DESCRIPTION
See:
https://github.com/prompt-toolkit/python-prompt-toolkit/pull/1811#issuecomment-1827043359 https://github.com/prompt-toolkit/python-prompt-toolkit/pull/1821

Since the update to `prompt_toolkit-3.0.41_1` we get:
```
$ sage
┌────────────────────────────────────────────────────────────────────┐
│ SageMath version 10.1, Release Date: 2023-08-20                    │
│ Using Python 3.12.0. Type "help()" for help.                       │
└────────────────────────────────────────────────────────────────────┘
/usr/lib/python3.12/site-packages/prompt_toolkit/application/application.py:988: DeprecationWarning: There is no current event loop
  loop = asyncio.get_event_loop()
```

This is due to https://github.com/prompt-toolkit/python-prompt-toolkit/pull/1811, which works around an issue with ipython <= 8.17. Since we already ship ipython 8.18 we can safely remove the workaround.

Note that I proposed this upstream and I was asked to do a PR, the patch here is taken from https://github.com/prompt-toolkit/python-prompt-toolkit/pull/1821.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

Cc: @ahesford 
<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
