### PR TITLE
pari: update to 2.15.5.

### DIFF
--- a/srcpkgs/pari/template
+++ b/srcpkgs/pari/template
@@ -1,6 +1,6 @@
 # Template file for 'pari'
 pkgname=pari
-version=2.15.4
+version=2.15.5
 revision=1
 build_style=configure
 build_helper=qemu
@@ -19,7 +19,7 @@ license="GPL-2.0-or-later"
 homepage="https://pari.math.u-bordeaux.fr"
 changelog="https://pari.math.u-bordeaux.fr/cgi-bin/gitweb.cgi?p=pari.git;a=blob_plain;f=CHANGES;hb=refs/heads/pari-${version%.*}"
 distfiles="https://pari.math.u-bordeaux.fr/pub/pari/unix/pari-${version}.tar.gz"
-checksum=c3545bfee0c6dfb40b77fb4bbabaf999d82e60069b9f6d28bcb6cf004c8c5c0f
+checksum=0efdda7515d9d954f63324c34b34c560e60f73a81c3924a71260a2cc91d5f981
 
 build_options="x11 pthreads"
 build_options_default="x11 pthreads"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**
<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
