### PR TITLE
rclone: update to 1.65.0.

### DIFF
--- a/srcpkgs/rclone/template
+++ b/srcpkgs/rclone/template
@@ -1,19 +1,21 @@
 # Template file for 'rclone'
 pkgname=rclone
-version=1.64.2
+version=1.65.0
 revision=1
 build_style=go
 build_helper=qemu
 go_import_path=github.com/rclone/rclone
 go_build_tags="noselfupdate"
 go_ldflags="-extldflags=-fuse-ld=bfd -X github.com/rclone/rclone/fs.Version=v${version}"
+depends="mime-types"
+checkdepends="${depends}"
 short_desc="Rsync for cloud storage"
 maintainer="Roberto Ricci <io@r-ricci.it>"
 license="MIT"
 homepage="https://rclone.org/"
 changelog="https://rclone.org/changelog/"
 distfiles="https://downloads.rclone.org/v${version}/rclone-v${version}.tar.gz"
-checksum=0c74d8fb887691e04e865e3b6bc32e8af47c3e54a9922ffdbed38c8323e281c9
+checksum=45ec732d50b2517dc2c860317a3bf79867634a8143e4a441a3e399434ad6c141
 # some tests fail on CI
 make_check=ci-skip
 


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

`mime-types` is used by Go's `mime.TypeByExtension`. A test fails without it.

#### Testing the changes
- I tested the changes in this PR: **YES**
<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
