### PR TITLE
chromium: update to 120.0.6099.129.

### DIFF
--- a/srcpkgs/chromium/template
+++ b/srcpkgs/chromium/template
@@ -1,7 +1,7 @@
 # Template file for 'chromium'
 pkgname=chromium
 # See https://chromiumdash.appspot.com/releases?platform=Linux for the latest version
-version=120.0.6099.109
+version=120.0.6099.129
 revision=1
 archs="i686* x86_64* aarch64* armv7l*"
 hostmakedepends="
@@ -27,7 +27,7 @@ maintainer="Duncaen <duncaen@voidlinux.org>"
 license="BSD-3-Clause"
 homepage="https://www.chromium.org/"
 distfiles="https://commondatastorage.googleapis.com/chromium-browser-official/${pkgname}-${version}.tar.xz"
-checksum=87c00c525ee07c2233b78dbece1496b697f686244a67fac2c71e4a30bd96849b
+checksum=be36d5abecfafdc68d9b27b0bee65136316610a295e844b99483a7520b245f85
 
 lib32disabled=yes
 


### PR DESCRIPTION
fixes: CVE-2023-7024

ref: https://thehackernews.com/2023/12/urgent-new-chrome-zero-day.html