### PR TITLE
haproxy: update to 2.8.9.

### DIFF
--- a/srcpkgs/haproxy/template
+++ b/srcpkgs/haproxy/template
@@ -1,6 +1,6 @@
 # Template file for 'haproxy'
 pkgname=haproxy
-version=2.6.16
+version=2.8.9
 revision=1
 build_style=gnu-makefile
 make_install_args="SBINDIR=${DESTDIR}/usr/bin DOCDIR=${DESTDIR}/usr/share/doc/${pkgname}"
@@ -13,7 +13,7 @@ license="GPL-2.0-or-later, LGPL-2.1-or-later"
 homepage="https://www.haproxy.org"
 changelog="https://www.haproxy.org/download/${version%.*}/src/CHANGELOG"
 distfiles="https://www.haproxy.org/download/${version%.*}/src/haproxy-${version}.tar.gz"
-checksum=faac6f9564caf6e106fe22c77a1fb35406afc8cd484c35c2c844aaf0d7a097fb
+checksum=7a821478f36f847607f51a51e80f4f890c37af4811d60438e7f63783f67592ff
 
 if [ "$XBPS_TARGET_LIBC" = "glibc" ]; then
 	makedepends+=" libxcrypt-devel"

--- a/srcpkgs/haproxy/update
+++ b/srcpkgs/haproxy/update
@@ -1,2 +1,2 @@
-# 2.6 is the current LTS
-ignore="2\.[!6].*"
+# 2.8 is the current LTS
+ignore="2\.[!8].*"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc

2.8.x is the latest LTS branch.

cc @zdykstra 