### PR TITLE
gnome-keyring: update to 46.1.

### DIFF
--- a/srcpkgs/gnome-keyring/template
+++ b/srcpkgs/gnome-keyring/template
@@ -1,9 +1,10 @@
 # Template file for 'gnome-keyring'
 pkgname=gnome-keyring
-version=42.1
+version=46.1
 revision=1
 build_style=gnu-configure
-configure_args="--with-pam-dir=/usr/lib/security --disable-schemas-compile"
+configure_args="--with-pam-dir=/usr/lib/security --disable-schemas-compile
+ --enable-ssh-agent"
 hostmakedepends="pkg-config glib-devel openssh docbook-xsl libxslt"
 makedepends="gcr-devel pam-devel"
 depends="dconf"
@@ -14,7 +15,7 @@ license="GPL-2.0-or-later, LGPL-2.1-or-later"
 homepage="https://wiki.gnome.org/Projects/GnomeKeyring/"
 changelog="https://gitlab.gnome.org/GNOME/gnome-keyring/-/raw/master/NEWS"
 distfiles="${GNOME_SITE}/$pkgname/${version%.*}/$pkgname-$version.tar.xz"
-checksum=c7f4d040cc76a6b7fe67e08ef9106911c3c80d40fc88cbfc8e2684a4c946e3e6
+checksum=b1d3ae9132ff2f8b3f25a190790892968e3d0acf952a487e40f644a8550ce3f6
 lib32disabled=yes
 make_check_pre="dbus-run-session xvfb-run"
 make_check=ci-skip # times out


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **NO**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)