### PR TITLE
libsigc++: update to 2.12.1

### DIFF
--- a/srcpkgs/libsigc++/template
+++ b/srcpkgs/libsigc++/template
@@ -1,6 +1,6 @@
 # Template file for 'libsigc++'
 pkgname=libsigc++
-version=2.12.0
+version=2.12.1
 revision=1
 build_style=meson
 configure_args="-Dbuild-examples=false -Dwarnings=max"
@@ -9,8 +9,9 @@ short_desc="Type-safe callback system for C++ programs"
 maintainer="Enno Boland <gottox@voidlinux.org>"
 license="LGPL-2.1-or-later"
 homepage="https://libsigcplusplus.github.io/libsigcplusplus/"
+changelog="https://raw.githubusercontent.com/libsigcplusplus/libsigcplusplus/libsigc%2B%2B-2-12/NEWS"
 distfiles="${GNOME_SITE}/libsigc++/${version%.*}/libsigc++-${version}.tar.xz"
-checksum=1c466d2e64b34f9b118976eb21b138c37ed124d0f61497df2a90ce6c3d9fa3b5
+checksum=a9dbee323351d109b7aee074a9cb89ca3e7bcf8ad8edef1851f4cf359bd50843
 
 if [ -z "$XBPS_CHECK_PKGS" ]; then
 	configure_args+=" -Dbuild-tests=false"


### PR DESCRIPTION
split into a separate pr (https://github.com/void-linux/void-packages/pull/48762#issuecomment-1976502687).

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl x
  - armv7l x
  - armv6l-musl x