### PR TITLE
i3status-rust: update to 0.32.3

### DIFF
--- a/srcpkgs/i3status-rust/template
+++ b/srcpkgs/i3status-rust/template
@@ -1,10 +1,11 @@
 # Template file for 'i3status-rust'
 pkgname=i3status-rust
-version=0.22.0
-revision=4
+version=0.32.3
+revision=1
 build_style=cargo
+build_helper="qemu"
 make_check_args="--bins"
-hostmakedepends="pkg-config"
+hostmakedepends="pkg-config pandoc"
 makedepends="dbus-devel pulseaudio-devel openssl-devel libsensors-devel"
 short_desc="Replacement for i3status, written in Rust"
 maintainer="Jan Christian Grünhage <jan.christian@gruenhage.xyz>"
@@ -12,12 +13,16 @@ license="GPL-3.0-only"
 homepage="https://github.com/greshake/i3status-rust"
 changelog="https://raw.githubusercontent.com/greshake/i3status-rust/master/NEWS.md"
 distfiles="https://github.com/greshake/i3status-rust/archive/refs/tags/v${version}.tar.gz"
-checksum=cd28a90ccb2f9faaaef1e528619f1018981609d77f409abe4877350d810d3324
+checksum=6a2c37d0e424d666f297d7ec36279b54a522acf5bf77af883be1991513e4da61
+
+post_build() {
+	cargo auditable build --release --target "${RUST_TARGET}" --package xtask
+	CARGO_MANIFEST_DIR=./xtask vtargetrun target/"${RUST_TARGET}"/release/xtask generate-manpage
+}
 
 post_install() {
 	vmkdir usr/share/i3status-rust
-	vcopy ${wrksrc}/files/icons usr/share/i3status-rust/
-	vcopy ${wrksrc}/files/themes usr/share/i3status-rust/
-
+	vcopy files/icons usr/share/i3status-rust/
+	vcopy files/themes usr/share/i3status-rust/
 	vman man/i3status-rs.1
 }


### PR DESCRIPTION
Update the version of `i3status-rust`

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, amd64/x86_64-libc
- `xbps-src -Q pkg i3status-rust` completes with no errors

Glad to update anything else if needed!