### PR TITLE
urh: update to 2.9.6

### DIFF
--- a/srcpkgs/urh/template
+++ b/srcpkgs/urh/template
@@ -1,7 +1,7 @@
 # Template file for 'urh'
 pkgname=urh
-version=2.9.5
-revision=2
+version=2.9.6
+revision=1
 build_style=python3-module
 hostmakedepends="python3-setuptools python3-Cython0.29 python3-numpy"
 makedepends="python3-devel python3-PyQt5 libairspy-devel librtlsdr-devel
@@ -15,7 +15,7 @@ license="GPL-3.0-or-later"
 homepage="https://github.com/jopohl/urh"
 changelog="https://github.com/jopohl/urh/releases"
 distfiles="https://github.com/jopohl/urh/archive/refs/tags/v${version}.tar.gz"
-checksum=aac1fd1f8335960600d22c0ad0b1bf8ec94e336f32294282c859fb9eb7fbf81e
+checksum=34128f15bf57b21241fd629938826e17bc6fb32c1662665fda8b1d4c14a74559
 make_check=no # Test suite is taking too long and CI times out
 
 post_install() {


### PR DESCRIPTION
- I tested the changes in this PR: **briefly**
- I built this PR locally for my native architecture, (x86_64-glibc)