### PR TITLE
New package: niri-0.1.5

### DIFF
--- a/srcpkgs/niri/template
+++ b/srcpkgs/niri/template
@@ -1,0 +1,21 @@
+# Template file for 'niri'
+pkgname=niri
+version=0.1.7
+revision=1
+build_style=cargo
+configure_args="--no-default-features --features xdp-gnome-screencast"
+hostmakedepends="pkg-config"
+makedepends="eudev-libudev-devel libxkbcommon-devel libinput-devel pipewire-devel pango-devel libseat-devel clang libgbm-devel"
+depends="eudev-libudev libxkbcommon libinput libpipewire pango libseat libgbm"
+short_desc="Scrollable-tiling Wayland compositor"
+maintainer="Eloi Torrents <eloitor@disroot.org>"
+license="GPL-3.0-or-later"
+homepage="https://github.com/YaLTeR/niri"
+changelog="https://github.com/YaLTeR/niri/releases"
+distfiles="https://github.com/YaLTeR/niri/archive/refs/tags/v${version}.tar.gz"
+checksum=2ce7a450b550164f99d6fd6d2815c04f2160fbf932f9c0d244b7b1e3481c9b21
+
+post_install() {
+	vmkdir etc/niri
+	vcopy resources/default-config.kdl etc/niri/config.kdl
+}


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)

Closes #48456 

To run I use `dbus-run-session niri --session`.
