### PR TITLE
evince: update to 46.1

### DIFF
--- a/srcpkgs/evince/template
+++ b/srcpkgs/evince/template
@@ -1,6 +1,6 @@
 # Template file for 'evince'
 pkgname=evince
-version=46.0
+version=46.1
 revision=1
 build_helper="gir"
 build_style=meson
@@ -20,7 +20,7 @@ homepage="https://wiki.gnome.org/Apps/Evince"
 #changelog="https://gitlab.gnome.org/GNOME/evince/-/raw/main/NEWS"
 changelog="https://gitlab.gnome.org/GNOME/evince/-/raw/gnome-46/NEWS"
 distfiles="${GNOME_SITE}/evince/${version%.*}/evince-${version}.tar.xz"
-checksum=aff6af69392c04956bfad976dec5d1583b41d5a334e937995f7c3ca0740de221
+checksum=94bb525365b060a28c2f6017d22cbf2af5115507254aa42e9bfc000bbc18ab62
 
 build_options="gir gtk_doc"
 build_options_default="gir gtk_doc"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)