### PR TITLE
astroid: apply upstream patch to prevent crashes while adding attachments

### DIFF
--- a/srcpkgs/astroid/patches/attachements.patch
+++ b/srcpkgs/astroid/patches/attachements.patch
@@ -1,0 +1,23 @@
+From 7fd64c41435a2b99fb9e0a5770a83ba30cd11450 Mon Sep 17 00:00:00 2001
+From: "Stephan C. Buchert" <scb@irfu.se>
+Date: Wed, 14 Jun 2023 17:44:05 +0200
+Subject: [PATCH] compose_message: to load as byte array, 'file' must be
+ wrapped with copy.
+
+---
+ src/compose_message.cc | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/compose_message.cc b/src/compose_message.cc
+index 189c20f99..329481f40 100644
+--- a/src/compose_message.cc
++++ b/src/compose_message.cc
+@@ -781,7 +781,7 @@ namespace Astroid {
+ 
+     } else {
+       /* load into byte array */
+-      refptr<Gio::File> fle = Glib::wrap (file, false);
++      refptr<Gio::File> fle = Glib::wrap (file, true);
+       refptr<Gio::FileInputStream> istr = fle->read ();
+ 
+       refptr<Glib::Bytes> b;

--- a/srcpkgs/astroid/template
+++ b/srcpkgs/astroid/template
@@ -1,7 +1,7 @@
 # Template file for 'astroid'
 pkgname=astroid
 version=0.16
-revision=11
+revision=12
 build_style=cmake
 build_helper=gir
 hostmakedepends="pkg-config scdoc protobuf gobject-introspection"


### PR DESCRIPTION
This update is applying a non-release upstream patch to prevent crashes while adding attachments.
See astroidmail/astroid/issues/726 for more information.

#### Testing the changes
- I tested the changes in this PR: YES

#### Local build testing
- I built this PR locally for my native architecture, (x68_64-glibc)