### PR TITLE
New package: biboumi-9.0.

### DIFF
--- a/srcpkgs/biboumi/files/biboumi/run
+++ b/srcpkgs/biboumi/files/biboumi/run
@@ -1,0 +1,3 @@
+#!/bin/sh
+exec 2>&1
+exec chpst -u _biboumi:_biboumi biboumi /etc/biboumi/biboumi.cfg

--- a/srcpkgs/biboumi/patches/remove-git.patch
+++ b/srcpkgs/biboumi/patches/remove-git.patch
@@ -1,0 +1,33 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 687d68b..47bb1a0 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -287,27 +287,6 @@ foreach(file ${source_all})
+   set_property(SOURCE ${file} APPEND PROPERTY COMPILE_DEFINITIONS __FILENAME__="${shorter_file}")
+ endforeach()
+ 
+-#
+-## Add a rule to download the catch unit test framework
+-#
+-include(ExternalProject)
+-ExternalProject_Add(catch
+-  GIT_REPOSITORY "https://lab.louiz.org/louiz/Catch.git"
+-  PREFIX "external"
+-  UPDATE_COMMAND ""
+-  CONFIGURE_COMMAND ""
+-  BUILD_COMMAND ""
+-  INSTALL_COMMAND ""
+-  )
+-set_target_properties(catch PROPERTIES EXCLUDE_FROM_ALL TRUE)
+-ExternalProject_Get_Property(catch SOURCE_DIR)
+-if(NOT EXISTS ${CMAKE_SOURCE_DIR}/tests/catch.hpp)
+-  target_include_directories(test_suite
+-    PUBLIC "${SOURCE_DIR}/single_include/"
+-    )
+-  add_dependencies(test_suite catch)
+-endif()
+-
+ #
+ ## Add some custom rules to launch the tests
+ #
+

--- a/srcpkgs/biboumi/template
+++ b/srcpkgs/biboumi/template
@@ -1,0 +1,24 @@
+# Template file for 'biboumi'
+pkgname=biboumi
+version=9.0
+revision=1
+build_style=cmake
+configure_args="-DWITHOUT_SYSTEMD=1 -Wno-dev"
+conf_files="/etc/biboumi/biboumi.cfg"
+make_dirs="/var/lib/biboumi/ 0755 _biboumi _biboumi"
+hostmakedepends="python3-Sphinx python3-sphinx_rtd_theme pkg-config"
+makedepends="expat-devel libticonv-devel sqlite-devel libpqxx-devel libidn-devel udns-devel botan-devel postgresql-libs-devel"
+short_desc="XMPP gateway that connects to IRC servers"
+maintainer="Luca Matei Pintilie <luca@lucamatei.com>"
+license="Zlib"
+homepage="https://biboumi.louiz.org/"
+changelog="https://codeberg.org/poezio/biboumi/src/branch/master/CHANGELOG.rst"
+distfiles="https://codeberg.org/poezio/biboumi/archive/${version}.tar.gz"
+checksum="618776cf3dccb59c84322a921681f4b1f8b144b523fd5e118d2b47fb0f3eb43f"
+
+system_accounts="_biboumi"
+
+post_install() {
+	cp conf/biboumi.cfg "${DESTDIR}/etc/biboumi/biboumi.cfg"
+	vsv biboumi
+}


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86\_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl (crossbuild)

Crossbuilt from x86\_64-glibc to aarch64-musl and tested with
prosody-0.12.4 (packaged on #48919).
