### PR TITLE
New package: gamescope-3.14.1

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -4274,3 +4274,4 @@ libunicode.so.0.4 libunicode-0.4.0_1
 libunicode_ucd.so.0.4 libunicode-0.4.0_1
 libunicode_loader.so.0.4 libunicode-0.4.0_1
 force-stage.so.0.1 void-force-stage-0.1_1
+libliftoff.so.0 libliftoff-0.4.1_1

--- a/srcpkgs/gamescope/template
+++ b/srcpkgs/gamescope/template
@@ -1,0 +1,50 @@
+# Template file for 'gamescope'
+pkgname=gamescope
+version=3.14.1
+revision=1
+_stb_hash=5736b15f7ea0ffb08dd38af21067c314d6a3aae9
+_vkroots_hash=d5ef31abc7cb5c69aee4bcb67b10dd543c1ff7ac
+_reshade_hash=9fdbea6892f9959fdc18095d035976c574b268b7
+build_style=meson
+configure_args="-Denable_openvr_support=false --force-fallback-for="
+hostmakedepends="glslang pkg-config wayland-devel"
+makedepends="pipewire-devel Vulkan-Headers SPIRV-Headers libX11-devel
+ libXdamage-devel libXcomposite-devel libXrender-devel libXxf86vm-devel
+ libXtst-devel libXres-devel libdrm-devel vulkan-loader wayland-protocols
+ libxkbcommon-devel libcap-devel SDL2-devel hwids wlroots0.17-devel
+ libliftoff-devel glm libXmu-devel libdisplay-info-devel benchmark-devel
+ libavif-devel"
+depends="xorg-server-xwayland"
+short_desc="SteamOS session compositing window manager"
+maintainer="Dexter Gaon-Shatford <dexter.gaonshatford@gmail.com>"
+license="BSD-2-Clause, BSD-3-Clause, MIT"
+homepage="https://github.com/ValveSoftware/gamescope"
+distfiles="https://github.com/ValveSoftware/gamescope/archive/refs/tags/${version}.tar.gz
+ https://github.com/nothings/stb/archive/${_stb_hash}.tar.gz
+ https://github.com/Joshua-Ashton/vkroots/archive/${_vkroots_hash}.tar.gz
+ https://github.com/Joshua-Ashton/reshade/archive/${_reshade_hash}.tar.gz"
+checksum="9e87688833effc9d52c746637aa6a82cdad37776bb372fdb0f22d84e815c9c6f
+ d00921d49b06af62aa6bfb97c1b136bec661dd11dd4eecbcb0da1f6da7cedb4c
+ b4eca5edca75355ea1443ad96fd59b0a407f6a2ce17ef5a8f9849c05fc10155f
+ 165726ad21fbfc221c0363e40b597834068a416a11a1204ae2ac6d13ec161035"
+skip_extraction="${_stb_hash}.tar.gz
+ ${_vkroots_hash}.tar.gz
+ ${_reshade_hash}.tar.gz"
+
+post_extract() {
+	vsrcextract -C subprojects/stb "${_stb_hash}.tar.gz"
+	cp subprojects/packagefiles/stb/meson.build subprojects/stb
+	vsrcextract -C subprojects/vkroots "${_vkroots_hash}.tar.gz"
+	vsrcextract -C src/reshade "${_reshade_hash}.tar.gz"
+}
+
+post_patch() {
+	# Use system SPIRV headers rather than gamescope's vendored headers
+	vsed -i src/meson.build -e "s|../thirdparty/SPIRV-Headers/include/spirv/unified1|${XBPS_CROSS_BASE}/usr/include/spirv/unified1|"
+}
+
+post_install() {
+	vlicense LICENSE
+	rm ${DESTDIR}/usr/lib/pkgconfig/vkroots.pc
+	rm ${DESTDIR}/usr/include/vkroots.h
+}

--- a/srcpkgs/gamescope/update
+++ b/srcpkgs/gamescope/update
@@ -1,0 +1,2 @@
+site=https://github.com/ValveSoftware/gamescope/tags
+pkgname=

--- a/srcpkgs/libliftoff-devel
+++ b/srcpkgs/libliftoff-devel
@@ -1,0 +1,1 @@
+libliftoff

--- a/srcpkgs/libliftoff/template
+++ b/srcpkgs/libliftoff/template
@@ -1,0 +1,34 @@
+# Template file for 'libliftoff'
+pkgname=libliftoff
+version=0.4.1
+revision=1
+build_style=meson
+hostmakedepends="pkg-config"
+makedepends="libdrm-devel"
+short_desc="Lightweight KMS plane library"
+maintainer="Dexter Gaon-Shatford <dexter.gaonshatford@gmail.com>"
+license="MIT"
+homepage="https://gitlab.freedesktop.org/emersion/libliftoff"
+distfiles="https://gitlab.freedesktop.org/emersion/libliftoff/-/archive/v${version}/libliftoff-v${version}.tar.gz"
+checksum=44ec5cfdd0df040d1023d4d6a48b23c31f21ce61ee2347da9e1ca244fe24dd1c
+
+CFLAGS="-Wno-error=unused-but-set-variable"
+
+if [ "$XBPS_CHECK_PKGS" ]; then
+	# The test suite checks for NDEBUG and fails if it is defined, even if all other tests would pass
+	CFLAGS+=" -UNDEBUG"
+fi
+
+post_install() {
+	vlicense LICENSE
+}
+
+libliftoff-devel_package() {
+	depends="libliftoff>=${version}_${revision}"
+	short_desc+=" - development files"
+	pkg_install() {
+		vmove usr/include
+		vmove usr/lib/pkgconfig
+		vmove "usr/lib/*.so"
+	}
+}


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->
Add Valve's Gamescope as requested in #36869. If this is merged, `steamos-compositor` should probably be removed from the repository at some point.

This PR also adds `libliftoff` as a dependency. Gamescope also vendors some dependencies, but I believe I've handled this correctly.

#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
