### PR TITLE
docker-compose: update to 2.26.1

### DIFF
--- a/srcpkgs/docker-compose/template
+++ b/srcpkgs/docker-compose/template
@@ -1,6 +1,6 @@
 # Template file for 'docker-compose'
 pkgname=docker-compose
-version=2.24.6
+version=2.26.1
 revision=1
 build_style=go
 go_import_path="github.com/docker/compose/v2"
@@ -13,7 +13,7 @@ license="Apache-2.0"
 homepage="https://docs.docker.com/compose/"
 changelog="https://github.com/docker/compose/releases"
 distfiles="https://github.com/docker/compose/archive/refs/tags/v${version}.tar.gz"
-checksum=14fffeba19b82c8e5a9cdf6d873522a11ee4e25bbb86bbdf468795274429db70
+checksum=081ad40241f8e144cad088a65e6fd0ec588e3d36931e5baabb3dc5ab068ceb60
 
 post_install() {
 	vmkdir usr/libexec/docker/cli-plugins


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
