### PR TITLE
prosody: update to 0.12.4.

### DIFF
--- a/srcpkgs/lua51-luasocket/template
+++ b/srcpkgs/lua51-luasocket/template
@@ -1,30 +1,95 @@
 # Template file for 'lua51-luasocket'
 pkgname=lua51-luasocket
 version=3.1.0
-revision=1
+revision=2
 build_style=gnu-makefile
-build_wrksrc=src
-makedepends="lua51-devel"
 depends="lua51"
-short_desc="Network support for the Lua language"
+_desc="Network support for the Lua language"
+short_desc="${_desc} (5.1.x)"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
 homepage="https://lunarmodules.github.io/luasocket/"
-distfiles="https://github.com/lunarmodules/luasocket/archive/refs/tags/v3.1.0.tar.gz"
+distfiles="https://github.com/lunarmodules/luasocket/archive/refs/tags/v${version}.tar.gz"
 checksum=bf033aeb9e62bcaa8d007df68c119c966418e8c9ef7e4f2d7e96bddeca9cca6e
 
+_lua_versions="lua5.1 lua5.2 lua5.3 lua5.4"
+for _lua_version in $_lua_versions; do
+	hostmakedepends+=" ${_lua_version/./}"
+	makedepends+=" ${_lua_version/./}-devel"
+done
+
+post_extract() {
+	mkdir -p lua51
+	mv * lua51 || true
+	cp -a lua51 lua52
+	cp -a lua51 lua53
+	cp -a lua51 lua54
+}
+
 do_build() {
-	make CC=$CC LD=$CC LUAINC=${XBPS_CROSS_BASE}/usr/include/lua5.1 \
-		PLAT=linux LUAVER=5.1 \
-		${makejobs} all-unix
+	for _lua_version in $_lua_versions; do
+		cd "${wrksrc}/${_lua_version/./}/src/"
+		make \
+			LD="$CC" \
+			CC="$CC" \
+			LUAINC="${XBPS_CROSS_BASE}/usr/include/${_lua_version}" \
+			LUAVER="${_lua_version#lua}" \
+			LUAV="${_lua_version#lua}" \
+			PLAT=linux \
+			${makejobs} \
+			all-unix
+	done
+}
+
+do_install() {
+	for _lua_version in $_lua_versions; do
+		cd "${wrksrc}/${_lua_version/./}/src/"
+		make \
+			STRIP=true \
+			PREFIX=/usr \
+			prefix=/usr \
+			DESTDIR="${DESTDIR}" \
+			LUAVER="${_lua_version#lua}" \
+			LUAV="${_lua_version#lua}" \
+			LDIR_linux="lib/lua/${_lua_version#lua}" \
+			PLAT=linux \
+			install
+	done
 }
 
 post_install() {
-	vlicense ../LICENSE
+	vlicense ./lua51/LICENSE
 }
 
 luasocket_package() {
 	depends="lua51-luasocket>=${version}_${revision}"
 	short_desc+=" (transitional dummy package)"
 	build_style=meta
+}
+
+lua52-luasocket_package() {
+	depends="lua52"
+	short_desc="${_desc} (5.2.x)"
+	pkg_install() {
+		vmove usr/lib/lua/5.2
+		vlicense ${wrksrc}/lua52/LICENSE
+	}
+}
+
+lua53-luasocket_package() {
+	depends="lua53"
+	short_desc="${_desc} (5.3.x)"
+	pkg_install() {
+		vmove usr/lib/lua/5.3
+		vlicense ${wrksrc}/lua53/LICENSE
+	}
+}
+
+lua54-luasocket_package() {
+	depends="lua54"
+	short_desc="${_desc} (5.4.x)"
+	pkg_install() {
+		vmove usr/lib/lua/5.4
+		vlicense ${wrksrc}/lua54/LICENSE
+	}
 }

--- a/srcpkgs/lua51-unbound
+++ b/srcpkgs/lua51-unbound
@@ -1,0 +1,1 @@
+lua54-unbound

--- a/srcpkgs/lua52-luasocket
+++ b/srcpkgs/lua52-luasocket
@@ -1,0 +1,1 @@
+lua51-luasocket

--- a/srcpkgs/lua52-unbound
+++ b/srcpkgs/lua52-unbound
@@ -1,0 +1,1 @@
+lua54-unbound

--- a/srcpkgs/lua53-luasocket
+++ b/srcpkgs/lua53-luasocket
@@ -1,0 +1,1 @@
+lua51-luasocket

--- a/srcpkgs/lua53-unbound
+++ b/srcpkgs/lua53-unbound
@@ -1,0 +1,1 @@
+lua54-unbound

--- a/srcpkgs/lua54-luasocket
+++ b/srcpkgs/lua54-luasocket
@@ -1,0 +1,1 @@
+lua51-luasocket

