### PR TITLE
tuxedo-keyboard: update to 3.2.14.

### DIFF
--- a/srcpkgs/tuxedo-keyboard/template
+++ b/srcpkgs/tuxedo-keyboard/template
@@ -1,6 +1,6 @@
 # Template file for 'tuxedo-keyboard'
 pkgname=tuxedo-keyboard
-version=3.2.11
+version=3.2.14
 revision=1
 depends="dkms"
 short_desc="TUXEDO kernel module drivers for keyboard & general hardware I/O"
@@ -8,7 +8,7 @@ maintainer="newbluemoon <blaumolch@mailbox.org>"
 license="GPL-3.0-or-later"
 homepage="https://github.com/tuxedocomputers/tuxedo-keyboard"
 distfiles="https://github.com/tuxedocomputers/tuxedo-keyboard/archive/v${version}.tar.gz"
-checksum=bb2513a7b07b5a304cb5dce2cec05ab04aa4a2aefff594836d5695b66a04772f
+checksum=e743f5878dc52ba671d4cd47707b00e7fa2c884ca540c99919f8a03345e2f354
 
 dkms_modules="tuxedo-keyboard ${version}"
 


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **NO**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl
  - i686
