### PR TITLE
xorg-server-xwayland: enable libdecor for rootful Xwayland

### DIFF
--- a/srcpkgs/xorg-server-xwayland/template
+++ b/srcpkgs/xorg-server-xwayland/template
@@ -1,7 +1,7 @@
 # Template file for 'xorg-server-xwayland'
 pkgname=xorg-server-xwayland
 version=23.2.4
-revision=1
+revision=2
 build_style=meson
 configure_args="-Dipv6=true -Dxvfb=false -Dxdmcp=false -Dxcsecurity=true
  -Ddri3=true -Dxwayland_eglstream=false -Dglamor=true -Dxkb_dir=/usr/share/X11/xkb
@@ -9,7 +9,7 @@ configure_args="-Dipv6=true -Dxvfb=false -Dxdmcp=false -Dxcsecurity=true
 hostmakedepends="pkg-config wayland-devel"
 makedepends="nettle-devel libepoxy-devel font-util libXfont2-devel pixman-devel
  libxkbfile-devel dbus-devel wayland-devel wayland-protocols libtirpc-devel
- MesaLib-devel libxcb-devel libxshmfence-devel libxcvt-devel"
+ MesaLib-devel libxcb-devel libxshmfence-devel libxcvt-devel libdecor-devel"
 depends="xorg-server-common"
 short_desc="Nested X server that runs as a wayland client"
 maintainer="Orphaned <orphan@voidlinux.org>"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl
  - i686
  - aarch64 (cross)
  - aarch64-musl (cross)
  - armv7l (cross)
  - armv7l-musl (cross)
  - armv6l (cross)
  - armv6l-musl (cross)
