### PR TITLE
qt6-declarative: build qmlls tool

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -2057,6 +2057,8 @@ libQt6WebEngineCore.so.6 qt6-webengine-6.3.1_1
 libQt6WebEngineQuickDelegatesQml.so.6 qt6-webengine-6.3.1_1
 libQt6WebEngineWidgets.so.6 qt6-webengine-6.3.1_1
 libQt6TextToSpeech.so.6 qt6-speech-6.6.0_1
+libQt6JsonRpc.so.6 qt6-languageserver-6.6.0_1
+libQt6LanguageServer.so.6 qt6-languageserver-6.6.0_1
 libnpth.so.0 npth-1.1_1
 libnpupnp.so.13 libnpupnp-6.1.1_1
 libglfw.so.3 glfw-3.0.4_1

--- a/srcpkgs/qt6-declarative/template
+++ b/srcpkgs/qt6-declarative/template
@@ -1,14 +1,14 @@
 # Template file for 'qt6-declarative'
 pkgname=qt6-declarative
 version=6.6.0
-revision=1
+revision=2
 build_style=cmake
 configure_args="-DQT_BUILD_TESTS=ON"
 hostmakedepends="qt6-base perl pkg-config wayland-devel qt6-shadertools python3"
-makedepends="qt6-base-devel Vulkan-Headers qt6-shadertools-devel"
+makedepends="qt6-base-devel Vulkan-Headers qt6-shadertools-devel qt6-languageserver-devel"
 short_desc="Cross-platform application and UI framework - Declarative"
 maintainer="John <me@johnnynator.dev>"
-license="GPL-3.0-only with Qt-GPL-exception-1.0, LGPL-3.0-only, GPL-2.0-or-later"
+license="GPL-3.0-only WITH Qt-GPL-exception-1.0, LGPL-3.0-only, GPL-2.0-or-later"
 homepage="https://www.qt.io"
 distfiles="https://download.qt.io/official_releases/qt/${version%.*}/${version}/submodules/qtdeclarative-everywhere-src-${version}.tar.xz"
 checksum=1b539bb0a918c8f0307fd07bd4ef0334bf7f8934bbc2eabfc04c433a7d7fa331
@@ -77,7 +77,7 @@ qt6-declarative-tools_package() {
 		for bin in qmlcachegen qmlimportscanner qmltyperegistrar; do
 			vmove usr/lib/qt6/libexec/$bin
 		done
-		for bin in qmlformat qmllint qmlpreview qmlprofiler; do
+		for bin in qmlformat qmllint qmlpreview qmlprofiler qmlls; do
 			vmove usr/lib/qt6/bin/$bin
 		done
 	}

--- a/srcpkgs/qt6-languageserver-devel
+++ b/srcpkgs/qt6-languageserver-devel
@@ -1,0 +1,1 @@
+qt6-languageserver

--- a/srcpkgs/qt6-languageserver/template
+++ b/srcpkgs/qt6-languageserver/template
@@ -1,0 +1,26 @@
+# Template file for 'qt6-languageserver'
+pkgname=qt6-languageserver
+version=6.6.0
+revision=1
+build_style=cmake
+configure_args="-DQT_BUILD_TESTS=ON"
+hostmakedepends="qt6-base"
+makedepends="qt6-base-devel"
+short_desc="Implementation of the Language Server Protocol for Qt6"
+maintainer="classabbyamp <void@placeviolette.net>"
+license="GPL-3.0-only WITH Qt-GPL-exception-1.0, LGPL-3.0-only, GPL-2.0-or-later"
+homepage="https://www.qt.io"
+distfiles="https://download.qt.io/official_releases/qt/${version%.*}/${version}/submodules/qtlanguageserver-everywhere-src-${version}.tar.xz"
+checksum=aec93019862bf63769206fe56a2230cd9e37994806a4bf28415203b4eb9a490e
+
+qt6-languageserver-devel_package() {
+	depends="${sourcepkg}>=${version}_${revision}"
+	short_desc+=" - development files"
+	pkg_install() {
+		vmove usr/include
+		vmove usr/lib/cmake
+		vmove usr/lib/qt6
+		vmove "usr/lib/*.so"
+		vmove "usr/lib/*.prl"
+	}
+}


### PR DESCRIPTION
QML language server, new in qt6.6. requires qt6-languageserver, a new package

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**
