### PR TITLE
gtk{+3,4}: move gtk-icon-browser to demo subpackage

### DIFF
--- a/srcpkgs/gtk+3/template
+++ b/srcpkgs/gtk+3/template
@@ -1,7 +1,7 @@
 # Template file for 'gtk+3'
 pkgname=gtk+3
 version=3.24.41
-revision=1
+revision=2
 build_style=meson
 build_helper="gir"
 configure_args="
@@ -87,12 +87,17 @@ gtk+3-demo_package() {
 	short_desc+=" - demonstration application"
 	pkg_install() {
 		vmove usr/bin/gtk3-demo
+		vmove usr/bin/gtk3-icon-browser
 		vmove usr/bin/gtk3-widget-factory
 		vmove usr/bin/gtk3-demo-application
+		vmove usr/share/man/man1/gtk3-demo.1
 		vmove usr/share/man/man1/gtk3-widget-factory.1
+		vmove usr/share/man/man1/gtk3-icon-browser.1
+		vmove usr/share/man/man1/gtk3-demo-application.1
 		vmove usr/share/gtk-3.0/gtkbuilder.rng
 		vmove usr/share/glib-2.0/schemas/org.gtk.Demo.gschema.xml
 		vmove usr/share/applications/gtk3-widget-factory.desktop
+		vmove usr/share/applications/gtk3-icon-browser.desktop
 		vmove usr/share/applications/gtk3-demo.desktop
 		vmove usr/share/icons
 	}

--- a/srcpkgs/gtk4/template
+++ b/srcpkgs/gtk4/template
@@ -1,7 +1,7 @@
 # Template file for 'gtk4'
 pkgname=gtk4
 version=4.14.2
-revision=1
+revision=2
 build_style=meson
 build_helper="gir"
 configure_args="-Dman-pages=true -Ddocumentation=true -Dbuild-tests=false
@@ -79,9 +79,6 @@ gtk4-devel_package() {
 gtk4-demo_package() {
 	short_desc+=" - demonstration application"
 	pkg_install() {
-		# gtk3-icon-browser is in main package,
-		# keep gtk4-icon-browser in main package too
-
 		vmove usr/bin/gtk4-demo
 		vmove usr/share/applications/org.gtk.Demo4.desktop
 		vmove usr/share/glib-2.0/schemas/org.gtk.Demo4.gschema.xml
@@ -117,6 +114,12 @@ gtk4-demo_package() {
 		vmove usr/share/man/man1/gtk4-node-editor.1
 		vmove usr/share/metainfo/org.gtk.gtk4.NodeEditor.appdata.xml
 
+		vmove usr/bin/gtk4-icon-browser
+		vmove usr/share/applications/org.gtk.IconBrowser4.desktop
+		vmove usr/share/icons/hicolor/scalable/apps/org.gtk.IconBrowser4.svg
+		vmove usr/share/icons/hicolor/symbolic/apps/org.gtk.IconBrowser4-symbolic.svg
+		vmove usr/share/man/man1/gtk4-icon-browser.1
+		vmove usr/share/metainfo/org.gtk.IconBrowser4.appdata.xml
 	}
 }
 


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

cc: @sgn 

Upstream, both gtk3-icon-browser and gtk4-icon-browser are considered demos and are are disabled if `-Dbuild-demos=false` is passed. For reference, Arch puts it in gtk4-icon-browser gtk4-demos, Fedora puts it in gtk4-devel-tools, Debian puts it in gtk-4-examples. The same is the case for gtk+3 (although Fedora puts the gtk+3 demos in gtk3-devel).

If moving them is an issue though, please let me know.

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
