### PR TITLE
tbb: fix tbbmalloc_proxy on musl

### DIFF
--- a/srcpkgs/tbb/template
+++ b/srcpkgs/tbb/template
@@ -1,7 +1,7 @@
 # Template file for 'tbb'
 pkgname=tbb
 version=2021.12.0
-revision=1
+revision=2
 build_style=cmake
 configure_args="-DTBB_STRICT=OFF -DTBB_TEST=OFF"
 makedepends="libgomp-devel libhwloc-devel"
@@ -26,13 +26,6 @@ if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
 	makedepends+=" libucontext-devel"
 	configure_args+=" -DCMAKE_CXX_STANDARD_LIBRARIES=-lucontext"
 fi
-
-post_extract() {
-	if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
-		vsed -e "s@#define MALLOC_UNIXLIKE_OVERLOAD_ENABLED __linux__@@" \
-		  -i src/tbbmalloc_proxy/proxy.h
-	fi
-}
 
 post_install() {
 	# The Python package is installed as an egg, which is deprecated


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, **aarch64-musl**
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64
  - x86_64-musl
  - i686
  - aarch64
  - aarch64-musl
  - armv7l (cross)
  - armv7l-msul (cross)
  - armv6l (cross)
  - armv6l-musl (cross)

This fixes a linker error when trying to build a project with tbbmalloc_proxy on musl systems

