### PR TITLE
nss-pam-ldapd: build libnss_ldap.so.2 for musl

### DIFF
--- a/srcpkgs/musl-nscd/files/nscd/run
+++ b/srcpkgs/musl-nscd/files/nscd/run
@@ -2,4 +2,4 @@
 exec 2>&1
 [ -r conf ] && . ./conf
 mkdir -p /var/run/nscd /var/db/nscd
-exec nscd -F ${OPTS} >/dev/null
+exec nscd ${OPTS} >/dev/null

--- a/srcpkgs/musl-nscd/template
+++ b/srcpkgs/musl-nscd/template
@@ -1,7 +1,7 @@
 # Template file for 'musl-nscd'
 pkgname=musl-nscd
 version=1.1.1
-revision=1
+revision=2
 archs="*-musl"
 build_style=gnu-configure
 hostmakedepends="bison flex"

--- a/srcpkgs/nss-pam-ldapd/patches/nss-pam-ldapd-0.9.12-netdb-defines.patch
+++ b/srcpkgs/nss-pam-ldapd/patches/nss-pam-ldapd-0.9.12-netdb-defines.patch
@@ -1,0 +1,26 @@
+Bug: https://bugs.gentoo.org/716272
+
+--- a/nss/hosts.c
++++ b/nss/hosts.c
+@@ -49,6 +49,9 @@
+   *h_errnop = NO_RECOVERY;                                                  \
+   return NSS_STATUS_UNAVAIL;
+
++#ifndef NETDB_INTERNAL
++#define NETDB_INTERNAL -1
++#endif
+ #undef ERROR_OUT_BUFERROR
+ #define ERROR_OUT_BUFERROR(fp)                                              \
+   *errnop = ERANGE;                                                         \
+--- a/nss/networks.c
++++ b/nss/networks.c
+@@ -49,6 +49,9 @@
+   *h_errnop = NO_RECOVERY;                                                  \
+   return NSS_STATUS_UNAVAIL;
+
++#ifndef NETDB_INTERNAL
++#define NETDB_INTERNAL -1
++#endif
+ #undef ERROR_OUT_BUFERROR
+ #define ERROR_OUT_BUFERROR(fp)                                              \
+   *errnop = ERANGE;                                                         \

--- a/srcpkgs/nss-pam-ldapd/template
+++ b/srcpkgs/nss-pam-ldapd/template
@@ -1,7 +1,7 @@
 # Template file for 'nss-pam-ldapd'
 pkgname=nss-pam-ldapd
 version=0.9.12
-revision=2
+revision=3
 build_style=gnu-configure
 configure_args="--enable-sasl --enable-kerberos --with-pam-seclib-dir=/usr/lib/security/"
 conf_files="/etc/nslcd.conf"
@@ -16,10 +16,15 @@ checksum=829b2371be42c040108165d2ea422eb6f6cacba6a01083f67025752a574a685b
 system_accounts="nslcd"
 
 case "$XBPS_TARGET_MACHINE" in
-	*musl) configure_args+=" --disable-nss";;
+	*musl) makedepends+=" musl-nscd-devel" ;;
 esac
 
 pre_configure() {
+	case "$XBPS_TARGET_MACHINE" in
+		*musl)
+			vsed -i 's/ lookup_netgroup / /' tests/Makefile.am
+			;;
+	esac
 	./autogen.sh
 }
 


### PR DESCRIPTION
Don't disable nss in configure. Grab patch from Gentoo for defines missing in musl netdb.h. Disable netgroup_lookup test for musl.

Also remove -F flag in runit script for musl-nscd as it's not recognized.

Tested against my ldap servers and can confirm that it fetches the data defined by nsswitch.conf. Have been running this for a few months and have seen no obvious issues.

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-musl)
- I built this PR locally for these architectures:
  - aarch64-musl
  - armv7l
  - armv6l-musl