### PR TITLE
newsboat: update to 2.35.

### DIFF
--- a/srcpkgs/newsboat/template
+++ b/srcpkgs/newsboat/template
@@ -1,6 +1,6 @@
 # Template file for 'newsboat'
 pkgname=newsboat
-version=2.34
+version=2.35
 revision=1
 build_style=configure
 build_helper="rust"
@@ -17,7 +17,7 @@ license="MIT"
 homepage="https://newsboat.org/"
 changelog="https://raw.githubusercontent.com/newsboat/newsboat/master/CHANGELOG.md"
 distfiles="https://newsboat.org/releases/${version}/newsboat-${version}.tar.xz"
-checksum=73d7b539b0c906f6843a1542e1904a02ae430e79d6be4d6f9e2e2034eac2434e
+checksum=f4f003f6ca38e44c0fef01fb6bc8c5ba6b53589c7c87db7b0cc2284e018db6c4
 python_version=3
 
 # tests fail when run by superuser


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86\_64-glibc)
