### PR TITLE
newsboat: update to 2.34

### DIFF
--- a/srcpkgs/newsboat/template
+++ b/srcpkgs/newsboat/template
@@ -1,6 +1,6 @@
 # Template file for 'newsboat'
 pkgname=newsboat
-version=2.33
+version=2.34
 revision=1
 build_style=configure
 build_helper="rust"
@@ -17,7 +17,7 @@ license="MIT"
 homepage="https://newsboat.org/"
 changelog="https://raw.githubusercontent.com/newsboat/newsboat/master/CHANGELOG.md"
 distfiles="https://newsboat.org/releases/${version}/newsboat-${version}.tar.xz"
-checksum=179d0d5e608337f14e5e670c0a6b144129ed4e504621ca2a117d188894cb34fa
+checksum=73d7b539b0c906f6843a1542e1904a02ae430e79d6be4d6f9e2e2034eac2434e
 python_version=3
 
 # tests fail when run by superuser


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)