### PR TITLE
Fix solaar udev rules

### DIFF
--- a/srcpkgs/Solaar/INSTALL.msg
+++ b/srcpkgs/Solaar/INSTALL.msg
@@ -1,0 +1,3 @@
+Previous versions of solaar required copying or symlinking udev rules to
+	/etc/udev/rules.d
+If this was done previously, it is recommended to remove that file or symlink.

--- a/srcpkgs/Solaar/files/README.voidlinux
+++ b/srcpkgs/Solaar/files/README.voidlinux
@@ -1,3 +1,0 @@
-To use Solaar without root privileges, copy the file
-    /usr/share/solaar/udev-rules.d/42-logitech-unify-permissions.rules
-into the directory /etc/udev/rules.d/ and reload udev rules.

--- a/srcpkgs/Solaar/template
+++ b/srcpkgs/Solaar/template
@@ -14,7 +14,3 @@ homepage="https://pwr-solaar.github.io/Solaar/"
 changelog="https://raw.githubusercontent.com/pwr-Solaar/Solaar/master/ChangeLog.md"
 distfiles="https://github.com/pwr-Solaar/Solaar/archive/refs/tags/${version}.tar.gz"
 checksum=2b292da8923e19a4a7a459d6fcd1119ce157cb579fd00077f87633c0dedfbba5
-
-post_install() {
-	vdoc "${FILESDIR}/README.voidlinux"
-}


### PR DESCRIPTION
This PR adds back in a missing udev rules file that is required for solaar to function.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
