### PR TITLE
strace: rebuild against newer libunwind

### DIFF
--- a/srcpkgs/strace/template
+++ b/srcpkgs/strace/template
@@ -1,7 +1,7 @@
 # Template file for 'strace'
 pkgname=strace
 version=6.7
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--enable-silent-rules $(vopt_with libunwind)"
 makedepends="$(vopt_if libunwind libunwind-devel)"


### PR DESCRIPTION
This fixes the

```
strace: Symbol `_UPT_accessors' has different size in shared object, consider re-linking
```

warning. I don't know what causes this warning. A proper solution that would prevent this warning from appearing again in the future would probably be better.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
