### PR TITLE
New package: sequoia-chameleon-gnupg-0.7.0

### DIFF
--- a/srcpkgs/sequoia-chameleon-gnupg/template
+++ b/srcpkgs/sequoia-chameleon-gnupg/template
@@ -1,0 +1,23 @@
+# Template file for 'sequoia-chameleon-gnupg'
+pkgname=sequoia-chameleon-gnupg
+version=0.9.0
+revision=1
+build_style=cargo
+hostmakedepends="pkg-config llvm clang"
+makedepends="nettle-devel openssl-devel sqlite-devel bzip2-devel"
+checkdepends="gnupg faketime sequoia-sq"
+short_desc="Re-implementation of gpg and gpgv from Sequoia OpenPGP"
+maintainer="classabbyamp <void@placeviolette.net>"
+license="GPL-3.0-or-later"
+homepage="https://gitlab.com/sequoia-pgp/sequoia-chameleon-gnupg"
+distfiles="https://gitlab.com/sequoia-pgp/sequoia-chameleon-gnupg/-/archive/v${version}/sequoia-chameleon-gnupg-v${version}.tar.gz"
+checksum=fce55bc7323d40476415bf52451ae8b71ab2760665d25d39b08c3caf574e7e16
+
+post_install() {
+	# allow users to add /usr/libexec/sequoia to $PATH to get gpg = gpg-sq
+	vmkdir /usr/libexec/sequoia
+	mv "${DESTDIR}"/usr/bin/gpg-sq "${DESTDIR}"/usr/libexec/sequoia/gpg
+	ln -s ../libexec/sequoia/gpg "${DESTDIR}"/usr/bin/gpg-sq
+	mv "${DESTDIR}"/usr/bin/gpgv-sq "${DESTDIR}"/usr/libexec/sequoia/gpgv
+	ln -s ../libexec/sequoia/gpgv "${DESTDIR}"/usr/bin/gpgv-sq
+}


### PR DESCRIPTION
- ~~gnupg1: add alternatives for gpg and gpgv~~
- ~~gnupg: add alternatives for gpg and gpgv~~
- New package: sequoia-chameleon-gnupg-0.6.0

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

revival of https://github.com/void-linux/void-packages/pull/41306

~~@sgn, you had comments in the previous PR about the alternatives groups. I've set `--enable-gpg-is-gpg2` for `gnupg`, so I believe that fixes your broken scenario:~~

```
$ gpgconf --check-programs
gpg:OpenPGP:/usr/bin/gpg2:1:1:
gpgsm:S/MIME:/usr/bin/gpgsm:1:1:
keyboxd:Public Keys:/usr/libexec/keyboxd:1:1:
gpg-agent:Private Keys:/usr/bin/gpg-agent:1:1:
scdaemon:Smartcards:/usr/libexec/scdaemon:1:1:
dirmngr:Network:/usr/bin/dirmngr:1:1:
pinentry:Passphrase Entry:/usr/bin/pinentry:1:1:
```

~~Additionally, should `gnupg2` just become a dummy package, with doc and examples directories being called `gnupg2` with a symlink to `gnupg` in the main package?~~
