### PR TITLE
[WIP][RFC] New package: cross-riscv64-none-elf

### DIFF
--- a/srcpkgs/cross-riscv64-none-elf-binutils/template
+++ b/srcpkgs/cross-riscv64-none-elf-binutils/template
@@ -1,0 +1,37 @@
+# Template file for 'cross-riscv64-none-elf-binutils'
+_triplet=riscv64-none-elf
+pkgname=cross-riscv64-none-elf-binutils
+version=2.42
+revision=1
+build_style=gnu-configure
+configure_args="
+ --disable-nls
+ --enable-deterministic-archives
+ --enable-interwork
+ --enable-ld
+ --enable-multilib
+ --enable-plugins
+ --host=${XBPS_CROSS_TRIPLET}
+ --prefix=/usr
+ --target=${_triplet}
+ --with-gnu-as
+ --with-gnu-ld
+ --with-sysroot=/usr/${_triplet}
+ --with-system-zlib
+ --without-isl
+"
+hostmakedepends="autoconf automake bison flex perl"
+makedepends="zlib-devel"
+depends="binutils-doc"
+short_desc="GNU binary utilities for RV32 and RV64 bare metal"
+maintainer="Mikhail Karpenko <karpenko@fastmail.com>"
+license="GPL-3.0-or-later"
+homepage="https://www.gnu.org/software/binutils/"
+distfiles="${GNU_SITE}/binutils/binutils-${version}.tar.xz"
+checksum=f6e4d41fd5fc778b06b7891457b3620da5ecea1006c6a4a41ae998109f85a800
+nocross=yes
+
+post_install() {
+	# Remove documents conflicting with host version
+	rm -fr ${DESTDIR}/usr/share/info
+}

--- a/srcpkgs/cross-riscv64-none-elf-gcc/template
+++ b/srcpkgs/cross-riscv64-none-elf-gcc/template
@@ -1,0 +1,76 @@
+# Template file for 'cross-riscv64-none-elf-gcc'
+_triplet=riscv64-none-elf
+pkgname=cross-riscv64-none-elf-gcc
+version=13.2.0
+revision=1
+build_wrksrc=build
+build_style=gnu-configure
+hostmakedepends="base-devel autoconf automake cross-riscv64-none-elf-binutils bison flex
+ perl tar texinfo"
+makedepends="gmp-devel isl15-devel libmpc-devel mpfr-devel zlib-devel"
+depends="cross-riscv64-none-elf-binutils"
+short_desc="GNU Compiler Collection for RV32 and RV64 bare metal"
+maintainer="Mikhail Karpenko <karpenko@fastmail.com>"
+license="GFDL-1.2-or-later, GPL-3.0-or-later, LGPL-2.1-or-later"
+homepage="https://gcc.gnu.org"
+distfiles="${GNU_SITE}/gcc/gcc-${version}/gcc-${version}.tar.xz"
+checksum=e275e76442a6067341a27f04c5c6b83d8613144004c0413528863dc6b5c743da
+alternatives="riscv64-none-elf:/usr/bin/riscv64-none-elf-cc:/usr/bin/riscv64-none-elf-gcc"
+nocross=yes
+nopie=yes
+nostrip_files="libgcc.a libgcov.a"
+
+post_extract() {
+	mkdir -p build
+}
+
+pre_configure() {
+	export CFLAGS_FOR_TARGET="-g -Os -mcmodel=medany -ffunction-sections -fdata-sections"
+	export CXXFLAGS_FOR_TARGET="-g -Os -mcmodel=medany -ffunction-sections -fdata-sections"
+}
+
+do_configure() {
+	../configure \
+		--disable-tm-clone-registry \
+		--disable-decimal-float \
+		--disable-libffi \
+		--disable-libgomp \
+		--disable-libmudflap \
+		--disable-libquadmath \
+		--disable-libssp \
+		--disable-libstdcxx-pch \
+		--disable-libstdc__-v3 \
+		--disable-nls \
+		--disable-shared \
+		--disable-threads \
+		--enable-tls \
+		--disable-werror \
+		--enable-languages=c,c++ \
+		--enable-multilib \
+		--enable-plugins \
+		--host=${XBPS_CROSS_TRIPLET} \
+		--libdir=/usr/lib \
+		--libexecdir=/usr/lib \
+		--prefix=/usr \
+		--target=${_triplet} \
+		--with-gnu-as \
+		--with-gnu-ld \
+		--with-host-libstdcxx='-static-libgcc -Wl,-Bstatic,-lstdc++,-Bdynamic -lm' \
+		--with-gmp \
+		--with-isl \
+		--with-mpc \
+		--with-mpfr \
+		--with-libelf \
+		--with-arch=rv64imafdc \
+		--with-abi=lp64d \
+		--with-native-system-header-dir=/include \
+		--with-sysroot=/usr/${_triplet} \
+		--with-newlib \
+		--with-system-zlib
+}
+
+post_install() {
+	# Remove documents conflicting with host version
+	rm -fr ${DESTDIR}/usr/share/{info,man/man7}
+	rm -fr ${DESTDIR}/usr/lib/libcc1.*
+}


