### PR TITLE
gnome-font-viewer: update to 46.0.

### DIFF
--- a/srcpkgs/gnome-font-viewer/template
+++ b/srcpkgs/gnome-font-viewer/template
@@ -1,6 +1,6 @@
 # Template file for 'gnome-font-viewer'
 pkgname=gnome-font-viewer
-version=45.0
+version=46.0
 revision=1
 build_style=meson
 hostmakedepends="pkg-config glib-devel gettext"
@@ -11,6 +11,7 @@ short_desc="Font viewer for GNOME"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="https://gitlab.gnome.org/GNOME/gnome-font-viewer"
-changelog="https://gitlab.gnome.org/GNOME/gnome-font-viewer/-/raw/main/NEWS"
+#changelog="https://gitlab.gnome.org/GNOME/gnome-font-viewer/-/raw/main/NEWS"
+changelog="https://gitlab.gnome.org/GNOME/gnome-font-viewer/-/raw/gnome-46/NEWS"
 distfiles="${GNOME_SITE}/gnome-font-viewer/${version%.*}/gnome-font-viewer-${version}.tar.xz"
-checksum=97cb6b68dda60de0ab3038383586f1e4bc1da5a48f44025bd6bbe74ea05c2b08
+checksum=592f401e485d02cc044d487bb5c8e04c961da6856216768a59f1ff98bd2d537c


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl
  - armv7l
