### PR TITLE
razergenie: update to 1.1.0

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -4503,3 +4503,4 @@ libcamera-base.so.0.2 libcamera-0.2.0_1
 libKPim6MimeTreeParserCore.so.6 mimetreeparser-24.02.0_1
 libKPim6MimeTreeParserWidgets.so.6 mimetreeparser-24.02.0_1
 /usr/lib/lua/5.1/lpeg.so lua51-lpeg-1.1.0_2
+libopenrazer.so.0 libopenrazer-0.2.0_1

--- a/srcpkgs/libopenrazer-devel
+++ b/srcpkgs/libopenrazer-devel
@@ -1,0 +1,1 @@
+libopenrazer

--- a/srcpkgs/libopenrazer/template
+++ b/srcpkgs/libopenrazer/template
@@ -1,0 +1,23 @@
+# Template file for 'libopenrazer'
+pkgname=libopenrazer
+version=0.2.0
+revision=1
+build_style=meson
+hostmakedepends="pkg-config qt5-host-tools"
+makedepends="qt5-devel"
+short_desc="Qt wrapper around the D-Bus API from OpenRazer"
+maintainer="Orphaned <orphan@voidlinux.org>"
+license="GPL-3.0-or-later"
+homepage="https://github.com/z3ntu/libopenrazer"
+distfiles="https://github.com/z3ntu/libopenrazer/releases/download/v${version}/libopenrazer-${version}.tar.xz"
+checksum=86c28a1203e03f6c8f93490414a3a9ddcdb0459ce04bf08b6e3b6181478935f9
+
+libopenrazer-devel_package() {
+	depends="${sourcepkg}>=${version}_${revision}"
+	short_desc+=" - development files"
+	pkg_install() {
+		vmove usr/include
+		vmove usr/lib/pkgconfig
+		vmove "usr/lib/*.so"
+	}
+}

--- a/srcpkgs/razergenie/template
+++ b/srcpkgs/razergenie/template
@@ -1,14 +1,14 @@
 # Template file for 'razergenie'
 pkgname=razergenie
-version=0.9.0
+version=1.1.0
 revision=1
 build_style=meson
 hostmakedepends="pkg-config qt5-host-tools"
-makedepends="qt5-devel"
+makedepends="qt5-devel libopenrazer-devel"
 depends="openrazer-meta"
 short_desc="Qt application for configuring your Razer devices under GNU/Linux"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-3.0-or-later"
 homepage="https://github.com/z3ntu/RazerGenie"
 distfiles="https://github.com/z3ntu/RazerGenie/releases/download/v${version}/RazerGenie-${version}.tar.xz"
-checksum=e4a35ce56f7a8bc102afaca121668831dab876a6f487849bce46b0c6613aa85e
+checksum=4210b030e6f13421299f45d3c6da83ec5705f754177f1ac09be2a412eda59b5c


### PR DESCRIPTION
I received a report that the current `razergenie` is showing errors or not working. Here's an update. Since I don't use it, I'm keeping the packages labeled as "Orphaned".

---

#### New package
- libopenrazer got split into a standalone project 
- This (libopenrazer) new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc