### PR TITLE
hugo: update to 0.125.3.

### DIFF
--- a/srcpkgs/hugo/template
+++ b/srcpkgs/hugo/template
@@ -1,6 +1,6 @@
 # Template file for 'hugo'
 pkgname=hugo
-version=0.125.2
+version=0.125.3
 revision=1
 build_style=go
 build_helper=qemu
@@ -11,7 +11,7 @@ maintainer="Andrea Brancaleoni <abc@pompel.me>"
 license="Apache-2.0"
 homepage="https://gohugo.io"
 distfiles="https://github.com/gohugoio/hugo/archive/v${version}.tar.gz"
-checksum=e38dc022aa9fff51216e95baffb7add75387aad07f00380ea3f74481bb9643d9
+checksum=2df0d592bc3db24c18ebbcad85019aefb47e33533488a7c066a77d80249eace1
 
 post_install() {
 	vdoc README.md


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):

**NOTE: This fixes an [XSS vulnerability](https://github.com/gohugoio/hugo/releases/tag/v0.125.3) in certain configurations.**