### PR TITLE
rio: update to 0.0.35

### DIFF
--- a/srcpkgs/rio/template
+++ b/srcpkgs/rio/template
@@ -1,6 +1,6 @@
 # Template file for 'rio'
 pkgname=rio
-version=0.0.33
+version=0.0.35
 revision=1
 build_style=cargo
 make_install_args="--path rio"
@@ -13,7 +13,7 @@ license="MIT"
 homepage="https://raphamorim.io/rio/"
 changelog="https://raw.githubusercontent.com/raphamorim/rio/main/CHANGELOG.md"
 distfiles="https://github.com/raphamorim/rio/archive/refs/tags/v${version}.tar.gz"
-checksum=1b2ad697a53918f8badbd7fdfb110ac136b989c80b52cfce14a8507919040226
+checksum=2c3bf1c257fac9121e661ecf8a79c58362c84d19acb6adf73d268c860703992e
 
 do_install() {
 	# avoid doing a rebuild in install due to complex feature setup


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
