### PR TITLE
gnome-clocks: update to 46.0.

### DIFF
--- a/srcpkgs/gnome-clocks/template
+++ b/srcpkgs/gnome-clocks/template
@@ -1,6 +1,6 @@
 # Template file for 'gnome-clocks'
 pkgname=gnome-clocks
-version=45.0
+version=46.0
 revision=1
 build_helper="gir"
 build_style=meson
@@ -17,4 +17,4 @@ license="GPL-2.0-or-later"
 homepage="https://wiki.gnome.org/Apps/Clocks"
 changelog="https://gitlab.gnome.org/GNOME/gnome-clocks/-/raw/master/NEWS"
 distfiles="${GNOME_SITE}/gnome-clocks/${version%.*}/gnome-clocks-${version}.tar.xz"
-checksum=fc8eb4fd9530f1e641dc00ee2086ee7d354a7a00b0a0d1722e305d5c9aab91b5
+checksum=eaa3c578cdcef9754e668b5626709b73f3526710235f4b72076d2ff49a4f99c7


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
