### PR TITLE
flatpak: update to 1.15.8

### DIFF
--- a/srcpkgs/flatpak/template
+++ b/srcpkgs/flatpak/template
@@ -1,6 +1,6 @@
 # Template file for 'flatpak'
 pkgname=flatpak
-version=1.15.7
+version=1.15.8
 revision=1
 build_style=meson
 build_helper="gir"
@@ -26,7 +26,7 @@ license="LGPL-2.1-or-later"
 homepage="https://flatpak.org/"
 changelog="https://github.com/flatpak/flatpak/raw/main/NEWS"
 distfiles="https://github.com/flatpak/flatpak/releases/download/${version}/flatpak-${version}.tar.xz"
-checksum=064089b4347aa9691e95fcd9bbe6729e038bff1eaec57fff954b58777d8c3875
+checksum=e89bcf42fd1eb0fadf14c8b5845bc31cb78a2624f3bdc9bcdd007cc75022e4d3
 
 build_options="gir"
 build_options_default="gir"


### PR DESCRIPTION
@Duncaen 

1.15.8 fixes [CVE-2024-32462](https://www.openwall.com/lists/oss-security/2024/04/18/5)

#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, (x86-64)
