### PR TITLE
R: update to 4.4.1.

### DIFF
--- a/srcpkgs/R-cran-backports/template
+++ b/srcpkgs/R-cran-backports/template
@@ -1,10 +1,10 @@
 # Template file for 'R-cran-backports'
 pkgname=R-cran-backports
-version=1.2.1
+version=1.5.0
 revision=1
 build_style=R-cran
 short_desc="Reimplementations of Functions Introduced Since R-3.0.0"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-only, GPL-3.0-only"
 homepage="https://github.com/r-lib/backports"
-checksum=a2834bbd57e305e5d8010322f1906ea1789b3b5ba5eca77c5ff4248aceb7c2d5
+checksum=0d3ed9db8f1505e88967f48d669b2a257e0c6b7e6320ea64b946c1bd40897ca2

--- a/srcpkgs/R-cran-callr/template
+++ b/srcpkgs/R-cran-callr/template
@@ -1,6 +1,6 @@
 # Template file for 'R-cran-callr'
 pkgname=R-cran-callr
-version=3.5.1
+version=3.7.6
 revision=1
 build_style=R-cran
 hostmakedepends="R-cran-processx R-cran-R6"
@@ -9,7 +9,7 @@ short_desc="Call R from R"
 maintainer="Luke Hannan <lukehannan@gmail.com>"
 license="MIT"
 homepage="https://github.com/r-lib/callr"
