### PR TITLE
gnome-text-editor: update to 45.3

### DIFF
--- a/srcpkgs/gnome-text-editor/template
+++ b/srcpkgs/gnome-text-editor/template
@@ -1,6 +1,6 @@
 # Template file for 'gnome-text-editor'
 pkgname=gnome-text-editor
-version=45.0
+version=45.3
 revision=1
 build_style=meson
 hostmakedepends="pkg-config gettext itstool glib-devel
@@ -14,4 +14,4 @@ homepage="https://gitlab.gnome.org/GNOME/gnome-text-editor"
 #changelog="https://gitlab.gnome.org/GNOME/gnome-text-editor/-/raw/gnome-45/NEWS"
 changelog="https://gitlab.gnome.org/GNOME/gnome-text-editor/-/raw/main/NEWS"
 distfiles="${GNOME_SITE}/gnome-text-editor/${version%.*}/gnome-text-editor-$version.tar.xz"
-checksum=47b3fbe4900eb204413d9af3ae8e0ecd06728d2ac15d02b1a050d02d47226bc1
+checksum=f3ffcb11a92dfd04ba3c3b3d0e667847d4449a21e012ae36f07dda05ac7d3a52


### PR DESCRIPTION
split into a separate pr (https://github.com/void-linux/void-packages/pull/48762#issuecomment-1976502687).

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl x
  - armv7l x
  - armv6l-musl x