### PR TITLE
openssl: update to 3.3.0.

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -1735,8 +1735,8 @@ libid3.so id3lib-3.8.3_7
 libid3-3.8.so.3 id3lib-3.8.3_7
 libgirara-gtk3.so.3 girara-0.2.8_1
 libjq.so.1 jq-1.6_2
-libcrypto.so.3 libcrypto3-3.1.2_1
-libssl.so.3 libssl3-3.1.2_1
+libcrypto.so.3 libcrypto3-3.3.0_1
+libssl.so.3 libssl3-3.3.0_1
 libvamp-hostsdk.so.3 libvamp-plugin-sdk-2.2_6
 libportmidi.so portmidi-217_1
 libWildMidi.so.2 libwildmidi-0.4.3_1

--- a/srcpkgs/openssl/template
+++ b/srcpkgs/openssl/template
@@ -1,6 +1,6 @@
 # Template file for 'openssl'
 pkgname=openssl
-version=3.1.5
+version=3.3.0
 revision=1
 bootstrap=yes
 build_style=configure
@@ -17,7 +17,7 @@ maintainer="John <me@johnnynator.dev>"
 license="Apache-2.0"
 homepage="https://www.openssl.org"
 distfiles="https://www.openssl.org/source/openssl-${version}.tar.gz"
-checksum=6ae015467dabf0469b139ada93319327be24b98251ffaeceda0221848dc09262
+checksum=53e66b043322a606abf0087e7699a0e033a37fa13feb9742df35c3a33b18fb02
 conf_files="/etc/ssl/openssl.cnf"
 replaces="libressl>=0"
 


### PR DESCRIPTION
- I tested the changes in this PR: **briefly**
4 CVEs were patched in versions 3.2.1, 3.2.2
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures:
  - x86_64-musl
  - armv7l-musl (cross)