### PR TITLE
bash: define SSH_SOURCE_BASHRC

### DIFF
--- a/srcpkgs/bash/template
+++ b/srcpkgs/bash/template
@@ -1,7 +1,7 @@
 # Template file for 'bash'
 pkgname=bash
 version=5.2.21
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--without-bash-malloc --with-curses --without-installed-readline"
 make_build_args="TERMCAP_LIB=${XBPS_CROSS_BASE}/usr/lib/libncursesw.a"
@@ -24,7 +24,7 @@ alternatives="
  sh:sh:/usr/bin/bash
  sh:sh.1:/usr/share/man/man1/bash.1"
 
-CFLAGS="-DNON_INTERACTIVE_LOGIN_SHELLS -DSYS_BASHRC='\"/etc/bash/bashrc\"'"
+CFLAGS="-DSSH_SOURCE_BASHRC -DNON_INTERACTIVE_LOGIN_SHELLS -DSYS_BASHRC='\"/etc/bash/bashrc\"'"
 
 post_install() {
 	rm -r ${DESTDIR}/usr/share/doc

--- a/srcpkgs/bash/update
+++ b/srcpkgs/bash/update
@@ -1,5 +1,0 @@
-site="http://git.savannah.gnu.org/cgit/bash.git/log/"
-pattern="Bash-\K\d(\.\d)+( patch \d+|-testing)?"
-version="$_bash_distver"
-[ ! -z "$_bash_patchlevel" ] && version+=" patch $_bash_patchlevel"
-ignore="*testing"


### PR DESCRIPTION
This makes bash agree with its documentation at
https://www.gnu.org/software/bash/manual/html_node/Bash-Startup-Files.html
```
   Bash attempts to determine when it is being run with its standard
   input connected to a network connection, as when executed by the
   historical remote shell daemon, usually rshd, or the secure shell
   daemon sshd. If Bash determines it is being run non-interactively in
   this fashion, it reads and executes commands from ~/.bashrc, if that
   file exists and is readable. [...]
```
Notes:
 - Disabled by upstream in 2.05a (2001), manual never changed
 - This is enabled in Debian, Fedora, Gentoo, ...

To avoid this feature, add
```
[[ $- != *i* ]] && return
```
to the top of ~/.bashrc to skip running it in non-interactive mode.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**
