### PR TITLE
mm-common: update to 1.0.6

### DIFF
--- a/srcpkgs/mm-common/template
+++ b/srcpkgs/mm-common/template
@@ -1,6 +1,6 @@
 # Template file for 'mm-common'
 pkgname=mm-common
-version=1.0.4
+version=1.0.6
 revision=1
 build_style=meson
 hostmakedepends="pkg-config"
@@ -9,5 +9,5 @@ short_desc="Common development macros for GTK+ C++"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="LGPL-2.1-or-later"
 homepage="https://gtkmm.org/en/"
-distfiles="http://download.gnome.org/sources/mm-common/${version%.*}/${pkgname}-${version}.tar.xz"
-checksum=e954c09b4309a7ef93e13b69260acdc5738c907477eb381b78bb1e414ee6dbd8
+distfiles="${GNOME_SITE}/mm-common/${version%.*}/mm-common-${version}.tar.xz"
+checksum=b55c46037dbcdabc5cee3b389ea11cc3910adb68ebe883e9477847aa660862e7


### PR DESCRIPTION
split into a separate pr (https://github.com/void-linux/void-packages/pull/48762#issuecomment-1976502687).

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl x
  - armv7l x
  - armv6l-musl x