### PR TITLE
python3-uvicorn: update to 0.28.0

### DIFF
--- a/srcpkgs/python3-uvicorn/template
+++ b/srcpkgs/python3-uvicorn/template
@@ -1,6 +1,6 @@
 # Template file for 'python3-uvicorn'
 pkgname=python3-uvicorn
-version=0.24.0
+version=0.28.0
 revision=1
 build_style=python3-pep517
 hostmakedepends="hatchling"
@@ -11,7 +11,7 @@ license="BSD-3-Clause"
 homepage="https://www.uvicorn.org/"
 changelog="https://github.com/encode/uvicorn/blob/master/CHANGELOG.md"
 distfiles="${PYPI_SITE}/u/uvicorn/uvicorn-${version}.tar.gz"
-checksum=368d5d81520a51be96431845169c225d771c9dd22a58613e1a181e6c4512ac33
+checksum=cab4473b5d1eaeb5a0f6375ac4bc85007ffc75c3cc1768816d9e5d589857b067
 
 post_install() {
 	vlicense LICENSE.md


### PR DESCRIPTION
- I tested the changes in this PR: **NO**
- I built this PR locally for my native architecture, (x86_64-glibc)