### PR TITLE
intel-media-driver: update to  23.4.3 and sync intel-gmmlib to 22.3.15

### DIFF
--- a/srcpkgs/intel-gmmlib/template
+++ b/srcpkgs/intel-gmmlib/template
@@ -1,6 +1,6 @@
 # Template file for 'intel-gmmlib'
 pkgname=intel-gmmlib
-version=22.3.12
+version=22.3.15
 revision=1
 archs="i686* x86_64*"
 build_style=cmake
@@ -18,7 +18,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
 homepage="https://github.com/intel/gmmlib"
 distfiles="https://github.com/intel/gmmlib/archive/intel-gmmlib-${version}.tar.gz"
-checksum=14ec859936aea696a65e6b9488e95a0ac26b15126ef65b20956ef219004dd9a6
+checksum=2abca3127f9996c14efa9b809839f0a516c02f2ee02bb9cbaf0b785601e19ca0
 
 lib32disabled=yes
 

--- a/srcpkgs/intel-media-driver/template
+++ b/srcpkgs/intel-media-driver/template
@@ -1,6 +1,6 @@
 # Template file for 'intel-media-driver'
 pkgname=intel-media-driver
-version=23.4.1
+version=23.4.3
 revision=1
 archs="x86_64*"
 build_style=cmake
@@ -13,7 +13,7 @@ license="MIT, BSD-3-Clause"
 homepage="https://github.com/intel/media-driver"
 changelog="https://github.com/intel/media-driver/releases"
 distfiles="https://github.com/intel/media-driver/archive/intel-media-${version}.tar.gz"
-checksum=c61e7bc8f495a2314b24d14c88a1a8955e1347d26afa54c9b37b5527b9b316ad
+checksum=83b95eefe86c9d58d92c2a77793541ea3cb643dff419599ffa87899fd58738cd
 
 build_options="nonfree"
 desc_option_nonfree="Enable nonfree kernels"


### PR DESCRIPTION
Update intel-media-driver to 23.4.3 and sync to the  intel-gmmlib dependency to the required 22.3.15 while we're at it.

#### Testing the changes
- I tested the changes in this PR: **YES**
