### PR TITLE
gallery-dl: update to 1.26.4.

### DIFF
--- a/srcpkgs/gallery-dl/template
+++ b/srcpkgs/gallery-dl/template
@@ -1,6 +1,6 @@
 # Template file for 'gallery-dl'
 pkgname=gallery-dl
-version=1.26.3
+version=1.26.4
 revision=1
 build_style=python3-module
 make_check_args="--ignore test/test_results.py"
@@ -13,7 +13,7 @@ license="GPL-2.0-only"
 homepage="https://github.com/mikf/gallery-dl"
 changelog="https://raw.githubusercontent.com/mikf/gallery-dl/master/CHANGELOG.md"
 distfiles="https://github.com/mikf/gallery-dl/archive/refs/tags/v${version}.tar.gz"
-checksum=57a1ea89a6f6b76f98c690330fd74cbf310b536feae549445ad7f26b592be9fd
+checksum=d2838639d073fa03482995e78733a4488296b102da8152d430679e8faaa6a87f
 
 pre_build() {
 	make man completion


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl
