### PR TITLE
xbps-src: don't mess with masterdir set in argv

### DIFF
--- a/xbps-src
+++ b/xbps-src
@@ -536,6 +536,8 @@ fi
 # unless in a container for simplicity of container/CI usage
 if [ "$XBPS_CHROOT_CMD" = ethereal ]; then
     : "${XBPS_MASTERDIR:=$XBPS_DISTDIR/masterdir}"
+elif [ -n "$XBPS_ARG_MASTERDIR" ]; then
+    : # Don't mess with masterdir in argv
 else
     : "${XBPS_MASTERDIR:=$XBPS_DISTDIR/masterdir-$XBPS_MACHINE}"
     # but use $XBPS_DISTDIR/masterdir if it exists and the new style doesn't


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**|**briefly**|**NO**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
