### PR TITLE
senpai: update homepage and distfiles URL.

### DIFF
--- a/srcpkgs/senpai/template
+++ b/srcpkgs/senpai/template
@@ -9,8 +9,8 @@ hostmakedepends="scdoc"
 short_desc="IRC client that works best with bouncers"
 maintainer="Emil Miler <em@0x45.cz>"
 license="ISC"
-homepage="https://git.sr.ht/~taiite/senpai"
-distfiles="https://git.sr.ht/~taiite/senpai/archive/v${version}.tar.gz"
+homepage="https://git.sr.ht/~delthas/senpai/"
+distfiles="https://git.sr.ht/~delthas/senpai/archive/v${version}.tar.gz"
 checksum=c02f63a7d76ae13ed888fc0de17fa9fd5117dcb3c9edc5670341bf2bf3b88718
 
 post_install() {


### PR DESCRIPTION
The repository has been moved, as https://git.sr.ht/~taiite/senpai/tree/5e771831a3196f49d4417e0f913da64a251e8cb5/item/README.md shows.

@realcharmer

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**|**briefly**|**NO**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
