### PR TITLE
muon: rebuild against libpkgconf.so.4

### DIFF
--- a/srcpkgs/muon/template
+++ b/srcpkgs/muon/template
@@ -1,7 +1,7 @@
 # Template file for 'muon'
 pkgname=muon
 version=0.2.0
-revision=1
+revision=2
 build_style=meson
 build_helper="qemu"
 configure_args="


### PR DESCRIPTION
muon started segfaulting after the recent pkgconf update:

```
~/src/sqsh-tools (main ✗) muon setup "build"

detected compiler gcc '13.2.0' (['cc']), linker ld.bfd
configuring 'sqsh-tools', version: 1.3.0
dependency threads found
found dependency threads
[1]    997 segmentation fault  muon setup "build"
```

Rebuild it fixed the issue.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**|**briefly**|**NO**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
