### PR TITLE
greybird-themes: update to 3.23.3, remove gtk-engine-murrine dep, adopt.

### DIFF
--- a/srcpkgs/greybird-themes/template
+++ b/srcpkgs/greybird-themes/template
@@ -1,13 +1,12 @@
 # Template file for 'greybird-themes'
 pkgname=greybird-themes
-version=3.23.1
+version=3.23.3
 revision=1
 build_style=meson
-hostmakedepends="sassc ninja glib-devel gdk-pixbuf-devel librsvg-devel"
-depends="gtk-engine-murrine"
+hostmakedepends="sassc glib-devel gdk-pixbuf-devel librsvg-devel"
 short_desc="Elegant grey GTK+2/3 theme"
-maintainer="Orphaned <orphan@voidlinux.org>"
+maintainer="Daniel Martinez <danielmartinez@cock.li>"
 license="GPL-2.0-or-later, CC-BY-SA-3.0"
 homepage="https://github.com/shimmerproject/Greybird"
 distfiles="https://github.com/shimmerproject/Greybird/archive/v${version}.tar.gz"
-checksum=d7e6b94f956874b819e2e17c2368ffd6babf02e5df7f08f508cee4380c3e4e8a
+checksum=2c97d3a7281c80f5752294f196bff22a814aef8da7ca3b7545f50bbb9ed16d64


### PR DESCRIPTION
removes dependancy on gtk-engine-murrine. I don't see why a bunch of themes need this dependency. It is only needed for gtk2 support, so if users really need gtk2 support, they could just install that it manually. I don't think it makes sense to pull in gtk2 when installing a theme package.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl
  - i686
  - aarch64 (cross)
  - aarch64-musl (cross)
  - armv7l (cross)
  - armv7l-musl (cross)
  - armv6l (cross)
  - armv6l-musl (cross)

