### PR TITLE
miniserve: update to 0.26.0.

### DIFF
--- a/srcpkgs/miniserve/template
+++ b/srcpkgs/miniserve/template
@@ -1,6 +1,6 @@
 # Template file for 'miniserve'
 pkgname=miniserve
-version=0.25.0
+version=0.26.0
 revision=1
 build_style=cargo
 build_helper=qemu
@@ -17,7 +17,7 @@ license="MIT"
 homepage="https://github.com/svenstaro/miniserve"
 changelog="https://raw.githubusercontent.com/svenstaro/miniserve/master/CHANGELOG.md"
 distfiles="https://github.com/svenstaro/miniserve/archive/refs/tags/v${version}.tar.gz"
-checksum=27986ea4f3ba6670798e6c78709b7c11d5bbd1417b93826123e829c40b5bd000
+checksum=5ac3e7220c0c86c23af46326cf88e4d0dc9eb296ca201c47c4c3f01d607edf63
 make_check=ci-skip  # port binding succeeds locally but fails in CI
 
 case "$XBPS_TARGET_MACHINE" in


### PR DESCRIPTION

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc

