### PR TITLE
inxi: update to 3.3.34.1

### DIFF
--- a/srcpkgs/inxi/template
+++ b/srcpkgs/inxi/template
@@ -1,6 +1,6 @@
 # Template file for 'inxi'
 pkgname=inxi
-version=3.3.33.1
+version=3.3.34.1
 revision=1
 _distver="${version%.*}-${version##*.}"
 depends="dmidecode file glxinfo pciutils perl procps-ng usbutils xdpyinfo
@@ -11,7 +11,7 @@ license="GPL-3.0-or-later"
 homepage="https://smxi.org/docs/inxi.htm"
 changelog="https://codeberg.org/smxi/inxi/raw/branch/master/inxi.changelog"
 distfiles="https://codeberg.org/smxi/inxi/archive/${_distver}.tar.gz"
-checksum=c2d7ae8914f2810d4377999c24d3839fa9a757a6ace59ff57ab366873161d38c
+checksum=7cfc5c0abe10cb59f281733ce1d526583312344007756e7713fd5c51200b80fb
 
 do_install() {
 	vbin inxi


### PR DESCRIPTION
- I tested the changes in this PR: **YES**
- I built this PR locally for my native architecture, (x86_64-glibc)

```
$ inxi --version
inxi 3.3.34-00 (2024-04-13)

Copyright (C) 2008-2024 Harald Hope aka h2
Forked from Infobash 3.02: 
Copyright (C) 2005-2007 Michiel de Boer aka locsmif. 
Using Perl version: 5.038002
Program Location: /usr/sbin

Website: https://codeberg.org/smxi/inxi or https://smxi.org/
IRC: irc.oftc.net channel: #smxi
Forums: https://techpatterns.com/forums/forum-33.html

This program is free software; you can redistribute it and/or modify it under 
the terms of the GNU General Public License as published by the Free Software 
Foundation; either version 3 of the License, or (at your option) any later 
version. (https://www.gnu.org/licenses/gpl.html) 
$ inxi
CPU: 6-core Intel Core i7-10710U (-MT MCP-) speed/min/max: 816/400/4700 MHz
Kernel: 6.6.29_1 x86_64 Up: 1d 59m Mem: 10.43/31.23 GiB (33.4%)
Storage: 465.76 GiB (56.8% used) Procs: 422 Shell: Bash inxi: 3.3.34
```