### PR TITLE
dracut: silence spurious setfont stderr warning

### DIFF
--- a/srcpkgs/dracut/patches/silence-setfont.patch
+++ b/srcpkgs/dracut/patches/silence-setfont.patch
@@ -1,0 +1,19 @@
+https://github.com/void-linux/void-packages/issues/45216
+
+I'm tired of seeing these setfont errors. This will hopefully/eventually be upstreamed, but I'm not holding my breath.
+
+---
+
+diff --git a/modules.d/10i18n/console_init.sh b/modules.d/10i18n/console_init.sh
+index 3fe3b673..0e19ae30 100755
+--- a/modules.d/10i18n/console_init.sh
++++ b/modules.d/10i18n/console_init.sh
+@@ -49,7 +49,7 @@ set_font() {
+     setfont "${FONT-${DEFAULT_FONT}}" \
+         -C "${1}" \
+         ${FONT_MAP:+-m "${FONT_MAP}"} \
+-        ${FONT_UNIMAP:+-u "${FONT_UNIMAP}"}
++        ${FONT_UNIMAP:+-u "${FONT_UNIMAP}"} 2>/dev/null
+ }
+ 
+ dev_close() {

--- a/srcpkgs/dracut/template
+++ b/srcpkgs/dracut/template
@@ -1,7 +1,7 @@
 # Template file for 'dracut'
 pkgname=dracut
 version=059
-revision=6
+revision=7
 build_style=configure
 configure_args="--prefix=/usr --sysconfdir=/etc"
 conf_files="/etc/dracut.conf"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

This error has been here for years, but unreported by setfont until recently. Throw it away as it's not actionable. 