### PR TITLE
gcr: update to 3.41.2, gcr4: update to 4.3.0

### DIFF
--- a/srcpkgs/gcr/patches/Fix-FTBFS-on-x32.patch
+++ b/srcpkgs/gcr/patches/Fix-FTBFS-on-x32.patch
@@ -1,0 +1,41 @@
+From: Laurent Bigonville <bigon@debian.org>
+Date: Sun, 19 Mar 2023 12:15:50 +0100
+Subject: Fix FTBFS on x32
+
+This patch is inspired from Simon proposal on the upstream bug:
+https://gitlab.gnome.org/GNOME/gcr/-/issues/45
+---
+ egg/egg-asn1x.c | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/egg/egg-asn1x.c b/egg/egg-asn1x.c
+index b7d9d11..63e6b16 100644
+--- a/egg/egg-asn1x.c
++++ b/egg/egg-asn1x.c
+@@ -2213,7 +2213,7 @@ anode_read_time (GNode *node,
+ 		return anode_failure (node, "invalid time content");
+ 
+ 	/* In order to work with 32 bit time_t. */
+-	if (sizeof (time_t) <= 4 && when->tm_year >= 138) {
++	if ((sizeof (time_t) <= 4 || sizeof (glong) <= 4) && when->tm_year >= 138) {
+ 		*value = (time_t)2145914603;  /* 2037-12-31 23:23:23 */
+ 
+ 	/* Convert to seconds since epoch */
+@@ -4740,7 +4740,7 @@ egg_asn1x_parse_time_general (const gchar *time, gssize n_time)
+ 		return -1;
+ 
+ 	/* In order to work with 32 bit time_t. */
+-	if (sizeof (time_t) <= 4 && when.tm_year >= 138) {
++	if ((sizeof (time_t) <= 4 || sizeof (glong) <= 4) && when.tm_year >= 138) {
+ 		value = (time_t)2145914603;  /* 2037-12-31 23:23:23 */
+ 
+ 	/* Convert to seconds since epoch */
+@@ -4771,7 +4771,7 @@ egg_asn1x_parse_time_utc (const gchar *time, gssize n_time)
+ 		return -1;
+ 
+ 	/* In order to work with 32 bit time_t. */
+-	if (sizeof (time_t) <= 4 && when.tm_year >= 138) {
++	if ((sizeof (time_t) <= 4 || sizeof (glong) <= 4) && when.tm_year >= 138) {
+ 		value = (time_t)2145914603;  /* 2037-12-31 23:23:23 */
+ 
+ 	/* Convert to seconds since epoch */

--- a/srcpkgs/gcr/template
+++ b/srcpkgs/gcr/template
@@ -1,10 +1,11 @@
 # Template file for 'gcr'
 pkgname=gcr
-version=3.41.1
+version=3.41.2
 revision=1
 build_style=meson
 build_helper="gir"
-configure_args="$(vopt_bool gir introspection) $(vopt_bool gir gtk_doc)"
+configure_args="$(vopt_bool gir introspection) $(vopt_bool gir gtk_doc)
+ -Dssh_agent=false"
 hostmakedepends="gettext glib-devel gnupg gi-docgen gettext pkg-config openssh
  libxslt $(vopt_if gir vala)"
 makedepends="gtk+3-devel libgcrypt-devel libsecret-devel p11-kit-devel libxslt-devel"
@@ -14,8 +15,9 @@ short_desc="GNOME crypto package"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="LGPL-2.0-or-later, LGPL-2.1-or-later, GPL-2.0-or-later"
 homepage="https://gitlab.gnome.org/GNOME/gcr"
+changelog="https://gitlab.gnome.org/GNOME/gcr/-/raw/gcr-3-41/NEWS"
 distfiles="${GNOME_SITE}/gcr/${version%.*}/gcr-${version}.tar.xz"
-checksum=bb7128a3c2febbfee9c03b90d77d498d0ceb237b0789802d60185c71c4bea24f
+checksum=bad10f3c553a0e1854649ab59c5b2434da22ca1a54ae6138f1f53961567e1ab7
 make_check_pre="dbus-run-session"
 make_check=no # Gcr:ERROR:../gcr/test-gnupg-collection.c:203:test_load: assertion failed: (record)
 

--- a/srcpkgs/gcr4/template
+++ b/srcpkgs/gcr4/template
@@ -1,6 +1,6 @@
 # Template file for 'gcr4'
 pkgname=gcr4
-version=4.2.1
+version=4.3.0
 revision=1
 build_style=meson
 build_helper="gir"
@@ -16,7 +16,7 @@ license="LGPL-2.0-or-later, LGPL-2.1-or-later, GPL-2.0-or-later"
 homepage="https://gitlab.gnome.org/GNOME/gcr"
 changelog="https://gitlab.gnome.org/GNOME/gcr/-/raw/master/NEWS"
 distfiles="${GNOME_SITE}/gcr/${version%.*}/gcr-${version}.tar.xz"
-checksum=ed783b5c80373cd058c02ea9e3e2a64e558599ca190a5abd598122e479967de5
+checksum=c3ee8728e4364b0397f435fa20f92f901ab139d2b264f4e059d67b3c0f43cd36
 make_check_pre="dbus-run-session"
 # secure memory tests fail
 make_check=no
@@ -24,10 +24,6 @@ make_check=no
 # Package build options
 build_options="gir"
 build_options_default="gir"
-
-post_install() {
-	rm ${DESTDIR}/usr/libexec/gcr-ssh-agent
-}
 
 gcr4-devel_package() {
 	depends="${makedepends} ${sourcepkg}>=${version}_${revision}"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)

p.s. all tests pass locally.  tests below fail in ci

**x86_64, i686**
`22/47 gcr:gck / object                  FAIL            0.16s   killed by signal 11 SIGSEGV`
**x86_64-musl**
`43/47 gcr:gcr-base / gnupg-collection   FAIL            0.17s   killed by signal 6 SIGABRT`
