### PR TITLE
python3-ipython: fix sagemath prompt

### DIFF
--- a/srcpkgs/python3-ipython/patches/fix-sagemath-prompt.patch
+++ b/srcpkgs/python3-ipython/patches/fix-sagemath-prompt.patch
@@ -1,0 +1,15 @@
+See: https://github.com/ipython/ipython/pull/14223#issuecomment-1869776898
+
+diff --git a/IPython/terminal/interactiveshell.py b/IPython/terminal/interactiveshell.py
+index 532287f5e..d92d6b7b2 100644
+--- a/IPython/terminal/interactiveshell.py
++++ b/IPython/terminal/interactiveshell.py
+@@ -764,7 +764,7 @@ def get_message():
+             "message": get_message,
+             "prompt_continuation": (
+                 lambda width, lineno, is_soft_wrap: PygmentsTokens(
+-                    self.prompts.continuation_prompt_tokens(width, lineno=lineno)
++                    self.prompts.continuation_prompt_tokens(width)
+                 )
+             ),
+             "multiline": True,

--- a/srcpkgs/python3-ipython/template
+++ b/srcpkgs/python3-ipython/template
@@ -1,7 +1,7 @@
 # Template file for 'python3-ipython'
 pkgname=python3-ipython
 version=8.19.0
-revision=1
+revision=2
 build_style=python3-pep517
 hostmakedepends="python3-setuptools python3-wheel"
 depends="python3-jedi python3-decorator python3-pickleshare


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

@ahesford nasty bug in ipython that makes (interactive) sagemath unusable.

See: https://github.com/ipython/ipython/pull/14223#issuecomment-1869776898

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
