### PR TITLE
New package: ollama-0.1.32

### DIFF
--- a/srcpkgs/ollama/files/ollama/run
+++ b/srcpkgs/ollama/files/ollama/run
@@ -1,0 +1,4 @@
+#!/bin/sh
+exec 2>&1
+export USER=ollama
+exec chpst -u ollama:ollama ollama serve 2>&1

--- a/srcpkgs/ollama/template
+++ b/srcpkgs/ollama/template
@@ -1,0 +1,37 @@
+# Template file for 'ollama'
+pkgname=ollama
+version=0.1.32
+revision=1
+_llama_cpp_hash=7593639ce335e8d7f89aa9a54d616951f273af60
+archs="x86_64* aarch64*"
+build_style=go
+go_import_path="github.com/ollama/ollama"
+hostmakedepends="cmake git"
+short_desc="Get up and running with large language models, locally"
+maintainer="IFoundSilentHouse <adeptslab@gmail.com>"
+license="MIT"
+homepage="https://ollama.com/"
+distfiles="https://github.com/ollama/ollama/archive/refs/tags/v${version}.tar.gz
+ https://github.com/ggerganov/llama.cpp/archive/${_llama_cpp_hash}.tar.gz>llama.cpp-${_llama_cpp_hash}.tgz"
+checksum="b8f43a9ce7731c8e19d801e6c08145e779ee607bf22864e495041e4440c5c283
+ 3183900a2825281df1bd6825b183f8df7febe9dfa666d3197ad6df44007678e1"
+
+system_accounts=_ollama
+
+skip_extraction=llama.cpp-${_llama_cpp_hash}.tgz
+
+post_extract() {
+	vsrcextract -C llm/llama.cpp llama.cpp-${_llama_cpp_hash}.tgz
+}
+
+pre_build() {
+	# "go generate" script uses "git submodule" command
+	git init
+	git add .
+	go generate ./...
+}
+
+post_install() {
+	vlicense LICENSE
+	vsv ollama
+}


### PR DESCRIPTION
I wanted to test ollama myself so reworked @ezag PR: https://github.com/void-linux/void-packages/pull/48199
Now it's fetching files the right way and updated to 0.1.32. I'm fine with @ezag maintaining it. Just wanted to share my progress

- I tested the changes in this PR: yes
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

- I built this PR locally for my native architecture, (x86-64-glibc)
- I built this PR locally for these architectures:
  - aarch64-musl

About archs: The only archs supported by upstream are x86_64 and arm64 so others were disabled
About `git init` line: `go generate` script has `git submodule` command so build doesn't work without `.git` folder.

Closes https://github.com/void-linux/void-packages/issues/50094
@ezag , thnx. @Bnyro , I used your review messages. Thnx