### PR TITLE
gnome-text-editor: update to 46.1

### DIFF
--- a/srcpkgs/gnome-text-editor/template
+++ b/srcpkgs/gnome-text-editor/template
@@ -1,6 +1,6 @@
 # Template file for 'gnome-text-editor'
 pkgname=gnome-text-editor
-version=45.3
+version=46.1
 revision=1
 build_style=meson
 hostmakedepends="pkg-config gettext itstool glib-devel
@@ -14,4 +14,4 @@ homepage="https://gitlab.gnome.org/GNOME/gnome-text-editor"
 #changelog="https://gitlab.gnome.org/GNOME/gnome-text-editor/-/raw/gnome-45/NEWS"
 changelog="https://gitlab.gnome.org/GNOME/gnome-text-editor/-/raw/main/NEWS"
 distfiles="${GNOME_SITE}/gnome-text-editor/${version%.*}/gnome-text-editor-$version.tar.xz"
-checksum=f3ffcb11a92dfd04ba3c3b3d0e667847d4449a21e012ae36f07dda05ac7d3a52
+checksum=8ebfa0bea12e75f5efeacc721be3b8ae65027b024aa81db9ecab8c312257a2eb


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)
