### PR TITLE
Fix help output alphabetically

### DIFF
--- a/xbps-src
+++ b/xbps-src
@@ -30,49 +30,52 @@ bootstrap-update
     Updates bootstrap packages with latest versions available from registered
     repositories in the XBPS configuration file.
 
-consistency-check
-    Runs a consistency check on all packages
+build <pkgname>
+    Build package source (fetch + extract + patch + configure + build).
 
 chroot
     Enter to the chroot in <masterdir>.
 
-clean-repocache
-    Removes obsolete packages from <hostdir>/repocache.
-
-fetch <pkgname>
-    Download package source distribution file(s).
-
-extract <pkgname>
-    Extract package source distribution file(s) into the build directory.
-    By default set to <masterdir>/builddir.
-
-patch <pkgname>
-    Patch the package sources and perform other operations required to
-    prepare a package for configuring and building
-
-configure <pkgname>
-    Configure a package (fetch + extract + patch + configure).
-
-build <pkgname>
-    Build package source (fetch + extract + patch + configure + build).
-
 check <pkgname>
     Run the package check(s) after building the package source.
-
-install <pkgname>
-    Install target package into <destdir> but not building the binary package
-    and not removing build directory for inspection purposes.
-
-pkg <pkgname>
-    Build binary package for <pkgname> and all required dependencies.
 
 clean [pkgname]
     Removes auto dependencies, cleans up <masterdir>/builddir and <masterdir>/destdir.
     If <pkgname> argument is specified, package files from <masterdir>/destdir and its
     build directory in <masterdir>/buiddir are removed.
 
+clean-repocache
+    Removes obsolete packages from <hostdir>/repocache.
+
+configure <pkgname>
+    Configure a package (fetch + extract + patch + configure).
+
+consistency-check
+    Runs a consistency check on all packages
+
+extract <pkgname>
+    Extract package source distribution file(s) into the build directory.
+    By default set to <masterdir>/builddir.
+
+fetch <pkgname>
+    Download package source distribution file(s).
+
+install <pkgname>
+    Install target package into <destdir> but not building the binary package
+    and not removing build directory for inspection purposes.
+
 list
     Lists installed packages in <masterdir>.
+
+patch <pkgname>
+    Patch the package sources and perform other operations required to
+    prepare a package for configuring and building
+
+pkg <pkgname>
+    Build binary package for <pkgname> and all required dependencies.
+
+purge-distfiles
+    Removes all obsolete distfiles in <hostdir>/sources.
 
 remove <pkgname>
     Remove target package from <destdir>. If <pkgname>-<version> is not matched
@@ -80,9 +83,6 @@ remove <pkgname>
 
 remove-autodeps
     Removes all package dependencies that were installed automatically.
-
-purge-distfiles
-    Removes all obsolete distfiles in <hostdir>/sources.
 
 show <pkgname>
     Show information for the specified package.
@@ -107,8 +107,14 @@ show-hostmakedepends <pkgname>
 show-makedepends <pkgname>
     Show required target build dependencies for <pkgname>.
 
+show-local-updates
+    Prints the list of outdated packages in your local repositories.
+
 show-options <pkgname>
     Show available build options by <pkgname>.
+
+show-repo-updates
+    Prints the list of outdated packages in XBPS repositories.
 
 show-shlib-provides <pkgname>
     Show list of provided shlibs for <pkgname>. Package must be installed into destdir.
@@ -116,17 +122,11 @@ show-shlib-provides <pkgname>
 show-shlib-requires <pkgname>
     Show list of required shlibs for <pkgname>. Package must be installed into destdir.
 
-show-var <var>
-    Prints the value of <var> if it's defined in xbps-src.
-
-show-repo-updates
-    Prints the list of outdated packages in XBPS repositories.
-
 show-sys-updates
     Prints the list of outdated packages in your system.
 
-show-local-updates
-    Prints the list of outdated packages in your local repositories.
+show-var <var>
+    Prints the value of <var> if it's defined in xbps-src.
 
 sort-dependencies <pkg> <pkgN+1> ...
     Given a list of packages specified as additional arguments, a sorted dependency
@@ -135,17 +135,17 @@ sort-dependencies <pkg> <pkgN+1> ...
 update-bulk
     Rebuilds all packages in the system repositories that are outdated.
 
-update-sys
-    Rebuilds all packages in your system that are outdated and updates them.
-
-update-local
-    Rebuilds all packages in your local repositories that are outdated.
-
 update-check <pkgname>
     Check upstream site of <pkgname> for new releases.
 
 update-hash-cache
     Update the hash cache with existing source distfiles.
+
+update-local
+    Rebuilds all packages in your local repositories that are outdated.
+
+update-sys
+    Rebuilds all packages in your system that are outdated and updates them.
 
 zap
     Removes a masterdir but preserving ccache, distcc and host directories.


### PR DESCRIPTION
Fix the help output of `xbps-src`, make the help output alphabetically again!

#### Testing the changes
- I tested the changes in this PR: **YES**
