### PR TITLE
terminus-font: bundled patches as build options

### DIFF
--- a/srcpkgs/terminus-font/template
+++ b/srcpkgs/terminus-font/template
@@ -1,7 +1,7 @@
 # Template file for 'terminus-font'
 pkgname=terminus-font
 version=4.49.1
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--x11dir=/usr/share/fonts/X11/misc
  --psfdir=/usr/share/kbd/consolefonts"
@@ -15,6 +15,21 @@ homepage="http://terminus-font.sourceforge.net/"
 distfiles="${SOURCEFORGE_SITE}/${pkgname}/${pkgname}-${version}.tar.gz"
 checksum=d961c1b781627bf417f9b340693d64fc219e0113ad3a3af1a3424c7aa373ef79
 font_dirs="/usr/share/fonts/X11/misc"
+build_options="ao2 br1 dv1 ge2 gq2 hi2 ij1 ll2 td1"
+build_options_default="td1"
+desc_option_ao2="variation of ascii a"
+desc_option_td1="center aligned tilde ~"
+desc_option_ll1="variation of ascii l"
+desc_option_hi1="higher upper case letters and digits"
+
+do_patch() {
+	for p in $build_options; do
+		if [ $(vopt_if $p true false) = true ]; then
+			echo "applying $p"
+			patch < "alt/$p.diff"
+		fi
+	done
+}
 
 post_install() {
 	vlicense OFL.TXT OFL.txt


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc

The source for terminus includes a couple of patches that can be applied. 

This PR also defaults to applying the centered `~` patch, instead of it being aligned to the top. This is something the creators of terminus themselves say maybe should've been the default. Since most other fonts use center-aligned tilde I took the liberty of applying this patch by default. 