### PR TITLE
gphoto2: update to 2.5.28

### DIFF
--- a/srcpkgs/gphoto2/template
+++ b/srcpkgs/gphoto2/template
@@ -1,6 +1,6 @@
 # Template file for 'gphoto2'
 pkgname=gphoto2
-version=2.5.27
+version=2.5.28
 revision=1
 build_style=gnu-configure
 configure_args="--disable-static --disable-rpath udevscriptdir=/usr/lib/udev
@@ -12,4 +12,4 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="http://www.gphoto.org"
 distfiles="${SOURCEFORGE_SITE}/gphoto/gphoto2-${version}.tar.bz2"
-checksum=30054e93a1bb59f501aabd5018713177ea04ce0cb28935319bd6ca80061e8d38
+checksum=2a648dcdf12da19e208255df4ebed3e7d2a02f905be4165f2443c984cf887375


### PR DESCRIPTION

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**
- I tested hardware: Ricoh Theta Z1

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
