### PR TITLE
New package: swaylock-effects-1.7.0.0

### DIFF
--- a/srcpkgs/swaylock-effects/template
+++ b/srcpkgs/swaylock-effects/template
@@ -1,0 +1,19 @@
+# Template file for 'swaylock-effects'
+pkgname=swaylock-effects
+version=1.7.0.0
+revision=1
+build_style=meson
+conf_files="/etc/pam.d/swaylock"
+hostmakedepends="pkg-config wayland-devel scdoc"
+makedepends="wayland-devel wayland-protocols libxkbcommon-devel gdk-pixbuf-devel cairo-devel libgomp-devel pam-devel"
+short_desc="Swaylock, with fancy effects"
+maintainer="Sam Close <sam.w.close@gmail.com>"
+license="MIT"
+homepage="https://github.com/jirutka/swaylock-effects"
+distfiles="${homepage}/archive/refs/tags/v${version}.tar.gz"
+checksum=e94d79e189602694bedfbafb553ce3c6c976426e16f76d93bf7e226dc2876eb6
+conflicts="swaylock>=0"
+
+post_install() {
+	vlicense LICENSE
+}


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - i686 (X)
  - i686-musl (X)
  - x86_64-musl (X)
  - armv6l (X)
  - armv6l-musl (X)

Opening as draft to discuss possible security concerns previously mentioned by @ericonr (https://github.com/void-linux/void-packages/pull/26392#issuecomment-883685280, https://github.com/void-linux/void-packages/pull/27971#pullrequestreview-570102279). [This version is a fork](https://github.com/jirutka/swaylock-effects) of the now [unmaintained original](https://github.com/mortie/swaylock-effects). The maintainer is active, and the current version of `jirutka/swaylock-effects` is behind `swaywm/swaylock` by [23 commits](https://github.com/jirutka/swaylock-effects/compare/master...swaywm:swaylock:master). Happy to discuss :)

Also, regarding the template, I'm not sure if it's preferred to have `conflicts` or `replaces`? I've gone for the former because the latter would require changing the `swaylock` template too.