### PR TITLE
ol: update to 2.5.1.

### DIFF
--- a/srcpkgs/ol/patches/http.patch
+++ b/srcpkgs/ol/patches/http.patch
@@ -1,0 +1,13 @@
+diff --git a/libraries/http/server b/libraries/http/server
+index 47127b8f..a51bd17f 100644
+--- a/libraries/http/server
++++ b/libraries/http/server
+@@ -148,7 +148,7 @@
+             (display "<folder> ")
+             ; list folder:
+             (define Out (pipe))
+-            (define Pid (system (list "/bin/sh" "-c" (string-append
++            (define Pid (execvp (list "/bin/sh" "-c" (string-append
+                            "ls -lah " filename)) #f Out))
+ 
+             (send "HTTP/1.0 200 OK\n"

--- a/srcpkgs/ol/patches/ppcxx.patch
+++ b/srcpkgs/ol/patches/ppcxx.patch
@@ -1,0 +1,15 @@
+diff --git a/extensions/ffi.c b/extensions/ffi.c
+index c6a16d79..02e5c268 100644
+--- a/extensions/ffi.c
++++ b/extensions/ffi.c
+@@ -2670,9 +2670,9 @@ word* OLVM_ffi(olvm_t* this, word arguments)
+ 							j = l;
+ 					}
+ 					else { // в регистр с плавающей запятой
++#if (__x86_64__ && (__unix__ || __APPLE__))
+ 						// move from ptr to the ad
+ 						*(int64_t*)&ad[d++] = args[j];
+-#if (__x86_64__ && (__unix__ || __APPLE__))						
+ 						fpmask |= 1;
+ #endif
+ 					}

--- a/srcpkgs/ol/patches/xxd.patch
+++ b/srcpkgs/ol/patches/xxd.patch
@@ -1,0 +1,24 @@
+diff --git a/GNUmakefile b/GNUmakefile
+index 218cc40b..1306f92c 100644
+--- a/GNUmakefile
++++ b/GNUmakefile
+@@ -49,19 +49,7 @@ includes/ol/vm.h: src/olvm.c
+ 
+ tmp/repl.c: repl
+ # vim
+-ifneq ($(shell which xxd),)
+ 	xxd --include repl >tmp/repl.c
+-else
+-# coreutils
+-ifneq ($(shell which od),)
+-	od -An -vtx1 repl| tr -d '\n'| sed \
+-	   -e 's/^ /0x/' -e 's/ /,0x/g' \
+-	   -e 's/^/unsigned char repl[] = {/' \
+-	   -e 's/$$/};/'> $@
+-else
+-	$(error "You must have 'od' (coreutils) or 'xxd' (vim) tool installed.")
+-endif
+-endif
+ 
+ # or
+ #	echo '(display "unsigned char repl[] = {") (lfor-each (lambda (x) (for-each display (list x ","))) (file->bytestream "repl")) (display "0};")'| ./vm repl> tmp/repl.c

--- a/srcpkgs/ol/template
+++ b/srcpkgs/ol/template
@@ -1,6 +1,6 @@
 # Template file for 'ol'
 pkgname=ol
-version=2.4
+version=2.5.1
 revision=1
 build_style=gnu-makefile
 make_use_env=yes
@@ -11,14 +11,27 @@ maintainer="rc-05 <rc23@email.it>"
 license="LGPL-3.0-or-later, MIT"
 homepage="https://yuriy-chumak.github.io/ol/"
 changelog="https://raw.githubusercontent.com/yuriy-chumak/ol/master/doc/CHANGELOG.md"
-distfiles="https://github.com/yuriy-chumak/ol/archive/${version}.tar.gz"
-checksum=019978ddcf0befc8b8de9f50899c9dd0f47a3e18cf9556bc72a75ae2d1d965d4
+distfiles="
+ https://github.com/yuriy-chumak/ol/archive/${version}.tar.gz
+ https://github.com/yuriy-chumak/libol-opengl/archive/refs/tags/${version}.tar.gz>libopengl-${version}.tar.gz"
+checksum="d9fe66bd15cf9c9c30bf45b97e5825c2101b518fc27c671c08a95798eec3c510
+ 5ccb4e056319e16e3825a7c05d8aa456ce0e87a3111597a2177cc63a67978ffb"
 
 if [[ "$XBPS_TARGET_WORDSIZE" -eq 32 ]]; then
 	make_check_args="HAS_64CDEFS=0"
 else
 	make_check_args="HAS_32CDEFS=0"
 fi
+
+post_extract() {
+	# collect project files:
+	mv -v ol-${version}/* .
+	mv -v ol-${version}/.* .
+	rmdir ol-${version}
+	# move OpenGL submodule to the proper location:
+	mv -v libol-opengl-${version}/* ./libraries/OpenGL/
+	rmdir libol-opengl-${version}
+}
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built and tested this PR locally for my native architecture, **x86_64**
- I built and tested (using **proot** and **qemu**) this PR locally for these architectures:
  - :heavy_check_mark: x86_64, :heavy_check_mark: x86_64-musl
  - :heavy_check_mark: aarch64, :heavy_check_mark: aarch64-musl
  - :heavy_check_mark: armv5te, :heavy_check_mark: armv5te-musl
  - :heavy_check_mark: armv5tel, :heavy_check_mark: armv5tel-musl
  - :heavy_check_mark: armv6l, :heavy_check_mark: armv6l-musl
  - :heavy_check_mark: armv6hf, :heavy_check_mark: armv6hf-musl
  - :heavy_check_mark: armv7l, :heavy_check_mark: armv7l-musl
  - :heavy_check_mark: armv7hf, :heavy_check_mark: armv7hf-musl
  - :heavy_check_mark: i686, :heavy_check_mark: i686-musl
  - :heavy_check_mark: mips-musl, :heavy_check_mark: mipsel-musl, :heavy_check_mark: mipshf-musl, :heavy_check_mark: mipselhf-musl
  - :heavy_check_mark: ppc64, :heavy_check_mark: ppc64-musl
  - :heavy_check_mark: ppc64le, :heavy_check_mark: ppc64le-musl
  - :heavy_check_mark: ppc, :heavy_check_mark: ppc-musl
  - :heavy_check_mark: ppcle (built but not tested), :heavy_check_mark: ppcle-musl (built but not tested)
