### PR TITLE
singond Build with Qt6, keep Qt5 for backward compatibility

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -2747,10 +2747,11 @@ libzimg.so.2 zimg-2.0.4_1
 libvapoursynth.so vapoursynth-R32_2
 libvapoursynth-script.so.0 vapoursynth-R32_1
 libtwolame.so.0 twolame-0.3.13_1
-libsignon-plugins.so.1 signond-8.58_1
-libsignon-qt5.so.1 signond-8.58_1
-libsignon-plugins-common.so.1 signond-8.58_1
-libsignon-extension.so.1 signond-8.58_1
+libsignon-plugins.so.1 signond-8.61_2
+libsignon-qt5.so.1 signond-8.61_2
+libsignon-qt6.so.1 signond-8.61_2
+libsignon-plugins-common.so.1 signond-8.61_2
+libsignon-extension.so.1 signond-8.61_2
 libj4status-plugin.so.0 j4status-0.1_1
 libvirglrenderer.so.1 virglrenderer-0.5.0_1
 libglpk.so.40 glpk-4.60_1

--- a/common/shlibs
+++ b/common/shlibs
@@ -3699,6 +3699,7 @@ libCOIN.so libogdf-2018.03_1
 librocksdb.so.7 rocksdb-7.4.5_1
 libfrr.so.0 libfrr-6.0_1
 libkaccounts.so.2 kaccounts-integration-20.04.3_1
+libkaccounts6.so.2 kf6-kaccounts-integration-24.02.0_1
 libfrrospfapiclient.so.0 libfrrospfapiclient-6.0_1
 liborocos-kdl.so.1.4 orocos-kdl-1.4.0_1
 libibumad.so.3 rdma-core-22.1_1

--- a/srcpkgs/kaccounts-integration/template
+++ b/srcpkgs/kaccounts-integration/template
@@ -1,12 +1,13 @@
 # Template file for 'kaccounts-integration'
 pkgname=kaccounts-integration
 version=23.08.5
-revision=1
+revision=2
 build_style=cmake
 hostmakedepends="extra-cmake-modules pkg-config qt5-host-tools qt5-qmake
  kcoreaddons libaccounts-qt5-devel signond-devel gettext kpackage kcmutils"
 makedepends="kcmutils-devel kparts-devel libaccounts-qt5-devel signond-devel qcoro-qt5-devel"
-depends="kinit signon-ui signon-plugin-oauth2 signon-kwallet-extension"
+depends="kinit signon-plugin-oauth2 signon-kwallet-extension
+ kf6-kaccounts-integration"
 short_desc="Administer web accounts for sites and services across the KDE desktop"
 maintainer="Piotr Wójcik <chocimier@tlen.pl>"
 license="GPL-2.0-or-later"
@@ -14,6 +15,16 @@ homepage="https://invent.kde.org/network/kaccounts-integration"
 changelog="https://kde.org/announcements/changelogs/gear/${version}/#kaccounts-integration"
 distfiles="${KDE_SITE}/release-service/${version}/src/kaccounts-integration-${version}.tar.xz"
 checksum=c02ee25495c387dfc9c7581babd4756e04d7c3dae68bffd1652cf418e1d129b9
