### PR TITLE
New package: cpufetch-1.05

### DIFF
--- a/srcpkgs/cpufetch/template
+++ b/srcpkgs/cpufetch/template
@@ -1,0 +1,19 @@
+# Template file for 'cpufetch'
+pkgname=cpufetch
+version=1.05
+revision=1
+archs="~armv5* ~mips*"
+build_style=gnu-makefile
+make_build_args="arch=${XBPS_TARGET_MACHINE%-musl}"
+make_use_env=yes
+short_desc="Simple yet fancy CPU architecture fetching tool"
+maintainer="Sam Close <sam.w.close@gmail.com>"
+license="GPL-2.0-or-later"
+homepage="https://github.com/Dr-Noob/cpufetch"
+distfiles="https://github.com/Dr-Noob/cpufetch/archive/refs/tags/v${version}.tar.gz"
+checksum=82c8195cc535ad468fa2e61fa9648bb09d55cbcc59f76a72b66bd99fd290a7e6
+
+do_install() {
+	vbin cpufetch
+	vman cpufetch.1
+}


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (x84_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl (X)
  - i686 (X)
  - i686-musl (X)

Follows #32612, closes #32305. In theory it should work on `ppc*` and `arm*`, but it won't build successfully for me due to the `-mavx*` flag.