### PR TITLE
python3-mpv: update to 1.0.6.

### DIFF
--- a/srcpkgs/checksec/template
+++ b/srcpkgs/checksec/template
@@ -1,6 +1,6 @@
 # Template file for 'checksec'
 pkgname=checksec
-version=2.7.0
+version=2.7.1
 revision=1
 depends="binutils"
 short_desc="Check for protections like RELRO, NoExec, Stack protection, ASLR, PIE"
@@ -8,7 +8,7 @@ maintainer="Leah Neukirchen <leah@vuxu.org>"
 license="BSD-3-Clause"
 homepage="https://github.com/slimm609/checksec.sh"
 distfiles="https://github.com/slimm609/checksec.sh/archive/${version}.tar.gz"
-checksum=0f8b37741bec40756da6801cf243405f4adfc5534242c9d0f3095b566b6b176a
+checksum=94b7cd8f9b1fb63341abf166d66d1264aa5136f6fc0f72d28ff9f8af1fcf3c0b
 
 do_install() {
 	vbin checksec

--- a/srcpkgs/crash/template
+++ b/srcpkgs/crash/template
@@ -1,6 +1,6 @@
 # Template file for 'crash'
 pkgname=crash
-version=8.0.4
+version=8.0.5
 revision=1
 archs="i686 x86_64"  # broken on musl
 build_style=gnu-makefile
@@ -13,7 +13,7 @@ license="GPL-3.0-or-later"
 homepage="https://crash-utility.github.io/"
 changelog="https://crash-utility.github.io/crash.changelog.html"
 distfiles="https://github.com/crash-utility/crash/archive/${version}.tar.gz"
-checksum=94df600c183301013787cd47112044e358fb37bb8e2b5544f40377dda98ee78f
+checksum=b3ec57a844706ef044b607ba67bc5ef62d9deef8aec3fb2d7ea4f77dff24f1ef
 nocross=yes
 disable_parallel_build=yes
 LDFLAGS="-llzo2"

--- a/srcpkgs/nvidia/template
+++ b/srcpkgs/nvidia/template
@@ -3,7 +3,7 @@
 _desc="NVIDIA drivers for linux"
 
 pkgname=nvidia
-version=550.67
+version=550.78
 revision=1
 maintainer="Andrew Benson <abenson+void@gmail.com>"
 license="custom:NVIDIA Proprietary"
@@ -19,7 +19,7 @@ conflicts="xserver-abi-video>25_1 nvidia470>=0 nvidia390>=0"
 
 _pkg="NVIDIA-Linux-x86_64-${version}"
 distfiles="http://uk.download.nvidia.com/XFree86/Linux-x86_64/${version}/${_pkg}.run"
-checksum=99201a09c71cff0fd0261eb0f0cbdad282eba81f9c3923b560ccf549eff7dae2
+checksum=34070434527ec9d575483e7f11ca078e467e73f6defc54366ecfbdcfe4a3bf73
 # subpackages need to be processed in this specific order
 subpackages="nvidia-gtklibs nvidia-dkms nvidia-firmware nvidia-opencl nvidia-libs nvidia-libs-32bit"
 depends="nvidia-libs-${version}_${revision}
@@ -207,6 +207,9 @@ do_install() {
 	# nvidia-powerd
 	vbin nvidia-powerd
 	vsv nvidia-powerd
+	mkdir -p usr/share/dbus-1/system.d
+	vinstall nvidia-dbus.conf 644 usr/share/dbus-1/system.d
+	vbin systemd/nvidia-sleep.sh
 
 	# opencl pkg
 	vinstall nvidia.icd 644 etc/OpenCL/vendors

--- a/srcpkgs/python3-mpv/template
+++ b/srcpkgs/python3-mpv/template
@@ -1,7 +1,7 @@
 # Template file for 'python3-mpv'
 pkgname=python3-mpv
-version=1.0.3
-revision=2
+version=1.0.6
+revision=1
 build_style=python3-pep517
 # this test takes too long and has a low chance of failure
 # https://github.com/jaseg/python-mpv/issues/209#issuecomment-1180248112
@@ -14,4 +14,4 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="https://github.com/jaseg/python-mpv"
 distfiles="https://github.com/jaseg/python-mpv/archive/v${version}.tar.gz"
-checksum=fe14008723fd3c380098e87a0fec811fca6e8885dd9501e20ee1db29aa4920a0
+checksum=652a4c35829f1faaa308314d1297911fdfdcd33c77dfac32d47a6f4dd958f11d

--- a/srcpkgs/python3-mpv/template
+++ b/srcpkgs/python3-mpv/template
@@ -7,8 +7,8 @@ build_style=python3-pep517
 # https://github.com/jaseg/python-mpv/issues/209#issuecomment-1180248112
 make_check_args="--deselect tests/test_mpv.py::TestLifecycle::test_wait_for_prooperty_event_overflow"
 hostmakedepends="python3-wheel"
-depends="python3 mpv"
-checkdepends="python3-pytest python3-xvfbwrapper mpv-devel"
+depends="python3 mpv python3-Pillow"
+checkdepends="python3-pytest python3-xvfbwrapper mpv-devel python3-PyVirtualDisplay"
 short_desc="Python3 interface to the MPV media player"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

Bump because mpv-0.38.0_1 broke python3-mpv-1.0.3_2