### PR TITLE
Rust 1.77

### DIFF
--- a/srcpkgs/cargo-bootstrap/template
+++ b/srcpkgs/cargo-bootstrap/template
@@ -1,6 +1,6 @@
 # Template file for 'cargo-bootstrap'
 pkgname=cargo-bootstrap
-version=1.76.0
+version=1.77.1
 revision=1
 short_desc="Bootstrap binaries of Rust package manager"
 maintainer="Orphaned <orphan@voidlinux.org>"
@@ -24,15 +24,15 @@ esac
 case "$XBPS_TARGET_MACHINE" in
 	i686)
 		distfiles="${_bootstrap_url}/cargo-${version}-i686-unknown-linux-gnu.tar.xz"
-		checksum="ffa9b2b65a3bd6298ffd5a2defd6ac5fa42d1a0dcefdea50b92ddf8d162db19c"
+		checksum="3fe49c81296a64c51b69ddbeecbdf12e12e41eb9ca636e75b4bc372ae09858ee"
 		;;
 	x86_64)
 		distfiles="${_bootstrap_url}/cargo-${version}-x86_64-unknown-linux-gnu.tar.xz"
-		checksum="30ec0ad9fca443ec12c544f9ce448dacdde411a45b9042961938b650e918ccfb"
+		checksum="87713287303cbb44d89d839ade3de7fe679fcadfe4688a9c6829c276a7946e79"
 		;;
 	x86_64-musl)
 		distfiles="${_bootstrap_url}/cargo-${version}-x86_64-unknown-linux-musl.tar.xz"
-		checksum="b18032e92bbd69a9ed9036393a3d5168d3071e2d47c74cb9e2fe1737b7d106b6"
+		checksum="d5ff9700b75c908ba0a1048386d0151414ad161da01d640c850b1955695b175f"
 		;;
 	# placeholders for user-supplied distfiles
 	ppc64le)

--- a/srcpkgs/cargo/template
+++ b/srcpkgs/cargo/template
@@ -1,8 +1,8 @@
 # Template file for 'cargo'
 pkgname=cargo
-version=1.76.0
-revision=2
-_cargo_revision=0.77.0
+version=1.77.1
+revision=1
+_cargo_revision=0.78.1
 build_helper=rust
 hostmakedepends="cargo-bootstrap rust python3 curl pkg-config zlib-devel"
 makedepends="rust libcurl-devel openssl-devel"
@@ -12,7 +12,7 @@ maintainer="Enno Boland <gottox@voidlinux.org>"
 license="MIT, Apache-2.0"
 homepage="https://crates.io/"
 distfiles="https://github.com/rust-lang/cargo/archive/refs/tags/${_cargo_revision}.tar.gz"
-checksum=1c33e2feb197f848f082fdc074162328e231c2f68394e0e1d2dbbbf79c9fc3ec
+checksum=0283fecebb6d3cbd111688eb0359edaf6676f4b2829201a8afe5a0e3afdb4b48
 replaces="cargo-tree>=0"
 
 build_options="static bindist"

--- a/srcpkgs/rust-bootstrap/template
+++ b/srcpkgs/rust-bootstrap/template
@@ -1,6 +1,6 @@
 # Template file for 'rust-bootstrap'
 pkgname=rust-bootstrap
-version=1.76.0
+version=1.77.1
 revision=1
 short_desc="Rust programming language bootstrap toolchain"
 maintainer="Orphaned <orphan@voidlinux.org>"
@@ -31,24 +31,24 @@ case "$XBPS_TARGET_MACHINE" in
 		 ${_bootstrap_url}/rustc-${version}-i686-unknown-linux-gnu.tar.xz
 		 ${_bootstrap_url}/rust-std-${version}-i686-unknown-linux-gnu.tar.xz"
 		checksum="
-		 e52ff92c605284b049e88912343a0f1c9c4cef7cc4a501d4e8f1ab9e4d9b1d7e
-		 78fb0859beb4f18af7227af3f09f0218169ca38c7751865e40d78d697ca190fc"
+		 204a79ddc33e74a23b817724a57fdaad5e2552d034653915a7508c7d0063045a
+		 7bf24ca93bde8cd761128e68cbcabc9d304c5cf19fcdd020bca2d56e43014381"
 		;;
 	x86_64)
 		distfiles="
 		 ${_bootstrap_url}/rustc-${version}-x86_64-unknown-linux-gnu.tar.xz
 		 ${_bootstrap_url}/rust-std-${version}-x86_64-unknown-linux-gnu.tar.xz"
 		checksum="
-		 9fadfcf71bc6a0ddfd026b9624163faf1c5689dd4a1f7cc1f857167ade4aa6eb
-		 e41150b52d923a3bbe166c4ecc5719f56576274b0d034d764768aee279ae2063"
+		 c9caaf8c214f6683281fa55e76a4d345004aa2933daca469952b3bead8cc5ca9
+		 317e604909360d1bb92f7558aaa5ce449312630d8226767ae9df99bf5bef4fd1"
 		;;
 	x86_64-musl)
 		distfiles="
 		 ${_bootstrap_url}/rustc-${version}-x86_64-unknown-linux-musl.tar.xz
 		 ${_bootstrap_url}/rust-std-${version}-x86_64-unknown-linux-musl.tar.xz"
 		checksum="
