### PR TITLE
ucspi-tcp6: provide ucspi-tcp for tinyssh and twoftpd

### DIFF
--- a/srcpkgs/ucspi-tcp6/template
+++ b/srcpkgs/ucspi-tcp6/template
@@ -1,7 +1,7 @@
 # Template file for 'ucspi-tcp6'
 pkgname=ucspi-tcp6
 version=1.11.6a
-revision=1
+revision=2
 create_wrksrc=yes
 build_wrksrc="net/${pkgname}/${pkgname}-${version}/src"
 build_style=gnu-makefile
@@ -15,6 +15,7 @@ distfiles="http://www.fehcom.de/ipnet/ucspi-tcp6/ucspi-tcp6-${version}.tgz"
 checksum=77c6cfb283dc6dde2615e2f52db1d5bf7e1cda085cc1e03f3c2b1ba48cd1d5a8
 disable_parallel_build="ad hoc build system breaks parallel build"
 conflicts="ucspi-tcp>=0"
+provides="ucspi-tcp-${version}_${revision}"
 
 pre_build() {
 	pwd >home


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
#### Local build testing
- I built this PR locally for my native architecture, (x86_64-musl)
