### PR TITLE
important: texlive: Rebuild with newer zlib

### DIFF
--- a/srcpkgs/texlive/template
+++ b/srcpkgs/texlive/template
@@ -1,7 +1,7 @@
 # Template file for 'texlive'
 pkgname=texlive
 version=20210325
-revision=7
+revision=8
 build_wrksrc="build"
 build_style=gnu-configure
 configure_script="../configure"


### PR DESCRIPTION
`lualatex` and possibly other executables are currently unusable, because zlib was updated.

```
> lualatex
PANIC: unprotected error in call to Lua API (zlib library version does not match - header: 1.3, library: 1.3.1)
zsh: IOT instruction  lualatex
```

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->

ping maintainer: @fosslinux 