### PR TITLE
gnome-maps: update to 45.5

### DIFF
--- a/srcpkgs/gnome-maps/template
+++ b/srcpkgs/gnome-maps/template
@@ -1,18 +1,18 @@
 # Template file for 'gnome-maps'
 pkgname=gnome-maps
-version=44.3
+version=45.5
 revision=1
 build_style=meson
 build_helper="gir"
 hostmakedepends="glib-devel gettext pkg-config AppStream gjs desktop-file-utils
  gtk-update-icon-cache"
 makedepends="geoclue2-devel gjs-devel geocode-glib-devel libgweather-devel
- gnome-desktop-devel libshumate-devel rest-devel libadwaita-devel"
+ gnome-desktop-devel libshumate-devel rest-devel libadwaita-devel libportal-devel"
 depends="geoclue2 gjs libadwaita libgweather rest"
 short_desc="GNOME maps application"
 maintainer="Enno Boland <gottox@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="https://wiki.gnome.org/Apps/Maps"
-changelog="https://gitlab.gnome.org/GNOME/gnome-maps/-/raw/gnome-44/NEWS"
+changelog="https://gitlab.gnome.org/GNOME/gnome-maps/-/raw/gnome-45/NEWS"
 distfiles="${GNOME_SITE}/gnome-maps/${version%.*}/gnome-maps-${version}.tar.xz"
-checksum=3be13b21eeba9a9da30e69df16d718beb130edbfbd406eb8f402bfea17412602
+checksum=1c20f5e10dce684adefb2961526266a224e6c46c16fa03b954affa0b3a1bb740


### PR DESCRIPTION
split into a separate pr (https://github.com/void-linux/void-packages/pull/48762#issuecomment-1976502687).

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl x
  - armv7l x
  - armv6l-musl x