### PR TITLE
ktouch: update to 24.02.2.

### DIFF
--- a/srcpkgs/ktouch/template
+++ b/srcpkgs/ktouch/template
@@ -1,6 +1,6 @@
 # Template file for 'ktouch'
 pkgname=ktouch
-version=23.08.5
+version=24.02.2
 revision=1
 build_style=cmake
 hostmakedepends="extra-cmake-modules kconfig kcoreaddons kdoctools
@@ -16,4 +16,4 @@ license="GPL-2.0-or-later"
 homepage="https://apps.kde.org/ktouch"
 changelog="https://kde.org/announcements/changelogs/gear/${version}/#ktouch"
 distfiles="${KDE_SITE}/release-service/${version}/src/ktouch-${version}.tar.xz"
-checksum=2d102a73560da4676628bb138eeec2d847dd35db0224b9fd0a7016ebfef59c5d
+checksum=53910f976e3741b2fcfbe233a5582f6accae50e0e25f12d5fdb7fe53114d48ea


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)
<!--- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
