### PR TITLE
python3-keyring: update to 25.1.0.

### DIFF
--- a/srcpkgs/python3-keyring/template
+++ b/srcpkgs/python3-keyring/template
@@ -1,11 +1,11 @@
 # Template file for 'python3-keyring'
 pkgname=python3-keyring
-version=24.3.1
+version=25.1.0
 revision=1
 build_style=python3-pep517
 hostmakedepends="python3-wheel python3-setuptools_scm"
 depends="python3-SecretStorage python3-jeepney
- python3-jaraco.classes"
+ python3-jaraco.classes python3-jaraco.functools python3-jaraco.context"
 checkdepends="${depends} python3-pytest-xdist"
 short_desc="Python interface to the system keyring service"
 maintainer="icp <pangolin@vivaldi.net>"
@@ -13,7 +13,7 @@ license="MIT"
 homepage="https://pypi.org/project/keyring/"
 changelog="https://raw.githubusercontent.com/jaraco/keyring/main/NEWS.rst"
 distfiles="${PYPI_SITE}/k/keyring/keyring-${version}.tar.gz"
-checksum=c3327b6ffafc0e8befbdb597cacdb4928ffe5c1212f7645f186e6d9957a898db
+checksum=7230ea690525133f6ad536a9b5def74a4bd52642abe594761028fc044d7c7893
 
 pre_check() {
 	vsed -e '/addopts/d' -i pytest.ini


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture: **x86_64**