### PR TITLE
dnsdist: update to 1.9.0

### DIFF
--- a/srcpkgs/dnsdist/template
+++ b/srcpkgs/dnsdist/template
@@ -1,7 +1,7 @@
 # Template file for 'dnsdist'
 pkgname=dnsdist
-version=1.8.1
-revision=2
+version=1.9.0
+revision=1
 build_style=gnu-configure
 configure_args="--with-pic --with-gnu-ld --with-libsodium --with-re2
  --with-net-snmp --with-libcap --with-libssl --enable-dnscrypt --with-nghttp2
@@ -11,15 +11,14 @@ configure_args="--with-pic --with-gnu-ld --with-libsodium --with-re2
 conf_files="/etc/dnsdist/dnsdist.conf"
 hostmakedepends="autoconf automake pkgconf"
 makedepends="libsodium-devel boost-devel re2-devel net-snmp-devel libcap-devel
- lua54-devel openssl-devel lmdb-devel fstrm-devel libedit-devel h2o-devel
- nghttp2-devel"
+ lua54-devel openssl-devel lmdb-devel fstrm-devel libedit-devel nghttp2-devel"
 short_desc="Dynamic DNS loadbalancer"
 maintainer="JailBird <jailbird@fdf.net>"
 license="GPL-2.0-only"
 homepage="https://dnsdist.org/"
 changelog="https://dnsdist.org/changelog.html"
 distfiles="https://downloads.powerdns.com/releases/${pkgname}-${version}.tar.bz2"
-checksum=05f356fcce29c4ece03c2d8df046adff3aaab0b036d6801c1a311c6d5bb3c07f
+checksum=16bab15cad9245571806398a8e4a5dc32a92b6bb60e617c12fe958c945889c7c
 
 system_accounts="_dnsdist"
 


### PR DESCRIPTION
No longer needs/uses libh2o

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-musl
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
