### PR TITLE
New package: python3-dparse-0.6.4b0

### DIFF
--- a/srcpkgs/python3-dparse/template
+++ b/srcpkgs/python3-dparse/template
@@ -1,0 +1,18 @@
+# Template file for 'python3-dparse'
+pkgname=python3-dparse
+version=0.6.4b0
+revision=1
+build_style=python3-pep517
+hostmakedepends="hatchling"
+depends="python3 python3-packaging python3-tomli python3-yaml"
+checkdepends="python3-pytest python3-pytest-cov ${depends}"
+short_desc="Parser for Python dependency files"
+maintainer="c0m4r <github@wolfet.pl>"
+license="MIT"
+homepage="https://github.com/pyupio/dparse"
+distfiles="https://github.com/pyupio/dparse/archive/refs/tags/${version}.tar.gz"
+checksum=36e0ab5273de5b42b6175c4ea7e1207fb33e4899faf1a945bb531c580987b28a
+
+post_install() {
+	vlicense LICENSE
+}


### PR DESCRIPTION
A parser for Python dependency files
https://github.com/pyupio/dparse

This is a wink wink beta, yes, but there's little changed in the module code. This version mainly consist of [changes](https://github.com/pyupio/dparse/compare/0.6.3...0.6.4b0) to the build system and unit tests so it can be built on Python > 3.10.

#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

#### Local build testing
- I built this PR locally for my native architecture, **x86_64-glibc**