### PR TITLE
New package: shairport-sync-classic-4.3.2

### DIFF
--- a/srcpkgs/shairport-sync-classic/template
+++ b/srcpkgs/shairport-sync-classic/template
@@ -1,0 +1,61 @@
+# Template file for 'shairport-sync-classic'
+pkgname=shairport-sync-classic
+version=4.3.2
+revision=1
+build_style=gnu-configure
+configure_args="(vopt_if dns_sd CPPFLAGS=-I/usr/include/avahi-compat-libdns_sd/ ) --with-configfiles --program-suffix=-classic --sysconfdir=/etc --with-metadata --with-ssl=$(vopt_if openssl openssl)$(vopt_if mbedtls mbedtls) $(vopt_with avahi) $(vopt_with tinysvcmdns) $(vopt_with dns_sd) $(vopt_with mqtt mqtt-client) $(vopt_with dbus dbus-interface) $(vopt_with mpris mpris-interface) $(vopt_with soxr) $(vopt_with convolution) $(vopt_with alac apple-alac) $(vopt_with alsa) $(vopt_with sndio) $(vopt_with pa) $(vopt_with pw) $(vopt_with jack) $(vopt_with stdout) $(vopt_with pipe)"
+hostmakedepends="autoconf automake pkg-config $(vopt_if dbus glib-devel) $(vopt_if mpris glib-devel)"
+makedepends="popt-devel libconfig-devel libconfig $(vopt_if openssl openssl-devel) $(vopt_if mdebtls mbedtls-devel) $(vopt_if avahi avahi-libs-devel) $(vopt_if mqtt libmosquitto-devel) $(vopt_if dbus glib-devel) $(vopt_if mpris glib-devel) $(vopt_if soxr libsoxr-devel) $(vopt_if alac alac-devel) $(vopt_if convolution libsndfile-devel) $(vopt_if alsa alsa-lib-devel) $(vopt_if sndio sndio-devel) $(vopt_if pa pulseaudio-devel) $(vopt_if pw pipewire-devel) $(vopt_if jack jack-devel)"
+short_desc="AirPlay 1 audio player"
+maintainer="dvdrw <void@dvdrw.dev>"
+# MIT except for tinysvcmdns under BSD-3-Clause, FFTConvolver under
+# GPL3-or-later, audio_sndio.c under ISC, tinyhttp under BSD-2-Clause
+license="MIT, BSD-2-Clause, BSD-3-Clause, GPL-3.0-or-later, ISC"
+homepage="https://github.com/mikebrady/shairport-sync"
+changelog="https://github.com/mikebrady/shairport-sync/releases"
+distfiles="https://github.com/mikebrady/shairport-sync/archive/refs/tags/${version}.tar.gz"
+checksum=dfb485c0603398032a00e51f84b874749bbf155b257adda3d270d5989de08bfd
+alternatives="shairport-sync:/usr/bin/shairport-sync:/usr/bin/shairport-sync-classic"
+
+# Package build options
+build_options="openssl mbedtls avahi tinysvcmdns dns_sd mqtt dbus mpris alac soxr convolution alsa sndio pa pw jack stdout pipe"
+
+# SSL library options
+desc_option_openssl="Use openssl as the TLS library"
+desc_option_mbedtls="Use mbedtls as the TLS library"
+vopt_conflict openssl mbedtls
+
+# Server advertising options
+desc_option_avahi="Enables Avahi mDNS advertising backend"
+desc_option_tinysvcmdns="Enables tinysvcmdns mDNS advertising backend"
+desc_option_dns_sd="Enables dns_sd (legacy Apple Bonjour) mDNS advertising backend"
+
+# IPC options
+desc_option_mqtt="Include a client for MQTT"
+desc_option_dbus="Expose the native Shairport Sync D-Bus interface"
+desc_option_mpris="Expose an MPRIS D-Bus interface"
+
+# Audio processing options
+desc_option_soxr="Use libsoxr resampling for improved interpolation"
+desc_option_alac="Use Apple ALAC decoder to support ALAC-compressed streams"
+desc_option_convolution="Enables convolution filtering. Uses libsndfile"
+
+# Audio backend options
+desc_option_alsa="Enables ALSA audio output support"
+desc_option_sndio="Enables sndio audio output support"
+desc_option_pa="Enables PulseAudio audio output support"
+desc_option_pw="Enables PipeWire audio output support"
+desc_option_jack="Enables JACK audio output support"
+desc_option_stdout="Enables stdout audio output support"
+desc_option_pipe="Enables Unix pipe audio output support"
+
+build_options_default="openssl avahi dbus mpris soxr alac convolution alsa pa pw jack
+stdout pipe"
+
+pre_configure() {
+	autoreconf -fi
+}
+
+post_install() {
+	vlicense LICENSES
+}


### PR DESCRIPTION
Implementation of an Airplay 1 audio receiver. [Homepage](https://github.com/mikebrady/shairport-sync).

Note: the source can be built into either an Airplay 1 or Airplay 2 receiver. The Airplay 2 version is packaged as another package `shairport-sync-airplay2`. Both packages provide the alternative `shairport-sync:/usr/bin/shairport-sync`.

The application supports virtually all audio systems, and it builds with support for ALSA, Pulse, JACK, and PipeWire by default (audio systems available in the Void repos). It does not build with Unix pipe output support -- (imo) use cases for this should be handled by the user's audio system instead.

I've been using this package for ~a year on Pulse and PipeWire now without issue.

Needs [alac](https://github.com/void-linux/void-packages/pull/47597) to build.

#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

#### Local build testing
- I built this PR locally for my native architecture, `x86_64-glibc`
- I built this PR locally for these architectures:
  - aarch64-musl
  - aarch64
  - armv7l-musl
  - armv7l
  - armv6l-musl
  - armv6l
