### PR TITLE
python3-natsort: update to 8.4.0, adopt

### DIFF
--- a/srcpkgs/python3-natsort/template
+++ b/srcpkgs/python3-natsort/template
@@ -1,22 +1,29 @@
 # Template file for 'python3-natsort'
 pkgname=python3-natsort
-version=6.0.0
-revision=7
+version=8.4.0
+revision=1
 build_style=python3-module
 hostmakedepends="python3-setuptools"
-depends="python3-setuptools"
+depends="python3"
 checkdepends="python3-pytest-mock python3-hypothesis"
 short_desc="Simple yet flexible natural sorting in Python3"
-maintainer="Orphaned <orphan@voidlinux.org>"
+maintainer="chrysos349 <chrysostom349@gmail.com>"
 license="MIT"
 homepage="https://github.com/SethMMorton/natsort"
 distfiles="${PYPI_SITE}/n/natsort/natsort-${version}.tar.gz"
-checksum=ff3effb5618232866de8d26e5af4081a4daa9bb0dfed49ac65170e28e45f2776
+checksum=45312c4a0e5507593da193dedd04abb1469253b601ecaf63445ad80f0a1ea581
 conflicts="python-natsort>=0"
 
-do_check() {
-	python3 -m pytest
-}
+if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
+	# tests fail on musl
+	make_check_args="
+	 --deselect tests/test_input_string_transform_factory.py::test_input_string_transform_factory_cleans_thousands
+	 --deselect tests/test_input_string_transform_factory.py::test_input_string_transform_factory_handles_us_locale
+	 --deselect tests/test_input_string_transform_factory.py::test_input_string_transform_factory_handles_german_locale
+	 --deselect tests/test_natsorted.py::test_natsorted_can_sort_locale_specific_numbers_en
+	 --deselect tests/test_natsorted.py::test_natsorted_can_sort_locale_specific_numbers_de
+	 --deselect tests/test_natsorted.py::test_natsorted_handles_mixed_types_with_locale"
+fi
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
@autrimpo 

the version in the repo is too old (5 years old). newer apps require the current version.

#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl x
  - armv7l x
  - armv6l-musl x