### PR TITLE
libmediaart: update to 1.9.6

### DIFF
--- a/srcpkgs/libmediaart/template
+++ b/srcpkgs/libmediaart/template
@@ -1,6 +1,6 @@
 # Template file for 'libmediaart'
 pkgname=libmediaart
-version=1.9.5
+version=1.9.6
 revision=1
 build_style=meson
 build_helper="gir"
@@ -14,7 +14,7 @@ license="LGPL-2.1-or-later"
 homepage="http://www.gnome.org/"
 changelog="https://gitlab.gnome.org/GNOME/libmediaart/-/raw/master/NEWS"
 distfiles="${GNOME_SITE}/${pkgname}/${version%.*}/${pkgname}-${version}.tar.xz"
-checksum=07def5a42c482ae71d3e1f77a4d0fdc337f74226059a65284d6d5a241f0e9cd6
+checksum=c3bc5025d7db380587f9c8eb800c611f6b5a16d6b4b78fcff93f62876a677f17
 
 # Package build options
 build_options="gir vala gtk_doc"


### PR DESCRIPTION
split into a separate pr (https://github.com/void-linux/void-packages/pull/48762#issuecomment-1976502687).

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl x
  - armv7l x
  - armv6l-musl x