### PR TITLE
gnome-connections: update to 46.0.

### DIFF
--- a/srcpkgs/gnome-connections/template
+++ b/srcpkgs/gnome-connections/template
@@ -1,16 +1,17 @@
 # Template file for 'gnome-connections'
 pkgname=gnome-connections
-version=44.0
+version=46.0
 revision=1
 build_style=meson
 build_helper="gir"
 hostmakedepends="pkg-config gettext itstool vala desktop-file-utils glib-devel"
 makedepends="gtk+3-devel libhandy1-devel gtk-vnc-devel libgcrypt-devel
- gnutls-devel libsasl-devel libsecret-devel freerdp-devel"
+ gnutls-devel libsasl-devel libsecret-devel freerdp-devel fuse3-devel"
 short_desc="Remote desktop client for the GNOME desktop environment"
 maintainer="oreo6391 <oreo6391@gmail.com>"
 license="GPL-3.0-or-later"
 homepage="https://gitlab.gnome.org/GNOME/connections/"
-changelog="https://gitlab.gnome.org/GNOME/connections/-/raw/gnome-44/NEWS"
+#changelog="https://gitlab.gnome.org/GNOME/connections/-/raw/master/NEWS"
+changelog="https://gitlab.gnome.org/GNOME/connections/-/raw/gnome-46/NEWS"
 distfiles="${GNOME_SITE}/gnome-connections/${version%.*}/gnome-connections-${version}.tar.xz"
-checksum=34c7a6bbfec9a9acfa9c2d2dba4b251431cd71874f8f055c5ff26f26f4244199
+checksum=fb1cea68e7930bbdc1db28b7cd0a9a37cd310d4b4e7872fe814f50a16a8d25d3


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)

Note: this might also depend on https://github.com/void-linux/void-packages/pull/49572 in the future, similar to `gnome-remote-desktop>=46.0`
For now, build and runtime works fine with `freerdp<=3.0.0`