### PR TITLE
xbps-src: stop invoking chroot-git explicitly 

### DIFF
--- a/srcpkgs/chroot-git/template
+++ b/srcpkgs/chroot-git/template
@@ -1,6 +1,6 @@
 # Template file for 'chroot-git'
 pkgname=chroot-git
-version=2.43.1
+version=2.45.0
 revision=1
 bootstrap=yes
 makedepends="zlib-devel"
@@ -9,7 +9,7 @@ maintainer="Đoàn Trần Công Danh <congdanhqx@gmail.com>"
 license="GPL-2.0-only"
 homepage="https://git-scm.com/"
 distfiles="https://www.kernel.org/pub/software/scm/git/git-${version}.tar.xz"
-checksum=2234f37b453ff8e4672c21ad40d41cc7393c9a8dcdfe640bec7ac5b5358f30d2
+checksum=0aac200bd06476e7df1ff026eb123c6827bc10fe69d2823b4bf2ebebe5953429
 repository=bootstrap
 
 if [ "$CHROOT_READY" ]; then
@@ -66,9 +66,7 @@ do_check() {
 }
 
 do_install() {
-	vmkdir usr/bin
 	vmkdir usr/libexec/chroot-git
-	vbin git chroot-git
 	vinstall git 755 usr/libexec/chroot-git
 	ln -s git $DESTDIR/usr/libexec/chroot-git/git-upload-pack
 	ln -s git $DESTDIR/usr/libexec/chroot-git/git-receive-pack

--- a/xbps-src
+++ b/xbps-src
@@ -568,13 +568,14 @@ if [ -d "$XBPS_MASTERDIR" -a ! -w "$XBPS_MASTERDIR" ]; then
 fi
 
 # Try using chroot-git then git from the host system
-if command -v chroot-git &>/dev/null; then
-    export XBPS_GIT_CMD=$(command -v chroot-git)
-elif command -v git &>/dev/null; then
-    export XBPS_GIT_CMD=$(command -v git)
+XBPS_GIT_CMD="$(PATH="/usr/libexec/chroot-git:$PATH:$XBPS_MASTERDIR/usr/libexec/chroot-git" command -v git 2>/dev/null)"
+if [ -n "$XBPS_GIT_CMD" ]; then
+    export XBPS_GIT_CMD
 elif [ -z "$XBPS_USE_BUILD_MTIME" ] || [ "$XBPS_USE_GIT_REVS" ]; then
     echo "neither chroot-git or git are available in your system!" 1>&2
     exit 1
+else
+    unset XBPS_GIT_CMD
 fi
 
 if [ -n "$XBPS_HOSTDIR" ]; then


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
