### PR TITLE
glibc: depend on libxcrypt to ensure partial upgrades work

### DIFF
--- a/srcpkgs/glibc/template
+++ b/srcpkgs/glibc/template
@@ -1,7 +1,7 @@
 # Template file for 'glibc'
 pkgname=glibc
 version=2.38
-revision=2
+revision=3
 bootstrap=yes
 short_desc="GNU C library"
 maintainer="Enno Boland <gottox@voidlinux.org>"
@@ -48,6 +48,9 @@ conf_files="
 	/etc/ld.so.conf"
 if [ "$CHROOT_READY" ]; then
 	hostmakedepends="bison gettext perl python3 texinfo"
+	# XXX: remove this on the next update
+	# ensures partial upgrades don't break things like PAM
+	depends="libxcrypt-compat"
 fi
 makedepends="kernel-libc-headers"
 lib32files="/usr/lib/gconv/gconv-modules"


### PR DESCRIPTION
if a partial upgrade occurs that includes glibc but not libxcrypt, libcrypt.so.1 will disappear and things like PAM will fail to work. This is only solvable by chrooting in and downgrading glibc or installing libxcrypt.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **NO** (currently away from other systems I can test on)
