### PR TITLE
Update a few sagemath dependencies

### DIFF
--- a/srcpkgs/palp/template
+++ b/srcpkgs/palp/template
@@ -1,14 +1,15 @@
 # Template file for 'palp'
 pkgname=palp
-version=2.20
+version=2.21
 revision=1
 build_style=gnu-makefile
+checkdepends="singular"
 short_desc="Package for analyzing lattice polytopes"
 maintainer="Gonzalo Tornaría <tornaria@cmat.edu.uy>"
 license="GPL-3.0-only"
 homepage="http://hep.itp.tuwien.ac.at/~kreuzer/CY/CYpalp.html"
 distfiles="http://hep.itp.tuwien.ac.at/~kreuzer/CY/palp/palp-${version}.tar.gz"
-checksum=723e89e78b2d3d94a720dd770c11b932b3e6b56f8a49e0bf3621c776f7a02ce0
+checksum=7e4a7bf219998a844c0bcce0a176e49d0743cb4b505a0e195329bf2ec196ddd7
 
 
 # build procedure taken from sagemath, see

--- a/srcpkgs/python3-cypari2/template
+++ b/srcpkgs/python3-cypari2/template
@@ -1,6 +1,6 @@
 # Template file for 'python3-cypari2'
 pkgname=python3-cypari2
-version=2.1.4
+version=2.1.5
 revision=1
 build_style=python3-pep517
 hostmakedepends="python3-setuptools python3-wheel python3-Cython
@@ -14,7 +14,7 @@ license="GPL-2.0-or-later"
 homepage="https://github.com/sagemath/cypari2"
 changelog="https://github.com/sagemath/cypari2/releases"
 distfiles="https://github.com/sagemath/cypari2/archive/refs/tags/${version}.tar.gz"
-checksum=95daf1a74275a35730bbca75144776c1bb0594dd90af82ebf7bf96bb1a52c3d8
+checksum=3cea1051f7cd8832b7907d11c68764e83a430036698a215abae48924a580d7fb
 
 do_check() {
 	# Please do not disable this custom check;

--- a/srcpkgs/python3-cypari2/update
+++ b/srcpkgs/python3-cypari2/update
@@ -1,0 +1,1 @@
+ignore="*a* *b* *rc*"

--- a/srcpkgs/python3-memory_allocator/template
+++ b/srcpkgs/python3-memory_allocator/template
@@ -1,9 +1,9 @@
 # Template file for 'python3-memory_allocator'
 pkgname=python3-memory_allocator
-version=0.1.3
-revision=4
-build_style=python3-module
-hostmakedepends="python3-setuptools python3-Cython"
+version=0.1.4
+revision=1
+build_style=python3-pep517
+hostmakedepends="python3-setuptools python3-wheel python3-Cython"
 makedepends="python3-devel"
 depends="python3"
 short_desc="Extension class to allocate memory easily with cython"
@@ -12,4 +12,4 @@ license="GPL-3.0-or-later"
 homepage="https://github.com/sagemath/memory_allocator"
 changelog="https://github.com/sagemath/memory_allocator#changelog"
 distfiles="${PYPI_SITE}/m/memory_allocator/memory_allocator-${version}.tar.gz"
-checksum=13805c2ae1c01b7489fab5e8eac9361662b4f2c02412e3652eece48ff6953162
+checksum=d609216b03031967e2b45a804b12ff9029578f4ec019fde42cf6aed6ca09efe4

--- a/srcpkgs/python3-memory_allocator/update
+++ b/srcpkgs/python3-memory_allocator/update
@@ -1,0 +1,1 @@
+ignore="*a* *b* *rc*"

--- a/srcpkgs/python3-pplpy/patches/dont-depend-on-sphinx.patch
+++ b/srcpkgs/python3-pplpy/patches/dont-depend-on-sphinx.patch
@@ -1,7 +1,0 @@
---- a/pyproject.toml
-+++ b/pyproject.toml
-@@ -1,3 +1,3 @@
- [build-system]
--requires = ["setuptools", "wheel", "Cython", "cysignals", "sphinx", "gmpy2>=2.1.0b1"]
-+requires = ["setuptools", "wheel", "Cython", "cysignals", "gmpy2>=2.1.0b1"]
- build-backend = "setuptools.build_meta"

--- a/srcpkgs/python3-pplpy/template
+++ b/srcpkgs/python3-pplpy/template
@@ -1,7 +1,7 @@
 # Template file for 'python3-pplpy'
 pkgname=python3-pplpy
-version=0.8.9
-revision=2
+version=0.8.10
+revision=1
 build_style=python3-pep517
 hostmakedepends="python3-setuptools python3-wheel python3-Cython
  python3-cysignals python3-gmpy2"
@@ -14,7 +14,7 @@ license="GPL-3.0-or-later"
 homepage="https://github.com/sagemath/pplpy"
 changelog="https://raw.githubusercontent.com/sagemath/pplpy/master/CHANGES.txt"
 distfiles="${PYPI_SITE}/p/pplpy/pplpy-${version}.tar.gz"
-checksum=db7a3b571d6ef053f75137975e947c3a1c1e45a30bab90eaf215b4e5cc15797e
+checksum=d42a216c82914dcf4d7c000debc98bb336b8f83e026ba5d952cccd9f8074effd
 
 do_check() {
 	PYTHONPATH=$(cd build/lib* && pwd) python3 setup.py test

--- a/srcpkgs/python3-pplpy/update
+++ b/srcpkgs/python3-pplpy/update
@@ -1,0 +1,1 @@
+ignore="*a* *b* *rc*"


### PR DESCRIPTION
- python3-pplpy: update to 0.8.10.
- python3-memory_allocator: update to 0.1.4.
- python3-cypari2: update to 2.1.5.
- palp: update to 2.21.

#### Testing the changes
- I tested the changes in this PR: **YES**

This does not require sagemath rebuild. I run the full testsuite with our current binary package to make sure.

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
