### PR TITLE
graphviz: fix update-check

### DIFF
--- a/srcpkgs/graphviz/update
+++ b/srcpkgs/graphviz/update
@@ -1,2 +1,1 @@
 site="https://gitlab.com/graphviz/graphviz/-/tags"
-pattern='stable_release_*\K[\d.]*(?=\.tar\.gz)'


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

`Stable Release` is no longer used since `v2.44.1`. See https://gitlab.com/graphviz/graphviz/-/tags?page=2.

cc @leahneukirchen 
