### PR TITLE
gnome-console: update to 46.0.

### DIFF
--- a/srcpkgs/gnome-console/template
+++ b/srcpkgs/gnome-console/template
@@ -1,6 +1,6 @@
 # Template file for 'gnome-console'
 pkgname=gnome-console
-version=45.0
+version=46.0
 revision=1
 build_style=meson
 hostmakedepends="pkg-config desktop-file-utils gettext
@@ -12,10 +12,10 @@ short_desc="Simple user-friendly terminal emulator for the GNOME desktop"
 maintainer="oreo639 <oreo6391@gmail.com>"
 license="GPL-3.0-or-later"
 homepage="https://gitlab.gnome.org/GNOME/console"
-changelog="https://gitlab.gnome.org/GNOME/console/-/raw/main/NEWS"
-#changelog="https://gitlab.gnome.org/GNOME/console/-/raw/gnome-45/NEWS"
+#changelog="https://gitlab.gnome.org/GNOME/console/-/raw/main/NEWS"
+changelog="https://gitlab.gnome.org/GNOME/console/-/raw/gnome-46/NEWS"
 distfiles="${GNOME_SITE}/gnome-console/${version%.*}/gnome-console-${version}.tar.xz"
-checksum=e7462128d2df2324a1d748062c40429cd0504af09e407067b33f3a9d0c59c8e1
+checksum=1619ce701773b2c0c903718f54768c192ea5074514d55a1774a92c97231d6c3e
 
 nautilus-gnome-console-extension_package() {
 	depends="${sourcepkg}>=${version}_${revision}"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)