### PR TITLE
nvidia: update to 550.67.

### DIFF
--- a/srcpkgs/nvidia/template
+++ b/srcpkgs/nvidia/template
@@ -3,7 +3,7 @@
 _desc="NVIDIA drivers for linux"
 
 pkgname=nvidia
-version=550.54.14
+version=550.67
 revision=1
 maintainer="Andrew Benson <abenson+void@gmail.com>"
 license="custom:NVIDIA Proprietary"
@@ -19,7 +19,7 @@ conflicts="xserver-abi-video>25_1 nvidia470>=0 nvidia390>=0"
 
 _pkg="NVIDIA-Linux-x86_64-${version}"
 distfiles="http://uk.download.nvidia.com/XFree86/Linux-x86_64/${version}/${_pkg}.run"
-checksum=8c497ff1cfc7c310fb875149bc30faa4fd26d2237b2cba6cd2e8b0780157cfe3
+checksum=99201a09c71cff0fd0261eb0f0cbdad282eba81f9c3923b560ccf549eff7dae2
 # subpackages need to be processed in this specific order
 subpackages="nvidia-gtklibs nvidia-dkms nvidia-firmware nvidia-opencl nvidia-libs nvidia-libs-32bit"
 depends="nvidia-libs-${version}_${revision}


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly** (Currently only tested on a machine with Nvidia 2080 Super)

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)


### Changelog
 * Fixed a bug that could cause the GPU driver to hang when running some Vkd3d games, such as F1 2021.
 * Fixed a bug that caused eglExportDMABUFImageQueryMESA() to return invalid DRM formats for the images that use the sRGB color space.
 * Fixed a bug that caused wgpu applications to hang on Wayland.
 * Fixed a bug that caused "Flip event timeout" messages to be printed to the system log when the system is suspended without using /usr/bin/nvidia-sleep.sh when nvidia-drm is loaded with the `fbdev=1` kernel module parameter.
 * Updated the nvidia-settings control panel to ensure that the entire Display Configuration page can be used when the Layout window is shown.
 * Updated the nvidia-settings control panel to allow the primary display to be set on any GPU in a multi-GPU system.
 * Fixed Xid error when playing Alan Wake 2 with ray tracing enabled.


