### PR TITLE
stig: update to 0.12.8a0, adopt

### DIFF
--- a/srcpkgs/stig/template
+++ b/srcpkgs/stig/template
@@ -1,15 +1,16 @@
 # Template file for 'stig'
 pkgname=stig
-version=0.12.3a0
-revision=3
+version=0.12.8a0
+revision=1
 build_style=python3-module
 hostmakedepends="python3-setuptools"
 depends="python3-blinker python3-natsort python3-xdg python3-aiohttp
- python3-aiohttp_socks python3-setproctitle python3-urwid python3-urwidtrees"
+ python3-aiohttp_socks python3-setproctitle python3-urwid python3-urwidtrees
+ python3-async-timeout"
 short_desc="TUI and CLI for the BitTorrent client Transmission"
-maintainer="Orphaned <orphan@voidlinux.org>"
+maintainer="Emil Miler <em@0x45.cz>"
 license="GPL-3.0-or-later"
 homepage="https://github.com/rndusr/stig"
 distfiles="https://github.com/rndusr/stig/archive/v${version}.tar.gz"
-checksum=49cf2b8d73fa7f61a500672d02cd18a7155d842907b09450a5f92a9b360c6575
+checksum=2c01f99988d8a536692e55bb22b7e0f265a213f70d85e70375771f002da88cbc
 make_check=no # needs python3-asynctest which is not packaged


### PR DESCRIPTION
- I tested the changes in this PR: **YES**
- I built this PR locally for my native architecture, (x86_64-glibc)
