### PR TITLE
dbeaver: update to 24.0.2.

### DIFF
--- a/srcpkgs/dbeaver/template
+++ b/srcpkgs/dbeaver/template
@@ -1,8 +1,8 @@
 # Template file for 'dbeaver'
 pkgname=dbeaver
-version=24.0.1
+version=24.0.2
 revision=1
-_common_commit=9939531b043b00f1f74cad3490ee1e5bdfa4dd62
+_common_commit=6b15285e2adcf28696d7b435e09663c402cb1128
 # the build downloads binaries linked to glibc
 archs="x86_64 aarch64"
 build_wrksrc="dbeaver"
@@ -15,8 +15,8 @@ homepage="https://dbeaver.io"
 changelog="https://dbeaver.io/news/"
 distfiles="https://github.com/dbeaver/dbeaver/archive/${version}.tar.gz
  https://github.com/dbeaver/dbeaver-common/archive/${_common_commit}.tar.gz"
-checksum="bcf9608aeaec6a9590d8f31b5aad0fc2bb0f467b95405adcc953dfecf0dff3b3
- d95199f3420cf12a738625ccf847c36ff65129369605044fca7f1f6ec70805ff"
+checksum="ae11d17a5888848f3b1ef6da331b12106acbedb25465d69881cf9ba421171b3e
+ 6e584b1aa3250a8cdd7caac124fd62ce272c2ae0c6c09a7e96e4ab2bd5102058"
 nopie=true
 
 post_extract() {


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64 glibc)
