### PR TITLE
python3-txtorcon: update to 23.11.0.

### DIFF
--- a/srcpkgs/python3-txtorcon/template
+++ b/srcpkgs/python3-txtorcon/template
@@ -1,19 +1,19 @@
 # Template file for 'python3-txtorcon'
 pkgname=python3-txtorcon
-version=23.5.0
-revision=2
+version=23.11.0
+revision=1
 build_style=python3-module
 hostmakedepends="python3 python3-setuptools"
 depends="lsof python3-automat python3-cryptography python3-six python3-Twisted
  python3-zope.interface which"
-checkdepends="${depends} python3-mock python3-pytest"
+checkdepends="${depends} python3-pytest"
 short_desc="Twisted-based asynchronous Tor control protocol implementation"
 maintainer="travankor <travankor@tuta.io>"
 license="MIT"
 homepage="https://txtorcon.readthedocs.io/en/latest/"
 changelog="https://raw.githubusercontent.com/meejah/txtorcon/main/docs/releases.rst"
 distfiles="https://github.com/meejah/txtorcon/archive/v${version}.tar.gz"
-checksum=01a98243caf49035a0e823f6633fb2c4ea9613aa123dda063845bf7ee5c920de
+checksum=b8283bec83ab2de45949e154abeeb9216acd93cd60323002f340e2b783406688
 make_check=ci-skip # Can not open ports in CI
 
 post_install() {


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
