### PR TITLE
tbb: fix Python module installation

### DIFF
--- a/srcpkgs/tbb/template
+++ b/srcpkgs/tbb/template
@@ -1,7 +1,7 @@
 # Template file for 'tbb'
 pkgname=tbb
 version=2021.11.0
-revision=3
+revision=4
 build_style=cmake
 configure_args="-DTBB_STRICT=OFF -DTBB_TEST=OFF"
 makedepends="libgomp-devel libhwloc-devel"
@@ -28,11 +28,39 @@ if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
 fi
 
 post_extract() {
-
 	if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
 		vsed -e "s@#define MALLOC_UNIXLIKE_OVERLOAD_ENABLED __linux__@@" \
 		  -i src/tbbmalloc_proxy/proxy.h
 	fi
+}
+
+post_install() {
+	# The Python package is installed as an egg, which is deprecated
+	# and isn't added to the Python path, so just unpack it.
+	local f sitelib
+	sitelib="${DESTDIR}/${py3_sitelib}"
+
+	for f in "${sitelib}"/TBB*-"py${py3_ver}"*.egg/EGG-INFO; do
+		[ -d "${f}" ] || continue
+		mv "${f}" "${f%-"py${py3_ver}"*.egg/EGG-INFO}-py${py3_ver}.egg-info"
+	done
+
+	for f in "${sitelib}"/TBB*.egg/*; do
+		[ -e "${f}" ] || continue
+		mv "${f}" "${DESTDIR}/${py3_sitelib}"
+	done
+
+	# Clean up the egg directory to confirm it was successfully unpacked
+	for f in "${sitelib}"/*.egg; do
+		[ -e "${f}" ] || continue
+		rmdir "${f}"
+	done
+
+	# Make sure the post-install hook finds this shlib for renaming
+	for f in "${sitelib}"/tbb/_api*.so; do
+		[ -e "${f}" ] || continue
+		chmod 0755 "${f}"
+	done
 }
 
 tbb-devel_package() {


### PR DESCRIPTION
Installing as an egg is deprecated and, without a path inclusion, makes the package un-importable anyway. The easiest path seems to be just unpacking the egg.

#### Testing the changes
- I tested the changes in this PR: **briefly**