### PR TITLE
zsh-history-substring-search: update to 1.1.0.

### DIFF
--- a/srcpkgs/zsh-history-substring-search/template
+++ b/srcpkgs/zsh-history-substring-search/template
@@ -1,14 +1,14 @@
 # Template file for 'zsh-history-substring-search'
 pkgname=zsh-history-substring-search
-version=1.0.2
-revision=2
+version=1.1.0
+revision=1
 depends="zsh"
 short_desc="Fish-like history search feature for zsh"
 maintainer="Young-Jin Park <youngjinpark20@gmail.com>"
 license="BSD-3-Clause"
 homepage="https://github.com/zsh-users/zsh-history-substring-search"
 distfiles="${homepage}/archive/v${version}.tar.gz"
-checksum=c1bb21490bd31273fb511b23000fb7caf49c258a79c4b8842f3e1f2ff76fd84c
+checksum=9b52eca6c894dd98caa5f07160199f3f3179ff017575d5acc9fdc467b1ac70f8
 
 do_install() {
 	vinstall ${pkgname}.zsh 644 usr/share/zsh/plugins/${pkgname}


### PR DESCRIPTION

#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc

