### PR TITLE
hatch: update to 1.9.3.

### DIFF
--- a/srcpkgs/hatch/template
+++ b/srcpkgs/hatch/template
@@ -1,17 +1,22 @@
 # Template file for 'hatch'
 pkgname=hatch
-version=1.6.3
-revision=3
+version=1.9.3
+revision=1
 build_style=python3-pep517
 # ignore backend tests, because updating hatchling when there is no new hatch
 # version yet breaks these in hatch.
 make_check_args="--ignore tests/backend
- --deselect tests/cli/run/test_run.py::test_scripts_no_environment"
-_deps="python3-click hatchling python3-httpx python3-hyperlink python3-keyring
- python3-packaging python3-pexpect python3-platformdirs python3-pyperclip
+# these tests create temporary files in /tmp, which does not work in the build
+# process
+ --ignore tests/cli/python/test_install.py
+ --deselect tests/cli/run/test_run.py::test_scripts_no_environment
+ --deselect tests/cli/env/test_create.py::test_plugin_dependencies_met
+ --deselect tests/cli/env/test_create.py::test_plugin_dependencies_met_as_app"
+_deps="python3-click hatchling python3-httpx python3-hyperlink
+ python3-keyring python3-packaging python3-pexpect python3-platformdirs
  python3-rich python3-shellingham python3-tomli-w python3-tomlkit
- python3-userpath python3-virtualenv"
-hostmakedepends="hatchling ${_deps}"
+ python3-userpath python3-virtualenv python3-zstandard"
+hostmakedepends="hatchling hatch-vcs ${_deps}"
 depends="${_deps}"
 checkdepends="${_deps} python3-pytest python3-pytest-mock
  python3-pytest-xdist git python3-pip"
@@ -21,7 +26,7 @@ license="MIT"
 homepage="https://hatch.pypa.io/latest/"
 changelog="https://raw.githubusercontent.com/pypa/hatch/master/docs/history/hatch.md"
 distfiles="${PYPI_SITE}/h/hatch/hatch-${version}.tar.gz"
-checksum=650e671ba300318e498ef93bbe3b99b32ce14920764fb8753f89993f63eed79a
+checksum=672017e349c548f8a957a5fee9aa2f8cfc2c8a994307378e45a8427972bdf8d9
 make_check_pre="env PYTHONPATH=./src"
 
 post_install() {


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

- I built this PR locally for my native architecture, (x86_64-glibc)

supersedes #47776 

I had to skip some of the tests, explanation is in the comments. Is there a way to make the pytest tmp_dir fixture work in the build environment?