### PR TITLE
gnome-system-monitor: update to 45.0.2

### DIFF
--- a/srcpkgs/gnome-system-monitor/template
+++ b/srcpkgs/gnome-system-monitor/template
@@ -1,6 +1,6 @@
 # Template file for 'gnome-system-monitor'
 pkgname=gnome-system-monitor
-version=44.0
+version=45.0.2
 revision=1
 build_style=meson
 configure_args="-Dsystemd=false"
@@ -12,5 +12,5 @@ maintainer="Enno Boland <gottox@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="https://wiki.gnome.org/Apps/SystemMonitor"
 changelog="https://gitlab.gnome.org/GNOME/gnome-system-monitor/-/raw/master/NEWS"
-distfiles="${GNOME_SITE}/${pkgname}/${version%.*}/${pkgname}-${version}.tar.xz"
-checksum=c2bab7eddba92827c4c8de44293e7e3c84c9e5076f31985887ff8969cec45e6e
+distfiles="${GNOME_SITE}/${pkgname}/${version:0:2}/${pkgname}-${version}.tar.xz"
+checksum=c5e272d90bf9986a3f8613d76e0d27fa42dfacee5c0192e73921bb94b1868a2e


### PR DESCRIPTION
split into a separate pr (https://github.com/void-linux/void-packages/pull/48762#issuecomment-1976502687).

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl x
  - armv7l x
  - armv6l-musl x