### PR TITLE
godot: update to 4.2.1.

### DIFF
--- a/srcpkgs/godot/template
+++ b/srcpkgs/godot/template
@@ -1,30 +1,31 @@
 # Template file for 'godot'
 pkgname=godot
-version=4.2
+version=4.2.1
 revision=1
 archs="x86_64* i686* aarch64* armv7* ppc64*"
 build_style=scons
 # Build currently fails with embree-4.X
 make_build_args="platform=linuxbsd target=editor progress=no production=yes
- builtin_embree=true builtin_enet=false builtin_freetype=false
- builtin_graphite=false builtin_harfbuzz=false builtin_libogg=false
- builtin_libpng=false builtin_libtheora=false builtin_libvorbis=false
- builtin_libwebp=false builtin_mbedtls=false builtin_miniupnpc=false
- builtin_pcre2=false builtin_zlib=false builtin_zstd=false"
+ lto=auto builtin_brotli=false builtin_embree=true builtin_enet=false
+ builtin_freetype=false builtin_graphite=false builtin_harfbuzz=false
+ builtin_icu4c=false builtin_libogg=false builtin_libpng=false
+ builtin_libtheora=false builtin_libvorbis=false builtin_libwebp=false
+ builtin_mbedtls=false builtin_miniupnpc=false builtin_pcre2=false
+ builtin_zlib=false builtin_zstd=false"
 hostmakedepends="pkg-config clang"
 makedepends="alsa-lib-devel freetype-devel mesa glu-devel libXcursor-devel
  libXi-devel libXinerama-devel libXrender-devel libXrandr-devel libX11-devel
  libpng-devel libwebp-devel libogg-devel libtheora-devel libvorbis-devel
  libenet-devel zlib-devel mbedtls-devel miniupnpc-devel pcre2-devel
  pulseaudio-devel graphite-devel harfbuzz-devel libzstd-devel
- speech-dispatcher-devel"
+ speech-dispatcher-devel brotli-devel icu-devel"
 depends="speech-dispatcher"
 short_desc="Multiplatform 2D and 3D engine"
 maintainer="dataCobra <datacobra@thinkbot.de>"
 license="MIT"
 homepage="https://www.godotengine.org/"
 distfiles="https://github.com/godotengine/godot/archive/${version}-stable.tar.gz"
-checksum=517e538ef7f3eebeb761c281fb71ac529424146f6b3b746d0861825ddcf18918
+checksum=716cfd489dbfc91b5e04cc0df8be415ba6eec74c5fb471840275d887cb53ff95
 nocross=https://build.voidlinux.org/builders/armv7l_builder/builds/6342/steps/shell_3/logs/stdio
 
 CFLAGS+=" -fPIE -fPIC"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES** (As far as I could think of)

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl
  - i686

Since we provide icu and brotli now in correct versions I've setup godot to use our packages instead of builtin variants.