### PR TITLE
libtool: sed and grep should be available in base-files

### DIFF
--- a/srcpkgs/libtool/template
+++ b/srcpkgs/libtool/template
@@ -1,10 +1,10 @@
 # Template file for 'libtool'
 pkgname=libtool
 version=2.4.7
-revision=5
+revision=6
 build_style=gnu-configure
 hostmakedepends="texinfo perl automake help2man xz gnulib tar"
-depends="tar sed grep"
+depends="tar"
 short_desc="Generic library support script"
 maintainer="Enno Boland <gottox@voidlinux.org>"
 license="GPL-2.0-or-later"


### PR DESCRIPTION
Fix: #50118

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**|**briefly**|**NO**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
