### PR TITLE
libwacom: add missing dep for -devel subpkg

### DIFF
--- a/srcpkgs/libwacom/template
+++ b/srcpkgs/libwacom/template
@@ -1,7 +1,7 @@
 # Template file for 'libwacom'
 pkgname=libwacom
 version=2.9.0
-revision=1
+revision=2
 build_style=meson
 configure_args="-Ddocumentation=disabled"
 hostmakedepends="pkg-config"
@@ -26,7 +26,8 @@ post_install() {
 }
 
 libwacom-devel_package() {
-	depends="libgudev-devel ${sourcepkg}>=${version}_${revision}"
+	depends="libgudev-devel ${sourcepkg}>=${version}_${revision}
+	 libevdev-devel"
 	short_desc+=" - development files"
 	pkg_install() {
 		vmove usr/include


### PR DESCRIPTION
`libwacom-devel-2.9.0` requires `libevdev-devel` as a dependency.

`mutter` which  depends on `libwacom-devel` fails to build and spits out this error:
```
meson.build:284:17: ERROR: Dependency lookup for libwacom with method 'pkgconfig' failed: Could not generate cflags for libwacom:
Package libevdev was not found in the pkg-config search path.
Perhaps you should add the directory containing `libevdev.pc'
to the PKG_CONFIG_PATH environment variable
Package 'libevdev', required by 'libwacom', not found
```

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)
