### PR TITLE
Allow build & check packages in addition to changed templates

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -69,6 +69,8 @@ jobs:
         BOOTSTRAP: '${{ matrix.config.host }}'
         TEST: '${{ matrix.config.test }}'
         HOSTREPO: /hostrepo
+        PR_TITLE: '${{ github.event.pull_request.title }}'
+        PR_BODY: '${{ github.event.pull_request.body }}'
 
     strategy:
       fail-fast: false

--- a/common/travis/changed_templates.sh
+++ b/common/travis/changed_templates.sh
@@ -2,6 +2,9 @@
 #
 # changed_templates.sh
 
+ci_check=$( echo -e "$PR_TITLE\n$PR_BODY" |
+	sed -ne 's/.*\[ci \+check \+\([^]]*[^ ]\) *].*/\1/p' )
+
 tip="$(git rev-list -1 --parents HEAD)"
 case "$tip" in
 	# This is a merge commit, pick last parent
@@ -27,3 +30,11 @@ git diff-tree -r --no-renames --name-only --diff-filter=AM \
 	xargs ./xbps-src sort-dependencies |
 	tee /tmp/templates |
 	sed "s/^/  /" >&2
+
+if [ -n "$ci_check" ]; then
+	/bin/echo -e '\x1b[32mAdditional packages to build and check:\x1b[0m'
+	printf "%s\n" $ci_check |
+		xargs ./xbps-src sort-dependencies |
+		tee -a /tmp/templates |
+		sed "s/^/  /" >&2
+fi


### PR DESCRIPTION
To use, add "[ci check pkg1 pkg2 ...]" in PR title or body.

The idea is that sometimes I change some package but I want to test if another package (depending on the changed package) builds and checks ok (example #47610, or when updating ipython / cython / etc try build&check sagemath to see everything is fine, etc).

The implementation is just passing the pr title and body in the environment and have changed_templates.sh scan these for "[ci check ...]"

#### Testing the changes
- I tested the changes in this PR: **YES**

See: https://github.com/tornaria/void-packages/actions/runs/7310706260/job/19919574047

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
