### PR TITLE
fix dependency sorting

### DIFF
--- a/common/hooks/pre-pkg/04-generate-runtime-deps.sh
+++ b/common/hooks/pre-pkg/04-generate-runtime-deps.sh
@@ -40,8 +40,8 @@ store_pkgdestdir_rundeps() {
                      -z "$($XBPS_UHELPER_CMD getpkgname ${_curdep} 2>/dev/null)" ]; then
                     _curdep="${_curdep}>=0"
                 fi
-                printf -- "${_curdep}\n"
-            done | sort | xargs > ${PKGDESTDIR}/rdeps
+                printf "%s " "${_curdep}"
+            done > "${PKGDESTDIR}/rdeps"
         fi
 }
 

--- a/srcpkgs/base-chroot/template
+++ b/srcpkgs/base-chroot/template
@@ -1,7 +1,7 @@
 # Template file for 'base-chroot'
 pkgname=base-chroot
 version=0.67
-revision=2
+revision=3
 bootstrap=yes
 build_style=meta
 short_desc="Minimal set of packages required for chroot with xbps-src"

--- a/srcpkgs/base-container-full/template
+++ b/srcpkgs/base-container-full/template
@@ -1,7 +1,7 @@
 # Template file for 'base-container-full'
 pkgname=base-container-full
 version=0.11
-revision=2
+revision=3
 build_style=meta
 short_desc="Void Linux base system meta package for containers/chroots"
 maintainer="Enno Boland <gottox@voidlinux.org>"

--- a/srcpkgs/base-container/template
+++ b/srcpkgs/base-container/template
@@ -1,7 +1,7 @@
 # Template file for 'base-container'
 pkgname=base-container
 version=0.3
-revision=2
+revision=3
 build_style=meta
 short_desc="Void Linux base system meta for minimal containers/chroots"
 maintainer="Enno Boland <gottox@voidlinux.org>"

--- a/srcpkgs/base-system/template
+++ b/srcpkgs/base-system/template
@@ -1,7 +1,7 @@
 # Template file for 'base-system'
 pkgname=base-system
 version=0.114
-revision=1
+revision=2
 build_style=meta
 short_desc="Void Linux base system meta package"
 maintainer="Enno Boland <gottox@voidlinux.org>"


### PR DESCRIPTION
- common/hooks/pre-pkg/04-generate-runtime-deps: partially revert sorting
- base-system: rebuild for dep sorting
- base-container: rebuild for dep sorting
- base-container-full: rebuild for dep sorting
- base-chroot: rebuild for dep sorting

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**
