### PR TITLE
telegram-desktop: remove unused makedeps

### DIFF
--- a/srcpkgs/telegram-desktop/template
+++ b/srcpkgs/telegram-desktop/template
@@ -1,7 +1,7 @@
 # Template file for 'telegram-desktop'
 pkgname=telegram-desktop
 version=4.14.15
-revision=2
+revision=3
 build_style=cmake
 build_helper="qemu gir"
 configure_args="-DTDESKTOP_API_ID=209235
@@ -14,10 +14,10 @@ hostmakedepends="pkg-config qt6-base python3 extra-cmake-modules
  qt6-wayland-tools wayland-devel protobuf"
 makedepends="alsa-lib-devel boost-devel fmt-devel ffmpeg-devel gobject-introspection libdbusmenu-glib-devel libopenal-devel
  minizip-devel opus-devel xxHash-devel pulseaudio-devel range-v3
- qt6-svg-devel libva-devel rapidjson liblz4-devel liblzma-devel gtk+3-devel
+ qt6-svg-devel libva-devel rapidjson liblz4-devel liblzma-devel
  MesaLib-devel qt6-wayland-devel qt6-qt5compat-devel
  xcb-util-keysyms-devel $(vopt_if spellcheck hunspell-devel) protobuf-devel
- glibmm2.68-devel tg_owt webkit2gtk-devel rnnoise-devel jemalloc-devel qt6-declarative-devel"
+ glibmm2.68-devel tg_owt rnnoise-devel jemalloc-devel qt6-declarative-devel"
 depends="qt6-imageformats ttf-opensans"
 short_desc="Telegram Desktop messaging app"
 maintainer="John <me@johnnynator.dev>"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

@Johnnynator webkit2gtk currently is not a rundep for `telegram-desktop` package.

Would you like it to stay that way (since there are multiple versions of webkit2gtk and if you don't have it installed telegram-desktop displays a message telling you to install it), otherwise I can add either libwebkitgtk60 or libwebkit2gtk41, either are supported: https://github.com/desktop-app/lib_webview/blob/4fce8b1971721da739619acf36da0fe79d614a23/webview/platform/linux/webview_linux_webkitgtk_library.cpp#L14-L16

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
