### PR TITLE
freerdp split (2.11.5, 3.5.0, libuwac0)

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -1571,6 +1571,9 @@ libZXing.so.3 zxing-cpp-2.0.0_1
 libfreerdp-client2.so.2 libfreerdp-2.2.0_3
 libfreerdp2.so.2 libfreerdp-2.2.0_3
 libwinpr2.so.2 libfreerdp-2.2.0_3
+libfreerdp-client3.so.3 libfreerdp3-3.4.0_1
+libfreerdp3.so.3 libfreerdp3-3.4.0_1
+libwinpr3.so.3 libfreerdp3-3.4.0_1
 libwinpr-tools2.so.2 libfreerdp-2.2.0_3
 libfreerdp-core.so.1.0 libfreerdp-2.2.0_3
 libfreerdp-channels.so.1.0 libfreerdp-2.2.0_3

--- a/srcpkgs/freerdp/template
+++ b/srcpkgs/freerdp/template
@@ -1,6 +1,6 @@
 # Template file for 'freerdp'
 pkgname=freerdp
-version=2.11.4
+version=2.11.5
 revision=1
 build_style=cmake
 configure_args="-DWITH_ALSA=ON -DWITH_CUPS=OFF -DWITH_FFMPEG=ON
@@ -20,7 +20,7 @@ license="Apache-2.0"
 homepage="https://www.freerdp.com/"
 changelog="https://raw.githubusercontent.com/FreeRDP/FreeRDP/2.10.0/ChangeLog"
 distfiles="https://github.com/FreeRDP/FreeRDP/archive/${version}.tar.gz"
-checksum=6ce0cd682515cc0ed6a8f43413ddf68351b2cd11e7ff9297bc2b558a607350fc
+checksum=8c2300545cd360889ac5420ba5c201532403b800188368c5b28bde9c9e3eec85
 CFLAGS="-Wno-dev"
 
 case "$XBPS_TARGET_MACHINE" in

--- a/srcpkgs/freerdp/template
+++ b/srcpkgs/freerdp/template
@@ -32,9 +32,10 @@ post_install() {
 	rm -f ${DESTDIR}/usr/lib64
 }
 
-# first we want to separate -server, everything else then goes to client
-subpackages="libfreerdp-server freerdp-server freerdp-server-devel libfreerdp
- freerdp-devel"
+# first we want to separate -server, then libuwac
+# everything else then goes to client
+subpackages="libfreerdp-server freerdp-server freerdp-server-devel
+ libuwac libuwac-devel libfreerdp freerdp-devel"
 
 libfreerdp_package() {
 	replaces="${sourcepkg}<1.0.2_2"
@@ -84,5 +85,22 @@ freerdp-server-devel_package() {
 		vmove usr/lib/pkgconfig/freerdp-shadow2.pc
 		vmove "usr/lib/libfreerdp-server*.so"
 		vmove "usr/lib/libfreerdp-shadow*.so"
+	}
+}
+
+libuwac_package() {
+	short_desc="Using wayland as client - runtime libraries"
+	pkg_install() {
+		vmove "usr/lib/libuwac*.so.*"
+	}
+}
+
+libuwac-devel_package() {
+	short_desc="Using wayland as client - development files"
+	pkg_install() {
+		vmove usr/include/uwac0
+		vmove usr/lib/cmake/uwac0
+		vmove usr/lib/pkgconfig/uwac0.pc
+		vmove "usr/lib/libuwac*.so"
 	}
 }

--- a/srcpkgs/freerdp3-devel
+++ b/srcpkgs/freerdp3-devel
@@ -1,0 +1,1 @@
+freerdp3

--- a/srcpkgs/freerdp3-server
+++ b/srcpkgs/freerdp3-server
@@ -1,0 +1,1 @@
+freerdp3

--- a/srcpkgs/freerdp3-server-devel
+++ b/srcpkgs/freerdp3-server-devel
@@ -1,0 +1,1 @@
+freerdp3

