### PR TITLE
xbps-triggers: gtk-icon-cache with gtk4

### DIFF
--- a/srcpkgs/xbps-triggers/files/gtk-icon-cache
+++ b/srcpkgs/xbps-triggers/files/gtk-icon-cache
@@ -15,6 +15,7 @@ VERSION="$4"
 UPDATE="$5"
 
 iconcache_bin=usr/bin/gtk-update-icon-cache
+gtk4_iconcache=usr/bin/gtk4-update-icon-cache
 
 case "$ACTION" in
 targets)
@@ -42,6 +43,7 @@ run)
 			if [ -d ".${dir}" ]; then
 				echo -n "Updating GTK+ icon cache for "
 				echo "${dir}..."
+				${gtk4_iconcache} -q -f -t .${dir} ||
 				${iconcache_bin} -q -f -t .${dir}
 			fi
 		done

--- a/srcpkgs/xbps-triggers/template
+++ b/srcpkgs/xbps-triggers/template
@@ -1,6 +1,6 @@
 # Template file for 'xbps-triggers'
 pkgname=xbps-triggers
-version=0.127
+version=0.128
 revision=1
 bootstrap=yes
 short_desc="XBPS triggers for Void Linux"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
