### PR TITLE
python3-rapidfuzz: update to 3.8.0

### DIFF
--- a/srcpkgs/python3-rapidfuzz/template
+++ b/srcpkgs/python3-rapidfuzz/template
@@ -1,6 +1,6 @@
 # Template file for 'python3-rapidfuzz'
 pkgname=python3-rapidfuzz
-version=3.5.2
+version=3.8.1
 revision=1
 build_style=python3-pep517
 hostmakedepends="cmake python3-scikit-build"
@@ -11,8 +11,9 @@ short_desc="Rapid fuzzy string matching in Python using various string metrics"
 maintainer="chrysos349 <chrysostom349@gmail.com>"
 license="MIT"
 homepage="https://github.com/maxbachmann/rapidfuzz"
+changelog="https://github.com/rapidfuzz/RapidFuzz/releases"
 distfiles="${PYPI_SITE}/r/rapidfuzz/rapidfuzz-${version}.tar.gz"
-checksum=9e9b395743e12c36a3167a3a9fd1b4e11d92fb0aa21ec98017ee6df639ed385e
+checksum=a357aae6791118011ad3ab4f2a4aa7bd7a487e5f9981b390e9f3c2c5137ecadf
 
 export CMAKE_ARGS="-DPython_INCLUDE_DIR:PATH=${XBPS_CROSS_BASE}/${py3_inc}"
 

--- a/srcpkgs/rapidfuzz-cpp/template
+++ b/srcpkgs/rapidfuzz-cpp/template
@@ -1,6 +1,6 @@
 # Template file for 'rapidfuzz-cpp'
 pkgname=rapidfuzz-cpp
-version=2.2.3
+version=3.0.4
 revision=1
 build_style=cmake
 short_desc="Rapid fuzzy string matching in C++ using the Levenshtein Distance"
@@ -8,7 +8,7 @@ maintainer="chrysos349 <chrysostom349@gmail.com>"
 license="MIT"
 homepage="https://github.com/maxbachmann/rapidfuzz-cpp"
 distfiles="https://github.com/maxbachmann/rapidfuzz-cpp/archive/v${version}.tar.gz"
-checksum=df4412e9593945782de2212095bd4b70a8f8e63ae8f313976c616809be124d2c
+checksum=18d1c41575ceddd6308587da8befc98c85d3b5bc2179d418daffed6d46b8cb0a
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl x
  - armv7l x
  - armv6l-musl x