### PR TITLE
libstdc++: Fix pretty printer warnings

### DIFF
--- a/srcpkgs/gcc/patches/fix-pretty-printer-warnings.patch
+++ b/srcpkgs/gcc/patches/fix-pretty-printer-warnings.patch
@@ -1,0 +1,125 @@
+--- a/libstdc++-v3/python/libstdcxx/v6/printers.py
++++ b/libstdc++-v3/python/libstdcxx/v6/printers.py
+@@ -1198,7 +1198,7 @@
+ 
+     def __init__ (self, typename, val):
+         self.typename = strip_versioned_namespace(typename)
+-        self.typename = re.sub('^std::experimental::fundamentals_v\d::', 'std::experimental::', self.typename, 1)
++        self.typename = re.sub(r'^std::experimental::fundamentals_v\d::', 'std::experimental::', self.typename, 1)
+         self.val = val
+         self.contained_type = None
+         contained_value = None
+@@ -1216,7 +1216,7 @@
+             mgrname = m.group(1)
+             # FIXME need to expand 'std::string' so that gdb.lookup_type works
+             if 'std::string' in mgrname:
+-                mgrname = re.sub("std::string(?!\w)", str(gdb.lookup_type('std::string').strip_typedefs()), m.group(1))
++                mgrname = re.sub(r"std::string(?!\w)", str(gdb.lookup_type('std::string').strip_typedefs()), m.group(1))
+ 
+             mgrtype = gdb.lookup_type(mgrname)
+             self.contained_type = mgrtype.template_argument(0)
+@@ -1246,7 +1246,7 @@
+     def __init__ (self, typename, val):
+         valtype = self._recognize (val.type.template_argument(0))
+         typename = strip_versioned_namespace(typename)
+-        self.typename = re.sub('^std::(experimental::|)(fundamentals_v\d::|)(.*)', r'std::\1\3<%s>' % valtype, typename, 1)
++        self.typename = re.sub(r'^std::(experimental::|)(fundamentals_v\d::|)(.*)', r'std::\1\3<%s>' % valtype, typename, 1)
+         payload = val['_M_payload']
+         if self.typename.startswith('std::experimental'):
+             engaged = val['_M_engaged']
+diff '--color=auto' -Naur a/libstdc++-v3/python/libstdcxx/v6/xmethods.py b/libstdc++-v3/python/libstdcxx/v6/xmethods.py
+--- a/libstdc++-v3/python/libstdcxx/v6/xmethods.py	2022-08-19 08:09:55.524700157 +0000
++++ b/libstdc++-v3/python/libstdcxx/v6/xmethods.py	2023-12-09 21:06:42.544909771 +0000
+@@ -148,7 +148,7 @@
+         self.methods = [self._method_dict[m] for m in self._method_dict]
+ 
+     def match(self, class_type, method_name):
+-        if not re.match('^std::(__\d+::)?array<.*>$', class_type.tag):
++        if not re.match(r'^std::(__\d+::)?array<.*>$', class_type.tag):
+             return None
+         method = self._method_dict.get(method_name)
+         if method is None or not method.enabled:
+@@ -265,7 +265,7 @@
+         self.methods = [self._method_dict[m] for m in self._method_dict]
+ 
+     def match(self, class_type, method_name):
+-        if not re.match('^std::(__\d+::)?deque<.*>$', class_type.tag):
++        if not re.match(r'^std::(__\d+::)?deque<.*>$', class_type.tag):
+             return None
+         method = self._method_dict.get(method_name)
+         if method is None or not method.enabled:
+@@ -309,7 +309,7 @@
+         self.methods = [self._method_dict[m] for m in self._method_dict]
+ 
+     def match(self, class_type, method_name):
+-        if not re.match('^std::(__\d+::)?forward_list<.*>$', class_type.tag):
++        if not re.match(r'^std::(__\d+::)?forward_list<.*>$', class_type.tag):
+             return None
+         method = self._method_dict.get(method_name)
+         if method is None or not method.enabled:
+@@ -390,7 +390,7 @@
+         self.methods = [self._method_dict[m] for m in self._method_dict]
+ 
+     def match(self, class_type, method_name):
+-        if not re.match('^std::(__\d+::)?(__cxx11::)?list<.*>$', class_type.tag):
++        if not re.match(r'^std::(__\d+::)?(__cxx11::)?list<.*>$', class_type.tag):
+             return None
+         method = self._method_dict.get(method_name)
+         if method is None or not method.enabled:
+@@ -505,7 +505,7 @@
+         self.methods = [self._method_dict[m] for m in self._method_dict]
+ 
+     def match(self, class_type, method_name):
+-        if not re.match('^std::(__\d+::)?vector<.*>$', class_type.tag):
++        if not re.match(r'^std::(__\d+::)?vector<.*>$', class_type.tag):
+             return None
+         method = self._method_dict.get(method_name)
+         if method is None or not method.enabled:
+@@ -554,7 +554,7 @@
+         self.methods = [self._method_dict[m] for m in self._method_dict]
+ 
+     def match(self, class_type, method_name):
+-        if not re.match('^std::(__\d+::)?%s<.*>$' % self._name, class_type.tag):
++        if not re.match(r'^std::(__\d+::)?%s<.*>$' % self._name, class_type.tag):
+             return None
+         method = self._method_dict.get(method_name)
+         if method is None or not method.enabled:
+@@ -587,9 +587,9 @@
+     def __call__(self, obj):
+         impl_type = obj.dereference().type.fields()[0].type.tag
+         # Check for new implementations first:
+-        if re.match('^std::(__\d+::)?__uniq_ptr_(data|impl)<.*>$', impl_type):
++        if re.match(r'^std::(__\d+::)?__uniq_ptr_(data|impl)<.*>$', impl_type):
+             tuple_member = obj['_M_t']['_M_t']
+-        elif re.match('^std::(__\d+::)?tuple<.*>$', impl_type):
++        elif re.match(r'^std::(__\d+::)?tuple<.*>$', impl_type):
+             tuple_member = obj['_M_t']
+         else:
+             return None
+@@ -651,7 +651,7 @@
+         self.methods = [self._method_dict[m] for m in self._method_dict]
+ 
+     def match(self, class_type, method_name):
+-        if not re.match('^std::(__\d+::)?unique_ptr<.*>$', class_type.tag):
++        if not re.match(r'^std::(__\d+::)?unique_ptr<.*>$', class_type.tag):
+             return None
+         method = self._method_dict.get(method_name)
+         if method is None or not method.enabled:
+@@ -720,7 +720,7 @@
+ 
+     def __call__(self, obj, index):
+         # Check bounds if _elem_type is an array of known bound
+-        m = re.match('.*\[(\d+)]$', str(self._elem_type))
++        m = re.match(r'.*\[(\d+)]$', str(self._elem_type))
+         if m and index >= int(m.group(1)):
+             raise IndexError('shared_ptr<%s> index "%d" should not be >= %d.' %
+                              (self._elem_type, int(index), int(m.group(1))))
+@@ -769,7 +769,7 @@
+         self.methods = [self._method_dict[m] for m in self._method_dict]
+ 
+     def match(self, class_type, method_name):
+-        if not re.match('^std::(__\d+::)?shared_ptr<.*>$', class_type.tag):
++        if not re.match(r'^std::(__\d+::)?shared_ptr<.*>$', class_type.tag):
+             return None
+         method = self._method_dict.get(method_name)
+         if method is None or not method.enabled:

