### PR TITLE
factor: update to 0.99.

### DIFF
--- a/srcpkgs/factor/template
+++ b/srcpkgs/factor/template
@@ -1,19 +1,19 @@
 # Template file for 'factor'
 pkgname=factor
-version=0.98
+version=0.99
 revision=1
 archs="i686 x86_64"
 build_style=gnu-makefile
 hostmakedepends="unzip pkg-config"
 makedepends="gtk+-devel gtkglext-devel"
 depends="gtk+-devel gtkglext-devel"
-nostrip_files="a.elf"
 short_desc="Concatenative programming language, similar to Forth"
 maintainer="B. Wilson <x@wilsonb.com>"
 license="BSD-2-Clause"
-homepage="http://factorcode.org/"
-distfiles="http://downloads.factorcode.org/releases/${version}/factor-src-${version}.zip"
-checksum=318fb8cdf84528fce17a83f7e9d76e55292ccc779c71d180d99a6465574d3706
+homepage="https://factorcode.org/"
+distfiles="https://downloads.factorcode.org/releases/${version}/factor-src-${version}.zip"
+checksum=f5626bb3119bd77de9ac3392fdbe188bffc26557fab3ea34f7ca21e372a8443e
+nostrip_files="a.elf"
 
 post_build() {
 	image=''


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly** - CLI runs basic factor programs, GUI does as well and allows debugging.

#### Local build testing
- I built this PR locally for my native architecture, x86-64 glibc

Note: I also switched homepage/distfiles to https, which is now supported upstream, and moved `nostrip_files` after `checksum` per the warning from `xlint`.

---

Update notes: https://re.factorcode.org/2023/08/factor-0-99-now-available.html