### PR TITLE
android-studio: update to 2023.1.1.26.

### DIFF
--- a/srcpkgs/android-studio/template
+++ b/srcpkgs/android-studio/template
@@ -1,6 +1,6 @@
 # Template file for 'android-studio'
 pkgname=android-studio
-version=2022.3.1.18
+version=2023.1.1.26
 revision=1
 archs="x86_64"
 hostmakedepends="tar"
@@ -10,7 +10,7 @@ license="Apache-2.0"
 homepage="http://tools.android.com"
 # changelog="https://developer.android.com/studio/releases/index.html"
 distfiles="https://dl.google.com/dl/android/studio/ide-zips/${version}/android-studio-${version}-linux.tar.gz"
-checksum=24215e1324a6ac911810b2cc1afb2d735cf745dfbc06918a42b8d6fbc6bf7433
+checksum=977e8a9855414f7d41157f0be0e10fb740c42bd337f763d5d96b3e059780663d
 repository=nonfree
 restricted=yes
 python_version=3


### PR DESCRIPTION

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc

