### PR TITLE
toot: update to 0.43.0.

### DIFF
--- a/srcpkgs/toot/template
+++ b/srcpkgs/toot/template
@@ -1,16 +1,16 @@
 # Template file for 'toot'
 pkgname=toot
-version=0.42.0
+version=0.43.0
 revision=1
 build_style=python3-pep517
-hostmakedepends="python3-setuptools python3-wheel"
+hostmakedepends="python3-setuptools_scm python3-wheel"
 depends="python3-click python3-requests python3-BeautifulSoup4 python3-wcwidth
  python3-urwid python3-urwidgets python3-tomlkit"
-checkdepends="${depends} python3-psycopg2 python3-pytest-xdist"
+checkdepends="${depends} python3-psycopg2 python3-Pillow python3-pytest-xdist"
 short_desc="Mastodon CLI client"
 maintainer="Jon Levin <jon@jefferiestube.net>"
 license="GPL-3.0-or-later"
 homepage="https://toot.bezdomni.net"
 changelog="https://raw.githubusercontent.com/ihabunek/toot/master/CHANGELOG.md"
-distfiles="https://github.com/ihabunek/toot/archive/refs/tags/${version}.tar.gz"
-checksum=05502896b3a75aa93c8895bab75669653601af502ac6cf44d1ab33de373ef229
+distfiles="${PYPI_SITE}/t/toot/toot-${version}.tar.gz"
+checksum=6aa84c4b8df6e2214a3e735142bf5bd57b3b10aa08e35579425c5dbe3bc25ae7


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture: **x86_64**

Switched to PyPI tarball due to dynamic versioning via `setuptools_scm`