### PR TITLE
fish-shell: update to 3.6.4.

### DIFF
--- a/srcpkgs/fish-shell/template
+++ b/srcpkgs/fish-shell/template
@@ -1,6 +1,6 @@
 # Template file for 'fish-shell'
 pkgname=fish-shell
-version=3.6.3
+version=3.6.4
 revision=1
 build_style=cmake
 hostmakedepends="gettext"
@@ -12,7 +12,7 @@ license="GPL-2.0-only"
 homepage="https://fishshell.com/"
 changelog="https://github.com/fish-shell/fish-shell/raw/master/CHANGELOG.rst"
 distfiles="https://github.com/fish-shell/fish-shell/releases/download/${version}/fish-${version}.tar.xz"
-checksum=55520128c8ef515908a3821423b430db9258527a6c6acb61c7cb95626b5a48d5
+checksum=0f3f610e580de092fbe882c8aa76623ecf91bb16fdf0543241e6e90d5d4bc393
 register_shell="/bin/fish /usr/bin/fish"
 # tests don't work as root
 make_check=ci-skip


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl
