### PR TITLE
spotify: update to 1.2.31.

### DIFF
--- a/srcpkgs/spotify/template
+++ b/srcpkgs/spotify/template
@@ -1,8 +1,8 @@
 # Template file for 'spotify'
 pkgname=spotify
-version=1.2.26
+version=1.2.31
 revision=1
-_subver=1187.g36b715a1
+_subver=1205.g4d59ad7c
 archs="x86_64"
 create_wrksrc=yes
 hostmakedepends="libcurl"
@@ -12,7 +12,7 @@ maintainer="Stefan Mühlinghaus <jazzman@alphabreed.com>"
 license="custom:Proprietary"
 homepage="https://www.spotify.com"
 distfiles="http://repository.spotify.com/pool/non-free/s/spotify-client/spotify-client_${version}.${_subver}_amd64.deb"
-checksum=83abdf8bd65348353110b6d858cb7adb53ef9d751d5f348af3fb8868f9eb1151
+checksum=71b724bd9ec37ccc37b340606bc37f46d47320b5fa429a4c9dce5bd24e07adb8
 repository=nonfree
 restricted=yes
 nostrip=yes


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)

Current upstream does not work. Log:
```
=> xbps-src: updating repositories for host (x86_64)...
[*] Updating repository `https://repo-default.voidlinux.org/current/bootstrap/x86_64-repodata' ...
[*] Updating repository `https://repo-default.voidlinux.org/current/x86_64-repodata' ...
[*] Updating repository `https://repo-default.voidlinux.org/current/nonfree/x86_64-repodata' ...
[*] Updating repository `https://repo-default.voidlinux.org/current/debug/x86_64-repodata' ...
[*] Updating repository `https://repo-default.voidlinux.org/current/multilib/bootstrap/x86_64-repodata' ...
[*] Updating repository `https://repo-default.voidlinux.org/current/multilib/x86_64-repodata' ...
[*] Updating repository `https://repo-default.voidlinux.org/current/multilib/nonfree/x86_64-repodata' ...
=> xbps-src: updating software in / masterdir...
=> xbps-src: cleaning up / masterdir...
=> spotify-1.2.26_1: removing autodeps, please wait...
=> spotify-1.2.26_1: building for x86_64...
   [host] libcurl-8.6.0_1: found (https://repo-default.voidlinux.org/current)
   [runtime] libcurl-8.6.0_1: found (https://repo-default.voidlinux.org/current)
=> spotify-1.2.26_1: installing host dependencies: libcurl-8.6.0_1 ...
=> spotify-1.2.26_1: running do-fetch hook: 00-distfiles ...
=> spotify-1.2.26_1: fetching distfile 'spotify-client_1.2.26.1187.g36b715a1_amd64.deb' from 'http://repository.spotify.com/pool/non-free/s/spotify-client/spotify-client_1.2.26.1187.g36b715a1_amd64.deb'...
http://repository.spotify.com/pool/non-free/s/spotify-client/spotify-client_1.2.26.1187.g36b715a1_amd64.deb: Not Found
=> ERROR: spotify-1.2.26_1: failed to fetch 'spotify-client_1.2.26.1187.g36b715a1_amd64.deb'.
```

Version 1.2.31 exists on the upstream but Spotify launches with a gray screen on my testing machine. Current upstream does not exist thus, ~it might be a good idea to downgrade the version unless installation of 1.2.31 is confirmed to work correctly.~

Edit:
I am unsure as if this problem only exists for me but even tough Spotify launches correctly it gives an error during login saying:
`A firewall may be blocking Spotify. Please update your firewall to allow Spotify. Additionally you could try changing the currently used proxy settings`

I need further confirmation and testing as both 1.2.31 and 1.1.26 seem to be working incorrectly on my machine.