### PR TITLE
p11-kit: update to 0.25.3.

### DIFF
--- a/srcpkgs/p11-kit/template
+++ b/srcpkgs/p11-kit/template
@@ -1,6 +1,6 @@
 # Template file for 'p11-kit'
 pkgname=p11-kit
-version=0.25.0
+version=0.25.3
 revision=1
 build_style=meson
 build_helper="qemu"
@@ -16,7 +16,7 @@ license="BSD-3-Clause"
 homepage="https://github.com/p11-glue/p11-kit"
 changelog="https://raw.githubusercontent.com/p11-glue/p11-kit/master/NEWS"
 distfiles="https://github.com/p11-glue/p11-kit/releases/download/${version}/p11-kit-${version}.tar.xz"
-checksum=d55583bcdde83d86579cabe3a8f7f2638675fef01d23cace733ff748fc354706
+checksum=d8ddce1bb7e898986f9d250ccae7c09ce14d82f1009046d202a0eb1b428b2adc
 conf_files="/etc/pkcs11/pkcs11.conf"
 
 if [ "$XBPS_CHECK_PKGS" ]; then
@@ -26,7 +26,6 @@ else
 fi
 
 build_options="gtk_doc"
-build_options_default=""
 
 if [ -z "$CROSS_BUILD" ]; then
 	build_options_default+=" gtk_doc"


### PR DESCRIPTION
Fixes issue where the wrong C_GetInterface may get loaded. https://github.com/p11-glue/p11-kit/pull/535
(this causes test failures for glib-networking)

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
