### PR TITLE
vale: update to 3.0.5.

### DIFF
--- a/srcpkgs/vale/template
+++ b/srcpkgs/vale/template
@@ -1,6 +1,6 @@
 # Template file for 'vale'
 pkgname=vale
-version=3.0.4
+version=3.0.5
 revision=1
 build_style=go
 go_import_path="github.com/errata-ai/vale/v2"
@@ -12,7 +12,7 @@ license="MIT"
 homepage="https://vale.sh"
 changelog="https://github.com/errata-ai/vale/releases"
 distfiles="https://github.com/errata-ai/vale/archive/refs/tags/v${version}.tar.gz"
-checksum=a845cd4545574f9a032542ee9034e7b9f2851319b4b765b1ae3266753d2814cd
+checksum=1628a218f9b20d5073bd264ba77c8b2c20deb436bc9d014e321fe68ff6435f23
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture: **x86_64**