### PR TITLE
 python-tkinter: glibc build requires libxcrypt-devel

### DIFF
--- a/srcpkgs/python-tkinter/template
+++ b/srcpkgs/python-tkinter/template
@@ -21,6 +21,10 @@ homepage="https://www.python.org"
 distfiles="https://github.com/ActiveState/cpython/archive/${_commit}.tar.gz"
 checksum=e41b3ebac8ac7b7e3364c7f28892f81153d23dd200ef6aaacec82080aa5d2b56
 
+if [ "$XBPS_TARGET_LIBC" = "glibc" ]; then
+	makedepends+=" libxcrypt-devel"
+fi
+
 pre_configure() {
 	# Ensure that internal copies of expat, libffi and zlib are not used.
 	rm -r Modules/expat


### PR DESCRIPTION
Like python3-tkinter, python-tkinter no longer builds/pkgs correctly since the libxcrypt separation

#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, (x86-glibc)
- I built this PR locally for these architectures (crossbuild)
  - aarch64
  - i686
  - riscv64
