### PR TITLE
jmol: update to 16.1.47, fix dep.

### DIFF
--- a/srcpkgs/jmol/template
+++ b/srcpkgs/jmol/template
@@ -1,15 +1,15 @@
 # Template file for 'jmol'
 pkgname=jmol
-version=16.1.9
+version=16.1.47
 revision=1
-depends="virtual?java-environment"
+depends="virtual?java-runtime"
 short_desc="Open-source Java/JavaScript-based molecule viewer"
 maintainer="Brenton Horne <brentonhorne77@gmail.com>"
 license="LGPL-2.1-or-later"
 homepage="http://jmol.sourceforge.net/"
 distfiles="${SOURCEFORGE_SITE}/jmol/Jmol/Version%20${version%.*}/Jmol%20${version}/Jmol-${version}-binary.tar.gz
  http://jmol.sourceforge.net/images/Jmol_icon_128.png"
-checksum="40676ea142963548cd94c1183b4c03e7e8a08ee174dd5e5256582ae387761c3b
+checksum="de1b07f9190f3e85622a9d5b73ff3c1835521bc8dff6188f28f9147def4f2249
  302b24c7b8898a04efd74c12592243d05e53b0643a66daf809e72bc590bf9b9e"
 skip_extraction="Jmol_icon_128.png"
 


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

The main change here is to depend on java-runtime instead of java-environment.

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
