### PR TITLE
libjxl: update to 0.10.2.

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -4254,9 +4254,9 @@ libplayerctl.so.2 playerctl-2.4.1_1
 libwireplumber-0.4.so.0 wireplumber-0.4.14_1
 libjodycode.so.3 libjodycode-3.0.1_1
 libgsoapssl++-2.8.124.so gsoap-2.8.124_1
-libjxl.so.0.9 libjxl-0.9.0_1
-libjxl_cms.so.0.9 libjxl-0.9.0_1
-libjxl_threads.so.0.9 libjxl-0.9.0_1
+libjxl.so.0.10 libjxl-0.10.0_1
+libjxl_cms.so.0.10 libjxl-0.10.0_1
+libjxl_threads.so.0.10 libjxl-0.10.0_1
 libtext-engine-0.1.so.0 text-engine-0.1.1_1
 libvmaf.so.1 vmaf-2.3.1_1
 liblc3.so.1 liblc3-1.0.3_1

--- a/srcpkgs/darktable/template
+++ b/srcpkgs/darktable/template
@@ -1,7 +1,7 @@
 # Template file for 'darktable'
 pkgname=darktable
 version=4.6.1
-revision=1
+revision=2
 # upstream only supports these archs:
 archs="x86_64* aarch64* ppc64le*"
 build_style=cmake

--- a/srcpkgs/highway/template
+++ b/srcpkgs/highway/template
@@ -1,6 +1,6 @@
 # Template file for 'highway'
 pkgname=highway
-version=1.0.7
+version=1.1.0
 revision=1
 build_style=cmake
 configure_args="-DHWY_SYSTEM_GTEST=ON -DHWY_ENABLE_EXAMPLES=OFF"
@@ -11,7 +11,7 @@ license="Apache-2.0"
 homepage="https://github.com/google/highway"
 changelog="https://raw.githubusercontent.com/google/highway/master/debian/changelog"
 distfiles="https://github.com/google/highway/archive/${version}.tar.gz"
-checksum=5434488108186c170a5e2fca5e3c9b6ef59a1caa4d520b008a9b8be6b8abe6c5
+checksum=354a8b4539b588e70b98ec70844273e3f2741302c4c377bcc4e81b3d1866f7c9
 
 if [ -z "$XBPS_CHECK_PKGS" ]; then
 	configure_args+=" -DBUILD_TESTING=OFF"

--- a/srcpkgs/imlib2/template
+++ b/srcpkgs/imlib2/template
@@ -1,7 +1,7 @@
 # Template file for 'imlib2'
 pkgname=imlib2
 version=1.12.2
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--disable-static --sysconfdir=/etc/imlib2 --enable-visibility-hiding"
 hostmakedepends="pkg-config"

--- a/srcpkgs/kimageformats/template
+++ b/srcpkgs/kimageformats/template
@@ -1,7 +1,7 @@
 # Template file for 'kimageformats'
 pkgname=kimageformats
 version=5.115.0
-revision=1
+revision=2
 build_style=cmake
 configure_args="-DKIMAGEFORMATS_HEIF=ON"
 hostmakedepends="kcoreaddons extra-cmake-modules qt5-qmake qt5-host-tools

--- a/srcpkgs/krita/template
+++ b/srcpkgs/krita/template
@@ -1,7 +1,7 @@
 # Template file for 'krita'
 pkgname=krita
 version=5.2.1
-revision=4
+revision=5
 build_style=cmake
 configure_args="-Wno-dev -DBUILD_TESTING=OFF"
 hostmakedepends="extra-cmake-modules gettext pkg-config python3

--- a/srcpkgs/libjxl/template
+++ b/srcpkgs/libjxl/template
@@ -1,10 +1,9 @@
 # Template file for 'libjxl'
 pkgname=libjxl
-version=0.9.2
+version=0.10.2
 revision=1
 _testdata_hash=ff8d743aaba05b3014f17e5475e576242fa979fc
 build_style=cmake
-build_wrksrc="libjxl-${version}"
 configure_args="-DJPEGXL_ENABLE_BENCHMARK=OFF -DJPEGXL_ENABLE_EXAMPLES=OFF
  -DJPEGXL_ENABLE_SJPEG=OFF -DJPEGXL_ENABLE_PLUGINS=ON -DJPEGXL_VERSION=${version}
  -DJPEGXL_ENABLE_SKCMS=OFF"
@@ -19,16 +18,16 @@ homepage="https://jpeg.org/jpegxl/"
 changelog="https://raw.githubusercontent.com/libjxl/libjxl/main/CHANGELOG.md"
 distfiles="https://github.com/libjxl/libjxl/archive/v${version}.tar.gz
  https://github.com/libjxl/testdata/archive/${_testdata_hash}.tar.gz>testdata-${_testdata_hash}.tar.gz"
-checksum="bf28e411d84c50578ab74107cdd624e099313129883a43907c261e8116a11b3b
+checksum="95e807f63143856dc4d161c071cca01115d2c6405b3d3209854ac6989dc6bb91
  9c45a108df32a002a69465df896d33acf77d97c88fb59dffa0dff5628370e96f"
-patch_args="-Np1 --directory=${build_wrksrc}"
+skip_extraction="testdata-${_testdata_hash}.tar.gz"
 
 if [ -z "$XBPS_CHECK_PKGS" ]; then
 	configure_args+=" -DBUILD_TESTING=OFF"
 fi
 
 post_extract() {
-	mv "testdata-${_testdata_hash}"/* "${build_wrksrc}/testdata/"
+	vsrcextract -C testdata "testdata-${_testdata_hash}.tar.gz"
 }
 
 post_install() {

--- a/srcpkgs/swayimg/template
+++ b/srcpkgs/swayimg/template
@@ -1,7 +1,7 @@
 # Template file for 'swayimg'
 pkgname=swayimg
 version=2.1
-revision=1
+revision=2
 build_style=meson
 configure_args="-D version=${version}"
 hostmakedepends="pkg-config wayland-devel"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**
  - built only: `swayimg`, `kimageformats`
  - built and tested: `darktable`, `imlib2`, `krita`, `libjxl-*`

#### Local build testing
- I built this PR locally for my native architecture, (`x86_64-glibc`)
- built `libjxl` for `x86_64-musl` and `i686-glibc`, didn't build any of the other packages

I also went from using a `build_wrksrc` to a `skip_extraction` -> `vsrcextract` in the `libjxl` package since [I was told to do that before](https://github.com/void-linux/void-packages/pull/48828#issuecomment-1974843065) so it's probably the correct way of doing this kinda thing now