### PR TITLE
libgit2: update to 1.6.5

### DIFF
--- a/srcpkgs/libgit2/template
+++ b/srcpkgs/libgit2/template
@@ -1,9 +1,9 @@
 # Template file for 'libgit2'
 pkgname=libgit2
-version=1.6.4
-revision=2
+version=1.6.5
+revision=1
 build_style=cmake
-configure_args="-DENABLE_REPRODUCIBLE_BUILDS=ON -DUSE_SSH=ON"
+configure_args="-DENABLE_REPRODUCIBLE_BUILDS=ON -DUSE_SSH=ON -DUSE_HTTP_PARSER=system"
 hostmakedepends="python3 pkg-config"
 makedepends="zlib-devel openssl-devel http-parser-devel libssh2-devel"
 short_desc="Git linkable library"
@@ -11,7 +11,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="custom:GPL-2.0-or-later WITH GCC-exception-2.0"
 homepage="https://libgit2.org"
 distfiles="https://github.com/libgit2/libgit2/archive/refs/tags/v${version}.tar.gz"
-checksum=d25866a4ee275a64f65be2d9a663680a5cf1ed87b7ee4c534997562c828e500d
+checksum=0f09dd49e409913c94df00eeb5b54f8b597905071b454c7f614f8c6e1ddb8d75
 
 if [ "$XBPS_CHECK_PKGS" ]; then
 	configure_args+=" -DBUILD_TESTS=ON"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

A security patch release while #45976 is in progress

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
