### PR TITLE
font-iosevka: update to 28.0.1.

### DIFF
--- a/srcpkgs/font-iosevka/template
+++ b/srcpkgs/font-iosevka/template
@@ -1,6 +1,6 @@
 # Template file for 'font-iosevka'
 pkgname=font-iosevka
-version=28.0.0
+version=28.0.1
 revision=1
 depends="font-util"
 short_desc="Slender monospace sans-serif and slab-serif typeface"
@@ -10,8 +10,8 @@ homepage="https://typeof.net/Iosevka/"
 changelog="https://raw.githubusercontent.com/be5invis/Iosevka/master/CHANGELOG.md"
 distfiles="https://github.com/be5invis/Iosevka/releases/download/v${version}/SuperTTC-Iosevka-${version}.zip
  https://github.com/be5invis/Iosevka/releases/download/v${version}/SuperTTC-IosevkaSlab-${version}.zip"
-checksum="9d123648fde276a44f2bf8225ec77a91c3f623f9d670033a22ddc79fe2467706
- 36a9319bf347e0f688301d58fc8e00a388eae4e603f0113d43d5c22db5a34143"
+checksum="461009f533e96fd47ab604f8df4f91cb68a726c32d2e24b9c50c243b28b21fdb
+ b1e166d35b1da79df08802cf2a69f14ed225f0f44e0ec9b1e8e9d2a4a64a3b58"
 
 font_dirs="/usr/share/fonts/TTF"
 


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
