### PR TITLE
valgrind: preserve debug symbols

### DIFF
--- a/srcpkgs/valgrind/template
+++ b/srcpkgs/valgrind/template
@@ -1,8 +1,9 @@
 # Template file for 'valgrind'
 pkgname=valgrind
 version=3.22.0
-revision=1
+revision=2
 build_style=gnu-configure
+nostrip=yes
 configure_args="--enable-tls --without-mpicc --enable-lto=yes"
 hostmakedepends="automake perl pkg-config"
 makedepends="libgomp-devel"


### PR DESCRIPTION
Added `nostrip=yes` to preserve debug symbols, required for upstream bug submissions. Bumps revision to 3.22.0_2. Closes #48427.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64 glibc (`Void 6.6.11_1 x86_64 AuthenticAMD uptodate rFFFF`)
