### PR TITLE
delve: update to 1.22.1.

### DIFF
--- a/srcpkgs/delve/template
+++ b/srcpkgs/delve/template
@@ -1,7 +1,7 @@
 # Template file for 'delve'
 pkgname=delve
-version=1.21.0
-revision=2
+version=1.22.1
+revision=1
 # https://github.com/go-delve/delve/blob/master/pkg/proc/native/support_sentinel_linux.go
 archs="x86_64* i686* aarch64*"
 build_style=go
@@ -13,7 +13,7 @@ license="MIT"
 homepage="https://github.com/go-delve/delve"
 changelog="https://raw.githubusercontent.com/go-delve/delve/master/CHANGELOG.md"
 distfiles="https://github.com/go-delve/delve/archive/v${version}.tar.gz"
-checksum=f00321e9333a61cb10c18141484c44ed55b1da1c4239a3f4faf2100b64613199
+checksum=fe6f0d97c233d4f0f1ed422c11508cc57c14e9e0915f9a258f1912c46824cbfb
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

`dlv exec` on a go program works fine, can break on main.main and step thru the program.

#### Local build testing
- I built this PR locally for my native architecture, x86_64