### PR TITLE
dunst: update to 1.11.0

### DIFF
--- a/srcpkgs/dunst/template
+++ b/srcpkgs/dunst/template
@@ -1,6 +1,6 @@
 # Template file for 'dunst'
 pkgname=dunst
-version=1.10.0
+version=1.11.0
 revision=1
 build_style=gnu-makefile
 make_check_target=test
@@ -18,11 +18,18 @@ license="BSD-3-Clause"
 homepage="https://dunst-project.org"
 changelog="https://raw.githubusercontent.com/dunst-project/dunst/master/CHANGELOG.md"
 distfiles="https://github.com/dunst-project/dunst/archive/v${version}.tar.gz"
-checksum=d1fbeba329b3801b931ad804f1fadd96a36be5edf2e49c8e30f081443079759f
+checksum=31c0eb749ca83dab7f5af33beb951c9f9a8451263fcee6cbcf8ba3dedbf2e1f1
 
 build_options="wayland"
 build_options_default="wayland"
 
 post_install() {
 	vlicense LICENSE
+	vcompletion completions/dunst.bashcomp bash
+	vcompletion completions/dunstctl.bashcomp bash
+	vcompletion completions/dunst.fishcomp fish
+	vcompletion completions/dunstctl.fishcomp fish
+	vcompletion completions/dunstify.fishcomp fish
+	vcompletion completions/_dunst.zshcomp zsh
+	vcompletion completions/_dunstctl.zshcomp zsh
 }


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

As [completions are considered official](https://github.com/dunst-project/dunst/releases/tag/v1.11.0) now, they are included in the install process.

#### Local build testing
- I built this PR locally for my native architecture: x86_64-libc
- I built this PR locally for these architectures:
  - armv7l (crossbuild)