### PR TITLE
[RFC] add EditorConfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,22 @@
+root = true
+
+[*]
+indent_style = tab
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+indent_size = 4
+indent_style = space
+
+[*.{yml,yaml}]
+indent_size = 2
+indent_style = space
+
+[*.{patch,diff}]
+indent_style = unset
+end_of_line = unset
+charset = unset
+trim_trailing_whitespace = unset

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 
 # exclude everything in root except files and directories from void-packages
 /*
+!/.editorconfig
 !/.gitattributes
 !/.github
 !/.gitignore


### PR DESCRIPTION
This PR adds an [EditorConfig](https://editorconfig.org) file to help following the general style used in the repo, along with xlint.

EditorConfig is supported by many editors (see previous link), and automatically adjusts editor settings for indentation, line endings, encoding, etc for a file based on rules. Editors that support it don't act as reformatters when saving; they only use the settings for additions and new files (just as if you has manually changed those settings), which should help new lines and new files follow basic style without user intervention and without generating large "reformat" git diffs[^1].

The exact rules in this PR are just what I surmised to be "the style", namely:
- utf-8, `lf` line-endings, no trailing whitespace at end of lines, and final newline for all files (mostly "files on linux in git")
- 4 space indent for markdown, 2 space indent for YAML
- tab indent for xbps-src and `template`/`update` (done in the everything glob)


[^1]: While that is the case, there are also linters/formatters that can use the `.editorconfig` file if a wholesale reformat is desired.