### PR TITLE
pdftk-java: Fix path to bcprov jar

### DIFF
--- a/srcpkgs/pdftk-java/files/pdftk
+++ b/srcpkgs/pdftk-java/files/pdftk
@@ -1,4 +1,4 @@
 #!/bin/sh
 
-"$JAVA_HOME"/bin/java -cp "/usr/lib/bc-java/bc-java.jar:/usr/lib/java-commons-lang/commons-lang.jar:/usr/lib/pdftk/pdftk.jar" \
+"$JAVA_HOME"/bin/java -cp "/usr/lib/bc-java/bcprov.jar:/usr/lib/java-commons-lang/commons-lang.jar:/usr/lib/pdftk/pdftk.jar" \
 	com.gitlab.pdftk_java.pdftk "$@"


### PR DESCRIPTION
pdftk was not able to load some java libraries because the path to one of them was incorrect.

This PR fixes the path so that it points to the [correct jar file](https://github.com/void-linux/void-packages/blob/master/srcpkgs/bc-java/template#L22).

#### Testing the changes
- I tested the changes in this PR: **briefly**

