### PR TITLE
common/xbps-src/shutils/update_check.sh: fix rx for gitlab

### DIFF
--- a/common/xbps-src/shutils/update_check.sh
+++ b/common/xbps-src/shutils/update_check.sh
@@ -138,7 +138,7 @@ update_check() {
                     *) pkgurlname="$(printf %s "$url" | cut -d / -f 1-5)";;
                 esac
                 url="$pkgurlname/-/tags"
-                rx='/archive/[^/]+/\Q'"$pkgname"'\E-v?\K[\d.]+(?=\.tar\.gz")';;
+                rx='/archive/[^/]+/\Q'"$pkgname"'\E-v?\K[\d.]+(?=\.tar\.gz)';;
             *bitbucket.org*)
                 pkgurlname="$(printf %s "$url" | cut -d/ -f4,5)"
                 url="https://bitbucket.org/$pkgurlname/downloads"


### PR DESCRIPTION
If you `View Source` on `https://gitlab.com/timvisee/prs/-/tags` or any other GitLab packages the archive links end with `&quot` instead of `"` - breaking `update-check` for multiple packages.