### PR TITLE
rpi-imager: update to 1.8.5.

### DIFF
--- a/srcpkgs/rpi-imager/template
+++ b/srcpkgs/rpi-imager/template
@@ -1,6 +1,6 @@
 # Template file for 'rpi-imager'
 pkgname=rpi-imager
-version=1.8.3
+version=1.8.5
 revision=1
 build_wrksrc=src
 build_style=cmake
@@ -14,7 +14,7 @@ maintainer="Adam Gausmann <adam@gaussian.dev>"
 license="Apache-2.0"
 homepage="https://github.com/raspberrypi/rpi-imager"
 distfiles="https://github.com/raspberrypi/rpi-imager/archive/v${version}.tar.gz"
-checksum=dd603bff1c76c8a9d7156232397c8428a781b2ce25bb6e3cf9c63e7820f794c4
+checksum=443e2ca2132067cc67038c82d890f70fd744da2503588852f014435dd11fb786
 
 pre_configure() {
 	ln -sf /bin/true $XBPS_WRAPPERDIR/lsblk


### PR DESCRIPTION
rpi-imager: update to 1.8.5

- I tested the changes in this PR: **briefly**

- I built this PR locally for my native architecture, (x86_64)
- I built this PR locally for these architectures:
  - armv6l
  - armv7l-musl
