### PR TITLE
New package: x3270-4.3ga8

### DIFF
--- a/srcpkgs/x3270/template
+++ b/srcpkgs/x3270/template
@@ -1,0 +1,22 @@
+# Template file for 'x3270'
+pkgname=x3270
+version=4.3ga8
+revision=1
+archs="x86_64* i686*"
+build_style=gnu-configure
+configure_args="--enable-unix --enable-c3270 --prefix=/usr --bindir=/usr/bin
+ --sysconfdir=/etc --with-fontdir=/usr/share/fonts/3270"
+make_install_target="install install.man"
+hostmakedepends="mkfontscale bdftopcf tcl m4"
+makedepends="libX11-devel libXaw-devel ncurses-devel expat-devel tcl-devel
+ openssl-devel readline-devel"
+short_desc="IBM 3270 terminal emulator"
+maintainer="Emil Miler <em@0x45.cz>"
+license="BSD-3-Clause, MIT"
+homepage="http://x3270.bgp.nu/"
+distfiles="${SOURCEFORGE_SITE}/x3270/suite3270-${version}-src.tgz"
+checksum=81c0ba4447d97a7b483c40e11b39d4498bbc9af55fa4f78ccff064b3e378dc59
+
+post_install() {
+	vlicense wc3270/LICENSE.txt.tmpl LICENSE
+}


### PR DESCRIPTION
IBM 3270 terminal emulator. This is needed for working with modern s390x IBM mainframes with z/VM.

http://x3270.bgp.nu/

#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
