### PR TITLE
cnijfilter2: build on aarch64

### DIFF
--- a/srcpkgs/cnijfilter2/template
+++ b/srcpkgs/cnijfilter2/template
@@ -1,9 +1,9 @@
 # Template file for 'cnijfilter2'
 pkgname=cnijfilter2
 version=6.60
-revision=1
+revision=2
 _uprevision=-1
-archs="i686 x86_64"
+archs="i686 x86_64 aarch64"
 build_style=gnu-configure
 hostmakedepends="automake autoconf libtool"
 makedepends="cups-devel glib-devel libusb-devel libxml2-devel"


### PR DESCRIPTION
Added aarch64. This filter compiles and works on an M1 MacBook Pro - tested with a Canon PIXMA G3600

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
