### PR TITLE
hunspell-*: provides bdic for qtwebengine (and Chromium like browsers).

### DIFF
--- a/srcpkgs/hunspell-en_GB-ize/template
+++ b/srcpkgs/hunspell-en_GB-ize/template
@@ -1,10 +1,9 @@
 # Template file for 'hunspell-en_GB-ize'
-_vpkgname=hunspell-en_GB
-_variant="ize"
-pkgname=${_vpkgname}-${_variant}
+pkgname=hunspell-en_GB-ize
+_vpkgname=${pkgname%-*}
+_variant=${pkgname##*-}
 version=2020.12.07
-revision=1
-create_wrksrc=yes
+revision=2
 hostmakedepends="unzip"
 short_desc="English dictionary for hunspell ${_variant} variant"
 maintainer="Leah Neukirchen <leah@vuxu.org>"
@@ -15,8 +14,38 @@ checksum=869b749ec9805b87cd05f43307f20998651331b5aa5b04506413af0c2df2f231
 provides="${_vpkgname}-${version}_${revision}"
 replaces="${_vpkgname}>=0"
 
+build_options="bdic"
+desc_option_bdic="Enable Chromium's bdic format"
+
+case "$XBPS_MACHINE" in
+	x86_64*)
+		hostmakedepends+=" qt6-webengine"
+		build_options_default="bdic"
+		;;
+	i686*)
+		hostmakedepends+=" qt5-webengine"
+		build_options_default="bdic"
+		;;
+esac
+
+if [ "$build_option_bdic" ]; then
+	depends="libreoffice-qtwebengine-dict"
+fi
+
+do_build() {
+	PATH="/usr/lib/qt6/libexec:/usr/lib/qt5/bin:$PATH"
+	if [ "$build_option_bdic" ]; then
+		qwebengine_convert_dict en_GB-${_variant}.dic \
+			en_GB-${_variant}.bdic
+	fi
+}
+
 do_install() {
 	vinstall en_GB-${_variant}.aff 644 /usr/share/hunspell en_GB.aff
 	vinstall en_GB-${_variant}.dic 644 /usr/share/hunspell en_GB.dic
+	if [ "$build_option_bdic" ]; then
+		vinstall en_GB-${_variant}.bdic 644 \
+			usr/share/hunspell-bdic en_GB.bdic
+	fi
 	vlicense README_en_GB-${_variant}.txt SCOWL
 }

--- a/srcpkgs/hunspell-fr_FR/template
+++ b/srcpkgs/hunspell-fr_FR/template
@@ -1,44 +1,87 @@
 # Template file for 'hunspell-fr_FR'
 pkgname=hunspell-fr_FR
 version=7.0
-revision=2
-create_wrksrc=yes
+revision=3
 hostmakedepends="unzip"
 short_desc="French dictionary for hunspell"
 maintainer="Leah Neukirchen <leah@vuxu.org>"
 license="MPL-1.1"
 homepage="http://www.dicollecte.org/home.php?prj=fr"
 distfiles="http://www.dicollecte.org/download/fr/hunspell-french-dictionaries-v${version}.zip"
+distfiles="https://sources.voidlinux.org/hunspell-fr_FR-${version}/hunspell-french-dictionaries-v${version}.zip"
 checksum=eb7ac36dc14b9c3e3c0cabae0f90304a137da8e6ae607bcaf56d65720fbd097f
 
