### PR TITLE
python3-future: update to 0.18.3, adopt

### DIFF
--- a/srcpkgs/python3-future/template
+++ b/srcpkgs/python3-future/template
@@ -1,16 +1,16 @@
 # Template file for 'python3-future'
 pkgname=python3-future
-version=0.18.2
-revision=7
-build_style=python3-module
-hostmakedepends="python3-setuptools"
-depends="python3-setuptools"
+version=0.18.3
+revision=1
+build_style=python3-pep517
+hostmakedepends="python3-setuptools python3-wheel"
+depends="python3"
 short_desc="Clean single-source support for Python 3 and 2 (Python3)"
-maintainer="Orphaned <orphan@voidlinux.org>"
+maintainer="Emil Miler <em@0x45.cz>"
 license="MIT"
 homepage="https://python-future.org/"
 distfiles="${PYPI_SITE}/f/future/future-${version}.tar.gz"
-checksum=b1bead90b70cf6ec3f0710ae53a525360fa360d306a86583adc6bf83a4db537d
+checksum=34a17436ed1e96697a86f9de3d15a3b0be01d8bc8de9c1dffd59fb8234ed5307
 
 conflicts="python-future>=0"
 


### PR DESCRIPTION
- I tested the changes in this PR: **briefly**
- I built this PR locally for my native architecture, (x86_64)