### PR TITLE
virtualbox-ose: Include UnattendedTemplates

### DIFF
--- a/srcpkgs/virtualbox-ose/template
+++ b/srcpkgs/virtualbox-ose/template
@@ -1,7 +1,7 @@
 # Template file for 'virtualbox-ose'
 pkgname=virtualbox-ose
 version=7.0.12a
-revision=1
+revision=2
 short_desc="General-purpose full virtualizer for x86 hardware"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-only, CDDL-1.0"
@@ -116,6 +116,8 @@ do_install() {
 	vsv vboxwebsrv
 
 	vdoc ${FILESDIR}/README.voidlinux
+
+	vcopy UnattendedTemplates usr/share/virtualbox
 }
 
 virtualbox-ose-dkms_package() {


### PR DESCRIPTION
These templates enable VirtualBox to do unattended installs. It fails with an error message complaining about missing
`/usr/share/virtualbox/UnattendedTemplates` without it.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
[ci skip] I will provide build testing soon.