### PR TITLE
New package: ags-1.8.0

### DIFF
--- a/srcpkgs/ags/template
+++ b/srcpkgs/ags/template
@@ -1,0 +1,30 @@
+# Template file for 'ags'
+pkgname=ags
+version=1.8.0
+revision=1
+build_style=meson
+build_helper=gir
+configure_args="--libdir /usr/lib/ags -Dbuild_types=true"
+hostmakedepends="nodejs pkg-config"
+makedepends="glib-devel gjs-devel gtk+3-devel pulseaudio-devel pam-devel"
+depends="gjs gtk-layer-shell libsoup3"
+short_desc="Aylurs's Gtk Shell (AGS), An eww inspired gtk widget system"
+maintainer="raitonoberu <raitonoberu@mail.ru>"
+license="GPL-3.0-or-later"
+homepage="https://github.com/Aylur/ags"
+changelog="https://github.com/Aylur/ags/releases"
+distfiles="https://github.com/Aylur/ags/releases/download/v${version}/ags-v${version}.tar.gz"
+checksum=c36f4ebc48caaf0cea4399dd870bcad939995a9d4805f79fdd431236f9de7d2e
+
+if [ "$CROSS_BUILD" ]; then
+	hostmakedepends+=" glib-devel gjs-devel"
+fi
+
+pre_configure() {
+	npm install
+	export PATH="$PATH:$wrksrc/node_modules/typescript/bin"
+}
+
+post_install() {
+	ln -sf /usr/share/com.github.Aylur.ags/com.github.Aylur.ags ${DESTDIR}/usr/bin/ags
+}


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

I used to build it successfully using this template, but now it crashes during compilation of `python3-3.12.1_1` as a Meson dependency, [full log](https://prcl.dev/iu3wedr70k55d8c). UPD: fixed by merging upstream