### PR TITLE
android-udev-rules: update to 20231124.

### DIFF
--- a/srcpkgs/android-udev-rules/template
+++ b/srcpkgs/android-udev-rules/template
@@ -1,6 +1,6 @@
 # Template file for 'android-udev-rules'
 pkgname=android-udev-rules
-version=20231104
+version=20231124
 revision=1
 short_desc="Android udev rules list aimed to be the most comprehensive on the net"
 maintainer="Mohammed Anas <triallax@tutanota.com>"
@@ -8,7 +8,7 @@ license="GPL-3.0-or-later"
 homepage="https://github.com/M0Rf30/android-udev-rules"
 changelog="https://github.com/M0Rf30/android-udev-rules/releases"
 distfiles="https://github.com/M0Rf30/android-udev-rules/archive/${version}.tar.gz"
-checksum=2f2e82c8d352d45a93806bc776df518da59c19ee9f0bf6aa8606d5d3ae05eccf
+checksum=0de9e2fa5ee2c65d3854c3c796701de1cbf9d47f70fa261bdadba4578632733c
 system_groups="adbusers"
 
 do_install() {


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
