### PR TITLE
OTPClient: update to 3.3.0

### DIFF
--- a/srcpkgs/OTPClient/template
+++ b/srcpkgs/OTPClient/template
@@ -1,7 +1,7 @@
 # Template file for 'OTPClient'
 pkgname=OTPClient
-version=3.2.1
-revision=2
+version=3.3.0
+revision=1
 build_style=cmake
 hostmakedepends="pkg-config"
 makedepends="gtk+3-devel libglib-devel libgcrypt-devel libpng-devel
@@ -12,4 +12,4 @@ maintainer="Emil Miler <em@0x45.cz>"
 license="GPL-3.0-or-later"
 homepage="https://github.com/paolostivanin/OTPClient"
 distfiles="https://github.com/paolostivanin/OTPClient/archive/refs/tags/v${version}.tar.gz"
-checksum=f926155ef104e4965561e668a2e5128cdb7ed19af49ba7e693b580883fdae048
+checksum=94c28004619d12c786a7d6e68c8e504980c426b2a814b037213352cdbbce362b


### PR DESCRIPTION
- I tested the changes in this PR: **briefly**
- I built this PR locally for my native architecture, (x86_64-glibc)