### PR TITLE
gnome-calendar: update to 46.1.

### DIFF
--- a/srcpkgs/gnome-calendar/template
+++ b/srcpkgs/gnome-calendar/template
@@ -1,7 +1,7 @@
 # Template file for 'gnome-calendar'
 pkgname=gnome-calendar
-version=46.0
-revision=2
+version=46.1
+revision=1
 build_style=meson
 hostmakedepends="gettext glib-devel pkg-config gtk4-update-icon-cache
  $(vopt_if gir 'gobject-introspection')"
@@ -15,7 +15,7 @@ homepage="https://wiki.gnome.org/Apps/Calendar"
 #changelog="https://gitlab.gnome.org/GNOME/gnome-calendar/-/raw/gnome-46/NEWS"
 changelog="https://gitlab.gnome.org/GNOME/gnome-calendar/-/raw/main/NEWS"
 distfiles="${GNOME_SITE}/gnome-calendar/${version%.*}/gnome-calendar-${version}.tar.xz"
-checksum=5e21960c174bd8606d9089bf79c70f31070ab4837919878b00db2f14af9fe718
+checksum=9861ff7b8abd5b7b20690ba55eb7542c7ec534b566269e29b5b1e858c1610897
 
 build_options="gir"
 build_options_default="gir"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)

