### PR TITLE
rz-ghidra: rebuild for qt6

### DIFF
--- a/srcpkgs/rz-ghidra/template
+++ b/srcpkgs/rz-ghidra/template
@@ -1,12 +1,12 @@
 # Template file for 'rz-ghidra'
 pkgname=rz-ghidra
 version=0.6.0
-revision=1
+revision=2
 build_style=cmake
 build_helper=qemu
 configure_args="-DCUTTER_INSTALL_PLUGDIR=/usr/lib/rizin/cutter/plugins/native
  -DBUILD_CUTTER_PLUGIN=ON"
-hostmakedepends="pkg-config qt5-host-tools qt5-qmake"
+hostmakedepends="pkg-config qt6-base qt6-tools"
 makedepends="cutter-devel rizin-devel"
 short_desc="Deep ghidra decompiler and sleigh disassembler integration for rizin"
 maintainer="classabbyamp <void@placeviolette.net>"


### PR DESCRIPTION
#### Description

Rebuild `rz-ghidra` to support the latest `cutter` release in the repositories, built against `qt6`. Currently, `cutter` fails to load the Ghidra plugin because it's being built against `qt5`.

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
