### PR TITLE
tcl: remove sqlite builtin bundle (use sqlite-tcl instead)

### DIFF
--- a/srcpkgs/tcl/template
+++ b/srcpkgs/tcl/template
@@ -1,14 +1,14 @@
 # Template file for 'tcl'
 pkgname=tcl
 version=8.6.13
-revision=1
+revision=2
 build_wrksrc=unix
 build_style=gnu-configure
 configure_args="--enable-threads --without-tzdata --enable-man-symlinks
- --disable-static --disable-rpath --with-system-sqlite
+ --disable-static --disable-rpath
  tcl_cv_strstr_unbroken=ok
  tcl_cv_strtoul_unbroken=ok"
-makedepends="zlib-devel sqlite-devel"
+makedepends="zlib-devel"
 short_desc="TCL scripting language"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="TCL"
@@ -17,6 +17,11 @@ distfiles="${SOURCEFORGE_SITE}/tcl/tcl${version}-src.tar.gz"
 checksum=43a1fae7412f61ff11de2cfd05d28cfc3a73762f354a417c62370a54e2caf066
 
 shlib_provides="libtcl${version%.*}.so"
+
+post_extract() {
+	rm -rf pkgs/sqlite*
+	rm -rf unix/pkgs/sqlite*
+}
 
 do_check() {
 	# thread-4.5 and thread-5* are skipped because they test UB


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**|**briefly**|**NO**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
