### PR TITLE
gramps: Replace deprecated imp by importlib

### DIFF
--- a/srcpkgs/gramps/patches/1411.patch
+++ b/srcpkgs/gramps/patches/1411.patch
@@ -1,0 +1,47 @@
+https://github.com/gramps-project/gramps/pull/1411
+From 47f392ef70618cfece86e5210c19c2c1a768a4e0 Mon Sep 17 00:00:00 2001
+From: David Straub <straub@protonmail.com>
+Date: Mon, 6 Feb 2023 17:12:28 +0100
+Subject: [PATCH] Replace deprecated imp by importlib
+
+---
+ gramps/gen/plug/_manager.py             | 10 +++-------
+ gramps/plugins/importer/importgedcom.py |  4 ++--
+ 2 files changed, 5 insertions(+), 9 deletions(-)
+
+diff --git a/gramps/gen/plug/_manager.py b/gramps/gen/plug/_manager.py
+index 1077de0cdb..16474d5b6e 100644
+--- a/gramps/gen/plug/_manager.py
++++ b/gramps/gen/plug/_manager.py
+@@ -372,13 +372,9 @@ def reload(self, module, pdata):
+         Reloads modules that might not be in the path.
+         """
+         try:
+-            import imp
+-            fp, pathname, description = imp.find_module(pdata.mod_name, [pdata.fpath])
+-            try:
+-                module = imp.load_module(pdata.mod_name, fp, pathname,description)
+-            finally:
+-                if fp:
+-                    fp.close()
++            spec = importlib.util.find_spec(pdata.mod_name, [pdata.fpath])
++            module = importlib.util.module_from_spec(spec)
++            spec.loader.exec_module(module)
+         except:
+             if pdata.mod_name in sys.modules:
+                 del sys.modules[pdata.mod_name]
+diff --git a/gramps/plugins/importer/importgedcom.py b/gramps/plugins/importer/importgedcom.py
+index ac2c604447..f2fa7fd5a4 100644
+--- a/gramps/plugins/importer/importgedcom.py
++++ b/gramps/plugins/importer/importgedcom.py
+@@ -47,8 +47,8 @@
+ # a quick turnround, without having to restart Gramps.
+ module = __import__("gramps.plugins.lib.libgedcom",
+                     fromlist=["gramps.plugins.lib"])   # why o why ?? as above!
+-import imp
+-imp.reload(module)
++import importlib
++importlib.reload(module)
+ 
+ from gramps.gen.config import config
+ 

--- a/srcpkgs/gramps/template
+++ b/srcpkgs/gramps/template
@@ -1,7 +1,7 @@
 # Template file for 'gramps'
 pkgname=gramps
 version=5.1.6
-revision=1
+revision=2
 build_style=python3-module
 hostmakedepends="pkg-config intltool python3-setuptools"
 depends="gtk+3 python3-gobject python3-bsddb3 python3-PyICU python3-jsonschema python3-lxml"


### PR DESCRIPTION
Patch Gramps with https://github.com/gramps-project/gramps/pull/1411 to allow imports to work when running with Python 3.12.

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
