### PR TITLE
curl: enable libpsl+libidn2; libpsl: switch from icu to libidn2, allow external public-suffix-list

### DIFF
--- a/srcpkgs/curl/template
+++ b/srcpkgs/curl/template
@@ -1,13 +1,14 @@
 # Template file for 'curl'
 pkgname=curl
 version=8.5.0
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="ac_cv_sizeof_off_t=8 --enable-threaded-resolver --enable-ipv6
  --enable-websockets --with-random=/dev/urandom
  $(vopt_with rtmp librtmp) $(vopt_with gssapi) $(vopt_enable ldap) $(vopt_with gnutls)
  $(vopt_enable ldap ldaps) $(vopt_with ssh libssh2) $(vopt_with ssl) $(vopt_with zstd)
- --with-ca-bundle=/etc/ssl/certs/ca-certificates.crt --without-libidn2
+ $(vopt_with psl libpsl) $(vopt_with idn libidn2)
+ --with-ca-bundle=/etc/ssl/certs/ca-certificates.crt
  ac_cv_path_NROFF=/usr/bin/mandoc"
 # 1477 verifies if headers and manpages are in sync which belongs in upstream processes
 make_check_args="TFLAGS=!1477"
@@ -17,6 +18,7 @@ hostmakedepends="perl pkg-config mdocml"
 makedepends="nghttp2-devel zlib-devel $(vopt_if gnutls 'gnutls-devel')
  $(vopt_if gssapi 'mit-krb5-devel') $(vopt_if ldap 'libldap-devel')
  $(vopt_if rtmp 'librtmp-devel') $(vopt_if ssh 'libssh2-devel')
+ $(vopt_if psl 'libpsl-devel') $(vopt_if idn 'libidn2-devel')
  $(vopt_if ssl 'openssl-devel') $(vopt_if zstd 'libzstd-devel')"
 depends="ca-certificates"
 # openssh isn't in checkdepends, because test 581 locks up
@@ -28,8 +30,8 @@ homepage="https://curl.se"
 changelog="https://curl.se/changes.html"
 distfiles="https://curl.se/download/curl-${version}.tar.gz"
 checksum=05fc17ff25b793a437a0906e0484b82172a9f4de02be5ed447e0cab8c3475add
-build_options="gnutls gssapi ldap rtmp ssh ssl zstd"
-build_options_default="ssh ssl zstd"
+build_options="gnutls gssapi idn ldap psl rtmp ssh ssl zstd"
+build_options_default="idn psl ssh ssl zstd"
 vopt_conflict ssl gnutls
 
 if [ "$CROSS_BUILD" ]; then

--- a/srcpkgs/libpsl/template
+++ b/srcpkgs/libpsl/template
@@ -1,20 +1,27 @@
 # Template file for 'libpsl'
 pkgname=libpsl
 version=0.21.2
-revision=2
+revision=3
 build_style=gnu-configure
-hostmakedepends="pkg-config python3"
-makedepends="icu-devel"
+configure_args="--enable-runtime=libidn2
+ --with-psl-distfile=/usr/share/publicsuffix/public_suffix_list.dafsa
+ --with-psl-file=/usr/share/publicsuffix/public_suffix_list.dat"
+hostmakedepends="pkg-config python3 public-suffix"
+makedepends="libidn2-devel libunistring-devel"
+depends="public-suffix"
 short_desc="Public Suffix List library functions"
 maintainer="Orphaned <orphan@voidlinux.org>"
-license="MIT"
+license="MIT, BSD-3-Clause"
 homepage="https://rockdaboot.github.io/libpsl/"
 changelog="https://raw.githubusercontent.com/rockdaboot/libpsl/master/NEWS"
 distfiles="https://github.com/rockdaboot/libpsl/releases/download/${version}/libpsl-${version}.tar.gz"
 checksum=e35991b6e17001afa2c0ca3b10c357650602b92596209b7492802f3768a6285f
+python_version=3
 
 post_install() {
+	vbin src/psl-make-dafsa
 	vlicense COPYING
+	vlicense src/LICENSE.chromium
 }
 
 libpsl-devel_package() {

--- a/srcpkgs/public-suffix/template
+++ b/srcpkgs/public-suffix/template
@@ -1,0 +1,33 @@
+# Template file for 'public-suffix'
+pkgname=public-suffix
+version=2023.11.21
+revision=1
+_rev=ae46e510d5e3a13841a188e0506449c311d28716
+hostmakedepends="python3"
+short_desc="Public Suffix List"
+maintainer="Đoàn Trần Công Danh <congdanhqx@gmail.com>"
+license="MPL-2.0"
+homepage="https://publicsuffix.org/"
+distfiles="https://github.com/publicsuffix/list/archive/${_rev}.tar.gz
+ https://raw.githubusercontent.com/rockdaboot/libpsl/0.21.2/src/psl-make-dafsa"
+checksum="c14450569530f999a021a69be485a4ae3a0f103cccd249dbd43b1e6af85c7f10
+ 252e22a3ad8e48542a71ae5625b3c2ca7e9b90ce5edbab68ecf4d0ccec82c604"
+
+skip_extraction="psl-make-dafsa"
+
+post_extract() {
+	vsrccopy psl-make-dafsa .
+}
+
+do_build() {
+	python3 psl-make-dafsa --output-format=binary \
+		public_suffix_list.dat public_suffix_list.dafsa
+}
+
+do_install() {
+	# Tools expect to find them here:
+	# https://bugzilla.mozilla.org/show_bug.cgi?id=1155581
+	vmkdir usr/share/publicsuffix
+	vinstall public_suffix_list.dat 644 usr/share/publicsuffix
+	vinstall public_suffix_list.dafsa 644 usr/share/publicsuffix
+}


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**
<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
