### PR TITLE
terragrunt: update to 0.58.2

### DIFF
--- a/srcpkgs/terragrunt/template
+++ b/srcpkgs/terragrunt/template
@@ -1,6 +1,6 @@
 # Template file for 'terragrunt'
 pkgname=terragrunt
-version=0.57.5
+version=0.58.2
 revision=1
 build_style=go
 go_import_path="github.com/gruntwork-io/terragrunt"
@@ -10,7 +10,7 @@ maintainer="Andrea Brancaleoni <abc@pompel.me>"
 license="MIT"
 homepage="https://github.com/gruntwork-io/terragrunt"
 distfiles="$homepage/archive/v$version.tar.gz"
-checksum=e9c83c5cd0dc0411f5dbc2f12f6846e954c4a2728146cd321de7f79b75546b04
+checksum=ea3e4c70bb393c00ca0995e13146d2dacdcbdbf74a210f309c469e41d0de743d
 
 post_install() {
 	vlicense LICENSE.txt


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, **x86-64-glibc**
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64
  - aarch64-musl
