### PR TITLE
rust: build rust-analyzer-proc-macro-srv

### DIFF
--- a/srcpkgs/rust/template
+++ b/srcpkgs/rust/template
@@ -9,7 +9,7 @@
 #
 pkgname=rust
 version=1.76.0
-revision=1
+revision=2
 hostmakedepends="curl pkg-config python3 tar cargo-bootstrap"
 makedepends="libffi-devel ncurses-devel libxml2-devel zlib-devel llvm17-devel"
 depends="rust-std gcc"
@@ -128,7 +128,7 @@ do_configure() {
 		--release-description="Void Linux" \
 		--llvm-libunwind=no \
 		--llvm-config=/usr/bin/llvm-config \
-		--tools=clippy,rustdoc,rustfmt \
+		--tools=clippy,rustdoc,rustfmt,rust-analyzer-proc-macro-srv \
 		--set="rust.optimize=true" \
 		--set="rust.debug=false" \
 		--set="rust.codegen-units=1" \


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)

Without it rust-analyzer doesn't expand macros.