+build_options="bdic"
+desc_option_bdic="Enable Chromium's bdic format"
+
+case "$XBPS_MACHINE" in
+	x86_64*)
+		hostmakedepends+=" qt6-webengine"
+		build_options_default="bdic"
+		;;
+	i686*)
+		hostmakedepends+=" qt5-webengine"
+		build_options_default="bdic"
+		;;
+esac
+
+if [ "$build_option_bdic" ]; then
+	depends="libreoffice-qtwebengine-dict"
+fi
+
+_vinstall_variant() {
+	local _variant="$1" l
+	local _all_locales="fr_FR fr_BE fr_CA fr_CH fr_LU fr_MC"
+	vinstall fr-${_variant}.aff 644 usr/share/hunspell fr.aff
+	vinstall fr-${_variant}.dic 644 usr/share/hunspell fr.dic
+	for l in $_all_locales
+	do
+		ln -s fr.aff "${PKGDESTDIR}/usr/share/hunspell/${l}.aff"
+		ln -s fr.dic "${PKGDESTDIR}/usr/share/hunspell/${l}.dic"
+	done
+	if [ "$build_option_bdic" ]; then
+		vinstall fr-${_variant}.bdic 644 usr/share/hunspell-bdic fr.bdic
+		for l in $_all_locales
+		do
+			ln -s fr.bdic \
+				"${PKGDESTDIR}/usr/share/hunspell-bdic/${l}.bdic"
+		done
+	fi
+}
+
+do_build() {
+	local variant
+	PATH="/usr/lib/qt6/libexec:/usr/lib/qt5/bin:$PATH"
+	if [ "$build_option_bdic" ]; then
+		for variant in classique reforme1990 toutesvariantes; do
+			qwebengine_convert_dict fr-${variant}.dic \
+				fr-${variant}.bdic
+		done
+	fi
+}
+
 do_install() {
-	_variant="classique"
-	vinstall fr-${_variant}.aff 644 /usr/share/hunspell fr_FR.aff
-	vinstall fr-${_variant}.dic 644 /usr/share/hunspell fr_FR.dic
+	_vinstall_variant classique
 	vdoc README_dict_fr.txt
 	vdoc $FILESDIR/README.voidlinux
 }
 
 hunspell-fr_FR-reforme1990_package() {
-	_variant="reforme1990"
 	short_desc+=" - Reforme 1990 Variant"
 	provides="${sourcepkg}-${version}_${revision}"
 	replaces="${sourcepkg}>=0"
 	pkg_install() {
-		vinstall ${wrksrc}/fr-${_variant}.aff 644 /usr/share/hunspell fr_FR.aff
-		vinstall ${wrksrc}/fr-${_variant}.dic 644 /usr/share/hunspell fr_FR.dic
+		_vinstall_variant reforme1990
 		vdoc ${wrksrc}/README_dict_fr.txt
 	}
 }
 
 hunspell-fr_FR-toutesvariantes_package() {
-	_variant="toutesvariantes"
 	short_desc+=" - All variant in one file"
 	provides="${sourcepkg}-${version}_${revision}"
 	replaces="${sourcepkg}>=0"
 	pkg_install() {
-		vinstall ${wrksrc}/fr-${_variant}.aff 644 /usr/share/hunspell fr_FR.aff
-		vinstall ${wrksrc}/fr-${_variant}.dic 644 /usr/share/hunspell fr_FR.dic
+		_vinstall_variant toutesvariantes
 		vdoc ${wrksrc}/README_dict_fr.txt
 	}
 }

--- a/srcpkgs/hunspell-pt_PT-preao/template
+++ b/srcpkgs/hunspell-pt_PT-preao/template
@@ -1,16 +1,49 @@
 # Template file for 'hunspell-pt_PT-preao'
 pkgname=hunspell-pt_PT-preao
 version=20220621
-revision=1
+revision=2
 short_desc="Pre-1990 Portuguese dictionary for hunspell"
 maintainer="Luis Henriques <henrix@camandro.org>"
 license="GPL-2.0-only, LGPL-2.1-only, MPL-1.1"
 homepage="https://natura.di.uminho.pt/wiki/doku.php?id=dicionarios:main"
 distfiles="https://natura.di.uminho.pt/download/sources/Dictionaries/hunspell/${pkgname}-${version}.tar.gz"
 checksum=ddfe261e867f0c5489ec06f2d83f390b28e9631d667e88a33670b6ce755b4cf5
