### PR TITLE
xbps-src: add flag to show verbose messages

### DIFF
--- a/common/xbps-src/shutils/common.sh
+++ b/common/xbps-src/shutils/common.sh
@@ -188,6 +188,12 @@ msg_normal() {
     fi
 }
 
+msg_verbose() {
+    if [ -n "$XBPS_VERBOSE" ]; then
+        printf >&2 "$@"
+    fi
+}
+
 report_broken() {
     if [ "$show_problems" = "ignore-problems" ]; then
         return

--- a/common/xbps-src/shutils/update_check.sh
+++ b/common/xbps-src/shutils/update_check.sh
@@ -8,19 +8,18 @@ update_check() {
     local urlpfx urlsfx
     local -A fetchedurls
 
+    # XBPS_UPDATE_CHECK_VERBOSE is the old way to show verbose messages
+    [ "$XBPS_UPDATE_CHECK_VERBOSE" ] && XBPS_VERBOSE="$XBPS_UPDATE_CHECK_VERBOSE"
+
     if [ -r $update_override ]; then
         . $update_override
-        if [ "$XBPS_UPDATE_CHECK_VERBOSE" ]; then
-            echo "using $XBPS_TARGET_PKG/update overrides" 1>&2
-        fi
+        msg_verbose "using $XBPS_TARGET_PKG/update overrides\n"
         if [ -n "$disabled" ]; then
-            echo "update-check DISABLED for $original_pkgname: $disabled" 1>&2
+            msg_verbose "update-check DISABLED for $original_pkgname: $disabled\n"
             return 0
         fi
     elif [ -z "$distfiles" ]; then
-        if [ "$XBPS_UPDATE_CHECK_VERBOSE" ]; then
-            echo "NO DISTFILES found for $original_pkgname" 1>&2
-        fi
+        msg_verbose "NO DISTFILES found for $original_pkgname\n"
         return 0
     fi
 
@@ -94,9 +93,7 @@ update_check() {
         esac
         if [ "$rx" ]; then
             # substitute url if needed
-            if [ -n "$XBPS_UPDATE_CHECK_VERBOSE" ]; then
-                echo "(folder) fetching $urlpfx and scanning with $rx" 1>&2
-            fi
+            msg_verbose "(folder) fetching $urlpfx and scanning with $rx\n"
             skipdirs=
             curl -A "xbps-src-update-check/$XBPS_SRC_VERSION" --max-time 10 -Lsk "$urlpfx" |
                 grep -Po -i "$rx" |
@@ -195,15 +192,11 @@ update_check() {
         rx=${rx:-'(?<!-)\b\Q'"$pkgname"'\E[-_]?((src|source)[-_])?v?\K([^-/_\s]*?\d[^-/_\s]*?)(?=(?:[-_.](?:src|source|orig))?\.(?:[jt]ar|shar|t[bglx]z|tbz2|zip))\b'}
 
         if [ "${fetchedurls[$url]}" ]; then
-            if [ -n "$XBPS_UPDATE_CHECK_VERBOSE" ]; then
-                echo "already fetched $url" 1>&2
-            fi
+            msg_verbose "already fetched $url\n"
             continue
         fi
 
-        if [ -n "$XBPS_UPDATE_CHECK_VERBOSE" ]; then
-            echo "fetching $url and scanning with $rx" 1>&2
-        fi
+        msg_verbose "fetching $url and scanning with $rx\n"
         curl -H 'Accept: text/html,application/xhtml+xml,application/xml,text/plain,application/rss+xml' -A "xbps-src-update-check/$XBPS_SRC_VERSION" --max-time 10 -Lsk "$url" |
             grep -Po -i "$rx"
         fetchedurls[$url]=yes
@@ -214,9 +207,7 @@ update_check() {
         grep . || echo "NO VERSION found for $original_pkgname" 1>&2
     } |
     while IFS= read -r found_version; do
-        if [ -n "$XBPS_UPDATE_CHECK_VERBOSE" ]; then
-            echo "found version $found_version"
-        fi
+        msg_verbose "found version $found_version\n"
         consider=true
         p="$ignore "
         while [ -n "$p" ]; do
@@ -225,9 +216,7 @@ update_check() {
             case "$found_version" in
             $i)
                 consider=false
-                if [ -n "$XBPS_UPDATE_CHECK_VERBOSE" ]; then
-                    echo "ignored $found_version due to $i"
-                fi
+                msg_verbose "ignored $found_version due to $i\n"
             esac
         done
         if $consider; then

--- a/srcpkgs/xbps/patches/xbps-src-comp.patch
+++ b/srcpkgs/xbps/patches/xbps-src-comp.patch
@@ -1,14 +1,43 @@
 --- a/data/_xbps_src
 +++ b/data/_xbps_src
-@@ -26,6 +26,7 @@
+@@ -25,25 +25,35 @@
+ 	compadd "$@" -- ${${dirs:t}%-*}
  }
  
  _arguments -s : \
++	'-1[Fail if dependencies are missing]' \
 +	'-A[Host architecture]:architecture:($archs)' \
  	'-a[Cross compile packages]:architecture:($archs)' \
++	'-b[Build broken, nocross, and excluded packages]' \
++	'-c[Configuration file]:config: ' \
  	'-C[Do not remove build directory/autodeps/destdir]' \
  	'-E[Exit immediately when binary package already exists]' \
-@@ -64,9 +65,7 @@
+ 	'-f[Force building and registering binary packages]' \
+ 	'-G[Enable XBPS_USE_GIT_REVS]' \
+-	'-Q[Enable running the check stage]' \
+ 	'-g[Enable building -dbg packages]' \
+ 	'-H[Absolute path to hostdir]:hostdir:_files -/' \
+ 	'-h[Help]' \
+ 	'-I[Ignore required dependencies]' \
++	'-i[Make internal errors non-fatal]' \
+ 	'-j[Number of parallel build jobs]:number: ' \
++	'-K[Enable extended checks]' \
+ 	'-L[Disable ASCII colors]' \
+ 	'-m[Absolute path to masterdir]:masterdir:_files -/' \
+ 	'-N[Disable use of remote repositories]' \
++	'-p[Show additional variables]:variables: ' \
+ 	'-o[Set package build options]:options: ' \
++	'-Q[Enable running the check stage]' \
+ 	'-q[Suppress output of xbps-src]' \
+ 	'-r[Use alternative local repository]:repo:_files -/' \
++	'-s[Make some warnings errors]' \
+ 	'-t[Create a temporary masterdir]' \
++	'-v[Show verbose messages]' \
++	'-V[Print version]' \
+ 	'1:target:->target' \
+ 	'*::args:->args' && ret=0
+ 
+@@ -64,9 +80,7 @@
  		case $words[1] in
  			build|check|configure|extract|fetch|install|patch|pkg|show|show-avail|show-build-deps|show-hostmakedepends|show-makedepends|show-options|update-check)
  				_arguments ':package:_xbps_src_all_packages' && ret=0;;

--- a/srcpkgs/xbps/template
+++ b/srcpkgs/xbps/template
@@ -1,7 +1,7 @@
 # Template file for 'xbps'
 pkgname=xbps
 version=0.59.2
-revision=2
+revision=3
 bootstrap=yes
 build_style=configure
 short_desc="XBPS package system utilities"

--- a/xbps-src
+++ b/xbps-src
@@ -242,6 +242,8 @@ $(print_cross_targets)
     This flag requires xbps-uchroot(1), and won't work on filesystems that don't
     support overlayfs.
 
+-v  Show verbose messages (only affects update-check).
+
 -V  Print version of xbps, then exit.
 
 _EOF
@@ -371,7 +373,7 @@ readonly XBPS_SRC_VERSION="113"
 export XBPS_MACHINE=$(xbps-uhelper -C /dev/null arch)
 
 XBPS_OPTIONS=
-XBPS_OPTSTRING="1A:a:bc:CEfgGhH:iIj:Lm:No:p:qsQKr:tV"
+XBPS_OPTSTRING="1A:a:bc:CEfgGhH:iIj:Lm:No:p:qsQKr:tvV"
 
 # Preprocess arguments in order to allow options before and after XBPS_TARGET.
 eval set -- $(getopt "$XBPS_OPTSTRING" "$@");
@@ -407,6 +409,7 @@ while getopts "$XBPS_OPTSTRING" opt; do
         r) XBPS_ARG_ALT_REPOSITORY="$OPTARG"; XBPS_OPTIONS+=" -r $OPTARG";;
         s) XBPS_ARG_STRICT=yes; XBPS_OPTIONS+=" -s";;
         t) XBPS_ARG_TEMP_MASTERDIR=1; XBPS_OPTIONS+=" -t -C";;
