### PR TITLE
evolution-ews: update to 3.50.3, evolution{,-data-server}: update to 3.50.4

### DIFF
--- a/srcpkgs/evolution-data-server/template
+++ b/srcpkgs/evolution-data-server/template
@@ -1,7 +1,7 @@
 # Template file for 'evolution-data-server'
 pkgname=evolution-data-server
-version=3.48.4
-revision=3
+version=3.50.4
+revision=1
 build_style=cmake
 build_helper="gir qemu"
 configure_args=" -DSYSCONF_INSTALL_DIR=/etc
@@ -18,9 +18,9 @@ short_desc="Centralized access to appointments and contacts"
 maintainer="Enno Boland <gottox@voidlinux.org>"
 license="LGPL-2.1-only"
 homepage="https://wiki.gnome.org/Apps/Evolution"
-changelog="https://gitlab.gnome.org/GNOME/evolution-data-server/-/raw/gnome-44/NEWS"
+changelog="https://gitlab.gnome.org/GNOME/evolution-data-server/-/raw/gnome-45/NEWS"
 distfiles="${GNOME_SITE}/evolution-data-server/${version%.*}/evolution-data-server-${version}.tar.xz"
-checksum=997e3f93b17efb0affcc017bee8780ba5fa2c009e36551bbc91a08ae552d6d60
+checksum=d7edffbe03a0bbcecbee67393214b831c7b18cd895b84c4dbfe1387776e257c5
 make_check=ci-skip # flaky in CI
 
 build_options="gir"

--- a/srcpkgs/evolution-ews/template
+++ b/srcpkgs/evolution-ews/template
@@ -1,6 +1,6 @@
 # Template file for 'evolution-ews'
 pkgname=evolution-ews
-version=3.48.2
+version=3.50.3
 revision=1
 build_style=cmake
 configure_args="-DLIBEXEC_INSTALL_DIR=/usr/lib/evolution"
@@ -11,6 +11,6 @@ short_desc="MS Exchange integration through Exchange Web Services"
 maintainer="Peter Kuchar <masaj@gmx.com>"
 license="LGPL-2.1-or-later"
 homepage="https://wiki.gnome.org/Apps/Evolution"
-changelog="https://gitlab.gnome.org/GNOME/evolution-ews/-/raw/gnome-44/NEWS"
+changelog="https://gitlab.gnome.org/GNOME/evolution-ews/-/raw/gnome-45/NEWS"
 distfiles="${GNOME_SITE}/evolution-ews/${version%.*}/evolution-ews-${version}.tar.xz"
-checksum=504d9800f5babcc5c170ef50c5464e4ebc1200e41902cda69fe8fabff2fb70c0
+checksum=e2fa5941376ad57e07d2673f8676c31f7f2b068d49f68ea0fb8bafeabb529bed

--- a/srcpkgs/evolution/template
+++ b/srcpkgs/evolution/template
@@ -1,7 +1,7 @@
 # Template file for 'evolution'
 pkgname=evolution
-version=3.48.4
-revision=2
+version=3.50.4
+revision=1
 build_style=cmake
 build_helper="qemu"
 configure_args="-DSYSCONF_INSTALL_DIR=/etc
@@ -18,9 +18,9 @@ short_desc="Integrated mail, addressbook and calendaring for GNOME"
 maintainer="Enno Boland <gottox@voidlinux.org>"
 license="LGPL-2.1-or-later, LGPL-3.0-or-later, GPL-2.0-or-later"
 homepage="https://wiki.gnome.org/Apps/Evolution"
-changelog="https://gitlab.gnome.org/GNOME/evolution/-/raw/gnome-44/NEWS"
+changelog="https://gitlab.gnome.org/GNOME/evolution/-/raw/gnome-45/NEWS"
 distfiles="${GNOME_SITE}/evolution/${version%.*}/evolution-${version}.tar.xz"
-checksum=a02f99eba050a771f2c47d43fc52e00b2260fc86d06320fbf52ebc7e8ce78bb7
+checksum=e0f955ca14dfb1b2e1682fcfa1816a03c114b8161998f96cf9d681a6a3842698
 shlib_provides="libevolution-calendar.so libevolution-util.so libemail-engine.so
  libevolution-mail.so libevolution-shell.so libevolution-mail-formatter.so
  libevolution-mail-composer.so"


### PR DESCRIPTION
split into a separate pr, according to @oreo639's recommendation (https://github.com/void-linux/void-packages/pull/48752#issuecomment-1968076680).

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl x
  - armv7l x
  - armv6l-musl x