### PR TITLE
openjdk-common: update to 2.

### DIFF
--- a/srcpkgs/openjdk-common/files/java.sh
+++ b/srcpkgs/openjdk-common/files/java.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+# allows scripts that assume java exists on PATH to work
+# and helps users use java without logging out/in for the profile script
+die() {
+	echo "java: $@" >&2
+	exit 1
+}
+. /etc/profile.d/jdk.sh
+[ -d "$JAVA_HOME" ] || die "/usr/lib/jvm/default-jre not found. Check xbps-alternatives -lg java"
+[ -x "$JAVA_HOME"/bin/java ] || die "$JAVA_HOME/bin/java does not exist or is not executable"
+exec "$JAVA_HOME"/bin/java "$@"

--- a/srcpkgs/openjdk-common/files/profile.sh
+++ b/srcpkgs/openjdk-common/files/profile.sh
@@ -1,7 +1,7 @@
 # only modify the environment if an openjdk*-jre package is installed
-if [ -e "/usr/lib/jvm/default-jre" ]; then
+if [ -d "/usr/lib/jvm/default-jre" ]; then
 	# if an openjdk* package is installed, prefer it to the selected jre
-	if [ -e "/usr/lib/jvm/default-jdk" ]; then
+	if [ -d "/usr/lib/jvm/default-jdk" ]; then
 		export JAVA_HOME="/usr/lib/jvm/default-jdk"
 	else
 		export JAVA_HOME="/usr/lib/jvm/default-jre"

--- a/srcpkgs/openjdk-common/template
+++ b/srcpkgs/openjdk-common/template
@@ -1,6 +1,6 @@
 # Template file for 'openjdk-common'
 pkgname=openjdk-common
-version=1
+version=2
 revision=1
 short_desc="Common files for OpenJDK packages"
 maintainer="classabbyamp <void@placeviolette.net>"
@@ -9,4 +9,5 @@ homepage="https://www.voidlinux.org"
 
 do_install() {
 	vinstall "${FILESDIR}"/profile.sh 644 /etc/profile.d jdk.sh
+	vbin "${FILESDIR}"/java.sh java
 }


### PR DESCRIPTION
adds /usr/bin/java script to bridge the gap between fully profile-based and fully /usr/bin symlinks

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**
