### PR TITLE
orc: update to 0.4.36.

### DIFF
--- a/srcpkgs/orc/template
+++ b/srcpkgs/orc/template
@@ -1,6 +1,6 @@
 # Template file for 'orc'
 pkgname=orc
-version=0.4.35
+version=0.4.36
 revision=1
 build_style=meson
 build_helper="gir"
@@ -13,7 +13,7 @@ license="BSD-2-Clause"
 homepage="https://cgit.freedesktop.org/gstreamer/orc"
 changelog="https://gitlab.freedesktop.org/gstreamer/orc/-/raw/main/RELEASE"
 distfiles="http://gstreamer.freedesktop.org/src/orc/orc-${version}.tar.xz"
-checksum=718cdb60db0d5f7d4fc8eb955cd0f149e0ecc78dcd5abdc6ce3be95221b793b9
+checksum=83b074cb67317d58bef1e8d0cc862f7ae8a77a45bbff056a1f987c6488b2f5fd
 
 build_options="gtk_doc"
 


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-musl)
---
This release fixes a bug introduced in the last release which causes webkit to crash on certain webpages such as [this one](https://cast.postmarketos.org/episode/37-Clayton-goes-full-time-v23.12-smart-speakers-musl-locales/). See the orc release note for details.

Cc: @cinerea0
