### PR TITLE
libvncserver: add missing buildepends (fixes broken functionality of vnc apps using encryption)

### DIFF
--- a/srcpkgs/libvncserver/template
+++ b/srcpkgs/libvncserver/template
@@ -1,11 +1,12 @@
 # Template file for 'libvncserver'
 pkgname=libvncserver
 version=0.9.14
-revision=2
+revision=3
 build_style=cmake
-confiugre_args="-DWITH_OPENSSL=ON -DWITH_GNUTLS=OFF"
+configure_args="-DWITH_OPENSSL=ON -DWITH_GNUTLS=OFF -DWITH_SYSTEMD=OFF"
 hostmakedepends="pkg-config"
-makedepends="zlib-devel libjpeg-turbo-devel libpng-devel openssl-devel"
+makedepends="zlib-devel libjpeg-turbo-devel libpng-devel openssl-devel
+ lzo-devel libgcrypt-devel"
 short_desc="C libraries to easily implement VNC server or client functionality"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later"
@@ -17,6 +18,7 @@ libvncserver-devel_package() {
 	depends="${makedepends} ${sourcepkg}-${version}_${revision}"
 	short_desc+=" - development files"
 	pkg_install() {
+		vmove usr/lib/cmake
 		vmove usr/include
 		vmove "usr/lib/*.so"
 		vmove usr/lib/pkgconfig


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**
#### Local build testing
- I built this PR locally for my native architecture, (x86_64-GLIBC)
