### PR TITLE
radicale: update to 3.2.1, fix conf file permissions

### DIFF
--- a/srcpkgs/radicale/INSTALL
+++ b/srcpkgs/radicale/INSTALL
@@ -1,0 +1,12 @@
+# *-*-shell-*-*
+#
+case ${ACTION} in
+post)
+	# fix permissions and owners
+	chown radicale:radicale /etc/radicale/config
+	chown radicale:radicale /etc/radicale/rights
+	chmod 644 /etc/radicale/config
+	chmod 640 /etc/radicale/rights
+	;;
+esac
+

--- a/srcpkgs/radicale/template
+++ b/srcpkgs/radicale/template
@@ -1,7 +1,7 @@
 # Template file for 'radicale'
 pkgname=radicale
-version=3.1.8
-revision=4
+version=3.2.1
+revision=1
 build_style=python3-module
 hostmakedepends="python3-setuptools"
 depends="python3-vobject python3-dateutil python3-passlib python3-bcrypt
@@ -14,15 +14,14 @@ license="GPL-3.0-or-later"
 homepage="https://radicale.org"
 changelog="https://raw.githubusercontent.com/Kozea/Radicale/master/CHANGELOG.md"
 distfiles="https://github.com/Kozea/Radicale/archive/refs/tags/v${version}.tar.gz"
-checksum=40078e0f05917c09664363a9e289a36d32e00d10a1d169ffc60b5c581deb4e77
+checksum=42d2bff32764046aa64e6774ecfaa24cd9332e13957d913347fa4b1d003154a7
 conf_files="
  /etc/radicale/config
- /etc/radicale/rights
- /etc/sv/radicale/log/run"
+ /etc/radicale/rights"
 make_dirs="
  /etc/radicale 755 root root
  /usr/share/radicale/ 755 root root
- /var/log/radicale/ 700 root root
+ /var/log/radicale/ 750 radicale radicale
  /var/lib/radicale 750 radicale radicale"
 system_accounts="radicale"
 radicale_homedir="/var/lib/radicale"


### PR DESCRIPTION
### Changes

- Update to 3.2.1
- https://github.com/void-linux/void-packages/issues/38923

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl
  - armv7l

This superseeds https://github.com/void-linux/void-packages/pull/46357.