### PR TITLE
rsync: update to 3.3.0.

### DIFF
--- a/srcpkgs/rsync/template
+++ b/srcpkgs/rsync/template
@@ -1,7 +1,7 @@
 # Template file for 'rsync'
 pkgname=rsync
-version=3.2.7
-revision=2
+version=3.3.0
+revision=1
 build_style=gnu-configure
 configure_args="--with-included-zlib=no --with-rrsync"
 conf_files="/etc/rsyncd.conf"
@@ -14,7 +14,7 @@ license="GPL-3.0-only"
 homepage="https://rsync.samba.org/"
 changelog="https://download.samba.org/pub/rsync/NEWS"
 distfiles="https://www.samba.org/ftp/rsync/src/rsync-$version.tar.gz"
-checksum=4e7d9d3f6ed10878c58c5fb724a67dacf4b6aac7340b13e488fb2dc41346f2bb
+checksum=7399e9a6708c32d678a72a63219e96f23be0be2336e50fd1348498d07041df90
 
 # Force enable IPv6 on musl - upstream bug https://bugzilla.samba.org/show_bug.cgi?id=10715
 CFLAGS="-DINET6"


### PR DESCRIPTION
- I tested the changes in this PR: yes
New option "-no-overwrite" works fine
- I built this PR locally for my native architecture, (x86_64)
- I built this PR locally for these architectures:
  - x86_64-musl
  - aarch64-musl