### PR TITLE
netsurf: update to 3.11 and update deps.

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -1025,7 +1025,7 @@ libns-9.16.22.so bind-libs-9.16.22_1
 libplist-2.0.so.3 libplist-2.2.0_1
 libplist++-2.0.so.3 libplist++-2.2.0_1
 libnsbmp.so.0 libnsbmp-0.0.3_1
-libnsgif.so.0 libnsgif-0.0.3_1
+libnsgif.so.1 libnsgif-1.0.0_1
 libparserutils.so.0 libparserutils-0.1.1_1
 libwapcaplet.so.0 libwapcaplet-0.1.0_1
 libcss.so.0 libcss-0.1.1_1

--- a/srcpkgs/libcss/template
+++ b/srcpkgs/libcss/template
@@ -1,25 +1,28 @@
 # Template file for 'libcss'
 pkgname=libcss
-version=0.9.1
+version=0.9.2
 revision=1
 hostmakedepends="pkg-config perl netsurf-buildsystem"
 makedepends="libparserutils-devel libwapcaplet-devel"
 short_desc="CSS parser and selection engine, written in C"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
-homepage="http://www.netsurf-browser.org"
-distfiles="http://download.netsurf-browser.org/libs/releases/${pkgname}-${version}-src.tar.gz"
-checksum=d2dce16e93392e8d6a7209420d47c2d56a3811701a0e81a724fc541c63d3c6dc
+homepage="https://www.netsurf-browser.org"
+distfiles="https://download.netsurf-browser.org/libs/releases/${pkgname}-${version}-src.tar.gz"
+checksum=2df215bbec34d51d60c1a04b01b2df4d5d18f510f1f3a7af4b80cddb5671154e
 CFLAGS="-Wno-error"
 
 do_build() {
+	make ${makejobs} HOST_CC=cc COMPONENT_TYPE=lib-static PREFIX=/usr BUILDDIR=build-static-lib
 	make ${makejobs} HOST_CC=cc COMPONENT_TYPE=lib-shared PREFIX=/usr
-	make ${makejobs} HOST_CC=cc COMPONENT_TYPE=lib-static PREFIX=/usr
 }
 
 do_install() {
 	make COMPONENT_TYPE=lib-shared PREFIX=/usr DESTDIR=${DESTDIR} install
-	make COMPONENT_TYPE=lib-static PREFIX=/usr DESTDIR=${DESTDIR} install
+
+#	workaround to avoid targets being rebuilt
+#	make COMPONENT_TYPE=lib-static PREFIX=/usr DESTDIR=${DESTDIR} BUILDDIR=build-static-lib install
+	vinstall build-static-lib/libcss.a 644 /usr/lib
 
 	vlicense COPYING
 }

--- a/srcpkgs/libdom/template
+++ b/srcpkgs/libdom/template
@@ -1,6 +1,6 @@
 # Template file for 'libdom'
 pkgname=libdom
-version=0.4.1
+version=0.4.2
 revision=1
 hostmakedepends="pkg-config perl netsurf-buildsystem"
 makedepends="expat-devel libparserutils-devel libwapcaplet-devel libhubbub-devel"
@@ -9,10 +9,10 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
 homepage="https://www.netsurf-browser.org"
 distfiles="https://download.netsurf-browser.org/libs/releases/libdom-${version}-src.tar.gz"
