### PR TITLE
nmap: update to 7.95, rework zenmap packaging

### DIFF
--- a/srcpkgs/nmap/template
+++ b/srcpkgs/nmap/template
@@ -1,19 +1,19 @@
 # Template file for 'nmap'
 pkgname=nmap
-version=7.94
-revision=4
+version=7.95
+revision=1
 build_style=gnu-configure
 configure_args="--without-ndiff --with-openssl --with-zenmap $(vopt_with lua liblua)"
-hostmakedepends="python3-setuptools"
+hostmakedepends="python3-setuptools automake python3-build python3-pip pkg-config python3-cairo python3-gobject"
 makedepends="libpcap-devel openssl-devel libssh2-devel pcre-devel
- $(vopt_if lua lua53-devel)"
+ $(vopt_if lua lua54-devel)"
 short_desc="Utility for network discovery and security auditing"
 maintainer="Piraty <mail@piraty.dev>"
 license="custom:nmap"
 homepage="https://nmap.org"
 changelog="https://raw.githubusercontent.com/nmap/nmap/master/CHANGELOG"
 distfiles="https://nmap.org/dist/nmap-${version}.tar.bz2"
-checksum=d71be189eec43d7e099bac8571509d316c4577ca79491832ac3e1217bc8f92cc
+checksum=e14ab530e47b5afd88f1c8a2bac7f89cd8fe6b478e22d255c5b9bddb7a1c5778
 repository=nonfree
 python_version=3
 
@@ -38,10 +38,12 @@ zenmap_package() {
 		vmove usr/bin/nmapfe
 		vmove usr/bin/xnmap
 		vmove usr/bin/zenmap
-		vmove usr/lib
 		vmove usr/share/applications
+		mv ${DESTDIR}/usr/lib/python3.12/site-packages/zenmapCore/data \
+			${DESTDIR}/usr/share/zenmap
 		vmove usr/share/zenmap
 		vmove usr/share/man/man1/zenmap.1
+		vmove usr/lib
 		rm -f ${DESTDIR}/usr/bin/uninstall_zenmap
 	}
 }


### PR DESCRIPTION
- I tested the changes in this PR: **YES**
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures:
  - x86_64-musl
  - aarch64(cross)

build fails without `automake`. Make cannot see `aclocal.m4` without it.
`python3-cairo python3-gobject` used for zenmap installation on `do_install` phase
line 42 were added so zenmap config, pixmaps etc. files will remain in their previous place `/usr/share/zenmap/`