### PR TITLE
Rebuild postgresql for glibc upgrade

### DIFF
--- a/srcpkgs/postgresql14/template
+++ b/srcpkgs/postgresql14/template
@@ -1,6 +1,6 @@
 # Template file for 'postgresql14'
 pkgname=postgresql14
-version=14.9
+version=14.10
 revision=1
 build_style=gnu-configure
 make_build_target=world
@@ -21,7 +21,7 @@ license="PostgreSQL"
 homepage="https://www.postgresql.org"
 changelog="https://www.postgresql.org/docs/current/release-${version//./-}.html"
 distfiles="https://ftp.postgresql.org/pub/source/v${version}/postgresql-${version}.tar.bz2"
-checksum=b1fe3ba9b1a7f3a9637dd1656dfdad2889016073fd4d35f13b50143cbbb6a8ef
+checksum=c99431c48e9d470b0d0ab946eb2141a3cd19130c2fb4dc4b3284a7774ecc8399
 make_check=ci-skip # Postgres server can't be run as root
 
 conf_files="

--- a/srcpkgs/postgresql15/template
+++ b/srcpkgs/postgresql15/template
@@ -1,6 +1,6 @@
 # Template file for 'postgresql15'
 pkgname=postgresql15
-version=15.4
+version=15.5
 revision=1
 build_style=gnu-configure
 make_build_target=world
@@ -21,7 +21,7 @@ license="PostgreSQL"
 homepage="https://www.postgresql.org"
 changelog="https://www.postgresql.org/docs/current/release-${version//./-}.html"
 distfiles="https://ftp.postgresql.org/pub/source/v${version}/postgresql-${version}.tar.bz2"
-checksum=baec5a4bdc4437336653b6cb5d9ed89be5bd5c0c58b94e0becee0a999e63c8f9
+checksum=8f53aa95d78eb8e82536ea46b68187793b42bba3b4f65aa342f540b23c9b10a6
 make_check=ci-skip # Postgres server can't be run as root
 
 conf_files="


### PR DESCRIPTION
Due to the [glibc update](https://github.com/void-linux/void-packages/pull/45501) a few days ago Postgresql needs to be rebuilt.
The following warning is shown when connecting to postgres after upgrading glibc.
```
WARNING:  database "postgres" has a collation version mismatch
DETAIL:  The database was created using collation version 2.36, but the operating system provides version 2.38.
HINT:  Rebuild all objects in this database that use the default collation and run ALTER DATABASE postgres REFRESH COLLATION VERSION, or build PostgreSQL with the right library version.
```
Since there is a new patch release for Postgresql available I decided to bump the version too.  If we just want to rebuild the existing versions I can change the template to continue using the current versions.

UPDATE: I installed the package created by this PR but the warning above didn't change.  I ended up running `ALTER DATABASE postgres REFRESH COLLATION VERSION` to resolve the warning.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
