### PR TITLE
refind: account for btrfs setups when generating manual stanzas

### DIFF
--- a/srcpkgs/refind/files/kernel.post-install
+++ b/srcpkgs/refind/files/kernel.post-install
@@ -20,14 +20,17 @@ touch "$REFIND_CONF"
 
 tmpfile=$(mktemp /tmp/refind.XXXXXXX)
 
+: ${REFIND_LABEL:="Void Linux"}
+: ${REFIND_BOOT_PREFIX:=""}
+
 zversion=$(echo "$VERSION" | sed 's/[.]/[.]/g')
 
 zentry=$(cat <<EOF
 menuentry "Void Linux $VERSION" {
-	volume   "Void Linux"
-	loader   /vmlinuz-$VERSION
-	initrd   /initramfs-$VERSION.img
-	options  "$OPTIONS"
+        volume   "$REFIND_LABEL"
+        loader   "$REFIND_BOOT_PREFIX/vmlinuz-$VERSION"
+        initrd   "$REFIND_BOOT_PREFIX/initramfs-$VERSION.img"
+        options  "$OPTIONS"
 }
 EOF
 )

--- a/srcpkgs/refind/files/refind-kernel-hook.conf
+++ b/srcpkgs/refind/files/refind-kernel-hook.conf
@@ -18,5 +18,11 @@ UPDATE_REFIND_CONF=0
 # /efi/EFI/BOOT/refind.conf
 REFIND_CONF=/boot/EFI/refind/refind.conf
 
-# addition kernel cmdline
+# Set a custom label for Void boot entries
+#REFIND_LABEL="Void Linux"
+
+# Prefix prepended to kernel and initramfs paths in Void boot entries
+#REFIND_BOOT_PREFIX=""
+
+# Additional kernel cmdline parameters
 OPTIONS="quiet loglevel=4"

--- a/srcpkgs/refind/patches/add-cross-compile-support.patch
+++ b/srcpkgs/refind/patches/add-cross-compile-support.patch
@@ -1,6 +1,6 @@
 --- a/Make.common
 +++ b/Make.common
-@@ -40,21 +40,13 @@ REFIND_SBAT_CSV = refind-sbat.csv
+@@ -40,21 +40,13 @@
  # Note: TIANOBASE is defined in master Makefile and exported
  GENFW           = $(TIANOBASE)/BaseTools/Source/C/bin/GenFw
  prefix          = /usr/bin/
@@ -29,3 +29,16 @@
  
  ifeq ($(MAKEWITH),TIANO)
  # Below file defines TARGET (RELEASE or DEBUG) and TOOL_CHAIN_TAG (GCC44, GCC45, GCC46, or GCC47)
+@@ -148,8 +140,10 @@
+ 
+ ifeq ($(ARCH), aarch64)
+   GNUEFI_CFLAGS += -DEFIAARCH64
+-  FORMAT          = -O binary
+-  FORMAT_DRIVER   = -O binary
++  ifneq ($(OBJCOPY_LT_2_38),)
++    FORMAT = -O binary
++    FORMAT_DRIVER = -O binary
++  endif
+   SUBSYSTEM_LDFLAG = -defsym=EFI_SUBSYSTEM=0xa
+   LDFLAGS         += --warn-common --no-undefined --fatal-warnings
+ 

--- a/srcpkgs/refind/template
+++ b/srcpkgs/refind/template
@@ -1,7 +1,7 @@
 # Template file for 'refind'
 pkgname=refind
 version=0.14.0.2
-revision=2
+revision=3
 archs="x86_64* i686* aarch64*"
 makedepends="gnu-efi-libs"
 depends="bash dosfstools efibootmgr"
@@ -72,7 +72,6 @@ do_install() {
 	vcopy drivers_${_EFI_ARCH} usr/share/refind/
 	vinstall gptsync/gptsync_${_EFI_ARCH}.efi 644 \
 		usr/share/refind/tools_${_EFI_ARCH}/
-
 
 	vinstall "${FILESDIR}/refind-kernel-hook.conf" 644 etc/default
 	vinstall ${FILESDIR}/kernel.post-install 744 \


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **yes** (I've been running it on x64-glibc for the past two weeks)

#### Local build testing
I built this PR locally for my native architecture, x86_64-glibc as well as for aarch64-glibc [EDIT: Feb 26 09:34:52 PM CET 2024].

#### My setup
/etc/default/refind-kernel-hook.conf
```
#!/bin/sh

# Change this line to 1 to update refind conf whenever new kernel is installed
UPDATE_REFIND_CONF=1

# refind.conf location
# It usually stays in
#
# /boot/EFI/refind/refind.conf
#       if you use all default configuration and EFI partition mounted to /boot
# /boot/efi/EFI/refind/refind.conf
#       if using default configuration and EFI partition mounted to /boot/efi
# /boot/EFI/BOOT/refind.conf
#       if you run refind-install --usedefault and EFI partition mounted to /boot
# /boot/efi/EFI/BOOT/refind.conf
#       likewise, EFI mounted to /boot/efi
# /efi/EFI/refind/refind.conf
# /efi/EFI/BOOT/refind.conf
REFIND_CONF=/boot/efi/EFI/refind/refind.conf

# addition kernel cmdline
OPTIONS="root=UUID=a9ee6e45-d348-4214-9560-0d0c73ab8077 ro rootflags=subvol=void/ROOT quiet loglevel=4 mem_sleep_default=deep i915.modeset=1 video=1920x1080"
```
/boot/efi/EFI/refind/refind.conf
```
timeout 5
use_nvram false
scanfor internal,optical,manual
also_scan_dirs void/ROOT/boot
dont_scan_volumes FIRE1TB-EFI,FIRE1TB-tank,KC1TB-EFI,KC2TB-EFI,KC2TB-tank,WD1TB-EFI,WD1TB-tank
resolution 1920 1080
```
_scanfor internal_ works as it takes _also_scan_dirs_ as a prefix to where to find _vmlinuz_ and _initramfs_ files.

However, manual stanzas generated by _/etc/kernel.d/post-install/50-refind_ hook get me nowhere near bootable entries.

The patch that I came up with may not be perfect but it works on my installation.

Further testing is needed, especially for people with EFI mounted at /boot and using filesystems other than btrfs. 

To test the changes one needs to run xbps-reconfigure -f linux6.6 or whichever kernel one's running (also make sure to adjust the settings in _/etc/default/refind-kernel-hook.conf_)
