### PR TITLE
texlive: rebuild vor zlib-1.3.1

### DIFF
--- a/srcpkgs/texlive/patches/relax-zlib-version-check.patch
+++ b/srcpkgs/texlive/patches/relax-zlib-version-check.patch
@@ -1,0 +1,26 @@
+From 3f53490d88387bbfe6c7d482089d9a597b257cf0 Mon Sep 17 00:00:00 2001
+From: Luigi Scarso <luigi.scarso@gmail.com>
+Date: Tue, 21 Nov 2023 11:17:29 +0100
+Subject: [PATCH] relax zlib version check to just checking the major version,
+ since (it turns out) zlib 1.3 is compatible with 1.2 (K. Berry).
+
+---
+ texk/web2c/luatexdir/ChangeLog           | 9 +++++++++
+ texk/web2c/luatexdir/luatex_svnversion.h | 2 +-
+ texk/web2c/luatexdir/luazlib/lzlib.c     | 2 +-
+ 3 files changed, 11 insertions(+), 2 deletions(-)
+
+diff --git a/texk/web2c/luatexdir/luazlib/lzlib.c b/texk/web2c/luatexdir/luazlib/lzlib.c
+index e61f92d58..ea123e541 100644
+--- a/texk/web2c/luatexdir/luazlib/lzlib.c
++++ b/texk/web2c/luatexdir/luazlib/lzlib.c
+@@ -546,7 +546,7 @@ LUALIB_API int luaopen_zlib(lua_State *L)
+ 
+     /* make sure header and library version are consistent */
+     const char* version = zlibVersion();
+-    if (strncmp(version, ZLIB_VERSION, 4))
++    if (strncmp(version, ZLIB_VERSION, 2))
+     {
+         lua_pushfstring(L, "zlib library version does not match - header: %s, library: %s", ZLIB_VERSION, version);
+         lua_error(L);
+-- 

--- a/srcpkgs/texlive/template
+++ b/srcpkgs/texlive/template
@@ -1,7 +1,7 @@
 # Template file for 'texlive'
 pkgname=texlive
 version=20210325
-revision=7
+revision=8
 build_wrksrc="build"
 build_style=gnu-configure
 configure_script="../configure"


### PR DESCRIPTION
Bump for `zlib-1.3.1`: 
```bash
lualatex
```
```
PANIC: unprotected error in call to Lua API (zlib library version does not match - header: 1.3, library: 1.3.1)
```
#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
