### PR TITLE
gnome-session: update to 46.0.

### DIFF
--- a/srcpkgs/gnome-session/template
+++ b/srcpkgs/gnome-session/template
@@ -1,10 +1,9 @@
 # Template file for 'gnome-session'
 pkgname=gnome-session
-version=45.0
+version=46.0
 revision=1
 build_style=meson
-configure_args="-Dsystemd_journal=false -Dsystemd_session=disable
- -Dsystemduserunitdir=/usr/lib/systemd/user"
+configure_args="-Dsystemduserunitdir=/usr/lib/systemd/user"
 hostmakedepends="glib-devel gettext pkg-config xmlto"
 makedepends="elogind-devel gnome-desktop-devel gtk+3-devel json-glib-devel
  libglib-devel libICE-devel libSM-devel xtrans"
@@ -16,4 +15,4 @@ license="GPL-2.0-or-later, LGPL-2.1-or-later"
 homepage="https://gitlab.gnome.org/GNOME/gnome-session"
 changelog="https://gitlab.gnome.org/GNOME/gnome-session/-/raw/main/NEWS"
 distfiles="${GNOME_SITE}/gnome-session/${version%.*}/gnome-session-${version}.tar.xz"
-checksum=706d2ffcacac38553a3c0185793f5a2b4aac940bb5e789d953c9808163bef2f1
+checksum=c6e1624af6090bc4e1a191fe2268abfa7a8de07831ca7a57f217e679bf7b9a54


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **NO**

@oreo639 

GNOME dropped `systemd_session` and `systemd_journal` build options and hard depend on systemd now
https://gitlab.gnome.org/GNOME/gnome-session/-/commit/76534bcc5e4e0ee38b8541dbb413d4b36d30d9d7#ca9bb7eff80503c97c83505e8acea4002fd87ac6_4_3

can this be stubbed by elogind?

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
