### PR TITLE
New package: importsort-d-0.3.2

### DIFF
--- a/srcpkgs/importsort-d/template
+++ b/srcpkgs/importsort-d/template
@@ -1,0 +1,22 @@
+# Template file for 'importsort-d'
+
+pkgname=importsort-d
+version=0.3.2
+revision=1
+hostmakedepends="dub"
+short_desc="Sorts imports in .d-files"
+maintainer="Friedel Schön <derfriedmundschoen@gmail.com>"
+license="Zlib"
+homepage="https://friedelschoen.github.io/importsort-d"
+distfiles="https://github.com/friedelschoen/importsort-d/archive/refs/tags/v${version}.tar.gz"
+checksum=ac22d23b37b5ab2e089c5d81c5c8afb04a7bc9df78dfadd77d6499a718db8827
+nocross="dmd compilation fails on cross"
+
+do_build() {
+	dub build -b release
+}
+
+do_install() {
+	vbin bin/importsort-d
+	vlicense LICENSE.txt
+}


### PR DESCRIPTION
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

#### Local build testing
- I built this PR locally for my native architecture: x86_64 (cross build not supported due to `dub`)