### PR TITLE
rxvt-unicode: fix for tmux-3.4

### DIFF
--- a/srcpkgs/rxvt-unicode/patches/fix-for-tmux-34.patch
+++ b/srcpkgs/rxvt-unicode/patches/fix-for-tmux-34.patch
@@ -1,0 +1,19 @@
+OSC commands returning the colour sequence must be terminated by either
+of ST, ESC \, or BEL. rxvt-unicode tries to use the same type of termination
+as was in the query but doesn't correctly handle the multiple-char sequence
+used for 7-bit queries. Force to using ESC \ instead for now.
+
+--- a/src/command.C
++++ b/src/command.C
+@@ -3426,9 +3426,9 @@
+         snprintf (rgba_str, sizeof (rgba_str), "rgb:%04x/%04x/%04x", c.r, c.g, c.b);
+ 
+       if (IN_RANGE_INC (color, minCOLOR, maxTermCOLOR))
+-        tt_printf ("\033]%d;%d;%s%c", report, color - minCOLOR, rgba_str, resp);
++        tt_printf ("\033]%d;%d;%s\033\\", report, color - minCOLOR, rgba_str);
+       else
+-        tt_printf ("\033]%d;%s%c", report, rgba_str, resp);
++        tt_printf ("\033]%d;%s\033\\", report, rgba_str, resp);
+     }
+   else
+     set_window_color (color, str);

--- a/srcpkgs/rxvt-unicode/template
+++ b/srcpkgs/rxvt-unicode/template
@@ -1,7 +1,7 @@
 # Template file for 'rxvt-unicode'
 pkgname=rxvt-unicode
 version=9.31
-revision=3
+revision=4
 build_style=gnu-configure
 configure_args="
  --with-terminfo=/usr/share/terminfo --enable-256-color


### PR DESCRIPTION
@leahneukirchen 

closes #48807 

#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl x
  - armv7l x
  - armv6l-musl x
