### PR TITLE
puzzles: update to 20240102.7a93ae5d.

### DIFF
--- a/srcpkgs/puzzles/template
+++ b/srcpkgs/puzzles/template
@@ -1,6 +1,6 @@
 # Template file for 'puzzles'
 pkgname=puzzles
-version=20231010.2d9e414
+version=20240102.7a93ae5
 revision=1
 build_style=cmake
 configure_args="-DNAME_PREFIX=puzzles-"
@@ -10,8 +10,8 @@ short_desc="Simon Tatham's Portable Puzzle Collection"
 maintainer="Leah Neukirchen <leah@vuxu.org>"
 license="MIT"
 homepage="https://www.chiark.greenend.org.uk/~sgtatham/puzzles/"
-distfiles="https://git.tartarus.org/?p=simon/puzzles.git;a=snapshot;h=2d9e414ee316b37143954150016e8f4f18358497;sf=tgz>${pkgname}-${version#*.}.tgz"
-checksum=cf2a20981de3eac20c4a44bcc53c1bc77fbd407f5fdc09d79b7eeda9d04ae384
+distfiles="https://git.tartarus.org/?p=simon/puzzles.git;a=snapshot;h=7a93ae5d3c90cb5d1d8d775a8cd9d30bc745f658;sf=tgz>${pkgname}-${version#*.}.tgz"
+checksum=a164b49f4868be8d4a7b004949c630083ef131ab5c27de221c761a9329c518c9
 
 post_install() {
 	vlicense LICENCE LICENSE


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture: **x86_64**