### PR TITLE
singular: update to 4.4.0.

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -4038,10 +4038,10 @@ libecl.so.23.9 ecl-23.9.9_1
 libecm.so.1 ecm-7.0.4_3
 libcliquer.so.1 cliquer-1.22_1
 libomalloc-0.9.6.so singular-4.2.1_1
-libSingular-4.3.2.so singular-4.3.2_1
-libfactory-4.3.2.so singular-4.3.2_1
-libpolys-4.3.2.so singular-4.3.2_1
-libsingular_resources-4.3.2.so singular-4.3.2_1
+libSingular-4.4.0.so singular-4.4.0_1
+libfactory-4.4.0.so singular-4.4.0_1
+libpolys-4.4.0.so singular-4.4.0_1
+libsingular_resources-4.4.0.so singular-4.4.0_1
 libbrial.so.3 brial-1.2.10_1
 libbrial_groebner.so.3 brial-1.2.10_1
 libm4ri-0.0.20200125.so m4ri-20200125_1

--- a/srcpkgs/sagemath/patches/37763-scipy_1.13.patch
+++ b/srcpkgs/sagemath/patches/37763-scipy_1.13.patch
@@ -1,0 +1,13 @@
+diff --git a/src/sage/matrix/matrix_double_dense.pyx b/src/sage/matrix/matrix_double_dense.pyx
+index 6877a924de2..a01defad999 100644
+--- a/src/sage/matrix/matrix_double_dense.pyx
++++ b/src/sage/matrix/matrix_double_dense.pyx
+@@ -3683,7 +3683,7 @@ cdef class Matrix_double_dense(Matrix_numpy_dense):
+             sage: A = matrix(CDF, 2, [1,2+I,3*I,4]); A                                  # needs sage.symbolic
+             [        1.0 2.0 + 1.0*I]
+             [      3.0*I         4.0]
+-            sage: A.exp()  # tol 1.1e-14                                                # needs sage.symbolic
++            sage: A.exp()  # tol 3e-14                                                  # needs sage.symbolic
+             [-19.614602953804912 + 12.517743846762578*I   3.7949636449582176 + 28.88379930658099*I]
+             [ -32.383580980922254 + 21.88423595789845*I   2.269633004093535 + 44.901324827684824*I]
+ 

--- a/srcpkgs/sagemath/patches/get_patches
+++ b/srcpkgs/sagemath/patches/get_patches
@@ -22,3 +22,4 @@ cd $(dirname "$0")
 
 # needs review
 get_pr 37492 "singular 4.3.2p16"
+get_pr 37763 "scipy 1.13"

--- a/srcpkgs/sagemath/template
+++ b/srcpkgs/sagemath/template
@@ -1,7 +1,7 @@
 # Template file for 'sagemath'
 pkgname=sagemath
 version=10.3
-revision=1
+revision=2
 build_wrksrc=pkgs/sagemath-standard
 build_style=python3-pep517
 make_build_args="--skip-dependency-check"

--- a/srcpkgs/singular/template
+++ b/srcpkgs/singular/template
@@ -1,6 +1,6 @@
 # Template file for 'singular'
 pkgname=singular
-version=4.3.2p16
+version=4.4.0
 revision=1
 _majver=${version%p*}
 build_style=gnu-configure
@@ -20,7 +20,7 @@ maintainer="dkwo <npiazza@disroot.org>, Gonzalo Tornaría <tornaria@cmat.edu.uy>
 license="GPL-2.0-or-later"
 homepage="https://www.singular.uni-kl.de"
 distfiles="https://www.singular.uni-kl.de/ftp/pub/Math/Singular/SOURCES/${_majver//./-}/singular-${version}.tar.gz"
-checksum=675733ba13a6ec67c564e753139f7c0c4b0d3e29bdb995de5341b616f1472a16
+checksum=c269abbd24c84fe33edc0af1e78b8fec53d8e94338410ac06c2666cfd40d43f2
 
 if [ -z "$CROSS_BUILD" ]; then
 	makedepends+=" ntl-devel"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

This needed bumping sagemath, so its testsuite is fully run here for a good test that singular works fine for us. One test fails due to the update of scipy to 1.13, so I added an easy fix (backported, already merged upstream).

@dkwo may want to test on aarch64.

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
