### PR TITLE
SuiteSparse: update to 7.6.0.

### DIFF
--- a/srcpkgs/SuiteSparse/template
+++ b/srcpkgs/SuiteSparse/template
@@ -1,6 +1,6 @@
 # Template file for 'SuiteSparse'
 pkgname=SuiteSparse
-version=7.4.0
+version=7.6.0
 revision=1
 build_style=cmake
 hostmakedepends="cmake gcc-fortran"
@@ -12,7 +12,7 @@ license="custom:multiple"
 homepage="https://people.engr.tamu.edu/davis/suitesparse.html"
 changelog="https://raw.githubusercontent.com/DrTimothyAldenDavis/SuiteSparse/master/ChangeLog"
 distfiles="https://github.com/DrTimothyAldenDavis/SuiteSparse/archive/refs/tags/v${version}.tar.gz"
-checksum=f9a5cc2316a967198463198f7bf10fb8c4332de6189b0e405419a7092bc921b7
+checksum=19cbeb9964ebe439413dd66d82ace1f904adc5f25d8a823c1b48c34bd0d29ea5
 
 build_options="openblas"
 

--- a/srcpkgs/python3-cvxopt/template
+++ b/srcpkgs/python3-cvxopt/template
@@ -32,4 +32,6 @@ pre_build() {
 	export CVXOPT_BUILD_FFTW=1
 	export CVXOPT_BLAS_LIB=$(vopt_if openblas 'openblas' 'blas;gslcblas')
 	export CVXOPT_LAPACK_LIB=$(vopt_if openblas 'openblas' 'lapack')
+	# setup.py gets this wrong for i686 (and other 32 bit?)
+	export CVXOPT_SUITESPARSE_INC_DIR=${XBPS_CROSS_BASE}/usr/include/suitesparse
 }


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

I built and checked `octave` and `python3-cvxopt` on top of this (#47887 would be nice to do this on CI as well).

While doing this I discovered building cvxopt is broken on i686, so I fixed it. It just happens that suitesparse moved header files in 7.4.0 to `/usr/include/suitesparse` and cvxopt figures this out for 64 bit but not for 32 bit). No need to rebuild cvxopt since our current binary is fine (it was last built with suitesparse 7.3.1).

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
