### PR TITLE
certbot: update to 2.10.0

### DIFF
--- a/srcpkgs/certbot-apache/template
+++ b/srcpkgs/certbot-apache/template
@@ -1,6 +1,6 @@
 # Template file for 'certbot-apache'
 pkgname=certbot-apache
-version=2.7.4
+version=2.10.0
 revision=1
 build_style=python3-pep517
 hostmakedepends="python3-poetry-core python3-setuptools python3-wheel"
@@ -11,4 +11,4 @@ maintainer="Kartik S. <kartik.ynwa@gmail.com>"
 license="Apache-2.0"
 homepage="https://certbot.eff.org/"
 distfiles="${PYPI_SITE}/c/certbot-apache/certbot-apache-${version}.tar.gz"
-checksum=6ff21ae1ca61d9f5546de6e6c7d155d4e24f50b5894a2f1323547694cbb64422
+checksum=c7a46ff67eac2834a3e3b975e7a1d1bc7a7be889f51c2cdc87825abd5ccc825a

--- a/srcpkgs/certbot-nginx/template
+++ b/srcpkgs/certbot-nginx/template
@@ -1,6 +1,6 @@
 # Template file for 'certbot-nginx'
 pkgname=certbot-nginx
-version=2.7.4
+version=2.10.0
 revision=1
 build_style=python3-pep517
 hostmakedepends="python3-poetry-core python3-setuptools python3-wheel"
@@ -11,4 +11,4 @@ maintainer="Kartik Singh <kartik.ynwa@gmail.com>"
 license="Apache-2.0"
 homepage="https://certbot.eff.org/"
 distfiles="${PYPI_SITE}/c/certbot-nginx/certbot-nginx-${version}.tar.gz"
-checksum=bfaf0daa6128de2386c1af91e2ec6fa46095d67a7787b8884f075f67f1cc9b54
+checksum=9add7e8b7005fe6d8405cb74fd868d4b3689a572957a9112d654a5ac1e7f4d91

--- a/srcpkgs/certbot/template
+++ b/srcpkgs/certbot/template
@@ -1,6 +1,6 @@
 # Template file for 'certbot'
 pkgname=certbot
-version=2.7.4
+version=2.10.0
 revision=1
 build_style=python3-pep517
 hostmakedepends="python3-poetry-core python3-setuptools python3-wheel"
@@ -15,4 +15,4 @@ maintainer="Alex Childs <misuchiru03+void@gmail.com>"
 license="Apache-2.0"
 homepage="https://certbot.eff.org/"
 distfiles="${PYPI_SITE}/c/certbot/certbot-${version}.tar.gz"
-checksum=173778fef4e2e3014f60be02d4798dff7ea32790277b90b3c7249c5d46d17c75
+checksum=892aa57d4db74af174aec5e4bb7f7537b200de2545a066c049d03a53215f0e4e


### PR DESCRIPTION
- I tested the changes in this PR: **briefly**

- I built this PR locally for my native architecture, (x86-64 GLIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l