### PR TITLE
podman: update to 4.9.3

### DIFF
--- a/srcpkgs/podman/template
+++ b/srcpkgs/podman/template
@@ -1,6 +1,6 @@
 # Template file for 'podman'
 pkgname=podman
-version=4.8.3
+version=4.9.3
 revision=1
 build_style=go
 go_import_path="github.com/containers/podman/v4"
@@ -16,7 +16,7 @@ license="Apache-2.0"
 homepage="https://podman.io/"
 changelog="https://raw.githubusercontent.com/containers/podman/main/RELEASE_NOTES.md"
 distfiles="https://github.com/containers/podman/archive/v${version}.tar.gz"
-checksum=3a99b6c82644fa52929cf4143943c63d6784c84094892bc0e14197fa38a1c7fa
+checksum=37afc5bba2738c68dc24400893b99226c658cc9a2b22309f4d7abe7225d8c437
 
 if [ "$CROSS_BUILD" ]; then
 	go_build_tags+=" containers_image_openpgp"

--- a/srcpkgs/slirp4netns/template
+++ b/srcpkgs/slirp4netns/template
@@ -1,6 +1,6 @@
 # Template file for 'slirp4netns'
 pkgname=slirp4netns
-version=1.2.2
+version=1.2.3
 revision=1
 build_style=gnu-configure
 hostmakedepends="autoconf automake pkg-config"
@@ -10,7 +10,7 @@ maintainer="Cameron Nemo <cam@nohom.org>"
 license="GPL-2.0-only"
 homepage="https://github.com/rootless-containers/slirp4netns"
 distfiles="https://github.com/rootless-containers/slirp4netns/archive/v${version}.tar.gz"
-checksum=2450afb5730ee86a70f9c3f0d3fbc8981ab8e147246f4e0d354f0226a3a40b36
+checksum=acce648fab8fe5f113c41a8fd6d20177708519b4ddaa60f845e1998a17b22ca5
 # tests fail due to use of unshare (unavailable with chroot util-linux)
 make_check=no
 


### PR DESCRIPTION
- podman: update to 4.9.3
- slirp4netns: update to 1.2.3

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
