### PR TITLE
Waydroid updates (libglibutil 1.0.79 & libgbinder 1.1.39)

### DIFF
--- a/srcpkgs/libgbinder/template
+++ b/srcpkgs/libgbinder/template
@@ -1,6 +1,6 @@
 # Template file for 'libgbinder'
 pkgname=libgbinder
-version=1.1.34
+version=1.1.39
 revision=1
 build_style=gnu-makefile
 make_use_env=1
@@ -16,7 +16,7 @@ license="BSD-3-Clause"
 homepage="https://github.com/mer-hybris/libgbinder"
 changelog="https://raw.githubusercontent.com/mer-hybris/libgbinder/master/debian/changelog"
 distfiles="https://github.com/mer-hybris/libgbinder/archive/refs/tags/${version}.tar.gz"
-checksum=f9150de954a3f15c863e7b60816dacf68147ae510b3ca0e49dbb24ba4b9e35dc
+checksum=fb10b125c4071413273b81de761cf3ef4ce169e814b740e6fc6ddb1ae2dad066
 
 post_install() {
 	vlicense LICENSE

--- a/srcpkgs/libglibutil/template
+++ b/srcpkgs/libglibutil/template
@@ -1,6 +1,6 @@
 # Template file for 'libglibutil'
 pkgname=libglibutil
-version=1.0.74
+version=1.0.79
 revision=1
 build_style=gnu-makefile
 make_use_env=1
@@ -16,7 +16,7 @@ license="BSD-3-Clause"
 homepage="https://github.com/sailfishos/libglibutil"
 changelog="https://raw.githubusercontent.com/sailfishos/libglibutil/master/debian/changelog"
 distfiles="https://github.com/sailfishos/libglibutil/archive/refs/tags/${version}.tar.gz"
-checksum=4d8ae1bed701613cd053c5ee073ecd3123537782eaaddebd47fe1e43ab27d825
+checksum=4d689cb79f8ea061e46b89008370dc771b07164ee496850d9d56d9d85f1be1c3
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
