### PR TITLE
chirp: update to 20240504

### DIFF
--- a/srcpkgs/chirp/template
+++ b/srcpkgs/chirp/template
@@ -1,14 +1,13 @@
 # Template file for 'chirp'
 pkgname=chirp
-version=20230911
-revision=3
+version=20240504
+revision=1
 build_style=python3-pep517
 hostmakedepends="python3-setuptools python3-wheel"
-depends="python3-six wxPython python3-pyserial python3-future python3-requests
- python3-suds python3-yattag"
+depends="wxPython python3-pyserial python3-requests python3-suds python3-yattag"
 short_desc="Open-source tool for programming amateur radios"
 maintainer="Emil Miler <em@0x45.cz>"
 license="GPL-3.0-or-later"
 homepage="https://chirp.danplanet.com/projects/chirp/wiki/Home"
 distfiles="https://trac.chirp.danplanet.com/chirp_next/next-${version}/chirp-${version}.tar.gz"
-checksum=948cfd8972626d9311ff4c1f3227d7965709462af2af38e5e7fd47cb7e79c36c
+checksum=a2cca594e68cce0b7b07cc806e724a3d43448c34f411581589fd11b05f715713


### PR DESCRIPTION
This update fixes a major runtime error of old CHIRP as well as other bugs.

- I tested the changes in this PR: **YES**
- I built this PR locally for my native architecture, (x86_64-glibc)