### PR TITLE
libxml2: update to 2.12.5.

### DIFF
--- a/srcpkgs/libmusicbrainz5/patches/libxml2-2.12.patch
+++ b/srcpkgs/libmusicbrainz5/patches/libxml2-2.12.patch
@@ -1,0 +1,36 @@
+From 558c9ba0e6d702d5c877f75be98176f57abf1b02 Mon Sep 17 00:00:00 2001
+From: Christopher Degawa <ccom@randomderp.com>
+Date: Sun, 8 Oct 2023 11:42:55 -0500
+Subject: [PATCH] libxml: constify the storage of xmlGetLastError()
+
+libxml2 recently made it a const return.
+Since nothing is being modified of it, this should have no real effect
+past satisfying the compiler.
+
+Signed-off-by: Christopher Degawa <ccom@randomderp.com>
+---
+ src/xmlParser.cc | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/xmlParser.cc b/src/xmlParser.cc
+index 53dec25..fee684c 100644
+--- a/src/xmlParser.cc
++++ b/src/xmlParser.cc
+@@ -57,7 +57,7 @@ XMLNode *XMLRootNode::parseFile(const std::string &filename, XMLResults* results
+ 
+     doc = xmlParseFile(filename.c_str());
+     if ((doc == NULL) && (results != NULL)) {
+-        xmlErrorPtr error = xmlGetLastError();
++        const xmlError *error = xmlGetLastError();
+         results->message = error->message;
+         results->line = error->line;
+         results->code = error->code;
+@@ -72,7 +72,7 @@ XMLNode *XMLRootNode::parseString(const std::string &xml, XMLResults* results)
+ 
+     doc = xmlParseMemory(xml.c_str(), xml.length());
+     if ((doc == NULL) && (results != NULL)) {
+-        xmlErrorPtr error = xmlGetLastError();
++        const xmlError *error = xmlGetLastError();
+         results->message = error->message;
+         results->line = error->line;
+         results->code = error->code;

--- a/srcpkgs/libxml2/patches/0b5650067b4ba37dc0dc1a889a17e96dc1610799.patch
+++ b/srcpkgs/libxml2/patches/0b5650067b4ba37dc0dc1a889a17e96dc1610799.patch
@@ -1,0 +1,98 @@
+From 0b5650067b4ba37dc0dc1a889a17e96dc1610799 Mon Sep 17 00:00:00 2001
+From: Nick Wellnhofer <wellnhofer@aevum.de>
+Date: Mon, 26 Feb 2024 01:03:34 +0100
+Subject: [PATCH] html: Fix htmlCreatePushParserCtxt with encoding
+
+Regression from commit ec7be506.
+
+Fixes #696.
+---
+ HTMLparser.c |  5 ++++-
+ testparser.c | 34 ++++++++++++++++++++++++++++++++++
+ 2 files changed, 38 insertions(+), 1 deletion(-)
+
+diff --git a/HTMLparser.c b/HTMLparser.c
+index 097ed2369..ea6a4f265 100644
+--- a/HTMLparser.c
++++ b/HTMLparser.c
+@@ -5987,7 +5987,7 @@ htmlCreatePushParserCtxt(htmlSAXHandlerPtr sax, void *user_data,
+ 
+     xmlInitParser();
+ 
+-    buf = xmlAllocParserInputBuffer(enc);
++    buf = xmlAllocParserInputBuffer(XML_CHAR_ENCODING_NONE);
+     if (buf == NULL) return(NULL);
+ 
+     ctxt = htmlNewSAXParserCtxt(sax, user_data);
+@@ -6018,6 +6018,9 @@ htmlCreatePushParserCtxt(htmlSAXHandlerPtr sax, void *user_data,
+ 
+     inputPush(ctxt, inputStream);
+ 
++    if (enc != XML_CHAR_ENCODING_NONE)
++        xmlSwitchEncoding(ctxt, enc);
++
+     if ((size > 0) && (chunk != NULL) && (ctxt->input != NULL) &&
+         (ctxt->input->buf != NULL))  {
+ 	size_t pos = ctxt->input->cur - ctxt->input->base;
+diff --git a/testparser.c b/testparser.c
+index e67cea5b1..705e61387 100644
+--- a/testparser.c
++++ b/testparser.c
+@@ -5,6 +5,7 @@
+  */
+ 
+ #include <libxml/parser.h>
++#include <libxml/HTMLparser.h>
+ 
+ static int
+ testStandaloneWithEncoding(void) {
+@@ -86,6 +87,36 @@ testHugeEncodedChunk(void) {
+ }
+ #endif
+ 
++#if defined(LIBXML_HTML_ENABLED) && defined(LIBXML_PUSH_ENABLED)
++static int
++testHtmlPushWithEncoding(void) {
++    htmlParserCtxtPtr ctxt;
++    htmlDocPtr doc;
++    htmlNodePtr node;
++    int err = 0;
++
++    ctxt = htmlCreatePushParserCtxt(NULL, NULL, NULL, 0, NULL,
++                                    XML_CHAR_ENCODING_UTF8);
++    htmlParseChunk(ctxt, "-\xC3\xA4-", 4, 1);
++
++    doc = ctxt->myDoc;
++    if (!xmlStrEqual(doc->encoding, BAD_CAST "UTF-8")) {
++        fprintf(stderr, "testHtmlPushWithEncoding failed\n");
++        err = 1;
++    }
++
++    node = xmlDocGetRootElement(doc)->children->children->children;
++    if (!xmlStrEqual(node->content, BAD_CAST "-\xC3\xA4-")) {
++        fprintf(stderr, "testHtmlPushWithEncoding failed\n");
++        err = 1;
++    }
++
++    xmlFreeDoc(doc);
++    htmlFreeParserCtxt(ctxt);
++    return err;
++}
++#endif
++
+ int
+ main(void) {
+     int err = 0;
+@@ -95,6 +126,9 @@ main(void) {
+     err |= testHugePush();
+     err |= testHugeEncodedChunk();
+ #endif
++#if defined(LIBXML_HTML_ENABLED) && defined(LIBXML_PUSH_ENABLED)
++    err |= testHtmlPushWithEncoding();
++#endif
+ 
+     return err;
+ }
+-- 
+GitLab
+

--- a/srcpkgs/libxml2/patches/387a952bdb7a4364100f009043e94e1bf44c6197.patch
+++ b/srcpkgs/libxml2/patches/387a952bdb7a4364100f009043e94e1bf44c6197.patch
@@ -1,0 +1,85 @@
+From 387a952bdb7a4364100f009043e94e1bf44c6197 Mon Sep 17 00:00:00 2001
+From: Nick Wellnhofer <wellnhofer@aevum.de>
+Date: Mon, 12 Feb 2024 16:45:16 +0100
+Subject: [PATCH] xmllint: Return error code if XPath returns empty nodeset
+
+Return an error code as before but make it possible to distinguish from
+real errors.
+
+Fixes #690.
+---
+ doc/xmllint.xml | 11 ++++++++++-
+ xmllint.c       | 24 +++++++++++++-----------
+ 2 files changed, 23 insertions(+), 12 deletions(-)
+
+diff --git a/doc/xmllint.xml b/doc/xmllint.xml
+index b81da3aa7..8bc665216 100644
+--- a/doc/xmllint.xml
++++ b/doc/xmllint.xml
+@@ -575,7 +575,9 @@
+                     result. In case of a nodeset result, each node in the
+                     node set is serialized in full in the output. In case
+                     of an empty node set the "XPath set is empty" result
+-                    will be shown and an error exit code will be returned.
++                    will be shown and exit code 11 will be returned..
++                    This feature is EXPERIMENTAL. Implementation details can
++                    change without futher notice.
+                 </para>
+             </listitem>
+         </varlistentry>
+@@ -945,6 +947,13 @@
+             </listitem>
+         </varlistentry>
+ 
++        <varlistentry>
++            <term><errorcode>11</errorcode></term>
++            <listitem>
++                <para>XPath result is empty</para>
++            </listitem>
++        </varlistentry>
++
+     </variablelist>
+ </refsect1>
+ 
+diff --git a/xmllint.c b/xmllint.c
+index 21dbe7d24..5c26c3fe8 100644
+--- a/xmllint.c
++++ b/xmllint.c
+@@ -86,17 +86,18 @@
+ #endif
+ 
+ typedef enum {
+-    XMLLINT_RETURN_OK = 0,	/* No error */
+-    XMLLINT_ERR_UNCLASS = 1,	/* Unclassified */
+-    XMLLINT_ERR_DTD = 2,	/* Error in DTD */
+-    XMLLINT_ERR_VALID = 3,	/* Validation error */
+-    XMLLINT_ERR_RDFILE = 4,	/* CtxtReadFile error */
+-    XMLLINT_ERR_SCHEMACOMP = 5,	/* Schema compilation */
+-    XMLLINT_ERR_OUT = 6,	/* Error writing output */
+-    XMLLINT_ERR_SCHEMAPAT = 7,	/* Error in schema pattern */
+-    XMLLINT_ERR_RDREGIS = 8,	/* Error in Reader registration */
+-    XMLLINT_ERR_MEM = 9,	/* Out of memory error */
+-    XMLLINT_ERR_XPATH = 10	/* XPath evaluation error */
++    XMLLINT_RETURN_OK = 0,	    /* No error */
++    XMLLINT_ERR_UNCLASS = 1,	    /* Unclassified */
++    XMLLINT_ERR_DTD = 2,	    /* Error in DTD */
++    XMLLINT_ERR_VALID = 3,	    /* Validation error */
++    XMLLINT_ERR_RDFILE = 4,	    /* CtxtReadFile error */
++    XMLLINT_ERR_SCHEMACOMP = 5,	    /* Schema compilation */
++    XMLLINT_ERR_OUT = 6,	    /* Error writing output */
++    XMLLINT_ERR_SCHEMAPAT = 7,	    /* Error in schema pattern */
++    XMLLINT_ERR_RDREGIS = 8,	    /* Error in Reader registration */
++    XMLLINT_ERR_MEM = 9,	    /* Out of memory error */
++    XMLLINT_ERR_XPATH = 10,	    /* XPath evaluation error */
++    XMLLINT_ERR_XPATH_EMPTY = 11    /* XPath result is empty */
+ } xmllintReturnCode;
+ #ifdef LIBXML_DEBUG_ENABLED
+ static int shell = 0;
+@@ -2019,6 +2020,7 @@ static void doXPathDump(xmlXPathObjectPtr cur) {
+             xmlOutputBufferPtr buf;
+ 
+             if ((cur->nodesetval == NULL) || (cur->nodesetval->nodeNr <= 0)) {
++                progresult = XMLLINT_ERR_XPATH_EMPTY;
+                 if (!quiet) {
+                     fprintf(stderr, "XPath set is empty\n");
+                 }

--- a/srcpkgs/libxml2/patches/4365a5e1153dd5ed7d269d00f8f14daee0fac5c8.patch
+++ b/srcpkgs/libxml2/patches/4365a5e1153dd5ed7d269d00f8f14daee0fac5c8.patch
@@ -1,0 +1,131 @@
+From 4365a5e1153dd5ed7d269d00f8f14daee0fac5c8 Mon Sep 17 00:00:00 2001
+From: Nick Wellnhofer <wellnhofer@aevum.de>
+Date: Mon, 26 Feb 2024 15:14:28 +0100
+Subject: [PATCH] xmlreader: Fix xmlTextReaderConstEncoding
+
+Regression from commit f1c1f5c6.
+
+Fixes #697.
+---
+ SAX2.c                   | 12 +-----------
+ include/private/parser.h |  2 ++
+ parserInternals.c        | 24 ++++++++++++++++++++++++
+ xmlreader.c              | 22 ++++++++++------------
+ 4 files changed, 37 insertions(+), 23 deletions(-)
+
+diff --git a/SAX2.c b/SAX2.c
+index ed21a559..bb72e160 100644
+--- a/SAX2.c
++++ b/SAX2.c
+@@ -955,17 +955,7 @@ xmlSAX2EndDocument(void *ctx)
+ 
+     doc = ctxt->myDoc;
+     if ((doc != NULL) && (doc->encoding == NULL)) {
+-        const xmlChar *encoding = NULL;
+-
+-        if ((ctxt->input->flags & XML_INPUT_USES_ENC_DECL) ||
+-            (ctxt->input->flags & XML_INPUT_AUTO_ENCODING)) {
+-            /* Preserve encoding exactly */
+-            encoding = ctxt->encoding;
+-        } else if ((ctxt->input->buf) && (ctxt->input->buf->encoder)) {
+-            encoding = BAD_CAST ctxt->input->buf->encoder->name;
+-        } else if (ctxt->input->flags & XML_INPUT_HAS_ENCODING) {
+-            encoding = BAD_CAST "UTF-8";
+-        }
++        const xmlChar *encoding = xmlGetActualEncoding(ctxt);
+ 
+         if (encoding != NULL) {
+             doc->encoding = xmlStrdup(encoding);
+diff --git a/include/private/parser.h b/include/private/parser.h
+index 40d179fe..7f8f6912 100644
+--- a/include/private/parser.h
++++ b/include/private/parser.h
+@@ -48,6 +48,8 @@ XML_HIDDEN void
+ xmlDetectEncoding(xmlParserCtxtPtr ctxt);
+ XML_HIDDEN void
+ xmlSetDeclaredEncoding(xmlParserCtxtPtr ctxt, xmlChar *encoding);
++XML_HIDDEN const xmlChar *
++xmlGetActualEncoding(xmlParserCtxtPtr ctxt);
+ 
+ XML_HIDDEN xmlParserNsData *
+ xmlParserNsCreate(void);
+diff --git a/parserInternals.c b/parserInternals.c
+index e6b4cb14..166397bd 100644
+--- a/parserInternals.c
++++ b/parserInternals.c
+@@ -1479,6 +1479,30 @@ xmlSetDeclaredEncoding(xmlParserCtxtPtr ctxt, xmlChar *encoding) {
+     }
+ }
+ 
++/**
++ * xmlGetActualEncoding:
++ * @ctxt:  the parser context
++ *
++ * Returns the actual used to parse the document. This can differ from
++ * the declared encoding.
++ */
++const xmlChar *
++xmlGetActualEncoding(xmlParserCtxtPtr ctxt) {
++    const xmlChar *encoding = NULL;
++
++    if ((ctxt->input->flags & XML_INPUT_USES_ENC_DECL) ||
++        (ctxt->input->flags & XML_INPUT_AUTO_ENCODING)) {
++        /* Preserve encoding exactly */
++        encoding = ctxt->encoding;
++    } else if ((ctxt->input->buf) && (ctxt->input->buf->encoder)) {
++        encoding = BAD_CAST ctxt->input->buf->encoder->name;
++    } else if (ctxt->input->flags & XML_INPUT_HAS_ENCODING) {
++        encoding = BAD_CAST "UTF-8";
++    }
++
++    return(encoding);
++}
++
+ /************************************************************************
+  *									*
+  *	Commodity functions to handle entities processing		*
+diff --git a/xmlreader.c b/xmlreader.c
+index 1f903306..5fdeb2b8 100644
+--- a/xmlreader.c
++++ b/xmlreader.c
+@@ -40,6 +40,7 @@
+ #endif
+ 
+ #include "private/buf.h"
++#include "private/parser.h"
+ #include "private/tree.h"
+ #ifdef LIBXML_XINCLUDE_ENABLED
+ #include "private/xinclude.h"
+@@ -2795,20 +2796,17 @@ xmlTextReaderReadAttributeValue(xmlTextReaderPtr reader) {
+  */
+ const xmlChar *
+ xmlTextReaderConstEncoding(xmlTextReaderPtr reader) {
+-    xmlDocPtr doc = NULL;
++    const xmlChar *encoding = NULL;
++
+     if (reader == NULL)
+-	return(NULL);
+-    if (reader->doc != NULL)
+-        doc = reader->doc;
+-    else if (reader->ctxt != NULL)
+-	doc = reader->ctxt->myDoc;
+-    if (doc == NULL)
+-	return(NULL);
++        return(NULL);
+ 
+-    if (doc->encoding == NULL)
+-	return(NULL);
+-    else
+-      return(CONSTSTR(doc->encoding));
++    if (reader->ctxt != NULL)
++        encoding = xmlGetActualEncoding(reader->ctxt);
++    else if (reader->doc != NULL)
++        encoding = reader->doc->encoding;
++
++    return(CONSTSTR(encoding));
+ }
+ 
+ 
+-- 
+GitLab
+

--- a/srcpkgs/libxml2/template
+++ b/srcpkgs/libxml2/template
@@ -1,8 +1,7 @@
 # Template file for 'libxml2'
 pkgname=libxml2
-reverts="2.12.1_1"
-version=2.11.4
-revision=6
+version=2.12.5
+revision=1
 build_style=gnu-configure
 configure_args="--with-threads --with-history --with-icu
  --with-legacy --with-ftp --with-xptr-locs --enable-static"
@@ -13,14 +12,17 @@ short_desc="Library providing XML and HTML support"
 maintainer="Enno Boland <gottox@voidlinux.org>"
 license="MIT"
 homepage="https://gitlab.gnome.org/GNOME/libxml2"
+changelog="https://gitlab.gnome.org/GNOME/libxml2/-/raw/master/NEWS"
 distfiles="${GNOME_SITE}/libxml2/${version%.*}/libxml2-${version}.tar.xz"
-checksum=737e1d7f8ab3f139729ca13a2494fd17bf30ddb4b7a427cf336252cab57f57f7
+checksum=a972796696afd38073e0f59c283c3a2f5a560b5268b4babc391b286166526b21
 python_version=3
 CFLAGS="-I$XBPS_CROSS_BASE/usr/include/python$py3_ver"
 
 post_extract() {
 	if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
+		# Disable broken encoding conversion tests on musl
 		rm -f test/ebcdic_566012.xml
+		rm -f test/icu_parse_test.xml
 	fi
 }
 

--- a/srcpkgs/osinfo-db-tools/patches/fix-libxml2-2.12.patch
+++ b/srcpkgs/osinfo-db-tools/patches/fix-libxml2-2.12.patch
@@ -1,0 +1,54 @@
+Not currently necessary, but will be with gcc 14
+
+From 34378a4ac257f2f5fcf364786d1634a8c36b304f Mon Sep 17 00:00:00 2001
+From: Michal Privoznik <mprivozn@redhat.com>
+Date: Mon, 27 Nov 2023 15:04:43 +0100
+Subject: [PATCH] Make xmlError structs constant
+
+In libxml2 commits v2.12.0~14 and v2.12.0~77 the API changed so
+that:
+
+1) xmlGetLastError() returns pointer to a constant xmlError
+   struct, and
+
+2) xmlSetStructuredErrorFunc() changed the signature of callback
+   (validate_structured_error_nop()), it too is passed pointer to
+   a constant xmlError struct.
+
+But of course, older libxml2 expects different callback
+signature. Therefore, we need to typecast it anyway.
+
+Also, drop obviously incorrect @error annotation in
+validate_structured_error_nop; the variable is used.
+
+Signed-off-by: Michal Privoznik <mprivozn@redhat.com>
+---
+ tools/osinfo-db-validate.c | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/tools/osinfo-db-validate.c b/tools/osinfo-db-validate.c
+index a721b4d..b1434a6 100644
+--- a/tools/osinfo-db-validate.c
++++ b/tools/osinfo-db-validate.c
+@@ -35,7 +35,7 @@ static void validate_generic_error_nop(void *userData G_GNUC_UNUSED,
+ }
+ 
+ static void validate_structured_error_nop(void *userData G_GNUC_UNUSED,
+-                                          xmlErrorPtr error G_GNUC_UNUSED)
++                                          const xmlError *error)
+ {
+     if (error->file)
+         g_printerr("%s:%d %s", error->file, error->line, error->message);
+@@ -173,7 +173,8 @@ static gboolean validate_files(GFile *schema, gsize nfiles, GFile **files, GErro
+     g_autofree gchar *schemapath = NULL;
+ 
+     xmlSetGenericErrorFunc(NULL, validate_generic_error_nop);
+-    xmlSetStructuredErrorFunc(NULL, validate_structured_error_nop);
++    /* Drop this typecast when >=libxml2-2.12.0 is required */
++    xmlSetStructuredErrorFunc(NULL, (xmlStructuredErrorFunc) validate_structured_error_nop);
+ 
+     schemapath = g_file_get_path(schema);
+     rngParser = xmlRelaxNGNewParserCtxt(schemapath);
+-- 
+GitLab
+

--- a/srcpkgs/qt5-webengine/patches/fix-libxml2-2.12.patch
+++ b/srcpkgs/qt5-webengine/patches/fix-libxml2-2.12.patch
@@ -1,0 +1,34 @@
+Based on: https://github.com/chromium/chromium/commit/871f8ae9b65ce2679b0bc0be36902d65edf0c1e4
+
+diff --git a/third_party/blink/renderer/core/xml/xslt_processor.h b/third_party/blink/renderer/core/xml/xslt_processor.h
+index d53835e9675793e..2eaea31ed29b90f 100644
+--- a/src/3rdparty/chromium/third_party/blink/renderer/core/xml/xslt_processor.h
++++ b/src/3rdparty/chromium/third_party/blink/renderer/core/xml/xslt_processor.h
+@@ -79,7 +79,11 @@ class XSLTProcessor final : public Scrip
+ 
+   void reset();
+ 
++#if LIBXML_VERSION >= 21200
++  static void ParseErrorFunc(void* user_data, const xmlError*);
++#else
+   static void ParseErrorFunc(void* user_data, xmlError*);
++#endif
+   static void GenericErrorFunc(void* user_data, const char* msg, ...);
+ 
+   // Only for libXSLT callbacks
+diff --git a/third_party/blink/renderer/core/xml/xslt_processor_libxslt.cc b/third_party/blink/renderer/core/xml/xslt_processor_libxslt.cc
+index 133e0b3355d2f09..f424077089da87d 100644
+--- a/src/3rdparty/chromium/third_party/blink/renderer/core/xml/xslt_processor_libxslt.cc
++++ b/src/3rdparty/chromium/third_party/blink/renderer/core/xml/xslt_processor_libxslt.cc
+@@ -60,7 +60,11 @@ void XSLTProcessor::GenericErrorFunc(voi
+   // It would be nice to do something with this error message.
+ }
+ 
++#if LIBXML_VERSION >= 21200
++void XSLTProcessor::ParseErrorFunc(void* user_data, const xmlError* error) {
++#else
+ void XSLTProcessor::ParseErrorFunc(void* user_data, xmlError* error) {
++#endif
+   FrameConsole* console = static_cast<FrameConsole*>(user_data);
+   if (!console)
+     return;

--- a/srcpkgs/qt6-pdf/patches/fix-libxml2-2.12.patch
+++ b/srcpkgs/qt6-pdf/patches/fix-libxml2-2.12.patch
@@ -1,0 +1,34 @@
+Based on: https://github.com/chromium/chromium/commit/871f8ae9b65ce2679b0bc0be36902d65edf0c1e4
+
+diff --git a/third_party/blink/renderer/core/xml/xslt_processor.h b/third_party/blink/renderer/core/xml/xslt_processor.h
+index d53835e9675793e..2eaea31ed29b90f 100644
+--- a/src/3rdparty/chromium/third_party/blink/renderer/core/xml/xslt_processor.h
++++ b/src/3rdparty/chromium/third_party/blink/renderer/core/xml/xslt_processor.h
+@@ -79,7 +79,11 @@ class XSLTProcessor final : public Scrip
+ 
+   void reset();
+ 
++#if LIBXML_VERSION >= 21200
++  static void ParseErrorFunc(void* user_data, const xmlError*);
++#else
+   static void ParseErrorFunc(void* user_data, xmlError*);
++#endif
+   static void GenericErrorFunc(void* user_data, const char* msg, ...);
+ 
+   // Only for libXSLT callbacks
+diff --git a/third_party/blink/renderer/core/xml/xslt_processor_libxslt.cc b/third_party/blink/renderer/core/xml/xslt_processor_libxslt.cc
+index 133e0b3355d2f09..f424077089da87d 100644
+--- a/src/3rdparty/chromium/third_party/blink/renderer/core/xml/xslt_processor_libxslt.cc
++++ b/src/3rdparty/chromium/third_party/blink/renderer/core/xml/xslt_processor_libxslt.cc
+@@ -60,7 +60,11 @@ void XSLTProcessor::GenericErrorFunc(voi
+   // It would be nice to do something with this error message.
+ }
+ 
++#if LIBXML_VERSION >= 21200
++void XSLTProcessor::ParseErrorFunc(void* user_data, const xmlError* error) {
++#else
+ void XSLTProcessor::ParseErrorFunc(void* user_data, xmlError* error) {
++#endif
+   FrameConsole* console = static_cast<FrameConsole*>(user_data);
+   if (!console)
+     return;

--- a/srcpkgs/recoll/patches/musl.patch
+++ b/srcpkgs/recoll/patches/musl.patch
@@ -27,11 +27,11 @@ diff --git a/common/conf_post.h b/common/conf_post.h
 index 7093ead..0ecd56b 100644
 --- a/common/conf_post.h
 +++ b/common/conf_post.h
-@@ -73,12 +73,4 @@ typedef int ssize_t;
+@@ -74,12 +74,4 @@ typedef int ssize_t;
  #define REAL_GCC   __GNUC__ // probably
  #endif
  
--#ifdef REAL_GCC
+-#if defined(REAL_GCC) && defined(HAVE_FEATURES_H)
 -// Older gcc versions pretended to supply std::regex, but the resulting programs mostly crashed.
 -#include <features.h>
 -#if ! __GNUC_PREREQ(6,0)

--- a/srcpkgs/recoll/template
+++ b/srcpkgs/recoll/template
@@ -1,7 +1,7 @@
 # Template file for 'recoll'
 pkgname=recoll
-version=1.32.7
-revision=3
+version=1.37.4
+revision=1
 build_style=gnu-configure
 build_helper="qmake python3"
 configure_args="--enable-recollq --disable-python-chm --disable-x11mon
@@ -9,10 +9,10 @@ configure_args="--enable-recollq --disable-python-chm --disable-x11mon
 hostmakedepends="pkg-config gettext-devel qt5-qmake qt5-host-tools
  which python3-setuptools"
 makedepends="libxslt-devel xapian-core-devel zlib-devel qt5-devel
- python3-devel"
+ python3-devel aspell-devel"
 short_desc="Full text search tool based on Xapian backend"
 maintainer="Rui Abreu Ferreira <raf-ep@gmx.com>"
 license="GPL-2.0-or-later"
 homepage="https://www.lesbonscomptes.com/recoll/"
 distfiles="https://www.lesbonscomptes.com/recoll/recoll-${version}.tar.gz"
-checksum=ca08a6f4bb0b519bf915a062a9b7aadc4f343473cc1f07895708208d66337dba
+checksum=3109d76a65bb2f887231b643994ed701c2efe6ba0771f8451b39e2f186c3b6ad

--- a/srcpkgs/squid/template
+++ b/srcpkgs/squid/template
@@ -1,7 +1,7 @@
 # Template file for 'squid'
 pkgname=squid
-version=5.7
-revision=4
+version=6.7
+revision=1
 build_style=gnu-configure
 configure_args="
  --sysconfdir=/etc/squid
@@ -52,9 +52,9 @@ short_desc="Caching proxy for the Web"
 maintainer="Toyam Cox <Vaelatern@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="http://www.squid-cache.org/"
-changelog="http://www.squid-cache.org/Versions/v5/changesets/"
-distfiles="http://www.squid-cache.org/Versions/v5/squid-${version}.tar.xz"
-checksum=6b0753aaba4c9c4efd333e67124caecf7ad6cc2d38581f19d2f0321f5b7ecd81
+changelog="http://www.squid-cache.org/Versions/v${version%%.*}/changesets/"
+distfiles="http://www.squid-cache.org/Versions/v${version%%.*}/squid-${version}.tar.xz"
+checksum=e14daa4eae41925d1ae3f08e64439a6aaa3011bdced686628b8de697d5ab8428
 system_accounts="squid"
 # squid-conf-tests requires a squid user in the system
 make_check=no

--- a/srcpkgs/xmlsec1/template
+++ b/srcpkgs/xmlsec1/template
@@ -1,6 +1,6 @@
 # Template file for 'xmlsec1'
 pkgname=xmlsec1
-version=1.3.2
+version=1.3.3
 revision=1
 build_style=gnu-configure
 hostmakedepends="pkg-config"
@@ -11,8 +11,8 @@ maintainer="Enno Boland <gottox@voidlinux.org>"
 license="MIT"
 homepage="https://www.aleksey.com/xmlsec/"
 changelog="https://www.aleksey.com/xmlsec/news.html"
-distfiles="https://www.aleksey.com/xmlsec/download/xmlsec1-${version}.tar.gz"
-checksum=4003c56b3d356d21b1db7775318540fad6bfedaf5f117e8f7c010811219be3cf
+distfiles="https://github.com/lsh123/xmlsec/releases/download/${version}/xmlsec1-${version}.tar.gz"
+checksum=ab5b9a9ffd6960f46f7466d9d91f174ec37e8c31989237ba6b9eacdd816464f2
 
 post_install() {
 	if [ "$CROSS_BUILD" ]; then


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

I tested building all packages depending on libxml2.
~~The only other build failure not addressed is vtk, which is gcc 13 related.~~
This depends on https://github.com/void-linux/void-packages/pull/48824

cc: @classabbyamp 

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