-checksum=ce338c648cc9ab501168a55f93e68fc81e31dc5ec881e908b5b4a9d6f5bd8696
+checksum=e4bce367e869e42eaeea05566d2033d8cee2103179b11cd9a401440b58a351f8
 
 post_install() {
 	vlicense LICENSE

--- a/srcpkgs/R-cran-cli/template
+++ b/srcpkgs/R-cran-cli/template
@@ -1,6 +1,6 @@
 # Template file for 'R-cran-cli'
 pkgname=R-cran-cli
-version=3.4.1
+version=3.6.3
 revision=1
 build_style=R-cran
 makedepends="R-cran-assertthat R-cran-glue"
@@ -9,8 +9,7 @@ short_desc="Helpers for Developing Command Line Interfaces"
 maintainer="Cameron Nemo <cam@nohom.org>"
 license="MIT"
 homepage="https://github.com/r-lib/cli/"
-checksum="1c585efbfd8b8685c66fac34bcb60f28c351691bb4b9931df214e6e47fd9744e
- 1c585efbfd8b8685c66fac34bcb60f28c351691bb4b9931df214e6e47fd9744e"
+checksum="4295085f11221c54b1dd2b1d39a675a85dfd9f900294297567e1d36f65ac4841"
 
 post_install() {
 	vlicense LICENSE

--- a/srcpkgs/R-cran-desc/template
+++ b/srcpkgs/R-cran-desc/template
@@ -1,15 +1,15 @@
 # Template file for 'R-cran-desc'
 pkgname=R-cran-desc
-version=1.2.0
-revision=2
+version=1.4.3
+revision=1
 build_style=R-cran
-hostmakedepends="R-cran-assertthat R-cran-crayon R-cran-R6 R-cran-rprojroot"
-depends="R-cran-assertthat R-cran-crayon R-cran-R6 R-cran-rprojroot"
+hostmakedepends="R-cran-cli R-cran-R6"
+depends="R-cran-cli R-cran-R6"
 short_desc="Manipulate DESCRIPTION Files"
 maintainer="Luke Hannan <lukehannan@gmail.com>"
 license="MIT"
 homepage="https://github.com/r-lib/desc"
-checksum=e66fb5d4fc7974bc558abcdc107a1f258c9177a29dcfcf9164bc6b33dd08dae8
+checksum=54468da73dd78fc9e7c565c41cfe3331802c2134b2e61a9ad197215317092f26
 
 post_install() {
 	vlicense LICENSE

--- a/srcpkgs/R-cran-evaluate/template
+++ b/srcpkgs/R-cran-evaluate/template
@@ -1,13 +1,13 @@
 # Template file for 'R-cran-evaluate'
 pkgname=R-cran-evaluate
-version=0.14
-revision=2
+version=0.24.0
+revision=1
 build_style=R-cran
 short_desc="Parsing and Evaluation Tools that Provide More Details than the Default"
 maintainer="luhann <lukehannan@gmail.com>"
 license="MIT"
 homepage="https://github.com/r-lib/evaluate"
-checksum=a8c88bdbe4e60046d95ddf7e181ee15a6f41cdf92127c9678f6f3d328a3c5e28
+checksum=e23d764a58e7525257d57da4ccfee9d6f63b5b3c18bf01c76818ec8c9c587fd6
 
 post_install() {
 	vlicense LICENSE

--- a/srcpkgs/R-cran-isoband/template
+++ b/srcpkgs/R-cran-isoband/template
@@ -1,14 +1,13 @@
 # Template file for 'R-cran-isoband'
 pkgname=R-cran-isoband
-version=0.2.5
+version=0.2.7
 revision=1
 build_style=R-cran
 short_desc="Generate Isolines and Isobands from Regularly Spaced Elevation Grids"
 maintainer="Luke Hannan <lukehannan@gmail.com>"
 license="MIT"
 homepage="https://github.com/wilkelab/isoband"
-checksum="46f53fa066f0966f02cb2bf050190c0d5e950dab2cdf565feb63fc092c886ba5
- 46f53fa066f0966f02cb2bf050190c0d5e950dab2cdf565feb63fc092c886ba5"
+checksum=7693223343b45b86de2b5b638ff148f0dafa6d7b1237e822c5272902f79cdf61
 
 post_install() {
 	vlicense LICENSE

--- a/srcpkgs/R-cran-nloptr/template
+++ b/srcpkgs/R-cran-nloptr/template
@@ -1,7 +1,7 @@
 # Template file for 'R-cran-nloptr'
 pkgname=R-cran-nloptr
-version=1.2.2.2
-revision=2
+version=2.1.1
+revision=1
 build_style=R-cran
 hostmakedepends="pkg-config"
 makedepends="nlopt-devel"
@@ -9,4 +9,4 @@ short_desc="R interface to NLopt"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="LGPL-3.0-only"
 homepage="https://cran.r-project.org/package=nloptr"
-checksum=e80ea9619ac18f4bfe44812198b40b9ae5c0ddf3f9cc91778f9ccc82168d1372
+checksum=4cdaf55dfdeb090119f2c2ca77f617962524654da4511bacd650f62bb6dad8ea

--- a/srcpkgs/R-cran-pkgbuild/template
+++ b/srcpkgs/R-cran-pkgbuild/template
@@ -1,14 +1,12 @@
 # Template file for 'R-cran-pkgbuild'
 pkgname=R-cran-pkgbuild
-version=1.1.0
-revision=2
+version=1.4.4
+revision=1
 build_style=R-cran
-hostmakedepends="R-cran-callr R-cran-cli R-cran-crayon R-cran-desc
- R-cran-prettyunits R-cran-R6 R-cran-rprojroot R-cran-withr"
-depends="R-cran-callr R-cran-cli R-cran-crayon R-cran-desc
- R-cran-prettyunits R-cran-R6 R-cran-rprojroot R-cran-withr"
+hostmakedepends="R-cran-callr R-cran-cli R-cran-desc R-cran-processx R-cran-R6"
+depends="R-cran-callr R-cran-cli R-cran-desc R-cran-processx R-cran-R6"
 short_desc="Find Tools Needed to Build R Packages"
 maintainer="Luke Hannan <lukehannan@gmail.com>"
 license="GPL-3.0-only"
 homepage="https://github.com/r-lib/pkgbuild"
-checksum=b39bfb7661fc53f88962e2380fa9ded2e323c6ad43ac6b582195c749b0ccabbd
+checksum=5972843cd43654715cdbdd28f50af013fa3d1c213146654992b2b5f39ed0e2a8

--- a/srcpkgs/R-cran-prettyunits/template
+++ b/srcpkgs/R-cran-prettyunits/template
@@ -1,13 +1,13 @@
 # Template file for 'R-cran-prettyunits'
 pkgname=R-cran-prettyunits
-version=1.1.1
-revision=2
+version=1.2.0
+revision=1
 build_style=R-cran
 short_desc="Pretty, Human Readable Formatting of Quantities"
 maintainer="Luke Hannan <lukehannan@gmail.com>"
 license="MIT"
 homepage="https://github.com/gaborcsardi/prettyunits"
-checksum=9a199aa80c6d5e50fa977bc724d6e39dae1fc597a96413053609156ee7fb75c5
+checksum=f059f27e2a5c82e351fe05b87ad712f7afc273c651450453f59d99af5deeacea
 
 post_install() {
 	vlicense LICENSE

--- a/srcpkgs/R-cran-processx/template
+++ b/srcpkgs/R-cran-processx/template
@@ -1,6 +1,6 @@
 # Template file for 'R-cran-processx'
 pkgname=R-cran-processx
-version=3.4.4
+version=3.8.4
 revision=1
 build_style=R-cran
 hostmakedepends="R-cran-ps R-cran-R6"
@@ -9,7 +9,7 @@ short_desc="Execute and Control System Processes"
 maintainer="Luke Hannan <lukehannan@gmail.com>"
 license="MIT"
 homepage="https://github.com/r-lib/processx"
-checksum=aaa40f10a6670eeb451e038bc0eb7c16f263dacb797f76d965b9fc75dda7482b
+checksum=6627672d7fb109f37dc1d0eaef913f4cfc7ad8ac807abf0397e6d37753b1e70b
 
 post_install() {
 	vlicense LICENSE

--- a/srcpkgs/R-cran-ps/template
+++ b/srcpkgs/R-cran-ps/template
@@ -1,13 +1,13 @@
 # Template file for 'R-cran-ps'
 pkgname=R-cran-ps
-version=1.4.0
+version=1.7.7
 revision=1
 build_style=R-cran
 short_desc="List, Query, Manipulate System Processes"
 maintainer="Luke Hannan <lukehannan@gmail.com>"
 license="MIT"
 homepage="https://github.com/r-lib/ps"
-checksum=5f79ae4489090e07abbea892049ec0db900d31955237b388664289e6dc00da7a
+checksum=46fedcb2b8faa94ea1451e48e6f31a1e4ed3b12f529e645f9efcfca1003d22f2
 
 post_install() {
 	vlicense LICENSE

--- a/srcpkgs/R-cran-rprojroot/template
+++ b/srcpkgs/R-cran-rprojroot/template
@@ -1,10 +1,10 @@
 # Template file for 'R-cran-rprojroot'
 pkgname=R-cran-rprojroot
-version=2.0.2
+version=2.0.4
 revision=1
 build_style=R-cran
 short_desc="Finding Files in Project Subdirectories"
 maintainer="Luke Hannan <lukehannan@gmail.com>"
 license="GPL-3.0-only"
 homepage="https://github.com/r-lib/rprojroot"
-checksum=5fa161f0d4ac3b7a99dc6aa2d832251001dc92e93c828593a51fe90afd019e1f
+checksum=b5f463fb25a24dac7a4ca916be57dbe22b5262e1f41e53871ca83e57d4336e99

--- a/srcpkgs/R-cran-rstudioapi/template
+++ b/srcpkgs/R-cran-rstudioapi/template
@@ -1,13 +1,13 @@
 # Template file for 'R-cran-rstudioapi'
 pkgname=R-cran-rstudioapi
-version=0.13
+version=0.16.0
 revision=1
 build_style=R-cran
 short_desc="Safely Access the RStudio API"
 maintainer="Luke Hannan <lukehannan@gmail.com>"
 license="MIT"
 homepage="https://github.com/rstudio/rstudioapi"
-checksum=aac35bbdcb4a8e8caba943bc8a2b98120e8940b80cd1020224bb1a26ff776d8b
+checksum=74ffa867199e87a54386fbd26919233371f314f73d7338dd4e4695708fed4fe6
 
 post_install() {
 	vlicense LICENSE

--- a/srcpkgs/R/template
+++ b/srcpkgs/R/template
@@ -1,6 +1,6 @@
 # Template file for 'R'
 pkgname=R
-version=4.3.1
+version=4.4.1
 revision=1
 build_style=gnu-configure
 configure_args="--docdir=/usr/share/doc/R rdocdir=/usr/share/doc/R
@@ -23,7 +23,7 @@ license="GPL-2.0-or-later"
 homepage="https://www.r-project.org/"
 changelog="https://cran.r-project.org/doc/manuals/r-release/NEWS.html"
 distfiles="https://cran.r-project.org/src/base/R-4/${pkgname}-${version}.tar.gz"
-checksum=8dd0bf24f1023c6f618c3b317383d291b4a494f40d73b983ac22ffea99e4ba99
+checksum=b4cb675deaaeb7299d3b265d218cde43f192951ce5b89b7bb1a5148a36b2d94d
 nocross=yes
 shlib_provides="libR.so"
 # tests require texlive distribution


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**



#### Local build testing
- I built this PR locally for my native architecture, (x86_64)


The only significant build change is:
>If the libdeflate library and headers are available, libdeflate rather than libz is
used to (de)compress R objects in lazy-load databases. Typically tasks spend up to
5% of their time on such operations, although creating lazy-data databases is one of
the exceptions.
This can be suppressed if the library is available by the configure option
‘--without-libdeflate-compression’.

I haven't included libdeflate here because as far as I can see no other distro does either.

There are a number of packages that depend on R, mostly the R-cran packages, should I update them here or make a separate PR?