### PR TITLE
hunspell-fr_FR: fix homepage and distfiles location

### DIFF
--- a/srcpkgs/hunspell-fr_FR/template
+++ b/srcpkgs/hunspell-fr_FR/template
@@ -1,14 +1,14 @@
 # Template file for 'hunspell-fr_FR'
 pkgname=hunspell-fr_FR
 version=7.0
-revision=6
+revision=7
+build_wrksrc="dictionaries"
 short_desc="French dictionary for hunspell"
 maintainer="Leah Neukirchen <leah@vuxu.org>"
 license="MPL-1.1"
-homepage="http://www.dicollecte.org/home.php?prj=fr"
-distfiles="http://www.dicollecte.org/download/fr/hunspell-french-dictionaries-v${version}.zip"
-distfiles="https://sources.voidlinux.org/hunspell-fr_FR-${version}/hunspell-french-dictionaries-v${version}.zip"
-checksum=eb7ac36dc14b9c3e3c0cabae0f90304a137da8e6ae607bcaf56d65720fbd097f
+homepage="https://grammalecte.net/"
+distfiles="https://grammalecte.net/oxt/lo-oo-ressources-linguistiques-fr-v${version}.oxt>linguistiques-fr-v${version}.zip"
+checksum=e8a352abd550bfd773b09d6631e96af3dbcfefecc9b50d3b7bb6094e429cc64b
 provides="hunspell-fr-libreoffice-24.2.2.2_2"
 replaces="hunspell-fr-libreoffice>=0"
 
@@ -77,7 +77,7 @@ hunspell-fr_FR-reforme1990_package() {
 	replaces="${sourcepkg}>=0"
 	pkg_install() {
 		_vinstall_variant reforme1990
-		vdoc ${wrksrc}/README_dict_fr.txt
+		vdoc README_dict_fr.txt
 	}
 }
 
@@ -90,6 +90,6 @@ hunspell-fr_FR-toutesvariantes_package() {
 	replaces="${sourcepkg}>=0"
 	pkg_install() {
 		_vinstall_variant toutesvariantes
-		vdoc ${wrksrc}/README_dict_fr.txt
+		vdoc README_dict_fr.txt
 	}
 }


### PR DESCRIPTION
discollete.org used to be the domain for Grammalecte, they moved to the grammalecte.net domain in 2019, and discollete.org became a redirect. Currently the domain is just spam.

The dictionary files in the 7.0 libreoffice plugin are identical to the ones in the old zip.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
