### PR TITLE
Accept -Q / -K in show-build-deps, sort-dependencies, xbps-cycles.py

### DIFF
--- a/common/scripts/xbps-cycles.py
+++ b/common/scripts/xbps-cycles.py
@@ -101,12 +101,19 @@ if __name__ == '__main__':
 			help='Directory used to cache build dependencies (must exist)')
 	parser.add_argument('-d', '--directory',
 			default=None, help='Path to void-packages repo')
+	parser.add_argument('-Q', dest='check_pkgs', action='store_const',
+			const='yes', help='Use build dependencies for check -Q')
+	parser.add_argument('-K', dest='check_pkgs', action='store_const',
+			const='full', help='Use build dependencies for check -K')
 
 	args = parser.parse_args()
 
 	if not args.directory:
 		try: args.directory = os.environ['XBPS_DISTDIR']
 		except KeyError: args.directory = '.'
+
+	if args.check_pkgs:
+		os.environ['XBPS_CHECK_PKGS'] = args.check_pkgs
 
 	pool = multiprocessing.Pool(processes = args.jobs)
 

--- a/common/travis/build.sh
+++ b/common/travis/build.sh
@@ -10,7 +10,7 @@ if [ "$3" = 1 ]; then
 	test="-Q"
 fi
 
-PKGS=$(/hostrepo/xbps-src sort-dependencies $(cat /tmp/templates))
+PKGS=$(/hostrepo/xbps-src $test sort-dependencies $(cat /tmp/templates))
 
 for pkg in ${PKGS}; do
 	/hostrepo/xbps-src -j$(nproc) -s -H "$HOME"/hostdir $arch $test pkg "$pkg"

--- a/common/xbps-src/shutils/build_dependencies.sh
+++ b/common/xbps-src/shutils/build_dependencies.sh
@@ -125,6 +125,17 @@ check_installed_pkg() {
 }
 
 #
+# Return 0 if we will skip the check step
+#
+skip_check_step() {
+    [ -z "$XBPS_CHECK_PKGS" ] ||
+        [ "$XBPS_CROSS_BUILD" ] ||
+        [ "$make_check" = ci-skip  -a "$XBPS_BUILD_ENVIRONMENT" = void-packages-ci ] ||
+        [ "$make_check" = extended -a "$XBPS_CHECK_PKGS" != full ] ||
+        [ "$make_check" = no ]
+}
+
+#
 # Build all dependencies required to build and run.
 #
 install_pkg_deps() {
@@ -137,7 +148,7 @@ install_pkg_deps() {
     local -a host_missing_deps missing_deps missing_rdeps
 
     [ -z "$pkgname" ] && return 2
-    [ -z "$XBPS_CHECK_PKGS" ] && unset checkdepends
+    skip_check_step && unset checkdepends
 
     if [[ $build_style ]] || [[ $build_helper ]]; then
         style=" with"
@@ -208,7 +219,7 @@ install_pkg_deps() {
     #
     # Host check dependencies.
     #
-    if [[ ${checkdepends} ]] && [[ $XBPS_CHECK_PKGS ]] && [ -z "$XBPS_CROSS_BUILD" ]; then
+    if [[ ${checkdepends} ]]; then
         templates=""
         # check validity
         for f in ${checkdepends}; do

--- a/common/xbps-src/shutils/show.sh
+++ b/common/xbps-src/shutils/show.sh
@@ -117,7 +117,9 @@ show_pkg_build_depends() {
 }
 
 show_pkg_build_deps() {
-    show_pkg_build_depends "${makedepends} $(setup_pkg_depends '' 1 1)" "${hostmakedepends}"
+    local build_depends="${makedepends} $(setup_pkg_depends '' 1 1)"
+    skip_check_step || build_depends+=" ${checkdepends}"
+    show_pkg_build_depends "${build_depends}" "${hostmakedepends}"
 }
 
 show_pkg_hostmakedepends() {
@@ -126,6 +128,10 @@ show_pkg_hostmakedepends() {
 
 show_pkg_makedepends() {
     show_pkg_build_depends "${makedepends}" ""
+}
+
+show_pkg_checkdepends() {
+    show_pkg_build_depends "${checkdepends}" ""
 }
 
 show_pkg_build_options() {

--- a/xbps-src
+++ b/xbps-src
@@ -91,6 +91,9 @@ show-avail <pkgname>
 show-build-deps <pkgname>
     Show required build dependencies for <pkgname>.
 
+show-check-deps <pkgname>
+    Show required check dependencies for <pkgname>.
+
 show-deps <pkgname>
     Show required run-time dependencies for <pkgname>. Package must be
     installed into destdir.
@@ -868,6 +871,10 @@ case "$XBPS_TARGET" in
     show-makedepends)
         read_pkg ignore-problems
         show_pkg_makedepends
+        ;;
+    show-checkdepends)
+        read_pkg ignore-problems
+        show_pkg_checkdepends
         ;;
     show-pkg-var-dump)
         read_pkg ignore-problems


### PR DESCRIPTION
As it is now, if `pkgA` checkdepends on `pkgB`, sort-dependencies will still print `pkgA` before `pkgB`. This causes CI to build `pkgB` twice: first build `pkgA` which forces implicit build of `pkgB`; then build of `pkgB` (explicit, so it will ignore the package is already built).

A concrete example:

```
$ ./xbps-src sort-dependencies python3-process-tests python3-pytest-cov
python3-pytest-cov
python3-process-tests
```

The example above causes `python-process-tests` to be built twice, as shown in:
https://github.com/void-linux/void-packages/actions/runs/7107346278/job/19348602412?pr=47610


After this commit one can do
```
$ ./xbps-src -Q sort-dependencies python3-process-tests python3-pytest-cov
python3-process-tests
python3-pytest-cov
```

The CI issue is fixed by pasing -Q to sort-dependencies when we are doing a test build.

Jump to https://github.com/void-linux/void-packages/pull/47888#issuecomment-1869639495 to skip comments about earlier versions of the PR.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
