### PR TITLE
python3-openssl: update to 24.0.0

### DIFF
--- a/srcpkgs/python3-openssl/template
+++ b/srcpkgs/python3-openssl/template
@@ -1,6 +1,6 @@
 # Template file for 'python3-openssl'
 pkgname=python3-openssl
-version=23.3.0
+version=24.0.0
 revision=1
 build_style=python3-module
 hostmakedepends="python3-setuptools"
@@ -12,7 +12,7 @@ license="Apache-2.0"
 homepage="https://pyopenssl.org/"
 changelog="https://raw.githubusercontent.com/pyca/pyopenssl/master/CHANGELOG.rst"
 distfiles="${PYPI_SITE}/p/pyOpenSSL/pyOpenSSL-${version}.tar.gz"
-checksum=6b2cba5cc46e822750ec3e5a81ee12819850b11303630d575e98108a079c2b12
+checksum=6aa33039a93fffa4563e655b61d11364d01264be8ccb49906101e02a334530bf
 
 if [ "$XBPS_TARGET_WORDSIZE" = "32" ]; then
 	# https://github.com/pyca/pyopenssl/issues/974


### PR DESCRIPTION
closes #48600 

#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl x
  - armv7l x
  - armv6l-musl x