### PR TITLE
python3-matrix-nio: update to 0.24.0.

### DIFF
--- a/srcpkgs/python3-aioresponses/template
+++ b/srcpkgs/python3-aioresponses/template
@@ -1,7 +1,7 @@
 # Template file for 'python3-aioresponses'
 pkgname=python3-aioresponses
-version=0.7.4
-revision=2
+version=0.7.6
+revision=1
 build_style=python3-module
 hostmakedepends="python3-pbr python3-setuptools"
 depends="python3-aiohttp"
@@ -11,7 +11,7 @@ maintainer="Jan Christian Grünhage <jan.christian@gruenhage.xyz>"
 license="MIT"
 homepage="https://github.com/pnuckowski/aioresponses"
 distfiles="${PYPI_SITE}/a/aioresponses/aioresponses-${version}.tar.gz"
-checksum=9b8c108b36354c04633bad0ea752b55d956a7602fe3e3234b939fc44af96f1d8
+checksum=f795d9dbda2d61774840e7e32f5366f45752d1adc1b74c9362afd017296c7ee1
 
 post_install() {
 	vlicense LICENSE

--- a/srcpkgs/python3-matrix-nio/template
+++ b/srcpkgs/python3-matrix-nio/template
@@ -1,11 +1,11 @@
 # Template file for 'python3-matrix-nio'
 pkgname=python3-matrix-nio
-version=0.20.2
-revision=2
+version=0.24.0
+revision=1
 build_style=python3-pep517
 hostmakedepends="python3-poetry-core"
-depends="python3-future python3-aiohttp python3-aiofiles python3-h11
- python3-h2 python3-logbook python3-jsonschema python3-unpaddedbase64
+depends="python3-aiohttp python3-aiofiles python3-h11
+ python3-h2 python3-jsonschema python3-unpaddedbase64
  python3-pycryptodome olm-python3 python3-peewee python3-cachetools
  python3-atomicwrites python3-aiohttp_socks"
 checkdepends="${depends} python3-pytest python3-pytest-isort python3-pytest-cov
@@ -17,7 +17,7 @@ license="ISC"
 homepage="https://github.com/poljar/matrix-nio"
 changelog="https://github.com/poljar/matrix-nio/raw/main/CHANGELOG.md"
 distfiles="${homepage}/archive/${version}.tar.gz"
-checksum=0beb12857e909671e6db57b0edd936efef23e9baae90e276cfe4e69c952b5e62
+checksum=bf7a92db99d8bc2d83a8776b4f5ea93320ea3f33a501b999dc4ee1dc0e23973c
 
 post_install() {
 	vlicense LICENSE.md


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->
The version of `python3-matrix-nio` currently packaged depends on `python3-future` which currently doesn't work under Python 3.12. The latest release of `python3-matrix-nio` does not have this problem.

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)