### PR TITLE
hydroxide: update to 0.2.28

### DIFF
--- a/srcpkgs/hydroxide/template
+++ b/srcpkgs/hydroxide/template
@@ -1,7 +1,7 @@
 # Template file for 'hydroxide'
 pkgname=hydroxide
-version=0.2.27
-revision=2
+version=0.2.28
+revision=1
 build_style=go
 go_import_path=github.com/emersion/hydroxide
 go_package=$go_import_path/cmd/hydroxide
@@ -10,7 +10,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
 homepage="https://github.com/emersion/hydroxide"
 distfiles="${homepage}/archive/v${version}.tar.gz"
-checksum=d0d13a66d7aa0b0d674df6dacd63b0cdacd7261f999077ca13223d18969d20fb
+checksum=c860a15617dce7916917ef6e3d906e5728114ec2a54f5c07fb489ee6bdbeb0f4
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
