### PR TITLE
xpadneo: update to 0.9.6

### DIFF
--- a/srcpkgs/xpadneo/template
+++ b/srcpkgs/xpadneo/template
@@ -1,6 +1,6 @@
 # Template file for 'xpadneo'
 pkgname=xpadneo
-version=0.9.5
+version=0.9.6
 revision=1
 depends="dkms bluez"
 short_desc="Bluetooth driver for Xbox One Wireless Controller"
@@ -8,7 +8,7 @@ maintainer="Joshua Krämer <joshua@kraemer.link>"
 license="GPL-3.0-or-later"
 homepage="https://github.com/atar-axis/xpadneo"
 distfiles="https://github.com/atar-axis/xpadneo/archive/v${version}.tar.gz"
-checksum=7518f75d7d30ae1c10ff110e7b066907a7e2c4586a670441d7c4bac9fc7afd52
+checksum=6fcb3376b31781a6341bf01912430bf7c3543d930dbee23915be77e7879330e3
 dkms_modules="hid-xpadneo ${version}"
 
 do_install() {


### PR DESCRIPTION

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl