### PR TITLE
jujutsu: add openssh dependency

### DIFF
--- a/srcpkgs/jujutsu/template
+++ b/srcpkgs/jujutsu/template
@@ -1,11 +1,13 @@
 # Template file for 'jujutsu'
 pkgname=jujutsu
 version=0.15.1
-revision=1
+revision=2
 build_style=cargo
 build_helper=qemu
 hostmakedepends="pkg-config"
 makedepends="libgit2-devel openssl-devel libzstd-devel"
+depends="openssh"
+checkdepends="openssh"
 short_desc="Git-compatible VCS that is both simple and powerful"
 maintainer="Leah Neukirchen <leah@vuxu.org>"
 license="Apache-2.0"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

Both tests and runtime expect `ssh-keygen` for signing features.

#### Testing the changes
- I tested the changes in this PR: **YES**

cc @leahneukirchen 

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
