### PR TITLE
autotiling: Update to 1.9.3

### DIFF
--- a/srcpkgs/autotiling/template
+++ b/srcpkgs/autotiling/template
@@ -1,6 +1,6 @@
 # Template file for 'autotiling'
 pkgname=autotiling
-version=1.9.1
+version=1.9.3
 revision=1
 build_style=python3-module
 hostmakedepends="python3-wheel"
@@ -10,6 +10,6 @@ maintainer="Adrian Göransson <adriangoransson@gmail.com>"
 license="GPL-3.0-or-later"
 homepage="https://github.com/nwg-piotr/autotiling"
 distfiles="https://github.com/nwg-piotr/autotiling/archive/refs/tags/v${version}.tar.gz"
-checksum=e7113b35df41b9da162c8fc1974219f55085659fba69fbc7861b146a3f380813
+checksum=3270a28de977f375c80984ef50f7433cb03cfdf198b079ae9c80d1513f0e9176
 # There is no test suite for this package
 make_check=no


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
