### PR TITLE
plasma5: update to 5.27.11.

### DIFF
--- a/srcpkgs/bluedevil/template
+++ b/srcpkgs/bluedevil/template
@@ -1,6 +1,6 @@
 # Template file for 'bluedevil'
 pkgname=bluedevil
-version=5.27.10
+version=5.27.11
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF -DKF5_HOST_TOOLING=/usr/lib/cmake"
@@ -14,4 +14,4 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later, LGPL-2.1-or-later"
 homepage="https://invent.kde.org/plasma/bluedevil"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=771fd58c2e1945e9f375598a5d1120671d9142d95580f08ec22494dd4d7fa180
+checksum=b4d5a8bfd066d66a4572732fd41ad3b8aad0428e899582d381e0ac6642bd6484

--- a/srcpkgs/breeze-gtk/template
+++ b/srcpkgs/breeze-gtk/template
@@ -1,6 +1,6 @@
 # Template file for 'breeze-gtk'
 pkgname=breeze-gtk
-version=5.27.10
+version=5.27.11
 revision=1
 build_style=cmake
 hostmakedepends="extra-cmake-modules sassc python3 python3-cairo qt5-devel"
@@ -10,4 +10,4 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/plasma/breeze-gtk"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=1da3f98cce2761bb2c9c72d0156b93cf7bf50f08d59fd64bfeb06149a87069b6
+checksum=dcbdd3bf87404dfeb5b05e220d0a8dd5b4168c7d4ce7650679f28c5accf67fee

--- a/srcpkgs/breeze/template
+++ b/srcpkgs/breeze/template
@@ -1,6 +1,6 @@
 # Template file for 'breeze'
 pkgname=breeze
-version=5.27.10
+version=5.27.11
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF"
@@ -14,7 +14,7 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later"
 homepage="https://invent.kde.org/plasma/breeze"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=bebc960752da9d53a9895ffc05d824cba702735428aa61347b703fea074700a2
+checksum=14756a2fe5bc3db11ca954ff0df9b98e8d78ada4b231111780c42ee627dd4cab
 
 if [ "$CROSS_BUILD" ]; then
 	configure_args+=" -DKF5_HOST_TOOLING=/usr/lib/cmake"

--- a/srcpkgs/flatpak-kcm/template
+++ b/srcpkgs/flatpak-kcm/template
@@ -1,6 +1,6 @@
 # Template file for 'flatpak-kcm'
 pkgname=flatpak-kcm
-version=5.27.10
+version=5.27.11
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF -DKF5_HOST_TOOLING=/usr/lib/cmake"
@@ -13,4 +13,4 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later, LGPL-2.1-or-later"
 homepage="https://invent.kde.org/plasma/flatpak-kcm"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=ba527040a4fa39ac0e3021bcf4117238d20eab148bc48259f5f9e3c86c885a55
+checksum=972c442b9447c072fb61496b39b8ed22949237ab823b44660a935de8d2ecdf4a

--- a/srcpkgs/kactivitymanagerd/template
+++ b/srcpkgs/kactivitymanagerd/template
@@ -1,6 +1,6 @@
 # Template file for 'kactivitymanagerd'
 pkgname=kactivitymanagerd
-version=5.27.10
+version=5.27.11
 revision=1
 build_style=cmake
 build_helper="qemu"
@@ -13,4 +13,4 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later"
 homepage="https://invent.kde.org/plasma/kactivitymanagerd"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=8ee262fb6c4987fb3e66b5adec4d60d10c98adb40ed7da3372b8b342d70e5dd9
+checksum=b2bb77b309850c6df61093cdbaf66faad122bf3be91428a3f42baeb907c45cd5

--- a/srcpkgs/kde-cli-tools/template
+++ b/srcpkgs/kde-cli-tools/template
@@ -1,6 +1,6 @@
 # Template file for 'kde-cli-tools'
 pkgname=kde-cli-tools
-version=5.27.10
+version=5.27.11
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF -DKF5_HOST_TOOLING=/usr/lib/cmake"
@@ -14,7 +14,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later, GPL-2.0-or-later"
 homepage="https://invent.kde.org/plasma/kde-cli-tools"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=7baa6d899cf0e14194f935cd2f2526123c40261f6fbd86dc17cf75bbc6a04d3f
