### PR TITLE
python3-vlc: update to 3.0.20123.

### DIFF
--- a/srcpkgs/python3-vlc/template
+++ b/srcpkgs/python3-vlc/template
@@ -1,13 +1,13 @@
 # Template file for 'python3-vlc'
 pkgname=python3-vlc
-version=3.0.18121
-revision=2
+version=3.0.20123
+revision=1
 build_style=python3-module
 hostmakedepends="python3-setuptools"
-depends="python3"
+depends="python3 libvlc"
 short_desc="VLC bindings for python"
 maintainer="Joel Beckmeyer <joel@beckmeyer.us>"
 license="LGPL-2.1-or-later"
 homepage="https://wiki.videolan.org/Python_bindings"
 distfiles="${PYPI_SITE}/p/python-vlc/python-vlc-${version}.tar.gz"
-checksum=24550314a3e6ed55fd347b009491c98b865f9dfa05a92e889d7b0a2210e7485b
+checksum=244fbb9e392a0326841fca926d6d12a2a36c546982191f493f148fa19e66b1d4


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

Needs dependency on libvlc, otherwise the package cannot function and throws errors:
```
>>> import vlc
>>> vlc.get_default_instance()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib/python3.12/site-packages/vlc.py", line 271, in get_default_instance
    _default_instance = Instance()
                        ^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/vlc.py", line 1814, in __new__
    return libvlc_new(len(args), args)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/vlc.py", line 4990, in libvlc_new
    _Cfunction('libvlc_new', ((1,), (1,),), class_result(Instance),
  File "/usr/lib/python3.12/site-packages/vlc.py", line 302, in _Cfunction
    raise NameError('no function %r' % (name,))
NameError: no function 'libvlc_new'
```

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
