### PR TITLE
got: update to 0.98.2

### DIFF
--- a/srcpkgs/got/patches/landlock.patch
+++ b/srcpkgs/got/patches/landlock.patch
@@ -1,0 +1,10 @@
+--- a/compat/landlock.c
++++ b/compat/landlock.c
+@@ -15,6 +15,7 @@
+  */
+ 
+ #include <linux/landlock.h>
++#include <linux/unistd.h>
+ 
+ #include <sys/prctl.h>
+ #include <sys/syscall.h>

--- a/srcpkgs/got/template
+++ b/srcpkgs/got/template
@@ -1,17 +1,17 @@
 # Template file for 'got'
 pkgname=got
-version=0.95
+version=0.98.2
 revision=1
 build_style=gnu-configure
 hostmakedepends="byacc pkg-config"
-makedepends="libmd-devel zlib-devel libuuid-devel libbsd-devel ncurses-devel openssl-devel libevent-devel"
+makedepends="libmd-devel zlib-devel libuuid-devel libbsd-devel ncurses-devel openssl-devel libevent-devel libtls-devel"
 short_desc="VCS which prioritizes ease of use and simplicity over flexibility"
 maintainer="Omar Polo <op@omarpolo.com>"
 license="ISC"
 homepage="https://gameoftrees.org"
 changelog="https://gameoftrees.org/releases/CHANGES"
 distfiles="https://gameoftrees.org/releases/portable/got-portable-${version}.tar.gz"
-checksum=e689fd7dfefa380166a1a293c153348540862e2019189cedebe8c2c76372820e
+checksum=ff5d4ad9922edf1c8055b2398650972fd463c809590dbe78e2eab1bf78a150c8
 
 post_install() {
 	sed -n '/Copyright/,/PERFORMANCE/p' got/got.c > LICENSE


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-muslc)

I'm not sure why I have to include `linux/unistd.h` to get `__NR_landlock_create_ruleset`, while for e.g. on alpine it's not needed.  This was the reason holding me to submit updates.