### PR TITLE
zathura: add patch to fix valid file detection

### DIFF
--- a/srcpkgs/zathura/patches/0001-The-function-file_valid_extension-should-return-True.patch
+++ b/srcpkgs/zathura/patches/0001-The-function-file_valid_extension-should-return-True.patch
@@ -1,0 +1,26 @@
+From d74091a7452846112c0bb11e1412cd2af48ee7cd Mon Sep 17 00:00:00 2001
+From: Carlo Buccisano <slashdeipoveri@gmail.com>
+Date: Tue, 12 Dec 2023 00:24:20 +0100
+Subject: [PATCH] The function file_valid_extension should return True if
+ plugin is different then NULL, not if it is equal.
+
+---
+ zathura/utils.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/zathura/utils.c b/zathura/utils.c
+index 802757f..8f379be 100644
+--- a/zathura/utils.c
++++ b/zathura/utils.c
+@@ -60,7 +60,7 @@ file_valid_extension(zathura_t* zathura, const char* path)
+   zathura_plugin_t* plugin = zathura_plugin_manager_get_plugin(zathura->plugins.manager, content_type);
+   g_free(content_type);
+ 
+-  return plugin == NULL;
++  return plugin != NULL;
+ }
+ 
+ static void
+-- 
+2.43.0
+

--- a/srcpkgs/zathura/template
+++ b/srcpkgs/zathura/template
@@ -1,7 +1,7 @@
 # Template file for 'zathura'
 pkgname=zathura
 version=0.5.4
-revision=1
+revision=2
 build_style=meson
 configure_args="-Dsynctex=enabled"
 hostmakedepends="pkg-config intltool python3-Sphinx desktop-file-utils


### PR DESCRIPTION
Without this patch, it is not possible to use completion for zathura's
`:open` command as it will only list files which zathura cannot open and
exclude all other, instead of doing it the other way around.

---

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-musl)
