### PR TITLE
runc: update to 1.1.12

### DIFF
--- a/srcpkgs/runc/template
+++ b/srcpkgs/runc/template
@@ -1,6 +1,6 @@
 # Template file for 'runc'
 pkgname=runc
-version=1.1.11
+version=1.1.12
 revision=1
 build_style=go
 go_import_path=github.com/opencontainers/runc
@@ -14,7 +14,7 @@ license="Apache-2.0"
 homepage="https://github.com/opencontainers/runc"
 changelog="https://github.com/opencontainers/runc/raw/main/CHANGELOG.md"
 distfiles="https://github.com/opencontainers/runc/releases/download/v${version}/runc.tar.xz"
-checksum=90a9f8a0093f9e06900e393c11c6b61c597eaf7f9e149aa3aad743961ed25478
+checksum=47d9e34500e478d860512b3b646724ee4b9e638692122ddaa82af417668ca4d7
 
 post_build() {
 	make man


### PR DESCRIPTION
Fixes CVE-2024-21626.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
