### PR TITLE
New package: fastfetch-2.13.2

### DIFF
--- a/srcpkgs/fastfetch/template
+++ b/srcpkgs/fastfetch/template
@@ -1,0 +1,26 @@
+# Template file for 'fastfetch'
+pkgname=fastfetch
+version=2.13.2
+revision=1
+build_style=cmake
+hostmakedepends="pkg-config"
+short_desc="Fast neofetch alternative written in C"
+maintainer="Fotios Valasiadis <fvalasiad@gmail.com>"
+license="MIT"
+homepage="https://github.com/fastfetch-cli/fastfetch"
+changelog="https://raw.githubusercontent.com/fastfetch-cli/fastfetch/master/CHANGELOG.md"
+distfiles="https://github.com/fastfetch-cli/${pkgname}/archive/refs/tags/${version}.tar.gz"
+checksum="69ff73a2f5da269bdfbde0a81182a427c6d141633a70cb4b69f7ad37e49726ba"
+
+if [ "$XBPS_CHECK_PKGS" ]; then
+	configure_args+=" -DBUILD_TESTS=ON"
+fi
+
+do_check() {
+	cd build
+	ctest ${makejobs}
+}
+
+post_install() {
+	vlicense LICENSE
+}


### PR DESCRIPTION
A solid neofetch replacement for void powerusers!

Closes #38293

#### Testing the changes
- I tested the changes in this PR: **briefly**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl
  - aarch64-glibc

