### PR TITLE
gnome-sudoku: update to 45.5

### DIFF
--- a/srcpkgs/gnome-sudoku/template
+++ b/srcpkgs/gnome-sudoku/template
@@ -1,8 +1,7 @@
 # Template file for 'gnome-sudoku'
 pkgname=gnome-sudoku
-version=45.2
+version=45.5
 revision=1
-build_helper="gir"
 build_style=meson
 hostmakedepends="gettext glib-devel itstool pkg-config vala
  desktop-file-utils gtk4-update-icon-cache"
@@ -12,6 +11,7 @@ short_desc="GNOME Sudoku Japanese logic game"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-3.0-or-later"
 homepage="https://wiki.gnome.org/Apps/Sudoku"
-changelog="https://gitlab.gnome.org/GNOME/gnome-sudoku/-/raw/master/NEWS"
+changelog=https://download.gnome.org/sources/gnome-sudoku/45/gnome-sudoku-45.5.news
+#changelog="https://gitlab.gnome.org/GNOME/gnome-sudoku/-/raw/master/NEWS"
 distfiles="${GNOME_SITE}/gnome-sudoku/${version%.*}/gnome-sudoku-${version}.tar.xz"
-checksum=55eb344797aec3d89f7abfcbe7b763027f5c0e2a5a22e68fbf32c7e9439d95f2
+checksum=8e8e2bca6cda49f05d0061c3f9866020b363ef84c3a30f5b7e8ed4e41a57fd0f


### PR DESCRIPTION
split into a separate pr (https://github.com/void-linux/void-packages/pull/48752#issuecomment-1976568640).

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl x
  - armv7l x
  - armv6l-musl x