### PR TITLE
miniserve: update to 0.27.1.

### DIFF
--- a/srcpkgs/miniserve/template
+++ b/srcpkgs/miniserve/template
@@ -1,6 +1,6 @@
 # Template file for 'miniserve'
 pkgname=miniserve
-version=0.26.0
+version=0.27.1
 revision=1
 build_style=cargo
 build_helper=qemu
@@ -17,7 +17,7 @@ license="MIT"
 homepage="https://github.com/svenstaro/miniserve"
 changelog="https://raw.githubusercontent.com/svenstaro/miniserve/master/CHANGELOG.md"
 distfiles="https://github.com/svenstaro/miniserve/archive/refs/tags/v${version}.tar.gz"
-checksum=5ac3e7220c0c86c23af46326cf88e4d0dc9eb296ca201c47c4c3f01d607edf63
+checksum=b65580574ca624072b1a94d59ebf201ab664eacacb46a5043ef7b81ebb538f80
 make_check=ci-skip  # port binding succeeds locally but fails in CI
 
 case "$XBPS_TARGET_MACHINE" in


### PR DESCRIPTION

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc

