### PR TITLE
New package: rsgain-3.4.0

### DIFF
--- a/srcpkgs/rsgain/template
+++ b/srcpkgs/rsgain/template
@@ -1,0 +1,17 @@
+# Template file for 'rsgain'
+pkgname=rsgain
+version=3.4
+revision=0
+build_style=cmake
+hostmakedepends="pkg-config"
+makedepends="libebur128-devel taglib-devel ffmpeg-devel inih-devel fmt-devel"
+short_desc="ReplayGain 2.0 loudness normalizer"
+maintainer="dezifit@gmx.de"
+license="BSD-2-Clause"
+homepage="https://github.com/complexlogic/rsgain"
+distfiles="https://github.com/complexlogic/rsgain/archive/refs/tags/v3.4.tar.gz"
+checksum=7a0b47b9ea7489bb13662d08fe53b668fa84e9c156d7919ab66b57e79d2bc446
+
+post_install() {
+	vlicense LICENSE
+}


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

rsgain (really simple gain) is a very heavily modified fork of [loudgain](https://github.com/Moonbase59/loudgain), and is licensed accordingly under the original 2 clause BSD license used by loudgain. 

#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - armv7l (only compiled, not tested)

