### PR TITLE
file-roller: fix for inconsistencies between p7zip and 7zip

### DIFF
--- a/srcpkgs/file-roller/patches/fix-symlink-handling-7zip.patch
+++ b/srcpkgs/file-roller/patches/fix-symlink-handling-7zip.patch
@@ -1,0 +1,24 @@
+Based on: https://gitlab.gnome.org/GNOME/file-roller/-/issues/148#note_1382009
+
+file-roller assumes p7zip and assumes that 'follow_links' is disabled by default.
+This is true in p7zip but not 7zip. 7zip does not have a -l flag, and instead provides,
+the -snl and -snh flags for disabling 'follow_links'.
+
+This fixes compressing 7z files with 'follow_links' enabled and compressing files with
+broken symlinks with 'follow_links' disabled.
+--- a/src/fr-command-7z.c.orig
++++ b/src/fr-command-7z.c
+@@ -325,8 +325,11 @@ fr_command_7z_add (FrCommand  *command,
+ 	fr_process_add_arg (command->process, "-bd");
+ 	fr_process_add_arg (command->process, "-bb1");
+ 	fr_process_add_arg (command->process, "-y");
+-	if (follow_links)
+-		fr_process_add_arg (command->process, "-l");
++	if (! follow_links)
++	{
++		fr_process_add_arg (command->process, "-snh");
++		fr_process_add_arg (command->process, "-snl");
++	}
+ 	add_password_arg (command, archive->password, FALSE);
+ 	if ((archive->password != NULL)
+ 	    && (*archive->password != 0)

--- a/srcpkgs/file-roller/template
+++ b/srcpkgs/file-roller/template
@@ -1,7 +1,7 @@
 # Template file for 'file-roller'
 pkgname=file-roller
 version=43.0
-revision=1
+revision=2
 build_style=meson
 hostmakedepends="gettext glib-devel itstool pkg-config desktop-file-utils
  gtk-update-icon-cache"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

p7zip and 7zip use different flags for link handling options, which causes errors in file-roller which assumes 7z is p7zip.

This fixes so that 'follow symlinks' works when enabled, and does not follow symlinks when the option is disabled.
Currently it follows symlinks when the option is disabled and errors when the option is enabled.

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
