### PR TITLE
profanity: Add qrcode support

### DIFF
--- a/srcpkgs/profanity/template
+++ b/srcpkgs/profanity/template
@@ -1,18 +1,16 @@
 # Template file for 'profanity'
 pkgname=profanity
 version=0.14.0
-revision=1
+revision=2
 build_style=gnu-configure
-configure_args="$(vopt_enable notify notifications) $(vopt_enable otr)
- $(vopt_enable pgp) $(vopt_enable python python-plugins) $(vopt_enable plugins)
- $(vopt_with xscreensaver) $(vopt_enable omemo) $(vopt_enable cplugins c-plugins)
- ac_cv_prog_PYTHON_CONFIG_EXISTS=yes PYTHON_VERSION=3"
-hostmakedepends="pkg-config $(vopt_if python python3-devel) $(vopt_if gtk gtk+3-devel)"
-makedepends="libcurl-devel libglib-devel libstrophe-devel readline-devel sqlite-devel
- $(vopt_if notify libnotify-devel) $(vopt_if otr 'libotr-devel libgcrypt-devel')
- $(vopt_if pgp gpgme-devel) $(vopt_if python python3-devel) $(vopt_if gtk gtk+3-devel)
- $(vopt_if xscreensaver libXScrnSaver-devel)
- $(vopt_if omemo 'libsignal-protocol-c-devel libgcrypt-devel')"
+configure_args="--enable-notifications --enable-otr --enable-pgp
+ --enable-python-plugins --enable-plugins --with-xscreensaver --enable-omemo
+ --enable-c-plugins ac_cv_prog_PYTHON_CONFIG_EXISTS=yes PYTHON_VERSION=3"
+hostmakedepends="pkg-config python3-devel gtk+3-devel"
+makedepends="libcurl-devel libglib-devel libstrophe-devel readline-devel
+ sqlite-devel libnotify-devel libotr-devel libgcrypt-devel gpgme-devel
+ python3-devel gtk+3-devel libXScrnSaver-devel libsignal-protocol-c-devel
+ libgcrypt-devel qrencode-devel"
 checkdepends="cmocka-devel"
 short_desc="Console based XMPP client"
 maintainer="Orphaned <orphan@voidlinux.org>"
@@ -27,12 +25,3 @@ case "$XBPS_TARGET_MACHINE" in
 		export PYTHON_CPPFLAGS="-I${XBPS_CROSS_BASE}/${py3_inc}"
 		export PYTHON_EXTRA_LIBS="-L${XBPS_CROSS_BASE}/usr/lib -lpython${py3_ver}" ;;
 esac
-
-# Package build options
-build_options="notify otr pgp omemo gtk python xscreensaver cplugins plugins"
-build_options_default="notify otr pgp gtk omemo python cplugins plugins xscreensaver"
-desc_option_otr="Enable support for OTR encryption"
-desc_option_pgp="Enable support for OpenPGP encryption"
-desc_option_omemo="Enable support for OMEMO encryption"
-desc_option_plugins="Enable support for plugins"
-desc_option_cplugins="Enable support for c-plugins"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86\_64-glibc)

Fixes the following error when running `/omemo qrcode`:
```
This version of Profanity has not been built with libqrencode
```
