### PR TITLE
inkscape: drop libsoup requirement

### DIFF
--- a/srcpkgs/inkscape/template
+++ b/srcpkgs/inkscape/template
@@ -8,7 +8,7 @@ hostmakedepends="automake gettext glib-devel intltool libgraphicsmagick-devel
  libtool perl-XML-Parser pkg-config which python3-Cython ragel"
 makedepends="aspell-devel cairomm-devel double-conversion-devel gc-devel
  gdl-devel gsl-devel gspell-devel gtkmm-devel gtkspell3-devel harfbuzz-devel
- hunspell-devel libatomic_ops-devel libcdr-devel libgomp-devel libsoup-devel
+ hunspell-devel libatomic_ops-devel libcdr-devel libgomp-devel
  libvisio-devel libwpd-devel libwpd-devel libwpg-devel libxslt-devel pango-devel
  poppler-devel poppler-glib-devel potrace-devel gtest-devel gtksourceview4-devel
  boost-devel lib2geom-devel popt-devel readline-devel libxml2-devel"
@@ -39,6 +39,9 @@ post_patch() {
 	fi
 	# disable glyph tests that fail due to different hinting
 	vsed -e \
-		"s/add_subdirectory(rendering_tests)/# \0 - skipped due to hinting issues/" \
-		-i testfiles//CMakeLists.txt
+		"s/add_subdirectory(rendering_tests)/# & - skipped due to hinting issues/" \
+		-i testfiles/CMakeLists.txt
+	# https://gitlab.com/inkscape/inkscape/-/commit/73c83ef9b8dc3e3dfd0fe24c75356623e7390ebd
+	: >src/io/http.cpp 2>src/io/http.h
+	vsed -i '/libsoup-2.4/d' CMakeScripts/DefineDependsandFlags.cmake
 }


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**|**briefly**|**NO**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
