### PR TITLE
New package: python3-paho_mqtt-2.0.0

### DIFF
--- a/srcpkgs/python3-paho_mqtt/template
+++ b/srcpkgs/python3-paho_mqtt/template
@@ -1,0 +1,21 @@
+# Template file for 'python3-paho_mqtt'
+pkgname=python3-paho_mqtt
+version=2.0.0
+revision=1
+build_style=python3-pep517
+hostmakedepends="hatchling"
+depends="python3"
+short_desc="Eclipse Paho MQTT python client"
+maintainer="Andrew J. Hesford <ajh@sideband.org>"
+license="custom:EDL-1.0, EPL-2.0"
+homepage="https://eclipse.dev/paho/"
+changelog="https://raw.githubusercontent.com/eclipse/paho.mqtt.python/master/ChangeLog.txt"
+distfiles="${PYPI_SITE}/p/paho_mqtt/paho_mqtt-${version}.tar.gz"
+checksum=13b205f29251e4f2c66a6c923c31fc4fd780561e03b2d775cff8e4f2915cf947
+# Most useful checks require a listening broker
+make_check=no
+
+post_install() {
+	vlicense edl-v10
+	vlicense epl-v20
+}


### PR DESCRIPTION
Still kind of exploring this, but might actually start using it for real work and, if so, will want to make it available. It seems like this is the most popular MQTT client for Python.

The name `paho.mqtt.python` is horrible, leaving me with choices like `python3-paho.mqtt` or `python3-paho.mqtt.python`, so I opted for the PyPI name and settled on `python3-paho_mqtt` instead.

#### Testing the changes
- I tested the changes in this PR: **in progress**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**