### PR TITLE
lziprecover: update to 1.24.

### DIFF
--- a/srcpkgs/lziprecover/template
+++ b/srcpkgs/lziprecover/template
@@ -1,6 +1,6 @@
 # Template file for 'lziprecover'
 pkgname=lziprecover
-version=1.23
+version=1.24
 revision=1
 build_style=configure
 checkdepends="lzip"
@@ -9,7 +9,7 @@ maintainer="Matt Boehlke <mtboehlke@gmail.com>"
 license="GPL-2.0-or-later"
 homepage="https://www.nongnu.org/lzip/lziprecover.html"
 distfiles="${NONGNU_SITE}/lzip/lziprecover/lziprecover-${version}.tar.lz"
-checksum=9a41c9823670541573b160945c23783b644e84eb940c2c803b6b8d11b2c3d208
+checksum=92d09e7e9d7c1f5a144fe631e5c20eb7e82ff6eb43d4f8ab6b260c926303d89e
 
 do_configure() {
 	./configure --prefix=/usr \


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
