### PR TITLE
common: support disabling python shebang rewriting

### DIFF
--- a/Manual.md
+++ b/Manual.md
@@ -1250,7 +1250,7 @@ package accordingly. Additionally, the following functions are available:
 - *vopt_feature()* `vopt_feature <option> <property>`
 
   Same as `vopt_bool`, but uses `-D<property=enabled` and
-	`-D<property>=disabled` respectively. 
+	`-D<property>=disabled` respectively.
 
 The following example shows how to change a source package that uses GNU
 configure to enable a new build option to support PNG images:
@@ -1630,6 +1630,8 @@ In most cases version is inferred from shebang, install path or build style.
 Only required for some multi-language
 applications (e.g., the application is written in C while the command is
 written in Python) or just single Python file ones that live in `/usr/bin`.
+If `python_version` is set to `ignore`, python-containing shebangs will not be rewritten.
+Use this only if a package should not be using a system version of python.
 
 Also, a set of useful variables are defined to use in the templates:
 

--- a/common/hooks/post-install/04-create-xbps-metadata-scripts.sh
+++ b/common/hooks/post-install/04-create-xbps-metadata-scripts.sh
@@ -272,7 +272,7 @@ _EOF
 		fi
 	fi
 
-	if [ -n "$python_version" ]; then
+	if [ -n "$python_version" ] && [ "$python_version" != ignore ]; then
 		pycompile_version=${python_version}
 	fi
 

--- a/common/hooks/pre-pkg/03-rewrite-python-shebang.sh
+++ b/common/hooks/pre-pkg/03-rewrite-python-shebang.sh
@@ -12,6 +12,10 @@ hook() {
 		pyver="$python_version"
 	fi
 
+	if [ "$python_version" = ignore ]; then
+		return
+	fi
+
 	if [ -n "$pyver" ]; then
 		default_shebang="#!/usr/bin/python${pyver%.*}"
 	fi

--- a/srcpkgs/ghidra/template
+++ b/srcpkgs/ghidra/template
@@ -1,7 +1,7 @@
 # Template file for 'ghidra'
 pkgname=ghidra
 version=11.0.3
-revision=1
+revision=2
 _dex_ver=2.1
 _yajsw_ver=13.09
 archs="x86_64* aarch64*"
@@ -69,7 +69,7 @@ skiprdeps="/usr/libexec/ghidra/docs/GhidraClass/ExerciseFiles/Advanced/animals
  /usr/libexec/ghidra/docs/GhidraClass/ExerciseFiles/Advanced/sharedReturn
  /usr/libexec/ghidra/docs/GhidraClass/ExerciseFiles/Advanced/switch
  /usr/libexec/ghidra/docs/GhidraClass/ExerciseFiles/Advanced/write"
-python_version=2 # Jython 2.7.2 stuff
+python_version=ignore # jython, not system python 2
 nocross=yes
 
 post_extract() {


### PR DESCRIPTION
Ghidra's embedded jython contains scripts with shebangs like `#!/usr/bin/env python`. These seem to be designed to be run by jython, *not* the system python, and as such, they should not have their shebangs changed to `#!/usr/bin/python2`. This adds support for disabling that hook in cases like this.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

