### PR TITLE
python3-cairo: update to 1.26.0.

### DIFF
--- a/srcpkgs/python3-cairo/template
+++ b/srcpkgs/python3-cairo/template
@@ -1,6 +1,6 @@
 # Template file for 'python3-cairo'
 pkgname=python3-cairo
-version=1.25.1
+version=1.26.0
 revision=1
 build_style=meson
 hostmakedepends="pkg-config"
@@ -9,11 +9,11 @@ depends="python3"
 checkdepends="python3-pytest"
 short_desc="Python3 bindings for the cairo graphics library"
 maintainer="Orphaned <orphan@voidlinux.org>"
-license="LGPL-2.1-or-later, MPL-1.1"
+license="LGPL-2.1-only, MPL-1.1"
 homepage="https://pycairo.readthedocs.io/"
 changelog="https://raw.githubusercontent.com/pygobject/pycairo/main/NEWS"
 distfiles="https://github.com/pygobject/pycairo/releases/download/v${version}/pycairo-${version}.tar.gz"
-checksum=7e2be4fbc3b4536f16db7a11982cbf713e75069a4d73d44fe5a49b68423f5c0c
+checksum=2dddd0a874fbddb21e14acd9b955881ee1dc6e63b9c549a192d613a907f9cbeb
 
 if [ "$XBPS_CHECK_PKGS" ]; then
 	configure_args="-Dtests=true"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture: **x86_64**