### PR TITLE
mu4e: update to 1.12.2

### DIFF
--- a/srcpkgs/mu4e/patches/fix-root-test.patch
+++ b/srcpkgs/mu4e/patches/fix-root-test.patch
@@ -1,20 +1,17 @@
-Remove a test which fails when run as root.
-
 diff --git a/lib/tests/test-mu-store.cc b/lib/tests/test-mu-store.cc
-index 872c56e3..c4e7eeb2 100644
+index da7f1202..7ff47b81 100644
 --- a/lib/tests/test-mu-store.cc
 +++ b/lib/tests/test-mu-store.cc
-@@ -470,13 +470,6 @@ test_store_fail()
+@@ -555,12 +555,6 @@ test_store_fail()
  		const auto store = Store::make("/root/non-existent-path/12345");
  		g_assert_false(!!store);
  	}
 -
 -	{
 -		const auto store = Store::make_new("/../../root/non-existent-path/12345",
--						   "/../../root/non-existent-path/54321",
--						   {}, {});
+-						   "/../../root/non-existent-path/54321");
 -		g_assert_false(!!store);
 -	}
  }
  
- int
+ 

--- a/srcpkgs/mu4e/patches/mu-utils-stdout.patch
+++ b/srcpkgs/mu4e/patches/mu-utils-stdout.patch
@@ -1,0 +1,12 @@
+# source: https://git.alpinelinux.org/aports/plain/community/mu/mu-utils-stdout.patch
+--- a/lib/utils/mu-utils.hh
++++ b/lib/utils/mu-utils.hh
+@@ -265,7 +265,7 @@
+ template<typename...T>
+ static inline bool mu_print_encoded(fmt::format_string<T...> frm, T&&... args) noexcept {
+ 	return fputs_encoded(fmt::format(frm, std::forward<T>(args)...),
+-			     ::stdout);
++			     stdout);
+ }
+
+ /**

--- a/srcpkgs/mu4e/template
+++ b/srcpkgs/mu4e/template
@@ -1,6 +1,6 @@
 # Template file for 'mu4e'
 pkgname=mu4e
-version=1.10.8
+version=1.12.2
 revision=1
 build_style=meson
 hostmakedepends="emacs libtool pkg-config texinfo glib-devel"
@@ -11,6 +11,6 @@ license="GPL-3.0-or-later"
 homepage="https://www.djcbsoftware.nl/code/mu/"
 changelog="https://github.com/djcb/mu/raw/master/NEWS.org"
 distfiles="https://github.com/djcb/mu/releases/download/v${version}/mu-${version}.tar.xz"
-checksum=6b11d8add2a7eeb0ebc4a5c7a6b9a9b3e1be8c5175c0c1c019a7ad8d7e363589
+checksum=7b1a1d840f120a1e777b366e6d52bda5a203dd31d831a5a285fbaef275c6b618
 replaces="mu<${version}"
 provides="mu-${version}_${revision}"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86-64_glibc

#### Notes
- New database schema, users will have to re-initialize their database, see `MU INIT(1)`.
- The README of the mu still states: "Distributions and non-adventurous users are instead recommended to use the [1.10 Release Branch](https://github.com/djcb/mu/tree/release/1.10) or to pick up one of the [1.10 Releases](https://github.com/djcb/mu/releases). ]" [[1]]. However, 1.12.2 is marked as stable.

[1]: https://github.com/djcb/mu