### PR TITLE
gnome-calculator: update to 45.0.2

### DIFF
--- a/srcpkgs/gnome-calculator/template
+++ b/srcpkgs/gnome-calculator/template
@@ -1,12 +1,12 @@
 # Template file for 'gnome-calculator'
 pkgname=gnome-calculator
-version=44.0
+version=45.0.2
 revision=1
 build_style=meson
 build_helper="gir"
 hostmakedepends="cmake gettext glib-devel itstool pkg-config vala
  gtk-update-icon-cache"
-makedepends="gsettings-desktop-schemas-devel gtksourceview5-devel libgee08-devel
+makedepends="gsettings-desktop-schemas-devel gtksourceview5-devel libgee-devel
  libmpc-devel libsoup3-devel gtk4-devel libadwaita-devel"
 depends="desktop-file-utils gsettings-desktop-schemas hicolor-icon-theme"
 short_desc="GNOME calculator"
@@ -15,4 +15,4 @@ license="GPL-2.0-or-later"
 homepage="https://wiki.gnome.org/Apps/Calculator"
 changelog="https://gitlab.gnome.org/GNOME/gnome-calculator/-/raw/master/NEWS"
 distfiles="${GNOME_SITE}/gnome-calculator/${version%%.*}/gnome-calculator-${version}.tar.xz"
-checksum=14e763329f88309a7e152780d57361b543100e323906b34e0655fdc315b71043
+checksum=7dcbf32384897171cbe5483ec664d994e5e755e912ae1df911624f03c90867c2


### PR DESCRIPTION
split into a separate pr (https://github.com/void-linux/void-packages/pull/48762#issuecomment-1976502687).

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl x
  - armv7l x
  - armv6l-musl x