### PR TITLE
gnu-efi-libs: update to 3.0.15.

### DIFF
--- a/srcpkgs/gnu-efi-libs/template
+++ b/srcpkgs/gnu-efi-libs/template
@@ -1,7 +1,7 @@
 # Template file for 'gnu-efi-libs'
 pkgname=gnu-efi-libs
 reverts="3.0w_1" # Not an actual revert, xbps considers 3.0w higher than 3.0.8
-version=3.0.14
+version=3.0.15
 revision=1
 makedepends="pciutils-devel"
 short_desc="Library for building UEFI Applications using GNU toolchain"
@@ -9,7 +9,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="https://sourceforge.net/projects/gnu-efi/"
 distfiles="${SOURCEFORGE_SITE}/gnu-efi/gnu-efi-${version}.tar.bz2"
-checksum=b73b643a0d5697d1f396d7431448e886dd805668789578e3e1a28277c9528435
+checksum=931a257b9c5c1ba65ff519f18373c438a26825f2db7866b163e96d1b168f20ea
 nostrip=yes
 
 # If we are cross-building we need to pass the cross-compilation triplet


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly** (With fwupd-efi)

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl
  - i686
