### PR TITLE
toot: update to 0.39.0

### DIFF
--- a/srcpkgs/python3-urwidgets/template
+++ b/srcpkgs/python3-urwidgets/template
@@ -1,0 +1,20 @@
+# Template file for 'python3-urwidgets'
+pkgname=python3-urwidgets
+version=0.1.1
+revision=1
+build_style=python3-module
+hostmakedepends="python3-setuptools"
+depends="python3-urwid"
+short_desc="Collection of widgets for urwid"
+maintainer="Luca Matei Pintilie <luca@lucamatei.com>"
+license="MIT"
+homepage="https://github.com/AnonymouX47/urwidgets"
+changelog="https://github.com/AnonymouX47/urwidgets/releases"
+distfiles="https://github.com/AnonymouX47/urwidgets/releases/download/v$version/urwidgets-$version.tar.gz"
+checksum=1e0dbceb875ace11067d93a585d8842a011db14ce78ec69ed485dc0df17f09e7
+# No tests available
+make_check=no
+
+post_install() {
+	vlicense LICENSE
+}

--- a/srcpkgs/toot/template
+++ b/srcpkgs/toot/template
@@ -1,11 +1,11 @@
 # Template file for 'toot'
 pkgname=toot
-version=0.38.2
+version=0.39.0
 revision=1
 build_style=python3-pep517
 hostmakedepends="python3-setuptools python3-wheel"
 depends="python3-BeautifulSoup4 python3-requests python3-wcwidth
- python3-urwid python3-tomlkit"
+ python3-urwid python3-urwidgets python3-tomlkit"
 checkdepends="${depends} python3-psycopg2 python3-pytest-xdist"
 short_desc="Mastodon CLI client"
 maintainer="Jon Levin <jon@jefferiestube.net>"
@@ -13,4 +13,4 @@ license="GPL-3.0-or-later"
 homepage="https://toot.bezdomni.net"
 changelog="https://raw.githubusercontent.com/ihabunek/toot/master/CHANGELOG.md"
 distfiles="https://github.com/ihabunek/toot/archive/refs/tags/${version}.tar.gz"
-checksum=2a8801d74e7ecf69812e3bd329db86ad6e99159dfb235060fedca7b5f5c72417
+checksum=8c5626e5586b73d1b940e9edea9276595ee85df5a67c69932a88b001f3e9ca77


### PR DESCRIPTION
- New package: python3-urwidgets-0.1.1.
- toot: update to 0.39.0.

#### Testing the changes
- I tested the changes in this PR: **YES**

<!-- #### New package -->
<!-- - This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO** -->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
#### Local build testing
- I built this PR locally for my native architecture, (x86\_64-glibc)
