### PR TITLE
xfce4-notifyd: update to 0.9.3

### DIFF
--- a/srcpkgs/xfce4-notifyd/template
+++ b/srcpkgs/xfce4-notifyd/template
@@ -1,11 +1,11 @@
 # Template file for 'xfce4-notifyd'
 pkgname=xfce4-notifyd
-version=0.6.4
+version=0.9.3
 revision=1
 build_style=gnu-configure
 configure_args="--with-locales-dir=/usr/share/locale --enable-dbus-start-daemon"
 hostmakedepends="pkg-config intltool glib-devel dbus-glib-devel"
-makedepends="libnotify-devel xfce4-panel-devel"
+makedepends="libnotify-devel xfce4-panel-devel sqlite-devel"
 depends="hicolor-icon-theme desktop-file-utils"
 short_desc="Simple, visually-appealing notification daemon for Xfce"
 maintainer="Orphaned <orphan@voidlinux.org>"
@@ -13,7 +13,7 @@ license="GPL-2.0-or-later"
 homepage="https://goodies.xfce.org/projects/applications/xfce4-notifyd"
 changelog="https://gitlab.xfce.org/apps/xfce4-notifyd/-/raw/master/NEWS"
 distfiles="https://archive.xfce.org/src/apps/${pkgname}/${version%.*}/${pkgname}-${version}.tar.bz2"
-checksum=0ece78f091f895374aad81a3bdc00701080b4ed07f7322fb680c4234319120f6
+checksum=79ee4701e2f8715a700de2431aa33682933cab18d76938bb18e2820302bbe030
 provides="notification-daemon-${version}_${revision}"
 replaces="notification-daemon>=0"
 


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

The log file was previously stored as a text file, but now it uses an sqlite database. The transition was friction-less and I didn't need to delete the old logfile - it was automatically archived with the `.old` extension.

Two things must be done after the upgrade:
- Restart `xfce4-notifyd`
- Reload the notification panel widget

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (amd64-glibc)