### PR TITLE
New package: rsgain-3.4

### DIFF
--- a/srcpkgs/rsgain/template
+++ b/srcpkgs/rsgain/template
@@ -1,0 +1,19 @@
+# Template file for 'rsgain'
+pkgname=rsgain
+version=3.4
+revision=1
+build_style=cmake
+configure_args=-DCMAKE_BUILD_TYPE=Release
+hostmakedepends="pkg-config"
+makedepends="ffmpeg-devel inih-devel libebur128-devel taglib-devel fmt-devel"
+short_desc="CLI utility to apply ReplayGain 2.0 metadata tags to your files"
+maintainer="dvdrw <void@dvdrw.dev>"
+license=BSD-2-Clause
+homepage="https://github.com/complexlogic/rsgain"
+changelog="https://github.com/complexlogic/rsgain/releases"
+distfiles="https://github.com/complexlogic/rsgain/archive/refs/tags/v${version}.tar.gz"
+checksum=7a0b47b9ea7489bb13662d08fe53b668fa84e9c156d7919ab66b57e79d2bc446
+
+port_install() {
+	vlicense LICENSE
+}


### PR DESCRIPTION
ReplayGain/EBU R 128 loudness normalisation tool. Similar to `loudgain` (already in Void repos), but with more recent development and friendlier user interface. Homepage [here](https://github.com/complexlogic/rsgain).

Needs C++{20,23}, so it needs a minimum GCC version of probably at least 10.

#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

#### Local build testing
- I built this PR locally for my native architecture, `x86_64-glibc`
- I built this PR locally for these architectures:
  - aarch64-musl
  - armv7l
  - amv6l
  - armv6l-musl
