### PR TITLE
New package: suggpicker-0.1.4

### DIFF
--- a/srcpkgs/suggpicker/template
+++ b/srcpkgs/suggpicker/template
@@ -1,0 +1,14 @@
+# Template file for 'suggpicker'
+pkgname=suggpicker
+version=0.1.4
+revision=1
+build_style=gnu-makefile
+make_use_env=yes
+hostmakedepends="wayland-devel pkg-config scdoc"
+makedepends="wayland-devel pango-devel cairo-devel"
+short_desc="Floating on-screen picker"
+maintainer="Eloi Torrents <eloitor@disroot.org>"
+license="GPL-3.0-only"
+homepage="https://git.sr.ht/~earboxer/suggpicker"
+distfiles="https://git.sr.ht/~earboxer/suggpicker/archive/v${version}.tar.gz"
+checksum=6e967f76732a362dc800389583a6a91c4fabe6ea7c803784a97d7c9c14aba2a9


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **no**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)


I get this error which I don't know how to fix: 

```
drw.h:4:10: fatal error: pango/pangocairo.h: No such file or directory
    4 | #include <pango/pangocairo.h>
      |          ^~~~~~~~~~~~~~~~~~~~
compilation terminated.
```