### PR TITLE
util-linux: fix manpage links

### DIFF
--- a/srcpkgs/util-linux/patches/fix_manpage_redirects.patch
+++ b/srcpkgs/util-linux/patches/fix_manpage_redirects.patch
@@ -1,0 +1,18 @@
+--- a/login-utils/lastb.1
++++ b/login-utils/lastb.1
+@@ -1 +1 @@
+-.so last.1
+\ No newline at end of file
++.so man1/last.1
+--- a/login-utils/vigr.8
++++ b/login-utils/vigr.8
+@@ -1 +1 @@
+-.so vipw.8
+\ No newline at end of file
++.so man8/vipw.8
+--- a/sys-utils/swapoff.8
++++ b/sys-utils/swapoff.8
+@@ -1 +1 @@
+-.so swapon.8
+\ No newline at end of file
++.so man8/swapon.8

--- a/srcpkgs/util-linux/template
+++ b/srcpkgs/util-linux/template
@@ -2,7 +2,7 @@
 # Keep this package sync with util-linux-common
 pkgname=util-linux
 version=2.38.1
-revision=5
+revision=6
 build_style=gnu-configure
 configure_args="--exec-prefix=\${prefix} --enable-libuuid --disable-makeinstall-chown
  --enable-libblkid --enable-fsck --disable-rpath --enable-fs-paths-extra=/usr/sbin:/usr/bin


### PR DESCRIPTION
Manpages of vigr, swapoff and lastb don't link properly.

I'm unsure whether this patch is the right solution to this problem, but it makes it work. It should probably also be reported upstream, but I don't really know. The manpage linking could be system dependent and their scheme could be valid on some systems.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
