### PR TITLE
libpciaccess: update to 0.17.

### DIFF
--- a/srcpkgs/libpciaccess/template
+++ b/srcpkgs/libpciaccess/template
@@ -1,14 +1,16 @@
-# Template build file for 'libpciaccess'.
+# Template file for 'libpciaccess'
 pkgname=libpciaccess
-version=0.16
+version=0.17
 revision=1
-build_style=gnu-configure
-short_desc="X11 PCI Access library"
+build_style=meson
+hostmakedepends="pkg-config"
+makedepends="zlib-devel"
+short_desc="Generic PCI access library"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
-homepage="http://xorg.freedesktop.org/"
-distfiles="${XORG_SITE}/lib/$pkgname-$version.tar.bz2"
-checksum=214c9d0d884fdd7375ec8da8dcb91a8d3169f263294c9a90c575bf1938b9f489
+homepage="https://gitlab.freedesktop.org/xorg/lib/libpciaccess"
+distfiles="https://gitlab.freedesktop.org/xorg/lib/libpciaccess/-/archive/libpciaccess-${version}/libpciaccess-libpciaccess-${version}.tar.gz"
+checksum=951c7556b9222b755a8f2d0bc6cc9370529b78df461000103d7cea839c13db72
 
 post_install() {
 	vlicense COPYING
@@ -20,7 +22,6 @@ libpciaccess-devel_package() {
 	pkg_install() {
 		vmove usr/include
 		vmove usr/lib/pkgconfig
-		vmove "usr/lib/*.a"
 		vmove "usr/lib/*.so"
 	}
 }


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl
  - i686
  - aarch64-musl (cross)
  - armv7l (cross)
  - armv6l-musl (cross)

