### PR TITLE
gnome-clocks: update to 45.0

### DIFF
--- a/srcpkgs/gnome-clocks/template
+++ b/srcpkgs/gnome-clocks/template
@@ -1,6 +1,6 @@
 # Template file for 'gnome-clocks'
 pkgname=gnome-clocks
-version=44.0
+version=45.0
 revision=1
 build_helper="gir"
 build_style=meson
@@ -17,4 +17,4 @@ license="GPL-2.0-or-later"
 homepage="https://wiki.gnome.org/Apps/Clocks"
 changelog="https://gitlab.gnome.org/GNOME/gnome-clocks/-/raw/master/NEWS"
 distfiles="${GNOME_SITE}/gnome-clocks/${version%.*}/gnome-clocks-${version}.tar.xz"
-checksum=17d7a97365cb8f1a023a1d78f7501f3353217fa7577d73afe7d0ca1e3b4f3838
+checksum=fc8eb4fd9530f1e641dc00ee2086ee7d354a7a00b0a0d1722e305d5c9aab91b5


### PR DESCRIPTION
split into a separate pr (https://github.com/void-linux/void-packages/pull/48762#issuecomment-1976502687).

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl x
  - armv7l x
  - armv6l-musl x