### PR TITLE
New package: loupe-46.0

### DIFF
--- a/srcpkgs/glycin-loaders/template
+++ b/srcpkgs/glycin-loaders/template
@@ -1,0 +1,27 @@
+# Template file for 'glycin-loaders'
+pkgname=glycin-loaders
+version=1.0.0
+revision=1
+build_style=meson
+build_helper=rust
+configure_args="-Dtest_skip_install=true"
+hostmakedepends="cargo clang17 gettext pkg-config"
+makedepends="gtk4-devel libheif-devel libjxl-devel libseccomp-devel rust-std"
+short_desc="Sandboxed and extendable image decoding"
+maintainer="chrysos349 <chrysostom349@gmail.com>"
+license="MPL-2.0"
+homepage="https://gitlab.gnome.org/sophie-h/glycin"
+changelog="https://gitlab.gnome.org/sophie-h/glycin/-/raw/main/NEWS"
+distfiles="${GNOME_SITE}/glycin-loaders/${version%.*}/${pkgname}-${version}.tar.xz"
+checksum=cd2a3979259fee56cbd882a4d890437684bf1926e65afeafcb904ca9d17ae282
+make_check=no # needs to be installed to run tests
+
+post_patch() {
+	if [ "$CROSS_BUILD" ]; then
+		vsed -i loaders/meson.build \
+			-e "s%rust_target /%'${RUST_TARGET}' / &%"
+	fi
+	# loaders/meson.build tries to call git to get hash for debug builds.
+	# Disable as it is useless for tarball builds.
+	ln -sf /bin/false ${XBPS_WRAPPERDIR}/git
+}

--- a/srcpkgs/loupe/template
+++ b/srcpkgs/loupe/template
@@ -1,0 +1,25 @@
+# Template file for 'loupe'
+pkgname=loupe
+version=46.0
+revision=1
+build_style=meson
+build_helper=rust
+hostmakedepends="cargo desktop-file-utils gettext gtk4-update-icon-cache
+ itstool pkg-config"
+makedepends="lcms2-devel libadwaita-devel libgweather-devel libseccomp-devel
+ rust-std"
+depends="glycin-loaders"
+short_desc="Simple image viewer for GNOME"
+maintainer="chrysos349 <chrysostom349@gmail.com>"
+license="GPL-3.0-or-later"
+homepage="https://gitlab.gnome.org/GNOME/loupe"
+changelog="https://gitlab.gnome.org/GNOME/loupe/-/raw/main/NEWS"
+distfiles="${GNOME_SITE}/loupe/${version%.*}/loupe-${version}.tar.xz"
+checksum=051aa45cf0ab362093fbf91863140be737db57bcb1f77bc1e00ab97255a252bd
+
+post_patch() {
+	if [ "$CROSS_BUILD" ]; then
+		vsed -i src/meson.build \
+			-e "s%rust_target /%'${RUST_TARGET}' / &%"
+	fi
+}


### PR DESCRIPTION
this app is a part of gnome-45 #48762

#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl x
  - armv7l x
  - armv6l-musl x