### PR TITLE
atop: update to 2.10.0.

### DIFF
--- a/srcpkgs/atop/template
+++ b/srcpkgs/atop/template
@@ -1,16 +1,18 @@
 # Template file for 'atop'
 pkgname=atop
-version=2.9.0
+version=2.10.0
 revision=1
 build_style=gnu-makefile
 make_install_target="sysvinstall"
-makedepends="ncurses-devel zlib-devel"
+make_use_env=true
+hostmakedepends="pkg-config"
+makedepends="ncurses-devel zlib-devel libglib-devel"
 short_desc="System and process level monitor"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="https://www.atoptool.nl/"
 distfiles="https://www.atoptool.nl/download/atop-${version}.tar.gz"
-checksum=bc355ebd7af3f9c6f01be2ff50e581622d24f5ea0d8d5f3366e2fd1311ab98f8
+checksum=e7a673cf2c82578e7dd82ecb0dec83fd9ecb30828b2561c28a9fa5aaf75d5f93
 
 make_dirs="/var/log/atop 755 root root"
 


### PR DESCRIPTION
- I tested the changes in this PR: **YES**
- I built this PR locally for my native architecture, (x86-64-glibc)
- I built this PR locally for these architectures:
  - x86-64-musl
  - aarch64-musl
