### PR TITLE
gnome-tour: update to 45.0

### DIFF
--- a/srcpkgs/gnome-tour/template
+++ b/srcpkgs/gnome-tour/template
@@ -1,6 +1,6 @@
 # Template file for 'gnome-tour'
 pkgname=gnome-tour
-version=44.0
+version=45.0
 revision=1
 build_style=meson
 build_helper=rust
@@ -13,7 +13,7 @@ license="GPL-3.0-or-later"
 homepage="https://gitlab.gnome.org/GNOME/gnome-tour/"
 changelog="https://gitlab.gnome.org/GNOME/gnome-tour/-/raw/master/NEWS"
 distfiles="${GNOME_SITE}/gnome-tour/${version%.*}/gnome-tour-${version}.tar.xz"
-checksum=06de7677dd1c590d0ea33a032c9ccf4c37c62bc56215b823c879e42ee630c2b6
+checksum=5be4b8ef4b8f4d5ecaccc31048db6e085a8f7bffadaa0843b8e8a788ff1dadee
 
 post_patch() {
 	[ -z "$CROSS_BUILD" ] && return 0


### PR DESCRIPTION
split into a separate pr (https://github.com/void-linux/void-packages/pull/48762#issuecomment-1976502687).
a part of #48752

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl x
  - armv7l x
  - armv6l-musl x