### PR TITLE
msmtp 1.8.26

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -1180,7 +1180,7 @@ libspice-client-glib-2.0.so.8 spice-gtk-0.41_2
 libspice-controller.so.0 spice-gtk-0.41_2
 libvirt-gconfig-1.0.so.0 libvirt-glib-0.1.2_1
 libvirt-gobject-1.0.so.0 libvirt-glib-0.1.2_1
-libgsasl.so.7 libgsasl-1.8.0_1
+libgsasl.so.18 libgsasl-2.2.1_1
 libzmq.so.5 zeromq-4.1.2_1
 libstatgrab.so.10 libstatgrab-0.91_1
 libseccomp.so.2 libseccomp-2.0.0_1

--- a/srcpkgs/gsasl/template
+++ b/srcpkgs/gsasl/template
@@ -1,6 +1,6 @@
 # Template file for 'gsasl'
 pkgname=gsasl
-version=1.10.0
+version=2.2.1
 revision=1
 build_style=gnu-configure
 configure_args="--with-gssapi-impl=mit"
@@ -11,7 +11,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-3.0-or-later"
 homepage="https://www.gnu.org/software/gsasl/"
 distfiles="${GNU_SITE}/${pkgname}/${pkgname}-${version}.tar.gz"
-checksum=85bcbd8ee6095ade7870263a28ebcb8832f541ea7393975494926015c07568d3
+checksum=d45b562e13bd13b9fc20b372f4b53269740cf6279f836f09ce11b9d32bcee075
 
 libgsasl_package() {
 	short_desc+=" - Runtime library"

--- a/srcpkgs/jreen/template
+++ b/srcpkgs/jreen/template
@@ -1,7 +1,7 @@
 # Template file for 'jreen'
 pkgname=jreen
 version=1.3.0
-revision=2
+revision=3
 build_style=cmake
 hostmakedepends="pkg-config"
 makedepends="gsasl-devel speex-devel qt5-devel zlib-devel"

--- a/srcpkgs/msmtp/template
+++ b/srcpkgs/msmtp/template
@@ -1,6 +1,6 @@
 # Template file for 'msmtp'
 pkgname=msmtp
-version=1.8.25
+version=1.8.26
 revision=1
 build_style=gnu-configure
 configure_args="$(vopt_with msmtpd)
@@ -17,7 +17,7 @@ maintainer="Leah Neukirchen <leah@vuxu.org>"
 license="GPL-3.0-or-later"
 homepage="https://marlam.de/msmtp/"
 distfiles="https://marlam.de/msmtp/releases/msmtp-${version}.tar.xz"
-checksum=2dfe1dbbb397d26fe0b0b6b2e9cd2efdf9d72dd42d18e70d7f363ada2652d738
+checksum=6cfc488344cef189267e60aea481f00d4c7e2a59b53c6c659c520a4d121f66d8
 
 build_options="idn sasl gnome msmtpd"
 build_options_default="idn sasl msmtpd"

--- a/srcpkgs/msmtp/template
+++ b/srcpkgs/msmtp/template
@@ -16,6 +16,7 @@ short_desc="Mini SMTP client"
 maintainer="Leah Neukirchen <leah@vuxu.org>"
 license="GPL-3.0-or-later"
 homepage="https://marlam.de/msmtp/"
+changelog="https://git.marlam.de/gitweb/?p=msmtp.git;a=blob_plain;f=NEWS"
 distfiles="https://marlam.de/msmtp/releases/msmtp-${version}.tar.xz"
 checksum=6cfc488344cef189267e60aea481f00d4c7e2a59b53c6c659c520a4d121f66d8
 

--- a/srcpkgs/mutt/template
+++ b/srcpkgs/mutt/template
@@ -1,7 +1,7 @@
 # Template file for 'mutt'
 pkgname=mutt
 version=2.2.13
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--enable-pop --enable-imap --enable-smtp --enable-hcache
  --enable-gpgme --with-idn2 --with-ssl --without-sasl --with-gsasl


### PR DESCRIPTION
- **gsasl: update to 2.2.1.**
- **mutt: revbump for libgsasl**
- **jreen: revbump for libgsasl**
- **msmtp: update to 1.8.26.**
- **msmtp: add changelog**
---

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I have tested msmtp, the other two packages (`mutt` and `jreen`) I only built for my architecture but did not try running them.

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
#### Local build testing
- I built this PR locally for my native architecture, (x86_64-musl)
