### PR TITLE
doomretro: recompile with newer SDL2

### DIFF
--- a/srcpkgs/doomretro/template
+++ b/srcpkgs/doomretro/template
@@ -1,7 +1,7 @@
 # Template file for 'doomretro'
 pkgname=doomretro
 version=5.2.1
-revision=1
+revision=2
 build_style=cmake
 hostmakedepends="pkg-config"
 makedepends="SDL2_image-devel SDL2_mixer-devel"


### PR DESCRIPTION
This fixes the following error:

```
The wrong version of SDL2_image.so was found. DOOM Retro requires v2.6.3.

```

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
