### PR TITLE
prometheus: update to 2.49.0.

### DIFF
--- a/srcpkgs/prometheus/template
+++ b/srcpkgs/prometheus/template
@@ -1,14 +1,15 @@
 # Template file for 'prometheus'
 pkgname=prometheus
-version=2.43.0
-revision=3
+version=2.49.1
+revision=1
 build_style=go
 go_import_path="github.com/prometheus/prometheus"
 go_package="github.com/prometheus/prometheus/cmd/prometheus github.com/prometheus/prometheus/cmd/promtool"
-go_ldflags="-X ${go_import_path}/version.Version=${version}
- -X ${go_import_path}/version.Revision=${version}
- -X ${go_import_path}/version.Branch=${version}
- -X ${go_import_path}/version.BuildUser=VoidLinux"
+go_ldflags="-X github.com/prometheus/common/version.Version=${version}
+ -X github.com/prometheus/common/version.Revision=${version}
+ -X github.com/prometheus/common/version.Branch=${version}
+ -X github.com/prometheus/common/version.BuildDate=$(date --date "@$SOURCE_DATE_EPOCH" "+%Y%m%d-%H:%M:%S")
+ -X github.com/prometheus/common/version.BuildUser=VoidLinux"
 go_build_tags="netgo,builtinassets"
 hostmakedepends="yarn"
 conf_files="/etc/prometheus/prometheus.yml"
@@ -18,7 +19,7 @@ license="Apache-2.0, MIT"
 homepage="https://prometheus.io/"
 changelog="https://raw.githubusercontent.com/prometheus/prometheus/master/CHANGELOG.md"
 distfiles="https://github.com/prometheus/prometheus/archive/v${version}.tar.gz"
-checksum=0cd8860e5f10d0ecb35d20d23252ddc459e8319882dc163bf71b723e3bcafd71
+checksum=985d7f45ed3d16e23a30eae490c17911518fae96cba0245d493eb07097a10b3b
 
 system_accounts="_prometheus"
 


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

The current package of Prometheus in the repos has missing version information. Pointing Version flags to github.com/prometheus/common sets things correctly:

```
# prometheus --version
prometheus, version 2.48.1 (branch: 2.48.1, revision: 2.48.1)
  build user:       VoidLinux
  build date:       20231228-02:47:53
  go version:       go1.21.5
  platform:         linux/amd64
  tags:             netgo,builtinassets
```