### PR TITLE
netavark: update to 1.10.3.

### DIFF
--- a/srcpkgs/netavark/template
+++ b/srcpkgs/netavark/template
@@ -1,6 +1,6 @@
 # Template file for 'netavark'
 pkgname=netavark
-version=1.9.0
+version=1.10.3
 revision=1
 build_style=cargo
 hostmakedepends="mandown protobuf"
@@ -10,7 +10,7 @@ license="Apache-2.0"
 homepage="https://github.com/containers/netavark"
 changelog="https://raw.githubusercontent.com/containers/netavark/main/RELEASE_NOTES.md"
 distfiles="https://github.com/containers/netavark/archive/refs/tags/v${version}.tar.gz"
-checksum=9ec50b715ded0a0699134c001656fdd1411e3fb5325d347695c6cb8cc5fcf572
+checksum=fdc3010cb221f0fcef0302f57ef6f4d9168a61f9606238a3e1ed4d2e348257b7
 # needs unshare which cannot be used in CI
 make_check=ci-skip
 


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
