### PR TITLE
hexchat: update to 2.16.2

### DIFF
--- a/srcpkgs/hexchat/template
+++ b/srcpkgs/hexchat/template
@@ -1,7 +1,7 @@
 # Template file for 'hexchat'
 pkgname=hexchat
-version=2.16.1
-revision=7
+version=2.16.2
+revision=1
 build_style=meson
 configure_args="-Ddbus=enabled -Dtls=enabled
  -Dwith-perl=/usr/bin/perl -Dwith-python=python3
@@ -17,7 +17,7 @@ license="GPL-2.0-or-later"
 homepage="https://hexchat.github.io/"
 changelog="https://hexchat.readthedocs.org/en/latest/changelog.html"
 distfiles="https://github.com/hexchat/hexchat/archive/v${version}.tar.gz"
-checksum=f15bc487312a96a902e042e8f197a8494a29bcf4a00bbfd276a5e8154263bfe5
+checksum=486d73cdb6a89fa91cfbe242107901d06e777bea25956a7786c4a831a2caa0e3
 build_options="LuaJIT"
 lib32disabled=yes
 


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, **x86_64**

Final release - https://hexchat.github.io/news/2.16.2.html