### PR TITLE
rofi-emoji: update to 3.3.0

### DIFF
--- a/srcpkgs/rofi-emoji/template
+++ b/srcpkgs/rofi-emoji/template
@@ -1,6 +1,6 @@
 # Template file for 'rofi-emoji'
 pkgname=rofi-emoji
-version=3.2.0
+version=3.3.0
 revision=1
 build_style=gnu-configure
 hostmakedepends="autoconf automake libtool pkg-config"
@@ -12,7 +12,7 @@ license="MIT"
 homepage="https://github.com/Mange/rofi-emoji"
 changelog="https://raw.githubusercontent.com/Mange/rofi-emoji/master/Changelog.md"
 distfiles="https://github.com/Mange/rofi-emoji/archive/v${version}.tar.gz"
-checksum=431e802171e55edeecc79f6e75cba072ea25dea2527884e4629b04891cd467ed
+checksum=a2d5f19f015b4014360d23a4fe2820baf09ef3b69d45677df52537206876ce47
 
 pre_configure() {
 	autoreconf -i


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture: x86_64-libc
- I built this PR locally for these architectures:
  - armv7l (crossbuild)