### PR TITLE
shared-mime-info: rebuild to hide libxml warning

### DIFF
--- a/srcpkgs/shared-mime-info/template
+++ b/srcpkgs/shared-mime-info/template
@@ -1,7 +1,7 @@
 # Template file for 'shared-mime-info'
 pkgname=shared-mime-info
 version=2.4
-revision=1
+revision=2
 build_style=meson
 configure_args="-Dupdate-mimedb=false"
 hostmakedepends="pkg-config gettext xmlto"


### PR DESCRIPTION
`Warning: program compiled against libxml 212 using older 211` was getting printed on every invocation of `update-mime-database` during both `xbps` and `flatpak` commands.

Test: `update-mime-database /usr/share/mime`

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
