### PR TITLE
libsoup: update to 2.74.3.

### DIFF
--- a/srcpkgs/libsoup/template
+++ b/srcpkgs/libsoup/template
@@ -1,6 +1,6 @@
 # Template file for 'libsoup'
 pkgname=libsoup
-version=2.74.0
+version=2.74.3
 revision=1
 build_style=meson
 build_helper="gir"
@@ -17,7 +17,7 @@ license="LGPL-2.1-or-later"
 homepage="https://wiki.gnome.org/Projects/libsoup"
 changelog="https://gitlab.gnome.org/GNOME/libsoup/-/raw/libsoup-2-74/NEWS"
 distfiles="${GNOME_SITE}/libsoup/${version%.*}/libsoup-${version}.tar.xz"
-checksum=33b1d4e0d639456c675c227877e94a8078d731233e2d57689c11abcef7d3c48e
+checksum=e4b77c41cfc4c8c5a035fcdc320c7bc6cfb75ef7c5a034153df1413fa1d92f13
 make_check=no # gio tests can't run in chroot
 
 # Package build options


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

Note: Updating to this version adds checks such that applications mixing libsoup3 and libsoup2 will abort with an error message.

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
