### PR TITLE
filelight: add kirigami-addons as dependency

### DIFF
--- a/srcpkgs/filelight/template
+++ b/srcpkgs/filelight/template
@@ -1,7 +1,7 @@
 # Template file for 'filelight'
 pkgname=filelight
 version=24.02.2
-revision=2
+revision=3
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins"
@@ -11,7 +11,7 @@ makedepends="kirigami-addons-devel kf6-kio-devel kf6-kcoreaddons-devel
  kf6-kconfig-devel kf6-kpackage-devel kf6-kdoctools-devel
  kf6-qqc2-desktop-style-devel kf6-kirigami-devel kf6-kquickcharts-devel
  kf6-kxmlgui-devel kf6-ki18n-devel"
-depends="kf6-kirigami kf6-kquickcharts kf6-kcoreaddons kf6-qqc2-desktop-style qt6-declarative"
+depends="kirigami-addons kf6-kquickcharts kf6-kcoreaddons kf6-qqc2-desktop-style qt6-declarative"
 short_desc="Interactive map that helps visualize disk usage on your computer"
 maintainer="Piotr Wójcik <chocimier@tlen.pl>"
 license="GPL-2.0-only"


### PR DESCRIPTION
Without `kirigami-addons`, parts of the application (such as its about page) don't work properly. `kirigami-addons` already depends on `kf6-kirigami`, so `kf6-kirigami` it can be removed as an explicit dependency

#### Testing the changes
- I tested the changes in this PR: **YES**
-
#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
