### PR TITLE
python3-openssl: update to 24.0.0.

### DIFF
--- a/srcpkgs/python3-openssl/template
+++ b/srcpkgs/python3-openssl/template
@@ -1,6 +1,6 @@
 # Template file for 'python3-openssl'
 pkgname=python3-openssl
-version=23.3.0
+version=24.0.0
 revision=1
 build_style=python3-module
 hostmakedepends="python3-setuptools"
@@ -12,7 +12,7 @@ license="Apache-2.0"
 homepage="https://pyopenssl.org/"
 changelog="https://raw.githubusercontent.com/pyca/pyopenssl/master/CHANGELOG.rst"
 distfiles="${PYPI_SITE}/p/pyOpenSSL/pyOpenSSL-${version}.tar.gz"
-checksum=6b2cba5cc46e822750ec3e5a81ee12819850b11303630d575e98108a079c2b12
+checksum=6aa33039a93fffa4563e655b61d11364d01264be8ccb49906101e02a334530bf
 
 if [ "$XBPS_TARGET_WORDSIZE" = "32" ]; then
 	# https://github.com/pyca/pyopenssl/issues/974


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

In the previous version, I get this error message when trying to run `deluged`:

```
pkg_resources.DistributionNotFound: The 'cryptography<42,>=41.0.5' distribution was not found and is required by pyopenssl
```

With this update, the error is resolved.

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
