### PR TITLE
go: update to 1.22.2

### DIFF
--- a/srcpkgs/go/template
+++ b/srcpkgs/go/template
@@ -1,6 +1,6 @@
 # Template file for 'go'
 pkgname=go
-version=1.22.0
+version=1.22.2
 revision=1
 create_wrksrc=yes
 build_wrksrc=go
@@ -12,7 +12,7 @@ license="BSD-3-Clause"
 homepage="https://go.dev/"
 changelog="https://go.dev/doc/devel/release.html"
 distfiles="https://go.dev/dl/go${version}.src.tar.gz"
-checksum=4d196c3d41a0d6c1dfc64d04e3cc1f608b0c436bd87b7060ce3e23234e1f4d5c
+checksum=374ea82b289ec738e968267cac59c7d5ff180f9492250254784b2044e90df5a9
 nostrip=yes
 noverifyrdeps=yes
 # on CI it tries to use `git submodule`, which is not part of chroot-git


### PR DESCRIPTION
Testing the changes

    I tested the changes in this PR: **YES**

Local build testing

    I built this PR locally for my native architecture: **x86_64-glibc**
    I built this PR locally for these architectures (if supported. mark crossbuilds):
        aarch64
        aarch64-musl
