### PR TITLE
python3-websocket-client: fix alternatives, update to 1.7.0

### DIFF
--- a/srcpkgs/python3-websocket-client/template
+++ b/srcpkgs/python3-websocket-client/template
@@ -1,17 +1,17 @@
 # Template file for 'python3-websocket-client'
 pkgname=python3-websocket-client
-version=1.6.3
-revision=2
-build_style=python3-module
+version=1.7.0
+revision=1
+build_style=python3-pep517
 make_check_target="websocket/tests"
-hostmakedepends="python3-setuptools"
+hostmakedepends="python3-setuptools python3-wheel"
 depends="python3 ca-certificates"
-checkdepends="python3-pytest"
+checkdepends="python3-pytest python3-socks"
 short_desc="WebSocket client for Python3"
 maintainer="Sergi Alvarez <pancake@nopcode.org>"
 license="Apache-2.0"
 homepage="https://github.com/websocket-client/websocket-client"
 changelog="https://raw.githubusercontent.com/websocket-client/websocket-client/master/ChangeLog"
 distfiles="https://github.com/websocket-client/websocket-client/archive/refs/tags/v${version}.tar.gz"
-checksum=65e9e02843ef02b8f9503d6b284a3605d92c201170b5b234afcaf1c5a01c64e0
-alternatives="websocket-client:wsdump:/usr/bin/wsdump.py"
+checksum=923c3b7d0cecfdc449eec5e95c90ae6b0ea24e8782d42f23c05d2bb43bfabd39
+conflicts="python-websocket-client"


### PR DESCRIPTION
discoverd this with `xbps-pkgdb -a`, and while at it also updated.
cc @tornaria @ahesford 
`/usr/bin/wsdump` was broken, now it works.