### PR TITLE
gtk4: fix grabbing X11 check window before 15s after boot

### DIFF
--- a/srcpkgs/gtk4/patches/wmspec.patch
+++ b/srcpkgs/gtk4/patches/wmspec.patch
@@ -1,0 +1,85 @@
+From ab33b56ec95b1867cc44808d60caddaf67887ba7 Mon Sep 17 00:00:00 2001
+From: oreo639 <oreo6391@gmail.com>
+Date: Tue, 16 Apr 2024 12:35:00 -0700
+Subject: [PATCH] x11: Remove last_wmspec_check_time
+
+In fetch_net_wm_check_window(), before updating the wmspec_check_window, a
+check is performed to verify a 15s difference between last_wmspec_check_time
+and the current monotonic time.
+
+The comment suggests that this check is done to ensure that it doesn't check
+for a new check window repeatedly over and over again. While that was the case
+origionally, currently the last_wmspec_check_time only gets updated when
+wmspec_check_window is set, which is already checked earlier, making the time
+check useless.
+
+This check causes issues on cold boots where gtk4 applications are not able
+to obtain the wmspec_check_window until 15 seconds after boot, making gtk
+unable to check for extended wm_hints during that time.
+
+Fixes: #6558
+---
+ gdk/x11/gdkdisplay-x11.c | 1 -
+ gdk/x11/gdkscreen-x11.c  | 7 -------
+ gdk/x11/gdkscreen-x11.h  | 1 -
+ 3 files changed, 9 deletions(-)
+
+diff --git a/gdk/x11/gdkdisplay-x11.c b/gdk/x11/gdkdisplay-x11.c
+index efd5107c52d..4e24acc33bb 100644
+--- a/gdk/x11/gdkdisplay-x11.c
++++ b/gdk/x11/gdkdisplay-x11.c
+@@ -665,7 +665,6 @@ gdk_x11_display_translate_event (GdkEventTranslator *translator,
+       if (x11_screen->wmspec_check_window == xevent->xdestroywindow.window)
+         {
+           x11_screen->wmspec_check_window = None;
+-          x11_screen->last_wmspec_check_time = 0;
+           g_free (x11_screen->window_manager_name);
+           x11_screen->window_manager_name = g_strdup ("unknown");
+ 
+diff --git a/gdk/x11/gdkscreen-x11.c b/gdk/x11/gdkscreen-x11.c
+index 2456f14b29d..c0584b2d591 100644
+--- a/gdk/x11/gdkscreen-x11.c
++++ b/gdk/x11/gdkscreen-x11.c
+@@ -1145,7 +1145,6 @@ fetch_net_wm_check_window (GdkX11Screen *x11_screen)
+ {
+   GdkDisplay *display;
+   Window window;
+-  guint64 now;
+   int error;
+ 
+   display = x11_screen->display;
+@@ -1155,11 +1154,6 @@ fetch_net_wm_check_window (GdkX11Screen *x11_screen)
+   if (x11_screen->wmspec_check_window != None)
+     return; /* already have it */
+ 
+-  now = g_get_monotonic_time ();
+-
+-  if ((now - x11_screen->last_wmspec_check_time) / 1e6 < 15)
+-    return; /* we've checked recently */
+-
+   window = get_net_supporting_wm_check (x11_screen, x11_screen->xroot_window);
+   if (window == None)
+     return;
+@@ -1184,7 +1178,6 @@ fetch_net_wm_check_window (GdkX11Screen *x11_screen)
+         return;
+ 
+       x11_screen->wmspec_check_window = window;
+-      x11_screen->last_wmspec_check_time = now;
+       x11_screen->need_refetch_net_supported = TRUE;
+       x11_screen->need_refetch_wm_name = TRUE;
+ 
+diff --git a/gdk/x11/gdkscreen-x11.h b/gdk/x11/gdkscreen-x11.h
+index d3775b23e51..bfd014997ba 100644
+--- a/gdk/x11/gdkscreen-x11.h
++++ b/gdk/x11/gdkscreen-x11.h
+@@ -48,7 +48,6 @@ struct _GdkX11Screen
+   int xft_dpi;
+ 
+   /* Window manager */
+-  gint64 last_wmspec_check_time;
+   Window wmspec_check_window;
+   char *window_manager_name;
+ 
+-- 
+GitLab
+

--- a/srcpkgs/gtk4/template
+++ b/srcpkgs/gtk4/template
@@ -1,7 +1,7 @@
 # Template file for 'gtk4'
 pkgname=gtk4
 version=4.14.2
-revision=2
+revision=3
 build_style=meson
 build_helper="gir"
 configure_args="-Dman-pages=true -Ddocumentation=true -Dbuild-tests=false


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

Fixes: #49575

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
