### PR TITLE
allegro5: enable pulseaudio support and fix audio in pipewire

### DIFF
--- a/srcpkgs/allegro5/template
+++ b/srcpkgs/allegro5/template
@@ -1,14 +1,14 @@
 # Template file for 'allegro5'
 pkgname=allegro5
 version=5.2.7.0
-revision=2
+revision=3
 build_style=cmake
 configure_args="-DWANT_DOCS=1 -DWANT_PHYSFS=1"
 hostmakedepends="pkg-config"
 makedepends="zlib-devel alsa-lib-devel jack-devel libXpm-devel libXxf86vm-devel
  libXxf86dga-devel libXcursor-devel libvorbis-devel libpng-devel glu-devel
  libjpeg-turbo-devel libtheora-devel freetype-devel libflac-devel physfs-devel
- libopenal-devel gtk+3-devel opus-devel opusfile-devel"
+ libopenal-devel gtk+3-devel opus-devel opusfile-devel pulseaudio-devel"
 depends="virtual?libGL"
 short_desc="Portable library mainly aimed at video game and multimedia programming"
 maintainer="Orphaned <orphan@voidlinux.org>"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

Currently, running an allegro5 application with a system using pipwire as a replacement for pulseaudio results in all applications not being able to output audio with `snd_pcm_avail after recover: Broken pipe`. Enabling pulseaudio fixed this issue for me.

You can test this using the `opensurge` which uses allegro5. As soon as you open the application, no applications (including opensurge) will be able to output audio until opensurge is closed.

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
