### PR TITLE
foliate: add missing libadwaita dependency

### DIFF
--- a/srcpkgs/foliate/template
+++ b/srcpkgs/foliate/template
@@ -1,12 +1,12 @@
 # Template file for 'foliate'
 pkgname=foliate
 version=3.1.0
-revision=1
+revision=2
 build_style=meson
 hostmakedepends="pkg-config gettext glib-devel
  gtk4-update-icon-cache desktop-file-utils"
 makedepends="gjs-devel gtk4-devel libadwaita-devel libwebkitgtk60-devel"
-depends="libwebkitgtk60 gjs"
+depends="libwebkitgtk60 gjs libadwaita"
 checkdepends="desktop-file-utils appstream-glib"
 short_desc="Simple and modern GTK eBook reader"
 maintainer="Orphaned <orphan@voidlinux.org>"


### PR DESCRIPTION
When libadwaita is not installed, foliate crashes on launch with the following error:

```
JS ERROR: Error: Requiring Adw, version 1: Typelib file for namespace 'Adw', version '1' not found require@resource:///org/gnome/gjs/modules/esm/gi.js:16:28 @gi://Adw?version=1:3:25
```
#### Testing the changes
- I tested the changes in this PR: **briefly** (foliate stopped crashing after I installed libadwaita)