-checksum=98ee072471e55e208c9878e515c410ad462ca36f87b4afcbecad023f3a2cef4a
+checksum=d05e45af16547014c2b0a3aecf3670fa13d419f505b3f5fc7ac8a1491fc30f3c
 
 post_extract() {
-	sed -i 's/_BSD_SOURCE/_DEFAULT_SOURCE/g' Makefile
+	vsed -i Makefile -e 's/_BSD_SOURCE/_DEFAULT_SOURCE/g'
 }
 
 do_build() {

--- a/srcpkgs/libhubbub/template
+++ b/srcpkgs/libhubbub/template
@@ -1,16 +1,15 @@
 # Template file for 'libhubbub'
 pkgname=libhubbub
-version=0.3.7
+version=0.3.8
 revision=1
-hostmakedepends="perl pkg-config netsurf-buildsystem"
+hostmakedepends="gperf perl pkg-config netsurf-buildsystem"
 makedepends="libxslt-devel json-c-devel libparserutils-devel"
 short_desc="HTML5 compliant parsing library, written in C"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
-homepage="http://www.netsurf-browser.org"
-distfiles="http://download.netsurf-browser.org/libs/releases/${pkgname}-${version}-src.tar.gz"
-checksum=9e7ae253e6c9069e757eb9ad4e4846f38b4db52c0ca0151446a9fa4a977735b6
-
+homepage="https://www.netsurf-browser.org"
+distfiles="https://download.netsurf-browser.org/libs/releases/${pkgname}-${version}-src.tar.gz"
+checksum=8ac1e6f5f3d48c05141d59391719534290c59cd029efc249eb4fdbac102cd5a5
 CFLAGS="-Wno-error"
 
 do_build() {

--- a/srcpkgs/libnsbmp/template
+++ b/srcpkgs/libnsbmp/template
@@ -1,14 +1,14 @@
 # Template file for 'libnsbmp'
 pkgname=libnsbmp
-version=0.1.6
+version=0.1.7
 revision=1
 hostmakedepends="netsurf-buildsystem"
 short_desc="Decoding library for BMP and ICO images in C"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
-homepage="http://www.netsurf-browser.org"
-distfiles="http://download.netsurf-browser.org/libs/releases/${pkgname}-${version}-src.tar.gz"
-checksum=79c49365f860ed451bfc4109eddec8de3e9b7ce5a3be069596bd2aa19279324f
+homepage="https://www.netsurf-browser.org"
+distfiles="https://download.netsurf-browser.org/libs/releases/${pkgname}-${version}-src.tar.gz"
+checksum=5407a7682a122baaaa5a15b505290e2d37df54c13c5edef4b09d12c862d82293
 CFLAGS="-Wno-error"
 
 do_build() {

--- a/srcpkgs/libnsgif/template
+++ b/srcpkgs/libnsgif/template
@@ -1,14 +1,14 @@
 # Template file for 'libnsgif'
 pkgname=libnsgif
-version=0.2.1
+version=1.0.0
 revision=1
 hostmakedepends="netsurf-buildsystem"
 short_desc="Decoding library for the GIF image file format, written in C"
 maintainer="Orphaned <orphan@voidlinux.org>"
-homepage="http://www.netsurf-browser.org"
 license="MIT"
-distfiles="http://download.netsurf-browser.org/libs/releases/${pkgname}-${version}-src.tar.gz"
-checksum=9eaea534cd70b53c5aaf45317ae957701685a6b4a88dbe34ed26f4faae879a4b
+homepage="https://www.netsurf-browser.org"
+distfiles="https://download.netsurf-browser.org/libs/releases/${pkgname}-${version}-src.tar.gz"
+checksum=6014c842f61454d2f5a0f8243d7a8d7bde9b7da3ccfdca2d346c7c0b2c4c061b
 CFLAGS="-Wno-error"
 
 do_build() {

--- a/srcpkgs/libnsutils/template
+++ b/srcpkgs/libnsutils/template
@@ -1,14 +1,14 @@
 # Template file for 'libnsutils'
 pkgname=libnsutils
-version=0.1.0
+version=0.1.1
 revision=1
 hostmakedepends="pkg-config perl netsurf-buildsystem"
-short_desc="CSS parser and selection engine, written in C"
+short_desc="NetSurf utility functions"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
-homepage="http://www.netsurf-browser.org"
-distfiles="http://download.netsurf-browser.org/libs/releases/${pkgname}-${version}-src.tar.gz"
-checksum=790c6516344abe82f6289d656392e9ccebe475b20cc7e1e2d843011385f7aef0
+homepage="https://www.netsurf-browser.org"
+distfiles="https://download.netsurf-browser.org/libs/releases/${pkgname}-${version}-src.tar.gz"
+checksum=5694b4526e458ed000413ce6027589cbe10a257a7ecf065a01421dc7299dea92
 
 do_build() {
 	make ${makejobs} HOST_CC=cc COMPONENT_TYPE=lib-shared PREFIX=/usr

--- a/srcpkgs/libparserutils/template
+++ b/srcpkgs/libparserutils/template
@@ -1,14 +1,14 @@
 # Template file for 'libparserutils'
 pkgname=libparserutils
-version=0.2.4
+version=0.2.5
 revision=1
 hostmakedepends="perl netsurf-buildsystem"
 short_desc="Library for building efficient parsers, written in C"
 maintainer="Orphaned <orphan@voidlinux.org>"
-homepage="http://www.netsurf-browser.org"
 license="MIT"
-distfiles="http://download.netsurf-browser.org/libs/releases/${pkgname}-${version}-src.tar.gz"
-checksum=322bae61b30ccede3e305bf6eae2414920649775bc5ff1d1b688012a3c4947d8
+homepage="https://www.netsurf-browser.org"
+distfiles="https://download.netsurf-browser.org/libs/releases/${pkgname}-${version}-src.tar.gz"
+checksum=317ed5c718f17927b5721974bae5de32c3fd6d055db131ad31b4312a032ed139
 CFLAGS="-Wno-error"
 
 do_build() {

--- a/srcpkgs/netsurf-buildsystem/template
+++ b/srcpkgs/netsurf-buildsystem/template
@@ -1,13 +1,13 @@
 # Template file for 'netsurf-buildsystem'
 pkgname=netsurf-buildsystem
-version=1.9
-revision=2
+version=1.10
+revision=1
 short_desc="Netsurf buildsystem"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
-homepage="http://www.netsurf-browser.org"
-distfiles="http://download.netsurf-browser.org/libs/releases/${pkgname#netsurf-}-${version}.tar.gz"
-checksum=93841e314a688209a20b8745f065393f3a90f01be68f45e96bc8d2f4a2aa9a2a
+homepage="https://www.netsurf-browser.org"
+distfiles="https://download.netsurf-browser.org/libs/releases/${pkgname#netsurf-}-${version}.tar.gz"
+checksum=3d3e39d569e44677c4b179129bde614c65798e2b3e6253160239d1fd6eae4d79
 
 do_build() {
 	make COMPONENT_TYPE=lib-shared PREFIX=/usr

--- a/srcpkgs/netsurf/template
+++ b/srcpkgs/netsurf/template
@@ -1,7 +1,7 @@
 # Template file for 'netsurf'
 pkgname=netsurf
-version=3.10
-revision=6
+version=3.11
+revision=1
 build_style=gnu-makefile
 make_use_env=yes
 make_build_args="TARGET=gtk3 NETSURF_USE_BMP=YES NETSURF_USE_WEBP=YES
@@ -10,16 +10,15 @@ make_install_args="$make_build_args"
 hostmakedepends="pkg-config gperf flex nsgenbind gdk-pixbuf-devel
  tar perl-HTML-Parser glib-devel xxd"
 makedepends="
- libidn-devel libmng-devel libxml2-devel libcurl-devel lcms-devel libwebp-devel
- libcss-devel libnsbmp-devel libnsgif-devel libutf8proc-devel
- libnsutils-devel libdom-devel gtk+3-devel"
+ libcurl-devel libwebp-devel libcss-devel libnsbmp-devel libnsgif-devel
+ libutf8proc-devel libnsutils-devel libdom-devel gtk+3-devel"
 depends="desktop-file-utils shared-mime-info"
 short_desc="Free, open source web browser written in C"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-only, MIT"
-homepage="http://www.netsurf-browser.org"
-distfiles="http://download.netsurf-browser.org/netsurf/releases/source/${pkgname}-${version}-src.tar.gz"
-checksum=36484429e193614685c2ff246f55bd0a6dddf31a018bee45e0d1f7c28851995e
+homepage="https://www.netsurf-browser.org"
+distfiles="https://download.netsurf-browser.org/netsurf/releases/source/${pkgname}-${version}-src.tar.gz"
+checksum=c28a626aefee428d053b13f88b5c440922245976522d12eaf137cfd32d201cb2
 
 post_install() {
 	# Install app icon (from Ubuntu)

--- a/srcpkgs/nsgenbind/template
+++ b/srcpkgs/nsgenbind/template
@@ -1,14 +1,14 @@
 # Template file for 'nsgenbind'
 pkgname=nsgenbind
-version=0.8
+version=0.9
 revision=1
 hostmakedepends="pkg-config flex netsurf-buildsystem"
 short_desc="Tool to generate javascript to dom bindings from w3c webid files"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
-homepage="http://www.netsurf-browser.org"
-distfiles="http://download.netsurf-browser.org/libs/releases/${pkgname}-${version}-src.tar.gz"
-checksum=4d8d53ad000ada712772365e6a73eb8fc5ce97584af9c865ac5b26a2187f1cb3
+homepage="https://www.netsurf-browser.org"
+distfiles="https://download.netsurf-browser.org/libs/releases/${pkgname}-${version}-src.tar.gz"
+checksum=232ce0f66cbc2c3eed6288ae26de2c567bbfbbc01d8b0f6fc6c1c1649d4b385d
 
 do_build() {
 	make ${makejobs} FLEX=flex BISON=bison PREFIX=/usr


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

In addition to updating netsurf and its dependencies, changes include:
- http -> https where needed
- libnsutils: fix package description
- libcss: workaround for targets being rebuilt during install phase
- netsurf: remove some unused makedepends

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
