### PR TITLE
lcms2: disable plugins for now

### DIFF
--- a/srcpkgs/lcms2/template
+++ b/srcpkgs/lcms2/template
@@ -1,7 +1,7 @@
 # Template file for 'lcms2'
 pkgname=lcms2
 version=2.16
-revision=1
+revision=2
 build_style=meson
 configure_args="-Dutils=true -Dsamples=true $(vopt_bool plugins fastfloat) $(vopt_bool plugins threaded)"
 hostmakedepends="pkg-config"
@@ -13,7 +13,7 @@ homepage="https://littlecms.com"
 distfiles="${SOURCEFORGE_SITE}/lcms/lcms2-${version}.tar.gz"
 checksum=d873d34ad8b9b4cea010631f1a6228d2087475e4dc5e763eb81acc23d9d45a51
 build_options="plugins"
-build_options_default="plugins"
+build_options_default=" "
 desc_option_plugins="Build with threaded and fast float plugins (GPL-3.0-or-later)"
 
 post_install() {


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

Plugins were enabled in https://github.com/void-linux/void-packages/commit/b9b9189c8a7c6f2e8e600958dbc298b7c69c7417
The plugins get linked to applications (`dlopen()` is not used). However they were not added to `common/shlibs` causing packages to link against the plugins but error due to the shlibs not having an associated package.

The plugins don't have a soversion, however, as this is inconsistent between configuring with autoconf vs meson, I assume this is a mistake. As such, disable until the following is addressed: https://github.com/mm2/Little-CMS/issues/432

Fixes building gimp, Krita, libraw, etc.

cc: @sgn 

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
