### PR TITLE
android-udev-rules: update to 20240114.

### DIFF
--- a/srcpkgs/android-udev-rules/template
+++ b/srcpkgs/android-udev-rules/template
@@ -1,6 +1,6 @@
 # Template file for 'android-udev-rules'
 pkgname=android-udev-rules
-version=20231207
+version=20240114
 revision=1
 short_desc="Android udev rules list aimed to be the most comprehensive on the net"
 maintainer="Orphaned <orphan@voidlinux.org>"
@@ -8,7 +8,7 @@ license="GPL-3.0-or-later"
 homepage="https://github.com/M0Rf30/android-udev-rules"
 changelog="https://github.com/M0Rf30/android-udev-rules/releases"
 distfiles="https://github.com/M0Rf30/android-udev-rules/archive/${version}.tar.gz"
-checksum=f8f5513e08cd0e9299ba707c9acc5dec53b9cbdc255d4bfd83abfd378928b6e6
+checksum=ba50560820ff89035068600f935d669068af7e507e560c7f4d9a1bc77fbf4636
 system_groups="adbusers"
 
 do_install() {


### PR DESCRIPTION

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc

