### PR TITLE
sshguard: update to 2.4.3

### DIFF
--- a/srcpkgs/sshguard/template
+++ b/srcpkgs/sshguard/template
@@ -1,6 +1,6 @@
 # Template file for 'sshguard'
 pkgname=sshguard
-version=2.4.2
+version=2.4.3
 revision=1
 build_style=gnu-configure
 hostmakedepends="flex"
@@ -9,7 +9,7 @@ maintainer="Lodvær <lodvaer@gmail.com>"
 license="BSD-3-Clause"
 homepage="https://www.sshguard.net/"
 distfiles="${SOURCEFORGE_SITE}/sshguard/sshguard-${version}.tar.gz"
-checksum=2770b776e5ea70a9bedfec4fd84d57400afa927f0f7522870d2dcbbe1ace37e8
+checksum=64029deff6de90fdeefb1f497d414f0e4045076693a91da1a70eb7595e97efeb
 
 make_dirs="/var/db/sshguard 0755 root root"
 conf_files="/etc/sshguard.conf"


### PR DESCRIPTION
just a version bump
tagging the maintainer @lodvaer 

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl

