### PR TITLE
gnome-bluetooth: update to 46.0.

### DIFF
--- a/srcpkgs/gnome-bluetooth/template
+++ b/srcpkgs/gnome-bluetooth/template
@@ -1,6 +1,6 @@
 # Template file for 'gnome-bluetooth'
 pkgname=gnome-bluetooth
-version=42.8
+version=46.0
 revision=1
 build_helper="gir"
 build_style=meson
@@ -15,7 +15,7 @@ license="GPL-2.0-or-later, LGPL-2.1-or-later"
 homepage="https://wiki.gnome.org/Projects/GnomeBluetooth"
 changelog="https://gitlab.gnome.org/GNOME/gnome-bluetooth/-/raw/master/NEWS"
 distfiles="${GNOME_SITE}/gnome-bluetooth/${version%.*}/gnome-bluetooth-${version}.tar.xz"
-checksum=76c241e8ca2c9b1035364535ca26084f89fc5c0e1829510f8909583115fcc2db
+checksum=13fe1e75f317acdbdf5e80c9029d2e0632d60a9ccf72a43ae36eb7545021fbef
 
 build_options="gir"
 build_options_default="gir"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)