### PR TITLE
New package: jbig2enc-0.29

### DIFF
--- a/srcpkgs/jbig2enc/patches/libleptonica-update.patch
+++ b/srcpkgs/jbig2enc/patches/libleptonica-update.patch
@@ -1,0 +1,70 @@
+From a614bdb580d65653dbfe5c9925940797a065deac Mon Sep 17 00:00:00 2001
+From: Federico <19206300+quaqo@users.noreply.github.com>
+Date: Sun, 8 Jan 2023 14:12:51 +0100
+Subject: [PATCH] Fix build with Leptonica >=1.83
+
+From leptonica 1.83 release notes:
+ * Use stdatomic.h to make cloning string safe. Remove all *GetRefcount() and *ChangeRefcount() accessors.
+ * Remove information about fields in many structs from the public interface allheaders.h, instead putting them in internal files pix_internal.h, array_internal.h and ccbord_internal.h.
+---
+ src/jbig2.cc    | 3 +++
+ src/jbig2enc.cc | 8 ++++++++
+ src/jbig2sym.cc | 4 ++++
+ 3 files changed, 15 insertions(+)
+
+diff --git a/src/jbig2.cc b/src/jbig2.cc
+index 0bddb90..baf62ea 100644
+--- a/src/jbig2.cc
++++ b/src/jbig2.cc
+@@ -29,6 +29,9 @@
+ #endif
+ 
+ #include <leptonica/allheaders.h>
++#if (LIBLEPT_MAJOR_VERSION == 1 && LIBLEPT_MINOR_VERSION >= 83) || LIBLEPT_MAJOR_VERSION > 1
++#include "leptonica/pix_internal.h"
++#endif
+ 
+ #include "jbig2enc.h"
+ 
+diff --git a/src/jbig2enc.cc b/src/jbig2enc.cc
+index 7603696..524b26f 100644
+--- a/src/jbig2enc.cc
++++ b/src/jbig2enc.cc
+@@ -24,6 +24,10 @@
+ #include <string.h>
+ 
+ #include <leptonica/allheaders.h>
++#if (LIBLEPT_MAJOR_VERSION == 1 && LIBLEPT_MINOR_VERSION >= 83) || LIBLEPT_MAJOR_VERSION > 1
++#include "leptonica/pix_internal.h"
++#include "leptonica/array_internal.h"
++#endif
+ 
+ #include <math.h>
+ #if defined(sun)
+@@ -206,7 +210,11 @@ unite_templates(struct jbig2ctx *ctx,
+         numaSetValue(ctx->classer->naclass, i, new_representant);
+       }
+     }
++#if (LIBLEPT_MAJOR_VERSION == 1 && LIBLEPT_MINOR_VERSION >= 83) || LIBLEPT_MAJOR_VERSION > 1
++    ctx->classer->pixat->pix[new_representant]->refcount += ctx->classer->pixat->pix[second_template]->refcount;
++#else
+     pixChangeRefcount(ctx->classer->pixat->pix[new_representant],pixGetRefcount(ctx->classer->pixat->pix[second_template]));
++#endif
+   }
+   return 0;
+ }
+diff --git a/src/jbig2sym.cc b/src/jbig2sym.cc
+index b419b71..43d2ff9 100644
+--- a/src/jbig2sym.cc
++++ b/src/jbig2sym.cc
+@@ -29,6 +29,10 @@
+ #include <stdio.h>
+ 
+ #include <leptonica/allheaders.h>
++#if (LIBLEPT_MAJOR_VERSION == 1 && LIBLEPT_MINOR_VERSION >= 83) || LIBLEPT_MAJOR_VERSION > 1
++#include "leptonica/pix_internal.h"
++#include "leptonica/array_internal.h"
++#endif
+ 
+ #include <math.h>
+ 

--- a/srcpkgs/jbig2enc/patches/rename-liblept-libleptonica.patch
+++ b/srcpkgs/jbig2enc/patches/rename-liblept-libleptonica.patch
@@ -1,0 +1,24 @@
+From d211d8c9c65fbc103594580484a3b7fa0249e160 Mon Sep 17 00:00:00 2001
+From: Federico <19206300+quaqo@users.noreply.github.com>
+Date: Sun, 8 Jan 2023 20:15:45 +0100
+Subject: [PATCH] Fix autotools with leptonica >= 1.83
+
+From leptonica 1.83 release notes:
+* Rename the autotools generated libraries from liblept to libleptonica
+---
+ configure.ac | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/configure.ac b/configure.ac
+index 3b8404b..b38f11e 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -73,7 +73,7 @@ AC_CONFIG_COMMANDS([libtool-rpath-patch],
+ 	fi],
+ [libtool_patch_use_rpath=$enable_rpath])
+ 
+-AC_CHECK_LIB([lept], [findFileFormatStream], [], [
++AC_CHECK_LIB([leptonica], [findFileFormatStream], [], [
+ 			echo "Error! Leptonica not detected."
+ 			exit -1
+ 			])

--- a/srcpkgs/jbig2enc/template
+++ b/srcpkgs/jbig2enc/template
@@ -1,0 +1,19 @@
+# Template file for 'jbig2enc'
+pkgname=jbig2enc
+version=0.29
+revision=1
+build_style=gnu-configure
+hostmakedepends="autoconf automake pkg-config libtool"
+makedepends="leptonica-devel tiff-devel libpng-devel giflib-devel libwebp-devel"
+depends="python3"
+short_desc="JBIG2 Encoder"
+maintainer="David Chen <dchen07@protonmail.com>"
+license="Apache-2.0"
+homepage="https://github.com/agl/jbig2enc"
+distfiles="https://github.com/agl/jbig2enc/archive/refs/tags/${version}.tar.gz"
+checksum=bfcf0d0448ee36046af6c776c7271cd5a644855723f0a832d1c0db4de3c21280
+python_version="3"
+
+pre_configure() {
+	./autogen.sh
+}


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

jbig2enc upstream has been sparsely maintained for a few years, only commits have been bug fixes without a new release tag, with the most recent two patches being necessary for libleptonia linkage.

I personally use this package alongside `ocrmypdf` (via pipx), though `jbig2enc` might not offer much of value to most users.

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl
  - i686
  - aarch64 (cross)
