### PR TITLE
lf: build with cgo=0, run checks

### DIFF
--- a/srcpkgs/lf/template
+++ b/srcpkgs/lf/template
@@ -1,7 +1,7 @@
 # Template file for 'lf'
 pkgname=lf
 version=r31
-revision=1
+revision=2
 build_style=go
 go_import_path="github.com/gokcehan/${pkgname}"
 go_ldflags="-X main.gVersion=$version"
@@ -11,6 +11,11 @@ license="MIT"
 homepage="https://github.com/gokcehan/lf"
 distfiles="https://github.com/gokcehan/lf/archive/${version}.tar.gz"
 checksum=ed47fc22c58cf4f4e4116a58c500bdb9f9ccc0b89f87be09f321e8d1431226ab
+export CGO_ENABLED=0
+
+do_check() {
+	go test ./...
+}
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
build static as suggested by upstream, run checks. cc maintainer @TeddyDD 

- I tested the changes in this PR: yes
- I built this PR locally for my native architecture, (x86_64)
- I built this PR locally for these architectures (cross aarch64-musl)