### PR TITLE
New package: auto-cpufreq-2.2.0

### DIFF
--- a/srcpkgs/auto-cpufreq/files/README.voidlinux
+++ b/srcpkgs/auto-cpufreq/files/README.voidlinux
@@ -1,0 +1,4 @@
+If you are using GNOME or KDE, you should turn off the Power Profiles daemon.
+This can turn it off permanently using the following command:
+
+# touch /etc/sv/power-profiles-daemon/down

--- a/srcpkgs/auto-cpufreq/files/auto-cpufreq/run
+++ b/srcpkgs/auto-cpufreq/files/auto-cpufreq/run
@@ -1,0 +1,3 @@
+#!/bin/sh
+exec 2>&1
+exec auto-cpufreq --daemon

--- a/srcpkgs/auto-cpufreq/patches/disable_poetry_dynamic_versioning.patch
+++ b/srcpkgs/auto-cpufreq/patches/disable_poetry_dynamic_versioning.patch
@@ -1,0 +1,25 @@
+The pyproject.toml already sets the correct version, so the version detection
+system doesn't even have to be replaced.
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -32,18 +32,12 @@
+ poetry = "^1.6.1"
+ 
+ [build-system]
+-requires = ["poetry-core>=1.0.0", "poetry-dynamic-versioning>=1.0.0,<2.0.0"]
+-build-backend = "poetry_dynamic_versioning.backend"
++requires = ["poetry-core>=1.0.0"]
++build-backend = "poetry.core.masonry.api"
+ 
+ [tool.poetry.scripts]
+ auto-cpufreq = "auto_cpufreq.bin.auto_cpufreq:main"
+ auto-cpufreq-gtk = "auto_cpufreq.bin.auto_cpufreq_gtk:main"
+ 
+-# https://github.com/mtkennerly/poetry-dynamic-versioning
+-[tool.poetry-dynamic-versioning]
+-enable = true
+-vcs = "git"
+-format = "v{base}+{commit}"
+-
+ # SideNote
+ # Regarding zip_safe = https://setuptools.pypa.io/en/latest/deprecated/zip_safe.html

--- a/srcpkgs/auto-cpufreq/patches/fix_icon_n_style_locations.patch
+++ b/srcpkgs/auto-cpufreq/patches/fix_icon_n_style_locations.patch
@@ -1,0 +1,15 @@
+This patch is taken from
+https://aur.archlinux.org/cgit/aur.git/tree/001-fix-icon-n-style-locations.patch?h=auto-cpufreq&id=2cb3f7935e7e0252e15d8dbcf1309ab246e143cf
+--- a/auto_cpufreq/gui/app.py
++++ b/auto_cpufreq/gui/app.py
+@@ -20,8 +20,8 @@
+     ICON_FILE = "/snap/auto-cpufreq/current/icon.png"
+     CSS_FILE = "/snap/auto-cpufreq/current/style.css"
+ else:
+-    ICON_FILE = "/usr/local/share/auto-cpufreq/images/icon.png"
+-    CSS_FILE = "/usr/local/share/auto-cpufreq/scripts/style.css"
++    ICON_FILE = "/usr/share/pixmaps/auto-cpufreq.png"
++    CSS_FILE = "/usr/share/auto-cpufreq/scripts/style.css"
+ 
+ HBOX_PADDING = 20
+ PKEXEC_ERROR = "Error executing command as another user: Not authorized\n\nThis incident has been reported.\n"

--- a/srcpkgs/auto-cpufreq/patches/fix_other_icon_path.patch
+++ b/srcpkgs/auto-cpufreq/patches/fix_other_icon_path.patch
@@ -1,0 +1,13 @@
+This patch is taken from
+https://aur.archlinux.org/cgit/aur.git/tree/002-fix-other-icon-path.patch?h=auto-cpufreq&id=2cb3f7935e7e0252e15d8dbcf1309ab246e143cf
+--- a/auto_cpufreq/gui/objects.py
++++ b/auto_cpufreq/gui/objects.py
+@@ -221,7 +221,7 @@
+         self.add_button("Close", Gtk.ResponseType.CLOSE)
+         self.set_default_size(400, 350)
+         img_buffer = GdkPixbuf.Pixbuf.new_from_file_at_scale(
+-                    filename="/usr/local/share/auto-cpufreq/images/icon.png",
++                    filename="/usr/share/pixmaps/auto-cpufreq.png",
+                     width=150,
+                     height=150,
+                     preserve_aspect_ratio=True)

--- a/srcpkgs/auto-cpufreq/template
+++ b/srcpkgs/auto-cpufreq/template
@@ -1,0 +1,36 @@
+# Template file for 'auto-cpufreq'
+pkgname=auto-cpufreq
+version=2.3.0
+revision=1
+build_style=python3-pep517
+# auto-cpufreq is executed in post_install() to get completions, so masterdir
+# needs part of $depends installed
+_core_deps="python3-click python3-psutil python3-distro python3-requests python3-inotify"
+hostmakedepends="python3-poetry-core $_core_deps"
+depends="$_core_deps dmidecode python3-gobject gtk+3"
+short_desc="Automatic CPU speed & power optimizer for Linux"
+maintainer="meator <meator.dev@gmail.com>"
+license="LGPL-3.0-only"
+homepage="https://github.com/AdnanHodzic/auto-cpufreq"
+distfiles="https://github.com/AdnanHodzic/auto-cpufreq/archive/refs/tags/v${version}.tar.gz"
+checksum=dba5a29a23b209f4ab398fd355cd9214353699e59df83d3eeb001a83a659cb00
+
+post_patch() {
+	patch -Np1 < nix/patches/prevent-install-and-copy.patch
+}
+
+post_install() {
+	vsconf auto-cpufreq.conf-example auto-cpufreq.conf
+	vinstall scripts/auto-cpufreq-gtk.desktop 644 usr/share/applications
+	vinstall images/icon.png 644 usr/share/pixmaps auto-cpufreq.png
+	vinstall scripts/style.css 644 usr/share/auto-cpufreq/scripts
+	vbin scripts/cpufreqctl.sh cpufreqctl.auto-cpufreq
+	vinstall scripts/org.auto-cpufreq.pkexec.policy 644 usr/share/polkit-1/actions
+	vdoc ${FILESDIR}/README.voidlinux
+	vsv auto-cpufreq
+
+	for completion in bash fish zsh; do
+		PYTHONPATH=$DESTDIR/$py3_sitelib _AUTO_CPUFREQ_COMPLETE=${completion}_source ${DESTDIR}/usr/bin/auto-cpufreq > auto-cpufreq.$completion
+		vcompletion auto-cpufreq.$completion $completion
+	done
+}


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

`auto-cpufreq` is doing some weeeeird stuff in `auto_cpufreq/core.py`. I will likely have to patch out a lot of things there.

#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