### PR DESCRIPTION
I am trying to package cross toolchain for bare metal risc-v targets and have some difficulties with building GCC. The build fails with a lot of errors while building `libgcc`:
```
/builddir/cross-riscv64-none-elf-gcc-13.2.0/build/./gcc/xgcc -B/builddir/cross-riscv64-none-elf-gcc-13.2.0/build/./gcc/ -B/usr/riscv64-none-elf/bin/ -B/usr/riscv64-none-elf/l
ib/ -isystem /usr/riscv64-none-elf/include -isystem /usr/riscv64-none-elf/sys-include    -g -Os -mcmodel=medany -ffunction-sections -fdata-sections -march=rv32i -mabi=ilp32 -
O2  -g -Os -mcmodel=medany -ffunction-sections -fdata-sections -DIN_GCC  -DCROSS_DIRECTORY_STRUCTURE  -W -Wall -Wno-narrowing -Wwrite-strings -Wcast-qual -Wstrict-prototypes 
-Wmissing-prototypes -Wold-style-definition  -isystem ./include   -g -DIN_LIBGCC2 -fbuilding-libgcc -fno-stack-protector -Dinhibit_libc  -I. -I. -I../../../.././gcc -I../../.
./../../libgcc -I../../../../../libgcc/. -I../../../../../libgcc/../gcc -I../../../../../libgcc/../include  -DHAVE_CC_TLS   -o _gcov_interval_profiler.o -MT _gcov_interval_pr
ofiler.o -MD -MP -MF _gcov_interval_profiler.dep -DL_gcov_interval_profiler -c ../../../../../libgcc/libgcov-profiler.c                                                       
In file included from ../../../../../libgcc/libgcov-merge.c:26:                                                                                                               
../../../../../libgcc/libgcov.h:49:10: fatal error: sys/mman.h: No such file or directory                                                                                     
   49 | #include <sys/mman.h>                                                                                                                                                 
      |          ^~~~~~~~~~~~                                                                                                                                                 
compilation terminated.                                                                                                                                                       
make[4]: *** [Makefile:924: _gcov_merge_add.o] Error 1
```
And the file is actually there:
```
find . -name mman.h
./masterdir-x86_64/usr/include/bits/mman.h
./masterdir-x86_64/usr/include/asm/mman.h
./masterdir-x86_64/usr/include/sys/mman.h
./masterdir-x86_64/usr/include/asm-generic/mman.h
./masterdir-x86_64/usr/include/linux/mman.h
./masterdir-x86_64/builddir/cross-riscv64-none-elf-gcc-13.2.0/fixincludes/tests/base/sys/mman.h
````
There is a workaround with patching `libgconv.h` and disabling `HAVE_SYS_MMAN_H` or using `--disable-gcov` configuration flag, but I don't think this is the right way to go.

At the same time I could successfully manually build it from sources on host system with almost the same set of configuration flags except for those pointing to different system directories. It looks like I am missing one step to build the package, and I would appreciate any help. I can attach full configuration and build logs if it will be helpful.
