### PR TITLE
Ansible: ansible-core 2.16 and ansible 9.0.1 update with native python 3.12 support

### DIFF
--- a/srcpkgs/ansible-core/template
+++ b/srcpkgs/ansible-core/template
@@ -1,7 +1,7 @@
 # Template file for 'ansible-core'
 pkgname=ansible-core
-version=2.15.0
-revision=2
+version=2.16.0
+revision=1
 hostmakedepends="python3-setuptools python3-wheel python3-packaging
  python3-straight.plugin python3-docutils python3-Jinja2 python3-yaml"
 depends="python3-cryptography python3-Jinja2 python3-paramiko python3-yaml
@@ -15,7 +15,7 @@ license="GPL-3.0-or-later"
 homepage="https://www.ansible.com/"
 changelog="https://raw.githubusercontent.com/ansible/ansible/stable-${version%.*}/changelogs/CHANGELOG-v${version%.*}.rst"
 distfiles="${PYPI_SITE}/a/ansible-core/ansible-core-${version}.tar.gz"
-checksum=cf690fd4ebb40590e00c5acdc0624758ca4c58d1e4b2b02ec026a034070ebf4d
+checksum=b4a6c60fbc2f51e3ae68ec733c931ef957a04d7c8c92aa39242990b0f8adf149
 conflicts="ansible<2.10.1_1"
 replaces="ansible-base<2.11.0_1"
 
@@ -30,13 +30,11 @@ do_check() {
 do_install() {
 	python setup.py install --root="${DESTDIR}"
 
-	make docs
-	for page in docs/man/man1/*.1; do
+	mkdir man
+	./packaging/cli-doc/build.py man --output-dir man
+	for page in man/*.1; do
 		vman ${page}
 	done
-
-	vsconf examples/ansible.cfg
-	vsconf examples/hosts
 }
 
 ansible-base_package() {

--- a/srcpkgs/ansible/template
+++ b/srcpkgs/ansible/template
@@ -1,7 +1,7 @@
 # Template file for 'ansible'
 pkgname=ansible
-version=8.0.0
-revision=2
+version=9.0.1
+revision=1
 build_style="python3-pep517"
 hostmakedepends="python3-setuptools python3-wheel"
 depends="ansible-core"
@@ -10,6 +10,6 @@ maintainer="Jan Christian Grünhage <jan.christian@gruenhage.xyz>"
 license="GPL-3.0-or-later"
 homepage="https://www.ansible.com/"
 distfiles="${PYPI_SITE}/a/ansible/ansible-${version}.tar.gz"
-checksum=8670c7c46021c188cac235e9fde7adadbb3c380c2436a3b0c1c493c4ba10bcab
+checksum=cc06c251f142837cf540b7977724596a94f3d0fe9da9619175e9de6539cd0705
 # Relevant tests happen in ansible-core
 make_check=no


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl
  - i686

Closes issue https://github.com/void-linux/void-packages/issues/47483 and also brings native python 3.12 support.

@jcgruenhage are you fine with this PR?