### PR TITLE
New package: keymapper-3.5.2

### DIFF
--- a/srcpkgs/keymapper/files/keymapperd/run
+++ b/srcpkgs/keymapper/files/keymapperd/run
@@ -1,0 +1,3 @@
+#!/bin/sh
+exec 2>&1
+exec keymapperd

--- a/srcpkgs/keymapper/template
+++ b/srcpkgs/keymapper/template
@@ -1,0 +1,19 @@
+# Template file for 'keymapper'
+pkgname=keymapper
+version=3.5.2
+revision=1
+build_style=cmake
+configure_args="-DVERSION=${version}"
+hostmakedepends="pkg-config wayland-devel"
+makedepends="eudev-libudev-devel libusb-devel libX11-devel dbus-devel wayland-devel libxkbcommon-devel"
+short_desc="Cross-platform context-aware key remapper"
+maintainer="deimonn <deimonn@outlook.com>"
+license="GPL-3.0-only"
+homepage="https://github.com/houmain/keymapper"
+changelog="https://raw.githubusercontent.com/houmain/keymapper/main/CHANGELOG.md"
+distfiles="https://github.com/houmain/keymapper/archive/refs/tags/${version}.tar.gz"
+checksum=efa1934230c266e58702b6d821060d6feb422cb2599f4695d05358dfc871e2e1
+
+post_install() {
+	vsv keymapperd
+}


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl
  - armv6l-glibc (cross)
  - armv6l-musl (cross)

Fixes the *original* request of #36218, although the author later clarified they meant `input-remapper`, so I am unsure if this PR actually closes the issue. Contributing as I wanted keymapper myself.
