### PR TITLE
libusb: update to 1.0.27.

### DIFF
--- a/srcpkgs/libusb/template
+++ b/srcpkgs/libusb/template
@@ -1,6 +1,6 @@
 # Template file for 'libusb'
 pkgname=libusb
-version=1.0.26
+version=1.0.27
 revision=1
 build_style=gnu-configure
 hostmakedepends="pkg-config"
@@ -11,7 +11,7 @@ license="LGPL-2.1-or-later"
 homepage="https://libusb.info"
 changelog="https://raw.githubusercontent.com/libusb/libusb/master/ChangeLog"
 distfiles="https://github.com/libusb/libusb/releases/download/v${version}/libusb-${version}.tar.bz2"
-checksum=12ce7a61fc9854d1d2a1ffe095f7b5fac19ddba095c259e6067a46500381b5a5
+checksum=ffaa41d741a8a3bee244ac8e54a72ea05bf2879663c098c82fc5757853441575
 
 libusb-devel_package() {
 	short_desc+=" - development files"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
