### PR TITLE
python3-peewee: update to 3.17.3.

### DIFF
--- a/srcpkgs/python3-peewee/template
+++ b/srcpkgs/python3-peewee/template
@@ -2,8 +2,8 @@
 pkgname=python3-peewee
 version=3.17.3
 revision=1
-build_style=python3-module
-hostmakedepends="python3-setuptools python3-Cython0.29"
+build_style=python3-pep517
+hostmakedepends="python3-setuptools python3-wheel python3-Cython0.29"
 makedepends="python3-devel sqlite-devel"
 depends="python3"
 short_desc="Small and simple ORM for Python3"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

This gets rid of the following warnings upon install:

```
usr/lib/python3.12/site-packages/playhouse/migrate.py:673: SyntaxWarning: invalid escape sequence '\('
  column_re = re.compile('(.+?)\((.+)\)')
usr/lib/python3.12/site-packages/playhouse/migrate.py:830: SyntaxWarning: invalid escape sequence '\]'
  if re.match('%s(?:[\'"`\]]?\s|$)' % column_to_update, column):
usr/lib/python3.12/site-packages/playhouse/reflection.py:421: SyntaxWarning: invalid escape sequence '\['
  begin = '(?:["\[\(]+)?'
usr/lib/python3.12/site-packages/playhouse/reflection.py:422: SyntaxWarning: invalid escape sequence '\]'
  end = '(?:["\]\)]+)?'
usr/lib/python3.12/site-packages/playhouse/reflection.py:424: SyntaxWarning: invalid escape sequence '\s'
  '(?:FOREIGN KEY\s*)?'
usr/lib/python3.12/site-packages/playhouse/reflection.py:425: SyntaxWarning: invalid escape sequence '\s'
  '{begin}(.+?){end}\s+(?:.+\s+)?'
usr/lib/python3.12/site-packages/playhouse/reflection.py:426: SyntaxWarning: invalid escape sequence '\s'
  'references\s+{begin}(.+?){end}'
usr/lib/python3.12/site-packages/playhouse/reflection.py:427: SyntaxWarning: invalid escape sequence '\s'
  '\s*\(["|\[]?(.+?)["|\]]?\)').format(begin=begin, end=end)
usr/lib/python3.12/site-packages/playhouse/reflection.py:437: SyntaxWarning: invalid escape sequence '\('
  column_type = re.sub('\(.+\)', '', raw_column_type)
usr/lib/python3.12/site-packages/playhouse/reflection.py:825: SyntaxWarning: invalid escape sequence '\('
  match_obj = re.match('^(.+?\()(.+)(\).*)', sql)
usr/lib/python3.12/site-packages/playhouse/migrate.py:673: SyntaxWarning: invalid escape sequence '\('
  column_re = re.compile('(.+?)\((.+)\)')
usr/lib/python3.12/site-packages/playhouse/migrate.py:830: SyntaxWarning: invalid escape sequence '\]'
  if re.match('%s(?:[\'"`\]]?\s|$)' % column_to_update, column):
usr/lib/python3.12/site-packages/playhouse/reflection.py:421: SyntaxWarning: invalid escape sequence '\['
  begin = '(?:["\[\(]+)?'
usr/lib/python3.12/site-packages/playhouse/reflection.py:422: SyntaxWarning: invalid escape sequence '\]'
  end = '(?:["\]\)]+)?'
usr/lib/python3.12/site-packages/playhouse/reflection.py:424: SyntaxWarning: invalid escape sequence '\s'
  '(?:FOREIGN KEY\s*)?'
usr/lib/python3.12/site-packages/playhouse/reflection.py:425: SyntaxWarning: invalid escape sequence '\s'
  '{begin}(.+?){end}\s+(?:.+\s+)?'
usr/lib/python3.12/site-packages/playhouse/reflection.py:426: SyntaxWarning: invalid escape sequence '\s'
  'references\s+{begin}(.+?){end}'
usr/lib/python3.12/site-packages/playhouse/reflection.py:427: SyntaxWarning: invalid escape sequence '\s'
  '\s*\(["|\[]?(.+?)["|\]]?\)').format(begin=begin, end=end)
usr/lib/python3.12/site-packages/playhouse/reflection.py:437: SyntaxWarning: invalid escape sequence '\('
  column_type = re.sub('\(.+\)', '', raw_column_type)
usr/lib/python3.12/site-packages/playhouse/reflection.py:825: SyntaxWarning: invalid escape sequence '\('
  match_obj = re.match('^(.+?\()(.+)(\).*)', sql)
```

#### Testing the changes
- I tested the changes in this PR: **NO**, ~I have yet to test this.~ I don't really know how to test this well. All arches build, so that's that. It doesn't have that many dependants that I could test.

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->

cc @jnbr (by the way, are you still an active maintainer?)