### PR TITLE
update xdebug and composer and add PHP 8.3 packages

### DIFF
--- a/srcpkgs/composer8.1/template
+++ b/srcpkgs/composer8.1/template
@@ -1,6 +1,6 @@
 # Template file for 'composer8.1'
 pkgname=composer8.1
-version=2.5.8
+version=2.6.6
 revision=1
 build_style=fetch
 depends="php8.1"
@@ -11,7 +11,7 @@ homepage="https://getcomposer.org/"
 changelog="https://raw.githubusercontent.com/composer/composer/main/CHANGELOG.md"
 distfiles="https://github.com/composer/composer/releases/download/${version}/composer.phar
  https://raw.githubusercontent.com/composer/composer/main/LICENSE"
-checksum="f07934fad44f9048c0dc875a506cca31cc2794d6aebfc1867f3b1fbf48dce2c5
+checksum="72600201c73c7c4b218f1c0511b36d8537963e36aafa244757f52309f885b314
  7855ac293067aebe7e51afdd23b9dea54b8be24187dbecc9b9142581c37f596c"
 alternatives="composer:composer:/usr/bin/composer8.1"
 

--- a/srcpkgs/composer8.2/template
+++ b/srcpkgs/composer8.2/template
@@ -1,6 +1,6 @@
 # Template file for 'composer8.2'
 pkgname=composer8.2
-version=2.5.8
+version=2.6.6
 revision=1
 build_style=fetch
 depends="php8.2"
@@ -11,7 +11,7 @@ homepage="https://getcomposer.org/"
 changelog="https://raw.githubusercontent.com/composer/composer/main/CHANGELOG.md"
 distfiles="https://github.com/composer/composer/releases/download/${version}/composer.phar
  https://raw.githubusercontent.com/composer/composer/main/LICENSE"
-checksum="f07934fad44f9048c0dc875a506cca31cc2794d6aebfc1867f3b1fbf48dce2c5
+checksum="72600201c73c7c4b218f1c0511b36d8537963e36aafa244757f52309f885b314
  7855ac293067aebe7e51afdd23b9dea54b8be24187dbecc9b9142581c37f596c"
 alternatives="composer:composer:/usr/bin/composer8.2"
 

--- a/srcpkgs/composer8.3/files/composer8.3
+++ b/srcpkgs/composer8.3/files/composer8.3
@@ -1,0 +1,2 @@
+#!/bin/sh
+php8.3 /usr/libexec/composer.phar8.3 "$@"

--- a/srcpkgs/composer8.3/template
+++ b/srcpkgs/composer8.3/template
@@ -1,0 +1,27 @@
+# Template file for 'composer8.3'
+pkgname=composer8.3
+version=2.6.6
+revision=1
+build_style=fetch
+depends="php8.3"
+short_desc="Dependency manager for PHP"
+maintainer="Joel Beckmeyer <joel@beckmeyer.us>"
+license="MIT"
+homepage="https://getcomposer.org/"
+changelog="https://raw.githubusercontent.com/composer/composer/main/CHANGELOG.md"
+distfiles="https://github.com/composer/composer/releases/download/${version}/composer.phar
+ https://raw.githubusercontent.com/composer/composer/main/LICENSE"
+checksum="72600201c73c7c4b218f1c0511b36d8537963e36aafa244757f52309f885b314
+ 7855ac293067aebe7e51afdd23b9dea54b8be24187dbecc9b9142581c37f596c"
+alternatives="composer:composer:/usr/bin/composer8.3"
+
+do_install() {
+	vbin ${FILESDIR}/composer8.3
+
+	vinstall composer.phar 644 usr/libexec composer.phar8.3
+	vlicense LICENSE
+
+	vmkdir /etc/php8.3/conf.d
+	printf 'extension=%s\n' phar iconv openssl zip \
+		>${DESTDIR}/etc/php8.3/conf.d/composer.ini
+}

--- a/srcpkgs/php/template
+++ b/srcpkgs/php/template
@@ -1,7 +1,7 @@
 # Template file for 'php'
 pkgname=php