+checksum=8a25f8fea64e5a7fd5a798041cab920217630eea809adfa07b9d111142b28255
 
 post_install() {
 	ln -sf ../libexec/kf5/kdesu ${DESTDIR}/usr/bin

--- a/srcpkgs/kde-gtk-config5/template
+++ b/srcpkgs/kde-gtk-config5/template
@@ -1,6 +1,6 @@
 # Template file for 'kde-gtk-config5'
 pkgname=kde-gtk-config5
-version=5.27.10
+version=5.27.11
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF"
@@ -14,7 +14,7 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later, LGPL-2.1-or-later"
 homepage="https://invent.kde.org/plasma/kde-gtk-config"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname%5}-${version}.tar.xz"
-checksum=6f3b3150b138b5c309ef2c47eee2ab15b0908cacf1487cbc9d561d64f0f68e6b
+checksum=a48915b5077b8b3a520549f2dc739886685868c94d9e832eeadb9bbb4bf10d0a
 
 if [ "$CROSS_BUILD" ]; then
 	hostmakedepends+=" kcoreaddons"

--- a/srcpkgs/kdecoration/template
+++ b/srcpkgs/kdecoration/template
@@ -1,6 +1,6 @@
 # Template file for 'kdecoration'
 pkgname=kdecoration
-version=5.27.10
+version=5.27.11
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF"
@@ -12,7 +12,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/plasma/kdecoration"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=64966cb8258b50b55da50a8ab01fd1dd201065f1512216a04ce92189df679dde
+checksum=71c417461993923a2245b6f954ff72fb1737bc10db218ca9595194017cf1f838
 
 kdecoration-devel_package() {
 	short_desc+=" - development"

--- a/srcpkgs/kdeplasma-addons5/template
+++ b/srcpkgs/kdeplasma-addons5/template
@@ -1,6 +1,6 @@
 # Template file for 'kdeplasma-addons5'
 pkgname=kdeplasma-addons5
-version=5.27.10
+version=5.27.11
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF -DKF5_HOST_TOOLING=/usr/lib/cmake"
@@ -13,4 +13,4 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later, LGPL-2.1-or-later"
 homepage="https://invent.kde.org/plasma/kdeplasma-addons"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname%5}-${version}.tar.xz"
-checksum=9e64ef3dd88aa355f49f8d2d11be3ef158431ceda6a6fe570a1288c3f50f3e8d
+checksum=e52068ba50b22c564c9fce262bd6713b435f5b3e1a650c2899d23f529ed3cd04

--- a/srcpkgs/kgamma5/template
+++ b/srcpkgs/kgamma5/template
@@ -1,6 +1,6 @@
 # Template file for 'kgamma5'
 pkgname=kgamma5
-version=5.27.10
+version=5.27.11
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF"
@@ -13,4 +13,4 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later"
 homepage="https://invent.kde.org/plasma/kgamma5"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=dd81bb62a35ce4fce4482ed498e4072a50f9ec1190ba2a9246139ba1e24ef570
+checksum=b654d80344ab8e5fdb7eec9fed98c68998a24430c354b8c591569f066e13d678

--- a/srcpkgs/khotkeys/template
+++ b/srcpkgs/khotkeys/template
@@ -1,6 +1,6 @@
 # Template file for 'khotkeys'
 pkgname=khotkeys
-version=5.27.10
+version=5.27.11
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF"
@@ -12,7 +12,7 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-only, LGPL-2.0-or-later"
 homepage="https://invent.kde.org/plasma/khotkeys"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=645c51e7b27a6bfb3105e5d5352350b651c782b43813c6a82b14ad1e09d9f6e7
+checksum=8b497c68e546874feb9350f1f17df5b285d5c41d2cb4c1fd8e4e665f84804459
 
 if [ "$CROSS_BUILD" ]; then
 	configure_args+=" -DDESKTOPTOJSON_EXECUTABLE=/usr/bin/desktoptojson"

--- a/srcpkgs/kinfocenter/template
+++ b/srcpkgs/kinfocenter/template
@@ -1,6 +1,6 @@
 # Template file for 'kinfocenter'
 pkgname=kinfocenter
-version=5.27.10
+version=5.27.11
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF -DKF5_HOST_TOOLING=/usr/lib/cmake"
@@ -16,4 +16,4 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later, LGPL-2.1-or-later, GFDL-1.2-only"
 homepage="https://invent.kde.org/plasma/kinfocenter"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=ce5c2a34840787b50fcbc70d82ff0b4b9f8260b6814276f68c6912c4db2aca11
+checksum=29a743152bf3007059b752c2e09ca969ff49f151dabf4bff40ce85bce9f40d07

--- a/srcpkgs/kmenuedit/template
+++ b/srcpkgs/kmenuedit/template
@@ -1,6 +1,6 @@
 # Template file for 'kmenuedit'
 pkgname=kmenuedit
