### PR TITLE
cdrdao: fix for whipper

### DIFF
--- a/srcpkgs/cdrdao/patches/fix-uninitialized-toc-file-name.patch
+++ b/srcpkgs/cdrdao/patches/fix-uninitialized-toc-file-name.patch
@@ -1,0 +1,23 @@
+From 251a40ab42305c412674c7c2d391374d91e91c95 Mon Sep 17 00:00:00 2001
+From: Ole Bertram <git@bertr.am>
+Date: Thu, 23 Mar 2023 17:08:48 +0100
+Subject: [PATCH] Fix uninitialized TOC data file name
+
+This caused spurious garbled TOC files and/or segfaults when not using
+the `--datafile` option.
+---
+ dao/main.cc | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/dao/main.cc b/dao/main.cc
+index 8bf4590..d09fc69 100644
+--- a/dao/main.cc
++++ b/dao/main.cc
+@@ -219,6 +219,7 @@ DaoCommandLine::DaoCommandLine() :
+     fullBurn(false), withCddb(false), taoSource(false), keepImage(false), overburn(false),
+     writeSpeedControl(false), keep(false), printQuery(false), no_utf8(false)
+ {
++    dataFilename = NULL;
+     readingSpeed = -1;
+     writingSpeed = -1;
+     command = UNKNOWN;

--- a/srcpkgs/cdrdao/template
+++ b/srcpkgs/cdrdao/template
@@ -1,7 +1,7 @@
 # Template file for 'cdrdao'
 pkgname=cdrdao
 version=1.2.5
-revision=1
+revision=2
 build_style=gnu-configure
 hostmakedepends="pkg-config"
 makedepends="lame-devel libao-devel libmad-devel libvorbis-devel"


### PR DESCRIPTION
From this PR: https://github.com/cdrdao/cdrdao/pull/21

More distributions seem to ship this patch.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**
<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