-version=8.2
-revision=2
+version=8.3
+revision=1
 build_style=meta
 depends="php${version}"
 short_desc="Meta package for PHP"

--- a/srcpkgs/xdebug8.1/template
+++ b/srcpkgs/xdebug8.1/template
@@ -1,6 +1,6 @@
 # Template file for 'xdebug8.1'
 pkgname=xdebug8.1
-version=3.2.2
+version=3.3.1
 revision=1
 build_style=gnu-configure
 configure_args="--with-php-config=/usr/bin/php-config8.1"
@@ -12,7 +12,7 @@ license="PHP-3.0"
 homepage="http://xdebug.org"
 changelog="https://xdebug.org/updates"
 distfiles="http://xdebug.org/files/xdebug-${version}.tgz"
-checksum=f48777371f90cbb315ea4ea082a1ede6765bcfb35d7d6356ab8f71fd6dfcc157
+checksum=4eb4ee270bbcc5f14195c38f6ee58580e007cf4886ce32e11430318ab5bc2315
 
 pre_configure() {
 	phpize8.1

--- a/srcpkgs/xdebug8.2/template
+++ b/srcpkgs/xdebug8.2/template
@@ -1,6 +1,6 @@
 # Template file for 'xdebug8.2'
 pkgname=xdebug8.2
-version=3.2.2
+version=3.3.1
 revision=1
 build_style=gnu-configure
 configure_args="--with-php-config=/usr/bin/php-config8.2"
@@ -12,7 +12,7 @@ license="PHP-3.0"
 homepage="http://xdebug.org"
 changelog="https://xdebug.org/updates"
 distfiles="http://xdebug.org/files/xdebug-${version}.tgz"
-checksum=f48777371f90cbb315ea4ea082a1ede6765bcfb35d7d6356ab8f71fd6dfcc157
+checksum=4eb4ee270bbcc5f14195c38f6ee58580e007cf4886ce32e11430318ab5bc2315
 
 pre_configure() {
 	phpize8.2

--- a/srcpkgs/xdebug8.3/files/README.voidlinux
+++ b/srcpkgs/xdebug8.3/files/README.voidlinux
@@ -1,0 +1,1 @@
+You should add 'zend_extension="xdebug.so"' to php.ini

--- a/srcpkgs/xdebug8.3/template
+++ b/srcpkgs/xdebug8.3/template
@@ -1,0 +1,25 @@
+# Template file for 'xdebug8.3'
+pkgname=xdebug8.3
+version=3.3.1
+revision=1
+build_style=gnu-configure
+configure_args="--with-php-config=/usr/bin/php-config8.3"
+hostmakedepends="autoconf php8.3-devel"
+makedepends="php8.3-devel"
+short_desc="PHP debugging extension"
+maintainer="Joel Beckmeyer <joel@beckmeyer.us>"
+license="PHP-3.0"
+homepage="http://xdebug.org"
+changelog="https://xdebug.org/updates"
+distfiles="http://xdebug.org/files/xdebug-${version}.tgz"
+checksum=4eb4ee270bbcc5f14195c38f6ee58580e007cf4886ce32e11430318ab5bc2315
+
+pre_configure() {
+	phpize8.3
+}
+
+do_install() {
+	make INSTALL_ROOT=${DESTDIR} install
+	vlicense LICENSE
+	vdoc "${FILESDIR}/README.voidlinux"
+}

--- a/srcpkgs/xdebug8.3/update
+++ b/srcpkgs/xdebug8.3/update
@@ -1,0 +1,2 @@
+site="https://xdebug.org/updates"
+pattern='<dt><a name=.*></a>.*Xdebug \K[\d.]+(?=</dt>)'


### PR DESCRIPTION
- composer8.1: update to 2.6.6.
- composer8.2: update to 2.6.6.
- New package: composer8.3-2.6.6
- xdebug8.1: update to 3.3.1.
- xdebug8.2: update to 3.3.1.
- New package: xdebug8.3-3.3.1
- php: update to 8.3.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
