### PR TITLE
python3-charset-normalizer: update to 3.3.2.

### DIFF
--- a/srcpkgs/python3-charset-normalizer/template
+++ b/srcpkgs/python3-charset-normalizer/template
@@ -1,7 +1,7 @@
 # Template file for 'python3-charset-normalizer'
 pkgname=python3-charset-normalizer
-version=3.2.0
-revision=2
+version=3.3.2
+revision=1
 build_style=python3-module
 hostmakedepends="python3-setuptools"
 depends="python3"
@@ -12,7 +12,7 @@ license="MIT"
 homepage="https://charset-normalizer.readthedocs.io/"
 changelog="https://raw.githubusercontent.com/Ousret/charset_normalizer/master/CHANGELOG.md"
 distfiles="https://github.com/Ousret/charset_normalizer/archive/refs/tags/$version.tar.gz"
-checksum=8f8c0a09ab745efc68ce4c1b85292ded2f06ea106f8086f614a0a9403c3dde0a
+checksum=9948e5c17831916ef192cf3f26c744d539eb6f4e9e3b02eea649552c52b10d91
 
 pre_check() {
 	vsed -i "s/--cov=charset_normalizer --cov-report=term-missing//" setup.cfg


### PR DESCRIPTION

#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc

