### PR TITLE
gnome-connections: update to 45.0

### DIFF
--- a/srcpkgs/gnome-connections/template
+++ b/srcpkgs/gnome-connections/template
@@ -1,16 +1,16 @@
 # Template file for 'gnome-connections'
 pkgname=gnome-connections
-version=44.0
+version=45.0
 revision=1
 build_style=meson
 build_helper="gir"
 hostmakedepends="pkg-config gettext itstool vala desktop-file-utils glib-devel"
 makedepends="gtk+3-devel libhandy1-devel gtk-vnc-devel libgcrypt-devel
- gnutls-devel libsasl-devel libsecret-devel freerdp-devel"
+ gnutls-devel libsasl-devel libsecret-devel freerdp-devel fuse3-devel"
 short_desc="Remote desktop client for the GNOME desktop environment"
 maintainer="oreo6391 <oreo6391@gmail.com>"
 license="GPL-3.0-or-later"
 homepage="https://gitlab.gnome.org/GNOME/connections/"
-changelog="https://gitlab.gnome.org/GNOME/connections/-/raw/gnome-44/NEWS"
+changelog="https://gitlab.gnome.org/GNOME/connections/-/raw/gnome-45/NEWS"
 distfiles="${GNOME_SITE}/gnome-connections/${version%.*}/gnome-connections-${version}.tar.xz"
-checksum=34c7a6bbfec9a9acfa9c2d2dba4b251431cd71874f8f055c5ff26f26f4244199
+checksum=b9fab525b90a3e27d113c16fb868c2b9c47bf8149310d14db862ea1912c06fb8


### PR DESCRIPTION
split into a separate pr (https://github.com/void-linux/void-packages/pull/48762#issuecomment-1976502687).
a part of #48752

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl x
  - armv7l x
  - armv6l-musl x