+        v) XBPS_ARG_VERBOSE=1; XBPS_OPTIONS+=" -v";;
         V) echo "xbps-src-$XBPS_SRC_VERSION $(xbps-uhelper -V)" && exit 0;;
         --) shift; break;;
     esac
@@ -497,6 +500,7 @@ fi
 [ -n "$XBPS_ARG_CROSS_BUILD" ] && XBPS_CROSS_BUILD="$XBPS_ARG_CROSS_BUILD"
 [ -n "$XBPS_ARG_CHECK_PKGS" ] && XBPS_CHECK_PKGS="$XBPS_ARG_CHECK_PKGS"
 [ -n "$XBPS_ARG_MAKEJOBS" ] && XBPS_MAKEJOBS="$XBPS_ARG_MAKEJOBS"
+[ -n "$XBPS_ARG_VERBOSE" ] && XBPS_VERBOSE="$XBPS_ARG_VERBOSE"
 
 # Default to nproc for XBPS_MAKEJOBS if not set and nproc is available
 if command -v nproc >/dev/null ; then


### PR DESCRIPTION
having to define/type out `XBPS_UPDATE_CHECK_VERBOSE` every time you want more diagnostics for `update-check` is really annoying (i even made a [wrapper](https://github.com/classabbyamp/xX_tools_Xx/blob/tools/xupcheck) for it previously, heh)

currently, this only applies to `update-check`, but if someone wants to add something later that can have higher verbosity, this would enable that.

#### Testing the changes
- I tested the changes in this PR: **YES**
