### PR TITLE
setup/archive: fix extraction of non-tar gz/bz2/xz/zst archives

### DIFF
--- a/common/environment/setup/archive.sh
+++ b/common/environment/setup/archive.sh
@@ -76,16 +76,16 @@ vextract() {
 			if [ "$dst" ]; then cd "$dst"; fi
 			case ${sfx} in
 			gz)
-				gunzip -f $archive
+				gunzip -f ${archive##*/}
 				;;
 			bz2)
-				bunzip2 -f $archive
+				bunzip2 -f ${archive##*/}
 				;;
 			xz)
-				unxz -f $archive
+				unxz -f ${archive##*/}
 				;;
 			zst)
-				unzstd $archive
+				unzstd ${archive##*/}
 				;;
 			esac
 		)


### PR DESCRIPTION
Extract archive in the destination directory instead of the source directory.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
