### PR TITLE
OTPClient: update to 3.5.2

### DIFF
--- a/srcpkgs/OTPClient/template
+++ b/srcpkgs/OTPClient/template
@@ -1,6 +1,6 @@
 # Template file for 'OTPClient'
 pkgname=OTPClient
-version=3.3.0
+version=3.5.2
 revision=1
 build_style=cmake
 hostmakedepends="pkg-config"
@@ -12,4 +12,4 @@ maintainer="Emil Miler <em@0x45.cz>"
 license="GPL-3.0-or-later"
 homepage="https://github.com/paolostivanin/OTPClient"
 distfiles="https://github.com/paolostivanin/OTPClient/archive/refs/tags/v${version}.tar.gz"
-checksum=94c28004619d12c786a7d6e68c8e504980c426b2a814b037213352cdbbce362b
+checksum=d65363003d497a59ebc7d48c142541ae9a787bc16dddce87fb7b77d9fdbf6ccf


### PR DESCRIPTION
- I tested the changes in this PR: **briefly**
- I built this PR locally for my native architecture, (x86_64-glibc)