### PR TITLE
ntdsextract2: update to 1.2.1.

### DIFF
--- a/srcpkgs/ntdsextract2/patches/no-cygwin-fs.patch
+++ b/srcpkgs/ntdsextract2/patches/no-cygwin-fs.patch
@@ -1,0 +1,23 @@
+--- a/ntdsextract2-1.2.1/Cargo.toml
++++ b/ntdsextract2-1.2.1/Cargo.toml
+@@ -37,8 +37,7 @@
+ paste = "1.0"
+ bodyfile = "0.1.4"
+ hashbrown = "0"
+-libesedb = "0.2.5"
+-#libesedb = {path="../rust-libesedb"}
++libesedb = {path="../rust-libesedb-libesedb-v0.2.5/"}
+ 
+ serde = { version = "1.0", features = ["derive"] }
+ serde_json = "1.0"
+--- a/rust-libesedb-libesedb-v0.2.5/libesedb-sys/libesedb-20230824/common/config.h
++++ b/rust-libesedb-libesedb-v0.2.5/libesedb-sys/libesedb-20230824/common/config.h
+@@ -26,7 +26,7 @@
+ #define HAVE_CLOSE 1
+ 
+ /* Define to 1 if you have the <cygwin/fs.h> header file. */
+-#define HAVE_CYGWIN_FS_H 1
++/*#define HAVE_CYGWIN_FS_H 1*/
+ 
+ /* Define if the GNU dcgettext() function is already present or preinstalled.
+    */

--- a/srcpkgs/ntdsextract2/template
+++ b/srcpkgs/ntdsextract2/template
@@ -1,12 +1,23 @@
 # Template file for 'ntdsextract2'
 pkgname=ntdsextract2
-reverts="1.0.0_1"
-version=0.13.0
-revision=2
+version=1.2.1
+revision=1
+_esedbver=0.2.5
+build_wrksrc="${pkgname}-${version}"
 build_style=cargo
 short_desc="Display contents of Active Directory database files"
 maintainer="Andrew Benson <abenson+void@gmail.com>"
 license="GPL-3.0-or-later"
 homepage="https://github.com/janstarke/ntdsextract2"
-distfiles="https://github.com/janstarke/ntdsextract2/archive/refs/tags/v${version}.tar.gz"
-checksum=6f11d86440f2ec9383bb0857864f96fd470c97be19b3d67af0a2c949c19aa3b1
+distfiles="https://github.com/janstarke/ntdsextract2/archive/refs/tags/v${version}.tar.gz
+ https://github.com/sunsetkookaburra/rust-libesedb/archive/refs/tags/libesedb-v${_esedbver}.tar.gz"
+checksum="2aac2a849f762322bc5c71d658375f490e5ab14948fcaa3debfe20de3b1c5e18
+ 30fce9b9766903280d3f6273e2f991b2296ccd3eed878262d1a68c7ceb76b658"
+make_check=no # testing requires a large sample test file that isn't distributed
+
+pre_configure() {
+	if [ "$XBPS_TARGET_WORDSIZE" = 32 ]; then
+		vsed -e "s/4096 \* 1024 \* 1024/usize::max_value()/" -i src/main.rs
+	fi
+	cargo generate-lockfile
+}


### PR DESCRIPTION

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl
  - aarch64
  - armv7l
  - i686