### PR TITLE
lutris: update to 0.5.16

### DIFF
--- a/srcpkgs/lutris/template
+++ b/srcpkgs/lutris/template
@@ -1,6 +1,6 @@
 # Template file for 'lutris'
 pkgname=lutris
-version=0.5.14
+version=0.5.16
 revision=1
 build_style=meson
 hostmakedepends="gettext python3-setuptools python3-gobject gtk+3-devel"
@@ -13,4 +13,4 @@ license="GPL-3.0-or-later"
 homepage="https://lutris.net"
 changelog="https://raw.githubusercontent.com/lutris/lutris/master/debian/changelog"
 distfiles="https://github.com/lutris/lutris/archive/v${version}.tar.gz"
-checksum=c844b4a8338c4bb15df62d1edd0a8bd86bc9a06254711ccf4214aef4bce82f1d
+checksum=e6f39bba5a2c1eb942cb3d6583b6b25c304c130076a3bb803879e13561361a72


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, (x64 glibc)