--- a/srcpkgs/freerdp3/template
+++ b/srcpkgs/freerdp3/template
@@ -1,0 +1,94 @@
+# Template file for 'freerdp3'
+pkgname=freerdp3
+version=3.5.0
+revision=1
+build_style=cmake
+configure_args="-DWITH_ALSA=ON -DWITH_CUPS=OFF -DWITH_FFMPEG=ON
+ -DWITH_GSTREAMER_0_10=OFF -DWITH_GSTREAMER_1_0=OFF -DWITH_JPEG=ON
+ -DWITH_LIBSYSTEMD=OFF -DWITH_PCSC=OFF -DWITH_PULSE=ON -DWITH_WAYLAND=ON
+ -DWITH_XCURSOR=ON -DWITH_XEXT=ON -DWITH_XI=ON -DWITH_XINERAMA=ON
+ -DWITH_XKBFILE=ON -DWITH_XRENDER=ON -DWITH_XV=ON -DWITH_SERVER=ON
+ -DWAYLAND_SCANNER=/usr/bin/wayland-scanner -DWITH_CAIRO=ON
+ -DRDTK_FORCE_STATIC_BUILD=ON -DUWAC_FORCE_STATIC_BUILD=ON
+ -DWITH_BINARY_VERSIONING=ON"
+hostmakedepends="pkg-config xmlto wayland-devel"
+makedepends="alsa-lib-devel ffmpeg-devel glib-devel libusb-devel
+ libXcursor-devel libXinerama-devel libXrandr-devel libXv-devel
+ libjpeg-turbo-devel openssl-devel libxkbfile-devel pulseaudio-devel
+ libxkbcommon-devel wayland-devel cairo-devel libXdamage-devel
+ pkcs11-helper-devel mit-krb5-devel icu-devel fuse3-devel SDL2-devel
+ SDL2_ttf-devel webkit2gtk-devel"
+short_desc="Free RDP (Remote Desktop Protocol) client"
+maintainer="Orphaned <orphan@voidlinux.org>"
+license="Apache-2.0"
+homepage="https://www.freerdp.com/"
+changelog="https://raw.githubusercontent.com/FreeRDP/FreeRDP/3.5.0/ChangeLog"
+distfiles="https://github.com/FreeRDP/FreeRDP/archive/${version}.tar.gz"
+checksum=03323b383980ee91decbed88270bac061ffb17fd04e52576c70da7885601ecbe
+conflicts="freerdp libfreerdp-server freerdp-server freerdp-server-devel
+ libfreerdp freerdp-devel"
+CFLAGS="-Wno-dev"
+
+case "$XBPS_TARGET_MACHINE" in
+	i686*|x86_64*) configure_args+=" -DWITH_SSE2=ON";;
+	armv5tel*) configure_args+=" -DWITH_NEON=OFF";;
+esac
+
+post_install() {
+	rm -f ${DESTDIR}/usr/lib64
+}
+
+# first we want to separate -server, everything else then goes to client
+subpackages="libfreerdp3-server freerdp3-server freerdp3-server-devel
+ libfreerdp3 freerdp3-devel"
+
+libfreerdp3_package() {
+	replaces="${sourcepkg}<1.0.2_2"
+	short_desc+=" - runtime libraries"
+	pkg_install() {
+		vmove "usr/lib/*.so.*"
+	}
+}
+
+freerdp3-devel_package() {
+	short_desc+=" - development files"
+	depends="openssl-devel lib${sourcepkg}>=${version}_${revision}"
+	pkg_install() {
+		vmove usr/include
+		vmove usr/lib/cmake
+		vmove usr/lib/pkgconfig
+		vmove "usr/lib/*.so"
+	}
+}
+
+libfreerdp3-server_package() {
+	short_desc="Free RDP (Remote Desktop Protocol) server - runtime files"
+	depends="libfreerdp3>=${version}_${revision}"
+	pkg_install() {
+		vmove "usr/lib/libfreerdp-server*.so.*"
+		vmove "usr/lib/libfreerdp-shadow*.so.*"
+	}
+}
+
+freerdp3-server_package() {
+	short_desc="Free RDP (Remote Desktop Protocol) server"
+	depends="libfreerdp3-server>=${version}_${revision}"
+	pkg_install() {
+		vmove usr/bin/freerdp-proxy3
+		vmove usr/bin/freerdp-shadow-cli3
+		vmove usr/share/man/man1/freerdp-shadow-cli3.1
+	}
+}
+
+freerdp3-server-devel_package() {
+	depends="libfreerdp3-server>=${version}_${revision}"
+	short_desc="Free RDP (Remote Desktop Protocol) server - development files"
+	pkg_install() {
+		vmove usr/lib/cmake/FreeRDP-Server3
+		vmove usr/lib/cmake/FreeRDP-Shadow3
+		vmove usr/lib/pkgconfig/freerdp-server3.pc
+		vmove usr/lib/pkgconfig/freerdp-shadow3.pc
+		vmove "usr/lib/libfreerdp-server*.so"
+		vmove "usr/lib/libfreerdp-shadow*.so"
+	}
+}

--- a/srcpkgs/libfreerdp3
+++ b/srcpkgs/libfreerdp3
@@ -1,0 +1,1 @@
+freerdp3

--- a/srcpkgs/libfreerdp3-server
+++ b/srcpkgs/libfreerdp3-server
@@ -1,0 +1,1 @@
+freerdp3

--- a/srcpkgs/libuwac
+++ b/srcpkgs/libuwac
@@ -1,0 +1,1 @@
+freerdp

--- a/srcpkgs/libuwac-devel
+++ b/srcpkgs/libuwac-devel
@@ -1,0 +1,1 @@
+freerdp


### PR DESCRIPTION
Required for `gnome-remote-desktop-46.1`

#### Testing the changes
- I tested the changes in this PR: **NO**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
