### PR TITLE
mupdf: update to 1.23.10

### DIFF
--- a/srcpkgs/cups-filters/template
+++ b/srcpkgs/cups-filters/template
@@ -1,7 +1,7 @@
 # Template file for 'cups-filters'
 pkgname=cups-filters
 version=1.28.17
-revision=3
+revision=4
 build_style=gnu-configure
 configure_args="--disable-static --with-rcdir=no --enable-avahi
  --with-browseremoteprotocols=DNSSD,CUPS

--- a/srcpkgs/fbpdf/template
+++ b/srcpkgs/fbpdf/template
@@ -1,7 +1,7 @@
 # Template file for 'fbpdf'
 pkgname=fbpdf
 version=0.0.20220624
-revision=4
+revision=5
 _githash=6276360f47edd71de736e153f5dcc82b6d60b3db
 _gitshort="${_githash:0:7}"
 build_style=gnu-makefile

--- a/srcpkgs/mupdf/template
+++ b/srcpkgs/mupdf/template
@@ -1,7 +1,7 @@
 # Template file for 'mupdf'
 # Static library, revbump all dependants on mupdf updates
 pkgname=mupdf
-version=1.23.6
+version=1.23.10
 revision=1
 hostmakedepends="pkg-config zlib-devel libcurl-devel freetype-devel
  libjpeg-turbo-devel jbig2dec-devel libXext-devel libXcursor-devel
@@ -15,7 +15,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="AGPL-3.0-only"
 homepage="https://mupdf.com"
 distfiles="https://mupdf.com/downloads/archive/mupdf-${version}-source.tar.lz"
-checksum=7beb083bedd18c2727ecfa4d8355db4371050cc002ebd20dee5ae7d640161f16
+checksum=11604853480ac3d126109c76506739e000c5e4ad17d090c6b519c7cf9caf1a5c
 
 pre_build() {
 	if [ "$CROSS_BUILD" ]; then

--- a/srcpkgs/sioyek/template
+++ b/srcpkgs/sioyek/template
@@ -1,7 +1,7 @@
 # Template file for 'sioyek'
 pkgname=sioyek
 version=2.0.0
-revision=6
+revision=7
 build_style=qmake
 configure_args="pdf_viewer_build_config.pro"
 hostmakedepends="qt5-qmake qt5-host-tools

--- a/srcpkgs/zathura-pdf-mupdf/template
+++ b/srcpkgs/zathura-pdf-mupdf/template
@@ -1,7 +1,7 @@
 # Template file for 'zathura-pdf-mupdf'
 pkgname=zathura-pdf-mupdf
 version=0.4.1
-revision=5
+revision=6
 build_style=meson
 hostmakedepends="pkg-config"
 makedepends="mupdf-devel zathura-devel libopenjpeg2-devel tesseract-ocr-devel


### PR DESCRIPTION
- I tested the changes in this PR: yes

With this mupdf version, which includes https://git.ghostscript.com/?p=mupdf.git;h=9c9ae0f6ef3ef45cb9ee8add96c6ee598b5f3080 , sioyek correctly parses the TOC of certain documents, see https://github.com/ahrm/sioyek/issues/856

cc #48182 