### PR TITLE
python3-zstandard: update to 0.22.0

### DIFF
--- a/srcpkgs/python3-zstandard/template
+++ b/srcpkgs/python3-zstandard/template
@@ -1,11 +1,14 @@
 # Template file for 'python3-zstandard'
 pkgname=python3-zstandard
-version=0.21.0
-revision=3
+version=0.22.0
+revision=1
 build_style=python3-module
-make_build_args="--system-zstd"
+# If the system's zstd is used and its version is not the same as
+# the bundled zstd, importing the python module fails.
+# https://github.com/indygreg/python-zstandard/issues/48#issuecomment-753344624
+#make_build_args="--system-zstd"
 hostmakedepends="python3-setuptools"
-makedepends="python3-devel libzstd-devel"
+makedepends="python3-devel"
 depends="python3"
 checkdepends="python3-hypothesis"
 short_desc="Python bindings to the Zstandard (zstd) compression library"
@@ -14,15 +17,7 @@ license="BSD-3-Clause"
 homepage="https://github.com/indygreg/python-zstandard"
 changelog="https://raw.githubusercontent.com/indygreg/python-zstandard/main/docs/news.rst"
 distfiles="https://github.com/indygreg/python-zstandard/archive/${version}.tar.gz"
-checksum=15adc6bfa629d48b0bb658e9eae94c484adb66a28738fa780478eebeb41599a5
-
-pre_check() {
-	# The skipped test ignored due to failure, see:
-	# https://github.com/indygreg/python-zstandard/issues/147#issuecomment-874278901
-	if [ "${XBPS_TARGET_MACHINE%-musl}" = i686 ]; then
-		vsed -i -e '/def test_estimated_compression_context_size/s/test//' tests/test_data_structures*.py
-	fi
-}
+checksum=34ce7ef020afca1344c538a778e2a2e30dc43b11509aa4cb5cf076228d959ca7
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
This happens when using system's zstd:

```
$ python3 -c 'import zstandard'
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/usr/lib/python3.12/site-packages/zstandard/__init__.py", line 39, in <module>
    from .backend_c import *  # type: ignore
    ^^^^^^^^^^^^^^^^^^^^^^^^
ImportError: zstd C API versions mismatch; Python bindings were not compiled/linked against expected zstd version (10506 returned by the lib, 10506 hardcoded in zstd headers, 10505 hardcoded in the cext)
```

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
