### PR TITLE
font-iosevka: update to 28.0.0.

### DIFF
--- a/srcpkgs/font-iosevka/template
+++ b/srcpkgs/font-iosevka/template
@@ -1,6 +1,6 @@
 # Template file for 'font-iosevka'
 pkgname=font-iosevka
-version=27.3.5
+version=28.0.0
 revision=1
 depends="font-util"
 short_desc="Slender monospace sans-serif and slab-serif typeface"
@@ -8,10 +8,10 @@ maintainer="Jose G Perez Taveras <josegpt27@gmail.com>"
 license="OFL-1.1"
 homepage="https://typeof.net/Iosevka/"
 changelog="https://raw.githubusercontent.com/be5invis/Iosevka/master/CHANGELOG.md"
-distfiles="https://github.com/be5invis/Iosevka/releases/download/v${version}/super-ttc-iosevka-${version}.zip
- https://github.com/be5invis/Iosevka/releases/download/v${version}/super-ttc-iosevka-slab-${version}.zip"
-checksum="e385e21e8ca96e4dfd412d1a117f278a173637e9e63083e1cd560b6323fa89cb
- 9cfce3ccf22dfe978848c42addc76397098a868512ceb77ef60637fdcf694cb0"
+distfiles="https://github.com/be5invis/Iosevka/releases/download/v${version}/SuperTTC-Iosevka-${version}.zip
+ https://github.com/be5invis/Iosevka/releases/download/v${version}/SuperTTC-IosevkaSlab-${version}.zip"
+checksum="9d123648fde276a44f2bf8225ec77a91c3f623f9d670033a22ddc79fe2467706
+ 36a9319bf347e0f688301d58fc8e00a388eae4e603f0113d43d5c22db5a34143"
 
 font_dirs="/usr/share/fonts/TTF"
 


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
#### Local build testing
- I built this PR locally for my native architecture, (x86_64-gblic)
