### PR TITLE
python3-sphinx-automodapi: update to 0.16.0, fix runtime crash.

### DIFF
--- a/srcpkgs/python3-imagesize/template
+++ b/srcpkgs/python3-imagesize/template
@@ -1,8 +1,10 @@
 # Template file for 'python3-imagesize'
 pkgname=python3-imagesize
-version=1.2.0
-revision=4
+version=1.4.1
+revision=1
 build_style=python3-module
+# Triest to fetch a dead url
+make_check_args="--deselect test/test_get_filelike.py::test_get_filelike"
 hostmakedepends="python3-setuptools"
 depends="python3"
 checkdepends="python3-pytest"
@@ -11,7 +13,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
 homepage="https://github.com/shibukawa/imagesize_py"
 distfiles="${PYPI_SITE}/i/imagesize/imagesize-${version}.tar.gz"
-checksum=b1f6b5a4eab1f73479a50fb79fcf729514a900c341d8503d62a62dbc4127a2b1
+checksum=69150444affb9cb0d5cc5a92b3676f0b2fb7cd9ae39e947a5e11a36b4497cd4a
 
 post_install() {
 	vlicense LICENSE.rst

--- a/srcpkgs/python3-snowballstemmer/template
+++ b/srcpkgs/python3-snowballstemmer/template
@@ -1,17 +1,17 @@
 # Template file for 'python3-snowballstemmer'
 pkgname=python3-snowballstemmer
-version=1.2.1
-revision=9
+version=2.2.0
+revision=1
 build_style=python3-module
 hostmakedepends="python3-setuptools"
 depends="python3"
 short_desc="Snowball stemming library collection for Python3"
 maintainer="Orphaned <orphan@voidlinux.org>"
-license="BSD-2-Clause"
-homepage="https://github.com/shibukawa/snowball_py"
+license="BSD-3-Clause"
+homepage="https://github.com/snowballstem/snowball"
 distfiles="${PYPI_SITE}/s/snowballstemmer/snowballstemmer-${version}.tar.gz"
-checksum=919f26a68b2c17a7634da993d91339e288964f93c274f1343e3bbbe2096e1128
+checksum=09b16deb8547d3412ad7b590689584cd0fe25ec8db3be37788be3810cbf19cb1
 
 post_install() {
-	vlicense LICENSE.rst
+	vlicense COPYING
 }

--- a/srcpkgs/python3-sphinx-automodapi/template
+++ b/srcpkgs/python3-sphinx-automodapi/template
@@ -1,16 +1,20 @@
 # Template file for 'python3-sphinx-automodapi'
 pkgname=python3-sphinx-automodapi
-version=0.13
-revision=4
+version=0.16.0
+revision=1
 build_style=python3-module
+# Something wrong with relative filepaths
+make_check_args="--deselect sphinx_automodapi/tests/test_automodapi.py::test_am_replacer_cython
+ --deselect sphinx_automodapi/tests/test_automodsumm.py::test_ams_cython"
 hostmakedepends="python3-setuptools"
 depends="python3-Sphinx"
+checkdepends="python3-Sphinx python3-pytest graphviz"
 short_desc="Sphinx extension for generating API documentation"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="BSD-3-Clause"
 homepage="https://github.com/astropy/sphinx-automodapi"
-distfiles="https://github.com/astropy/sphinx-automodapi/archive/refs/tags/v${version}.tar.gz"
-checksum=a6fc6d953e85112674b87c095c6f8e0de79cad395cbc9a9d07102d47edf80d73
+distfiles="${PYPI_SITE}/s/sphinx-automodapi/sphinx-automodapi-${version}.tar.gz"
+checksum=6c673ef93066408e5ad3e2fa3533044d432a47fe6a826212b9ebf5f52a872554
 
 post_install() {
 	vlicense LICENSE.rst

--- a/srcpkgs/python3-sphinxcontrib-serializinghtml/template
+++ b/srcpkgs/python3-sphinxcontrib-serializinghtml/template
@@ -1,16 +1,16 @@
 # Template file for 'python3-sphinxcontrib-serializinghtml'
 pkgname=python3-sphinxcontrib-serializinghtml
-version=1.1.5
-revision=4
-build_style=python3-module
-hostmakedepends="python3-setuptools"
+version=1.1.9
+revision=1
+build_style=python3-pep517
+hostmakedepends="python3-setuptools_scm python3-wheel python3-flit_core"
 depends="python3"
 short_desc="Sphinx extension which outputs serialized HTML document"
 maintainer="Đoàn Trần Công Danh <congdanhqx@gmail.com>"
 license="BSD-2-Clause"
 homepage="http://sphinx-doc.org"
-distfiles="${PYPI_SITE}/s/sphinxcontrib-serializinghtml/sphinxcontrib-serializinghtml-${version}.tar.gz"
-checksum=aa5f6de5dfdf809ef505c4895e51ef5c9eac17d0f287933eb49ec495280b6952
+distfiles="${PYPI_SITE}/s/sphinxcontrib_serializinghtml/sphinxcontrib_serializinghtml-${version}.tar.gz"
+checksum=0c64ff898339e1fac29abd2bf5f11078f3ec413cfe9c046d3120d7ca65530b54
 make_check=no # cyclic Sphinx
 
 post_install() {


### PR DESCRIPTION
  tarball from github is lacking the version
needed for setup tools. The module was crashing
immediately since it was unable to source the version.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc

