### PR TITLE
python3-keyring: update to 24.3.0.

### DIFF
--- a/srcpkgs/python3-keyring/template
+++ b/srcpkgs/python3-keyring/template
@@ -1,10 +1,10 @@
 # Template file for 'python3-keyring'
 pkgname=python3-keyring
-version=24.2.0
-revision=2
+version=24.3.0
+revision=1
 build_style=python3-pep517
 hostmakedepends="python3-wheel python3-setuptools_scm"
-depends="python3-SecretStorage python3-jeepney python3-importlib_metadata
+depends="python3-SecretStorage python3-jeepney
  python3-jaraco.classes"
 checkdepends="${depends} python3-pytest-xdist"
 short_desc="Python interface to the system keyring service"
@@ -13,7 +13,7 @@ license="MIT"
 homepage="https://pypi.org/project/keyring/"
 changelog="https://raw.githubusercontent.com/jaraco/keyring/main/NEWS.rst"
 distfiles="${PYPI_SITE}/k/keyring/keyring-${version}.tar.gz"
-checksum=ca0746a19ec421219f4d713f848fa297a661a8a8c1504867e55bfb5e09091509
+checksum=e730ecffd309658a08ee82535a3b5ec4b4c8669a9be11efb66249d8e0aeb9a25
 
 pre_check() {
 	vsed -e '/addopts/d' -i pytest.ini


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture: **x86_64**