### PR TITLE
environment/configure/hardening.sh: fix copy-paste error with nopie=yes

### DIFF
--- a/common/environment/configure/hardening.sh
+++ b/common/environment/configure/hardening.sh
@@ -24,7 +24,7 @@ if [ -z "$nopie" ]; then
 	fi
 else
 	CFLAGS="-fno-PIE ${CFLAGS}"
-	CXXFLAGS="-fno-PIE ${CFLAGS}"
+	CXXFLAGS="-fno-PIE ${CXXFLAGS}"
 	FFLAGS="-fno-PIE ${FFLAGS}"
 	LDFLAGS="-no-pie ${LDFLAGS}"
 fi


### PR DESCRIPTION
CFLAGS => CXXFLAGS

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
