### PR TITLE
common/build-helper/meson.sh: Fix deprecation warn

### DIFF
--- a/common/build-helper/meson.sh
+++ b/common/build-helper/meson.sh
@@ -64,7 +64,7 @@ cat > "${XBPS_WRAPPERDIR}/meson/xbps_meson.cross" <<-EOF
 	strip = '${STRIP}'
 	readelf = '${READELF}'
 	objcopy = '${OBJCOPY}'
-	pkgconfig = '${PKG_CONFIG}'
+	pkg-config = '${PKG_CONFIG}'
 	rust = ['rustc', '--target', '${RUST_TARGET}' ,'--sysroot', '${XBPS_CROSS_BASE}/usr']
 	g-ir-scanner = '${XBPS_CROSS_BASE}/usr/bin/g-ir-scanner'
 	g-ir-compiler = '${XBPS_CROSS_BASE}/usr/bin/g-ir-compiler'


### PR DESCRIPTION
When you try to build anything using the `meson` build style, this will appear as the first line of output in the `do_configure` step:

```
DEPRECATION: "pkgconfig" entry is deprecated and should be replaced by "pkg-config"
```

This PR follows the warning's advice and replaces `pkgconfig` with `pkg-config`. I have tested building a meson package using both `meson-1.3.2_1` and using `meson-1.4.0_1` from #49288

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
