### PR TITLE
neovim: update to 0.10.0

### DIFF
--- a/common/hooks/pre-pkg/04-generate-runtime-deps.sh
+++ b/common/hooks/pre-pkg/04-generate-runtime-deps.sh
@@ -98,7 +98,12 @@ hook() {
     for f in ${verify_deps}; do
         unset _rdep _pkgname _rdepver
 
-        if [ "$(find ${PKGDESTDIR} -name "$f")" ]; then
+        local _findargs="-name"
+        # if SONAME is a path, find should use -wholename
+        if [[ "$f" = */* ]]; then
+            _findargs="-wholename"
+        fi
+        if [ "$(find "${PKGDESTDIR}" $_findargs "$f")" ]; then
             # Ignore libs by current pkg
             echo "   SONAME: $f <-> $pkgname (ignored)"
             continue

--- a/common/shlibs
+++ b/common/shlibs
@@ -4438,3 +4438,4 @@ libcamera.so.0.2 libcamera-0.2.0_1
 libcamera-base.so.0.2 libcamera-0.2.0_1
 libKPim6MimeTreeParserCore.so.6 mimetreeparser-24.02.0_1
 libKPim6MimeTreeParserWidgets.so.6 mimetreeparser-24.02.0_1
+/usr/lib/lua/5.1/lpeg.so lua51-lpeg-1.1.0_2

--- a/srcpkgs/lua54-lpeg/template
+++ b/srcpkgs/lua54-lpeg/template
@@ -1,7 +1,7 @@
 # Template file for 'lua54-lpeg'
 pkgname=lua54-lpeg
 version=1.1.0
-revision=1
+revision=2
 hostmakedepends="lua51 lua52 lua53 lua54"
 makedepends="lua51-devel lua52-devel lua53-devel lua54-devel"
 depends="lua54"
@@ -61,6 +61,7 @@ do_install() {
 lua51-lpeg_package() {
 	depends="lua51"
 	short_desc="${_desc} (5.1.x)"
+	shlib_provides="/usr/lib/lua/5.1/lpeg.so"
 	pkg_install() {
 		vmove usr/lib/lua/5.1
 		vmove usr/share/lua/5.1

--- a/srcpkgs/neovim/patches/cmake-allow-build-type-none.patch
+++ b/srcpkgs/neovim/patches/cmake-allow-build-type-none.patch
@@ -1,31 +1,28 @@
+Void uses the "None" build type to apply our chosen compile settings.
+
+diff --git a/cmake/Util.cmake b/cmake/Util.cmake
+index f09de78..f48f2d0 100644
 --- a/cmake/Util.cmake
 +++ b/cmake/Util.cmake
-@@ -162,7 +162,7 @@ endfunction()
- # Passing CMAKE_BUILD_TYPE for multi-config generators will now not only
- # not be used, but also generate a warning for the user.
- function(set_default_buildtype)
+@@ -193,7 +193,7 @@ endfunction()
+ # Passing CMAKE_BUILD_TYPE for multi-config generators will not only not be
+ # used, but also generate a warning for the user.
+ function(set_default_buildtype BUILD_TYPE)
 -  set(allowableBuildTypes Debug Release MinSizeRel RelWithDebInfo)
 +  set(allowableBuildTypes Debug Release MinSizeRel RelWithDebInfo None)
- 
-   get_property(isMultiConfig GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
-   if(isMultiConfig)
-@@ -177,7 +177,7 @@ function(set_default_buildtype)
-       message(STATUS "CMAKE_BUILD_TYPE not specified, default is 'Debug'")
-       set(CMAKE_BUILD_TYPE Debug CACHE STRING "Choose the type of build" FORCE)
-     elseif(NOT CMAKE_BUILD_TYPE IN_LIST allowableBuildTypes)
--      message(FATAL_ERROR "Invalid build type: ${CMAKE_BUILD_TYPE}")
-+      message(WARNING "Invalid build type: ${CMAKE_BUILD_TYPE}")
-     else()
-       message(STATUS "CMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}")
-     endif()
+   if(NOT BUILD_TYPE IN_LIST allowableBuildTypes)
+     message(FATAL_ERROR "Invalid build type: ${BUILD_TYPE}")
+   endif()
+diff --git a/runtime/lua/nvim/health.lua b/runtime/lua/nvim/health.lua
+index 5bc0319..40a72c1 100644
 --- a/runtime/lua/nvim/health.lua
 +++ b/runtime/lua/nvim/health.lua
-@@ -152,7 +152,7 @@
+@@ -153,7 +153,7 @@ local function check_performance()
    local buildtype = vim.fn.matchstr(vim.fn.execute('version'), [[\v\cbuild type:?\s*[^\n\r\t ]+]])
-   if empty(buildtype) then
-     health.report_error('failed to get build type from :version')
+   if buildtype == '' then
+     health.error('failed to get build type from :version')
 -  elseif vim.regex([[\v(MinSizeRel|Release|RelWithDebInfo)]]):match_str(buildtype) then
 +  elseif vim.regex([[\v(MinSizeRel|Release|RelWithDebInfo|None)]]):match_str(buildtype) then
-     health.report_ok(buildtype)
+     health.ok(buildtype)
    else
-     health.report_info(buildtype)
+     health.info(buildtype)

--- a/srcpkgs/neovim/patches/cross-build.patch
+++ b/srcpkgs/neovim/patches/cross-build.patch
@@ -1,0 +1,135 @@
+diff --git a/runtime/CMakeLists.txt b/runtime/CMakeLists.txt
+index c171fab..cb29798 100644
+--- a/runtime/CMakeLists.txt
++++ b/runtime/CMakeLists.txt
+@@ -11,7 +11,7 @@ get_directory_property(LUA_GEN DIRECTORY ${PROJECT_SOURCE_DIR}/src/nvim DEFINITI
+ get_directory_property(LUA_GEN_DEPS DIRECTORY ${PROJECT_SOURCE_DIR}/src/nvim DEFINITION LUA_GEN_DEPS)
+ 
+ add_custom_command(OUTPUT ${GENERATED_SYN_VIM}
+-  COMMAND ${LUA_GEN} ${SYN_VIM_GENERATOR} ${GENERATED_SYN_VIM} ${FUNCS_DATA}
++  COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} ${LUA_GEN} ${SYN_VIM_GENERATOR} ${GENERATED_SYN_VIM} ${FUNCS_DATA}
+   DEPENDS
+     ${LUA_GEN_DEPS}
+     ${SYN_VIM_GENERATOR}
+@@ -33,7 +33,7 @@ foreach(PACKAGE ${PACKAGES})
+     add_custom_command(OUTPUT "${GENERATED_PACKAGE_DIR}/${PACKNAME}/doc/tags"
+       COMMAND ${CMAKE_COMMAND} -E copy_directory
+         ${PACKAGE} ${GENERATED_PACKAGE_DIR}/${PACKNAME}
+-      COMMAND $<TARGET_FILE:nvim_bin>
++      COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:nvim_bin>
+         -u NONE -i NONE -e --headless -c "helptags doc" -c quit
+       DEPENDS
+         nvim_bin
+@@ -65,7 +65,7 @@ add_custom_command(OUTPUT ${GENERATED_HELP_TAGS}
+   COMMAND ${CMAKE_COMMAND} -E remove_directory doc
+   COMMAND ${CMAKE_COMMAND} -E copy_directory
+     ${PROJECT_SOURCE_DIR}/runtime/doc doc
+-  COMMAND $<TARGET_FILE:nvim_bin>
++  COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:nvim_bin>
+     -u NONE -i NONE -e --headless -c "helptags ++t doc" -c quit
+   DEPENDS
+     nvim_bin
+diff --git a/src/nvim/CMakeLists.txt b/src/nvim/CMakeLists.txt
+index d9cc695..81e9b50 100644
+--- a/src/nvim/CMakeLists.txt
++++ b/src/nvim/CMakeLists.txt
+@@ -541,7 +541,7 @@ foreach(sfile ${NVIM_SOURCES}
+   add_custom_command(
+     OUTPUT "${gf_c_h}" "${gf_h_h}"
+     COMMAND ${CMAKE_C_COMPILER} ${sfile} ${PREPROC_OUTPUT} ${gen_cflags}
+-    COMMAND ${LUA_GEN} "${HEADER_GENERATOR}" "${sfile}" "${gf_c_h}" "${gf_h_h}" "${gf_i}"
++    COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} ${LUA_GEN} "${HEADER_GENERATOR}" "${sfile}" "${gf_c_h}" "${gf_h_h}" "${gf_i}"
+     DEPENDS ${depends})
+   list(APPEND NVIM_GENERATED_FOR_SOURCES "${gf_c_h}")
+   list(APPEND NVIM_GENERATED_FOR_HEADERS "${gf_h_h}")
+@@ -551,7 +551,7 @@ foreach(sfile ${NVIM_SOURCES}
+ endforeach()
+ 
+ add_custom_command(OUTPUT ${GENERATED_UNICODE_TABLES}
+-  COMMAND ${LUA_PRG} ${UNICODE_TABLES_GENERATOR}
++  COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} ${LUA_PRG} ${UNICODE_TABLES_GENERATOR}
+                      ${UNICODE_DIR}
+                      ${GENERATED_UNICODE_TABLES}
+   DEPENDS
+@@ -565,7 +565,7 @@ configure_file(${GENERATOR_DIR}/nvim_version.lua.in ${NVIM_VERSION_LUA})
+ add_custom_command(
+   OUTPUT ${GENERATED_API_DISPATCH} ${GENERATED_API_METADATA}
+   ${FUNCS_METADATA} ${LUA_API_C_BINDINGS} ${GENERATED_KEYSETS_DEFS}
+-         COMMAND ${LUA_GEN} ${API_DISPATCH_GENERATOR}
++         COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} ${LUA_GEN} ${API_DISPATCH_GENERATOR}
+                          ${GENERATED_API_DISPATCH}
+                          ${GENERATED_API_METADATA} ${FUNCS_METADATA}
+                          ${LUA_API_C_BINDINGS}
+@@ -589,7 +589,7 @@ add_custom_command(
+   OUTPUT ${VIM_MODULE_FILE}
+   COMMAND ${CMAKE_COMMAND} -E env
+       "LUAC_PRG=${LUAC_PRG}"
+-      ${LUA_PRG} ${CHAR_BLOB_GENERATOR} -c ${VIM_MODULE_FILE}
++      ${CMAKE_CROSSCOMPILING_EMULATOR} ${LUA_PRG} ${CHAR_BLOB_GENERATOR} -c ${VIM_MODULE_FILE}
+       # NB: vim._init_packages and vim.inspect must be be first and second ones
+       # respectively, otherwise --luamod-dev won't work properly.
+       ${LUA_INIT_PACKAGES_MODULE_SOURCE} "vim._init_packages"
+@@ -624,7 +624,7 @@ add_custom_command(
+          ${GENERATED_UI_EVENTS_REMOTE}
+          ${UI_METADATA}
+          ${GENERATED_UI_EVENTS_CLIENT}
+-  COMMAND ${LUA_GEN} ${API_UI_EVENTS_GENERATOR}
++  COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} ${LUA_GEN} ${API_UI_EVENTS_GENERATOR}
+                      ${CMAKE_CURRENT_LIST_DIR}/api/ui_events.in.h
+                      ${GENERATED_UI_EVENTS_CALL}
+                      ${GENERATED_UI_EVENTS_REMOTE}
+@@ -656,29 +656,29 @@ list(APPEND NVIM_GENERATED_FOR_SOURCES
+ )
+ 
+ add_custom_command(OUTPUT ${GENERATED_EX_CMDS_ENUM} ${GENERATED_EX_CMDS_DEFS}
+-  COMMAND ${LUA_GEN} ${EX_CMDS_GENERATOR} ${GENERATED_INCLUDES_DIR} ${GENERATED_DIR}
++  COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} ${LUA_GEN} ${EX_CMDS_GENERATOR} ${GENERATED_INCLUDES_DIR} ${GENERATED_DIR}
+   DEPENDS ${LUA_GEN_DEPS} ${EX_CMDS_GENERATOR} ${CMAKE_CURRENT_LIST_DIR}/ex_cmds.lua
+ )
+ 
+ add_custom_command(OUTPUT ${GENERATED_FUNCS} ${FUNCS_DATA}
+-  COMMAND ${LUA_GEN} ${FUNCS_GENERATOR} ${GENERATED_DIR} ${FUNCS_METADATA} ${FUNCS_DATA}
++  COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} ${LUA_GEN} ${FUNCS_GENERATOR} ${GENERATED_DIR} ${FUNCS_METADATA} ${FUNCS_DATA}
+   DEPENDS ${LUA_GEN_DEPS} ${FUNCS_GENERATOR} ${CMAKE_CURRENT_LIST_DIR}/eval.lua ${FUNCS_METADATA}
+ )
+ list(APPEND NVIM_GENERATED_FOR_SOURCES
+   "${GENERATED_FUNCS}")
+ 
+ add_custom_command(OUTPUT ${GENERATED_EVENTS_ENUM} ${GENERATED_EVENTS_NAMES_MAP}
+-  COMMAND ${LUA_GEN} ${EVENTS_GENERATOR} ${GENERATED_EVENTS_ENUM} ${GENERATED_EVENTS_NAMES_MAP}
++  COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} ${LUA_GEN} ${EVENTS_GENERATOR} ${GENERATED_EVENTS_ENUM} ${GENERATED_EVENTS_NAMES_MAP}
+   DEPENDS ${LUA_GEN_DEPS} ${EVENTS_GENERATOR} ${CMAKE_CURRENT_LIST_DIR}/auevents.lua
+ )
+ 
+ add_custom_command(OUTPUT ${GENERATED_OPTIONS}
+-  COMMAND ${LUA_GEN} ${OPTIONS_GENERATOR} ${GENERATED_OPTIONS}
++  COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} ${LUA_GEN} ${OPTIONS_GENERATOR} ${GENERATED_OPTIONS}
+   DEPENDS ${LUA_GEN_DEPS} ${OPTIONS_GENERATOR} ${CMAKE_CURRENT_LIST_DIR}/options.lua
+ )
+ 
+ add_custom_command(OUTPUT ${GENERATED_OPTIONS_ENUM} ${GENERATED_OPTIONS_MAP}
+-  COMMAND ${LUA_GEN} ${OPTIONS_ENUM_GENERATOR} ${GENERATED_OPTIONS_ENUM} ${GENERATED_OPTIONS_MAP}
++  COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} ${LUA_GEN} ${OPTIONS_ENUM_GENERATOR} ${GENERATED_OPTIONS_ENUM} ${GENERATED_OPTIONS_MAP}
+   DEPENDS ${LUA_GEN_DEPS} ${OPTIONS_ENUM_GENERATOR} ${CMAKE_CURRENT_LIST_DIR}/options.lua
+ )
+ 
+diff --git a/src/nvim/po/CMakeLists.txt b/src/nvim/po/CMakeLists.txt
+index 6c20089..0e99128 100644
+--- a/src/nvim/po/CMakeLists.txt
++++ b/src/nvim/po/CMakeLists.txt
+@@ -53,13 +53,13 @@ if(HAVE_WORKING_LIBINTL AND GETTEXT_FOUND AND XGETTEXT_PRG AND ICONV_PRG)
+   list(SORT NVIM_RELATIVE_SOURCES)
+   add_custom_command(
+     OUTPUT ${NVIM_POT}
+-    COMMAND $<TARGET_FILE:nvim_bin> -u NONE -i NONE -n --headless --cmd "set cpo+=+"
++    COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:nvim_bin> -u NONE -i NONE -n --headless --cmd "set cpo+=+"
+       -S ${CMAKE_CURRENT_SOURCE_DIR}/tojavascript.vim ${NVIM_POT} ${PROJECT_SOURCE_DIR}/runtime/optwin.vim
+     COMMAND ${XGETTEXT_PRG} -o ${NVIM_POT} --default-domain=nvim
+       --add-comments --keyword=_ --keyword=N_ --keyword=NGETTEXT:1,2
+       -D ${CMAKE_CURRENT_SOURCE_DIR} -D ${CMAKE_CURRENT_BINARY_DIR}
+       ${NVIM_RELATIVE_SOURCES} optwin.js
+-    COMMAND $<TARGET_FILE:nvim_bin> -u NONE -i NONE -n --headless --cmd "set cpo+=+"
++    COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:nvim_bin> -u NONE -i NONE -n --headless --cmd "set cpo+=+"
+       -S ${CMAKE_CURRENT_SOURCE_DIR}/fixfilenames.vim ${NVIM_POT} ../../../runtime/optwin.vim
+     VERBATIM
+     DEPENDS ${NVIM_SOURCES} nvim_bin nvim_runtime_deps)

--- a/srcpkgs/neovim/patches/disable-parser-download.patch
+++ b/srcpkgs/neovim/patches/disable-parser-download.patch
@@ -1,0 +1,20 @@
+diff --git a/cmake.deps/cmake/BuildTreesitterParsers.cmake b/cmake.deps/cmake/BuildTreesitterParsers.cmake
+index 837d075..6c3fccb 100644
+--- a/cmake.deps/cmake/BuildTreesitterParsers.cmake
++++ b/cmake.deps/cmake/BuildTreesitterParsers.cmake
+@@ -19,13 +19,12 @@ function(BuildTSParser)
+ 
+   get_externalproject_options(${NAME} ${DEPS_IGNORE_SHA})
+   ExternalProject_Add(${NAME}
+-    DOWNLOAD_DIR ${DEPS_DOWNLOAD_DIR}/${NAME}
++    SOURCE_DIR ${DEPS_BUILD_DIR}/src/${NAME}
+     PATCH_COMMAND ${CMAKE_COMMAND} -E copy
+       ${CMAKE_CURRENT_SOURCE_DIR}/cmake/${TS_CMAKE_FILE}
+       ${DEPS_BUILD_DIR}/src/${NAME}/CMakeLists.txt
+     CMAKE_ARGS ${DEPS_CMAKE_ARGS}
+-      -D PARSERLANG=${TS_LANG}
+-    ${EXTERNALPROJECT_OPTIONS})
++      -D PARSERLANG=${TS_LANG})
+ endfunction()
+ 
+ foreach(lang c lua vim vimdoc query python bash)

--- a/srcpkgs/neovim/template
+++ b/srcpkgs/neovim/template
@@ -1,26 +1,61 @@
 # Template file for 'neovim'
 pkgname=neovim
-version=0.9.5
-revision=2
+version=0.10.0
+revision=1
+# as per https://github.com/neovim/neovim/blob/master/cmake.deps/deps.txt
+_treesitter_c_version=0.21.0
+_treesitter_lua_version=0.1.0
+_treesitter_vim_version=0.4.0
+_treesitter_vimdoc_version=2.5.1
+_treesitter_query_version=0.3.0
+_treesitter_python_version=0.21.0
+_treesitter_bash_version=0.21.0
+_treesitter_markdown_version=0.2.3
 build_style=cmake
 build_helper="qemu"
 configure_args="-DCOMPILE_LUA=OFF -DPREFER_LUA=$(vopt_if luajit OFF ON)"
-hostmakedepends="gettext lua51-lpeg lua51-mpack lua51-BitOp
- $(vopt_if luajit LuaJIT lua51)"
-makedepends="libtermkey-devel libuv-devel libvterm-devel msgpack-devel
- libluv-devel tree-sitter-devel $(vopt_if luajit LuaJIT-devel lua51-devel)"
+hostmakedepends="gettext patchelf"
+makedepends="libuv-devel libvterm-devel msgpack-devel
+ libluv-devel tree-sitter-devel unibilium-devel
+ lua51-lpeg $(vopt_if luajit LuaJIT-devel lua51-devel)"
 short_desc="Fork of Vim aiming to improve user experience, plugins and GUIs"
 maintainer="Marcin Puc <tranzystorek.io@protonmail.com>"
 license="Apache-2.0, Vim"
 homepage="https://neovim.io"
 changelog="https://github.com/neovim/neovim/releases"
-distfiles="https://github.com/neovim/neovim/archive/refs/tags/v${version}.tar.gz"
-checksum=fe74369fc30a32ec7a086b1013acd0eacd674e7570eb1acc520a66180c9e9719
+distfiles="https://github.com/neovim/neovim/archive/refs/tags/v${version}.tar.gz
+ https://github.com/tree-sitter/tree-sitter-c/archive/refs/tags/v${_treesitter_c_version}.tar.gz>treesitter_c_${_treesitter_c_version}.tar.gz
+ https://github.com/tree-sitter-grammars/tree-sitter-lua/archive/refs/tags/v${_treesitter_lua_version}.tar.gz>treesitter_lua_${_treesitter_lua_version}.tar.gz
+ https://github.com/tree-sitter-grammars/tree-sitter-vim/archive/refs/tags/v${_treesitter_vim_version}.tar.gz>treesitter_vim_${_treesitter_vim_version}.tar.gz
+ https://github.com/neovim/tree-sitter-vimdoc/archive/refs/tags/v${_treesitter_vimdoc_version}.tar.gz>treesitter_vimdoc_${_treesitter_vimdoc_version}.tar.gz
+ https://github.com/tree-sitter-grammars/tree-sitter-query/archive/refs/tags/v${_treesitter_query_version}.tar.gz>treesitter_query_${_treesitter_query_version}.tar.gz
+ https://github.com/tree-sitter/tree-sitter-python/archive/refs/tags/v${_treesitter_python_version}.tar.gz>treesitter_python_${_treesitter_python_version}.tar.gz
+ https://github.com/tree-sitter/tree-sitter-bash/archive/refs/tags/v${_treesitter_bash_version}.tar.gz>treesitter_bash_${_treesitter_bash_version}.tar.gz
+ https://github.com/tree-sitter-grammars/tree-sitter-markdown/archive/refs/tags/v${_treesitter_markdown_version}.tar.gz>treesitter_markdown_${_treesitter_markdown_version}.tar.gz"
+checksum="372ea2584b0ea2a5a765844d95206bda9e4a57eaa1a2412a9a0726bab750f828
+ 6f0f5d1b71cf8ffd8a37fb638c6022fa1245bd630150b538547d52128ce0ea7e
+ 230cfcbfa74ed1f7b8149e9a1f34c2efc4c589a71fe0f5dc8560622f8020d722
+ 9f856f8b4a10ab43348550fa2d3cb2846ae3d8e60f45887200549c051c66f9d5
+ 063645096504b21603585507c41c6d8718ff3c11b2150c5bfc31e8f3ee9afea3
+ f878ff37abcb83250e31a6569e997546f3dbab74dcb26683cb2d613f7568cfc0
+ 720304a603271fa89e4430a14d6a81a023d6d7d1171b1533e49c0ab44f1e1c13
+ f0515efda839cfede851adb24ac154227fbc0dfb60c6c11595ecfa9087d43ceb
+ 4909d6023643f1afc3ab219585d4035b7403f3a17849782ab803c5f73c8a31d5"
+
+skip_extraction="
+ treesitter_c_${_treesitter_c_version}.tar.gz
+ treesitter_lua_${_treesitter_lua_version}.tar.gz
+ treesitter_vim_${_treesitter_vim_version}.tar.gz
+ treesitter_vimdoc_${_treesitter_vimdoc_version}.tar.gz
+ treesitter_query_${_treesitter_query_version}.tar.gz
+ treesitter_python_${_treesitter_python_version}.tar.gz
+ treesitter_bash_${_treesitter_bash_version}.tar.gz
+ treesitter_markdown_${_treesitter_markdown_version}.tar.gz"
 
 build_options=luajit
 
 case "$XBPS_TARGET_MACHINE" in
-	riscv64*) build_options_default="" ;;
+	armv7l|riscv64*) build_options_default="" ;;
 	*) build_options_default="luajit" ;;
 esac
 
@@ -35,13 +70,24 @@ alternatives="
 # They want assertion
 CFLAGS=-UNDEBUG
 
+post_extract() {
+	for _distfile in ${skip_extraction}; do
+		vsrcextract -C .deps/build/src/${_distfile%_*} ${_distfile}
+	done
+}
+
 pre_configure() {
-	vsed -i runtime/CMakeLists.txt \
-		-e "s|\".*/bin/nvim|\${CMAKE_CROSSCOMPILING_EMULATOR} &|g"
-	vsed -i src/nvim/po/CMakeLists.txt \
-		-e "s|\$<TARGET_FILE:nvim|\${CMAKE_CROSSCOMPILING_EMULATOR} &|g"
+	# build bundled treesitter parsers
+	cmake -S cmake.deps -B .deps -G Ninja -DUSE_BUNDLED=OFF -DUSE_BUNDLED_TS_PARSERS=ON
+	cmake --build .deps
 }
 
 post_install() {
 	vlicense LICENSE.txt
+
+	if [ "${CROSS_BUILD}" ]; then
+		patchelf --replace-needed \
+			${XBPS_CROSS_BASE}/usr/lib/lua/5.1/lpeg.so /usr/lib/lua/5.1/lpeg.so \
+			${DESTDIR}/usr/bin/nvim
+	fi
 }


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: YES

Neovim now depends on lua-lpeg as a library and dynamically links to it, but we don't serve it as a shlib.

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
