### PR TITLE
common/chroot-style/uchroot.sh: check if xbps-uchroot is executable

### DIFF
--- a/common/chroot-style/uchroot.sh
+++ b/common/chroot-style/uchroot.sh
@@ -9,12 +9,27 @@ readonly EXTRA_ARGS="$4"
 readonly CMD="$5"
 shift 5
 
-if ! command -v xbps-uchroot >/dev/null 2>&1; then
+msg_red() {
+	# error messages in bold/red
+	[ -n "$NOCOLORS" ] || printf >&2 "\033[1m\033[31m"
+	printf "=> ERROR: %s\\n" "$@" >&2
+	[ -n "$NOCOLORS" ] || printf >&2 "\033[m"
+}
+
+readonly XBPS_UCHROOT_CMD="$(command -v xbps-uchroot 2>/dev/null)"
+
+if [ -z "$XBPS_UCHROOT_CMD" ]; then
+	msg_red "could not find xbps-uchroot"
 	exit 1
 fi
 
-if [ -z "$MASTERDIR" -o -z "$DISTDIR" ]; then
-	echo "$0 MASTERDIR/DISTDIR not set"
+if ! [ -x "$XBPS_UCHROOT_CMD" ]; then
+	msg_red "xbps-uchroot is not executable. Are you in the $(stat -c %G "$XBPS_UCHROOT_CMD") group?"
+	exit 1
+fi
+
+if [ -z "$MASTERDIR" ] || [ -z "$DISTDIR" ]; then
+	msg_red "$0: MASTERDIR/DISTDIR not set"
 	exit 1
 fi
 


### PR DESCRIPTION
...and show a friendly error message

This can be a common failure mode when using `-t` if not in the group `xbps-uchroot` is owned by, because it is SUID. Previously, the error was the cryptic message `ERROR: prctl SECBIT_NOROOT (Operation not permitted)`.

#### Testing the changes
- I tested the changes in this PR: **YES**
