### PR TITLE
at-spi2-core: update to 2.50.1

### DIFF
--- a/srcpkgs/at-spi2-core/template
+++ b/srcpkgs/at-spi2-core/template
@@ -1,6 +1,6 @@
 # Template file for 'at-spi2-core'
 pkgname=at-spi2-core
-version=2.48.0
+version=2.50.1
 revision=1
 build_style=meson
 build_helper="gir"
@@ -13,7 +13,7 @@ maintainer="Enno Boland <gottox@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="https://gitlab.gnome.org/GNOME/at-spi2-core"
 distfiles="${GNOME_SITE}/at-spi2-core/${version%.*}/at-spi2-core-${version}.tar.xz"
-checksum=905a5b6f1790b68ee803bffa9f5fab4ceb591fb4fae0b2f8c612c54f1d4e8a30
+checksum=5727b5c0687ac57ba8040e79bd6731b714a36b8fcf32190f236b8fb3698789e7
 make_check=no # non-trivial dbus setup
 
 # Package build options


### PR DESCRIPTION
split into a separate pr, according to @oreo639's recommendation (https://github.com/void-linux/void-packages/pull/48752#issuecomment-1968076680).

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl x
  - armv7l x
  - armv6l-musl x