### PR TITLE
android-file-transfer-linux: Add missing dependency

### DIFF
--- a/srcpkgs/android-file-transfer-linux/template
+++ b/srcpkgs/android-file-transfer-linux/template
@@ -1,12 +1,13 @@
 # Template file for 'android-file-transfer-linux'
 pkgname=android-file-transfer-linux
 version=4.2
-revision=3
+revision=4
 build_style=cmake
 configure_args="-DBUILD_SHARED_LIB=1"
 hostmakedepends="qt5-qmake qt5-host-tools ninja pkg-config"
 makedepends="file-devel fuse-devel qt5-devel readline-devel
  qt5-tools-devel"
+depends="qt5-svg"
 short_desc="Android File Transfer for Linux"
 maintainer="Toyam Cox <Vaelatern@voidlinux.org>"
 license="LGPL-2.1-or-later"


### PR DESCRIPTION
android-file-transfer-linux doesn't depend on its icons, which can be confusing if someone doesn't have them. This is not a problem when the user is running Kde, but if someone (like me) is using aft "standalone", `qt5-svg` doesn't get pulled.

#### Testing the changes
- I tested the changes in this PR: **YES**