-		 3669762d7ee90d06bc3b532e15fc29e7918b40b85c93ea314b98d6cad18f435b
-		 995bda2aeff09ecbda9a1892a6c47beb087e99c9be924dc8fa6416f6813f4edc"
+		 d00be127d978177c0b2f439a1e63e4c25a3ca5f035a7282187555ab540cc18a3
+		 899c2668e65ad3557033169e67a6fa3d9c816c62d39ee11d5ebef4eded226d0b"
 		;;
 	# placeholders for user-supplied distfiles
 	ppc64le)

--- a/srcpkgs/rust/patches/0014-copy-new-version-of-need-ssp_nonshared.patch-from-al.patch
+++ b/srcpkgs/rust/patches/0014-copy-new-version-of-need-ssp_nonshared.patch-from-al.patch
@@ -5,24 +5,24 @@ Subject: [PATCH 14/15] copy new version of need-ssp_nonshared.patch from
  alpine
 
 ---
- library/std/src/sys/unix/mod.rs | 4 ++++
+ library/std/src/sys/pal/unix/mod.rs | 4 ++++
  1 file changed, 4 insertions(+)
 
-diff --git a/library/std/src/sys/unix/mod.rs b/library/std/src/sys/unix/mod.rs
-index 34a023b02..934a87570 100644
---- a/library/std/src/sys/unix/mod.rs
-+++ b/library/std/src/sys/unix/mod.rs
-@@ -297,6 +297,10 @@ cfg_if::cfg_if! {
-         #[link(name = "dl")]
-         #[link(name = "log")]
+diff --git a/library/std/src/sys/pal/unix/mod.rs b/library/std/src/sys/pal/unix/mod.rs
+index 43cb9d89b..4158c79da 100644
+--- a/library/std/src/sys/pal/unix/mod.rs
++++ b/library/std/src/sys/pal/unix/mod.rs
+@@ -379,6 +379,10 @@ cfg_if::cfg_if! {
+         #[link(name = "dl", cfg(not(target_feature = "crt-static")))]
+         #[link(name = "log", cfg(not(target_feature = "crt-static")))]
          extern "C" {}
 +    } else if #[cfg(all(target_os = "linux", target_env = "musl"))] {
-+	    #[link(name = "ssp_nonshared")]
++        #[link(name = "ssp_nonshared")]
 +        #[link(name = "execinfo")]
-+	    extern "C" {}
++        extern "C" {}
      } else if #[cfg(target_os = "freebsd")] {
          #[link(name = "execinfo")]
          #[link(name = "pthread")]
 -- 
-2.37.2
+2.44.0
 

--- a/srcpkgs/rust/template
+++ b/srcpkgs/rust/template
@@ -8,8 +8,8 @@
 # uploaded to https://repo-default.voidlinux.org/distfiles/
 #
 pkgname=rust
-version=1.76.0
-revision=2
+version=1.77.1
+revision=1
 hostmakedepends="curl pkg-config python3 tar cargo-bootstrap"
 makedepends="libffi-devel ncurses-devel libxml2-devel zlib-devel llvm17-devel"
 depends="rust-std gcc"
@@ -18,7 +18,7 @@ maintainer="Enno Boland <gottox@voidlinux.org>"
 license="MIT, Apache-2.0"
 homepage="https://www.rust-lang.org/"
 distfiles="https://static.rust-lang.org/dist/rustc-${version}-src.tar.gz"
-checksum=9e5cff033a7f0d2266818982ad90e4d3e4ef8f8ee1715776c6e25073a136c021
+checksum=ee106e4c569f52dba3b5b282b105820f86bd8f6b3d09c06b8dce82fb1bb3a4a1
 lib32disabled=yes
 make_check=no # CBA for now
 python_version=3 # needed for python files in rust-src
@@ -139,6 +139,7 @@ do_configure() {
 		--set="build.submodules=false" \
 		--set="build.rustc=/usr/bin/rustc" \
 		--set="build.cargo=/usr/bin/cargo" \
+		--set="build.optimized-compiler-builtins=false" \
 		--set="target.${RUST_BUILD}.crt-static=false" \
 		--set="target.${RUST_BUILD}.cc=${CC_host:-$CC}" \
 		--set="target.${RUST_BUILD}.cxx=${CXX_host:-$CXX}" \


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

Cargo 1.77 started using features from git2 0.18 that we currently patch back to 0.17 to accommodate libgit2 1.6:
https://github.com/rust-lang/cargo/blob/3fe68eabf93cbf3772bbcad09a9206c783e2de3f/src/cargo/sources/git/utils.rs#L1108-L1110

The simplest way forward is probably to stop downgrading git2, but that requires merging https://github.com/void-linux/void-packages/pull/45976 first.

Also had to manually disable optimized-compiler-builtins as they are incorrectly enabled by default: https://github.com/rust-lang/rust/pull/119556

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
