### PR TITLE
gupnp: update to 1.6.6

### DIFF
--- a/srcpkgs/gupnp/template
+++ b/srcpkgs/gupnp/template
@@ -1,6 +1,6 @@
 # Template file for 'gupnp'
 pkgname=gupnp
-version=1.6.5
+version=1.6.6
 revision=1
 build_style=meson
 build_helper="gir"
@@ -14,7 +14,7 @@ license="LGPL-2.1-or-later"
 homepage="https://wiki.gnome.org/Projects/GUPnP"
 changelog="https://gitlab.gnome.org/GNOME/gupnp/-/raw/master/NEWS"
 distfiles="${GNOME_SITE}/gupnp/${version%.*}/gupnp-${version}.tar.xz"
-checksum=437dff970142e8407087a89855f717e20d27c9d76e05b4cd517df621c7d888cd
+checksum=c9dc50e8c78b3792d1b0e6c5c5f52c93e9345d3dae2891e311a993a574f5a04f
 
 build_options="gir"
 build_options_default="gir"


### PR DESCRIPTION
split into a separate pr (https://github.com/void-linux/void-packages/pull/48762#issuecomment-1976502687).

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl x
  - armv7l x
  - armv6l-musl x