### PR TITLE
Fix exported env variable for qt6ct.

### DIFF
--- a/srcpkgs/qt6ct/files/qt6ct.sh
+++ b/srcpkgs/qt6ct/files/qt6ct.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env sh
 
 if [ "$XDG_CURRENT_DESKTOP" != "KDE" ]; then
-	export QT_QPA_PLATFORMTHEME=qt5ct
+	export QT_QPA_PLATFORMTHEME=qt6ct
 fi
 if [ "$XDG_SESSION_TYPE" = "wayland" ]; then
 	export QT_QPA_PLATFORM=wayland

--- a/srcpkgs/qt6ct/template
+++ b/srcpkgs/qt6ct/template
@@ -1,7 +1,7 @@
 # Template file for 'qt6ct'
 pkgname=qt6ct
 version=0.9
-revision=1
+revision=2
 build_style=cmake
 hostmakedepends="qt6-tools qt6-base"
 makedepends="qt6-base-devel"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: YES
- pkg can be built locally and installed
- Qt6 apps now have fixed style

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-libc)
