### PR TITLE
xbps-src: Don't unset IFS

### DIFF
--- a/common/environment/setup/sourcepkg.sh
+++ b/common/environment/setup/sourcepkg.sh
@@ -20,7 +20,7 @@ for var in $(awk 'BEGIN{for (i in ENVIRON) {print i}}' </dev/null); do
 		;;
 	FREEDESKTOP_SITE | KDE_SITE | VIDEOLAN_SITE | UBUNTU_SITE)
 		;;
-	_ | PWD | SHLVL | USER | PATH | SHELL | HOME | LC_COLLATE | LANG | TERM | PS1)
+	_ | PWD | SHLVL | USER | PATH | SHELL | HOME | LC_COLLATE | LANG | TERM | PS1 | IFS)
 		# known variables for shell
 		;;
 	DISTCC_HOSTS | DISTCC_DIR)


### PR DESCRIPTION
If IFS is unset, the shell behaves as if it has the default value of `<space><tab><newline>`. However, after unsetting IFS, constructs like
```
OFS="$IFS"; IFS=','
...
IFS="$OIFS"
```
(for example in [common/xbps-src/shutils/common.sh lines 246-253](https://github.com/void-linux/void-packages/blob/d2fbe47cac44061f1154db62f6f939178f204d15/common/xbps-src/shutils/common.sh#L246)) have the effect of setting IFS with an empty value, which breaks word-splitting. This results in an error like
```
./common/xbps-src/shutils/bulk.sh: line 125: sudo /bin/sh -c: No such file or directory
```
when running `./xbps-src update-sys` with `XBPS_SUCMD` set to the default value (`sudo /bin/sh -c`).

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **yes**