### PR TITLE
vpcs: update to 0.8.3 (GNS3's continuation fork)

### DIFF
--- a/srcpkgs/vpcs/patches/ldflags.patch
+++ b/srcpkgs/vpcs/patches/ldflags.patch
@@ -4,8 +4,8 @@
  CPUTYPE=i386
  HVOPT=-DHV
  
--CFLAGS=-D$(OSTYPE) -D$(CPUTYPE) $(HVOPT) -Wall -I. -DTAP
--LDFLAGS=-lpthread -lutil -s -static
+-CFLAGS=-D$(OSTYPE) -D$(CPUTYPE) $(HVOPT) -Wall -DTAP
+-LDFLAGS=-lpthread -lutil
 +override CFLAGS+=-D$(OSTYPE) -D$(CPUTYPE) $(HVOPT) -Wall -I. -DTAP
 +override LDFLAGS+=-lpthread -lutil -s -static
  OBJS=vpcs.o \

--- a/srcpkgs/vpcs/template
+++ b/srcpkgs/vpcs/template
@@ -1,16 +1,17 @@
 # Template file for 'vpcs'
 pkgname=vpcs
-version=0.8
-revision=2
+version=0.8.3
+revision=1
 build_wrksrc="src"
 build_style=gnu-makefile
 make_cmd="make -f Makefile.linux"
 short_desc="Virtual PC Simulator"
 maintainer="Michael Aldridge <maldridge@voidlinux.org>"
 license="BSD-2-Clause"
-homepage="https://sourceforge.net/projects/vpcs"
-distfiles="${SOURCEFORGE_SITE}/project/vpcs/${version}/${pkgname}-${version}-src.tbz"
-checksum=dca602d0571ba852c916632c4c0060aa9557dd744059c0f7368860cfa8b3c993
+homepage="https://github.com/GNS3/vpcs/"
+distfiles="https://github.com/GNS3/vpcs/archive/refs/tags/v${version}.tar.gz"
+checksum=73018c923fdb8bbd7d76ddf4877bb7b3babbabed014f409f6b78a2e2b0a33da7
+make_check=no #checks unavailable in source makefiles
 
 archs="i686* x86_64*"
 

--- a/srcpkgs/vpcs/template
+++ b/srcpkgs/vpcs/template
@@ -2,6 +2,7 @@
 pkgname=vpcs
 version=0.8.3
 revision=1
+archs="i686* x86_64*"
 build_wrksrc="src"
 build_style=gnu-makefile
 make_cmd="make -f Makefile.linux"
@@ -12,8 +13,6 @@ homepage="https://github.com/GNS3/vpcs/"
 distfiles="https://github.com/GNS3/vpcs/archive/refs/tags/v${version}.tar.gz"
 checksum=73018c923fdb8bbd7d76ddf4877bb7b3babbabed014f409f6b78a2e2b0a33da7
 make_check=no #checks unavailable in source makefiles
-
-archs="i686* x86_64*"
 
 CFLAGS="-fcommon"
 


### PR DESCRIPTION
Fixes #43766 

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-libc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl (xbuild)
  - i686-musl (xbuild)
  - i686-libc (xbuild)
