### PR TITLE
gocryptfs: update to 2.4.0, enable OpenSSL

### DIFF
--- a/srcpkgs/gocryptfs/template
+++ b/srcpkgs/gocryptfs/template
@@ -1,11 +1,12 @@
 # Template file for 'gocryptfs'
 pkgname=gocryptfs
-version=2.3.1
-revision=4
+version=2.4.0
+revision=1
 build_style=go
 go_import_path="github.com/rfjakob/gocryptfs/v2"
-go_build_tags="without_openssl"
 go_ldflags="-X main.GitVersion=v${version} -X main.GitVersionFuse="[vendored]" -X main.BuildDate=$(date +%Y-%m-%d)"
+hostmakedepends="pkg-config"
+makedepends="openssl-devel"
 depends="fuse3"
 short_desc="Encrypted overlay filesystem written in Go"
 maintainer="Felipe Nogueira <contato.fnog@gmail.com>"
@@ -13,7 +14,7 @@ license="MIT"
 homepage="https://nuetzlich.net/gocryptfs"
 changelog="https://github.com/rfjakob/gocryptfs#changelog"
 distfiles="https://github.com/rfjakob/gocryptfs/releases/download/v${version}/gocryptfs_v${version}_src-deps.tar.gz"
-checksum=62a856a9771307b34a75a1e9ab9489abe4a4e7e7f9230c2b1046ca037ea2ba50
+checksum=45158daf20df7f94e0c9ec57ba07af21df2e25e15b8584bf3c7de96adbbc2efd
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

--- 
Enabling OpenSSL fixes `gocryptfs -speed` crashing. Before:

```
$ gocryptfs -speed
gocryptfs v2.3.1 without_openssl; go-fuse [vendored]; 2023-10-02 go1.21.1 linux/amd64
cpu: AMD EPYC 7702P 64-Core Processor; with AES acceleration
AES-GCM-256-OpenSSL       	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x5aab40]

goroutine 7 [running]:
testing.(*common).decorate(0x40f2c5?, {0xc00001a210, 0x2a}, 0x83d801?)
	/usr/lib/go/src/testing/testing.go:772 +0xa0
testing.(*common).logDepth(0xc000140280, {0xc00001a210, 0x2a}, 0x3)
	/usr/lib/go/src/testing/testing.go:1035 +0x1dd
testing.(*common).log(...)
	/usr/lib/go/src/testing/testing.go:1004
testing.(*common).Skip(0xc000140280, {0xc00004ef08?, 0x48a7af?, 0xc00004ef18?})
	/usr/lib/go/src/testing/testing.go:1089 +0x4a
github.com/rfjakob/gocryptfs/v2/internal/speed.bStupidGCM(0xc000140280)
	/builddir/gocryptfs-2.3.1/internal/speed/speed.go:125 +0x45
testing.(*B).runN(0xc000140280, 0x1)
	/usr/lib/go/src/testing/benchmark.go:193 +0x102
testing.(*B).run1.func1()
	/usr/lib/go/src/testing/benchmark.go:233 +0x4e
created by testing.(*B).run1 in goroutine 1
	/usr/lib/go/src/testing/benchmark.go:226 +0x90
```

After:
```
$ gocryptfs -speed
gocryptfs v2.4.0; go-fuse [vendored]; 2024-02-26 go1.22.0 linux/amd64
cpu: AMD EPYC 7702P 64-Core Processor; with AES acceleration
AES-GCM-256-OpenSSL             1459.24 MB/s
AES-GCM-256-Go                  3129.59 MB/s    (selected in auto mode)
AES-SIV-512-Go                   228.40 MB/s
XChaCha20-Poly1305-OpenSSL       883.58 MB/s
XChaCha20-Poly1305-Go           1643.98 MB/s    (selected in auto mode)
```

Maintainer ping: @fnogcps
