### PR TITLE
podman: update to 5.0.2.

### DIFF
--- a/srcpkgs/podman/template
+++ b/srcpkgs/podman/template
@@ -1,12 +1,12 @@
 # Template file for 'podman'
 pkgname=podman
-version=4.9.3
+version=5.0.2
 revision=1
 build_style=go
-go_import_path="github.com/containers/podman/v4"
+go_import_path="github.com/containers/podman/v5"
 go_package="${go_import_path}/cmd/podman ${go_import_path}/cmd/rootlessport"
 go_build_tags="seccomp apparmor containers_image_ostree_stub"
-hostmakedepends="pkg-config go-md2man python3"
+hostmakedepends="pkg-config go-md2man python3 mdocml"
 makedepends="gpgme-devel libseccomp-devel device-mapper-devel libbtrfs-devel"
 depends="runc conmon cni-plugins slirp4netns fuse-overlayfs
  containers-common containers.image containers.storage"
@@ -16,14 +16,24 @@ license="Apache-2.0"
 homepage="https://podman.io/"
 changelog="https://raw.githubusercontent.com/containers/podman/main/RELEASE_NOTES.md"
 distfiles="https://github.com/containers/podman/archive/v${version}.tar.gz"
-checksum=37afc5bba2738c68dc24400893b99226c658cc9a2b22309f4d7abe7225d8c437
+checksum=85c3f70a1c293ccf48907d8e9fe13c6c9aac67242525a539296beeef31ba11a8
 
 if [ "$CROSS_BUILD" ]; then
 	go_build_tags+=" containers_image_openpgp"
 fi
 
+case $XBPS_TARGET_MACHINE in
+	aarch64* | x86_64*) ;;
+	*) make_check="no" ;; # Upstream only supports tests on aarch64 and x86_64
+esac
+
 post_build() {
 	make docs
+}
+
+do_check() {
+	make .install.ginkgo
+	make localunit
 }
 
 post_install() {


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86\_64-glibc)

Tested locally with an nginx image (plus netavark and passt).

The tests failed locally for me when compiling for i686, but passed for
x86\_64-glibc and x86\_64-musl
