### PR TITLE
lighttpd: update to 1.4.76

### DIFF
--- a/srcpkgs/lighttpd/template
+++ b/srcpkgs/lighttpd/template
@@ -1,6 +1,6 @@
 # Template file for 'lighttpd'
 pkgname=lighttpd
-version=1.4.75
+version=1.4.76
 revision=1
 build_style=meson
 configure_args="-Dwith_brotli=disabled -Dwith_bzip=disabled
@@ -20,7 +20,7 @@ maintainer="Enno Boland <gottox@voidlinux.org>"
 license="BSD-3-Clause"
 homepage="https://lighttpd.net"
 distfiles="https://download.lighttpd.net/lighttpd/releases-1.4.x/lighttpd-${version}.tar.xz"
-checksum=8b721ca939d312afaa6ef31dcbd6afb5161ed385ac828e6fccd4c5b76be189d6
+checksum=8cbf4296e373cfd0cedfe9d978760b5b05c58fdc4048b4e2bcaf0a61ac8f5011
 
 conf_files="/etc/lighttpd/lighttpd.conf"
 system_accounts="_lighttpd"


### PR DESCRIPTION
lighttpd: update to 1.4.76
Testing the changes

I tested the changes in this PR: NO

(build-tested elsewhere: on openwrt)
(release tag built and automated tests run on many platforms: https://github.com/lighttpd/lighttpd1.4/actions)