### PR TITLE
meson: fix build with rust proc-macro

### DIFF
--- a/srcpkgs/meson/patches/rust-proc-macro.patch
+++ b/srcpkgs/meson/patches/rust-proc-macro.patch
@@ -1,0 +1,74 @@
+commit 4f0b3c650baacf02c1ca82b7cce97665dd4fefea
+Author: Daniel Martinez <danielmartinez@cock.li>
+Date:   Thu May 9 08:31:57 2024 -0400
+
+    Revert "rust: recursively pull proc-macro dependencies as well"
+    
+    This reverts commit aee941559c4b88a062e88186819a820c69c200ae.
+
+diff --git a/mesonbuild/build.py b/mesonbuild/build.py
+index da4c4373d..1d5bf7bd6 100644
+--- a/mesonbuild/build.py
++++ b/mesonbuild/build.py
+@@ -1295,6 +1295,8 @@ class BuildTarget(Target):
+         for t in self.link_targets:
+             if t in result:
+                 continue
++            if t.rust_crate_type == 'proc-macro':
++                continue
+             if include_internals or not t.is_internal():
+                 result.add(t)
+             if isinstance(t, StaticLibrary):
+diff --git a/test cases/rust/18 proc-macro/lib.rs b/test cases/rust/18 proc-macro/lib.rs
+deleted file mode 100644
+index 5242886cc..000000000
+--- a/test cases/rust/18 proc-macro/lib.rs	
++++ /dev/null
+@@ -1,8 +0,0 @@
+-extern crate proc_macro_examples;
+-use proc_macro_examples::make_answer;
+-
+-make_answer!();
+-
+-pub fn func() -> u32 {
+-    answer()
+-}
+diff --git a/test cases/rust/18 proc-macro/meson.build b/test cases/rust/18 proc-macro/meson.build
+index e8b28eda1..c5f0dfc82 100644
+--- a/test cases/rust/18 proc-macro/meson.build	
++++ b/test cases/rust/18 proc-macro/meson.build	
+@@ -31,14 +31,3 @@ main = executable(
+ )
+ 
+ test('main_test2', main)
+-
+-subdir('subdir')
+-
+-staticlib = static_library('staticlib', 'lib.rs',
+-  link_with: pm_in_subdir,
+-  rust_dependency_map : {'proc_macro_examples3' : 'proc_macro_examples'}
+-)
+-
+-executable('transitive-proc-macro', 'transitive-proc-macro.rs',
+-  link_with: staticlib,
+-)
+diff --git a/test cases/rust/18 proc-macro/subdir/meson.build b/test cases/rust/18 proc-macro/subdir/meson.build
+deleted file mode 100644
+index 04842c431..000000000
+--- a/test cases/rust/18 proc-macro/subdir/meson.build	
++++ /dev/null
+@@ -1 +0,0 @@
+-pm_in_subdir = rust.proc_macro('proc_macro_examples3', '../proc.rs')
+diff --git a/test cases/rust/18 proc-macro/transitive-proc-macro.rs b/test cases/rust/18 proc-macro/transitive-proc-macro.rs
+deleted file mode 100644
+index 4c804b3b6..000000000
+--- a/test cases/rust/18 proc-macro/transitive-proc-macro.rs	
++++ /dev/null
+@@ -1,7 +0,0 @@
+-extern crate staticlib;
+-use staticlib::func;
+-
+-
+-fn main() {
+-    assert_eq!(42, func());
+-}

--- a/srcpkgs/meson/template
+++ b/srcpkgs/meson/template
@@ -1,7 +1,7 @@
 # Template file for 'meson'
 pkgname=meson
 version=1.4.0
-revision=1
+revision=2
 build_style=python3-module
 hostmakedepends="python3-devel python3-setuptools"
 depends="ninja python3-setuptools"


### PR DESCRIPTION
Fixes an issue causing mesa to fail when cross-compiling 

https://github.com/mesonbuild/meson/issues/12973

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl
  - i686
  - aarch64 (cross)
  - aarch64-musl (cross)
  - armv7l (cross)
  - armv7l-musl (cross)
  - armv6l (cross)
  - armv6l-musl (cross)

