### PR TITLE
streamlink: update to 6.7.3

### DIFF
--- a/srcpkgs/python3-trio-websocket/template
+++ b/srcpkgs/python3-trio-websocket/template
@@ -1,0 +1,23 @@
+# Template file for 'python3-trio-websocket'
+pkgname=python3-trio-websocket
+version=0.11.1
+revision=1
+build_style=python3-pep517
+make_check_args="--ignore tests/test_connection.py"
+hostmakedepends="python3-setuptools python3-wheel"
+depends="python3-trio python3-wsproto"
+checkdepends="$depends python3-pytest python3-pytest-trio iana-etc pylint python3-astroid
+	python3-async_generator python3-jedi python3-openssl python3-trustme"
+short_desc="Library implementing server and client WebSocket protocol"
+maintainer="Tom Strausbaugh <tstrausbaugh@straustech.net>"
+license="Apache-2.0, MIT"
+homepage="https://github.com/python-trio/trio-websocket"
+changelog="https://raw.githubusercontent.com/python-trio/trio-websocket/master/CHANGELOG.md"
+distfiles="${PYPI_SITE}/t/trio-websocket/trio-websocket-${version}.tar.gz"
+checksum=18c11793647703c158b1f6e62de638acada927344d534e3c7628eedcb746839f
+make_check_pre="env PY_IGNORE_IMPORTMISMATCH=1"
+make_check=no # Some kind of check is failing. I ignore any tests anyway. Similar to how python3-trio package works.
+
+post_install() {
+	vlicense LICENSE
+}

--- a/srcpkgs/streamlink/patches/streamlink.patch
+++ b/srcpkgs/streamlink/patches/streamlink.patch
@@ -1,0 +1,102 @@
+exceptiongroup is for python<3.11 compat
+
+--- a/src/streamlink.egg-info/requires.txt
++++ b/src/streamlink.egg-info/requires.txt
+@@ -1,5 +1,4 @@
+ certifi
+-exceptiongroup
+ isodate
+ lxml<6,>=4.6.4
+ pycountry
+--- a/src/streamlink.egg-info/PKG-INFO
++++ b/src/streamlink.egg-info/PKG-INFO
+@@ -32,7 +32,6 @@
+ Description-Content-Type: text/markdown
+ License-File: LICENSE
+ Requires-Dist: certifi
+-Requires-Dist: exceptiongroup
+ Requires-Dist: isodate
+ Requires-Dist: lxml<6,>=4.6.4
+ Requires-Dist: pycountry
+--- a/PKG-INFO
++++ b/PKG-INFO
+@@ -32,7 +32,6 @@
+ Description-Content-Type: text/markdown
+ License-File: LICENSE
+ Requires-Dist: certifi
+-Requires-Dist: exceptiongroup
+ Requires-Dist: isodate
+ Requires-Dist: lxml<6,>=4.6.4
+ Requires-Dist: pycountry
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -56,7 +56,6 @@
+ requires-python = ">=3.8"
+ dependencies = [
+   "certifi",
+-  "exceptiongroup",
+   "isodate",
+   "lxml >=4.6.4,<6",
+   "pycountry",
+--- a/src/streamlink/plugins/twitch.py
++++ b/src/streamlink/plugins/twitch.py
+@@ -541,7 +541,6 @@
+         headers: Mapping[str, str],
+         device_id: str,
+     ) -> Optional[Tuple[str, int]]:
+-        from exceptiongroup import BaseExceptionGroup  # noqa: PLC0415, I001
+         from streamlink.webbrowser.cdp import CDPClient, CDPClientSession, devtools  # noqa: PLC0415
+ 
+         url = f"https://www.twitch.tv/{channel}"
+--- a/src/streamlink/webbrowser/webbrowser.py
++++ b/src/streamlink/webbrowser/webbrowser.py
+@@ -8,7 +8,6 @@
+ from typing import AsyncContextManager, AsyncGenerator, Generator, List, Optional, Union
+ 
+ import trio
+-from exceptiongroup import BaseExceptionGroup
+ 
+ from streamlink.utils.path import resolve_executable
+ from streamlink.webbrowser.exceptions import WebbrowserError
+--- a/src/streamlink/compat.py
++++ b/src/streamlink/compat.py
+@@ -5,9 +5,6 @@
+ import warnings
+ from typing import Any, Callable, Dict, Optional, Tuple
+ 
+-# import exceptiongroup, so it can monkeypatch ExceptionGroup logic on <=py311
+-import exceptiongroup  # noqa: F401
+-
+ from streamlink.exceptions import StreamlinkDeprecationWarning
+ 
+ 
+--- a/tests/webbrowser/test_webbrowser.py
++++ b/tests/webbrowser/test_webbrowser.py
+@@ -7,7 +7,6 @@
+ 
+ import pytest
+ import trio
+-from exceptiongroup import BaseExceptionGroup
+ 
+ from streamlink.compat import is_win32
+ from streamlink.webbrowser.exceptions import WebbrowserError
+--- a/tests/webbrowser/cdp/test_connection.py
++++ b/tests/webbrowser/cdp/test_connection.py
+@@ -7,7 +7,6 @@
+ 
+ import pytest
+ import trio
+-from exceptiongroup import ExceptionGroup
+ from trio.testing import MockClock, wait_all_tasks_blocked
+ from trio_websocket import CloseReason, ConnectionClosed, ConnectionTimeout  # type: ignore[import]
+ 
+--- a/tests/webbrowser/cdp/test_client.py
++++ b/tests/webbrowser/cdp/test_client.py
+@@ -4,7 +4,6 @@
+ 
+ import pytest
+ import trio
+-from exceptiongroup import ExceptionGroup
+ from trio.testing import wait_all_tasks_blocked
+ 
+ from streamlink.session import Streamlink

