### PR TITLE
zutty: update to 0.15

### DIFF
--- a/srcpkgs/zutty/template
+++ b/srcpkgs/zutty/template
@@ -1,7 +1,9 @@
 # Template file for 'zutty'
 pkgname=zutty
-version=0.14
+version=0.15
 revision=1
+_githash=7e481c04507e9b5cacfe67fe2b96bdb449b08726
+_gitshort="${_githash:0:7}"
 build_style=waf3
 hostmakedepends="pkg-config"
 makedepends="libglvnd-devel freetype-devel libXmu-devel"
@@ -10,8 +12,8 @@ short_desc="X terminal emulator rendering through OpenGL ES Compute Shaders"
 maintainer="Javier Caballero <jacallo@protonmail.com>"
 license="GPL-3.0-or-later"
 homepage="https://tomscii.sig7.se/zutty"
-distfiles="https://github.com/tomscii/zutty/archive/refs/tags/${version}.tar.gz"
-checksum=6de17d6b7a3fe6991df30ba1ca7d6a08e605369cf92247deeb19758379b5af2f
+distfiles="https://git.hq.sig7.se/zutty.git/snapshot/${_githash}.tar.gz"
+checksum=65ef7896476de83a29183a16bcc4bd2c2e92218b4cd0817f5d98a8c1fdd1e51e
 
 post_install() {
 	# Copy icons


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl (cross)
  - aarch64 (cross)
  - aarch64-musl (cross)
  - armv7l (cross)
  - armv7l-musl (cross)
  - armv6l (cross)
  - armv6l-musl (cross)

#### Project migrated
The project has been migrated to a new home. It uses gitweb interface and does not provide a releases page like previously, so I had to mimic other templates like that off the "guilt" package.