### PR TITLE
vala: update to 0.56.14.

### DIFF
--- a/srcpkgs/vala/template
+++ b/srcpkgs/vala/template
@@ -1,7 +1,7 @@
 # Template file for 'vala'
 pkgname=vala
 # Should be kept in sync with 'valadoc' (shared distfiles)
-version=0.56.13
+version=0.56.14
 revision=1
 build_style=gnu-configure
 configure_args="--disable-valadoc"
@@ -14,7 +14,7 @@ license="LGPL-2.1-or-later"
 homepage="https://wiki.gnome.org/Projects/Vala"
 changelog="https://gitlab.gnome.org/GNOME/vala/raw/master/NEWS"
 distfiles="${GNOME_SITE}/vala/${version%.*}/vala-${version}.tar.xz"
-checksum=4988223036c7e1e4874c476d0de8bd9cbe500ee25ef19a76e560dc0b6d56ae07
+checksum=9382c268ca9bdc02aaedc8152a9818bf3935273041f629c56de410e360a3f557
 shlib_provides="libvalaccodegen.so"
 make_check=extended # take a lot of time
 


### PR DESCRIPTION
Update to fix buffer overflow crash when building NetworkManager.
See: https://gitlab.gnome.org/GNOME/vala/-/issues/1485

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
