### PR TITLE
bird: update to 2.15.1

### DIFF
--- a/srcpkgs/bird/template
+++ b/srcpkgs/bird/template
@@ -1,6 +1,6 @@
 # Template file for 'bird'
 pkgname=bird
-version=2.15
+version=2.15.1
 revision=1
 build_style=gnu-configure
 hostmakedepends="flex"
@@ -11,7 +11,7 @@ license="GPL-2.0-or-later"
 homepage="https://bird.network.cz"
 changelog="https://gitlab.nic.cz/labs/bird/-/raw/master/NEWS"
 distfiles="https://bird.network.cz/download/bird-${version}.tar.gz"
-checksum=7a6458fa41109c005531b23e3f7abd63d7000a99d195db4944ebccb539ed02f0
+checksum=48e85c622de164756c132ea77ad1a8a95cc9fd0137ffd0d882746589ce75c75d
 
 conf_files="/etc/bird.conf"
 system_accounts="_bird"


### PR DESCRIPTION
This release fixes a regression related to OSPF PtP links introduced in 2.15 among other things.

#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc, x86_64-musl)
- I built this PR locally for these architectures:
  - aarch64-musl
  - armv7l
  - armv6l-musl