### PR TITLE
rsClock: update to 0.1.11.

### DIFF
--- a/srcpkgs/rsClock/template
+++ b/srcpkgs/rsClock/template
@@ -1,6 +1,6 @@
 # Template file for 'rsClock'
 pkgname=rsClock
-version=0.1.10
+version=0.1.11
 revision=1
 build_style=cargo
 short_desc="Simple terminal clock written in Rust"
@@ -9,7 +9,7 @@ license="MIT"
 homepage="https://github.com/valebes/rsClock"
 changelog="https://github.com/valebes/rsClock/releases"
 distfiles="https://github.com/valebes/rsClock/archive/refs/tags/v${version}.tar.gz"
-checksum=b4ce70801680fec5c80422b9f3367615c3a0ca96f620058f93f79a522b88a30e
+checksum=4811e7fb134be086c38f3bfbc9bb871a2b3eaf3e6638f19f5a77dd273dffdffc
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture: **x86_64**