### PR TITLE
tmux: update to 3.4

### DIFF
--- a/srcpkgs/tmux/template
+++ b/srcpkgs/tmux/template
@@ -1,9 +1,9 @@
 # Template file for 'tmux'
 pkgname=tmux
-version=3.3a
-revision=2
+version=3.4
+revision=1
 build_style=gnu-configure
-configure_args="--enable-utempter"
+configure_args="--enable-utempter --enable-sixel"
 hostmakedepends="byacc automake pkg-config"
 makedepends="libevent-devel libutempter-devel ncurses-devel"
 depends="ncurses-base"
@@ -13,7 +13,7 @@ license="ISC"
 homepage="https://tmux.github.io"
 changelog="https://raw.githubusercontent.com/tmux/tmux/master/CHANGES"
 distfiles="https://github.com/tmux/tmux/releases/download/${version}/tmux-${version}.tar.gz"
-checksum=e4fd347843bd0772c4f48d6dde625b0b109b7a380ff15db21e97c11a4dcdf93f
+checksum=551ab8dea0bf505c0ad6b7bb35ef567cdde0ccb84357df142c254f35a23e19aa
 
 pre_configure() {
 	autoreconf -fi


### PR DESCRIPTION
A [basic support for sixel](https://github.com/tmux/tmux/commit/dfbc6b1888c110cf0ade66f20188c57757ee1298) was added on this [release](https://github.com/tmux/tmux/blob/608d113486835515e7a89b1511704440c68ae817/CHANGES#L13) (enabled with `--enable-sixel`), so it would be good if more people can test it.

A list of terminal emulators that do support sixel is available [here](https://www.arewesixelyet.com/).

#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture: x86_64-libc
- I built this PR locally for these architectures:
  - armv7l (crossbuild)