### PR TITLE
gnupg: update to 2.4.4

### DIFF
--- a/srcpkgs/gnupg/template
+++ b/srcpkgs/gnupg/template
@@ -1,8 +1,8 @@
 # Template file for 'gnupg'
 # minor version updates (2.3-> 2.4) often need a fix in reverse dependencies
 pkgname=gnupg
-version=2.4.3
-revision=2
+version=2.4.4
+revision=1
 # We're building outside of the source tree, because upstream told us to:
 # https://dev.gnupg.org/T6313#166339
 build_wrksrc=build
@@ -24,7 +24,7 @@ maintainer="Jan Christian Grünhage <jan.christian@gruenhage.xyz>"
 license="GPL-3.0-or-later"
 homepage="https://www.gnupg.org/"
 distfiles="https://gnupg.org/ftp/gcrypt/gnupg/gnupg-${version}.tar.bz2"
-checksum=a271ae6d732f6f4d80c258ad9ee88dd9c94c8fdc33c3e45328c4d7c126bd219d
+checksum=67ebe016ca90fa7688ce67a387ebd82c6261e95897db7b23df24ff335be85bc6
 make_check_pre='env TESTFLAGS="--parallel=${XBPS_MAKEJOBS}"'
 build_options="ldap"
 build_options_default="ldap"


### PR DESCRIPTION
just a version bump
tagging the maintainer @jcgruenhage 

#### Testing the changes
I've done the following regression testing:
- encrypt/decrypt
- key import/export
- keyserver sync
- symmetric encryption/decryption
- non-resident key (yubikey gen5)

No regresions found.

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)

