### PR TITLE
n: reverts addition of `xz` 

### DIFF
--- a/srcpkgs/n/template
+++ b/srcpkgs/n/template
@@ -1,9 +1,9 @@
 # Template file for 'n'
 pkgname=n
 version=9.2.1
-revision=1
+revision=2
 build_style=gnu-makefile
-depends="curl tar xz"
+depends="curl tar"
 short_desc="Simple command line NodeJS version management"
 maintainer="anelki <akierig@fastmail.de>"
 license="MIT"


### PR DESCRIPTION
cf. https://www.openwall.com/lists/oss-security/2024/03/29/4

#### Testing the changes
- I tested the changes in this PR: **YES**


#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