--- a/srcpkgs/lua54-unbound/template
+++ b/srcpkgs/lua54-unbound/template
@@ -1,0 +1,74 @@
+# Template file for 'lua54-unbound'
+pkgname=lua54-unbound
+version=1.0.0
+revision=1
+hostmakedepends="pkg-config"
+makedepends="unbound-devel"
+depends="lua54"
+_desc="Binding to libunbound for Lua"
+short_desc="${_desc} (5.4.x)"
+maintainer="Luca Matei Pintilie <luca@lucamatei.com>"
+license="MIT"
+homepage="https://www.zash.se/luaunbound.html"
+distfiles="https://code.zash.se/dl/luaunbound/luaunbound-${version}.tar.gz"
+checksum=6de45aa64c21cf0ecbccb734b7c1eda8873a6135bbe142fbf353f772a90750d3
+
+_lua_versions="lua5.1 lua5.2 lua5.3 lua5.4"
+for _lua_version in $_lua_versions; do
+	hostmakedepends+=" ${_lua_version/./}"
+	makedepends+=" ${_lua_version/./}-devel"
+done
+
+post_extract() {
+	mkdir -p lua51
+	mv * lua51 || true
+	cp -a lua51 lua52
+	cp -a lua51 lua53
+	cp -a lua51 lua54
+}
+
+do_build() {
+	for _lua_version in $_lua_versions; do
+		cd "${wrksrc}/${_lua_version/./}"
+		make \
+			LD="$CC" \
+			CC="$CC" \
+			LUA_PC="${_lua_version}" \
+			${makejobs}
+	done
+}
+
+do_install() {
+	for _lua_version in $_lua_versions; do
+		cd "${wrksrc}/${_lua_version/./}"
+		vinstall lunbound.so 755 usr/lib/lua/${_lua_version#lua}/
+	done
+	vlicense LICENSE
+}
+
+lua51-unbound_package() {
+	depends="lua51"
+	short_desc="${_desc} (5.1.x)"
+	pkg_install() {
+		vmove usr/lib/lua/5.1
+		vlicense ${wrksrc}/lua51/LICENSE
+	}
+}
+
+lua52-unbound_package() {
+	depends="lua52"
+	short_desc="${_desc} (5.2.x)"
+	pkg_install() {
+		vmove usr/lib/lua/5.2
+		vlicense ${wrksrc}/lua52/LICENSE
+	}
+}
+
+lua53-unbound_package() {
+	depends="lua53"
+	short_desc="${_desc} (5.3.x)"
+	pkg_install() {
+		vmove usr/lib/lua/5.3
+		vlicense ${wrksrc}/lua53/LICENSE
+	}
+}

--- a/srcpkgs/lua54-unbound/update
+++ b/srcpkgs/lua54-unbound/update
@@ -1,0 +1,1 @@
+pkgname=luaunbound

--- a/srcpkgs/prosody/files/prosody.cfg.lua
+++ b/srcpkgs/prosody/files/prosody.cfg.lua
@@ -13,7 +13,6 @@
 
 
 ------ Void settings ------
-daemonize = false;
 pidfile = "/run/prosody/prosody.pid"
 
 ---------- Server-wide settings ----------

--- a/srcpkgs/prosody/files/prosody/run
+++ b/srcpkgs/prosody/files/prosody/run
@@ -2,4 +2,4 @@
 exec 2>&1
 mkdir -p /run/prosody
 chown prosody:prosody /run/prosody
-exec chpst -u prosody:prosody prosody
+exec chpst -u prosody:prosody prosody --no-daemonize

--- a/srcpkgs/prosody/template
+++ b/srcpkgs/prosody/template
@@ -1,17 +1,17 @@
 # Template file for 'prosody'
 pkgname=prosody
-version=0.12.1
-revision=4
+version=0.12.4
+revision=1
 build_style=configure
 configure_args="
  --ostype=linux
  --prefix=/usr
  --no-example-certs
- --with-lua-include=${XBPS_CROSS_BASE}/usr/include/lua5.1
+ --with-lua-include=${XBPS_CROSS_BASE}/usr/include/lua5.4
  --with-lua=${XBPS_CROSS_BASE}/usr
- --lua-version=5.1
- --lua-suffix=5.1
- --runwith=lua5.1"
+ --lua-version=5.4
+ --lua-suffix=5.4
+ --runwith=lua5.4"
 conf_files="
  /etc/prosody/prosody.cfg.lua
  /etc/prosody/certs/localhost.cnf
@@ -19,16 +19,15 @@ conf_files="
  /etc/prosody/certs/makefile
  /etc/prosody/certs/GNUmakefile"
 make_dirs="/var/lib/prosody 0755 prosody prosody"
-makedepends="lua51-devel openssl-devel libidn-devel icu-devel"
-depends="lua51-luasocket lua51-luafilesystem lua51-luaexpat lua51-luasec
- lua51-BitOp"
+makedepends="lua54-devel openssl-devel libidn-devel icu-devel"
+depends="lua54-luasocket lua54-luafilesystem lua54-luaexpat lua54-luasec lua54-unbound"
 short_desc="Lightweight and extensible Jabber/XMPP server written in Lua"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
 homepage="https://prosody.im/"
 changelog="https://prosody.im/doc/release/${version}"
 distfiles="https://prosody.im/downloads/source/${pkgname}-${version}.tar.gz"
-checksum=a7ecbbe41f01a4251805593ac6d15dbc6cb75d9c7a876c76b456cf74ff4b90e5
+checksum=47d712273c2f29558c412f6cdaec073260bbc26b7dda243db580330183d65856
 
 system_accounts="prosody"
 prosody_homedir="/var/lib/prosody"


### PR DESCRIPTION
- **New package: lua-unbound-1.0.0**
- **prosody: add lua51-unbound as a dependency**

#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86\_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl

Crossbuilt from x86\_64-glibc and tested on aarch64-musl

Fixes the following warning that shows up when using prosodyctl (any
command):

```
**************************
Prosody was unable to find lua-unbound
This package can be obtained in the following ways:

  Debian/Ubuntu | sudo apt install lua-unbound
       luarocks | luarocks install luaunbound
         Source | https://www.zash.se/luaunbound.html

Old DNS resolver library will be used
More help can be found on our website, at https://prosody.im/doc/depends
**************************
```

Fixes the following deprecation as well:

| Option    | Default | Notes                                                                                                |
|-----------|---------|------------------------------------------------------------------------------------------------------|
| daemonize | true    | Whether to daemonize Prosody or not. DEPRECATED since 0.12, use command line flags -D or -F instead. |
