### PR TITLE
restic: update to 0.16.3.

### DIFF
--- a/srcpkgs/restic/template
+++ b/srcpkgs/restic/template
@@ -1,6 +1,6 @@
 # Template file for 'restic'
 pkgname=restic
-version=0.16.2
+version=0.16.3
 revision=1
 build_style=go
 go_import_path=github.com/restic/restic
@@ -12,7 +12,7 @@ license="BSD-2-Clause"
 homepage="https://restic.net/"
 changelog="https://raw.githubusercontent.com/restic/restic/master/CHANGELOG.md"
 distfiles="https://github.com/restic/restic/releases/download/v${version}/restic-${version}.tar.gz"
-checksum=88165b5b89b6064df37a9964d660f40ac62db51d6536e459db9aaea6f2b2fc11
+checksum=a94d6c1feb0034fcff3e8b4f2d65c0678f906fc21a1cf2d435341f69e7e7af52
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86-64-LIBC)