+provides="hunspell-pt_PT-0.1_1"
+replaces="hunspell-pt_PT>=0"
+
+build_options="bdic"
+desc_option_bdic="Enable Chromium's bdic format"
+
+case "$XBPS_MACHINE" in
+	x86_64*)
+		hostmakedepends+=" qt6-webengine"
+		build_options_default="bdic"
+		;;
+	i686*)
+		hostmakedepends+=" qt5-webengine"
+		build_options_default="bdic"
+		;;
+esac
+
+if [ "$build_option_bdic" ]; then
+	depends="libreoffice-qtwebengine-dict"
+fi
+
+do_build() {
+	PATH="/usr/lib/qt6/libexec:/usr/lib/qt5/bin:$PATH"
+	if [ "$build_option_bdic" ]; then
+		qwebengine_convert_dict pt_PT-preao.dic \
+			pt_PT.bdic
+	fi
+}
 
 do_install() {
 	vinstall pt_PT-preao.aff 644 usr/share/hunspell
 	vinstall pt_PT-preao.dic 644 usr/share/hunspell
+	ln -s pt_PT-preao.aff "${PKGDESTDIR}/usr/share/hunspell/pt_PT.aff"
+	ln -s pt_PT-preao.dic "${PKGDESTDIR}/usr/share/hunspell/pt_PT.dic"
+	if [ "$build_option_bdic" ]; then
+		vinstall pt_PT.bdic 644 usr/share/hunspell-bdic
+	fi
 	vdoc README_pt_PT.txt
 }

--- a/srcpkgs/hunspell-ru_RU-ieyo/template
+++ b/srcpkgs/hunspell-ru_RU-ieyo/template
@@ -1,7 +1,7 @@
 # Template file for 'hunspell-ru_RU-ieyo'
 pkgname=hunspell-ru_RU-ieyo
 version=0.3.9
-revision=3
+revision=4
 hostmakedepends="unzip"
 short_desc="Russian dictionary for hunspell, variant with ie and yo"
 maintainer="Andrey Raugas <kainonergon@gmail.com>"
@@ -10,9 +10,38 @@ homepage="http://extensions.openoffice.org/en/projectrelease/russkiy-orfografich
 distfiles="${SOURCEFORGE_SITE}/project/aoo-extensions/5149/3/dict_ru_ru-aot-${version}-ieyo.oxt>dict-ru_RU-ieyo.zip"
 checksum=3b374cf18f00fd0a9b6514eb8413438ce5d425a2e04435ffd81d8acc7ee1e578
 provides="hunspell-ru_RU-${version}_${revision}"
-replaces="hunspell-ru_RU"
+replaces="hunspell-ru_RU>=0"
+
+build_options="bdic"
+desc_option_bdic="Enable Chromium's bdic format"
+
+case "$XBPS_MACHINE" in
+	x86_64*)
+		hostmakedepends+=" qt6-webengine"
+		build_options_default="bdic"
+		;;
+	i686*)
+		hostmakedepends+=" qt5-webengine"
+		build_options_default="bdic"
+		;;
+esac
+
+if [ "$build_option_bdic" ]; then
+	depends="libreoffice-qtwebengine-dict"
+fi
+
+do_build() {
+	PATH="/usr/lib/qt6/libexec:/usr/lib/qt5/bin:$PATH"
+	if [ "$build_option_bdic" ]; then
+		qwebengine_convert_dict russian-aot-ieyo.dic \
+			ru_RU.bdic
+	fi
+}
 
 do_install() {
 	vinstall russian-aot-ieyo.aff 644 usr/share/hunspell ru_RU.aff
 	vinstall russian-aot-ieyo.dic 644 usr/share/hunspell ru_RU.dic
+	if [ "$build_option_bdic" ]; then
+		vinstall ru_RU.bdic 644 usr/share/hunspell-bdic
+	fi
 }


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

This PR expands the work of #49189 
- `pt_PT-preao` nows provides `pt_PT`, too, not sure if this is correct though.
- `fr_FR` nows provides spelling check for `fr_BE`, `fr_CA`, `fr_CH`, `fr_LU`, `fr_MC`, to the best of my knowledge, these regions also use French French spelling rules. But with different format for other things. (The list obtained by Libre Office).
- #49030 should be done with this PR.

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
