### PR TITLE
baresip: update to 3.11.0.

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -3425,7 +3425,7 @@ libhtmlcxx.so.3 htmlcxx-0.86_1
 libcss_parser_pp.so.0 htmlcxx-0.86_1
 libcss_parser.so.0 htmlcxx-0.86_1
 libaom.so.3 libaom-3.4.0_1
-libre.so.18 re-3.6.0_1
+libre.so.23 re-3.11.0_1
 libtpms.so.0 libtpms-0.9.0_1
 libswtpm_libtpms.so.0 libswtpm-0.6.1_1
 libspandsp.so.2 spandsp-0.0.6_1

--- a/srcpkgs/baresip/template
+++ b/srcpkgs/baresip/template
@@ -1,7 +1,7 @@
 # Template file for 'baresip'
 pkgname=baresip
-version=3.6.0
-revision=3
+version=3.11.0
+revision=1
 build_style=cmake
 hostmakedepends="pkg-config glib-devel"
 makedepends="libgsm-devel libpng-devel openssl-devel libsndfile-devel
@@ -17,7 +17,7 @@ license="BSD-3-Clause"
 homepage="https://github.com/baresip/baresip"
 changelog="https://raw.githubusercontent.com/baresip/baresip/main/CHANGELOG.md"
 distfiles="https://github.com/baresip/baresip/archive/refs/tags/v${version}.tar.gz"
-checksum=9996197bcba8bd2cbbed209f39b52dd811d2f4e35386819370da075b7d24b864
+checksum=2b03fbbdb59ac1de91c0264ebb7256886c298e9efe0bcb0b9514ea00a4d48f40
 
 post_install() {
 	vlicense LICENSE

--- a/srcpkgs/re/template
+++ b/srcpkgs/re/template
@@ -1,6 +1,6 @@
 # Template file for 're'
 pkgname=re
-version=3.6.0
+version=3.11.0
 revision=1
 build_style=cmake
 configure_args="-DUSE_OPENSSL=yes"
@@ -10,7 +10,7 @@ maintainer="John <me@johnnynator.dev>"
 license="BSD-3-Clause"
 homepage="https://github.com/baresip/re/"
 distfiles="https://github.com/baresip/re/archive/refs/tags/v${version}.tar.gz"
-checksum=12a46474875ef39f1179aca0138939bd84bb9357f54341518022a203c110d879
+checksum=a29dbdbbacd27461b9c8e94b0e52773f3b1396a64e31e258635f18cf5f27e44e
 
 CFLAGS=-D_GNU_SOURCE
 


### PR DESCRIPTION
- **re: update to 3.11.0.**
- **baresip: update to 3.11.0.**

- I tested the changes in this PR: **YES**

- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
