### PR TITLE
compiz-core: fix xml handling and fix building with gcc14

### DIFF
--- a/srcpkgs/compiz-core/patches/gcc14.patch
+++ b/srcpkgs/compiz-core/patches/gcc14.patch
@@ -1,0 +1,93 @@
+From d4213fa4fe6bdd44ba652f5407cefc83def2b14e Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Jaroslav=20=C5=A0karvada?= <jskarvad@redhat.com>
+Date: Tue, 6 Feb 2024 13:57:53 +0100
+Subject: [PATCH] Fixed compilation with gcc-14
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Signed-off-by: Jaroslav Škarvada <jskarvad@redhat.com>
+---
+ plugins/commands.c   | 1 +
+ plugins/cube.c       | 1 +
+ plugins/matecompat.c | 1 +
+ plugins/obs.c        | 1 +
+ src/core.c           | 1 +
+ src/metadata.c       | 1 +
+ 6 files changed, 6 insertions(+)
+
+diff --git a/plugins/commands.c b/plugins/commands.c
+index 97ad06e1..cb165b48 100644
+--- a/plugins/commands.c
++++ b/plugins/commands.c
+@@ -23,6 +23,7 @@
+  * Author: Danny Baumann <dannybaumann@web.de>
+  */
+ 
++#include <stdlib.h>
+ #include <compiz-core.h>
+ 
+ static CompMetadata commandsMetadata;
+diff --git a/plugins/cube.c b/plugins/cube.c
+index 5a77091d..eeb86fbe 100644
+--- a/plugins/cube.c
++++ b/plugins/cube.c
+@@ -24,6 +24,7 @@
+  *         Mirco Müller <macslow@bangang.de> (Skydome support)
+  */
+ 
++#include <stdlib.h>
+ #include <string.h>
+ #include <math.h>
+ 
+diff --git a/plugins/matecompat.c b/plugins/matecompat.c
+index 6c631627..9b2fe690 100644
+--- a/plugins/matecompat.c
++++ b/plugins/matecompat.c
+@@ -23,6 +23,7 @@
+  * Author: Danny Baumann <dannybaumann@web.de>
+  */
+ 
++#include <stdlib.h>
+ #include <compiz-core.h>
+ 
+ static CompMetadata mateMetadata;
+diff --git a/plugins/obs.c b/plugins/obs.c
+index 0f5b9d06..009bf365 100644
+--- a/plugins/obs.c
++++ b/plugins/obs.c
+@@ -23,6 +23,7 @@
+  * Author: Danny Baumann <dannybaumann@web.de>
+  */
+ 
++#include <stdlib.h>
+ #include <compiz-core.h>
+ 
+ static CompMetadata obsMetadata;
+diff --git a/src/core.c b/src/core.c
+index 6b69a285..d10d6727 100644
+--- a/src/core.c
++++ b/src/core.c
+@@ -23,6 +23,7 @@
+  * Author: David Reveman <davidr@novell.com>
+  */
+ 
++#include <stdlib.h>
+ #include <string.h>
+ 
+ #include <compiz-core.h>
+diff --git a/src/metadata.c b/src/metadata.c
+index 559734aa..1d224231 100644
+--- a/src/metadata.c
++++ b/src/metadata.c
+@@ -25,6 +25,7 @@
+  *          David Reveman <davidr@novell.com>
+  */
+ 
++#include <stdlib.h>
+ #include <string.h>
+ #include <libxml/tree.h>
+ #include <libxml/xpath.h>
+-- 
+GitLab
+

--- a/srcpkgs/compiz-core/patches/libxml2-2.12.patch
+++ b/srcpkgs/compiz-core/patches/libxml2-2.12.patch
@@ -1,0 +1,55 @@
+From ea7b3731b1a8a0f2fb7aa765a84374658b67b1b7 Mon Sep 17 00:00:00 2001
+From: Sixu Hu <husixu1@hotmail.com>
+Date: Wed, 22 Nov 2023 00:54:10 +0800
+Subject: [PATCH] Fix compatibility with libxml 2.12
+
+---
+ src/main.c     | 6 ++++--
+ src/metadata.c | 7 +++++--
+ 2 files changed, 9 insertions(+), 4 deletions(-)
+
+diff --git a/src/main.c b/src/main.c
+index 26b4c512..7182b75b 100644
+--- a/src/main.c
++++ b/src/main.c
+@@ -271,8 +271,10 @@ readCoreXmlCallback (void *context,
+     i += compReadXmlChunk ("</screen></core></compiz>", &offset, buffer + i,
+ 			   length - i);
+ 
+-    if (!offset && length > i)
+-	buffer[i++] = '\0';
++    if (!offset && length > i) {
++	    // buffer[i] = '\0';
++        ctx->offset += 1;
++    }
+ 
+     ctx->offset += i;
+ 
+diff --git a/src/metadata.c b/src/metadata.c
+index 3c1fa9ff..559734aa 100644
+--- a/src/metadata.c
++++ b/src/metadata.c
+@@ -30,6 +30,7 @@
+ #include <libxml/xpath.h>
+ #include <libxml/xpathInternals.h>
+ #include <locale.h>
++#include <stdlib.h>
+ 
+ #include <compiz-core.h>
+ 
+@@ -285,8 +286,10 @@ readPluginXmlCallback (void *context,
+     i += compReadXmlChunk ("</plugin></compiz>", &offset, buffer + i,
+ 			   length - i);
+ 
+-    if (!offset && length > i)
+-	buffer[i++] = '\0';
++    if (!offset && length > i) {
++	    // buffer[i] = '\0';
++        ctx->offset += 1;
++    }
+ 
+     ctx->offset += i;
+ 
+-- 
+GitLab
+

--- a/srcpkgs/compiz-core/template
+++ b/srcpkgs/compiz-core/template
@@ -1,7 +1,7 @@
 # Template file for 'compiz-core'
 pkgname=compiz-core
 version=0.8.18
-revision=2
+revision=3
 build_style=gnu-configure
 configure_args="--disable-static"
 hostmakedepends="automake gettext-devel intltool libtool pkg-config libxslt"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
