### PR TITLE
New package: font-fantasque-sans-otf-1.8.0

### DIFF
--- a/srcpkgs/font-fantasque-sans-otf/template
+++ b/srcpkgs/font-fantasque-sans-otf/template
@@ -1,0 +1,21 @@
+# Template file for 'font-fantasque-sans-otf'
+pkgname=font-fantasque-sans-otf
+version=1.8.0
+revision=1
+create_wrksrc=yes
+depends="font-util xbps-triggers"
+short_desc="Handwriting-like programming typeface"
+maintainer="Leon (adigitoleo) <adigitoleo@posteo.net>"
+license="OFL-1.1"
+homepage="https://fontlibrary.org/en/font/fantasque-sans-mono"
+distfiles="https://github.com/belluzj/fantasque-sans/releases/download/v${version}/FantasqueSansMono-Normal.tar.gz"
+checksum=645709a54ea6fba24c926135a213d342ddb18f0f8b49f4e604b2210b73e9068a
+font_dirs="/usr/share/fonts/OTF"
+
+do_install() {
+	vmkdir usr/share/fonts/OTF
+	vcopy OTF/*.otf usr/share/fonts/OTF
+	# dos2unix
+	sed -i LICENSE.txt -e 's;\r;;g'
+	vlicense LICENSE.txt
+}


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR for these architectures (cross-builds):
  - x86_64-musl
  - i686
  - aarch64-musl
  - armv7l
  - armv6l-musl

If maintenance burden is a concern, I suggest removing the TTF package of the same font in favour of this one. OTF fonts bring significant improvements such as ligatures, smallcaps, spline and bezier curves for more accurate font shapes (besides being an open format). In spite of this, there is no significant change to the install size in this case (both OTF and TTF around 600KB).