### PR TITLE
volk 3.1.0 [ci skip]

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -3188,7 +3188,7 @@ libarcan_tui.so.0.15 arcan-0.6.1.1_1
 libarcan_a12.so.0.1 arcan-0.6.1.1_1
 liblwipv6.so.2 lwipv6-1.5a_1
 libpipewire-0.3.so.0 libpipewire-0.3.6_1
-libvolk.so.3.0 volk-3.0.0_1
+libvolk.so.3.1 volk-3.1.0_1
 libgnuradio-runtime.so.3.10.5 gnuradio-3.10.5.0_1
 libgnuradio-pmt.so.3.10.5 gnuradio-3.10.5.0_1
 libgnuradio-blocks.so.3.10.5 gnuradio-3.10.5.0_1

--- a/srcpkgs/SDRPlusPlus/template
+++ b/srcpkgs/SDRPlusPlus/template
@@ -1,7 +1,7 @@
 # Template file for 'SDRPlusPlus'
 pkgname=SDRPlusPlus
 version=1.0.4
-revision=2
+revision=3
 build_style=cmake
 configure_args="-DOPT_BUILD_PLUTOSDR_SOURCE=0"
 hostmakedepends="pkg-config"

--- a/srcpkgs/cpu_features-devel
+++ b/srcpkgs/cpu_features-devel
@@ -1,0 +1,1 @@
+cpu_features

--- a/srcpkgs/cpu_features/template
+++ b/srcpkgs/cpu_features/template
@@ -1,0 +1,21 @@
+# Template file for 'cpu_features'
+pkgname=cpu_features
+version=0.9.0
+revision=1
+build_style=cmake
+configure_args="-DBUILD_TESTING=NO"
+short_desc="Cross platform C99 library to get cpu features at runtime"
+maintainer="Andrew Benson <abenson+void@gmail.com>"
+license="Apache-2.0"
+homepage="https://github.com/google/cpu_features"
+distfiles="https://github.com/google/cpu_features/archive/v${version}.tar.gz"
+checksum=bdb3484de8297c49b59955c3b22dba834401bc2df984ef5cfc17acbe69c5018e
+
+cpu_features-devel_package() {
+	short_desc+=" - development files"
+	depends+=" $sourcepkg>=${version}_${revision}"
+	pkg_install() {
+		vmove usr/include
+		vmove usr/lib
+	}
+}

--- a/srcpkgs/gnuradio/template
+++ b/srcpkgs/gnuradio/template
@@ -1,7 +1,7 @@
 # Template file for 'gnuradio'
 pkgname=gnuradio
 version=3.10.5.1
-revision=5
+revision=6
 build_style=cmake
 conf_files="/etc/gnuradio/conf.d/*"
 configure_args="-DMATHJAX2_USE_ROOT=/usr/share/mathjax

--- a/srcpkgs/gqrx/template
+++ b/srcpkgs/gqrx/template
@@ -1,7 +1,7 @@
 # Template file for 'gqrx'
 pkgname=gqrx
 version=2.17.3
-revision=1
+revision=2
 build_style=cmake
 configure_args="$(vopt_if gr_audio -DLINUX_AUDIO_BACKEND=Gr-audio)
  $(vopt_if portaudio -DLINUX_AUDIO_BACKEND=Portaudio)"

--- a/srcpkgs/volk/template
+++ b/srcpkgs/volk/template
@@ -1,20 +1,20 @@
 # Template file for 'volk'
 pkgname=volk
-version=3.0.0
-revision=2
+version=3.1.0
+revision=1
 _cpu_features_gitrev="188d0d3c383689cdb6bb70dc6da2469faec84f61"
 create_wrksrc=yes
 build_style=cmake
 configure_args="-DENABLE_LGPL=OFF"
 hostmakedepends="pkg-config python3-cheetah3 git python3-Mako python3-six"
-makedepends="python3-cheetah3 python3-devel python3-Mako python3-six"
+makedepends="python3-cheetah3 python3-devel python3-Mako python3-six cpu_features-devel"
 short_desc="Vector-Optimized Library of Kernels"
 maintainer="Andrew Benson <abenson+void@gmail.com>"
 license="LGPL-3.0-or-later"
 homepage="http://libvolk.org/"
 distfiles="https://github.com/gnuradio/volk/archive/v${version}.tar.gz
  https://github.com/google/cpu_features/archive/${_cpu_features_gitrev}.tar.gz"
-checksum="617c25a5a240e41e50d695851925541b19e011d516c3e0c288a5aeefb3ceb7fd
+checksum="9a46d85d24435b8f221e1ae03d4e9e8458d4281e3e4d2b541a8844a55b7526ac
  ef383c81e84e7ce56eeb9207ded6937f0aefd6747c319d8d3265e6d9be164db1"
 
 case "$XBPS_TARGET_MACHINE" in


### PR DESCRIPTION

#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, x86_64
- I built this PR locally for these architectures (if supported. mark crossbuilds):

```
pkg           host         target        cross  result
cpu_features  x86_64       x86_64        n      OK
volk          x86_64       x86_64        n      OK
gnuradio      x86_64       x86_64        n      OK
gqrx          x86_64       x86_64        n      OK
SDRPlusPlus   x86_64       x86_64        n      OK
cpu_features  x86_64-musl  x86_64-musl   n      OK
volk          x86_64-musl  x86_64-musl   n      OK
gnuradio      x86_64-musl  x86_64-musl   n      OK
gqrx          x86_64-musl  x86_64-musl   n      OK
SDRPlusPlus   x86_64-musl  x86_64-musl   n      OK
cpu_features  i686         i686          n      OK
volk          i686         i686          n      OK
gnuradio      i686         i686          n      OK
gqrx          i686         i686          n      OK
SDRPlusPlus   i686         i686          n      OK
cpu_features  x86_64       aarch64-musl  y      OK
volk          x86_64       aarch64-musl  y      OK
gnuradio      x86_64       aarch64-musl  y      OK
gqrx          x86_64       aarch64-musl  y      OK
SDRPlusPlus   x86_64       aarch64-musl  y      OK
cpu_features  x86_64       aarch64       y      OK
volk          x86_64       aarch64       y      OK
gnuradio      x86_64       aarch64       y      OK
gqrx          x86_64       aarch64       y      OK
SDRPlusPlus   x86_64       aarch64       y      OK
cpu_features  x86_64       armv7l-musl   y      OK
volk          x86_64       armv7l-musl   y      OK
gnuradio      x86_64       armv7l-musl   y      OK
gqrx          x86_64       armv7l-musl   y      OK
SDRPlusPlus   x86_64       armv7l-musl   y      OK
cpu_features  x86_64       armv7l        y      OK
volk          x86_64       armv7l        y      OK
gnuradio      x86_64       armv7l        y      OK
gqrx          x86_64       armv7l        y      OK
SDRPlusPlus   x86_64       armv7l        y      OK
cpu_features  x86_64       armv6l-musl   y      OK
volk          x86_64       armv6l-musl   y      OK
gnuradio      x86_64       armv6l-musl   y      OK
gqrx          x86_64       armv6l-musl   y      OK
SDRPlusPlus   x86_64       armv6l-musl   y      OK
cpu_features  x86_64       armv6l        y      OK
volk          x86_64       armv6l        y      OK
gnuradio      x86_64       armv6l        y      OK
gqrx          x86_64       armv6l        y      OK
SDRPlusPlus   x86_64       armv6l        y      OK
```