### PR TITLE
gnote: update to 45.1

### DIFF
--- a/srcpkgs/gnote/template
+++ b/srcpkgs/gnote/template
@@ -1,19 +1,19 @@
 # Template file for 'gnote'
 pkgname=gnote
-version=44.0
+version=45.1
 revision=1
 build_style=meson
 hostmakedepends="pkg-config gettext itstool
  desktop-file-utils gtk-update-icon-cache"
-makedepends="libsecret-devel libxslt-devel libuuid-devel gtkmm-devel
- libxml2-devel gtkspell3-devel"
+makedepends="libsecret-devel libxslt-devel libuuid-devel gtkmm4-devel
+ libxml2-devel"
 depends="desktop-file-utils"
 checkdepends="glib-devel"
 short_desc="GNOME note taking application"
 maintainer="Enno Boland <gottox@voidlinux.org>"
 license="GPL-3.0-or-later"
 homepage="https://wiki.gnome.org/Apps/Gnote"
-changelog="https://gitlab.gnome.org/GNOME/gnote/-/raw/gnome-44/NEWS"
+changelog="https://gitlab.gnome.org/GNOME/gnote/-/raw/gnome-45/NEWS"
 distfiles="${GNOME_SITE}/gnote/${version%.*}/gnote-${version}.tar.xz"
-checksum=dc3bd79268fe99d4ed56679ac076cc9d9aaaf62796138d371cf08815f7e6492d
+checksum=9eec27f8cb0a10d2fdb914a451e8b8418c260e78bf07360781a78a5e418cf941
 lib32disabled=yes


### PR DESCRIPTION
split into a separate pr (https://github.com/void-linux/void-packages/pull/48762#issuecomment-1976502687).

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl x
  - armv7l x
  - armv6l-musl x