### PR TITLE
xfce4-weather-plugin: update to 0.11.1.

### DIFF
--- a/srcpkgs/xfce4-weather-plugin/patches/0003-parsers-Generalise-input-to-array-of-gchar.patch
+++ b/srcpkgs/xfce4-weather-plugin/patches/0003-parsers-Generalise-input-to-array-of-gchar.patch
@@ -1,0 +1,266 @@
+From dc3e3cdcba7d1c5159bb27b390ffd1b3a7feeb84 Mon Sep 17 00:00:00 2001
+From: Đoàn Trần Công Danh <congdanhqx@gmail.com>
+Date: Fri, 1 Mar 2024 21:56:34 +0700
+Subject: [PATCH 3/4] parsers: Generalise input to array of gchar
+
+In a later change, we will move to libsoup-3.0, which doesn't expose
+`response_body' in SoupMessage.
+
+Prepare for that move.
+---
+ panel-plugin/weather-config.c  | 18 +++++++++++++++--
+ panel-plugin/weather-parsers.c | 36 ++++++++++++++++++----------------
+ panel-plugin/weather-parsers.h |  7 +++----
+ panel-plugin/weather-search.c  | 18 +++++++++++++++--
+ panel-plugin/weather.c         | 26 ++++++++++++++++++++----
+ 5 files changed, 76 insertions(+), 29 deletions(-)
+
+diff --git a/panel-plugin/weather-config.c b/panel-plugin/weather-config.c
+index 66e0719..d08f2d2 100644
+--- a/panel-plugin/weather-config.c
++++ b/panel-plugin/weather-config.c
+@@ -241,9 +241,16 @@ cb_lookup_altitude(SoupSession *session,
+     xfceweather_dialog *dialog = (xfceweather_dialog *) user_data;
+     xml_altitude *altitude;
+     gdouble alt = 0;
++    const gchar *body = NULL;
++    gsize len = 0;
++
++    if (G_LIKELY(msg->response_body && msg->response_body->data)) {
++        body = msg->response_body->data;
++        len = msg->response_body->length;
++    }
+ 
+     altitude = (xml_altitude *)
+-        parse_xml_document(msg, (XmlParseFunc) parse_altitude);
++        parse_xml_document(body, len, (XmlParseFunc) parse_altitude);
+ 
+     if (altitude) {
+         alt = string_to_double(altitude->altitude, -9999);
+@@ -265,9 +272,16 @@ cb_lookup_timezone(SoupSession *session,
+ {
+     xfceweather_dialog *dialog = (xfceweather_dialog *) user_data;
+     xml_timezone *xml_tz;
++    const gchar *body = NULL;
++    gsize len = 0;
++
++    if (G_LIKELY(msg->response_body && msg->response_body->data)) {
++        body = msg->response_body->data;
++        len = msg->response_body->length;
++    }
+ 
+     xml_tz = (xml_timezone *)
+-        parse_xml_document(msg, (XmlParseFunc) parse_timezone);
++        parse_xml_document(body, len, (XmlParseFunc) parse_timezone);
+     weather_dump(weather_dump_timezone, xml_tz);
+ 
+     if (xml_tz) {
+diff --git a/panel-plugin/weather-parsers.c b/panel-plugin/weather-parsers.c
+index d53a2bc..28934c4 100644
+--- a/panel-plugin/weather-parsers.c
++++ b/panel-plugin/weather-parsers.c
+@@ -791,49 +791,51 @@ parse_timezone(xmlNode *cur_node)
+ 
+ 
+ xmlDoc *
+-get_xml_document(SoupMessage *msg)
++get_xml_document(const gchar *data, gsize len)
+ {
+-    if (G_LIKELY(msg && msg->response_body && msg->response_body->data)) {
+-        if (g_utf8_validate(msg->response_body->data, -1, NULL)) {
++    if (G_LIKELY(data && len)) {
++        if (g_utf8_validate(data, len, NULL)) {
+             /* force parsing as UTF-8, the XML encoding header may lie */
+-            return xmlReadMemory(msg->response_body->data,
+-                                 strlen(msg->response_body->data),
++            return xmlReadMemory(data, len,
+                                  NULL, "UTF-8", 0);
+         } else {
+-            return xmlParseMemory(msg->response_body->data,
+-                                  strlen(msg->response_body->data));
++            return xmlParseMemory(data, len);
+         }
+     }
+     return NULL;
+ }
+ 
+ json_object *
+-get_json_tree(SoupMessage *msg)
++get_json_tree(const gchar *data, gsize len)
+ {
+     json_object *res=NULL;
+-    enum json_tokener_error err;
++    struct json_tokener *tok = json_tokener_new();
+ 
+-    if (G_LIKELY(msg && msg->response_body && msg->response_body->data)) {
+-        res =  json_tokener_parse_verbose(msg->response_body->data, &err);
+-        if (err != json_tokener_success)
+-            g_warning("get_json_tree: error =%d",err);
++    if (G_UNLIKELY(tok == NULL)) {
++        return NULL;
++    } else if (G_LIKELY(data && len)) {
++        res =  json_tokener_parse_ex(tok, data, len);
++        if (res == NULL)
++            g_warning("get_json_tree: error =%d",
++                      json_tokener_get_error(tok));
+     }
++    json_tokener_free(tok);
+     return res;
+ }
+ 
+ gpointer
+-parse_xml_document(SoupMessage *msg,
++parse_xml_document(const gchar *data, gsize len,
+                    XmlParseFunc parse_func)
+ {
+     xmlDoc *doc;
+     xmlNode *root_node;
+     gpointer user_data = NULL;
+ 
+-    g_assert(msg != NULL);
+-    if (G_UNLIKELY(msg == NULL))
++    g_assert(data != NULL);
++    if (G_UNLIKELY(data == NULL || len == 0))
+         return NULL;
+ 
+-    doc = get_xml_document(msg);
++    doc = get_xml_document(data, len);
+     if (G_LIKELY(doc)) {
+         root_node = xmlDocGetRootElement(doc);
+         if (G_LIKELY(root_node))
+diff --git a/panel-plugin/weather-parsers.h b/panel-plugin/weather-parsers.h
+index a9d019d..09b9c02 100644
+--- a/panel-plugin/weather-parsers.h
++++ b/panel-plugin/weather-parsers.h
+@@ -22,7 +22,6 @@
+ #include <glib.h>
+ #include <gtk/gtk.h>
+ #include <libxml/parser.h>
+-#include <libsoup/soup.h>
+ #include <json-c/json_tokener.h>
+ 
+ #define DATA_EXPIRY_TIME (24 * 3600)
+@@ -157,11 +156,11 @@ xml_astro *get_astro(const GArray *astrodata,
+                      const time_t day_t,
+                      guint *index);
+ 
+-xmlDoc *get_xml_document(SoupMessage *msg);
++xmlDoc *get_xml_document(const gchar *data, gsize len);
+ 
+-json_object *get_json_tree(SoupMessage *msg);
++json_object *get_json_tree(const gchar *data, gsize len);
+ 
+-gpointer parse_xml_document(SoupMessage *msg,
++gpointer parse_xml_document(const gchar *data, gsize len,
+                             XmlParseFunc parse_func);
+ 
+ xml_astro *xml_astro_copy(const xml_astro *src);
+diff --git a/panel-plugin/weather-search.c b/panel-plugin/weather-search.c
+index b63e68d..cfbcd55 100644
+--- a/panel-plugin/weather-search.c
++++ b/panel-plugin/weather-search.c
+@@ -87,10 +87,17 @@ cb_searchdone(SoupSession *session,
+     gint found = 0;
+     GtkTreeIter iter;
+     GtkTreeSelection *selection;
++    const gchar *body = NULL;
++    gsize len = 0;
++
++    if (G_LIKELY(msg->response_body && msg->response_body->data)) {
++        body = msg->response_body->data;
++        len = msg->response_body->length;
++    }
+ 
+     gtk_widget_set_sensitive(dialog->find_button, TRUE);
+ 
+-    doc = get_xml_document(msg);
++    doc = get_xml_document(body, len);
+     if (!doc)
+         return;
+ 
+@@ -377,9 +384,16 @@ cb_geolocation(SoupSession *session,
+     xml_geolocation *geo;
+     gchar *full_loc;
+     units_config *units;
++    const gchar *body = NULL;
++    gsize len = 0;
++
++    if (G_LIKELY(msg->response_body && msg->response_body->data)) {
++        body = msg->response_body->data;
++        len = msg->response_body->length;
++    }
+ 
+     geo = (xml_geolocation *)
+-        parse_xml_document(msg, (XmlParseFunc) parse_geolocation);
++        parse_xml_document(body, len, (XmlParseFunc) parse_geolocation);
+     weather_dump(weather_dump_geolocation, geo);
+ 
+     if (!geo) {
+diff --git a/panel-plugin/weather.c b/panel-plugin/weather.c
+index daebd00..3a6a2b6 100644
+--- a/panel-plugin/weather.c
++++ b/panel-plugin/weather.c
+@@ -494,11 +494,17 @@ cb_astro_update_sun(SoupSession *session,
+     json_object *json_tree;
+     time_t now_t;
+     guint astro_forecast_days;
++    const gchar *body = NULL;
++    gsize len = 0;
+ 
+     data->msg_parse->sun_msg_processed++;
+     data->astro_update->http_status_code = msg->status_code;
+     if ((msg->status_code == 200 || msg->status_code == 203)) {
+-        json_tree = get_json_tree(msg);
++        if (G_LIKELY(msg->response_body && msg->response_body->data)) {
++            body = msg->response_body->data;
++            len = msg->response_body->length;
++        }
++        json_tree = get_json_tree(body, len);
+         if (G_LIKELY(json_tree)) {
+             if (!parse_astrodata_sun(json_tree, data->astrodata))  {
+                 data->msg_parse->sun_msg_parse_error++;
+@@ -550,11 +556,17 @@ cb_astro_update_moon(SoupSession *session,
+     json_object *json_tree;
+     time_t now_t;
+     guint astro_forecast_days;
++    const gchar *body = NULL;
++    gsize len = 0;
+ 
+     data->msg_parse->moon_msg_processed++;
+     data->astro_update->http_status_code = msg->status_code;
+     if ((msg->status_code == 200 || msg->status_code == 203)) {
+-        json_tree = get_json_tree(msg);
++        if (G_LIKELY(msg->response_body && msg->response_body->data)) {
++            body = msg->response_body->data;
++            len = msg->response_body->length;
++        }
++        json_tree = get_json_tree(body, len);
+         if (G_LIKELY(json_tree)) {
+             if (!parse_astrodata_moon(json_tree, data->astrodata))  {
+                 data->msg_parse->moon_msg_parse_error++;
+@@ -611,17 +623,23 @@ cb_weather_update(SoupSession *session,
+                   gpointer user_data)
+ {
+     plugin_data *data = user_data;
+-    xmlDoc *doc;
++    xmlDoc *doc = NULL;
+     xmlNode *root_node;
+     time_t now_t;
+     gboolean parsing_error = TRUE;
++    const gchar *body = NULL;
++    gsize len = 0;
+ 
+     weather_debug("Processing downloaded weather data.");
+     time(&now_t);
+     data->weather_update->attempt++;
+     data->weather_update->http_status_code = msg->status_code;
+     if (msg->status_code == 200 || msg->status_code == 203) {
+-        doc = get_xml_document(msg);
++        if (G_LIKELY(msg->response_body && msg->response_body->data)) {
++            body = msg->response_body->data;
++            len = msg->response_body->length;
++        }
++        doc = get_xml_document(body, len);
+         if (G_LIKELY(doc)) {
+             root_node = xmlDocGetRootElement(doc);
+             if (G_LIKELY(root_node))

--- a/srcpkgs/xfce4-weather-plugin/patches/0004-libsoup-Port-to-libsoup-3.0.patch
+++ b/srcpkgs/xfce4-weather-plugin/patches/0004-libsoup-Port-to-libsoup-3.0.patch
@@ -1,0 +1,540 @@
+From ec857414aaf53ff447062631734cdf44ab29d141 Mon Sep 17 00:00:00 2001
+From: Đoàn Trần Công Danh <congdanhqx@gmail.com>
+Date: Fri, 1 Mar 2024 21:56:34 +0700
+Subject: [PATCH 4/4] libsoup: Port to libsoup-3.0
+
+---
+ README                         |   4 +-
+ configure.ac.in                |   2 +-
+ panel-plugin/weather-config.c  |  32 ++++---
+ panel-plugin/weather-search.c  |  37 ++++++---
+ panel-plugin/weather-summary.c |  23 ++++--
+ panel-plugin/weather.c         | 147 +++++++++++++++------------------
+ panel-plugin/weather.h         |   2 +-
+ 7 files changed, 132 insertions(+), 115 deletions(-)
+
+diff --git a/configure.ac.in b/configure.ac.in
+index 8127fb0..0bf3da4 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -71,7 +71,7 @@ XDT_CHECK_PACKAGE([LIBXFCE4UI], [libxfce4ui-2], [4.16.0])
+ XDT_CHECK_PACKAGE([LIBXFCE4PANEL], [libxfce4panel-2.0], [4.14.0])
+ XDT_CHECK_PACKAGE([XFCONF], [libxfconf-0], [4.12.0])
+ XDT_CHECK_PACKAGE([LIBXML], [libxml-2.0], [2.4.0])
+-XDT_CHECK_PACKAGE([SOUP], [libsoup-2.4], [2.42.0])
++XDT_CHECK_PACKAGE([SOUP], [libsoup-3.0], [3.0.0])
+ XDT_CHECK_PACKAGE([JSON], [json-c], [0.13.1])
+ XDT_CHECK_OPTIONAL_PACKAGE([UPOWER_GLIB], [upower-glib], [0.9.0], [upower],
+                            [upower for adapting update interval to power state])
+diff --git a/panel-plugin/weather-config.c b/panel-plugin/weather-config.c
+index d08f2d2..06bd802 100644
+--- a/panel-plugin/weather-config.c
++++ b/panel-plugin/weather-config.c
+@@ -234,8 +234,8 @@ sanitize_location_name(const gchar *location_name)
+ 
+ 
+ static void
+-cb_lookup_altitude(SoupSession *session,
+-                   SoupMessage *msg,
++cb_lookup_altitude(GObject *source,
++                   GAsyncResult *result,
+                    gpointer user_data)
+ {
+     xfceweather_dialog *dialog = (xfceweather_dialog *) user_data;
+@@ -243,11 +243,14 @@ cb_lookup_altitude(SoupSession *session,
+     gdouble alt = 0;
+     const gchar *body = NULL;
+     gsize len = 0;
++    GError *error = NULL;
++    GBytes *response =
++        soup_session_send_and_read_finish(SOUP_SESSION(source), result, &error);
+ 
+-    if (G_LIKELY(msg->response_body && msg->response_body->data)) {
+-        body = msg->response_body->data;
+-        len = msg->response_body->length;
+-    }
++    if (G_UNLIKELY(error))
++        g_error_free(error);
++    else
++        body = g_bytes_get_data(response, &len);
+ 
+     altitude = (xml_altitude *)
+         parse_xml_document(body, len, (XmlParseFunc) parse_altitude);
+@@ -262,23 +265,27 @@ cb_lookup_altitude(SoupSession *session,
+     else if (dialog->pd->units->altitude == FEET)
+         alt /= 0.3048;
+     gtk_spin_button_set_value(GTK_SPIN_BUTTON(dialog->spin_alt), alt);
++    g_bytes_unref(response);
+ }
+ 
+ 
+ static void
+-cb_lookup_timezone(SoupSession *session,
+-                   SoupMessage *msg,
++cb_lookup_timezone(GObject *source,
++                   GAsyncResult *result,
+                    gpointer user_data)
+ {
+     xfceweather_dialog *dialog = (xfceweather_dialog *) user_data;
+     xml_timezone *xml_tz;
+     const gchar *body = NULL;
+     gsize len = 0;
++    GError *error = NULL;
++    GBytes *response =
++        soup_session_send_and_read_finish(SOUP_SESSION(source), result, &error);
+ 
+-    if (G_LIKELY(msg->response_body && msg->response_body->data)) {
+-        body = msg->response_body->data;
+-        len = msg->response_body->length;
+-    }
++    if (G_UNLIKELY(error))
++        g_error_free(error);
++    else
++        body = g_bytes_get_data(response, &len);
+ 
+     xml_tz = (xml_timezone *)
+         parse_xml_document(body, len, (XmlParseFunc) parse_timezone);
+@@ -290,6 +297,7 @@ cb_lookup_timezone(SoupSession *session,
+         xml_timezone_free(xml_tz);
+     } else
+         gtk_entry_set_text(GTK_ENTRY(dialog->text_timezone), "");
++    g_bytes_unref(response);
+ }
+ 
+ 
+diff --git a/panel-plugin/weather-search.c b/panel-plugin/weather-search.c
+index cfbcd55..d49dd79 100644
+--- a/panel-plugin/weather-search.c
++++ b/panel-plugin/weather-search.c
+@@ -76,8 +76,8 @@ sanitize_str(const gchar *str)
+ 
+ 
+ static void
+-cb_searchdone(SoupSession *session,
+-              SoupMessage *msg,
++cb_searchdone(GObject *source,
++              GAsyncResult *result,
+               gpointer user_data)
+ {
+     search_dialog *dialog = (search_dialog *) user_data;
+@@ -89,17 +89,22 @@ cb_searchdone(SoupSession *session,
+     GtkTreeSelection *selection;
+     const gchar *body = NULL;
+     gsize len = 0;
++    GError *error = NULL;
++    GBytes *response =
++        soup_session_send_and_read_finish(SOUP_SESSION(source), result, &error);
+ 
+-    if (G_LIKELY(msg->response_body && msg->response_body->data)) {
+-        body = msg->response_body->data;
+-        len = msg->response_body->length;
+-    }
++    if (G_UNLIKELY(error))
++        g_error_free(error);
++    else
++        body = g_bytes_get_data(response, &len);
+ 
+     gtk_widget_set_sensitive(dialog->find_button, TRUE);
+ 
+     doc = get_xml_document(body, len);
+-    if (!doc)
++    if (!doc) {
++        g_bytes_unref(response);
+         return;
++    }
+ 
+     cur_node = xmlDocGetRootElement(doc);
+     if (cur_node) {
+@@ -133,6 +138,7 @@ cb_searchdone(SoupSession *session,
+         }
+ 
+     gtk_tree_view_column_set_title(dialog->column, _("Results"));
++    g_bytes_unref(response);
+ }
+ 
+ 
+@@ -376,8 +382,8 @@ get_preferred_units(const gchar *country_code)
+ 
+ 
+ static void
+-cb_geolocation(SoupSession *session,
+-               SoupMessage *msg,
++cb_geolocation(GObject *source,
++               GAsyncResult *result,
+                gpointer user_data)
+ {
+     geolocation_data *data = (geolocation_data *) user_data;
+@@ -386,11 +392,14 @@ cb_geolocation(SoupSession *session,
+     units_config *units;
+     const gchar *body = NULL;
+     gsize len = 0;
++    GError *error = NULL;
++    GBytes *response =
++        soup_session_send_and_read_finish(SOUP_SESSION(source), result, &error);
+ 
+-    if (G_LIKELY(msg->response_body && msg->response_body->data)) {
+-        body = msg->response_body->data;
+-        len = msg->response_body->length;
+-    }
++    if (G_UNLIKELY(error))
++        g_error_free(error);
++    else
++        body = g_bytes_get_data(response, &len);
+ 
+     geo = (xml_geolocation *)
+         parse_xml_document(body, len, (XmlParseFunc) parse_geolocation);
+@@ -398,6 +407,7 @@ cb_geolocation(SoupSession *session,
+ 
+     if (!geo) {
+         data->cb(NULL, NULL, NULL, NULL, data->user_data);
++        g_bytes_unref(response);
+         g_free(data);
+         return;
+     }
+@@ -428,6 +438,7 @@ cb_geolocation(SoupSession *session,
+     g_slice_free(units_config, units);
+     xml_geolocation_free(geo);
+     g_free(full_loc);
++    g_bytes_unref(response);
+     g_free(data);
+ }
+ 
+diff --git a/panel-plugin/weather-summary.c b/panel-plugin/weather-summary.c
+index a6a2f56..224bb34 100644
+--- a/panel-plugin/weather-summary.c
++++ b/panel-plugin/weather-summary.c
+@@ -234,22 +234,29 @@ get_logo_path(void)
+ 
+ 
+ static void
+-logo_fetched(SoupSession *session,
+-             SoupMessage *msg,
++logo_fetched(GObject *source,
++             GAsyncResult *result,
+              gpointer user_data)
+ {
+-    if (msg && msg->response_body && msg->response_body->length > 0) {
++    GError *error = NULL;
++    GBytes *response =
++        soup_session_send_and_read_finish(SOUP_SESSION(source), result, &error);
++
++    if (G_LIKELY(error == NULL)) {
++        gsize len = 0;
++        const gchar *body = g_bytes_get_data(response, &len);
+         gchar *path = get_logo_path();
+-        GError *error = NULL;
+         GdkPixbuf *pixbuf = NULL;
+         gint scale_factor;
+-        if (!g_file_set_contents(path, msg->response_body->data,
+-                                 msg->response_body->length, &error)) {
++        g_file_set_contents(path, body, len, &error);
++        g_bytes_unref(response);
++        if (error) {
+             g_warning("Error downloading met.no logo image to %s, "
+                       "reason: %s\n", path,
+                       error ? error->message : "unknown");
+             g_error_free(error);
+             g_free(path);
++            g_bytes_unref(response);
+             return;
+         }
+         scale_factor = gtk_widget_get_scale_factor(user_data);
+@@ -261,7 +268,9 @@ logo_fetched(SoupSession *session,
+             cairo_surface_destroy(surface);
+             g_object_unref(pixbuf);
+         }
+-    }
++        g_bytes_unref(response);
++    } else
++        g_error_free(error);
+ }
+ 
+ 
+diff --git a/panel-plugin/weather.c b/panel-plugin/weather.c
+index 3a6a2b6..18fca37 100644
+--- a/panel-plugin/weather.c
++++ b/panel-plugin/weather.c
+@@ -23,6 +23,8 @@
+ #include <string.h>
+ #include <sys/stat.h>
+ 
++#include <glib.h>
++
+ #include <libxfce4util/libxfce4util.h>
+ #include <libxfce4ui/libxfce4ui.h>
+ #include <xfconf/xfconf.h>
+@@ -106,13 +108,14 @@ static void schedule_next_wakeup(plugin_data *data);
+ void
+ weather_http_queue_request(SoupSession *session,
+                            const gchar *uri,
+-                           SoupSessionCallback callback_func,
++                           GAsyncReadyCallback callback_func,
+                            gpointer user_data)
+ {
+     SoupMessage *msg;
+ 
+     msg = soup_message_new("GET", uri);
+-    soup_session_queue_message(session, msg, callback_func, user_data);
++    soup_session_send_and_read_async(session, msg, G_PRIORITY_DEFAULT, NULL,
++                                     callback_func, user_data);
+ }
+ 
+ 
+@@ -486,8 +489,8 @@ calc_next_download_time(const update_info *upi,
+  * Process downloaded sun astro data and schedule next astro update.
+  */
+ static void
+-cb_astro_update_sun(SoupSession *session,
+-                    SoupMessage *msg,
++cb_astro_update_sun(GObject *source,
++                    GAsyncResult *result,
+                     gpointer user_data)
+ {
+     plugin_data *data = user_data;
+@@ -496,14 +499,17 @@ cb_astro_update_sun(SoupSession *session,
+     guint astro_forecast_days;
+     const gchar *body = NULL;
+     gsize len = 0;
++    SoupMessage *msg;
++    GError *error = NULL;
++    GBytes *response;
+ 
++    msg = soup_session_get_async_result_message(SOUP_SESSION(source), result);
+     data->msg_parse->sun_msg_processed++;
+-    data->astro_update->http_status_code = msg->status_code;
+-    if ((msg->status_code == 200 || msg->status_code == 203)) {
+-        if (G_LIKELY(msg->response_body && msg->response_body->data)) {
+-            body = msg->response_body->data;
+-            len = msg->response_body->length;
+-        }
++    data->astro_update->http_status_code = soup_message_get_status(msg);
++    response = soup_session_send_and_read_finish(SOUP_SESSION(source),
++                                                 result, &error);
++    if (G_LIKELY(error == NULL)) {
++        body = g_bytes_get_data(response, &len);
+         json_tree = get_json_tree(body, len);
+         if (G_LIKELY(json_tree)) {
+             if (!parse_astrodata_sun(json_tree, data->astrodata))  {
+@@ -519,10 +525,12 @@ cb_astro_update_sun(SoupSession *session,
+             g_warning("Error parsing sun astronomical data!");
+             weather_debug("No json_tree");
+         }
++        g_bytes_unref(response);
+     } else {
+         data->msg_parse->http_msg_fail = TRUE;
+-        g_warning_once("Download of sun astronomical data failed with HTTP Status Code %d, Reason phrase: %s",
+-                       msg->status_code, msg->reason_phrase);
++        g_warning_once("Download of sun astronomical data failed: %s",
++                       error->message);
++        g_error_free(error);
+     }
+ 
+     astro_forecast_days = data->forecast_days + 1;
+@@ -548,8 +556,8 @@ cb_astro_update_sun(SoupSession *session,
+  * Process downloaded moon astro data and schedule next astro update.
+  */
+ static void
+-cb_astro_update_moon(SoupSession *session,
+-                     SoupMessage *msg,
++cb_astro_update_moon(GObject *source,
++                     GAsyncResult *result,
+                      gpointer user_data)
+ {
+     plugin_data *data = user_data;
+@@ -558,14 +566,17 @@ cb_astro_update_moon(SoupSession *session,
+     guint astro_forecast_days;
+     const gchar *body = NULL;
+     gsize len = 0;
++    SoupMessage *msg;
++    GError *error = NULL;
++    GBytes *response;
+ 
++    response = soup_session_send_and_read_finish(SOUP_SESSION(source),
++                                                 result, &error);
++    msg = soup_session_get_async_result_message(SOUP_SESSION(source), result);
+     data->msg_parse->moon_msg_processed++;
+-    data->astro_update->http_status_code = msg->status_code;
+-    if ((msg->status_code == 200 || msg->status_code == 203)) {
+-        if (G_LIKELY(msg->response_body && msg->response_body->data)) {
+-            body = msg->response_body->data;
+-            len = msg->response_body->length;
+-        }
++    data->astro_update->http_status_code = soup_message_get_status(msg);
++    if (G_LIKELY(error == NULL)) {
++        body = g_bytes_get_data(response, &len);
+         json_tree = get_json_tree(body, len);
+         if (G_LIKELY(json_tree)) {
+             if (!parse_astrodata_moon(json_tree, data->astrodata))  {
+@@ -581,10 +592,12 @@ cb_astro_update_moon(SoupSession *session,
+             g_warning("Error parsing moon astronomical data");
+             weather_debug("No json_tree");
+         }
++        g_bytes_unref(response);
+     } else {
+         data->msg_parse->http_msg_fail = TRUE;
+-        g_warning_once("Download of moon astronomical data failed with HTTP Status Code %d, Reason phrase: %s",
+-                       msg->status_code, msg->reason_phrase);
++        g_warning_once("Download of moon astronomical data failed: %s",
++                       error->message);
++        g_error_free(error);
+     }
+ 
+     astro_forecast_days = data->forecast_days + 1;
+@@ -618,8 +631,8 @@ cb_astro_update_moon(SoupSession *session,
+  * Process downloaded weather data and schedule next weather update.
+  */
+ static void
+-cb_weather_update(SoupSession *session,
+-                  SoupMessage *msg,
++cb_weather_update(GObject *source,
++                  GAsyncResult *result,
+                   gpointer user_data)
+ {
+     plugin_data *data = user_data;
+@@ -629,16 +642,19 @@ cb_weather_update(SoupSession *session,
+     gboolean parsing_error = TRUE;
+     const gchar *body = NULL;
+     gsize len = 0;
++    SoupMessage *msg;
++    GError *error = NULL;
++    GBytes *response = NULL;
+ 
+     weather_debug("Processing downloaded weather data.");
++    response = soup_session_send_and_read_finish(SOUP_SESSION(source),
++                                                 result, &error);
++    msg = soup_session_get_async_result_message(SOUP_SESSION(source), result);
+     time(&now_t);
+     data->weather_update->attempt++;
+-    data->weather_update->http_status_code = msg->status_code;
+-    if (msg->status_code == 200 || msg->status_code == 203) {
+-        if (G_LIKELY(msg->response_body && msg->response_body->data)) {
+-            body = msg->response_body->data;
+-            len = msg->response_body->length;
+-        }
++    data->weather_update->http_status_code = soup_message_get_status(msg);
++    if (G_LIKELY(error == NULL)) {
++        body = g_bytes_get_data(response, &len);
+         doc = get_xml_document(body, len);
+         if (G_LIKELY(doc)) {
+             root_node = xmlDocGetRootElement(doc);
+@@ -650,12 +666,13 @@ cb_weather_update(SoupSession *session,
+                 }
+             xmlFreeDoc(doc);
+         }
++        g_bytes_unref(response);
+         if (parsing_error)
+             g_warning("Error parsing weather data!");
+-    } else
+-        weather_debug
+-            ("Download of weather data failed with HTTP Status Code %d, "
+-             "Reason phrase: %s", msg->status_code, msg->reason_phrase);
++    } else {
++        weather_debug("Download of weather data failed: %s", error->message);
++        g_error_free(error);
++    }
+     data->weather_update->next = calc_next_download_time(data->weather_update,
+                                                          now_t);
+ 
+@@ -1713,32 +1730,6 @@ mi_click(GtkWidget *widget,
+     update_weatherdata_with_reset(data);
+ }
+ 
+-static void
+-proxy_auth(SoupSession *session,
+-           SoupMessage *msg,
+-           SoupAuth *auth,
+-           gboolean retrying,
+-           gpointer user_data)
+-{
+-    SoupURI *soup_proxy_uri;
+-    const gchar *proxy_uri;
+-
+-    if (!retrying) {
+-        if (msg->status_code == SOUP_STATUS_PROXY_AUTHENTICATION_REQUIRED) {
+-            proxy_uri = g_getenv("HTTP_PROXY");
+-            if (!proxy_uri)
+-                proxy_uri = g_getenv("http_proxy");
+-            if (proxy_uri) {
+-                soup_proxy_uri = soup_uri_new(proxy_uri);
+-                soup_auth_authenticate(auth,
+-                                       soup_uri_get_user(soup_proxy_uri),
+-                                       soup_uri_get_password(soup_proxy_uri));
+-                soup_uri_free(soup_proxy_uri);
+-            }
+-        }
+-    }
+-}
+-
+ 
+ #ifdef HAVE_UPOWER_GLIB
+ static void
+@@ -2038,9 +2029,10 @@ static plugin_data *
+ xfceweather_create_control(XfcePanelPlugin *plugin)
+ {
+     plugin_data *data = g_slice_new0(plugin_data);
+-    SoupURI *soup_proxy_uri;
++    GProxyResolver *proxy_resolver;
+     const gchar *proxy_uri;
+-    const gchar *proxy_user;
++    const gchar *no_proxy;
++    gchar **no_proxy_lst = NULL;
+     GtkWidget *refresh;
+     cairo_surface_t *icon = NULL;
+     data_types lbl;
+@@ -2078,29 +2070,26 @@ xfceweather_create_control(XfcePanelPlugin *plugin)
+ 
+     /* Setup session for HTTP connections */
+     data->session = soup_session_new();
+-    g_object_set(data->session, SOUP_SESSION_USER_AGENT,
+-                 PACKAGE_NAME "-" PACKAGE_VERSION, NULL);
+-    g_object_set(data->session, SOUP_SESSION_TIMEOUT,
+-                 CONN_TIMEOUT, NULL);
++    soup_session_set_user_agent(data->session,
++                                PACKAGE_NAME "-" PACKAGE_VERSION);
++    soup_session_set_timeout(data->session, CONN_TIMEOUT);
+ 
+     /* Set the proxy URI from environment */
+     proxy_uri = g_getenv("HTTP_PROXY");
+     if (!proxy_uri)
+         proxy_uri = g_getenv("http_proxy");
+     if (proxy_uri) {
+-        soup_proxy_uri = soup_uri_new(proxy_uri);
+-        g_object_set(data->session, SOUP_SESSION_PROXY_URI,
+-                     soup_proxy_uri, NULL);
+-
+-        /* check if uri contains authentication info */
+-        proxy_user = soup_uri_get_user(soup_proxy_uri);
+-        if (proxy_user && strlen(proxy_user) > 0) {
+-            g_signal_connect(G_OBJECT(data->session), "authenticate",
+-                             G_CALLBACK(proxy_auth), NULL);
+-        }
+-
+-        soup_uri_free(soup_proxy_uri);
+-    }
++        no_proxy = g_getenv("no_proxy");
++        if (!no_proxy)
++            no_proxy = g_getenv("NO_PROXY");
++        if (no_proxy)
++            no_proxy_lst = g_strsplit(no_proxy, ",", -1);
++        proxy_resolver = g_simple_proxy_resolver_new(proxy_uri, no_proxy_lst);
++        g_strfreev(no_proxy_lst);
++        soup_session_set_proxy_resolver(data->session, proxy_resolver);
++        g_object_unref(proxy_resolver);
++    }
++    /* Otherwise, g_proxy_resolver_get_default() will be used */
+ 
+     data->scrollbox = gtk_scrollbox_new();
+ 
+diff --git a/panel-plugin/weather.h b/panel-plugin/weather.h
+index 208de09..01974ce 100644
+--- a/panel-plugin/weather.h
++++ b/panel-plugin/weather.h
+@@ -183,7 +183,7 @@ extern gboolean debug_mode;
+ 
+ void weather_http_queue_request(SoupSession *session,
+                                 const gchar *uri,
+-                                SoupSessionCallback callback_func,
++                                GAsyncReadyCallback callback_func,
+                                 gpointer user_data);
+ 
+ void scrollbox_set_visible(plugin_data *data);

--- a/srcpkgs/xfce4-weather-plugin/template
+++ b/srcpkgs/xfce4-weather-plugin/template
@@ -1,16 +1,21 @@
 # Template file for 'xfce4-weather-plugin'
 pkgname=xfce4-weather-plugin
-version=0.11.0
+version=0.11.2
 revision=1
 build_style=gnu-configure
 configure_args="--with-locales-dir=/usr/share/locale"
-hostmakedepends="pkg-config intltool"
-makedepends="libxfce4ui-devel xfce4-panel-devel libxml2-devel libsoup-devel upower-devel"
+hostmakedepends="pkg-config intltool xfce4-dev-tools gettext-devel"
+makedepends="libxfce4ui-devel xfce4-panel-devel libxml2-devel libsoup3-devel
+ json-c-devel upower-devel"
 depends="hicolor-icon-theme"
 short_desc="XFCE panel plugin to show temperature and weather"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="https://goodies.xfce.org/projects/panel-plugins/xfce4-weather-plugin"
 distfiles="https://archive.xfce.org/src/panel-plugins/${pkgname}/${version%.*}/${pkgname}-${version}.tar.bz2"
-checksum=e3242ea951d51bc0fded1d02a4f1f662bec16a1fb10c855f71bda6541a1153fc
+checksum=65d40aff7863550858a9f9d2b6054f27c69a3e7e712991785987f9a73bba876b
 lib32disabled=yes
+
+pre_configure() {
+	autoreconf -fi
+}


### PR DESCRIPTION
Carry patches for libsoup-3.0 because upstream wants to wait until  Xfce 4.20 is released  or  late 2024 - early 2025,
https://gitlab.xfce.org/panel-plugins/xfce4-weather-plugin/-/merge_requests/28

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
