### PR TITLE
intel-ucode: update to 20240514.

### DIFF
--- a/srcpkgs/intel-ucode/template
+++ b/srcpkgs/intel-ucode/template
@@ -1,6 +1,6 @@
 # Template file for 'intel-ucode'
 pkgname=intel-ucode
-version=20231114
+version=20240514
 revision=1
 archs="i686* x86_64*"
 short_desc="Microcode update files for Intel CPUs"
@@ -9,7 +9,7 @@ license="custom: Proprietary"
 homepage="https://github.com/intel/Intel-Linux-Processor-Microcode-Data-Files"
 changelog="https://raw.githubusercontent.com/intel/Intel-Linux-Processor-Microcode-Data-Files/main/releasenote.md"
 distfiles="https://github.com/intel/Intel-Linux-Processor-Microcode-Data-Files/archive/refs/tags/microcode-${version}.tar.gz"
-checksum=cee26f311f7e2c039dd48cd30f995183bde9b98fb4c3039800e2ddaf5c090e55
+checksum=b5e3cbcb2e34d4c32dcdbfee36603dd68e8a4162cf7e44084f6989d440e69a08
 repository=nonfree
 
 do_install() {


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

Void is a couple of ucode verions behind. This updated fixes a few vulnerabilities

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
