### PR TITLE
pmbootstrap: update to 2.2.0, adopt

### DIFF
--- a/srcpkgs/pmbootstrap/template
+++ b/srcpkgs/pmbootstrap/template
@@ -1,7 +1,7 @@
 # Template file for 'pmbootstrap'
 pkgname=pmbootstrap
-version=2.0.0
-revision=2
+version=2.2.1
+revision=1
 build_style=python3-module
 hostmakedepends="python3-setuptools"
 depends="git openssl python3"
@@ -9,7 +9,7 @@ short_desc="Package build and device flashing tool for postmarketOS"
 maintainer="Jami Kettunen <jami.kettunen@protonmail.com>"
 license="GPL-3.0-or-later"
 homepage="https://postmarketos.org"
-changelog="https://git.sr.ht/~postmarketos/pmbootstrap/refs"
-distfiles="https://git.sr.ht/~postmarketos/pmbootstrap/archive/${version}.tar.gz"
-checksum=e8d63b6f746c50cba3abd604902ee3f61ccd25dcfc026b0c1418df7540fd99f7
+changelog="https://gitlab.com/postmarketOS/pmbootstrap/-/tags"
+distfiles="https://gitlab.com/postmarketOS/pmbootstrap/-/archive/${version}/pmbootstrap-${version}.tar.gz"
+checksum=195a3cb430c9ede354bc575ddb765f10b205067f8c478f153c84f6f793785c09
 make_check=no # tests require chroot


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)

Without this update it is not possible to install postmarketOS  v23.12.
