### PR TITLE
ferium: update to 4.5.2.

### DIFF
--- a/srcpkgs/ferium/template
+++ b/srcpkgs/ferium/template
@@ -1,6 +1,6 @@
 # Template file for 'ferium'
 pkgname=ferium
-version=4.5.0
+version=4.5.2
 revision=1
 build_style=cargo
 build_helper=qemu
@@ -11,7 +11,7 @@ license="MPL-2.0"
 homepage="https://github.com/gorilla-devs/ferium"
 changelog="https://raw.githubusercontent.com/gorilla-devs/ferium/main/CHANGELOG.md"
 distfiles="https://github.com/gorilla-devs/ferium/archive/refs/tags/v${version}.tar.gz"
-checksum=c9b54673a494cecabfc62a48d03d504b6fea00af1b749c3ccb210021f8528bf0
+checksum=5b4fde3eee2336c4874d8bf5c412e019843f9cef018f750bbb4c51c1fceb9484
 
 post_install() {
 	local ferium="${DESTDIR}/usr/bin/ferium"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, (`x86_64-glibc`)