### PR TITLE
xorg-server-xwayland: update to 24.1.0

### DIFF
--- a/srcpkgs/xorg-server-xwayland/patches/fix-i686-build.patch
+++ b/srcpkgs/xorg-server-xwayland/patches/fix-i686-build.patch
@@ -1,0 +1,12 @@
+diff --git a/os/osdep.h b/os/osdep.h
+index 0687f568d..d3c5f4e4f 100644
+--- a/os/osdep.h
++++ b/os/osdep.h
+@@ -60,6 +60,7 @@ SOFTWARE.
+ #include <limits.h>
+ #include <stddef.h>
+ #include <X11/Xos.h>
++#include <X11/Xmd.h>
+ 
+ /* If EAGAIN and EWOULDBLOCK are distinct errno values, then we check errno
+  * for both EAGAIN and EWOULDBLOCK, because some supposedly POSIX

--- a/srcpkgs/xorg-server-xwayland/template
+++ b/srcpkgs/xorg-server-xwayland/template
@@ -1,10 +1,10 @@
 # Template file for 'xorg-server-xwayland'
 pkgname=xorg-server-xwayland
-version=23.2.4
-revision=2
+version=24.1.0
+revision=1
 build_style=meson
 configure_args="-Dipv6=true -Dxvfb=false -Dxdmcp=false -Dxcsecurity=true
- -Ddri3=true -Dxwayland_eglstream=false -Dglamor=true -Dxkb_dir=/usr/share/X11/xkb
+ -Ddri3=true -Dglamor=true -Dxkb_dir=/usr/share/X11/xkb
  -Dxkb_output_dir=/var/lib/xkb"
 hostmakedepends="pkg-config wayland-devel"
 makedepends="nettle-devel libepoxy-devel font-util libXfont2-devel pixman-devel
@@ -16,7 +16,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
 homepage="https://xorg.freedesktop.org"
 distfiles="https://gitlab.freedesktop.org/xorg/xserver/-/archive/xwayland-${version}/xserver-xwayland-${version}.tar.gz"
-checksum=e23fb908c5699c9668cba478082f81d8b8fbc3f744f36821554aa087e4f92e36
+checksum=73b308e1054507e6189de090ec98e5e7ea0dcef3a8fde288dd4a2361ac561c6e
 make_check=no # needs xtest repository
 
 post_install() {


### PR DESCRIPTION

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl (cross) 
  - i686 (cross) (fix-i686-build.patch added)
  - aarch64 (cross)
  - aarch64-musl (cross)
  - armv7l (cross)
  - armv7l-musl (cross)
  - armv6l (cross)
  - armv6l-musl (cross)

