### PR TITLE
New package: filtile-1.2.1

### DIFF
--- a/srcpkgs/filtile/template
+++ b/srcpkgs/filtile/template
@@ -1,0 +1,11 @@
+# Template file for 'filtile'
+pkgname=filtile
+version=1.2.1
+revision=1
+build_style=cargo
+short_desc="Layout manager for the River window manager"
+maintainer="Emil Miler <em@0x45.cz>"
+license="GPL-3.0-or-later"
+homepage="https://github.com/pkulak/filtile"
+distfiles="https://github.com/pkulak/filtile/archive/refs/tags/v${version}.tar.gz"
+checksum=fe978e880db802d7c5678b5d05aa8236c49107a0c99fd2565c2f4ca3c35b7a22


### PR DESCRIPTION
Filtile is a layout manager for the River window manager with features such as: per-tag layout assignment, monocle layout, window padding and a new "pad" layout.

https://github.com/pkulak/filtile

#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

#### Local build testing
- I built this PR locally for my native architecture, (86_64-glibc)