### PR TITLE
dhcpcd: update to 10.0.6

### DIFF
--- a/srcpkgs/dhcpcd/template
+++ b/srcpkgs/dhcpcd/template
@@ -1,6 +1,6 @@
 # Template file for 'dhcpcd'
 pkgname=dhcpcd
-version=10.0.5
+version=10.0.6
 revision=1
 build_style=configure
 make_check_target=test
@@ -15,7 +15,7 @@ license="BSD-2-Clause"
 homepage="https://roy.marples.name/projects/dhcpcd"
 changelog="https://github.com/NetworkConfiguration/dhcpcd/releases"
 distfiles="https://github.com/NetworkConfiguration/dhcpcd/archive/refs/tags/v${version}.tar.gz"
-checksum=046b060d72b158f813ea61acc1eff773dea4d9ad035a674ed87ecd95bd35cff7
+checksum=f997a869437cc77304d5817064ecea4f488f5a0893fa642703807b5007727204
 lib32disabled=yes
 conf_files=/etc/dhcpcd.conf
 


### PR DESCRIPTION
it's just a version bump

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)

