### PR TITLE
gtk4: update to 4.12.5

### DIFF
--- a/srcpkgs/gtk4/template
+++ b/srcpkgs/gtk4/template
@@ -1,6 +1,6 @@
 # Template file for 'gtk4'
 pkgname=gtk4
-version=4.12.3
+version=4.12.5
 revision=1
 build_style=meson
 build_helper="gir"
@@ -33,7 +33,7 @@ homepage="https://www.gtk.org/"
 # changelog="https://gitlab.gnome.org/GNOME/gtk/-/raw/main/NEWS"
 changelog="https://gitlab.gnome.org/GNOME/gtk/-/raw/gtk-4-12/NEWS"
 distfiles="${GNOME_SITE}/gtk/${version%.*}/gtk-${version}.tar.xz"
-checksum=148ce262f6c86487455fb1d9793c3f58bc3e1da477a29617fadb0420f5870a89
+checksum=28b356d590ee68ef626e2ef9820b2dd21441484a9a042a5a3f0c40e9dfc4f4f8
 
 # Package build options
 build_options="broadway cloudproviders colord cups gir vulkan wayland x11 tracker"


### PR DESCRIPTION
split into a separate pr, according to @oreo639's recommendation (https://github.com/void-linux/void-packages/pull/48752#issuecomment-1968076680).

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl x
  - armv7l x
  - armv6l-musl x