### PR TITLE
SDL2_ttf: move cmake to -devel

### DIFF
--- a/srcpkgs/SDL2_ttf/template
+++ b/srcpkgs/SDL2_ttf/template
@@ -1,7 +1,7 @@
 # Template file for 'SDL2_ttf'
 pkgname=SDL2_ttf
 version=2.20.2
-revision=1
+revision=2
 build_style=cmake
 configure_args="-DSDL2TTF_HARFBUZZ=ON"
 makedepends="SDL2-devel freetype-devel harfbuzz-devel"
@@ -24,5 +24,6 @@ SDL2_ttf-devel_package() {
 		vmove usr/include
 		vmove usr/lib/pkgconfig
 		vmove usr/lib/*.so
+		vmove usr/lib/cmake
 	}
 }


### PR DESCRIPTION
cnake files belong in devel subpackage, not the main one.

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)