### PR TITLE
New package: portproton-1.5

### DIFF
--- a/srcpkgs/portproton/template
+++ b/srcpkgs/portproton/template
@@ -1,0 +1,21 @@
+# Template file for 'portproton'
+pkgname=portproton
+version=1.5
+revision=1
+archs="x86_64"
+depends="bash icoutils yad bubblewrap zstd cabextract gzip tar xz openssl curl dbus freetype xdg-utils gdk-pixbuf noto-fonts-ttf nss libXrandr lsof mesa-demos ImageMagick Vulkan-Tools libgcc python3-Pillow alsa-plugins-32bit libX11-32bit freetype-32bit libglvnd-32bit libgpg-error-32bit openssl-32bit vulkan-loader vulkan-loader-32bit nss-32bit libXScrnSaver-32bit desktop-file-utils"
+short_desc="Program to run Windows games with Valve Proton configurations"
+maintainer="Petr iFoundSilentHouse <adeptslab@gmail.com>"
+license="MIT"
+homepage="https://linux-gaming.ru/"
+changelog="https://github.com/Castro-Fidel/PortProton_ALT/tags"
+distfiles="https://github.com/Castro-Fidel/PortProton_ALT/archive/v${version}.tar.gz"
+checksum="0fde67c49f87805f03b3c39204ac8f48a6c6c584bec2a31086c90c953c3723f6"
+do_install() {
+	vlicense LICENSE
+	vbin portproton
+	vmkdir /usr/share/icons/scalable/apps/
+	vcopy portproton.svg /usr/share/icons/scalable/apps/portproton.svg
+	vmkdir /usr/share/applications/
+	vcopy portproton.desktop /usr/share/applications/portproton.desktop
+}


### PR DESCRIPTION
New package: portproton

- I tested the changes in this PR: Yes

- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): Yes

- I built this PR locally for my native architecture, (x86_64). And this package is x86_64-only.