+
+# depends on webengine
+if [ "$XBPS_WORDSIZE$XBPS_WORDSIZE" = "64$XBPS_TARGET_WORDSIZE" ]; then
+	depends+=" signon-ui"
+fi
+
+post_install() {
+	# Pulled by kf6-kaccounts-integration
+	rm -rf "${DESTDIR}/usr/share/locale"
+}
 
 kaccounts-integration-devel_package() {
 	short_desc+=" - development"

--- a/srcpkgs/kf6-kaccounts-integration-devel
+++ b/srcpkgs/kf6-kaccounts-integration-devel
@@ -1,0 +1,1 @@
+kf6-kaccounts-integration

--- a/srcpkgs/kf6-kaccounts-integration/template
+++ b/srcpkgs/kf6-kaccounts-integration/template
@@ -1,0 +1,36 @@
+# Template file for 'kf6-kaccounts-integration'
+pkgname=kf6-kaccounts-integration
+version=24.02.2
+revision=1
+build_style=cmake
+build_helper=qemu
+configure_args="-DKF6_HOST_TOOLING=/usr/lib/cmake
+ -DKDE_INSTALL_QMLDIR=lib/qt6/qml
+ -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins"
+hostmakedepends="extra-cmake-modules pkg-config qt6-base gettext
+ kf6-kpackage kf6-kcmutils qt6-declarative-host-tools"
+makedepends="kf6-kcmutils-devel kf6-kparts-devel libaccounts-qt6-devel
+ signond-devel qcoro-qt6-devel kf6-ki18n-devel"
+depends="signon-plugin-oauth2 signon-kwallet-extension"
+short_desc="Administer web accounts for sites and services across the KDE desktop"
+maintainer="Piotr Wójcik <chocimier@tlen.pl>"
+license="GPL-2.0-or-later"
+homepage="https://invent.kde.org/network/kaccounts-integration"
+changelog="https://kde.org/announcements/changelogs/gear/${version}/#kaccounts-integration"
+distfiles="${KDE_SITE}/release-service/${version}/src/kaccounts-integration-${version}.tar.xz"
+checksum=d50b3d790d8df6a24d1afe7660fa7c6e61c38159d777380f87b813c91d06d307
+
+# depends on webengine
+if [ "$XBPS_WORDSIZE$XBPS_WORDSIZE" = "64$XBPS_TARGET_WORDSIZE" ]; then
+	depends+=" signon-ui"
+fi
+
+kf6-kaccounts-integration-devel_package() {
+	short_desc+=" - development files"
+	depends="${makedepends} ${sourcepkg}>=${version}_${revision}"
+	pkg_install() {
+		vmove usr/include
+		vmove usr/lib/cmake
+		vmove "usr/lib/*.so"
+	}
+}

--- a/srcpkgs/signon-kwallet-extension/template
+++ b/srcpkgs/signon-kwallet-extension/template
@@ -1,14 +1,15 @@
 # Template file for 'signon-kwallet-extension'
 pkgname=signon-kwallet-extension
-version=23.08.5
+version=24.02.2
 revision=1
 build_style=cmake
-hostmakedepends="extra-cmake-modules pkg-config qt5-host-tools qt5-qmake"
-makedepends="kwallet-devel qt5-devel signond-devel"
+configure_args="-DQT_MAJOR_VERSION=6"
+hostmakedepends="extra-cmake-modules pkg-config qt6-base"
+makedepends="kf6-kwallet-devel signond-devel"
 short_desc="KWallet integration for signon framework"
 maintainer="Piotr Wójcik <chocimier@tlen.pl>"
 license="GPL-2.0-only"
 homepage="https://invent.kde.org/network/signon-kwallet-extension"
 changelog="https://kde.org/announcements/changelogs/gear/${version}/#signon-kwallet-extension"
 distfiles="${KDE_SITE}/release-service/${version}/src/signon-kwallet-extension-${version}.tar.xz"
-checksum=e556caad3efde683c6a626c2aaec5ec2cb157aba1a10c7d4ea5280005fe59bfc
+checksum=373275e239d887d58ed4502c2ec0417b1ca14757e97bc6827dc0633322a976e2

--- a/srcpkgs/signon-plugin-oauth2/template
+++ b/srcpkgs/signon-plugin-oauth2/template
@@ -1,31 +1,30 @@
 # Template file for 'signon-plugin-oauth2'
 pkgname=signon-plugin-oauth2
-version=0.24
-revision=2
+version=0.25
+revision=1
+_commit=fab698862466994a8fdc9aa335c87b4f05430ce6
 build_style=qmake
 configure_args="LIBDIR=/usr/lib"
-hostmakedepends="pkg-config qt5-host-tools qt5-qmake"
-makedepends="qt5-devel signond-devel"
+hostmakedepends="pkg-config qt6-base"
+makedepends="qt6-base-devel signond-devel"
 short_desc="OAuth 1.0/2.0 plugin for the SignOn daemon"
 maintainer="Piotr Wójcik <chocimier@tlen.pl>"
 license="LGPL-2.1-only"
 homepage="https://gitlab.com/accounts-sso/signon-plugin-oauth2"
-distfiles="https://gitlab.com/accounts-sso/signon-plugin-oauth2/-/archive/VERSION_${version}/signon-plugin-oauth2-VERSION_${version}.tar.bz2"
-checksum=d37f6c93b6cd2885b517fd93cdb2407b0164655454ded2ed56e41704f81f05c4
+#distfiles="https://gitlab.com/accounts-sso/signon-plugin-oauth2/-/archive/VERSION_${version}/signon-plugin-oauth2-VERSION_${version}.tar.bz2"
+distfiles="https://gitlab.com/accounts-sso/signon-plugin-oauth2/-/archive/$_commit/signon-plugin-oauth2-$_commit.tar.gz"
+checksum=5a1298cc49f504503f54f20f0f5f685e43f541244a654dd3da58951f43782625
+export QT=qt6
 
 pre_configure() {
-	vsed -i common-project-config.pri -e 's/ -Werror/& -Wno-error=deprecated-declarations/'
+	# Don't install tests and example
+	echo 'INSTALLS =' >> tests/tests.pro
+	echo 'INSTALLS =' >> example/example.pro
 }
 
 if [ "$CROSS_BUILD" ]; then
-	CXXFLAGS+=" -I${XBPS_CROSS_BASE}/usr/include/qt5"
-	for i in ${XBPS_CROSS_BASE}/usr/include/qt5/*; do
+	CXXFLAGS+=" -I${XBPS_CROSS_BASE}/usr/include/qt6"
+	for i in ${XBPS_CROSS_BASE}/usr/include/qt6/*; do
 		CXXFLAGS+=" -I$i"
 	done
 fi
-
-post_install() {
-	rm "${DESTDIR}/usr/bin/signon-oauth2plugin-tests"
-	# conflict with kaccounts-providers, this file is less useful
-	rm "${DESTDIR}/etc/signon-ui/webkit-options.d/www.facebook.com.conf"
-}

--- a/srcpkgs/signon-ui/template
+++ b/srcpkgs/signon-ui/template
@@ -1,18 +1,25 @@
 # Template file for 'signon-ui'
 pkgname=signon-ui
-version=0.15
+version=0.17
 revision=1
+_commit="eef943f0edf3beee8ecb85d4a9dae3656002fc24"
 build_style=qmake
-hostmakedepends="qt5-qmake pkg-config qt5-host-tools"
-makedepends="libaccounts-qt5-devel libnotify-devel libproxy-devel
- qt5-webkit-devel qt5-x11extras-devel signond-devel"
+hostmakedepends="pkg-config qt6-base qt6-tools"
+makedepends="libaccounts-qt6-devel libnotify-devel libproxy-devel
+ qt6-webengine-devel signond-devel"
 short_desc="Online Accounts Sign-on UI"
 maintainer="Piotr Wójcik <chocimier@tlen.pl>"
 license="GPL-3.0-only"
-homepage="https://launchpad.net/signon-ui"
-distfiles="https://launchpad.net/signon-ui/trunk/${version}/+download/signon-ui-${version}.tar.bz2"
-checksum=a14f0a82af129e33476e9d6839fa2d5e40c46a6e8bb71d7deb6255d995764af3
+homepage="https://gitlab.com/accounts-sso/signon-ui"
+distfiles="https://gitlab.com/accounts-sso/signon-ui/-/archive/$_commit/signon-ui-$_commit.tar.gz"
+checksum=0906a1adee88e331e9dcf1f2d5978c24f8564fb734f5c114c88bddb63196d3d4
+export QT=qt6
 
-post_install() {
-	rm "${DESTDIR}/usr/bin/signon-ui-unittest"
+if [ "$XBPS_WORDSIZE$XBPS_WORDSIZE" != "64$XBPS_TARGET_WORDSIZE" ]; then
+	broken="no qt6-webengine"
+fi
+
+post_patch() {
+	# Don't build tests, they still require Webkit
+	vsed -e "s|src \\\|src|" -e "/tests/d" -i signon-ui.pro
 }

--- a/srcpkgs/signond/patches/cross.patch
+++ b/srcpkgs/signond/patches/cross.patch
@@ -1,14 +1,20 @@
---- a/lib/SignOn/SignOnQt5Config.cmake.in	2018-09-17 18:28:27.000000000 +0200
-+++ b/lib/SignOn/SignOnQt5Config.cmake.in	2018-09-17 18:28:27.000000000 +0200
-@@ -2,6 +2,21 @@
+diff --git a/lib/SignOn/SignOnQt5Config.cmake.in b/lib/SignOn/SignOnQt5Config.cmake.in
+index 128ee8d..bae7705 100644
+--- a/lib/SignOn/SignOnQt5Config.cmake.in
++++ b/lib/SignOn/SignOnQt5Config.cmake.in
+@@ -2,6 +2,25 @@
  #  SIGNONQT_LIBRARIES - The libraries needed to use libsignon-qt
  #  SIGNONQT_LIBRARIES_STATIC - The static version of libsignon-qt
  
 -set(SIGNONQT_LIBRARIES $${INSTALL_LIBDIR}/lib$${TARGET}.so)
 -set(SIGNONQT_LIBRARIES_STATIC $${INSTALL_LIBDIR}/lib$${TARGET}.a)
 -set(SIGNONQT_INCLUDE_DIRS $${INSTALL_PREFIX}/include/$${TARGET})
-\ No newline at end of file
++# Compute the installation prefix relative to this file.
 +get_filename_component(_IMPORT_PREFIX "${CMAKE_CURRENT_LIST_FILE}" PATH)
++# Use original install prefix when loaded through a
++# cross-prefix symbolic link such as /lib -> /usr/lib.
++get_filename_component(_realCurr "${_IMPORT_PREFIX}" REALPATH)
++get_filename_component(_realOrig "/usr/lib/cmake/SignOnQt5" REALPATH)
 +if(_realCurr STREQUAL _realOrig)
 +  set(_IMPORT_PREFIX "/usr/lib/cmake/SignOnQt5")
 +endif()
@@ -22,7 +28,41 @@
 +endif()
 +
 +set(SIGNONQT_LIBRARIES ${_IMPORT_PREFIX}/lib/lib$${TARGET}.so)
-+set(SIGNONQT_LIBRARIES_STATIC ${_IMPORT_PREFIX}/lib/lib$${TARGET}.a)
-+set(SIGNONQT_INCLUDE_DIRS ${_IMPORT_PREFIX}/include/$${TARGET})
++set(SIGNONQT_INCLUDE_DIRS ${_IMPORT_PREFIX}/include/$${TARGET}/)
++set(SIGNONQT_LIBRARIES ${_IMPORT_PREFIX}/lib/lib$${TARGET}.so)
++set(SIGNONQT_INCLUDE_DIRS ${_IMPORT_PREFIX}/include/$${TARGET}/)
+diff --git a/lib/SignOn/SignOnQt6Config.cmake.in b/lib/SignOn/SignOnQt6Config.cmake.in
+index 128ee8d..9222038 100644
+--- a/lib/SignOn/SignOnQt6Config.cmake.in
++++ b/lib/SignOn/SignOnQt6Config.cmake.in
+@@ -2,6 +2,25 @@
+ #  SIGNONQT_LIBRARIES - The libraries needed to use libsignon-qt
+ #  SIGNONQT_LIBRARIES_STATIC - The static version of libsignon-qt
+ 
+-set(SIGNONQT_LIBRARIES $${INSTALL_LIBDIR}/lib$${TARGET}.so)
+-set(SIGNONQT_LIBRARIES_STATIC $${INSTALL_LIBDIR}/lib$${TARGET}.a)
+-set(SIGNONQT_INCLUDE_DIRS $${INSTALL_PREFIX}/include/$${TARGET})
++# Compute the installation prefix relative to this file.
++get_filename_component(_IMPORT_PREFIX "${CMAKE_CURRENT_LIST_FILE}" PATH)
++# Use original install prefix when loaded through a
++# cross-prefix symbolic link such as /lib -> /usr/lib.
++get_filename_component(_realCurr "${_IMPORT_PREFIX}" REALPATH)
++get_filename_component(_realOrig "/usr/lib/cmake/SignOnQt6" REALPATH)
++if(_realCurr STREQUAL _realOrig)
++  set(_IMPORT_PREFIX "/usr/lib/cmake/SignOnQt6")
++endif()
++unset(_realOrig)
++unset(_realCurr)
++get_filename_component(_IMPORT_PREFIX "${_IMPORT_PREFIX}" PATH)
++get_filename_component(_IMPORT_PREFIX "${_IMPORT_PREFIX}" PATH)
++get_filename_component(_IMPORT_PREFIX "${_IMPORT_PREFIX}" PATH)
++if(_IMPORT_PREFIX STREQUAL "/")
++  set(_IMPORT_PREFIX "")
++endif()
 +
-+set(_IMPORT_PREFIX)
++set(SIGNONQT_LIBRARIES ${_IMPORT_PREFIX}/lib/lib$${TARGET}.so)
++set(SIGNONQT_INCLUDE_DIRS ${_IMPORT_PREFIX}/include/$${TARGET}/)
++set(SIGNONQT_LIBRARIES ${_IMPORT_PREFIX}/lib/lib$${TARGET}.so)
++set(SIGNONQT_INCLUDE_DIRS ${_IMPORT_PREFIX}/include/$${TARGET}/)
+
+

--- a/srcpkgs/signond/template
+++ b/srcpkgs/signond/template
@@ -1,26 +1,45 @@
 # Template file for 'signond'
+# NOTE: drop Qt5 once everything migrated to Qt6
 pkgname=signond
 version=8.61
-revision=1
+revision=2
+_commit="c8ad98249af541514ff7a81634d3295e712f1a39"
 build_style=qmake
-configure_args="LIBDIR=/usr/lib"
+configure_args="LIBDIR=/usr/lib .."
 conf_files="/etc/signond.conf"
-hostmakedepends="pkg-config doxygen qt5-host-tools qt5-qmake"
-makedepends="qt5-devel"
+hostmakedepends="pkg-config doxygen qt6-base qt5-qmake qt5-host-tools"
+makedepends="qt6-base-devel qt5-devel"
 short_desc="Daemon providing SSO over D-Bus for the gSSO framework"
 maintainer="John Rowley <enterthevoid@codesector.co>"
 license="LGPL-2.1-only"
 homepage="https://gitlab.com/accounts-sso/signond"
-distfiles="${homepage}/-/archive/VERSION_${version}/signond-VERSION_${version}.tar.gz"
-checksum=3dd57c25e1bf1583b2cb857f96831e38e73d40264ff66ca43e63bb7233f76828
+distfiles="https://gitlab.com/accounts-sso/signond/-/archive/$_commit/signond-$_commit.tar.gz"
+checksum=2c3dd97fcdb90f38bb9884f7e11d0fb9ba214f78bddaacb27e4969cefff7d690
+
+post_extract() {
+	mkdir -p build-qt5 build-qt6
+}
 
 pre_configure() {
-	if [ "$CROSS_BUILD" ]; then
-		CXXFLAGS+=" -I${XBPS_CROSS_BASE}/usr/include/qt5"
-		for i in ${XBPS_CROSS_BASE}/usr/include/qt5/*; do
-			CXXFLAGS+=" -I$i"
-		done
-	fi
+	build_wrksrc=build-qt5
+}
+
+post_configure() {
+	build_wrksrc="build-qt6"
+	QT=qt6
+	do_configure
+}
+
+do_build() {
+	make -C build-qt5 ${make_jobs}
+	make -C build-qt6 ${make_jobs}
+}
+
+do_install() {
+	make -C build-qt5 install DESTDIR=${DESTDIR} PREFIX=/usr \
+		INSTALL_ROOT=${DESTDIR} STRIP=true
+	make -C build-qt6 install DESTDIR=${DESTDIR} PREFIX=/usr \
+		INSTALL_ROOT=${DESTDIR} STRIP=true
 }
 
 signond-doc_package() {
@@ -32,7 +51,7 @@ signond-doc_package() {
 
 signond-devel_package() {
 	short_desc+=" - development files"
-	depends="${makedepends} ${sourcepkg}>=${version}_${revision}"
+	depends="qt6-base-devel ${sourcepkg}>=${version}_${revision}"
 	pkg_install() {
 		vmove usr/include
 		vmove usr/lib/*.so


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**|**briefly**|**NO**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
