### PR TITLE
New package: contour-0.4.0.6245

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -4277,3 +4277,6 @@ libpdal_base.so.15 libpdal-2.5.6_1
 libpdal_util.so.15 libpdal-2.5.6_1
 libdisplay-info.so.1 libdisplay-info-0.1.1_1
 libsqsh.so.1 libsqsh-1.3.0_1
+libunicode.so.0.4 libunicode-0.4.0_1
+libunicode_ucd.so.0.4 libunicode-0.4.0_1
+libunicode_loader.so.0.4 libunicode-0.4.0_1

--- a/srcpkgs/boxed-cpp/template
+++ b/srcpkgs/boxed-cpp/template
@@ -1,0 +1,11 @@
+# Template file for 'boxed-cpp'
+pkgname=boxed-cpp
+version=1.1.0
+revision=1
+build_style=cmake
+short_desc="Boxing primitive types in C++"
+maintainer="0x5c <dev@0x5c.io>"
+license="Apache-2.0"
+homepage="https://github.com/contour-terminal/boxed-cpp"
+distfiles="https://github.com/contour-terminal/boxed-cpp/archive/refs/tags/v${version}.tar.gz"
+checksum=dd1c78c3bad24e777bc33aa19e8e8efb8c579f8faa3220592c3aae4d7b103bf0

--- a/srcpkgs/contour-shell-integration
+++ b/srcpkgs/contour-shell-integration
@@ -1,0 +1,1 @@
+contour

--- a/srcpkgs/contour-terminfo
+++ b/srcpkgs/contour-terminfo
@@ -1,0 +1,1 @@
+contour

--- a/srcpkgs/contour/patches/0000-phtread_musl.patch
+++ b/srcpkgs/contour/patches/0000-phtread_musl.patch
@@ -1,0 +1,15 @@
+--- a/src/crispy/utils.cpp
++++ b/src/crispy/utils.cpp
+@@ -31,8 +31,12 @@
+     }
+     return ""s;
+ #else
++    #ifdef __GLIBC__
+     char text[32] = {};
+     pthread_getname_np(pthread_self(), text, sizeof(text));
+     return text;
++    #else
++        return ""s;
++    #endif
+ #endif
+ }

--- a/srcpkgs/contour/template
+++ b/srcpkgs/contour/template
@@ -1,0 +1,34 @@
+# Template file for 'contour'
+pkgname=contour
+version=0.4.1.6292
+revision=1
+build_style=cmake
+build_helper="qemu"
+configure_args="-DCONTOUR_QT_VERSION=6 -DCONTOUR_TESTING=OFF
+ -DCRISPY_TESTING=OFF -DVTPARSER_TESTING=OFF -DLIBTERMINAL_TESTING=OFF"
+hostmakedepends="pkg-config qt6-base qt6-tools"
+makedepends="boxed-cpp fmt-devel guidelines-support-library freetype-devel
+ harfbuzz-devel libunicode-devel libutempter-devel range-v3 yaml-cpp-devel
+ qt6-base-devel qt6-core qt6-declarative-devel qt6-gui qt6-multimedia-devel
+ qt6-network qt6-opengl-widgets qt6-qt5compat-devel qt6-widgets"
+depends="contour-terminfo-${version}_${revision} contour-shell-integration-${version}_${revision}"
+short_desc="Modern C++ Terminal Emulator"
+maintainer="0x5c <dev@0x5c.io>"
+license="Apache-2.0"
+homepage="http://contour-terminal.org/"
+distfiles="https://github.com/contour-terminal/contour/archive/refs/tags/v${version}.tar.gz"
+checksum=3755dd93065b7cfab7eafedf6c2e8c00b9ca1b028f9fa2742905efe06f6084d1
+
+contour-terminfo_package() {
+	short_desc+=" - terminfo data"
+	pkg_install() {
+		vmove usr/share/terminfo
+	}
+}
+
+contour-shell-integration_package() {
+	short_desc+=" - shell integration scripts"
+	pkg_install() {
+		vmove usr/share/contour/shell-integration
+	}
+}

--- a/srcpkgs/guidelines-support-library/template
+++ b/srcpkgs/guidelines-support-library/template
@@ -1,0 +1,16 @@
+# Template file for 'guidelines-support-library'
+pkgname=guidelines-support-library
+version=4.0.0
+revision=1
+build_style=cmake
+configure_args="-DGSL_TEST:BOOL=OFF"
+short_desc="C++ Guidelines Support Library"
+maintainer="0x5c <dev@0x5c.io>"
+license="MIT"
+homepage="https://github.com/microsoft/GSL"
+distfiles="https://github.com/microsoft/GSL/archive/refs/tags/v${version}.tar.gz"
+checksum=f0e32cb10654fea91ad56bde89170d78cfbf4363ee0b01d8f097de2ba49f6ce9
+
+post_install() {
+	vlicense LICENSE
+}

--- a/srcpkgs/libunicode-devel
+++ b/srcpkgs/libunicode-devel
@@ -1,0 +1,1 @@
+libunicode

--- a/srcpkgs/libunicode/template
+++ b/srcpkgs/libunicode/template
@@ -1,0 +1,38 @@
+# Template file for 'libunicode'
+pkgname=libunicode
+version=0.4.0
+revision=1
+_ucd_version=15.0.0
+build_style=cmake
+build_helper="qemu"
+configure_args="-DLIBUNICODE_TESTING=OFF"
+hostmakedepends="python3"
+makedepends="fmt-devel"
+short_desc="Modern C++17 Unicode library"
+maintainer="0x5c <dev@0x5c.io>"
+license="Apache-2.0"
+homepage="https://github.com/contour-terminal/libunicode"
+changelog="https://github.com/contour-terminal/libunicode/raw/master/Changelog.md"
+distfiles="https://github.com/contour-terminal/libunicode/archive/refs/tags/v${version}.tar.gz
+ https://www.unicode.org/Public/${_ucd_version}/ucd/UCD.zip>ucd-${_ucd_version}.zip"
+checksum="a5c8ba2cd3df539985bfafe43f812de143a56f01e4074e95831a37a13606beda
+ 5fbde400f3e687d25cc9b0a8d30d7619e76cb2f4c3e85ba9df8ec1312cb6718c"
+skip_extraction="ucd-${_ucd_version}.zip"
+
+if [ "$XBPS_TARGET_WORDSIZE" -eq 32 ]; then
+	broken="32bit architectures not currently supported, problems with SIMD"
+fi
+
+post_extract() {
+	vsrccopy "ucd-${_ucd_version}.zip" _ucd
+}
+
+libunicode-devel_package() {
+	depends="${sourcepkg}>=${version}_${revision}"
+	short_desc+=" - development files"
+	pkg_install() {
+		vmove usr/include
+		vmove "usr/lib/*.so"
+		vmove usr/lib/cmake
+	}
+}


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->
Fixes #34513

~~`libunicode` provides a tool, currently packaged in `-devel`, should it be somewhere else? It's a simple tool that provides info on characters passed as argument.~~ With feedback, the tool is now left in the main package.

~~I'm also not a fan of the way I have to download the Unicode UCD archive manually. The `linunicode` build system tries to do it, but it fails locally in xbps-src.~~ While having it as a distfile is still a but annoying, it's way less clunky.

#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
