### PR TITLE
qbittorrent: update to 4.6.4

### DIFF
--- a/srcpkgs/libtorrent-rasterbar/template
+++ b/srcpkgs/libtorrent-rasterbar/template
@@ -1,8 +1,8 @@
 # Template file for 'libtorrent-rasterbar'
 # Breaks ABI/API without changing soname, revbump all dependants
 pkgname=libtorrent-rasterbar
-version=1.2.18
-revision=5
+version=1.2.19
+revision=1
 build_style=cmake
 configure_args="-Dbuild_examples=ON -Dbuild_tools=ON
  -Dpython-bindings=ON -Dbuild_tests=ON"
@@ -13,7 +13,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="BSD-3-Clause"
 homepage="https://libtorrent.org/"
 distfiles="https://github.com/arvidn/libtorrent/releases/download/v${version}/${pkgname}-${version}.tar.gz"
-checksum=fef2b6817de4e6d960e019c27f21daf27bc2468a81d9e028a19d45d61456fa72
+checksum=eee8e99548dc5eb5e643e49db9202f4f97112c032dba883dfdc8144af5b6e40e
 
 CXXFLAGS="-std=c++14"
 

--- a/srcpkgs/qbittorrent/template
+++ b/srcpkgs/qbittorrent/template
@@ -1,6 +1,6 @@
 # Template file for 'qbittorrent'
 pkgname=qbittorrent
-version=4.5.4
+version=4.6.4
 revision=1
 create_wrksrc=yes
 build_style=gnu-configure
@@ -16,7 +16,7 @@ license="GPL-2.0-or-later"
 homepage="https://www.qbittorrent.org/"
 changelog="https://www.qbittorrent.org/news.php"
 distfiles="${SOURCEFORGE_SITE}/qbittorrent/qbittorrent-${version}.tar.xz"
-checksum=f92bcd3ed25600796c59257c507e56a252a65af60bd042b71f1e7ff3fe5264da
+checksum=8e62a24145582a0b36e8268a2e574c5d61a396d28a7d02b899ca59f2244a8913
 CXXFLAGS=-std=gnu++17
 
 do_extract() {


### PR DESCRIPTION
- I tested the changes in this PR: yes
I2p is unavailable. It works only if build with libtorrent-rasterbar version 2
- I built this PR locally for my native architecture, (x86_64-glibc)