### PR TITLE
gnome-boxes: update to 45.0

### DIFF
--- a/srcpkgs/gnome-boxes/template
+++ b/srcpkgs/gnome-boxes/template
@@ -1,6 +1,6 @@
 # Template file for 'gnome-boxes'
 pkgname=gnome-boxes
-version=44.0
+version=45.0
 revision=1
 build_helper="gir"
 build_style=meson
@@ -16,7 +16,6 @@ short_desc="GNOME application to access remote or virtual systems"
 maintainer="Enno Boland <gottox@voidlinux.org>"
 license="LGPL-2.0-or-later"
 homepage="https://wiki.gnome.org/Apps/Boxes"
-#changelog="https://gitlab.gnome.org/GNOME/gnome-boxes/-/raw/main/NEWS"
-changelog="https://gitlab.gnome.org/GNOME/gnome-boxes/-/raw/gnome-44/NEWS"
+changelog="https://gitlab.gnome.org/GNOME/gnome-boxes/-/raw/main/NEWS"
 distfiles="${GNOME_SITE}/gnome-boxes/${version%%.*}/gnome-boxes-${version}.tar.xz"
-checksum=dd64df34d8385860f0a7af13eec12e615faffe2143e58a3c92e50128fa9bf3c9
+checksum=cc63080eefa147a8472ab1a5ff087b97a27ab723a4ee005ed41e8c9dd7798e41


### PR DESCRIPTION
split into a separate pr (https://github.com/void-linux/void-packages/pull/48762#issuecomment-1976502687).

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl x
  - armv7l x
  - armv6l-musl x