### PR TITLE
rtl8812au-dkms: move head to  compile with 6.7.x, bump revision

### DIFF
--- a/srcpkgs/rtl8812au-dkms/template
+++ b/srcpkgs/rtl8812au-dkms/template
@@ -1,16 +1,16 @@
 # Template file for 'rtl8812au-dkms'
 pkgname=rtl8812au-dkms
 version=20210629
-revision=4
+revision=5
 _modver=5.13.6
-_gitrev=b5f4e6e894eca8fea38661e2fc22a2570e0274ad
+_gitrev=d4638de07724cf5c6ba7793920abf6d802311508
 depends="dkms"
 short_desc="Realtek 8812AU USB WiFi driver (DKMS)"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-only"
 homepage="https://github.com/morrownr/8812au"
 distfiles="https://github.com/morrownr/8812au-${version}/archive/${_gitrev}.tar.gz"
-checksum=8eb01e1c9159cbeea1fd7a0d711a87e05380183487d244ce26fb58c03f081038
+checksum=81c7538f29fe1483ef16aaa688eb9d4863da063fde29c18228d0d66559ba3b7d
 dkms_modules="rtl8812au ${_modver}"
 
 case "$XBPS_TARGET_MACHINE" in


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (x86_64)
- I built this PR locally for these architectures: NO
-->
