### PR TITLE
zathura: update to 0.5.4; revbump support plugins

### DIFF
--- a/srcpkgs/girara/template
+++ b/srcpkgs/girara/template
@@ -1,6 +1,6 @@
 # Template file for 'girara'
 pkgname=girara
-version=0.4.0
+version=0.4.1
 revision=1
 build_style=meson
 configure_args="$(vopt_feature notify notify)"
@@ -13,7 +13,7 @@ license="Zlib"
 homepage="https://pwmt.org/projects/girara/"
 changelog="https://pwmt.org/projects/girara/changelog/${version}/index.html"
 distfiles="https://git.pwmt.org/pwmt/girara/-/archive/${version}/girara-${version}.tar.gz"
-checksum=24edfa3d493e7d4bbf491bb730d036cfedbd6c34ada1a7cfcd6273e78cffa44c
+checksum=6feb6e567bec9294c734012f459788a4e70567c3491b7c769e2284de4573ec8e
 make_check_pre="xvfb-run"
 
 build_options="notify"

--- a/srcpkgs/zathura-cb/template
+++ b/srcpkgs/zathura-cb/template
@@ -1,7 +1,7 @@
 # Template file for 'zathura-cb'
 pkgname=zathura-cb
 version=0.1.10
-revision=1
+revision=2
 build_style=meson
 hostmakedepends="pkg-config"
 makedepends="zathura-devel libarchive-devel"

--- a/srcpkgs/zathura-djvu/template
+++ b/srcpkgs/zathura-djvu/template
@@ -1,7 +1,7 @@
 # Template file for 'zathura-djvu'
 pkgname=zathura-djvu
 version=0.2.9
-revision=3
+revision=4
 build_style=meson
 hostmakedepends="pkg-config"
 makedepends="djvulibre-devel zathura-devel"

--- a/srcpkgs/zathura-pdf-mupdf/template
+++ b/srcpkgs/zathura-pdf-mupdf/template
@@ -1,7 +1,7 @@
 # Template file for 'zathura-pdf-mupdf'
 pkgname=zathura-pdf-mupdf
 version=0.4.1
-revision=4
+revision=5
 build_style=meson
 hostmakedepends="pkg-config"
 makedepends="mupdf-devel zathura-devel libopenjpeg2-devel tesseract-ocr-devel

--- a/srcpkgs/zathura-pdf-poppler/template
+++ b/srcpkgs/zathura-pdf-poppler/template
@@ -1,7 +1,7 @@
 # Template file for 'zathura-pdf-poppler'
 pkgname=zathura-pdf-poppler
 version=0.3.1
-revision=1
+revision=2
 build_style=meson
 hostmakedepends="pkg-config"
 makedepends="poppler-devel poppler-glib-devel zathura-devel"

--- a/srcpkgs/zathura-ps/template
+++ b/srcpkgs/zathura-ps/template
@@ -1,7 +1,7 @@
 # Template file for 'zathura-ps'
 pkgname=zathura-ps
 version=0.2.7
-revision=3
+revision=4
 build_style=meson
 hostmakedepends="pkg-config"
 makedepends="libspectre-devel zathura-devel"

--- a/srcpkgs/zathura/template
+++ b/srcpkgs/zathura/template
@@ -1,6 +1,6 @@
 # Template file for 'zathura'
 pkgname=zathura
-version=0.5.2
+version=0.5.4
 revision=1
 build_style=meson
 configure_args="-Dsynctex=enabled"
@@ -8,14 +8,14 @@ hostmakedepends="pkg-config intltool python3-Sphinx desktop-file-utils
  appstream-glib glib-devel librsvg-utils"
 makedepends="girara-devel sqlite-devel file-devel zlib-devel libseccomp-devel
  libglib-devel texlive-devel"
-checkdepends="gettext-devel check-devel"
+checkdepends="gettext-devel check-devel xvfb-run"
 short_desc="Highly customizable and functional document viewer"
 maintainer="lemmi <lemmi@nerd2nerd.org>"
 license="Zlib"
 homepage="https://pwmt.org/projects/zathura/"
 changelog="https://pwmt.org/projects/zathura/changelog/${version}/index.html"
 distfiles="https://pwmt.org/projects/zathura/download/zathura-${version}.tar.xz"
-checksum=c64ba7cb9facf2b1499b9dc929b6736c72c69f8062eed4f2940556c852256194
+checksum=a3037f7aa94d4096bfd97069f62ffcdca9f06431e8663548c1cd6b945c556f32
 
 if [ "$XBPS_CHECK_PKGS" ]; then
 	configure_args+=" -Dtests=enabled"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

---

I noticed past zathura updates did not require revbumps for the support plugins, but when I tried to load a pdf prior to the revbumps I got a "symbol not found" error.