### PR TITLE
strongswan: disable libsoup

### DIFF
--- a/srcpkgs/strongswan/template
+++ b/srcpkgs/strongswan/template
@@ -1,16 +1,16 @@
 # Template file for 'strongswan'
 pkgname=strongswan
 version=5.9.13
-revision=1
+revision=2
 build_style=gnu-configure
 # tpm support waits on libtss2
 configure_args="--disable-static --enable-blowfish --enable-curl --enable-md4
  --enable-openssl --enable-eap-radius --enable-eap-mschapv2 --enable-eap-md5
  --enable-eap-identity --enable-eap-dynamic --enable-led --enable-ha --enable-dhcp
- --enable-mediation --enable-soup --disable-des --enable-chapoly --enable-nm
+ --enable-mediation --disable-soup --disable-des --enable-chapoly --enable-nm
  --enable-pkcs11"
 hostmakedepends="pkg-config flex bison python3"
-makedepends="gmp-devel libsoup-devel libldns-devel unbound-devel libcurl-devel
+makedepends="gmp-devel libldns-devel unbound-devel libcurl-devel
  NetworkManager-devel openssl-devel"
 depends="iproute2 sqlite"
 conf_files="/etc/*.conf /etc/strongswan.d/*.conf /etc/strongswan.d/charon/*.conf /etc/ipsec.secrets"


### PR DESCRIPTION
libsoup is used for soup-fetcher, but strongswan has another fetcher, which is curl-fetcher.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **NO**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
