### PR TITLE
python3-typing_extensions: update to 4.9.0.

### DIFF
--- a/srcpkgs/python3-typing_extensions/template
+++ b/srcpkgs/python3-typing_extensions/template
@@ -1,6 +1,6 @@
 # Template file for 'python3-typing_extensions'
 pkgname=python3-typing_extensions
-version=4.8.0
+version=4.9.0
 revision=1
 build_style=python3-pep517
 hostmakedepends="python3-flit_core"
@@ -11,7 +11,7 @@ license="Python-2.0"
 homepage="https://github.com/python/typing_extensions"
 changelog="https://github.com/python/typing_extensions/raw/main/CHANGELOG.md"
 distfiles="${PYPI_SITE}/t/typing_extensions/typing_extensions-${version}.tar.gz"
-checksum=df8e4339e9cb77357558cbdbceca33c303714cf861d1eef15e1070055ae8b7ef
+checksum=23478f88c37f27d76ac8aee6c905017a143b0b1b886c3c9f66bc2fd94f9f5783
 # Depends on the `test` module, which is intentionally not included in the
 # `python3` package.
 make_check=no


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
