### PR TITLE
libsasl: fix build with glibc 2.38

### DIFF
--- a/srcpkgs/libsasl/template
+++ b/srcpkgs/libsasl/template
@@ -8,6 +8,7 @@ configure_args="--enable-cram --enable-digest --enable-auth-sasldb
  --enable-plain --enable-anon --enable-login --enable-gssapi --enable-ntlm
  --with-configdir=/etc/sasl2:/etc/sasl:/usr/lib/sasl2
  --disable-otp --disable-srp --disable-srp-setpass --disable-krb4
+ --with-saslauthd=no --with-authdaemond=no --with-pwcheck=no
  --with-devrandom=/dev/random
  ac_cv_gssapi_supports_spnego=yes"
 hostmakedepends="automake libtool pkg-config"


### PR DESCRIPTION
disable rm'd applications that depend on crypt()

The `cyrus-sasl` package was updated to use libxcrypt-devel, however here, the application that depends on it isn't needed so just disable it, along with some other rm'd applications.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
