### PR TITLE
google-chrome: update to 120.0.6099.129.

### DIFF
--- a/srcpkgs/google-chrome/template
+++ b/srcpkgs/google-chrome/template
@@ -1,6 +1,6 @@
 # Template file for 'google-chrome'
 pkgname=google-chrome
-version=119.0.6045.159
+version=120.0.6099.129
 revision=1
 _channel=stable
 archs="x86_64"
@@ -11,7 +11,7 @@ maintainer="Michael Aldridge <maldridge@voidlinux.org>"
 license="custom:chrome"
 homepage="https://www.google.com/chrome/"
 distfiles="https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-${_channel}_${version}-1_amd64.deb"
-checksum=c409bb6cfb279c90fb516353b4728cbf97a71e8deb33dc3433cd503ea65594fe
+checksum=d050758136ec8ea151cb4a1c134c39002b43f64489e40327c60faa071a82ba57
 
 skiprdeps="/opt/google/chrome/libqt5_shim.so /opt/google/chrome/libqt6_shim.so"
 repository=nonfree

--- a/srcpkgs/google-chrome/update
+++ b/srcpkgs/google-chrome/update
@@ -1,7 +1,5 @@
-# This site is an official source of version numbers, but it is not
-# obviously associated as such.  We save bytes here and request the
-# CSV, and then only the row containing the stable version number for
-# the Linux desktop build.  As a result the regex can be pretty simple
-# to just grab the version number out of the correct column.
-site="https://omahaproxy.appspot.com/all?os=linux&channel=stable"
-pattern="stable,\K[\d.]+(?=,)"
+# Call Google's version history API to get stable linux desktop releases
+# that are still being served (endtime=none). Look for the 'version' in
+# the JSON response.
+site="https://versionhistory.googleapis.com/v1/chrome/platforms/linux/channels/stable/versions/all/releases?filter=endtime=none"
+pattern="\"version\": *\"\K[\d.]+(?=\")"


### PR DESCRIPTION
Update `google-chrome` to latest stable version.

This also updates the site and pattern used to check for new releases as omahaproxy.appspot.com has been shut down. There is no replacement for the CSV release history, instead the recommendation [here](https://groups.google.com/a/chromium.org/g/chromium-dev/c/uH-nFrOLWtE/m/PhUj_inyAQAJ) is to use Google's version history API to get the released version data in JSON form.

#### Testing the changes
- I tested the changes in this PR: **YES**


#### Local build testing
- I built this PR locally for my native architecture, x86_64