### PR TITLE
slack-desktop: allow the use of WebRTCPipeWireCapturer flag, adopt

### DIFF
--- a/srcpkgs/slack-desktop/template
+++ b/srcpkgs/slack-desktop/template
@@ -1,11 +1,11 @@
 # Template file for 'slack-desktop'
 pkgname=slack-desktop
 version=4.36.140
-revision=1
+revision=2
 archs="x86_64"
 depends="xdg-utils"
 short_desc="Messaging app for teams"
-maintainer="dataCobra <datacobra@thinkbot.de>"
+maintainer="Rodrigo Oliveira <mdkcore@qtrnn.io>"
 license="custom:Proprietary"
 homepage="https://slack.com/"
 distfiles="https://downloads.slack-edge.com/releases/linux/${version}/prod/x64/${pkgname}-${version}-amd64.deb"
@@ -19,6 +19,7 @@ do_install() {
 	vinstall usr/share/applications/slack.desktop 644 usr/share/applications
 	vinstall usr/share/pixmaps/slack.png 644 usr/share/pixmaps
 	mkdir ${DESTDIR}/usr/bin
+	vsed -i -e 's/,"WebRTCPipeWireCapturer"/,"LebRTCPipeWireCapturer"/' usr/lib/slack/resources/app.asar
 	vcopy usr/lib/slack usr/lib
 	ln -s ../lib/slack/slack ${DESTDIR}/usr/bin/slack
 }


### PR DESCRIPTION
Slack seems to [disable screen sharing on Wayland](https://forums.slackcommunity.com/s/question/0D53a00009BSEGACA5/when-will-slack-support-wayland-screen-sharing-does-anyone-have-workarounds-or-hacks-to-make-it-work), this commit allow the use of WebRTCPipeWireCapturer.
Final user still needs to add the flag on the command line to make use of it:
`--enable-features=WebRTCPipeWireCapturer --ozone-platform-hint=auto`.

Note: just tested on Wayland, it would be great if someone tested it on x11 too.
Note2: As discussed below with @dataCobra, I'm adopting this package.

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture: x86_64-libc