--- a/srcpkgs/gcc/template
+++ b/srcpkgs/gcc/template
@@ -4,7 +4,7 @@
 
 pkgname=gcc
 version=12.2.0
-revision=3
+revision=4
 _minorver="${version%.*}"
 _majorver="${_minorver%.*}"
 _gmp_version=6.2.1


### PR DESCRIPTION
Every time a C++ program is debugged under gdb, the following message is printed:

```
/usr/lib/../share/gcc-12.2.0/python/libstdcxx/v6/printers.py:1201: SyntaxWarning: invalid escape sequence '\d'
  self.typename = re.sub('^std::experimental::fundamentals_v\d::', 'std::experimental::', self.typename, 1)
/usr/lib/../share/gcc-12.2.0/python/libstdcxx/v6/printers.py:1219: SyntaxWarning: invalid escape sequence '\w'
  mgrname = re.sub("std::string(?!\w)", str(gdb.lookup_type('std::string').strip_typedefs()), m.group(1))
/usr/lib/../share/gcc-12.2.0/python/libstdcxx/v6/printers.py:1249: SyntaxWarning: invalid escape sequence '\d'
  self.typename = re.sub('^std::(experimental::|)(fundamentals_v\d::|)(.*)', r'std::\1\3<%s>' % valtype, typename, 1)
/usr/lib/../share/gcc-12.2.0/python/libstdcxx/v6/xmethods.py:151: SyntaxWarning: invalid escape sequence '\d'
  if not re.match('^std::(__\d+::)?array<.*>$', class_type.tag):
/usr/lib/../share/gcc-12.2.0/python/libstdcxx/v6/xmethods.py:268: SyntaxWarning: invalid escape sequence '\d'
  if not re.match('^std::(__\d+::)?deque<.*>$', class_type.tag):
/usr/lib/../share/gcc-12.2.0/python/libstdcxx/v6/xmethods.py:312: SyntaxWarning: invalid escape sequence '\d'
  if not re.match('^std::(__\d+::)?forward_list<.*>$', class_type.tag):
/usr/lib/../share/gcc-12.2.0/python/libstdcxx/v6/xmethods.py:393: SyntaxWarning: invalid escape sequence '\d'
  if not re.match('^std::(__\d+::)?(__cxx11::)?list<.*>$', class_type.tag):
/usr/lib/../share/gcc-12.2.0/python/libstdcxx/v6/xmethods.py:508: SyntaxWarning: invalid escape sequence '\d'
  if not re.match('^std::(__\d+::)?vector<.*>$', class_type.tag):
/usr/lib/../share/gcc-12.2.0/python/libstdcxx/v6/xmethods.py:557: SyntaxWarning: invalid escape sequence '\d'
  if not re.match('^std::(__\d+::)?%s<.*>$' % self._name, class_type.tag):
/usr/lib/../share/gcc-12.2.0/python/libstdcxx/v6/xmethods.py:590: SyntaxWarning: invalid escape sequence '\d'
  if re.match('^std::(__\d+::)?__uniq_ptr_(data|impl)<.*>$', impl_type):
/usr/lib/../share/gcc-12.2.0/python/libstdcxx/v6/xmethods.py:592: SyntaxWarning: invalid escape sequence '\d'
  elif re.match('^std::(__\d+::)?tuple<.*>$', impl_type):
/usr/lib/../share/gcc-12.2.0/python/libstdcxx/v6/xmethods.py:654: SyntaxWarning: invalid escape sequence '\d'
  if not re.match('^std::(__\d+::)?unique_ptr<.*>$', class_type.tag):
/usr/lib/../share/gcc-12.2.0/python/libstdcxx/v6/xmethods.py:723: SyntaxWarning: invalid escape sequence '\['
  m = re.match('.*\[(\d+)]$', str(self._elem_type))
/usr/lib/../share/gcc-12.2.0/python/libstdcxx/v6/xmethods.py:772: SyntaxWarning: invalid escape sequence '\d'
  if not re.match('^std::(__\d+::)?shared_ptr<.*>$', class_type.tag):
```

This is fixed in the up to date version of the pretty printers in libstdc++ (in gcc). This is a temporary solution until gcc is updated.

I have made a patch that uses raw string literals on these lines which makes the warnings go away.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly** (I have tested the modified `xmethods.py` and `printers.py` but I haven't compiled gcc for it.)

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
[ci skip]
#### Local build testing
- none, gcc itself wasn't changed, only "data files" were modified, the build should act the same as the revision 3 build

<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
