### PR TITLE
Revert "xz: update to 5.6.0."

### DIFF
--- a/srcpkgs/xz/template
+++ b/srcpkgs/xz/template
@@ -1,21 +1,18 @@
 # Template file for 'xz'
+reverts="5.6.0_1"
 pkgname=xz
-version=5.6.0
-revision=1
+version=5.4.6
+revision=2
 bootstrap=yes
 build_style=gnu-configure
 configure_args="--disable-doc"
 short_desc="XZ compression utilities"
 maintainer="Enno Boland <gottox@voidlinux.org>"
-license="0BSD, GPL-2.0-or-later, GPL-3.0-or-later, LGPL-2.1-or-later"
+license="Public Domain, GPL-2.0-or-later, GPL-3.0-or-later, LGPL-2.1-or-later"
 homepage="https://xz.tukaani.org"
 changelog="https://git.tukaani.org/?p=xz.git;a=blob_plain;f=NEWS"
 distfiles="https://github.com/tukaani-project/xz/releases/download/v${version}/xz-${version}.tar.gz"
-checksum=0f5c81f14171b74fcc9777d302304d964e63ffc2d7b634ef023a7249d9b5d875
-
-if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
-	configure_args+=" --disable-sandbox"
-fi
+checksum=aeba3e03bf8140ddedf62a0a367158340520f6b384f75ca6045ccc6c0d43fd5c
 
 liblzma_package() {
 	short_desc="XZ-format compression library"
@@ -33,9 +30,4 @@ liblzma-devel_package() {
 		vmove "usr/lib/*.so"
 		vmove usr/lib/pkgconfig
 	}
-}
-
-post_install() {
-	vlicense COPYING
-	vlicense COPYING.0BSD
 }


### PR DESCRIPTION
This reverts commit ba6c7f1ffc6012148b0deea038c23794cb93c6c5.

See: https://www.openwall.com/lists/oss-security/2024/03/29/4
