### PR TITLE
gtksourceview5: update to 5.10.0

### DIFF
--- a/srcpkgs/gtksourceview5/template
+++ b/srcpkgs/gtksourceview5/template
@@ -1,6 +1,6 @@
 # Template file for 'gtksourceview5'
 pkgname=gtksourceview5
-version=5.8.0
+version=5.10.0
 revision=1
 build_style=meson
 build_helper="gir"
@@ -18,7 +18,7 @@ homepage="https://wiki.gnome.org/Projects/GtkSourceView"
 changelog="https://gitlab.gnome.org/GNOME/gtksourceview/-/raw/master/NEWS"
 #changelog="https://gitlab.gnome.org/GNOME/gtksourceview/-/raw/gtksourceview-5-8/NEWS"
 distfiles="${GNOME_SITE}/gtksourceview/${version%.*}/gtksourceview-${version}.tar.xz"
-checksum=110dd4c20def21886fbf777298fe0ef8cc2ad6023b8f36c7424411a414818933
+checksum=b38a3010c34f59e13b05175e9d20ca02a3110443fec2b1e5747413801bc9c23f
 make_check_pre="xvfb-run"
 
 # Package build options


### PR DESCRIPTION
split into a separate pr (https://github.com/void-linux/void-packages/pull/48762#issuecomment-1976502687).

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl x
  - armv7l x
  - armv6l-musl x