### PR TITLE
autorestic: update to 1.8.0

### DIFF
--- a/srcpkgs/autorestic/template
+++ b/srcpkgs/autorestic/template
@@ -1,6 +1,6 @@
 # Template file for 'autorestic'
 pkgname=autorestic
-version=1.7.9
+version=1.8.0
 revision=1
 build_style=go
 go_import_path="github.com/cupcakearmy/autorestic"
@@ -11,4 +11,4 @@ license="Apache-2.0"
 homepage="https://autorestic.vercel.app/"
 changelog="https://github.com/cupcakearmy/autorestic/raw/master/CHANGELOG.md"
 distfiles="https://github.com/cupcakearmy/autorestic/archive/refs/tags/v${version}.tar.gz"
-checksum=e57bbc045edee4aabd850da2e61da9c18a6d12bd323866be1eb3edca4709b363
+checksum=a3174c795938b9d70a6af99d90c71083c228d82fc3c6a9961f8315ac12860f37


### PR DESCRIPTION
- I built this PR locally for my native architecture, (x86_64-glibc)
- I tested the changes in this PR: **YES**

```
$ autorestic --version
autorestic version 1.7.10
$ autorestic check
Using config: 	 /home/em/.autorestic.yaml
Using env:	 /home/em/.autorestic.env
Using lock:	 /home/em/.autorestic.lock.yml
Everything is fine.
```
