### PR TITLE
gnome-disk-utility: update to 45.1

### DIFF
--- a/srcpkgs/gnome-disk-utility/template
+++ b/srcpkgs/gnome-disk-utility/template
@@ -1,6 +1,6 @@
 # Template file for 'gnome-disk-utility'
 pkgname=gnome-disk-utility
-version=44.0
+version=45.1
 revision=1
 build_style=meson
 configure_args="-Dlogind=none"
@@ -15,5 +15,5 @@ maintainer="Enno Boland <gottox@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="https://wiki.gnome.org/Apps/Disks"
 distfiles="${GNOME_SITE}/gnome-disk-utility/${version%.*}/gnome-disk-utility-${version}.tar.xz"
-checksum=02031097896cdb37d8717a5823f93e3723d4dfce7fdc4002c9dfcb16b7e7a3ef
+checksum=540ff4ec9a6b9630003ff4cd60d624f39fe70f25a9559e5333389603c85b9529
 lib32disabled=yes


### PR DESCRIPTION
split into a separate pr (https://github.com/void-linux/void-packages/pull/48762#issuecomment-1976502687).

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl x
  - armv7l x
  - armv6l-musl x