### PR TITLE
qt5: use a sane default platform

### DIFF
--- a/srcpkgs/qt5/template
+++ b/srcpkgs/qt5/template
@@ -3,9 +3,9 @@
 # revbump libqtxdg after bumping patch version
 pkgname=qt5
 version=5.15.11+20231124
+revision=3
 # commit 4765fa1df7a837db9c1f89c4da0dd76b74bb5fab
 # base repo: https://invent.kde.org/qt/qt/qt5
-revision=2
 build_style=meta
 hostmakedepends="cmake clang17 flex perl glib-devel pkg-config
  python3 re2c ruby which"
@@ -158,6 +158,9 @@ _create_config() {
 	echo "QMAKE_LFLAGS = ${LDFLAGS}" >> ${qmake_conf}
 	echo "QMAKE_CFLAGS = ${CFLAGS}" >> ${qmake_conf}
 	echo "QMAKE_CXXFLAGS = ${CXXFLAGS}" >> ${qmake_conf}
+	echo >> ${qmake_conf}
+	# use a sane default platform (prevent defaulting to eglfs)
+	echo "QT_QPA_DEFAULT_PLATFORM = xcb" >> ${qmake_conf}
 	echo >> ${qmake_conf}
 	case "$XBPS_TARGET_MACHINE" in
 		arm*)


### PR DESCRIPTION
on `arm*`/`aarch64*`, qt5 defaults to the `eglfs` QPA platform, which is designed for embedded devices. because this is probably a less-common use-case on Void, it's more sane to default to `xcb`, like `x86_64*` does.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**
