### PR TITLE
meson: update to 1.3.1

### DIFF
--- a/srcpkgs/meson/template
+++ b/srcpkgs/meson/template
@@ -1,6 +1,6 @@
 # Template file for 'meson'
 pkgname=meson
-version=1.3.0
+version=1.3.1
 revision=1
 build_style=python3-module
 hostmakedepends="python3-devel python3-setuptools"
@@ -14,7 +14,7 @@ license="Apache-2.0"
 homepage="https://mesonbuild.com"
 changelog="https://raw.githubusercontent.com/mesonbuild/meson/master/docs/markdown/Release-notes-for-${version%.*}.0.md"
 distfiles="https://github.com/mesonbuild/meson/releases/download/${version}/meson-${version}.tar.gz"
-checksum=4ba253ef60e454e23234696119cbafa082a0aead0bd3bbf6991295054795f5dc
+checksum=6020568bdede1643d4fb41e28215be38eff5d52da28ac7d125457c59e0032ad7
 
 # XXX: sanitizers aren't available on musl
 if [ "$XBPS_TARGET_LIBC" = glibc ]; then


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, **x86_64**, **i686**

#### Comments

need this and [libdrm-2.4.119](https://github.com/void-linux/void-packages/pull/48170) for mesa-24 soonish

@SpidFightFR fyi