### PR TITLE
autorestic: update to 1.8.1

### DIFF
--- a/srcpkgs/autorestic/template
+++ b/srcpkgs/autorestic/template
@@ -1,6 +1,6 @@
 # Template file for 'autorestic'
 pkgname=autorestic
-version=1.8.0
+version=1.8.1
 revision=1
 build_style=go
 go_import_path="github.com/cupcakearmy/autorestic"
@@ -11,4 +11,4 @@ license="Apache-2.0"
 homepage="https://autorestic.vercel.app/"
 changelog="https://github.com/cupcakearmy/autorestic/raw/master/CHANGELOG.md"
 distfiles="https://github.com/cupcakearmy/autorestic/archive/refs/tags/v${version}.tar.gz"
-checksum=a3174c795938b9d70a6af99d90c71083c228d82fc3c6a9961f8315ac12860f37
+checksum=2bee19866dd365cddf306ab8fddceacac7ef11162da90b355d44f6ae9943350c


### PR DESCRIPTION
- I tested the changes in this PR: **YES**
- I built this PR locally for my native architecture, (x86_64-glibc)

Quick regression test:
```
$ autorestic --version
autorestic version 1.8.1
$ autorestic check
Using config: 	/home/em/.autorestic.yaml
Using env:	/home/em/.autorestic.env
Using lock:	/home/em/.autorestic.lock.yml
Everything is fine.
$ autorestic backup --all
Using config: 	/home/em/.autorestic.yaml
Using env:	/home/em/.autorestic.env
Using lock:	/home/em/.autorestic.lock.yml
...
Done
```