### PR TITLE
[ci skip] glibc: fix memalign performance regression

### DIFF
--- a/srcpkgs/busybox/template
+++ b/srcpkgs/busybox/template
@@ -1,7 +1,7 @@
 # Template file for 'busybox'
 pkgname=busybox
 version=1.34.1
-revision=5
+revision=6
 hostmakedepends="perl"
 checkdepends="tar which zip"
 short_desc="Swiss Army Knife of Embedded Linux"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

The upgrade to 2.38 brought a very sad performance regression in sagemath:
```
$ time python -c 'from sage.graphs.generators.distance_regular import DoubleGrassmannGraph; print(DoubleGrassmannGraph(2,2))'
<string>:1: UserWarning: Resolving lazy import GF during startup
<string>:1: UserWarning: Resolving lazy import VectorSpace during startup
Double Grassmann graph (5, 2, 2)

real	0m30.101s
user	0m29.959s
sys	0m0.060s
```
while the same thing in 2.36 (or after this PR) takes ~ 1-2 seconds.

Thanks to @oreo639 for figuring out it was https://sourceware.org/bugzilla/show_bug.cgi?id=30723

Indeed, all the performance regressions I was seeing are gone now.

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
