### PR TITLE
inkscape: do not detect dev releases as updates

### DIFF
--- a/srcpkgs/inkscape/update
+++ b/srcpkgs/inkscape/update
@@ -1,2 +1,2 @@
 site="https://inkscape.org/release/"
-pattern='href="/release/inkscape-\K[0-9.]+'
+pattern='<link rel="alternate" hreflang="en" href="https:\/\/inkscape\.org\/release\/inkscape-\K[\d.]+(?=\/">)'


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

Inkscape download page changed again so that update version links have now the same format as release ones; this detects the version based on a different feature of the page.

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
