### PR TITLE
swirc: update to 3.4.7.

### DIFF
--- a/srcpkgs/swirc/template
+++ b/srcpkgs/swirc/template
@@ -1,6 +1,6 @@
 # Template file for 'swirc'
 pkgname=swirc
-version=3.4.6
+version=3.4.7
 revision=1
 build_style=configure
 configure_args="$(vopt_with notify libnotify)"
@@ -12,12 +12,12 @@ makedepends="gettext-devel hunspell-devel libcurl-devel libidn-devel
  ncurses-devel openssl-devel $(vopt_if notify libnotify-devel)"
 checkdepends="cmocka-devel"
 short_desc="Curses ICB and IRC client"
-maintainer="Markus Uhlin <markus.uhlin@bredband.net>"
+maintainer="Markus Uhlin <markus@nifty-networks.net>"
 license="BSD-3-Clause, ISC, MIT"
 homepage="https://www.nifty-networks.net/swirc"
 changelog="https://raw.githubusercontent.com/uhlin/swirc/master/CHANGELOG.md"
 distfiles="https://www.nifty-networks.net/swirc/releases/swirc-${version}.tgz"
-checksum=b34b2fed727eb4ebd7f7fdd134e2466d70665e3fc397b1488bdb2c0f475da982
+checksum=9341f077af1d74e161a853791fa9db172ab5258e9b031ff9091c453f948aae98
 
 build_options="notify"
 build_options_default="notify"
@@ -31,6 +31,14 @@ post_configure() {
 
 	vsed -i "$_file" -e "s/CC =/CC ?=/"
 	vsed -i "$_file" -e "s/CXX =/CXX ?=/"
+	vsed -i "$_file" -e "s/LDFLAGS =/LDFLAGS ?=/"
+}
+
+do_check() {
+	# The usage of the "-Wl,-z,now" and "-Wl,-z,relro" LDFLAGS
+	# results in linking errors and are disabled during "make
+	# check".
+	LDFLAGS="-L/usr/local/lib" make check
 }
 
 post_check() {


### PR DESCRIPTION
Swirc 3.4.7 out.

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, **x86_64-musl**
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - armv6l-musl **cross**
