### PR TITLE
caddy: update to 2.7.6.

### DIFF
--- a/srcpkgs/caddy/template
+++ b/srcpkgs/caddy/template
@@ -1,6 +1,6 @@
 # Template file for 'caddy'
 pkgname=caddy
-version=2.7.5
+version=2.7.6
 revision=1
 build_style=go
 go_import_path=github.com/caddyserver/caddy/v2
@@ -13,7 +13,7 @@ license="Apache-2.0"
 homepage="https://caddyserver.com"
 changelog="https://github.com/caddyserver/caddy/releases"
 distfiles="https://github.com/caddyserver/caddy/archive/v${version}.tar.gz"
-checksum=eeaecc1ea18b7aa37ece168562beb1ab592767cbedfaa411040ae0301aaeeef1
+checksum=e1c524fc4f4bd2b0d39df51679d9d065bb811e381b7e4e51466ba39a0083e3ed
 
 system_accounts="caddy"
 caddy_homedir="/var/lib/caddy"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: briefly


#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
