### PR TITLE
acpid: Only read cpuinfo_{min,max}_freq when needed

### DIFF
--- a/srcpkgs/acpid/files/handler.sh
+++ b/srcpkgs/acpid/files/handler.sh
@@ -14,8 +14,8 @@ step_backlight() {
     done
 }
 
-minspeed=$(cat /sys/devices/system/cpu/cpu0/cpufreq/cpuinfo_min_freq)
-maxspeed=$(cat /sys/devices/system/cpu/cpu0/cpufreq/cpuinfo_max_freq)
+minspeed="/sys/devices/system/cpu/cpu0/cpufreq/cpuinfo_min_freq"
+maxspeed="/sys/devices/system/cpu/cpu0/cpufreq/cpuinfo_max_freq"
 setspeed="/sys/devices/system/cpu/cpu0/cpufreq/scaling_setspeed"
 
 
@@ -44,11 +44,11 @@ case "$1" in
             AC|ACAD|ADP0)
                 case "$4" in
                     00000000)
-                        printf '%s' "$minspeed" >"$setspeed"
+                        cat "$minspeed" >"$setspeed"
                         #/etc/laptop-mode/laptop-mode start
                     ;;
                     00000001)
-                        printf '%s' "$maxspeed" >"$setspeed"
+                        cat "$maxspeed" >"$setspeed"
                         #/etc/laptop-mode/laptop-mode stop
                     ;;
                 esac

--- a/srcpkgs/acpid/template
+++ b/srcpkgs/acpid/template
@@ -1,7 +1,7 @@
 # Template file for 'acpid'
 pkgname=acpid
 version=2.0.34
-revision=2
+revision=3
 build_style=gnu-configure
 short_desc="ACPI Daemon (acpid) With Netlink Support"
 maintainer="Enno Boland <gottox@voidlinux.org>"


### PR DESCRIPTION
Previously handler.sh would unconditionally fork/exec 'cat' twice to read these files on any invocation, though their values are only used for ac_adapter events.  Tidy it up to only read them when handling that case.

#### Testing the changes
- I tested the changes in this PR: **briefly**
