### PR TITLE
libxcrypt: noverifyrdeps on libxcrypt-compat to prevent a cycle

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -43,6 +43,7 @@ libnss_dns.so.2 glibc-2.38_1
 libnss_hesiod.so.2 glibc-2.38_1
 libBrokenLocale.so.1 glibc-2.38_1
 libcrypt.so.2 libxcrypt-4.4.36_1
+libcrypt.so.1 libxcrypt-compat-4.4.36_1
 libSimGearCore.so.2020.3.17 simgear-2020.3.17_1
 libSimGearScene.so.2020.3.17 simgear-2020.3.17_1
 libmemusage.so glibc-2.38_1

--- a/srcpkgs/libxcrypt/template
+++ b/srcpkgs/libxcrypt/template
@@ -1,10 +1,11 @@
 # Template file for 'libxcrypt'
 pkgname=libxcrypt
 version=4.4.36
-revision=2
+revision=3
 archs="~*-musl"
 build_style=gnu-configure
 configure_args="--enable-hashes=all --disable-failure-tokens --enable-obsolete-api=no"
+make_cmd="make -C build"
 hostmakedepends="perl-bootstrap"
 checkdepends="python3-passlib"
 short_desc="Modern library for one-way hashing of passwords"
@@ -13,7 +14,6 @@ license="LGPL-2.1-or-later, BSD-3-Clause, BSD-2-Clause, 0BSD, Public Domain"
 homepage="https://github.com/besser82/libxcrypt"
 distfiles="https://github.com/besser82/libxcrypt/releases/download/v${version}/libxcrypt-${version}.tar.xz"
 checksum=e5e1f4caee0a01de2aee26e3138807d6d3ca2b8e67287966d1fefd65e1fd8943
-make_cmd="make -C build"
 
 if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
 	broken="musl already provides libcrypt"
@@ -66,6 +66,7 @@ libxcrypt-devel_package() {
 
 libxcrypt-compat_package() {
 	short_desc+=" - legacy compatibility"
+	noverifyrdeps=yes
 	pkg_install() {
 		vmove usr/lib/libcrypt.so.1*
 	}


### PR DESCRIPTION
this fixes the dependency cycle when installing e.g. `base-system` on an empty root:
```
$ mkdir /tmp/testroot
$ xbps-install -SdR https://repo-default.voidlinux.org/current -r /tmp/testroot base-system
...
[DEBUG] Error checking glibc>=2.36_1 for rundeps: Too many levels of symbolic links
[DEBUG] Error checking libxcrypt-compat>=0 for rundeps: Too many levels of symbolic links
...
```

After this change, there should be no special user intervention needed or error to resolve.

#### Testing the changes
- I tested the changes in this PR: **YES** (on both systems with glibc 2.36 and empty roots)

