### PR TITLE
digikam: update to 8.3.0, add dependancies on mysql and sqlite plugins

### DIFF
--- a/srcpkgs/digikam/template
+++ b/srcpkgs/digikam/template
@@ -1,7 +1,7 @@
 # Template file for 'digikam'
 pkgname=digikam
-version=8.2.0
-revision=2
+version=8.3.0
+revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins -DBUILD_WITH_QT6=ON
@@ -9,8 +9,7 @@ configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
  -DECM_MKSPECS_INSTALL_DIR=/usr/lib/qt6/mkspecs/modules"
 hostmakedepends="extra-cmake-modules gettext pkg-config bison flex qt6-base
  kf6-kcoreaddons kf6-kconfig"
-makedepends="qt6-base-devel libjpeg-turbo-devel qt6-plugin-mysql qt6-plugin-odbc
- qt6-plugin-pgsql qt6-plugin-sqlite qt6-scxml-devel
+makedepends="qt6-base-devel libjpeg-turbo-devel qt6-scxml-devel
  qt6-declarative-devel kf6-kxmlgui-devel kf6-kfilemetadata-devel
  kf6-kcoreaddons-devel kf6-kconfig-devel kf6-kservice-devel kf6-kwindowsystem-devel
  kf6-solid-devel kf6-ki18n-devel kf6-kio-devel kf6-kiconthemes-devel
@@ -18,13 +17,15 @@ makedepends="qt6-base-devel libjpeg-turbo-devel qt6-plugin-mysql qt6-plugin-odbc
  akonadi-contacts-devel libksane6-devel kf6-kcalendarcore-devel tiff-devel
  lcms2-devel qtav libopencv-devel liblqr-devel libgphoto2-devel qt6-webengine-devel
  lensfun-devel eigen jasper-devel MesaLib-devel glu-devel qt6-webchannel-devel
- kf6-kconfigwidgets-devel kf6-kwidgetsaddons-devel libheif-devel qt6-networkauth-devel"
+ kf6-kconfigwidgets-devel kf6-kwidgetsaddons-devel libheif-devel qt6-networkauth-devel
+ libmagick-devel"
+depends="qt6-plugin-sqlite qt6-plugin-mysql"
 short_desc="Advanced digital photo management application"
 maintainer="Helmut Pozimski <helmut@pozimski.eu>"
 license="GPL-2.0-or-later, LGPL-2.1-or-later"
 homepage="https://www.digikam.org"
-distfiles="${KDE_SITE}/digikam/${version}/digiKam-${version}.tar.xz"
-checksum=2f7fcb559b123ed9ecae5a5aef6f4560eee5f49206d9d1746dec9ab6c8fb38bf
+distfiles="${KDE_SITE}/digikam/${version}/digiKam-${version}-1.tar.xz"
+checksum=05b145ff7f2f2005fa21bc579c152ab23c8191b678ff2944c8f0406d6b9de6d8
 
 # TODO add marble back when it's ported to Qt6
 


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

adds dependancies on qt6-plugin-{sqlite,mysql} because digikam needs at least one of those to function.

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - 86_64-musl
  - aarch64 (cross)
  - aarch64-musl (cross)

cannot be built on other archs because of webengine
