### PR TITLE
xbps-src: fix NOCOLORS

### DIFF
--- a/common/environment/setup/sourcepkg.sh
+++ b/common/environment/setup/sourcepkg.sh
@@ -11,7 +11,7 @@ for var in $(awk 'BEGIN{for (i in ENVIRON) {print i}}' </dev/null); do
 		var="${var#BASH_FUNC_}"
 		unset -f "$var"
 		;;
-	XBPS_* | IN_CHROOT | CHROOT_READY | SOURCE_DATE_EPOCH)
+	XBPS_* | IN_CHROOT | CHROOT_READY | SOURCE_DATE_EPOCH | NOCOLORS)
 		# xbps-src specific
 		;;
 	SOURCEFORGE_SITE | NONGNU_SITE | XORG_SITE | DEBIAN_SITE | GNOME_SITE)


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

Easy way to reproduce: `./xbps-src show-build-deps xyz | cat` which should not print colors, in fact prints colors.


<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
