### PR TITLE
New package: winegui-2.3.5

### DIFF
--- a/srcpkgs/winegui/files/README.voidlinux
+++ b/srcpkgs/winegui/files/README.voidlinux
@@ -1,0 +1,36 @@
+WineGUI on i686 should work without needing to install any extra packages.
+
+WineGUI on x86_64 requires support for Wine in 32bits mode and OpenGL/Vulkan in 32bits mode,
+the 32bit packages are available in the multilib repository.
+
+Install the multilib repository to your system:
+
+	# xbps-install -S void-repo-multilib{,-nonfree}
+
+Generic (for all systems):
+
+	# xbps-install -S wine-32bit libgcc-32bit libstdc++-32bit libdrm-32bit libglvnd-32bit
+
+For users of the open source drivers (eg. AMD):
+
+	# xbps-install -S mesa-dri-32bit
+
+For users of the proprietary NVIDIA driver, install the appropriate 32-bit
+libraries for the version of nvidia you have installed:
+
+	# xbps-install -S nvidia-libs-32bit (for the latest nvidia package)
+	# xbps-install -S nvidia470-libs-32bit (for the latest previous package)
+	# xbps-install -S nvidia390-libs-32bit (for the legacy previous package)
+
+For mesa users this would result in:
+
+	# xbps-install -S wine-32bit libgcc-32bit libstdc++-32bit libdrm-32bit libglvnd-32bit mesa-dri-32bit
+
+The dbus service must be enabled, and the mono package will need to be
+installed for some apps/games to function.
+
+If games are running slowly or not at all, or there are issues with network
+streaming, verify that your user belongs to the video group.
+
+If your audio is not working, try installing pulseaudio,
+alsa-plugins-pulseaudio, and their "<package>-32bit" equivalents.

--- a/srcpkgs/winegui/template
+++ b/srcpkgs/winegui/template
@@ -1,0 +1,21 @@
+# Template file for 'winegui'
+pkgname=winegui
+version=2.3.5
+revision=1
+archs="i686* x86_64*"
+build_style=cmake
+configure_args="-DCUSTOM_PROJECT_VERSION:STRING=${version}"
+hostmakedepends="pkg-config"
+makedepends="gtkmm-devel"
+depends="wine wget unzip p7zip cabextract zenity"
+short_desc="User-friendly WINE manager"
+maintainer="Melroy van den Berg <melroy@melroy.org>"
+license="AGPL-3.0-only"
+homepage="https://gitlab.melroy.org/melroy/winegui"
+distfiles="https://gitlab.melroy.org/melroy/winegui/-/archive/v${version}/winegui-v${version}.tar.gz"
+checksum=49eb2cf881bca4e3174ec08e34b270badd6a8275ad9a1a48ff6df621df1a9a24
+
+post_install() {
+	vlicense LICENSE
+	vdoc "${FILESDIR}/README.voidlinux"
+}


### PR DESCRIPTION
Introducing WineGUI package. At last, a user-friendly Wine graphical interface.

I'm the developer of [WineGUI](https://gitlab.melroy.org/melroy/winegui).

#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

The x86_64 build went fine. I also tested the WineGUI application itself, running on Void Linux. I did notice that wine-32bit was missing as well. But multilib can't be added as depends too bad! 

Hence I added a `README.voidlinux`, just like the Steam package. However, I hope there will be a **better solution** in the neat future. 

I also tried `armv6l` and `armv7l` cross-builds, but this seems to fail on wine? That is too bad.

```sh
=> wine-9.1_1: the following build options are set:
   mingw: Use the MinGW cross compiler to build WinPE DLLs (ON)
   xshm: Enable support for the X Shared Memory Extension (ON)
   staging: Apply the wine-staging patchset (OFF)
=> ERROR: wine-9.1_1: this package cannot be built for armv6l.
```

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc) -> OK

- I tried to build this PR locally for these architectures, but failed...:
  - armv7l
  - armv6l
