### PR TITLE
pinebookpro-firmware: update to 0.0.20220515, fix dead links.

### DIFF
--- a/srcpkgs/pinebookpro-firmware/template
+++ b/srcpkgs/pinebookpro-firmware/template
@@ -1,35 +1,26 @@
 # Template file for 'pinebookpro-firmware'
 pkgname=pinebookpro-firmware
 reverts=20200215_1
-version=0.0.20201114
+version=0.0.20220515
 revision=1
-_rockchip_commit=72c91aa297a10140781e3f83419c077d4bf8890c
-_manjaro_commit=7074a2e21dd804e229eab1c031bc00246e9173e0
+_manjaro_commit=056d5f6776e515f90bbbbead1be06857aaef17d0
 archs="aarch64*"
-create_wrksrc=yes
 short_desc="Firmware files for the Pinebook Pro"
 maintainer="Orphaned <orphan@voidlinux.org>"
-license="Apache-2.0"
-homepage="https://github.com/rockchip-linux/rkwifibt"
-distfiles="
- https://github.com/rockchip-linux/rkwifibt/archive/${_rockchip_commit}.tar.gz
- https://gitlab.manjaro.org/manjaro-arm/packages/community/ap6256-firmware/-/archive/${_manjaro_commit}/ap6256-firmware-${_manjaro_commit}.tar.gz"
-checksum="
- f73a89b09cccb283b92911e978188987859c97cb78957ab1dbc2f169a0a5ec05
- 190653595f0dbf564bf726bc0de3d3f06aa9a6fcd7743a9b3fdd5b3b233b6c6b"
+license="custom:Unknown"
+# can't use vlicense since the license is unknown
+# https://lore.kernel.org/linux-firmware/CAMEGJJ2XYvGEekfLzjL1KE6VUF-71s+S8RbJ1DuBkYU98F9nsg@mail.gmail.com/
+homepage="https://gitlab.manjaro.org/manjaro-arm/packages/community/ap6256-firmware"
+distfiles="https://gitlab.manjaro.org/manjaro-arm/packages/community/ap6256-firmware/-/archive/${_manjaro_commit}/ap6256-firmware-${_manjaro_commit}.tar.gz"
+checksum=e933c27c68102b32cc0e4cb0ea69d8c95cc29d3efe486c4dd78e8af5a13520ad
+repository=nonfree
 
 do_install() {
-	cd "${wrksrc}"
-	cd "ap6256-firmware-${_manjaro_commit}"
 	vinstall brcmfmac43456-sdio.clm_blob 644 usr/lib/firmware/brcm
-	cd ..
-	cd "rkwifibt-${_rockchip_commit}"
-	vinstall firmware/broadcom/AP6256/bt/BCM4345C5.hcd 644 usr/lib/firmware/brcm
-	vinstall firmware/broadcom/AP6256/wifi/fw_bcm43456c5_ag.bin 644 usr/lib/firmware/brcm brcmfmac43456-sdio.bin
-	cp -f firmware/broadcom/AP6256/wifi/nvram_ap6256.txt .
-	vsed -i 's/ccode=DE/ccode=all/' nvram_ap6256.txt
-	vinstall nvram_ap6256.txt 644 usr/lib/firmware/brcm brcmfmac43456-sdio.txt
-	cd ..
+	vinstall BCM4345C5.hcd 644 usr/lib/firmware/brcm
+	vinstall fw_bcm43456c5_ag.bin 644 usr/lib/firmware/brcm brcmfmac43456-sdio.bin
+	vinstall brcmfmac43456-sdio.AP6256.txt 644 usr/lib/firmware/brcm brcmfmac43456-sdio.txt
+
 	for dev in pine64,pinebook-pro radxa,rockpi4b radxa,rockpi4c rockpro64-v2.1 rk3399-orangepi; do
 		ln -sf brcmfmac43456-sdio.txt "${DESTDIR}/usr/lib/firmware/brcm/brcmfmac43456-sdio.${dev}.txt"
 	done


### PR DESCRIPTION
This is firmware for broadcom 43456

It's unclear if this firmware is needed at all.

linux-firmware has broadcom 43455 with patchset for pinebookpro

Manajro has license as "unknown".

The linux-firmware mailing suggests that the firmware hasn't been upstreamed due to licensing issues:
https://lore.kernel.org/linux-firmware/CAMEGJJ2XYvGEekfLzjL1KE6VUF-71s+S8RbJ1DuBkYU98F9nsg@mail.gmail.com/

Should void be distributing this at all?

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
