### PR TITLE
ostree: build with soup3 instead of soup2

### DIFF
--- a/srcpkgs/ostree/template
+++ b/srcpkgs/ostree/template
@@ -12,7 +12,7 @@ configure_args="
  $(vopt_enable gir introspection)"
 hostmakedepends="bison docbook-xsl glib-devel libxslt pkg-config"
 makedepends="e2fsprogs-devel fuse-devel glib-devel gpgme-devel libarchive-devel
- libcurl-devel libsoup-devel libsodium-devel $(vopt_if gir 'gobject-introspection')"
+ libcurl-devel libsoup3-devel libsodium-devel $(vopt_if gir 'gobject-introspection')"
 checkdepends="attr-progs cpio elfutils gnupg python3-yaml tar which xz"
 short_desc="Operating system and container binary deployment and upgrades"
 maintainer="Duncaen <duncaen@voidlinux.org>"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

soup is only really required for tests since curl is the default backend when enabled, but soup2 isn't necessary anymore.

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
