### PR TITLE
scaleway-cli: update to 2.26.0.

### DIFF
--- a/srcpkgs/scaleway-cli/template
+++ b/srcpkgs/scaleway-cli/template
@@ -1,7 +1,7 @@
 # Template file for 'scaleway-cli'
 pkgname=scaleway-cli
-version=2.19.0
-revision=2
+version=2.26.0
+revision=1
 build_style=go
 go_import_path=github.com/scaleway/scaleway-cli/v2
 go_package=github.com/scaleway/scaleway-cli/v2/cmd/scw
@@ -11,7 +11,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
 homepage="https://github.com/scaleway/scaleway-cli"
 distfiles="https://github.com/scaleway/scaleway-cli/archive/v${version}.tar.gz"
-checksum=5b728c364aac9d7b9785d5f6c9f06972d126d9125f719bfa73aa705411256b6e
+checksum=2fb389135d359afda4798b05ab2babba67c56cbbfe74b7ce2756c647f847c7d8
 
 post_install() {
 	vdoc README.md README


### PR DESCRIPTION
Fixes serial console.

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
