### PR TITLE
qpdf: update to 11.6.4. Move cmake files to libqpdf-devel

### DIFF
--- a/srcpkgs/qpdf/template
+++ b/srcpkgs/qpdf/template
@@ -1,6 +1,6 @@
 # Template file for 'qpdf'
 pkgname=qpdf
-version=11.6.3
+version=11.6.4
 revision=1
 build_style=cmake
 hostmakedepends="perl pkg-config"
@@ -11,7 +11,7 @@ license="Apache-2.0"
 homepage="https://github.com/qpdf/qpdf"
 changelog="https://raw.githubusercontent.com/qpdf/qpdf/stable/manual/release-notes.rst"
 distfiles="https://github.com/qpdf/qpdf/archive/refs/tags/v${version}.tar.gz"
-checksum=79e980c249feeb614de8ff30d16cc361f6d50512479eb57832016ce13a043b06
+checksum=8da100130dff5dfc0bd637752a39687cf4a4f591ca3bfaf17fd4ceff0c0529f2
 
 if [ "$CROSS_BUILD" ]; then
 	configure_args="-DLL_FMT=%lld -DRANDOM_DEVICE=/dev/urandom"
@@ -28,6 +28,7 @@ libqpdf-devel_package() {
 	depends="libqpdf>=${version}_${revision} libjpeg-turbo zlib-devel"
 	short_desc+=" - development files"
 	pkg_install() {
+		vmove usr/lib/cmake
 		vmove usr/include
 		vmove usr/lib/pkgconfig
 		vmove "usr/lib/*.a"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (X86_64-LIBC)

