### PR TITLE
libcotp: update to 3.0.0

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -3491,7 +3491,7 @@ libpantheon-files-widgets.so.6 libio.elementary.files-6.0.0_1
 libwlroots.so.10 wlroots0.15-0.15.1_1
 libwlroots.so.11 wlroots0.16-0.16.0_1
 libbaseencode.so.1 libbaseencode-1.0.9_1
-libcotp.so.2 libcotp-2.0.1_1
+libcotp.so.3 libcotp-3.0.0_1
 libunarr.so.1 libunarr-1.0.1_1
 libretro-gtk-1.so.0 retro-gtk-1.0.0_1
 libmanette-0.2.so.0 libmanette-0.2.1_1

--- a/srcpkgs/OTPClient/template
+++ b/srcpkgs/OTPClient/template
@@ -1,7 +1,7 @@
 # Template file for 'OTPClient'
 pkgname=OTPClient
 version=3.2.1
-revision=1
+revision=2
 build_style=cmake
 hostmakedepends="pkg-config"
 makedepends="gtk+3-devel libglib-devel libgcrypt-devel libpng-devel

--- a/srcpkgs/libcotp/template
+++ b/srcpkgs/libcotp/template
@@ -1,6 +1,6 @@
 # Template file for 'libcotp'
 pkgname=libcotp
-version=2.0.2
+version=3.0.0
 revision=1
 build_style=cmake
 hostmakedepends="pkg-config"
@@ -10,7 +10,7 @@ maintainer="Emil Miler <em@0x45.cz>"
 license="Apache-2.0"
 homepage="https://github.com/paolostivanin/libcotp"
 distfiles="https://github.com/paolostivanin/libcotp/archive/refs/tags/v${version}.tar.gz"
-checksum=c5357af4b3f6b3c5ad91e7f6cc6866a6139d0f89e780a057be34b31d4620caec
+checksum=ff0b9ce208c4c6542a0f1e739cf31978fbf28848c573837c671a6cb7b56b2c12
 
 libcotp-devel_package() {
 	depends="${sourcepkg}>=${version}_${revision}"


### PR DESCRIPTION
OTPClient needs to be rebuilt, since the internal API in libcotp has changed, hence the revision bump.

- I tested the changes in this PR: **briefly**
- I built this PR locally for my native architecture, (x86_64-glibc)
