### PR TITLE
rustypaste: update to 0.14.2.

### DIFF
--- a/srcpkgs/rustypaste/template
+++ b/srcpkgs/rustypaste/template
@@ -1,6 +1,6 @@
 # Template file for 'rustypaste'
 pkgname=rustypaste
-version=0.14.1
+version=0.14.2
 revision=1
 build_style=cargo
 make_check_args="-- --test-threads 1"
@@ -12,7 +12,7 @@ license="MIT"
 homepage="https://github.com/orhun/rustypaste"
 changelog="https://raw.githubusercontent.com/orhun/rustypaste/master/CHANGELOG.md"
 distfiles="https://github.com/orhun/rustypaste/archive/refs/tags/v${version}.tar.gz"
-checksum=5b7affb978babaaf1f8f77ac5414d000e134fb24a9bd678337dfa3298158a7dc
+checksum=b8ced6cf34d0ddb27ed6eaefbc877510ee869b0779b449d14b2cb5a6198c7e1a
 conf_files="/etc/rustypaste/config.toml"
 
 system_accounts="_rustypaste"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-musl
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - armv6l-musl
