### PR TITLE
openssl: update to 3.3.0.

### DIFF
--- a/srcpkgs/openssl-doc
+++ b/srcpkgs/openssl-doc
@@ -1,0 +1,1 @@
+openssl

--- a/srcpkgs/openssl/template
+++ b/srcpkgs/openssl/template
@@ -1,6 +1,6 @@
 # Template file for 'openssl'
 pkgname=openssl
-version=3.1.5
+version=3.3.0
 revision=1
 bootstrap=yes
 build_style=configure
@@ -17,7 +17,7 @@ maintainer="John <me@johnnynator.dev>"
 license="Apache-2.0"
 homepage="https://www.openssl.org"
 distfiles="https://www.openssl.org/source/openssl-${version}.tar.gz"
-checksum=6ae015467dabf0469b139ada93319327be24b98251ffaeceda0221848dc09262
+checksum=53e66b043322a606abf0087e7699a0e033a37fa13feb9742df35c3a33b18fb02
 conf_files="/etc/ssl/openssl.cnf"
 replaces="libressl>=0"
 
@@ -57,7 +57,7 @@ pre_build() {
 
 post_install() {
 	if [ ! "$CHROOT_READY" ]; then
-		rm -f "${DESTDIR}/usr/bin/c_rehash"
+		rm -f "${DESTDIR}/usr/bin/c_rehash" "${DESTDIR}/usr/share/man/man1/c_rehash.1ssl"
 	fi
 }
 
@@ -81,6 +81,7 @@ openssl-c_rehash_package() {
 	depends="openssl perl"
 	pkg_install() {
 		vmove usr/bin/c_rehash
+		vmove usr/share/man/man1/c_rehash.1ssl
 	}
 }
 
@@ -89,11 +90,19 @@ openssl-devel_package() {
 	replaces="libressl-devel>=0"
 	short_desc+=" - development files"
 	pkg_install() {
-		vmove usr/share/man/man3
-		vmove usr/share/doc
 		vmove usr/include
 		vmove usr/lib/pkgconfig
+		vmove usr/lib/cmake
 		vmove "usr/lib/*.a"
 		vmove "usr/lib/*.so"
+	}
+}
+
+openssl-doc_package() {
+	short_desc+=" - documentation"
+	pkg_install() {
+		vmove usr/share/man/man3
+		vmove usr/share/man/man7
+		vmove usr/share/doc
 	}
 }


### PR DESCRIPTION
* move c_rehash manpage to its package
* move dev docs to their own subpackage. there's a huge amount of them and they don't need to be installed for building packages with openssl-devel

#### Testing the changes
- I tested the changes in this PR: **YES**
