### PR TITLE
dwm: patch to make Firefox doesn't always run in workspace 9

### DIFF
--- a/srcpkgs/dwm/patches/fix-firefox.patch
+++ b/srcpkgs/dwm/patches/fix-firefox.patch
@@ -1,0 +1,20 @@
+diff '--color=auto' -crB dwm-6.5.orig/config.def.h dwm-6.5/config.def.h
+*** dwm-6.5.orig/config.def.h	2024-05-21 14:45:25.373046861 +0700
+--- dwm-6.5/config.def.h	2024-05-21 14:45:53.374487102 +0700
+***************
+*** 28,34 ****
+  	 */
+  	/* class      instance    title       tags mask     isfloating   monitor */
+  	{ "Gimp",     NULL,       NULL,       0,            1,           -1 },
+! 	{ "Firefox",  NULL,       NULL,       1 << 8,       0,           -1 },
+  };
+  
+  /* layout(s) */
+--- 28,34 ----
+  	 */
+  	/* class      instance    title       tags mask     isfloating   monitor */
+  	{ "Gimp",     NULL,       NULL,       0,            1,           -1 },
+! 	{ "Firefox",  NULL,       NULL,       0,            0,           -1 },
+  };
+  
+  /* layout(s) */


### PR DESCRIPTION
Testing the changes

    I tested the changes in this PR: YES

Local build testing

    I built this PR locally for my native architecture: x86_64 (glibc)

Note:

Using default config.h from dwm, every instance of Firefox will **always** run in workspace 9. This patch is used to make dwm run Firefox in current active workspace so that user may run Firefox in any workspace (0-9).