### PR TITLE
gcab: update to 1.6

### DIFF
--- a/srcpkgs/gcab/template
+++ b/srcpkgs/gcab/template
@@ -1,6 +1,6 @@
 # Template file for 'gcab'
 pkgname=gcab
-version=1.5
+version=1.6
 revision=1
 build_style=meson
 build_helper=gir
@@ -13,7 +13,7 @@ license="LGPL-2.1-or-later"
 homepage="https://wiki.gnome.org/msitools"
 changelog="https://gitlab.gnome.org/GNOME/gcab/-/raw/master/NEWS"
 distfiles="${GNOME_SITE}/${pkgname}/${version}/${pkgname}-${version}.tar.xz"
-checksum=46bf7442491faa4148242b9ec2a0786a5f6e9effb1b0566e5290e8cc86f00f0c
+checksum=2f0c9615577c4126909e251f9de0626c3ee7a152376c15b5544df10fc87e560b
 
 build_options="gir"
 build_options_default="gir"


### PR DESCRIPTION
split into a separate pr (https://github.com/void-linux/void-packages/pull/48762#issuecomment-1976502687).

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl x
  - armv7l x
  - armv6l-musl x