### PR TITLE
New package: sesh (v0.13.0)

### DIFF
--- a/srcpkgs/sesh/template
+++ b/srcpkgs/sesh/template
@@ -1,0 +1,16 @@
+# Template file for 'sesh'
+pkgname=sesh
+version=0.9.0
+revision=1
+build_style=go
+go_import_path=github.com/joshmedeski/sesh
+short_desc="Smart session manager for the terminal"
+maintainer="Rahul Garg <rg@vihu.dev>"
+license="MIT"
+homepage="https://github.com/joshmedeski/sesh"
+distfiles="https://github.com/joshmedeski/sesh/archive/v${version}.tar.gz"
+checksum=9308c8bbfa1328ea29f1cf058c98733e3a60089997678b27f5e4e824bd90d899
+
+post_install() {
+	vlicense LICENSE
+}

--- a/srcpkgs/sesh/template
+++ b/srcpkgs/sesh/template
@@ -1,6 +1,6 @@
 # Template file for 'sesh'
 pkgname=sesh
-version=0.9.0
+version=0.13.0
 revision=1
 build_style=go
 go_import_path=github.com/joshmedeski/sesh
@@ -9,7 +9,7 @@ maintainer="Rahul Garg <rg@vihu.dev>"
 license="MIT"
 homepage="https://github.com/joshmedeski/sesh"
 distfiles="https://github.com/joshmedeski/sesh/archive/v${version}.tar.gz"
-checksum=9308c8bbfa1328ea29f1cf058c98733e3a60089997678b27f5e4e824bd90d899
+checksum=6d7b938122d7b258e9e7321ee6d0faf2c43c87cd5b348e48a0a1375431de3795
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
Summary
----

#### I tested the changes in this PR: YES

- I have confirmed that building the package is successful and have installed it locally.

#### Build

