### PR TITLE
openblas: update to 0.3.26, numpy: update to 1.26.3

### DIFF
--- a/srcpkgs/openblas/template
+++ b/srcpkgs/openblas/template
@@ -1,6 +1,6 @@
 # Template file for 'openblas'
 pkgname=openblas
-version=0.3.25
+version=0.3.26
 revision=1
 build_style=gnu-makefile
 make_build_args="HOSTCC=gcc USE_OPENMP=1"
@@ -13,7 +13,7 @@ license="BSD-3-Clause"
 homepage="https://www.openblas.net/"
 changelog="https://raw.githubusercontent.com/xianyi/OpenBLAS/develop/Changelog.txt"
 distfiles="https://github.com/xianyi/OpenBLAS/archive/v${version}.tar.gz"
-checksum=4c25cb30c4bb23eddca05d7d0a85997b8db6144f5464ba7f8c09ce91e2f35543
+checksum=4e6e4f5cb14c209262e33e6816d70221a2fe49eb69eaf0a06f065598ac602c68
 
 case "$XBPS_TARGET_MACHINE" in
 	ppc64*) ;;

--- a/srcpkgs/python3-numpy/template
+++ b/srcpkgs/python3-numpy/template
@@ -1,6 +1,6 @@
 # Template file for 'python3-numpy'
 pkgname=python3-numpy
-version=1.26.2
+version=1.26.3
 revision=1
 build_style=python3-pep517
 build_helper="meson qemu"
@@ -17,9 +17,9 @@ short_desc="Fast and sophisticated array facility to Python3"
 maintainer="Andrew J. Hesford <ajh@sideband.org>"
 license="BSD-3-Clause"
 homepage="https://www.numpy.org/"
-changelog="https://numpy.org/doc/stable/release.html"
+changelog="https://github.com/numpy/numpy/releases"
 distfiles="${PYPI_SITE}/n/numpy/numpy-${version}.tar.gz"
-checksum=f65738447676ab5777f11e6bbbdb8ce11b785e105f690bc45966574816b6d3ea
+checksum=697df43e2b6310ecc9d95f05d5ef20eacc09c7c4ecc9da3f235d39e71b7da1e4
 alternatives="numpy:f2py:/usr/bin/f2py3"
 
 build_options="openblas"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

Tested with sagemath
 - with our current binary package 10.2_1 (run testsuite without recompilation)
 - with the draft PR for 10.3.beta4 in #47712

@ahesford this should be ready to go once CI on #47712 passes.

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
