### PR TITLE
ruby-tmuxinator: update to 3.2.1 and let it work with tmux 3.4

### DIFF
--- a/srcpkgs/ruby-thor/template
+++ b/srcpkgs/ruby-thor/template
@@ -1,13 +1,13 @@
 # Template file for 'ruby-thor'
 pkgname=ruby-thor
-version=1.2.1
-revision=3
+version=1.3.1
+revision=1
 build_style=gem
 short_desc="Toolkit for building powerful command-line interfaces"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
 homepage="http://whatisthor.com/"
-checksum=b1752153dc9c6b8d3fcaa665e9e1a00a3e73f28da5e238b81c404502e539d446
+checksum=fa7e3471d4f6a27138e3d9c9b0d4daac9c3d7383927667ae83e9ab42ae7401ef
 
 post_install() {
 	vlicense LICENSE.md

--- a/srcpkgs/ruby-tmuxinator/patches/xdg.patch
+++ b/srcpkgs/ruby-tmuxinator/patches/xdg.patch
@@ -1,5 +1,5 @@
 diff --git a/lib/tmuxinator/config.rb b/lib/tmuxinator/config.rb
-index 25620bf..fcc61a3 100644
+index d14eb9a17a5..d4eccaa36b0 100644
 --- a/lib/tmuxinator/config.rb
 +++ b/lib/tmuxinator/config.rb
 @@ -29,7 +29,7 @@ module Tmuxinator
@@ -12,13 +12,13 @@ index 25620bf..fcc61a3 100644
 
        def xdg?
 diff --git a/spec/lib/tmuxinator/config_spec.rb b/spec/lib/tmuxinator/config_spec.rb
-index 71b8da2..d28a60a 100644
+index 09ab25f8831..9e971e0a414 100644
 --- a/spec/lib/tmuxinator/config_spec.rb
 +++ b/spec/lib/tmuxinator/config_spec.rb
 @@ -53,7 +53,8 @@ describe Tmuxinator::Config do
 
          Dir.mktmpdir do |dir|
-           config_parent = "#{dir}/non_existant_parent/s"
+           config_parent = "#{dir}/non_existent_parent/s"
 -          allow(XDG).to receive(:[]).with("CONFIG").and_return config_parent
 +          allow(XDG::Config).to receive_message_chain(:new, :home, :to_s).
 +            and_return config_parent
@@ -36,13 +36,13 @@ index 71b8da2..d28a60a 100644
    end
 
 diff --git a/tmuxinator.gemspec b/tmuxinator.gemspec
-index 1b02053..3f4c8f8 100644
+index df933d888e2..f8e9fe71d4e 100644
 --- a/tmuxinator.gemspec
 +++ b/tmuxinator.gemspec
 @@ -41,7 +41,7 @@ Gem::Specification.new do |s|
 
    s.add_dependency "erubis", "~> 2.6"
-   s.add_dependency "thor", "~> 1.2.1"
+   s.add_dependency "thor", "~> 1.3.0"
 -  s.add_dependency "xdg", "~> 2.2", ">= 2.2.5"
 +  s.add_dependency "xdg", ">= 4.3.0"
 

--- a/srcpkgs/ruby-tmuxinator/template
+++ b/srcpkgs/ruby-tmuxinator/template
@@ -1,16 +1,16 @@
 # Template file for 'ruby-tmuxinator'
 pkgname=ruby-tmuxinator
-version=3.0.5
-revision=3
+version=3.2.1
+revision=1
 build_style=gemspec
-depends="ruby-erubis>=2.6 ruby-thor>=1.2.1 ruby-xdg>=4.3.0 tmux"
+depends="ruby-erubis>=2.6 ruby-thor>=1.3.0 ruby-xdg>=4.3.0 tmux"
 short_desc="Create and manage complex tmux sessions easily"
-maintainer="Alexander Egorenkov <egorenar-dev@posteo.net>"
+maintainer="dataCobra <datacobra@thinkbot.de>"
 license="MIT"
 homepage="https://github.com/tmuxinator/tmuxinator"
 changelog="https://raw.githubusercontent.com/tmuxinator/tmuxinator/master/CHANGELOG.md"
 distfiles="https://github.com/tmuxinator/tmuxinator/archive/refs/tags/v${version}.tar.gz"
-checksum=f67296a0b600fb5d8e51bf8fc9f8376a887754fd74cd59b6a8d9c962ad8f80a4
+checksum=56c0b26b37c801ba8dc95666e39bf69f4041817b34471bd915f587cface6220b
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl
  - i686

Also adopting the package.