### PR TITLE
kbd: update to 2.6.4.

### DIFF
--- a/srcpkgs/kbd/template
+++ b/srcpkgs/kbd/template
@@ -1,6 +1,6 @@
 # Template file for 'kbd'
 pkgname=kbd
-version=2.6.3
+version=2.6.4
 revision=1
 build_style=gnu-configure
 configure_args="--datadir=/usr/share/kbd --localedir=/usr/share/kbd/locale"
@@ -10,8 +10,9 @@ short_desc="Linux keyboard utilities"
 maintainer="Enno Boland <gottox@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="https://www.kbd-project.org/"
+changelog="https://github.com/legionus/kbd/releases"
 distfiles="${KERNEL_SITE}/utils/kbd/kbd-${version}.tar.xz"
-checksum=04996c08d7d1c460966fb244a3d3883352c2674b7ad522003d9f4ecb8ab48deb
+checksum=519f8d087aecca7e0a33cd084bef92c066eb19731666653dcc70c9d71aa40926
 replaces="kbd-data>=0"
 
 post_patch() {


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl
  - i686

Changed the homepage because there is currently an outdated SSL certificate.