### PR TITLE
New package: ryzen_smu-dkms-0.1.5

### DIFF
--- a/srcpkgs/ryzen_smu-dkms/template
+++ b/srcpkgs/ryzen_smu-dkms/template
@@ -1,0 +1,28 @@
+# Template file for 'ryzen_smu-dkms'
+pkgname=ryzen_smu-dkms
+version=0.1.5
+revision=1
+archs="x86_64*"
+depends="dkms"
+short_desc="Kernel driver to provide SMU access for AMD Ryzen processors"
+maintainer="Brandon Little <blittle@inco.cc>"
+license="GPL-2.0-or-later"
+homepage="https://gitlab.com/leogx9r/ryzen_smu"
+distfiles="${homepage}/-/archive/v${version}/ryzen_smu-v${version}.tar.gz"
+checksum=25c7e6885b14fcad27430aa3fa273009c889794158d94f1b3040ad432b94d037
+dkms_modules="ryzen_smu ${version}"
+
+do_install() {
+	vmkdir usr/src/ryzen_smu-${version}
+	vmkdir usr/src/ryzen_smu-${version}/lib
+	vmkdir usr/src/ryzen_smu-${version}/userspace
+	vsed -i dkms.conf -e "s/@CFLGS@//" -e "s/@VERSION@/${version}/"
+	vcopy Makefile usr/src/ryzen_smu-${version}
+	vcopy dkms.conf usr/src/ryzen_smu-${version}
+	vcopy *.c usr/src/ryzen_smu-${version}
+	vcopy *.h usr/src/ryzen_smu-${version}
+	vcopy lib/*.c usr/src/ryzen_smu-${version}/lib
+	vcopy lib/*.h usr/src/ryzen_smu-${version}/lib
+	vcopy userspace/Makefile usr/src/ryzen_smu-${version}/userspace
+	vcopy userspace/*.c usr/src/ryzen_smu-${version}/userspace
+}


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, x86_64

This module is required for [RyzenAdj](https://github.com/void-linux/void-packages/tree/master/srcpkgs/RyzenAdj) to access the SMU on AMD Ryzen processors.