### PR TITLE
[RFC] build-style/haskell-stack: place stack root in /host to make it persistent

### DIFF
--- a/common/build-style/haskell-stack.sh
+++ b/common/build-style/haskell-stack.sh
@@ -20,11 +20,10 @@ do_build() {
 			msg_error "Stackage version not set in \$stackage.\n"
 		fi
 		msg_normal "Using stackage resolver ${stackage}.\n"
-		STACK_ROOT="$wrksrc/.stack" \
-			stack init ${_stack_args} --force --resolver ${stackage}
+		stack init ${_stack_args} --force --resolver ${stackage}
 	fi
 
-	STACK_ROOT="$wrksrc/.stack" stack ${_stack_args} ${makejobs} build \
+	stack ${_stack_args} ${makejobs} build --ghc-options ${makejobs} \
 		${make_build_args}
 }
 
@@ -32,6 +31,6 @@ do_install() {
 	local _stack_args="--system-ghc --skip-ghc-check"
 
 	vmkdir usr/bin
-	STACK_ROOT="$wrksrc/.stack" stack ${_stack_args} install \
+	stack ${_stack_args} install \
 	       	${make_build_args} --local-bin-path=${DESTDIR}/usr/bin
 }

--- a/common/environment/build-style/haskell-stack.sh
+++ b/common/environment/build-style/haskell-stack.sh
@@ -1,1 +1,3 @@
 hostmakedepends+=" ghc stack"
+
+export STACK_ROOT="/host/stack/${XBPS_TARGET_MACHINE}"


### PR DESCRIPTION
Similar to `CARGO_HOME=/host/cargo` maybe we should set `STACK_ROOT=/host/stack`.

@leahneukirchen any thoughts?

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
