### PR TITLE
gthumb: update to 3.12.5, disable Flickr integration

### DIFF
--- a/srcpkgs/gthumb/template
+++ b/srcpkgs/gthumb/template
@@ -1,29 +1,29 @@
 # Template file for 'gthumb'
 pkgname=gthumb
-version=3.12.4
-revision=2
+version=3.12.5
+revision=1
 build_style=meson
+configure_args="-Dwebservices=false"
 hostmakedepends="gettext pkg-config itstool glib-devel"
-makedepends="webkit2gtk-devel json-glib-devel libsecret-devel librsvg-devel
+makedepends="json-glib-devel libsecret-devel librsvg-devel
  libwebp-devel exiv2-devel gtk+3-devel libraw-devel libchamplain-devel
  colord-devel gsettings-desktop-schemas-devel libheif-devel libgomp-devel
  $(vopt_if brasero brasero-devel) $(vopt_if clutter 'clutter-devel clutter-gtk-devel')
- $(vopt_if gstreamer gstreamer1-devel) $(vopt_if soup libsoup-devel)"
+ $(vopt_if gstreamer gstreamer1-devel)"
 short_desc='Image viewer and browser for the GNOME Desktop'
 maintainer="Bnyro <bnyro@tutanota.com>"
 license="GPL-2.0-or-later"
 homepage="https://wiki.gnome.org/action/show/Apps/Gthumb"
 changelog="https://gitlab.gnome.org/GNOME/gthumb/-/raw/master/NEWS"
 distfiles="${GNOME_SITE}/gthumb/${version%.*}/gthumb-${version}.tar.xz"
-checksum=add693ac0aeb9a30d829ba03a06208289d3f6868dc3b02573549e88190c794e8
+checksum=f6385df45fe8c7262ec349e13f81512e90e99798dd2377932e4291d63359f3ab
 
 LDFLAGS="-fPIC"
 
-build_options="brasero clutter gstreamer soup"
+build_options="brasero clutter gstreamer"
 desc_option_brasero="Enable burning discs"
 desc_option_clutter="Enable clutter (for slideshows)"
-desc_option_soup="Enable webservices"
-build_options_default="clutter gstreamer soup"
+build_options_default="clutter gstreamer"
 
 post_install() {
 	vdoc $FILESDIR/README.voidlinux


### PR DESCRIPTION
Relies on libwebkit2gtk-4.0, which is becoming increasingly burdensome. Also relies on libsoup2.

Re-enable when upstream fixes that:
https://gitlab.gnome.org/GNOME/gthumb/-/issues/244

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

cc: @Bnyro 

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
