### PR TITLE
grilo{,-plugins}: update to 0.3.16

### DIFF
--- a/srcpkgs/grilo-plugins/template
+++ b/srcpkgs/grilo-plugins/template
@@ -1,9 +1,9 @@
 # Template file for 'grilo-plugins'
 pkgname=grilo-plugins
-version=0.3.14
-revision=3
+version=0.3.16
+revision=1
 build_style=meson
-configure_args="-Dgoa=disabled"
+configure_args="-Dgoa=enabled"
 hostmakedepends="pkg-config gettext itstool glib-devel gperf tracker"
 # XXX missing plugins: fakemetadata.
 makedepends="grilo-devel gom-devel json-glib-devel
@@ -17,7 +17,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="LGPL-2.1-or-later"
 homepage="https://wiki.gnome.org/Projects/Grilo"
 distfiles="${GNOME_SITE}/grilo-plugins/${version%.*}/grilo-plugins-${version}.tar.xz"
-checksum=686844b34ec73b24931ff6cc4f6033f0072947a6db60acdc7fb3eaf157a581c8
+checksum=fe6f4dbe586c6b8ba2406394e202f22d009d642a96eb3a54f32f6a21d084cdcb
 make_check=no # feel free to fix
 
 post_patch() {

--- a/srcpkgs/grilo/patches/fix-pc-file.patch
+++ b/srcpkgs/grilo/patches/fix-pc-file.patch
@@ -1,0 +1,19 @@
+We patch girdir and typelibdir in gobject-introspection to include pc_sysrootdir
+for cross compiling.
+Avoid using pkg-config variables for girdir_for_pc_file and typelibdir_for_pc_file
+since they include pc_sysrootdir, which cannot be overridden using pkgconfig_define.
+meson needs non-absolute paths in order to correctly generate datadir.
+--- a/meson.build
++++ b/meson.build
+@@ -96,9 +96,9 @@ typelibdir_for_pc_file = join_paths('${libdir}', 'girepository-1.0')
+ gobject_introspection = dependency('gobject-introspection-1.0', required: false)
+ if gobject_introspection.found()
+     girdir = gobject_introspection.get_variable(pkgconfig: 'girdir', pkgconfig_define: ['datadir', datadir])
+-    girdir_for_pc_file = gobject_introspection.get_variable(pkgconfig: 'girdir', pkgconfig_define: ['datadir', '${datadir}'])
++    girdir_for_pc_file = join_paths('${datadir}', 'gir-1.0') 
+     typelibdir = gobject_introspection.get_variable(pkgconfig: 'typelibdir', pkgconfig_define: ['libdir', libdir])
+-    typelibdir_for_pc_file = gobject_introspection.get_variable(pkgconfig: 'typelibdir', pkgconfig_define: ['libdir', '${libdir}'])
++    typelibdir_for_pc_file = join_paths('${libdir}', 'girepository-1.0')
+ endif
+ 
+ vapidir = join_paths(datadir, 'vala', 'vapi')

--- a/srcpkgs/grilo/template
+++ b/srcpkgs/grilo/template
@@ -1,24 +1,29 @@
 # Template file for 'grilo'
 pkgname=grilo
-version=0.3.13
+version=0.3.16
 revision=1
 build_style=meson
 build_helper="gir"
 configure_args="$(vopt_bool gir enable-introspection) $(vopt_bool gir enable-vala)
- -Denable-gtk-doc=false"
-hostmakedepends="gettext pkg-config glib-devel $(vopt_if gir vala)"
-makedepends="gtk+3-devel libxml2-devel libsoup-devel liboauth-devel
+ $(vopt_bool gtk_doc enable-gtk-doc)"
+hostmakedepends="gettext pkg-config glib-devel $(vopt_if gir vala)
+ $(vopt_if gtk_doc gtk-doc)"
+makedepends="gtk+3-devel libxml2-devel libsoup3-devel liboauth-devel
  totem-pl-parser-devel"
 short_desc="Framework focused on making media discovery and browsing easy"
 maintainer="Enno Boland <gottox@voidlinux.org>"
 license="LGPL-2.1-or-later"
-homepage="http://live.gnome.org/Grilo"
+homepage="https://wiki.gnome.org/Projects/Grilo"
 distfiles="${GNOME_SITE}/${pkgname}/${version%.*}/${pkgname}-${version}.tar.xz"
-checksum=d14837f22341943ed8a189d9f0827a17016b802d18d0ed080e1413de0fdc927b
+checksum=884580e8c5ece280df23aa63ff5234b7d48988a404df7d6bfccd1e77b473bd96
 
 # Package build options
-build_options="gir"
+build_options="gir gtk_doc"
 build_options_default="gir"
+
+if [ -z "$CROSS_BUILD" ]; then
+	build_options_default+=" gtk_doc"
+fi
 
 grilo-devel_package() {
 	depends="${makedepends} grilo>=${version}_${revision}"
@@ -31,5 +36,8 @@ grilo-devel_package() {
 		fi
 		vmove usr/lib/pkgconfig
 		vmove "usr/lib/*.so"
+		if [ "$build_option_gtk_doc" ]; then
+			vmove usr/share/gtk-doc
+		fi
 	}
 }


### PR DESCRIPTION
split into a separate pr, according to @oreo639's recommendation (https://github.com/void-linux/void-packages/pull/48752#issuecomment-1968076680).

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl x
  - armv7l x
  - armv6l-musl x