--- a/srcpkgs/streamlink/template
+++ b/srcpkgs/streamlink/template
@@ -1,21 +1,21 @@
 # Template file for 'streamlink'
 pkgname=streamlink
-version=5.5.1
-revision=2
+version=6.7.3
+revision=1
 build_style=python3-pep517
 hostmakedepends="python3-wheel python3-versioningit"
 depends="python3-lxml python3-pycryptodome python3-pycountry
- python3-pysocks python3-requests python3-websocket-client python3-isodate
- python3-urllib3 python3-certifi"
+	python3-pysocks python3-requests python3-websocket-client python3-isodate
+	python3-urllib3 python3-certifi python3-typing_extensions python3-trio python3-trio-websocket"
 checkdepends="$depends python3-pytest python3-mock python3-requests-mock
- python3-freezegun python3-pytest-asyncio"
+	python3-freezegun python3-pytest-asyncio"
 short_desc="Utility extracting streams from services, forked from livestreamer"
-maintainer="Orphaned <orphan@voidlinux.org>"
+maintainer="Tom Strausbaugh <tstrausbaugh@straustech.net>"
 license="BSD-2-Clause"
 homepage="https://streamlink.github.io/"
 changelog="https://raw.githubusercontent.com/streamlink/streamlink/master/CHANGELOG.md"
 distfiles="https://github.com/streamlink/streamlink/releases/download/$version/streamlink-$version.tar.gz"
-checksum=b2b4fe8d6436dbe7bcec78de2d4bb780156388561435b61a1963156e9fc5fbd0
+checksum=0daf89f8d3975be9f9e4bbda3d0c3a5e24612494383dce19d69db5a8cca6fd7c
 make_check_pre="env PYTHONPATH=src"
 make_check=ci-skip # some tests fail when running as root
 


### PR DESCRIPTION
It is a requirement for updating the streamlink package which I plan to do once this has been accepted/merged. I have been looking at the streamlink package and it is a little behind and this seems to be the only missing python3 package from the repositories that it needs. Void currently has the python3-trio package, which is used as a starting point for this template. If there is more that is needed for this package, or if I missed anything, in the template let me know. Thanks.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86-64-musl
