### PR TITLE
gnome-remote-desktop: update to 45.1

### DIFF
--- a/srcpkgs/gnome-remote-desktop/template
+++ b/srcpkgs/gnome-remote-desktop/template
@@ -1,18 +1,18 @@
 # Template file for 'gnome-remote-desktop'
 pkgname=gnome-remote-desktop
-version=44.0
+version=45.1
 revision=1
 build_style=meson
 configure_args="-Drdp=true -Dvnc=true -Dsystemd=false
- -Dsystemd_user_unit_dir=/usr/lib/systemd/user"
+ -Dsystemd_user_unit_dir=/usr/lib/systemd/user -Dtests=false"
 hostmakedepends="pkg-config gettext glib-devel asciidoc"
 makedepends="glib-devel pipewire-devel libsecret-devel libnotify-devel
  freerdp-devel freerdp-server-devel fuse3-devel libvncserver-devel
- libgudev-devel nv-codec-headers tpm2-tss-devel fdk-aac-devel"
+ libgudev-devel nv-codec-headers tpm2-tss-devel fdk-aac-devel libei-devel"
 short_desc="GNOME remote desktop server"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="https://wiki.gnome.org/Projects/Mutter/RemoteDesktop"
 distfiles="${GNOME_SITE}/gnome-remote-desktop/${version%%.*}/gnome-remote-desktop-${version}.tar.xz"
-checksum=f7e5088c18fdb08690ae034bf76a1aead59a7dcd17b26e1f7c9975480510a0fd
+checksum=dcd9c18ac2306695631fcf00a88645c38e370eba05c69df39f540204d4eafd8d
 make_check=no # xvfb failed to start


### PR DESCRIPTION
split into a separate pr (https://github.com/void-linux/void-packages/pull/48762#issuecomment-1976502687).

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl x
  - armv7l x
  - armv6l-musl x