### PR TITLE
go: update to 1.21.5.

### DIFF
--- a/srcpkgs/go/template
+++ b/srcpkgs/go/template
@@ -1,6 +1,6 @@
 # Template file for 'go'
 pkgname=go
-version=1.21.4
+version=1.21.5
 revision=1
 create_wrksrc=yes
 build_wrksrc=go
@@ -12,20 +12,26 @@ license="BSD-3-Clause"
 homepage="https://go.dev/"
 changelog="https://go.dev/doc/devel/release.html"
 distfiles="https://go.dev/dl/go${version}.src.tar.gz"
-checksum=47b26a83d2b65a3c1c1bcace273b69bee49a7a7b5168a7604ded3d26a37bd787
+checksum=285cbbdf4b6e6e62ed58f370f3f6d8c30825d6e56c5853c66d3c23bcdb09db19
 nostrip=yes
 noverifyrdeps=yes
 # on CI it tries to use `git submodule`, which is not part of chroot-git
 make_check=ci-skip
 
+# keep in sync with common/environment/build-style/go.sh
 case "${XBPS_TARGET_MACHINE}" in
-	aarch64*) _goarch=arm64 ;;
-	arm*) _goarch=arm ;;
-	i686*) _goarch=386 ;;
-	x86_64*) _goarch=amd64 ;;
-	ppc64le*) _goarch=ppc64le ;;
-	mips*) _goarch=mips ;;
-	riscv64*) _goarch=riscv64 ;;
+	aarch64*) export GOARCH=arm64 ;;
+	armv5*) export GOARCH=arm; export GOARM=5 ;;
+	armv6*) export GOARCH=arm; export GOARM=6 ;;
+	armv7*) export GOARCH=arm; export GOARM=7 ;;
+	i686*) export GOARCH=386 ;;
+	x86_64*) export GOARCH=amd64 ;;
+	ppc64le*) export GOARCH=ppc64le ;;
+	ppc64*) export GOARCH=ppc64 ;;
+	ppc*) export GOARCH=ppc ;;
+	mipsel*) export GOARCH=mipsle ;;
+	mips*) export GOARCH=mips ;;
+	riscv64*) export GOARCH=riscv64 ;;
 	*) broken="Unsupported architecture ${XBPS_TARGET_MACHINE}" ;;
 esac
 
@@ -56,7 +62,6 @@ do_build() {
 
 	export GOROOT_BOOTSTRAP="/usr/lib/go1.17.13"
 	export GOROOT=$PWD
-	export GOARCH=${_goarch}
 
 	cd "src"
 
@@ -76,7 +81,7 @@ do_install() {
 	local bindir
 
 	if [ "$CROSS_BUILD" ]; then
-		bindir=bin/linux_${_goarch}
+		bindir=bin/linux_${GOARCH}
 	else
 		bindir=bin
 	fi
@@ -85,7 +90,7 @@ do_install() {
 	vmkdir usr/lib/go
 	vmkdir usr/lib/go/bin
 	vmkdir usr/share/go
-	cp -d --preserve=all ${bindir}/* ${DESTDIR}/usr/lib/go/bin || true
+	cp -d --preserve=all ${bindir}/* ${DESTDIR}/usr/lib/go/bin
 	cp -a pkg src lib ${DESTDIR}/usr/lib/go
 	cp -r doc misc -t ${DESTDIR}/usr/share/go
 	ln -s /usr/share/go/doc ${DESTDIR}/usr/lib/go/doc


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**


#### Local build testing
- I built this PR locally for my native architecture, (amd64)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - i686
  - armv7l
  - aarch64

--------------------------------------------

### CHANGELOG

go1.21.5 (released 2023-12-05) includes security fixes to the go command, and the `net/http` and `path/filepath` packages, as well as bug fixes to the compiler, the go command, the runtime, and the crypto/rand, net, os, and syscall packages. See the [Go 1.21.5 milestone](https://github.com/golang/go/issues?q=milestone%3AGo1.21.5+label%3ACherryPickApproved) on our issue tracker for details.

See: https://go.dev/doc/devel/release#go1.21.minor
