### PR TITLE
linux6.{6..8}: fix module signing

### DIFF
--- a/srcpkgs/linux6.6/template
+++ b/srcpkgs/linux6.6/template
@@ -27,7 +27,7 @@ noshlibprovides=yes
 preserve=yes
 
 hostmakedepends="tar xz bc elfutils-devel flex gmp-devel kmod libmpc-devel
- openssl-devel perl uboot-mkimage cpio pahole python3 zstd"
+ pkg-config openssl-devel perl uboot-mkimage cpio pahole python3 zstd"
 
 _kernver="${version}_${revision}"
 triggers="kernel-hooks"
@@ -208,6 +208,9 @@ do_install() {
 	mkdir -p ${hdrdest}/arch/${arch}
 	cp -a arch/${arch}/include ${hdrdest}/arch/${arch}
 
+	# needed for mv-debug
+	cp scripts/sign-file "${XBPS_WRAPPERDIR}"
+
 	# Remove helper binaries built for host,
 	# if generated files from the scripts/ directory need to be included,
 	# they need to be copied to ${hdrdest} before this step
@@ -311,7 +314,7 @@ do_install() {
 	(
 	cd ${DESTDIR}
 	export DESTDIR
-	export SIGN_FILE="${wrksrc}/scripts/sign-file sha512 ${wrksrc}/certs/signing_key.pem ${wrksrc}/certs/signing_key.x509"
+	export SIGN_FILE="${XBPS_WRAPPERDIR}/sign-file sha512 ${wrksrc}/certs/signing_key.pem ${wrksrc}/certs/signing_key.x509"
 	find ./ -name '*.ko' -print0 | \
 		xargs -0r -n1 -P ${XBPS_MAKEJOBS} ${FILESDIR}/mv-debug
 	)

--- a/srcpkgs/linux6.7/template
+++ b/srcpkgs/linux6.7/template
@@ -27,7 +27,7 @@ noshlibprovides=yes
 preserve=yes
 
 hostmakedepends="tar xz bc elfutils-devel flex gmp-devel kmod libmpc-devel
- openssl-devel perl uboot-mkimage cpio pahole python3 zstd"
+ pkg-config openssl-devel perl uboot-mkimage cpio pahole python3 zstd"
 
 _kernver="${version}_${revision}"
 triggers="kernel-hooks"
@@ -211,6 +211,9 @@ do_install() {
 	mkdir -p ${hdrdest}/arch/${arch}
 	cp -a arch/${arch}/include ${hdrdest}/arch/${arch}
 
+	# needed for mv-debug
+	cp scripts/sign-file "${XBPS_WRAPPERDIR}"
+
 	# Remove helper binaries built for host,
 	# if generated files from the scripts/ directory need to be included,
 	# they need to be copied to ${hdrdest} before this step
@@ -314,7 +317,7 @@ do_install() {
 	(
 	cd ${DESTDIR}
 	export DESTDIR
-	export SIGN_FILE="${wrksrc}/scripts/sign-file sha512 ${wrksrc}/certs/signing_key.pem ${wrksrc}/certs/signing_key.x509"
+	export SIGN_FILE="${XBPS_WRAPPERDIR}/sign-file sha512 ${wrksrc}/certs/signing_key.pem ${wrksrc}/certs/signing_key.x509"
 	find ./ -name '*.ko' -print0 | \
 		xargs -0r -n1 -P ${XBPS_MAKEJOBS} ${FILESDIR}/mv-debug
 	)

--- a/srcpkgs/linux6.8/template
+++ b/srcpkgs/linux6.8/template
@@ -27,7 +27,7 @@ noshlibprovides=yes
 preserve=yes
 
 hostmakedepends="tar xz bc elfutils-devel flex gmp-devel kmod libmpc-devel
- openssl-devel perl uboot-mkimage cpio pahole python3 zstd"
+ pkg-config openssl-devel perl uboot-mkimage cpio pahole python3 zstd"
 
 _kernver="${version}_${revision}"
 triggers="kernel-hooks"
@@ -211,6 +211,9 @@ do_install() {
 	mkdir -p ${hdrdest}/arch/${arch}
 	cp -a arch/${arch}/include ${hdrdest}/arch/${arch}
 
+	# needed for mv-debug
+	cp scripts/sign-file "${XBPS_WRAPPERDIR}"
+
 	# Remove helper binaries built for host,
 	# if generated files from the scripts/ directory need to be included,
 	# they need to be copied to ${hdrdest} before this step
@@ -314,7 +317,7 @@ do_install() {
 	(
 	cd ${DESTDIR}
 	export DESTDIR
-	export SIGN_FILE="${wrksrc}/scripts/sign-file sha512 ${wrksrc}/certs/signing_key.pem ${wrksrc}/certs/signing_key.x509"
+	export SIGN_FILE="${XBPS_WRAPPERDIR}/sign-file sha512 ${wrksrc}/certs/signing_key.pem ${wrksrc}/certs/signing_key.x509"
 	find ./ -name '*.ko' -print0 | \
 		xargs -0r -n1 -P ${XBPS_MAKEJOBS} ${FILESDIR}/mv-debug
 	)


### PR DESCRIPTION
`sign-file` needs `pkg-config` to find libcrypto: https://github.com/torvalds/linux/blob/2dde18cd1d8fac735875f2e4987f11817cc0bc2c/scripts/Makefile#L25-L26

On cross, it is removed by `make _mrproper_scripts`, so copy it to `XBPS_WRAPPERDIR` before running it.

failure symptom:
```
/void-packages/srcpkgs/linux6.8/files/mv-debug: line 7: /builddir/linux6.8-6.8.1/scripts/sign-file: No such file or directory
```

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

[ci skip]
