### PR TITLE
OTPClient: update to 3.6.0

### DIFF
--- a/srcpkgs/OTPClient/template
+++ b/srcpkgs/OTPClient/template
@@ -1,6 +1,6 @@
 # Template file for 'OTPClient'
 pkgname=OTPClient
-version=3.5.2
+version=3.6.0
 revision=1
 build_style=cmake
 hostmakedepends="pkg-config"
@@ -12,4 +12,4 @@ maintainer="Emil Miler <em@0x45.cz>"
 license="GPL-3.0-or-later"
 homepage="https://github.com/paolostivanin/OTPClient"
 distfiles="https://github.com/paolostivanin/OTPClient/archive/refs/tags/v${version}.tar.gz"
-checksum=d65363003d497a59ebc7d48c142541ae9a787bc16dddce87fb7b77d9fdbf6ccf
+checksum=e5a4e848be12b761e632e070149f7999974b4ce7620cb92a05a0dd149822beec


### PR DESCRIPTION
- I tested the changes in this PR: **YES**
- I built this PR locally for my native architecture, (x86_64-glibc)