```bash
./xbps-src pkg sesh
=> xbps-src: updating repositories for host (x86_64)...
[*] Updating repository `https://repo-default.voidlinux.org/current/bootstrap/x86_64-repodata' ...
[*] Updating repository `https://repo-default.voidlinux.org/current/x86_64-repodata' ...
[*] Updating repository `https://repo-default.voidlinux.org/current/nonfree/x86_64-repodata' ...
[*] Updating repository `https://repo-default.voidlinux.org/current/debug/x86_64-repodata' ...
[*] Updating repository `https://repo-default.voidlinux.org/current/multilib/bootstrap/x86_64-repodata' ...
[*] Updating repository `https://repo-default.voidlinux.org/current/multilib/x86_64-repodata' ...
[*] Updating repository `https://repo-default.voidlinux.org/current/multilib/nonfree/x86_64-repodata' ...
=> xbps-src: updating software in / masterdir...
=> xbps-src: cleaning up / masterdir...
=> sesh-0.9.0_1: removing autodeps, please wait...
=> sesh-0.9.0_1: building with [go] for x86_64...
   [host] go-1.21.5_1: found (https://repo-default.voidlinux.org/current)
=> sesh-0.9.0_1: installing host dependencies: go-1.21.5_1 ...
=> sesh-0.9.0_1: running pre-build hook: 02-script-wrapper ...
=> sesh-0.9.0_1: running do_build ...
go: downloading github.com/urfave/cli/v2 v2.27.1
go: downloading github.com/pelletier/go-toml/v2 v2.1.1
go: downloading github.com/cpuguy83/go-md2man/v2 v2.0.3
go: downloading github.com/xrash/smetrics v0.0.0-20231213231151-1d8dd44e695e
go: downloading github.com/russross/blackfriday/v2 v2.1.0
internal/goarch
internal/goexperiment
internal/coverage/rtcov
internal/godebugs
internal/race
internal/itoa
log/internal
encoding
internal/unsafeheader
unicode/utf16
unicode
math/bits
unicode/utf8
internal/goos
runtime/internal/syscall
internal/cpu
sync/atomic
runtime/internal/atomic
runtime/internal/math
internal/abi
runtime/internal/sys
github.com/pelletier/go-toml/v2/internal/characters
internal/bytealg
math
runtime
internal/reflectlite
sync
internal/testlog
internal/bisect
internal/godebug
errors
sort
internal/oserror
io
internal/safefilepath
path
strconv
syscall
text/tabwriter
bytes
strings
reflect
html
regexp/syntax
internal/syscall/execenv
internal/syscall/unix
time
regexp
context
io/fs
internal/poll
internal/fmtsort
encoding/binary
os
encoding/base64
io/ioutil
fmt
path/filepath
os/exec
github.com/joshmedeski/sesh/git
github.com/pelletier/go-toml/v2/internal/danger
github.com/joshmedeski/sesh/dir
log
flag
net/url
github.com/xrash/smetrics
encoding/json
github.com/russross/blackfriday/v2
text/template/parse
github.com/pelletier/go-toml/v2/unstable
github.com/joshmedeski/sesh/convert
github.com/pelletier/go-toml/v2/internal/tracker
github.com/pelletier/go-toml/v2
text/template
github.com/cpuguy83/go-md2man/v2/md2man
github.com/joshmedeski/sesh/config
github.com/joshmedeski/sesh/tmux
github.com/urfave/cli/v2
github.com/joshmedeski/sesh/zoxide
github.com/joshmedeski/sesh/session
github.com/joshmedeski/sesh/connect
github.com/joshmedeski/sesh/cmds
github.com/joshmedeski/sesh/seshcli
github.com/joshmedeski/sesh
=> sesh-0.9.0_1: skipping check (XBPS_CHECK_PKGS is disabled) ...
=> sesh-0.9.0_1: running pre-install hook: 00-libdir ...
=> sesh-0.9.0_1: running pre-install hook: 02-script-wrapper ...
=> sesh-0.9.0_1: running pre-install hook: 98-fixup-gir-path ...
=> sesh-0.9.0_1: running do_install ...
=> sesh-0.9.0_1: running post_install ...
=> sesh-0.9.0_1: running post-install hook: 00-compress-info-files ...
=> sesh-0.9.0_1: running post-install hook: 00-fixup-gir-path ...
=> sesh-0.9.0_1: running post-install hook: 00-libdir ...
=> sesh-0.9.0_1: running post-install hook: 00-uncompress-manpages ...
=> sesh-0.9.0_1: running post-install hook: 01-remove-misc ...
=> sesh-0.9.0_1: running post-install hook: 02-remove-libtool-archives ...
=> sesh-0.9.0_1: running post-install hook: 02-remove-perl-files ...
=> sesh-0.9.0_1: running post-install hook: 02-remove-python-bytecode-files ...
=> sesh-0.9.0_1: running post-install hook: 03-remove-empty-dirs ...
=> WARNING: sesh-0.9.0_1: removed empty dir: /usr/lib
=> sesh-0.9.0_1: running post-install hook: 04-create-xbps-metadata-scripts ...
=> sesh-0.9.0_1: running post-install hook: 05-generate-gitrevs ...
=> sesh-0.9.0_1: running post-install hook: 06-strip-and-debug-pkgs ...
   Stripped static executable: /usr/bin/sesh
=> sesh-0.9.0_1: running post-install hook: 10-pkglint-devel-paths ...
=> sesh-0.9.0_1: running post-install hook: 11-pkglint-elf-in-usrshare ...
=> sesh-0.9.0_1: running post-install hook: 12-rename-python3-c-bindings ...
=> sesh-0.9.0_1: running post-install hook: 13-pkg-config-clean-xbps-cross-base-ref ...
=> sesh-0.9.0_1: running post-install hook: 14-fix-permissions ...
=> sesh-0.9.0_1: running post-install hook: 80-prepare-32bit ...
=> sesh-0.9.0_1: running post-install hook: 98-shlib-provides ...
=> sesh-0.9.0_1: running post-install hook: 99-pkglint-warn-cross-cruft ...
=> sesh-0.9.0_1: running pre-pkg hook: 03-rewrite-python-shebang ...
=> sesh-0.9.0_1: running pre-pkg hook: 04-generate-runtime-deps ...
=> sesh-0.9.0_1: running pre-pkg hook: 05-generate-32bit-runtime-deps ...
=> sesh-0.9.0_1: running pre-pkg hook: 90-set-timestamps ...
=> sesh-0.9.0_1: setting mtimes to Sun Jan 28 11:45:52 PM UTC 2024
=> sesh-0.9.0_1: running pre-pkg hook: 99-pkglint-subpkgs ...
=> sesh-0.9.0_1: running pre-pkg hook: 99-pkglint ...
=> sesh-0.9.0_1: running pre-pkg hook: 999-collected-rdeps ...
=> sesh-0.9.0_1: running do-pkg hook: 00-gen-pkg ...
=> Creating sesh-0.9.0_1.x86_64.xbps for repository /host/binpkgs ...
=> sesh-0.9.0_1: running post-pkg hook: 00-register-pkg ...
=> Registering new packages to /host/binpkgs
index: added `sesh-0.9.0_1' (x86_64).
index: 1 packages registered.
=> sesh-0.9.0_1: removing autodeps, please wait...
=> sesh-0.9.0_1: cleaning build directory...
=> sesh: removing files from destdir...
```
#### Installation
```bash
[*] Updating repository `https://mirror.vofr.net/voidlinux/current/x86_64-repodata' ...
[*] Updating repository `https://mirror.vofr.net/voidlinux/current/multilib/x86_64-repodata' ...
[*] Updating repository `https://mirror.vofr.net/voidlinux/current/nonfree/x86_64-repodata' ...

Name Action    Version           New version            Download size
sesh install   -                 0.9.0_1                -

Size required on disk:        3555KB
Space available on disk:       704GB

Do you want to continue? [Y/n] Y

[*] Verifying package integrity
sesh-0.9.0_1: verifying SHA256 hash...

[*] Collecting package files
sesh-0.9.0_1: collecting files...

[*] Unpacking packages
sesh-0.9.0_1: unpacking ...

[*] Configuring unpacked packages
sesh-0.9.0_1: configuring ...
sesh-0.9.0_1: installed successfully.

0 downloaded, 1 installed, 0 updated, 1 configured, 0 removed.
```

#### This new package conforms to the package requirements: YES

- I built this PR locally for my native architecture, (x86_64-glibc)

#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/ **YES**

