### PR TITLE
gnome-font-viewer: update to 45.0

### DIFF
--- a/srcpkgs/gnome-font-viewer/patches/gcc14.patch
+++ b/srcpkgs/gnome-font-viewer/patches/gcc14.patch
@@ -1,0 +1,31 @@
+From f2cfa9b2d9f97b4322bf6b4a38c7bd59e6a446c9 Mon Sep 17 00:00:00 2001
+From: Florian Weimer <fweimer@redhat.com>
+Date: Sun, 21 Jan 2024 13:12:27 +0100
+Subject: [PATCH] Match type of action_toggle_search_cb to its use
+
+This avoids an incompatible-pointer-types error and a build failure
+with GCC 14.
+---
+ src/font-view-window.c | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/src/font-view-window.c b/src/font-view-window.c
+index 639ac33..24461f7 100644
+--- a/src/font-view-window.c
++++ b/src/font-view-window.c
+@@ -758,8 +758,11 @@ font_view_window_show_overview (FontViewWindow *self)
+ }
+ 
+ static void
+-action_toggle_search_cb (FontViewWindow *self)
++action_toggle_search_cb (GtkWidget  *widget,
++                         const char *action_name,
++                         GVariant   *parameter)
+ {
++  FontViewWindow *self = FONT_VIEW_WINDOW (widget);
+ 
+  gtk_toggle_button_set_active (self->search_button,
+                                !gtk_toggle_button_get_active (self->search_button));
+-- 
+GitLab
+

--- a/srcpkgs/gnome-font-viewer/template
+++ b/srcpkgs/gnome-font-viewer/template
@@ -1,6 +1,6 @@
 # Template file for 'gnome-font-viewer'
 pkgname=gnome-font-viewer
-version=44.0
+version=45.0
 revision=1
 build_style=meson
 hostmakedepends="pkg-config glib-devel gettext"
@@ -13,4 +13,4 @@ license="GPL-2.0-or-later"
 homepage="https://gitlab.gnome.org/GNOME/gnome-font-viewer"
 changelog="https://gitlab.gnome.org/GNOME/gnome-font-viewer/-/raw/main/NEWS"
 distfiles="${GNOME_SITE}/gnome-font-viewer/${version%.*}/gnome-font-viewer-${version}.tar.xz"
-checksum=a1511df30b228cc2ef1175dd9d2b93438ea912e25913404b263cf3d457bb9f97
+checksum=97cb6b68dda60de0ab3038383586f1e4bc1da5a48f44025bd6bbe74ea05c2b08


### PR DESCRIPTION
split into a separate pr (https://github.com/void-linux/void-packages/pull/48762#issuecomment-1976502687).

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl x
  - armv7l x
  - armv6l-musl x