### PR TITLE
refind: make loader and initrd entires bootable again

### DIFF
--- a/srcpkgs/refind/files/kernel.post-install
+++ b/srcpkgs/refind/files/kernel.post-install
@@ -28,8 +28,8 @@ zversion=$(echo "$VERSION" | sed 's/[.]/[.]/g')
 zentry=$(cat <<EOF
 menuentry "Void Linux $VERSION" {
         volume   "$REFIND_LABEL"
-        loader   "$REFIND_BOOT_PREFIX/vmlinuz-$VERSION"
-        initrd   "$REFIND_BOOT_PREFIX/initramfs-$VERSION.img"
+        loader   $REFIND_BOOT_PREFIX/vmlinuz-$VERSION
+        initrd   $REFIND_BOOT_PREFIX/initramfs-$VERSION.img
         options  "$OPTIONS"
 }
 EOF

--- a/srcpkgs/refind/files/refind-kernel-hook.conf
+++ b/srcpkgs/refind/files/refind-kernel-hook.conf
@@ -16,7 +16,7 @@ UPDATE_REFIND_CONF=0
 # 	likewise, EFI mounted to /boot/efi
 # /efi/EFI/refind/refind.conf
 # /efi/EFI/BOOT/refind.conf
-REFIND_CONF=/boot/EFI/refind/refind.conf
+REFIND_CONF="/boot/EFI/refind/refind.conf"
 
 # Set a custom label for Void boot entries
 #REFIND_LABEL="Void Linux"

--- a/srcpkgs/refind/template
+++ b/srcpkgs/refind/template
@@ -1,7 +1,7 @@
 # Template file for 'refind'
 pkgname=refind
 version=0.14.0.2
-revision=3
+revision=4
 archs="x86_64* i686* aarch64*"
 makedepends="gnu-efi-libs"
 depends="bash dosfstools efibootmgr"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**


#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**


<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture: (x86_64-glibc)

#### Context
When using loader and initrd entries in refind.conf one needs to either avoid using quotation marks whatsoever or use backslashes to satisfy the EFI stub bootloader. Otherwise the manual stanzas won't boot. I tested revision 3 which had been merged yesterday and experienced this bug.

More on this issue here: https://wiki.archlinux.org/title/REFInd#For_manual_boot_stanzas

@sgn @ahesford ping