### PR TITLE
gsettings-desktop-schemas: added missing font dependency

### DIFF
--- a/srcpkgs/gsettings-desktop-schemas/template
+++ b/srcpkgs/gsettings-desktop-schemas/template
@@ -7,6 +7,7 @@ build_style=meson
 configure_args="-Dintrospection=$(vopt_if gir true false)"
 hostmakedepends="gettext pkg-config glib-devel"
 makedepends="libglib-devel"
+depends="font-adobe-source-code-pro"
 short_desc="Collection of GSettings schemas"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="LGPL-2.1-or-later"


### PR DESCRIPTION
org.gnome.desktop.interface monospace-font-name default is 'Source Code Pro 10', which is missing
adding this dependency will fix default configuration with dependent packages like tilix, terminator and probably others

#### Testing the changes
- I tested the changes in this PR: **YES**
