### PR TITLE
[WIP] Fix autofirma with firefox

### DIFF
--- a/srcpkgs/autofirma/template
+++ b/srcpkgs/autofirma/template
@@ -1,13 +1,13 @@
 # Template file for 'autofirma'
 pkgname=autofirma
 version=1.8.2
-revision=1
+revision=2
 _jmulticard_version=1.8
 hostmakedepends="apache-maven openjdk11"
 depends="virtual?java-environment"
 short_desc="Electronic signature client from the Spanish Public Administration"
 maintainer="Eloi Torrents <eloitor@disroot.org>"
-license="GPL-3.0-or-later"
+license="GPL-2.0-or-later, EUPL-1.1" # OR
 homepage="https://firmaelectronica.gob.es/"
 distfiles="https://github.com/ctt-gob-es/clienteafirma/archive/v${version}.tar.gz
  https://github.com/ctt-gob-es/jmulticard/archive/refs/tags/v${_jmulticard_version}.tar.gz"
@@ -16,6 +16,13 @@ checksum="40ebcd1200129ca08c21176a5fbd64c04ce0ac6bd932c4b213d4b7213f851a0d
 
 # maven-surefire-plugin needed
 make_check=no
+
+do_patch() {
+	cd "clienteafirma-${version}"
+	sed -i 's|/usr/bin/AutoFirma|/usr/bin/autofirma|g' afirma-simple/src/main/resources/linux/AutoFirma.js
+	sed -i 's|/usr/bin/AutoFirma|/usr/bin/autofirma|g' afirma-simple/src/main/resources/help/Spanish.lproj/pgs/LineaComandos.html
+	sed -i 's|/usr/lib/AutoFirma/AutoFirma.png|Autofirma|g' afirma-simple-installer/linux/instalador_deb/src/usr/share/applications/afirma.desktop
+}
 
 do_build() {
 	. /etc/profile.d/jdk.sh
@@ -35,5 +42,7 @@ do_check() {
 do_install() {
 	vmkdir usr/share/java/${pkgname}
 	vinstall clienteafirma-${version}/afirma-simple/target/AutoFirma.jar 644 usr/share/java/autofirma
+	vinstall clienteafirma-${version}/afirma-simple-installer/linux/instalador_deb/src/usr/share/applications/afirma.desktop 644 usr/share/applications
+	vinstall clienteafirma-${version}/afirma-simple-installer/linux/instalador_deb/src/usr/share/AutoFirma/AutoFirma.svg 644 usr/share/applications/icons
 	vbin "${FILESDIR}/autofirma"
 }


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **NO**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)

I received a bug report for using autofirma from firefox. Basically, somehow autofirma generates a file `/usr/lib64/firefox/defaults/pref/AutoFirma.js` which searches the file `/usr/bin/AutoFirma` which is not the name of the binary provided in the void package.

Maybe we should provide this file in the package instead of letting autofirma generate it? IDK.
I will ask for more testing of this PR (I don't know how to reproduce it) and I'll let you know when this is ready.