### PR TITLE
tree-sitter: update to 0.22.5

### DIFF
--- a/srcpkgs/tree-sitter/template
+++ b/srcpkgs/tree-sitter/template
@@ -1,6 +1,6 @@
 # Template file for 'tree-sitter'
 pkgname=tree-sitter
-version=0.22.1
+version=0.22.5
 revision=1
 build_style=cargo
 make_install_args="--path=cli"
@@ -10,7 +10,7 @@ license="MIT"
 homepage="https://tree-sitter.github.io"
 changelog="https://raw.githubusercontent.com/tree-sitter/tree-sitter/master/CHANGELOG.md"
 distfiles="https://github.com/tree-sitter/tree-sitter/archive/refs/tags/v${version}.tar.gz"
-checksum=b21065e78da33e529893c954e712ad15d9ad44a594b74567321d4a3a007d6090
+checksum=6bc22ca7e0f81d77773462d922cf40b44bfd090d92abac75cb37dbae516c2417
 make_check=no # tests require generating fixtures from remote repositories
 
 post_build() {


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture: x86-64_libc