### PR TITLE
mdbook-toc: Fix mdbook warning

### DIFF
--- a/srcpkgs/mdbook-toc/template
+++ b/srcpkgs/mdbook-toc/template
@@ -1,7 +1,7 @@
 # Template file for 'mdbook-toc'
 pkgname=mdbook-toc
 version=0.14.2
-revision=1
+revision=2
 build_style=cargo
 short_desc="Preprocessor for mdbook to add inline TOC support"
 maintainer="Orphaned <orphan@voidlinux.org>"


### PR DESCRIPTION
mdbook complains that mdbook-toc was built against mdbook version 0.4.36 which is outdated now:

```
Warning: The mdbook-toc preprocessor was built against version 0.4.36 of mdbook, but we're being called from version 0.4.37
```

There are probably more elegant and future proof ways to solve this (one of which is just ignoring the warning because it's a warning and not an error), but bumping mdbook-toc fixes it too.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
