### PR TITLE
swayimg: update to 2.1.

### DIFF
--- a/srcpkgs/swayimg/template
+++ b/srcpkgs/swayimg/template
@@ -1,8 +1,9 @@
 # Template file for 'swayimg'
 pkgname=swayimg
-version=2.0
-revision=2
+version=2.1
+revision=1
 build_style=meson
+configure_args="-D version=${version}"
 hostmakedepends="pkg-config wayland-devel"
 makedepends="wayland-devel cairo-devel json-c-devel libxkbcommon-devel
  wayland-protocols libheif-devel giflib-devel libjpeg-turbo-devel
@@ -13,7 +14,7 @@ maintainer="voidbert <humbertogilgomes@protonmail.com>"
 license="MIT"
 homepage="https://github.com/artemsen/swayimg"
 distfiles="https://github.com/artemsen/swayimg/archive/v${version}.tar.gz"
-checksum=afcf69d9c69d826e010065dd08732fc5b0c0402c26f98d977f27b77ebd2bdee1
+checksum=d82fb8e75cdabf470677797444ec19b00c83e0e06d80be774727194404624e7e
 
 post_install() {
 	vcompletion extra/bash.completion bash


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-musl)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - armv6l-musl

This PR also solves `swayimg --version` showing `0.0.0`. ~~Could some more experienced maintainer provide a way of solving this issue without a patch? Would using `sed` be preferred?~~