### PR TITLE
pdfpc: disable REST server

### DIFF
--- a/srcpkgs/pdfpc/template
+++ b/srcpkgs/pdfpc/template
@@ -1,16 +1,21 @@
 # Template file for 'pdfpc'
 pkgname=pdfpc
 version=4.6.0
-revision=1
+revision=2
 build_style=cmake
+configure_args="-DREST=OFF"
 hostmakedepends="pkg-config vala libgee08-devel"
 makedepends="gst-plugins-base1-devel gtk+3-devel libgee08-devel
  libzstd-devel poppler-glib-devel json-glib-devel vala-devel
- webkit2gtk-devel discount-devel qrencode-devel"
+ libwebkit2gtk41-devel discount-devel"
 short_desc="Presenter console with multi-monitor support for PDF files"
 maintainer="Aaron Marcher <info@nulltime.net>"
 license="GPL-2.0-or-later"
 homepage="https://pdfpc.github.io/"
-changelog="https://raw.githubusercontent.com/pdfpc/pdfpc/master/CHANGELOG.txt"
+changelog="https://raw.githubusercontent.com/pdfpc/pdfpc/master/CHANGELOG.rst"
 distfiles="https://github.com/pdfpc/pdfpc/archive/v${version}.tar.gz"
 checksum=3b1a393f36a1b0ddc29a3d5111d8707f25fb2dd2d93b0401ff1c66fa95f50294
+
+post_patch() {
+	vsed -e 's/webkit2gtk-4.0/webkit2gtk-4.1/' -i src/CMakeLists.txt
+}


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

Build with webkit2gtk-4.1, which provides an identical api to webkit2gtk-4.0 except it uses libsoup3.
The REST server functionality requires libsoup2. libsoup2 and libsoup3 cannot be loaded in the same process at the same time.

One of the maintainers recommended just disabling the rest server and building the markdown presentation notes viewer with webkit2gtk-4.1 stating that as far as he knows, he is the only one that actually uses the rest server function. https://github.com/pdfpc/pdfpc/issues/671#issuecomment-1552713117

I was wondering if anyone here that uses pdfpc uses the rest server function?

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
