### PR TITLE
python3-Faker: update to 25.2.0.

### DIFF
--- a/srcpkgs/python3-Faker/template
+++ b/srcpkgs/python3-Faker/template
@@ -1,6 +1,6 @@
 # Template file for 'python3-Faker'
 pkgname=python3-Faker
-version=19.12.0
+version=25.2.0
 revision=1
 build_style=python3-module
 hostmakedepends="python3-setuptools"
@@ -12,7 +12,7 @@ license="MIT"
 homepage="https://faker.readthedocs.io/en/master/"
 changelog="https://github.com/joke2k/faker/raw/master/CHANGELOG.md"
 distfiles="${PYPI_SITE}/F/Faker/Faker-${version}.tar.gz"
-checksum=91438f6b1713274ec3f24970ba303617be86ce5caf6f6a0776f1d04777b6ff5f
+checksum=45b84f47ff1ef86e3d1a8d11583ca871ecf6730fad0660edadc02576583a2423
 
 post_install() {
 	vlicense LICENSE.txt


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES** (I have tested building `pantalaimon`, `python3-pydantic` and `python3-matrix-nio` with checks; these are all the packages that depend on python3-Faker through checkdepends.)

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
