### PR TITLE
libedit: fix badly-generated man pages

### DIFF
--- a/srcpkgs/libedit/template
+++ b/srcpkgs/libedit/template
@@ -1,8 +1,9 @@
 # Template file for 'libedit'
 pkgname=libedit
 version=20230828.3.1
-revision=1
+revision=2
 build_style=gnu-configure
+hostmakedepends="groff"
 makedepends="ncurses-devel"
 short_desc="Port of the NetBSD Command Line Editor Library"
 maintainer="Orphaned <orphan@voidlinux.org>"


### PR DESCRIPTION
If nroff isn't detected by the build script, it will attempt to convert the mdoc macros into classic man macros.  Unfortunately, this results in the syntax being broken to the point where the man pages are pretty much useless.  Adding groff as a make dependency fixes this.

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc