### PR TITLE
cookiecutter: update to 2.6.0

### DIFF
--- a/srcpkgs/cookiecutter/template
+++ b/srcpkgs/cookiecutter/template
@@ -1,6 +1,6 @@
 # Template file for 'cookiecutter'
 pkgname=cookiecutter
-version=2.5.0
+version=2.6.0
 revision=1
 build_style=python3-module
 hostmakedepends="python3-setuptools"
@@ -13,7 +13,7 @@ license="BSD-3-Clause"
 homepage="https://github.com/cookiecutter/cookiecutter"
 changelog="https://raw.githubusercontent.com/cookiecutter/cookiecutter/main/HISTORY.md"
 distfiles="${PYPI_SITE}/c/cookiecutter/cookiecutter-${version}.tar.gz"
-checksum=e61e9034748e3f41b8bd2c11f00d030784b48711c4d5c42363c50989a65331ec
+checksum=db21f8169ea4f4fdc2408d48ca44859349de2647fbe494a9d6c3edfc0542c21c
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