-version=5.27.10
+version=5.27.11
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF"
@@ -13,4 +13,4 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later"
 homepage="https://invent.kde.org/plasma/kmenuedit"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=1c090b7e96c65043d2d75c359e536cb05a44ed6655e4e12c437ef233fa4f20d7
+checksum=904dde062c0651dd5296659f4c409d621f31c93ab5527d2cdf9a9e395cc43b57

--- a/srcpkgs/kpipewire/template
+++ b/srcpkgs/kpipewire/template
@@ -1,6 +1,6 @@
 # Template file for 'kpipewire'
 pkgname=kpipewire
-version=5.27.10
+version=5.27.11
 revision=1
 build_style=cmake
 hostmakedepends="extra-cmake-modules plasma-wayland-protocols gettext
@@ -13,7 +13,7 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-3.0-or-later"
 homepage="https://invent.kde.org/plasma/kpipewire"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=c23ca5169ae2ef069b1d79107c5ae4ff859d8848fe6c98decfd0f357f378c3ee
+checksum=ac9a0f24942eb8dc2521376f234a2e37485223b68e4ed1227e46808f8bff4cc0
 
 kpipewire-devel_package() {
 	depends="${sourcepkg}>=${version}_${revision}"

--- a/srcpkgs/kscreen/template
+++ b/srcpkgs/kscreen/template
@@ -1,6 +1,6 @@
 # Template file for 'kscreen'
 pkgname=kscreen
-version=5.27.10
+version=5.27.11
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF -DKF5_HOST_TOOLING=/usr/lib/cmake"
@@ -14,4 +14,4 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later, LGPL-2.1-or-later"
 homepage="https://invent.kde.org/plasma/kscreen"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=8987bfcdb4e8617a229090ff42c4e4142ac0b5228e9bed7c3d2f03ed4e981c3c
+checksum=7e7f7a8ef4e7d5c8567653b8278c3412ff28bbb55d37a28ad890be144acbc753

--- a/srcpkgs/kscreenlocker/template
+++ b/srcpkgs/kscreenlocker/template
@@ -1,6 +1,6 @@
 # Template file for 'kscreenlocker'
 pkgname=kscreenlocker
-version=5.27.10
+version=5.27.11
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF -DKF5_HOST_TOOLING=/usr/lib/cmake"
@@ -14,7 +14,7 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later"
 homepage="https://invent.kde.org/plasma/kscreenlocker"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=d74d80b87fc5b4915d615c288819f9006c0103ee864cadc565141bf468cb3d89
+checksum=33b8ceea3b4240354d87f55d67659a542bf5933947550aff7530c6a1eb77d6df
 
 kscreenlocker-devel_package() {
 	short_desc+=" - development"

--- a/srcpkgs/ksshaskpass/template
+++ b/srcpkgs/ksshaskpass/template
@@ -1,6 +1,6 @@
 # Template file for 'ksshaskpass'
 pkgname=ksshaskpass
-version=5.27.10
+version=5.27.11
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF"
@@ -12,5 +12,5 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later"
 homepage="https://invent.kde.org/plasma/ksshaskpass"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=d38de7ddcb9c3e58d04cb240510db7f48448e9700de443b40a9062897239e26a
+checksum=9e78bdf1b29c88ad7f61f1a7885480a29bd78c2e288107b3f9ed3d97ace119bb
 alternatives="ssh-askpass:/usr/libexec/ssh-askpass:/usr/bin/ksshaskpass"

--- a/srcpkgs/ksystemstats/template
+++ b/srcpkgs/ksystemstats/template
@@ -1,6 +1,6 @@
 # Template file for 'ksystemstats'
 pkgname=ksystemstats
-version=5.27.10
+version=5.27.11
 revision=1
 build_style=cmake
 hostmakedepends="extra-cmake-modules qt5-qmake gettext
@@ -12,4 +12,4 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-only OR GPL-3.0-only, LGPL-2.1-only OR LGPL-3-only"
 homepage="https://invent.kde.org/plasma/ksystemstats"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=5a5eda2ded432b380882ede9fbe9a30b090cfbbe6c84ce9274dd795eb01fe238
+checksum=378e5fc88899d538bde930a8f20fc22e7d4067ecfd63dfce47a1e7c722825cd5

--- a/srcpkgs/kwallet-pam/template
+++ b/srcpkgs/kwallet-pam/template
@@ -1,6 +1,6 @@
 # Template file for 'kwallet-pam'
 pkgname=kwallet-pam
-version=5.27.10
+version=5.27.11
 revision=1
 build_style=cmake
 hostmakedepends="qt5-qmake qt5-host-tools extra-cmake-modules"
@@ -11,4 +11,4 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/plasma/kwallet-pam"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=ac191714d637c9f43041b08f9c946ff01ffef1b77cf80f33c7ae0f819244a1fb
+checksum=7f53b88f2a86e1794eefcad9658051ca444cf7dc79d88d3523b5284c68aed840

--- a/srcpkgs/kwayland-integration/template
+++ b/srcpkgs/kwayland-integration/template
@@ -1,6 +1,6 @@
 # Template file for 'kwayland-integration'
 pkgname=kwayland-integration
-version=5.27.10
+version=5.27.11
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF"
@@ -13,4 +13,4 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/plasma/kwayland-integration"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=f37d054662b6b294faee9dae9a8a808023cf2ec5a0508b76fcaceb61b4a3bd9f
+checksum=8b4947bbe67b4a03ec5338763fab52407eb7419ca63db09ebdc7e8c2eb68bcb6

--- a/srcpkgs/kwin/template
+++ b/srcpkgs/kwin/template
@@ -1,6 +1,6 @@
 # Template file for 'kwin'
 pkgname=kwin
-version=5.27.10
+version=5.27.11
 revision=1
 build_style=cmake
 build_helper=qemu
@@ -21,7 +21,7 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later"
 homepage="https://invent.kde.org/plasma/kwin"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=b85a25125900b62cb5a3c609961088c45a58f55004317e4f5e8ba2039ae6dac6
+checksum=8902b23b29bd54cd26590fe04abfe58fe334a5bf9c0dfd1f7dc5aacc4191b56f
 replaces="kwayland-server>=0"
 
 kwin-devel_package() {

--- a/srcpkgs/kwrited/template
+++ b/srcpkgs/kwrited/template
@@ -1,6 +1,6 @@
 # Template file for 'kwrited'
 pkgname=kwrited
-version=5.27.10
+version=5.27.11
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF"
@@ -11,4 +11,4 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later"
 homepage="https://invent.kde.org/plasma/kwrited"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=5aa19eba68eb9df0ac9ee894773028f093c9fb54f8ca69cf878ee8e8ec6f4d41
+checksum=0711c5ac7e24355e952be6ce75c6a846bca2e4a1aedd0277d47d4ea13c29c0a1

--- a/srcpkgs/layer-shell-qt/template
+++ b/srcpkgs/layer-shell-qt/template
@@ -1,6 +1,6 @@
 # Template file for 'layer-shell-qt'
 pkgname=layer-shell-qt
-version=5.27.10
+version=5.27.11
 revision=1
 build_style=cmake
 confiugre_args="-DWaylandScanner_EXECUTABLE=/usr/bin/wayland-scanner"
@@ -13,7 +13,7 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-3.0-or-later"
 homepage="https://invent.kde.org/plasma/layer-shell-qt"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=0aed80cf2a143033c186df5343215acd638c80e419b4e854a14bd35ba3d4c3c2
+checksum=f4c321091619c9aeffe9e3568ff22ba4434538dcb3e89e6e23f5950d1e76d350
 
 layer-shell-qt-devel_package() {
 	depends="${sourcepkg}>=${version}_${revision}"

--- a/srcpkgs/libkscreen/template
+++ b/srcpkgs/libkscreen/template
@@ -1,6 +1,6 @@
 # Template file for 'libkscreen'
 pkgname=libkscreen
-version=5.27.10
+version=5.27.11
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF"
@@ -13,7 +13,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/plasma/libkscreen"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=27f59f088929bc7fb560c353fb9da98832dde5b58fde88d9c694c98fdf3aff98
+checksum=0d11f41d489f32303988e5a2eee8cef7f4eb18faea5614e65bf202007ea21dd5
 
 libkscreen-devel_package() {
 	short_desc+=" - development"

--- a/srcpkgs/libksysguard/template
+++ b/srcpkgs/libksysguard/template
@@ -1,6 +1,6 @@
 # Template file for 'libksysguard'
 pkgname=libksysguard
-version=5.27.10
+version=5.27.11
 revision=1
 build_style=cmake
 hostmakedepends="extra-cmake-modules gettext kauth qt5-host-tools qt5-qmake
@@ -13,7 +13,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/plasma/libksysguard"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=17fc33b028cb272391b68c46e93b2d806d8254e6af9399d61375d49041ff3ce5
+checksum=21f4f54cdde8cda10a5ab2f05ebb22b67c375a1d47cf6a0c0fecc0f0cacb9659
 
 build_options="webengine"
 

--- a/srcpkgs/milou/template
+++ b/srcpkgs/milou/template
@@ -1,6 +1,6 @@
 # Template file for 'milou'
 pkgname=milou
-version=5.27.10
+version=5.27.11
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF"
@@ -12,7 +12,7 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later, LPGL-2.1-or-later"
 homepage="https://invent.kde.org/plasma/milou"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=7c19dd8b16cc9bdf594118bbe49e8aa6e5cf12984665377cc8bc369d5f110ac3
+checksum=0b816940dc7adb2921f7af1befb79f6ee611cbef067dc7cf40bfa760bf583e1a
 
 if [ "$CROSS_BUILD" ]; then
 	hostmakedepends+=" kpackage-devel kconfig-devel kcoreaddons-devel plasma-framework"

--- a/srcpkgs/oxygen-sounds/template
+++ b/srcpkgs/oxygen-sounds/template
@@ -1,6 +1,6 @@
 # Template file for 'oxygen-sounds'
 pkgname=oxygen-sounds
-version=5.27.10
+version=5.27.11
 revision=1
 build_style=cmake
 hostmakedepends="extra-cmake-modules"
@@ -9,4 +9,4 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-3.0-or-later"
 homepage="https://invent.kde.org/plasma/oxygen-sounds"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=23a1f090aaeee966476ff03aecad1f60b1e067d7948edd1b61c3a5d2b33bc35f
+checksum=6fa249c55a51941e023b982e20279e594279e216c53e065a928de6b4089df1de

--- a/srcpkgs/oxygen/template
+++ b/srcpkgs/oxygen/template
@@ -1,6 +1,6 @@
 # Template file for 'oxygen'
 pkgname=oxygen
-version=5.27.10
+version=5.27.11
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF"
@@ -13,4 +13,4 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later, GPL-2.0-or-later"
 homepage="https://invent.kde.org/plasma/oxygen"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=5b16f6e3e5ee11bb959fc0e1fd233bbb0231b54ea8eff5e14fd78003ba2d090b
+checksum=ba2f47033bd78b7c9f1bbda1faefca530453965999b4d7fad85b1ddd08b4f570

--- a/srcpkgs/plasma-browser-integration/template
+++ b/srcpkgs/plasma-browser-integration/template
@@ -1,6 +1,6 @@
 # Template file for 'plasma-browser-integration'
 pkgname=plasma-browser-integration
-version=5.27.10
+version=5.27.11
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF
@@ -14,4 +14,4 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-3.0-or-later"
 homepage="https://invent.kde.org/plasma/plasma-browser-integration"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=a17dbeae99d25def0c8e43b03b4be58bbfc0e3986f3c25e8de2e71047ecfccce
+checksum=c4e6aa1c6986ae88fa0d6bd590834da6a11ce4b193fc8538ee61bfba215c124c

--- a/srcpkgs/plasma-desktop/template
+++ b/srcpkgs/plasma-desktop/template
@@ -1,6 +1,6 @@
 # Template file for 'plasma-desktop'
 pkgname=plasma-desktop
-version=5.27.10
+version=5.27.11
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF
@@ -20,6 +20,6 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later, LGPL-2.0-or-later, LGPL-2.1-or-later, GFDL-1.2-or-later"
 homepage="https://invent.kde.org/plasma/plasma-desktop"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=de015fc921d34da23d85998a03afa7c81d935f5d9c55261ff7a2b413c9cfd09f
+checksum=d09f1e576251e7b4b6fde20407bdbfb018e495eba604487b0a05f4f011fc44a3
 replaces="user-manager>=0"
 python_version=3

--- a/srcpkgs/plasma-disks/template
+++ b/srcpkgs/plasma-disks/template
@@ -1,6 +1,6 @@
 # Template file for 'plasma-disks'
 pkgname=plasma-disks
-version=5.27.10
+version=5.27.11
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF"
@@ -13,4 +13,4 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later"
 homepage="https://invent.kde.org/plasma/plasma-disks"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=1e8f4d145a9f16c98a5dc1ac5449ee8178b119f63b4faecd99feec25fc54587b
+checksum=98d074f772c71cbd06440cfb495e4ef3a559583e6981d431831a1eb80ca941cb

--- a/srcpkgs/plasma-firewall/template
+++ b/srcpkgs/plasma-firewall/template
@@ -1,6 +1,6 @@
 # Template file for 'plasma-firewall'
 pkgname=plasma-firewall
-version=5.27.10
+version=5.27.11
 revision=1
 build_style=cmake
 configure_args="-DKF5_HOST_TOOLING=/usr/lib/cmake"
@@ -12,4 +12,4 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-only OR GPL-3.0-only"
 homepage="https://invent.kde.org/network/plasma-firewall"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=755a6a00848f536e567ea9672b4fa70af958a875ab7651e2edc75bbb661c84cc
+checksum=34cee9fdf4916bc51957bd223c70d7d6c59a7d0e89cbaa398233273d9320c105

--- a/srcpkgs/plasma-integration/template
+++ b/srcpkgs/plasma-integration/template
@@ -1,6 +1,6 @@
 # Template file for 'plasma-integration'
 pkgname=plasma-integration
-version=5.27.10
+version=5.27.11
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF"
@@ -14,4 +14,4 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.0-or-later"
 homepage="https://invent.kde.org/plasma/plasma-integration"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=35f2c81e8586051acd4bbccd9c44bab7dc86a1b3f5f0988589f43777032affbb
+checksum=b214a97f30609047d7519a4974087236c23e4d54eefde2838eca48e35df0bf79

--- a/srcpkgs/plasma-nm/template
+++ b/srcpkgs/plasma-nm/template
@@ -1,6 +1,6 @@
 # Template file for 'plasma-nm'
 pkgname=plasma-nm
-version=5.27.10
+version=5.27.11
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF -DKF5_HOST_TOOLING=/usr/lib/cmake"
@@ -16,4 +16,4 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/plasma/plasma-nm"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=b75dd3a7624e137ce350f438c3e3535c24d015d0e096e8e2f513b75df1b3dcb0
+checksum=ff6a819de2d48e17860d822b048de7157561742c067eb85a6dafa76e255e9e56

--- a/srcpkgs/plasma-pa/template
+++ b/srcpkgs/plasma-pa/template
@@ -1,6 +1,6 @@
 # Template file for 'plasma-pa'
 pkgname=plasma-pa
-version=5.27.10
+version=5.27.11
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF -DKF5_HOST_TOOLING=/usr/lib/cmake"
@@ -15,4 +15,4 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/plasma/plasma-pa"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=0d713742f1472587e3e678d8ce99fb62333fbda5106dfae99cad7298316b3f08
+checksum=3daa671ea7163b69846b9c96ddf310e791a41f71ba0b6381adb0c5dbb9a720b3

--- a/srcpkgs/plasma-sdk/template
+++ b/srcpkgs/plasma-sdk/template
@@ -1,6 +1,6 @@
 # Template file for 'plasma-sdk'
 pkgname=plasma-sdk
-version=5.27.10
+version=5.27.11.1
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF -DKF5_HOST_TOOLING=/usr/lib/cmake"
@@ -12,5 +12,5 @@ short_desc="Plasma development applications"
 maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later, LGPL-2.1-or-later"
 homepage="https://invent.kde.org/plasma/plasma-sdk"
-distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=eea9ea1d0eca8a0126edb3040701331e29421fb867ee7d8352e74d1cc9690123
+distfiles="${KDE_SITE}/plasma/${version%.1}/${pkgname}-${version}.tar.xz"
+checksum=90a2a18b699a374362f870b22685d4ed3d5e00fe7fa27b768fd2e626361e0744

--- a/srcpkgs/plasma-systemmonitor/template
+++ b/srcpkgs/plasma-systemmonitor/template
@@ -1,6 +1,6 @@
 # Template file for 'plasma-systemmonitor'
 pkgname=plasma-systemmonitor
-version=5.27.10
+version=5.27.11
 revision=1
 build_style=cmake
 hostmakedepends="extra-cmake-modules gettext qt5-host-tools qt5-qmake
@@ -13,4 +13,4 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-only OR GPL-3.0-only, LGPL-2.1-only OR LGPL-3.0-only"
 homepage="https://invent.kde.org/plasma/plasma-systemmonitor"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=64a1705797b42be1ed0be8258b11829b10f8b155e09bb4fbcf4757e2d7eb8a0e
+checksum=0acacbbd921b5d43e72a8e0e26635bab50e0aab7ca3f40d83dee7a28736b5dfd

--- a/srcpkgs/plasma-thunderbolt/template
+++ b/srcpkgs/plasma-thunderbolt/template
@@ -1,6 +1,6 @@
 # Template file for 'plasma-thunderbolt'
 pkgname=plasma-thunderbolt
-version=5.27.10
+version=5.27.11
 revision=1
 build_style=cmake
 configure_args="-DKF5_HOST_TOOLING=/usr/lib/cmake"
@@ -13,7 +13,7 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-3.0-or-later"
 homepage="https://invent.kde.org/plasma/plasma-thunderbolt"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=4d245ee5cb373d8cab39939e11002ee983c0f223070c30d2fba76f4c70306196
+checksum=5fe7c2d6338bcdb234eecb31296ccd49cc3746626ac41c7bc65d2e76ab5a89fb
 
 do_check() {
 	: # Requires running dbus and bolt services

--- a/srcpkgs/plasma-vault/template
+++ b/srcpkgs/plasma-vault/template
@@ -1,6 +1,6 @@
 # Template file for 'plasma-vault'
 pkgname=plasma-vault
-version=5.27.10
+version=5.27.11
 revision=1
 build_style=cmake
 configure_args=" -DKF5_HOST_TOOLING=/usr/lib/cmake
@@ -14,4 +14,4 @@ maintainer="Giuseppe Fierro <gspe@ae-design.ws>"
 license="GPL-2.0-or-later, LGPL-2.0-or-later, LGPL-2.1-or-later"
 homepage="https://github.com/KDE/plasma-vault"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=75f1d05661ac553fc8fec14f4ea683bfbb60b0dea816cd7cffb22a2ae3d11a5b
+checksum=0b599d79d7f728bcc1517b30d0462894dc2186fa76601628d3d0f2198c2276c2

--- a/srcpkgs/plasma-workspace-wallpapers/template
+++ b/srcpkgs/plasma-workspace-wallpapers/template
@@ -1,6 +1,6 @@
 # Template file for 'plasma-workspace-wallpapers'
 pkgname=plasma-workspace-wallpapers
-version=5.27.10
+version=5.27.11
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF"
@@ -10,4 +10,4 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later"
 homepage="https://invent.kde.org/plasma/plasma-workspace-wallpapers"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=82862d512993b958f7f96e191ce951ff2748012292941f73cdd308f37e2e64d0
+checksum=223c27fc68127afd6fc21d06ec11a3e37ce86e172375c906bda390474a4de50a

--- a/srcpkgs/plasma-workspace/template
+++ b/srcpkgs/plasma-workspace/template
@@ -1,7 +1,7 @@
 # Template file for 'plasma-workspace'
 pkgname=plasma-workspace
-version=5.27.10
-revision=3
+version=5.27.11
+revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF
  -DWaylandScanner_EXECUTABLE=/usr/bin/wayland-scanner
@@ -23,7 +23,7 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later, GFDL-1.2-or-later, LGPL-2.1-or-later"
 homepage="https://invent.kde.org/plasma/plasma-workspace"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=525dc164c61a6730f33d54ff5013d57184b9d671786fe898ca7e054426359778
+checksum=07d69bc43660ec5335f250abb34c1059cef6cc64833838a7f0f749a4b4ee7add
 
 build_options="pipewire"
 build_options_default="pipewire"

--- a/srcpkgs/polkit-kde-agent/template
+++ b/srcpkgs/polkit-kde-agent/template
@@ -1,6 +1,6 @@
 # Template file for 'polkit-kde-agent'
 pkgname=polkit-kde-agent
-version=5.27.10
+version=5.27.11
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF"
@@ -12,4 +12,4 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later"
 homepage="https://commits.kde.org/polkit-kde-agent"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-1-${version}.tar.xz"
-checksum=a3952a2785e468317a41bbc49ae02af816646afe3108d0612730f4f2398f8bdb
+checksum=c9e908894f101940b9152132b53ee4a5ebf348374c09aec05cd2a14458be5c1b

--- a/srcpkgs/powerdevil/template
+++ b/srcpkgs/powerdevil/template
@@ -1,6 +1,6 @@
 # Template file for 'powerdevil'
 pkgname=powerdevil
-version=5.27.10
+version=5.27.11
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF -DKF5_HOST_TOOLING=/usr/lib/cmake"
@@ -13,4 +13,4 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later"
 homepage="https://invent.kde.org/plasma/powerdevil"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=06c1a3c09880dd2060e3c8026189d8568d8a0f166ea33c2584669f85a04ec8f1
+checksum=28d2ab2e05bcbd39b8f5e5eafef2860c94efd5c7562fc5a4e81d5e5ab36c7573

--- a/srcpkgs/sddm-kcm/template
+++ b/srcpkgs/sddm-kcm/template
@@ -1,6 +1,6 @@
 # Template file for 'sddm-kcm'
 pkgname=sddm-kcm
-version=5.27.10
+version=5.27.11
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF -DKF5_HOST_TOOLING=/usr/lib/cmake"
@@ -14,4 +14,4 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later"
 homepage="https://invent.kde.org/plasma/sddm-kcm"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=83e43177bf83d7b2c5d617349bb913dbdb80b0354aecbcc47febd4e50d95f4ad
+checksum=3b9bfe81359be12eb7aeee492160877bf29d1a6ff6ed381c6afcbd0c8b7874c0

--- a/srcpkgs/systemsettings/template
+++ b/srcpkgs/systemsettings/template
@@ -1,6 +1,6 @@
 # Template file for 'systemsettings'
 pkgname=systemsettings
-version=5.27.10
+version=5.27.11
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF"
@@ -14,4 +14,4 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later, GFDL-1.2-only"
 homepage="https://invent.kde.org/plasma/systemsettings"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=af4c47f2cbe3a5cd8789eaad69d6ab4e73909dfe7500c5a71b01f5b82c860d39
+checksum=0f5f24279e44ad567f1ad3f2f9368f0e5c13c29f9f3de8078afcdae1181f924a

--- a/srcpkgs/xdg-desktop-portal-kde/template
+++ b/srcpkgs/xdg-desktop-portal-kde/template
@@ -1,6 +1,6 @@
 # Template file for 'xdg-desktop-portal-kde'
 pkgname=xdg-desktop-portal-kde
-version=5.27.10
+version=5.27.11
 revision=1
 build_style=cmake
 configure_args="-DWaylandScanner_EXECUTABLE=/usr/bin/wayland-scanner"
@@ -13,4 +13,4 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-3.0-or-later"
 homepage="https://phabricator.kde.org/source/xdg-desktop-portal-kde/"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=bd731ff0c3e27293728292e1b07276af53ad8a4fbbb915f1d0fd77b99d7bef2b
+checksum=3676898b1e145447a5e2d26fbe95a6b2f75c323e7e5e8645077db72c9916d9b3


### PR DESCRIPTION
- **bluedevil: update to 5.27.11.**
- **breeze-gtk: update to 5.27.11.**
- **breeze: update to 5.27.11.**
- **flatpak-kcm: update to 5.27.11.**
- **kactivitymanagerd: update to 5.27.11.**
- **kde-cli-tools: update to 5.27.11.**
- **kde-gtk-config5: update to 5.27.11.**
- **kdecoration: update to 5.27.11.**
- **kdeplasma-addons5: update to 5.27.11.**
- **kgamma5: update to 5.27.11.**
- **khotkeys: update to 5.27.11.**
- **kinfocenter: update to 5.27.11.**
- **kmenuedit: update to 5.27.11.**
- **kpipewire: update to 5.27.11.**
- **kscreen: update to 5.27.11.**
- **kscreenlocker: update to 5.27.11.**
- **ksshaskpass: update to 5.27.11.**
- **ksystemstats: update to 5.27.11.**
- **kwallet-pam: update to 5.27.11.**
- **kwayland-integration: update to 5.27.11.**
- **kwin: update to 5.27.11.**
- **kwrited: update to 5.27.11.**
- **layer-shell-qt: update to 5.27.11.**
- **libkscreen: update to 5.27.11.**
- **libksysguard: update to 5.27.11.**
- **milou: update to 5.27.11.**
- **oxygen-sounds: update to 5.27.11.**
- **oxygen: update to 5.27.11.**
- **plasma-browser-integration: update to 5.27.11.**
- **plasma-desktop: update to 5.27.11.**
- **plasma-disks: update to 5.27.11.**
- **plasma-firewall: update to 5.27.11.**
- **plasma-integration: update to 5.27.11.**
- **plasma-nm: update to 5.27.11.**
- **plasma-pa: update to 5.27.11.**
- **plasma-sdk: update to 5.27.11.**
- **plasma-systemmonitor: update to 5.27.11.**
- **plasma-thunderbolt: update to 5.27.11.**
- **plasma-vault: update to 5.27.11.**
- **plasma-workspace-wallpapers: update to 5.27.11.**
- **plasma-workspace: update to 5.27.11.**
- **polkit-kde-agent: update to 5.27.11.**
- **powerdevil: update to 5.27.11.**
- **sddm-kcm: update to 5.27.11.**
- **systemsettings: update to 5.27.11.**
- **xdg-desktop-portal-kde: update to 5.27.11.**

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**|**briefly**|**NO**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
