### PR TITLE
base-files: add zsh completions for vkpurge

### DIFF
--- a/srcpkgs/base-files/files/_vkpurge
+++ b/srcpkgs/base-files/files/_vkpurge
@@ -1,0 +1,34 @@
+#compdef vkpurge
+
+local context state state_descr line
+typeset -A opt_args
+local curcontext="$curcontext"
+
+_arguments -C \
+	'1: :->subcmd' \
+	'*:: :->kernels'
+
+case "$state" in
+subcmd)
+	local subcommands=(
+		'list:list removable kernel versions'
+		'rm:remove removable kernel versions'
+	)
+	_describe -t commands subcommand subcommands
+	;;
+kernels)
+	curcontext="${curcontext%:*:*}:vkpurge-$line[1]:"
+	case "$line[1]" in
+	list)
+		_arguments '1::version glob: '
+		;;
+	rm)
+		local kernels=(
+			'all:all removable kernels'
+			$(vkpurge list all)
+		)
+		_describe -t kernels kernel kernels
+		;;
+	esac
+	;;
+esac

--- a/srcpkgs/base-files/template
+++ b/srcpkgs/base-files/template
@@ -1,7 +1,7 @@
 # Template file for 'base-files'
 pkgname=base-files
-version=0.143
-revision=4
+version=0.144
+revision=1
 bootstrap=yes
 depends="xbps-triggers"
 short_desc="Void Linux base system files"
@@ -84,6 +84,7 @@ do_install() {
 	# vkpurge
 	vbin ${FILESDIR}/vkpurge
 	vman ${FILESDIR}/vkpurge.8
+	vcompletion "${FILESDIR}"/_vkpurge zsh vkpurge
 
 	vbin ${FILESDIR}/lsb_release
 


### PR DESCRIPTION
completes subcommands, versions and all for `rm`, and says it expects a version glob for `list` (without completing anything because that would be hard)

#### Testing the changes
- I tested the changes in this PR: **YES**
