### PR TITLE
bats-*: install in bats search path

### DIFF
--- a/srcpkgs/bats-assert/template
+++ b/srcpkgs/bats-assert/template
@@ -1,28 +1,28 @@
-# Template file for 'bats-assert'.
+# Template file for 'bats-assert'
 pkgname=bats-assert
 version=2.1.0
-revision=1
+revision=2
 depends="bats bats-support"
 checkdepends="$depends"
 short_desc="Common assertions for BATS"
 maintainer="Andrew J. Hesford <ajh@sideband.org>"
 license="CC0-1.0"
 homepage="https://github.com/bats-core/bats-assert"
-distfiles="${homepage}/archive/v${version}.tar.gz"
+distfiles="https://github.com/bats-core/bats-assert/archive/v${version}.tar.gz"
 checksum=98ca3b685f8b8993e48ec057565e6e2abcc541034ed5b0e81f191505682037fd
 
 do_check() {
-	BATS_LIB_PATH=/usr/lib bats test
+	bats test
 }
 
 do_install() {
 	local f
 
 	for f in *.bash; do
-		vinstall "$f" 644 usr/lib/bats-assert
+		vinstall "$f" 644 usr/lib/bats/bats-assert
 	done
 
 	for f in src/*.bash; do
-		vinstall "$f" 644 usr/lib/bats-assert/src
+		vinstall "$f" 644 usr/lib/bats/bats-assert/src
 	done
 }

--- a/srcpkgs/bats-support/template
+++ b/srcpkgs/bats-support/template
@@ -1,14 +1,14 @@
-# Template file for 'bats-support'.
+# Template file for 'bats-support'
 pkgname=bats-support
 version=0.3.0
-revision=1
+revision=2
 depends="bats"
 checkdepends="$depends"
 short_desc="Supporting library for BATS test helpers"
 maintainer="Andrew J. Hesford <ajh@sideband.org>"
 license="CC0-1.0"
 homepage="https://github.com/bats-core/bats-support"
-distfiles="${homepage}/archive/v${version}.tar.gz"
+distfiles="https://github.com/bats-core/bats-support/archive/v${version}.tar.gz"
 checksum=7815237aafeb42ddcc1b8c698fc5808026d33317d8701d5ec2396e9634e2918f
 
 do_check() {
@@ -19,10 +19,10 @@ do_install() {
 	local f
 
 	for f in *.bash; do
-		vinstall "$f" 644 usr/lib/bats-support
+		vinstall "$f" 644 usr/lib/bats/bats-support
 	done
 
 	for f in src/*.bash; do
-		vinstall "$f" 644 usr/lib/bats-support/src
+		vinstall "$f" 644 usr/lib/bats/bats-support/src
 	done
 }


### PR DESCRIPTION
without this, there are errors like this when running a bats test suite that needs these modules:
```
Could not find library 'bats-assert' relative to test file or in BATS_LIB_PATH
Could not find library 'bats-support' relative to test file or in BATS_LIB_PATH
```

@ahesford 

#### Testing the changes
- I tested the changes in this PR: **YES**

