### PR TITLE
incus: update to 0.5.1

### DIFF
--- a/srcpkgs/incus/template
+++ b/srcpkgs/incus/template
@@ -1,6 +1,6 @@
 # Template file for 'incus'
 pkgname=incus
-version=0.4.0
+version=0.5.1
 revision=1
 build_style=go
 go_import_path=github.com/lxc/incus
@@ -20,7 +20,7 @@ maintainer="dkwo <npiazza@disroot.org>"
 license="Apache-2.0"
 homepage="https://linuxcontainers.org/incus"
 distfiles="https://github.com/lxc/incus/archive/refs/tags/v${version}.tar.gz"
-checksum=1195d8aecaf838806b88580dfc8b48302dcbb4612addcb6d6bfa480f14d97a0d
+checksum=ca757fa69272650fc2a3aab73d27b11cee48f3872115b664f234af74cc6684ec
 system_groups="_incus-admin _incus"
 make_dirs="
  /var/lib/incus 0755 root root


### PR DESCRIPTION
First contribution, be aware. Simple version update.

#### Testing the changes
- I tested the changes in this PR: **YES**

Running this on an incus/lxc server established with the prior version (4.0); no issues noted. 

#### Local build testing
- I built this PR locally for my native architecture, (x86-64 glibc)
- I built this PR locally (with -Q) for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl

