### PR TITLE
folks: update to 0.15.9

### DIFF
--- a/srcpkgs/folks/template
+++ b/srcpkgs/folks/template
@@ -1,6 +1,6 @@
 # Template file for 'folks'
 pkgname=folks
-version=0.15.8
+version=0.15.9
 revision=1
 build_style=meson
 build_helper="gir"
@@ -17,8 +17,11 @@ license="LGPL-2.1-or-later"
 homepage="https://wiki.gnome.org/Projects/Folks"
 changelog="https://gitlab.gnome.org/GNOME/folks/-/raw/master/NEWS"
 distfiles="${GNOME_SITE}/folks/${version%.*}/folks-${version}.tar.xz"
-checksum=954a6afb3e378f01d310fd443790f235cb0eb71e2139cff4f05f09ab725e49c2
+checksum=2311b37355c351f33f163fdc394874a22a0a0682c319493d6d8a6e420711415f
 make_check_pre="dbus-run-session"
+# FIXME: test failures with glib 2.80
+# https://gitlab.gnome.org/GNOME/folks/-/issues/140
+make_check=no
 
 # disable parallelism to fix some failing tests in the ci
 export MESON_TESTTHREADS=1


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)

I had to disable tests for now,  because they fail with glib-2.80. see [here](https://gitlab.gnome.org/GNOME/folks/-/issues/140)