### PR TITLE
[WIP] taskwarrior-tui: update to 0.26.3.

### DIFF
--- a/srcpkgs/task/template
+++ b/srcpkgs/task/template
@@ -1,15 +1,16 @@
 # Template file for 'task'
 pkgname=task
-version=2.6.2
+version=3.0.2
 revision=1
 build_style=cmake
+hostmakedepends="rust cargo"
 makedepends="libuuid-devel gnutls-devel"
 short_desc="Task Warrior command-line todo list manager"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
 homepage="https://taskwarrior.org"
 distfiles="https://github.com/GothenburgBitFactory/taskwarrior/releases/download/v${version}/task-${version}.tar.gz"
-checksum=b1d3a7f000cd0fd60640670064e0e001613c9e1cb2242b9b3a9066c78862cfec
+checksum=633b76637b0c74e4845ffa28249f01a16ed2c84000ece58d4358e72bf88d5f10
 
 post_install() {
 	vcompletion scripts/zsh/_task zsh

--- a/srcpkgs/taskwarrior-tui/template
+++ b/srcpkgs/taskwarrior-tui/template
@@ -1,7 +1,7 @@
 # Template file for 'taskwarrior-tui'
 pkgname=taskwarrior-tui
-version=0.25.4
-revision=2
+version=0.26.3
+revision=1
 build_style=cargo
 depends="task"
 checkdepends="git task"
@@ -10,7 +10,7 @@ maintainer="Eloi Torrents <eloitor@disroot.org>"
 license="MIT"
 homepage="https://kdheepak.com/taskwarrior-tui/"
 distfiles="https://github.com/kdheepak/taskwarrior-tui/archive/refs/tags/v${version}.tar.gz"
-checksum=86a00c0c33f825824ac432c50e57a9bac150c3ba9e3d06e6d86f65790a99a458
+checksum=76f053e2e3c9e71b8106e3fc3c18fd4400a98c09a8cde5972305e0eeaecc08d3
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**


#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)

Users should run `task export > all-tasks.json` before updating: https://taskwarrior.org/docs/upgrade-3/