### PR TITLE
Fix dependencies so show-build-deps won't fail 

### DIFF
--- a/common/xbps-src/shutils/show.sh
+++ b/common/xbps-src/shutils/show.sh
@@ -75,7 +75,7 @@ show_avail() {
 
 show_eval_dep() {
     local f x _pkgname _srcpkg found
-    local _dep="$1"
+    local _dep="${1%-32bit}"
     local _host="$2"
     if [ -z "$CROSS_BUILD" ] || [ -z "$_host" ]; then
         # ignore dependency on itself
@@ -92,8 +92,7 @@ show_eval_dep() {
         [[ $_dep == $x ]] && found=1 && break
     done
     [[ $found ]] && return
-    _pkgname=${_dep/-32bit}
-    _srcpkg=$(readlink -f ${XBPS_SRCPKGDIR}/${_pkgname})
+    _srcpkg=$(readlink -f ${XBPS_SRCPKGDIR}/${_dep})
     _srcpkg=${_srcpkg##*/}
     echo $_srcpkg
 }

--- a/srcpkgs/bcachefs-tools/template
+++ b/srcpkgs/bcachefs-tools/template
@@ -8,7 +8,7 @@ make_install_args="ROOT_SBINDIR=/usr/bin"
 make_use_env=yes
 hostmakedepends="pkg-config cargo clang liburcu-devel"
 makedepends="rust attr-devel keyutils-devel libaio-devel libblkid-devel
- liblz4-devel libscrypt-devel libsodium-devel libudev-devel liburcu-devel
+ liblz4-devel libscrypt-devel libsodium-devel eudev-libudev-devel liburcu-devel
  libuuid-devel libzstd-devel zlib-devel"
 short_desc="Userspace tools for bcachefs"
 maintainer="Leah Neukirchen <leah@vuxu.org>"

--- a/srcpkgs/python3-QtPy/template
+++ b/srcpkgs/python3-QtPy/template
@@ -16,7 +16,7 @@ _qt5check="${_qtcommon} :location :opengl :quick :x11extras :xmlpatterns
 _qt6check="${_qtcommon} :dbus :declarative :devel-tools :gui :network
  :opengl-widgets :printsupport :quick3d :remoteobjects :test :widgets :xml
  qt6-plugin-sqlite"
-checkdepends="python3-pytest-cov python3-pytest-qt font-liberation-ttf
+checkdepends="python3-pytest-cov python3-pytest-qt liberation-fonts-ttf
  ${_qt5check//:/python3-PyQt5-} ${_qt6check//:/python3-pyqt6-}"
 short_desc="Abstraction layer on top of various Python Qt bindings"
 maintainer="Gonzalo Tornaría <tornaria@cmat.edu.uy>"

--- a/srcpkgs/python3-google-api-python-client/template
+++ b/srcpkgs/python3-google-api-python-client/template
@@ -8,7 +8,7 @@ make_check_args="--deselect=tests/test__helpers.py::PositionalTests::test_usage
 hostmakedepends="python3-setuptools"
 depends="python3-httplib2 python3-google-auth python3-google-auth-httplib2
  python3-google-api-core python3-uritemplate"
-checkdepends="${depends} python3-Django python3-parameterized python3-openssl
+checkdepends="${depends} python3-parameterized python3-openssl
  python3-oauth2client python3-pytest-xdist"
 short_desc="Google API client library for Python3"
 maintainer="Orphaned <orphan@voidlinux.org>"

--- a/srcpkgs/qgis/template
+++ b/srcpkgs/qgis/template
@@ -9,7 +9,7 @@ hostmakedepends="bison flex pkg-config protobuf python3 python3-sip-PyQt5 sip"
 makedepends="exiv2-devel draco-devel expat-devel freexl-devel geos-devel
  gsl-devel grass-devel hdf5-devel libgdal-devel libpdal-devel librttopo-devel
  libspatialindex-devel libspatialite-devel libxml2-devel libzip-devel
- minizip-devel netcdf-devel ocl-icd-devel opencl-clhpp postgresql-libs-devel
+ minizip-devel netcdf-devel ocl-icd-devel postgresql-libs-devel
  proj-devel protobuf-devel python3-devel python3-PyQt-builder
  python3-PyQt5-devel python3-PyQt5-devel-tools python3-PyQt5-multimedia
  python3-pyqt5-qsci-devel python3-PyQt5-webkit python3-sip-PyQt5 qca-qt5-devel


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->
Split up from #47888 to avoid long CI in that PR.

This fixes dependencies in four packages and also fixes handling of `*-32bit` deps.

Before this change:
```
$ for p in bcachefs-tools brother-dcp197c-lpr gcc-multilib nvidia nvidia470 python3-QtPy python3-google-api-python-client qgis ; do ./xbps-src show-build-deps -K $p > /dev/null; done
=> ERROR: bcachefs-tools-1.3.6_1: dependency 'libudev-devel' does not exist!
=> ERROR: brother-dcp197c-lpr-1.1.3_6: dependency 'glibc-32bit' does not exist!
=> ERROR: gcc-multilib-12.2.0_2: dependency 'glibc-32bit' does not exist!
=> ERROR: nvidia-535.146.02_1: dependency 'glibc-32bit' does not exist!
=> ERROR: nvidia470-470.223.02_1: dependency 'glibc-32bit' does not exist!
=> ERROR: python3-QtPy-2.4.1_1: dependency 'font-liberation-ttf' does not exist!
=> ERROR: python3-google-api-python-client-2.80.0_2: dependency 'python3-Django' does not exist!
=> ERROR: qgis-3.34.1_1: dependency 'opencl-clhpp' does not exist!
```

After this change, there is no error. Also running `common/scripts/xbps-cycles.py` will do every package (Those 8 are all the failures I got).

Note that the errors for `python3-QtPy` and `python3-google-api-python-client` show only if #47888 is applied, since they are for checkdepends.

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
