### PR TITLE
snapcast: update to 0.28.0

### DIFF
--- a/srcpkgs/snapcast/template
+++ b/srcpkgs/snapcast/template
@@ -1,7 +1,8 @@
 # Template file for 'snapcast'
 pkgname=snapcast
-version=0.27.0
-revision=3
+version=0.28.0
+revision=1
+_snapweb_version=0.7.0
 build_style=cmake
 configure_args="-DCMAKE_INSTALL_SYSCONFDIR=/etc -DBUILD_WITH_TREMOR=OFF
  -DBUILD_WITH_AVAHI=$(vopt_if avahi ON OFF)
@@ -15,11 +16,18 @@ maintainer="amak <amak.git@outlook.com>"
 license="GPL-3.0-or-later"
 homepage="https://github.com/badaix/snapcast"
 changelog="https://raw.githubusercontent.com/badaix/snapcast/master/changelog.md"
-distfiles="https://github.com/badaix/snapcast/archive/v${version}.tar.gz"
-checksum=c662c6eafbaa42a4797a4ed6ba4a7602332abf99f6ba6ea88ff8ae59978a86ba
+distfiles="https://github.com/badaix/snapcast/archive/v${version}.tar.gz
+ https://github.com/badaix/snapweb/releases/download/v${_snapweb_version}/snapweb.zip>snapweb-${_snapweb_version}.zip"
+checksum="7911037dd4b06fe98166db1d49a7cd83ccf131210d5aaad47507bfa0cfc31407
+ 2acfc3538e4f4daefb0a2eac9126925f5a455dfd68b14ba5500fac5f1f82cb8f"
+skip_extraction="snapweb-${_snapweb_version}.zip"
 
 build_options="avahi pulseaudio"
 build_options_default="avahi pulseaudio"
+
+post_extract() {
+	vsrcextract -C server/etc/snapweb --strip-components=0 snapweb-${_snapweb_version}.zip
+}
 
 post_install() {
 	vdoc README.md


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->

This release no longer bundles the pre-built [Snapweb](https://github.com/badaix/snapweb). When accessing the Snapweb page, you are now greeted with the following notice.
```
This is a placeholder for Snapweb, a web based control client and player for Snapcast.
To install Snapweb, please follow these steps:

    1. Download Snapweb on the Snapweb release page. You can either download
        * snapweb.zip and extract it on your Snapcast server machine, e.g. into /usr/share/snapserver/snapweb or
        * snapweb_x.y.z-1_all.deb and install it with sudo apt install ./snapweb_x.y.z-1_all.deb to /usr/share/snapweb
    2. Configure the document root (doc_root, see below) in the snapserver configuration file snapserver.conf — usually located in /etc/snapserver.conf — to the location where snapweb is extracted or installed.
    3. Restart Snapserver to activate the changes: sudo service snapserver restart
```
What should we do with Snapweb?
1. Leave the `snapcast` package as is and let the user fetch and extract the pre-built Snapweb as per instructions.
2. Fetch and install the pre-built Snapweb from the `snapserver` subpackage.
3. Create a new `snapweb` package and build it from source. The user can then install it if needed.