### PR TITLE
osc: update to 1.6.2

### DIFF
--- a/srcpkgs/osc/template
+++ b/srcpkgs/osc/template
@@ -1,6 +1,6 @@
 # Template file for 'osc'
 pkgname=osc
-version=1.6.0
+version=1.6.2
 revision=1
 build_style=python3-module
 hostmakedepends="python3-setuptools python3-cryptography python3-devel
@@ -13,4 +13,4 @@ license="GPL-2.0-or-later"
 homepage="https://github.com/openSUSE/osc"
 changelog="https://raw.githubusercontent.com/openSUSE/osc/master/NEWS"
 distfiles="https://github.com/openSUSE/osc/archive/refs/tags/${version}.tar.gz"
-checksum=7920dedfc793590829b93ddbd9dfbdbe6e2ccf471fd4f33d03117a309738b1ae
+checksum=05c6b0bd4dd093fe57a6760e284ef285a28e978f247d54cee5cd174d1ec9c5dd


### PR DESCRIPTION
- I tested the changes in this PR: **YES**
- I built this PR locally for my native architecture, (x86_64-glibc)