### PR TITLE
gnome-calendar: update to 46.0.

### DIFF
--- a/srcpkgs/gnome-calendar/template
+++ b/srcpkgs/gnome-calendar/template
@@ -1,6 +1,6 @@
 # Template file for 'gnome-calendar'
 pkgname=gnome-calendar
-version=45.1
+version=46.0
 revision=1
 build_style=meson
 hostmakedepends="gettext glib-devel pkg-config gtk4-update-icon-cache
@@ -12,10 +12,10 @@ short_desc="Calendar application designed to perfectly fit the GNOME desktop"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="https://wiki.gnome.org/Apps/Calendar"
-#changelog="https://gitlab.gnome.org/GNOME/gnome-calendar/-/raw/gnome-45/NEWS"
+#changelog="https://gitlab.gnome.org/GNOME/gnome-calendar/-/raw/gnome-46/NEWS"
 changelog="https://gitlab.gnome.org/GNOME/gnome-calendar/-/raw/main/NEWS"
 distfiles="${GNOME_SITE}/gnome-calendar/${version%.*}/gnome-calendar-${version}.tar.xz"
-checksum=7fa8507543865aa7432bb5319830c87158b5447ca09cca45b607dc6796c71008
+checksum=5e21960c174bd8606d9089bf79c70f31070ab4837919878b00db2f14af9fe718
 
 build_options="gir"
 build_options_default="gir"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)