### PR TITLE
Python3 Ansible: lint 6.22.1 and compat 4.1.10 update to newest versions.

### DIFF
--- a/srcpkgs/python3-ansible-compat/template
+++ b/srcpkgs/python3-ansible-compat/template
@@ -1,7 +1,7 @@
 # Template file for 'python3-ansible-compat'
 pkgname=python3-ansible-compat
-version=4.1.0
-revision=2
+version=4.1.10
+revision=1
 build_style=python3-pep517
 hostmakedepends="python3-wheel python3-setuptools_scm"
 depends="python3-subprocess-tee python3-yaml"
@@ -10,7 +10,7 @@ maintainer="Jan Christian Grünhage <jan.christian@gruenhage.xyz>"
 license="MIT"
 homepage="https://github.com/ansible/ansible-compat"
 distfiles="${PYPI_SITE}/a/ansible-compat/ansible-compat-${version}.tar.gz"
-checksum=bcc6b3cf4bb102e1b1b36a8639fee7ad18ddb1d99fb055d208c8a0f650a51621
+checksum=2be8c7b510d2e15eed1e9ef443209d67d9aec8f427026b88936d4535ff59863d
 
 post_patch() {
 	export SETUPTOOLS_SCM_PRETEND_VERSION="${version}"

--- a/srcpkgs/python3-ansible-lint/template
+++ b/srcpkgs/python3-ansible-lint/template
@@ -1,7 +1,7 @@
 # Template file for 'python3-ansible-lint'
 pkgname=python3-ansible-lint
-version=6.17.1
-revision=2
+version=6.22.1
+revision=1
 build_style=python3-pep517
 hostmakedepends="python3-wheel python3-setuptools_scm"
 depends="python3-ansible-compat ansible-core black python3-filelock
@@ -17,7 +17,7 @@ maintainer="Jan Christian Grünhage <jan.christian@gruenhage.xyz>"
 license="GPL-3.0-only"
 homepage="https://github.com/ansible/ansible-lint"
 distfiles="${PYPI_SITE}/a/ansible-lint/ansible-lint-${version}.tar.gz"
-checksum=f34e333f3555c99ff34c778f61d470d1e3a1eb6dc76090d0dd7b95b2c94745c2
+checksum=d4a3116e0726b98ffbc253f35c5ede98bee546d72d9c363f65e6e79467784d15
 # cba anymore, the list of failing tests changes with every update
 make_check="no"
 


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl
  - i686

@jcgruenhage are you okay with this? This skips your PR and also updates lint to the latest version.
