### PR TITLE
llvm15: remove crypt interceptor for sanitizers and fix build with gcc13

### DIFF
--- a/srcpkgs/llvm15/patches/compiler-rt-sanitizer-nocrypt.patch
+++ b/srcpkgs/llvm15/patches/compiler-rt-sanitizer-nocrypt.patch
@@ -1,0 +1,223 @@
+From d7bead833631486e337e541e692d9b4a1ca14edd Mon Sep 17 00:00:00 2001
+From: Fangrui Song <i@maskray.me>
+Date: Fri, 28 Apr 2023 09:59:17 -0700
+Subject: [PATCH] [sanitizer] Remove crypt and crypt_r interceptors
+
+From Florian Weimer's D144073
+
+> On GNU/Linux (glibc), the crypt and crypt_r functions are not part of the main shared object (libc.so.6), but libcrypt (with multiple possible sonames). The sanitizer libraries do not depend on libcrypt, so it can happen that during sanitizer library initialization, no real implementation will be found because the crypt, crypt_r functions are not present in the process image (yet). If its interceptors are called nevertheless, this results in a call through a null pointer when the sanitizer library attempts to forward the call to the real implementation.
+>
+> Many distributions have already switched to libxcrypt, a library that is separate from glibc and that can be build with sanitizers directly (avoiding the need for interceptors). This patch disables building the interceptor for glibc targets.
+
+Let's remove crypt and crypt_r interceptors (D68431) to fix issues with
+newer glibc.
+
+For older glibc, msan will not know that an uninstrumented crypt_r call
+initializes `data`, so there is a risk for false positives. However, with some
+codebase survey, I think crypt_r uses are very few and the call sites typically
+have a `memset(&data, 0, sizeof(data));` anyway.
+
+Fix https://github.com/google/sanitizers/issues/1365
+Related: https://bugzilla.redhat.com/show_bug.cgi?id=2169432
+
+Reviewed By: #sanitizers, fweimer, thesamesam, vitalybuka
+
+Differential Revision: https://reviews.llvm.org/D149403
+---
+ .../sanitizer_common_interceptors.inc         | 37 -------------------
+ .../sanitizer_platform_interceptors.h         |  2 -
+ .../sanitizer_platform_limits_posix.cpp       |  8 ----
+ .../sanitizer_platform_limits_posix.h         |  1 -
+ .../TestCases/Linux/crypt_r.cpp               | 36 ------------------
+ .../TestCases/Posix/crypt.cpp                 | 32 ----------------
+ 6 files changed, 116 deletions(-)
+ delete mode 100644 compiler-rt/test/sanitizer_common/TestCases/Linux/crypt_r.cpp
+ delete mode 100644 compiler-rt/test/sanitizer_common/TestCases/Posix/crypt.cpp
+
+diff --git a/compiler-rt/lib/sanitizer_common/sanitizer_common_interceptors.inc b/compiler-rt/lib/sanitizer_common/sanitizer_common_interceptors.inc
+index b30c91f06cfeb0..490a8b12d8b17d 100644
+--- a/compiler-rt/lib/sanitizer_common/sanitizer_common_interceptors.inc
++++ b/compiler-rt/lib/sanitizer_common/sanitizer_common_interceptors.inc
+@@ -10086,41 +10086,6 @@ INTERCEPTOR(SSIZE_T, getrandom, void *buf, SIZE_T buflen, unsigned int flags) {
+ #define INIT_GETRANDOM
+ #endif
+ 
+-#if SANITIZER_INTERCEPT_CRYPT
+-INTERCEPTOR(char *, crypt, char *key, char *salt) {
+-  void *ctx;
+-  COMMON_INTERCEPTOR_ENTER(ctx, crypt, key, salt);
+-  COMMON_INTERCEPTOR_READ_RANGE(ctx, key, internal_strlen(key) + 1);
+-  COMMON_INTERCEPTOR_READ_RANGE(ctx, salt, internal_strlen(salt) + 1);
+-  char *res = REAL(crypt)(key, salt);
+-  if (res != nullptr)
+-    COMMON_INTERCEPTOR_INITIALIZE_RANGE(res, internal_strlen(res) + 1);
+-  return res;
+-}
+-#define INIT_CRYPT COMMON_INTERCEPT_FUNCTION(crypt);
+-#else
+-#define INIT_CRYPT
+-#endif
+-
+-#if SANITIZER_INTERCEPT_CRYPT_R
+-INTERCEPTOR(char *, crypt_r, char *key, char *salt, void *data) {
+-  void *ctx;
+-  COMMON_INTERCEPTOR_ENTER(ctx, crypt_r, key, salt, data);
+-  COMMON_INTERCEPTOR_READ_RANGE(ctx, key, internal_strlen(key) + 1);
+-  COMMON_INTERCEPTOR_READ_RANGE(ctx, salt, internal_strlen(salt) + 1);
+-  char *res = REAL(crypt_r)(key, salt, data);
+-  if (res != nullptr) {
+-    COMMON_INTERCEPTOR_WRITE_RANGE(ctx, data,
+-                                   __sanitizer::struct_crypt_data_sz);
+-    COMMON_INTERCEPTOR_INITIALIZE_RANGE(res, internal_strlen(res) + 1);
+-  }
+-  return res;
+-}
+-#define INIT_CRYPT_R COMMON_INTERCEPT_FUNCTION(crypt_r);
+-#else
+-#define INIT_CRYPT_R
+-#endif
+-
+ #if SANITIZER_INTERCEPT_GETENTROPY
+ INTERCEPTOR(int, getentropy, void *buf, SIZE_T buflen) {
+   void *ctx;
+@@ -10698,8 +10663,6 @@ static void InitializeCommonInterceptors() {
+   INIT_GETUSERSHELL;
+   INIT_SL_INIT;
+   INIT_GETRANDOM;
+-  INIT_CRYPT;
+-  INIT_CRYPT_R;
+   INIT_GETENTROPY;
+   INIT_QSORT;
+   INIT_QSORT_R;
+diff --git a/compiler-rt/lib/sanitizer_common/sanitizer_platform_interceptors.h b/compiler-rt/lib/sanitizer_common/sanitizer_platform_interceptors.h
+index eb39fabfd59839..c82ab5c2105621 100644
+--- a/compiler-rt/lib/sanitizer_common/sanitizer_platform_interceptors.h
++++ b/compiler-rt/lib/sanitizer_common/sanitizer_platform_interceptors.h
+@@ -569,8 +569,6 @@
+ #define SANITIZER_INTERCEPT_FDEVNAME SI_FREEBSD
+ #define SANITIZER_INTERCEPT_GETUSERSHELL (SI_POSIX && !SI_ANDROID)
+ #define SANITIZER_INTERCEPT_SL_INIT (SI_FREEBSD || SI_NETBSD)
+-#define SANITIZER_INTERCEPT_CRYPT (SI_POSIX && !SI_ANDROID)
+-#define SANITIZER_INTERCEPT_CRYPT_R (SI_LINUX && !SI_ANDROID)
+ 
+ #define SANITIZER_INTERCEPT_GETRANDOM \
+   ((SI_LINUX && __GLIBC_PREREQ(2, 25)) || SI_FREEBSD)
+diff --git a/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.cpp b/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.cpp
+index a04eed7aa5a6e3..6d61d276d77e35 100644
+--- a/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.cpp
++++ b/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.cpp
+@@ -177,10 +177,6 @@ typedef struct user_fpregs elf_fpregset_t;
+ #  include "sanitizer_platform_interceptors.h"
+ #  include "sanitizer_platform_limits_posix.h"
+ 
+-#if SANITIZER_INTERCEPT_CRYPT_R
+-#include <crypt.h>
+-#endif
+-
+ namespace __sanitizer {
+   unsigned struct_utsname_sz = sizeof(struct utsname);
+   unsigned struct_stat_sz = sizeof(struct stat);
+@@ -300,10 +296,6 @@ namespace __sanitizer {
+   unsigned struct_statvfs64_sz = sizeof(struct statvfs64);
+ #endif // SANITIZER_GLIBC
+ 
+-#if SANITIZER_INTERCEPT_CRYPT_R
+-  unsigned struct_crypt_data_sz = sizeof(struct crypt_data);
+-#endif
+-
+ #if SANITIZER_LINUX && !SANITIZER_ANDROID
+   unsigned struct_timex_sz = sizeof(struct timex);
+   unsigned struct_msqid_ds_sz = sizeof(struct msqid_ds);
+diff --git a/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.h b/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.h
+index e6f298c26e1fb6..58244c9944a03a 100644
+--- a/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.h
++++ b/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.h
+@@ -309,7 +309,6 @@ extern unsigned struct_msqid_ds_sz;
+ extern unsigned struct_mq_attr_sz;
+ extern unsigned struct_timex_sz;
+ extern unsigned struct_statvfs_sz;
+-extern unsigned struct_crypt_data_sz;
+ #endif  // SANITIZER_LINUX && !SANITIZER_ANDROID
+ 
+ struct __sanitizer_iovec {
+diff --git a/compiler-rt/test/sanitizer_common/TestCases/Linux/crypt_r.cpp b/compiler-rt/test/sanitizer_common/TestCases/Linux/crypt_r.cpp
+deleted file mode 100644
+index 69bfb46aa5f171..00000000000000
+--- a/compiler-rt/test/sanitizer_common/TestCases/Linux/crypt_r.cpp
++++ /dev/null
+@@ -1,36 +0,0 @@
+-// RUN: %clangxx -O0 -g %s -lcrypt -o %t && %run %t
+-
+-// crypt.h is missing from Android.
+-// UNSUPPORTED: android
+-
+-#include <assert.h>
+-#include <unistd.h>
+-#include <cstring>
+-#include <crypt.h>
+-
+-int main(int argc, char **argv) {
+-  {
+-    crypt_data cd;
+-    cd.initialized = 0;
+-    char *p = crypt_r("abcdef", "xz", &cd);
+-    volatile size_t z = strlen(p);
+-  }
+-  {
+-    crypt_data cd;
+-    cd.initialized = 0;
+-    char *p = crypt_r("abcdef", "$1$", &cd);
+-    volatile size_t z = strlen(p);
+-  }
+-  {
+-    crypt_data cd;
+-    cd.initialized = 0;
+-    char *p = crypt_r("abcdef", "$5$", &cd);
+-    volatile size_t z = strlen(p);
+-  }
+-  {
+-    crypt_data cd;
+-    cd.initialized = 0;
+-    char *p = crypt_r("abcdef", "$6$", &cd);
+-    volatile size_t z = strlen(p);
+-  }
+-}
+diff --git a/compiler-rt/test/sanitizer_common/TestCases/Posix/crypt.cpp b/compiler-rt/test/sanitizer_common/TestCases/Posix/crypt.cpp
+deleted file mode 100644
+index 3a8faaa1ae7682..00000000000000
+--- a/compiler-rt/test/sanitizer_common/TestCases/Posix/crypt.cpp
++++ /dev/null
+@@ -1,32 +0,0 @@
+-// RUN: %clangxx -O0 -g %s -o %t -lcrypt && %run %t
+-
+-// crypt() is missing from Android and -lcrypt from darwin.
+-// UNSUPPORTED: android, darwin
+-
+-#include <assert.h>
+-#include <unistd.h>
+-#include <cstring>
+-#if __has_include(<crypt.h>)
+-#include <crypt.h>
+-#endif
+-
+-int
+-main (int argc, char** argv)
+-{
+-  {
+-    char *p = crypt("abcdef", "xz");
+-    volatile size_t z = strlen(p);
+-  }
+-  {
+-    char *p = crypt("abcdef", "$1$");
+-    volatile size_t z = strlen(p);
+-  }
+-  {
+-    char *p = crypt("abcdef", "$5$");
+-    volatile size_t z = strlen(p);
+-  }
+-  {
+-    char *p = crypt("abcdef", "$6$");
+-    volatile size_t z = strlen(p);
+-  }
+-}
+

--- a/srcpkgs/llvm15/patches/libcxx-gcc13.patch
+++ b/srcpkgs/llvm15/patches/libcxx-gcc13.patch
@@ -1,0 +1,42 @@
+From 484e64f7e7b2c0494d7b2dbfdd528bcd707ee652 Mon Sep 17 00:00:00 2001
+From: Roland McGrath <mcgrathr@google.com>
+Date: Thu, 27 Apr 2023 14:18:18 -0700
+Subject: [PATCH] [libc++] Use __is_convertible built-in when available
+
+https://github.com/llvm/llvm-project/issues/62396 reports that
+GCC 13 barfs on parsing <type_traits> because of the declarations
+of `struct __is_convertible`.  In GCC 13, `__is_convertible` is a
+built-in, but `__is_convertible_to` is not.  Clang has both, so
+using either should be fine.
+
+Reviewed By: #libc, philnik
+
+Differential Revision: https://reviews.llvm.org/D149313
+---
+ libcxx/include/__type_traits/is_convertible.h | 9 ++++++++-
+ 1 file changed, 8 insertions(+), 1 deletion(-)
+
+diff --git a/libcxx/include/__type_traits/is_convertible.h b/libcxx/include/__type_traits/is_convertible.h
+index 873a64b5a486cc..749d6fd47af9c6 100644
+--- a/libcxx/include/__type_traits/is_convertible.h
++++ b/libcxx/include/__type_traits/is_convertible.h
+@@ -24,11 +24,18 @@
+ 
+ _LIBCPP_BEGIN_NAMESPACE_STD
+ 
+-#if __has_builtin(__is_convertible_to) && !defined(_LIBCPP_USE_IS_CONVERTIBLE_FALLBACK)
++#if __has_builtin(__is_convertible) && !defined(_LIBCPP_USE_IS_CONVERTIBLE_FALLBACK)
++
++template <class _T1, class _T2>
++struct _LIBCPP_TEMPLATE_VIS is_convertible : public integral_constant<bool, __is_convertible(_T1, _T2)> {};
++
++#elif __has_builtin(__is_convertible_to) && !defined(_LIBCPP_USE_IS_CONVERTIBLE_FALLBACK)
+ 
+ template <class _T1, class _T2> struct _LIBCPP_TEMPLATE_VIS is_convertible
+     : public integral_constant<bool, __is_convertible_to(_T1, _T2)> {};
+ 
++// TODO: Remove this fallback when GCC < 13 support is no longer required.
++// GCC 13 has the __is_convertible built-in.
+ #else  // __has_builtin(__is_convertible_to) && !defined(_LIBCPP_USE_IS_CONVERTIBLE_FALLBACK)
+ 
+ namespace __is_convertible_imp

--- a/srcpkgs/llvm15/patches/libomp-gcc13.patch
+++ b/srcpkgs/llvm15/patches/libomp-gcc13.patch
@@ -1,0 +1,23 @@
+From 1b4fdf18bc2aaa2d46bf072475dd9cbcd44a9fee Mon Sep 17 00:00:00 2001
+From: Nikita Popov <npopov@redhat.com>
+Date: Fri, 20 Jan 2023 10:11:01 +0100
+Subject: [PATCH] [libomp] Explicitly include <string> header (NFC)
+
+This is required to build against libstdc++ 13. Debug.h uses
+std::stoi() from <string> without explicitly including it.
+---
+ openmp/libomptarget/include/Debug.h | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/openmp/libomptarget/include/Debug.h b/openmp/libomptarget/include/Debug.h
+index 4e7da8b7d53f24..387dfe50659e43 100644
+--- a/openmp/libomptarget/include/Debug.h
++++ b/openmp/libomptarget/include/Debug.h
+@@ -39,6 +39,7 @@
+ 
+ #include <atomic>
+ #include <mutex>
++#include <string>
+ 
+ /// 32-Bit field data attributes controlling information presented to the user.
+ enum OpenMPInfoType : uint32_t {

--- a/srcpkgs/llvm15/template
+++ b/srcpkgs/llvm15/template
@@ -1,7 +1,7 @@
 # Template file for 'llvm15'
 pkgname=llvm15
 version=15.0.7
-revision=2
+revision=3
 build_wrksrc=llvm
 build_style=cmake
 _ext_suffix=".cpython-${py3_ver/./}-linux-${XBPS_TARGET_LIBC/glibc/gnu}.so"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->
[ci skip]
#### Testing the changes
- I tested the changes in this PR: **briefly**

This fixes compiling with glibc 2.38+. crypt.h was used for getting the size of `struct crypt_data` in the crypt interceptor. The interceptor has since been removed in LLVM and gcc upstreams.

Revbump since this changes the behavior of sanitizers and modifies a public libc++ header.

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
