### PR TITLE
chrony: update URLs, remove update file.

### DIFF
--- a/srcpkgs/chrony/template
+++ b/srcpkgs/chrony/template
@@ -2,7 +2,7 @@
 # When Updating: Please confirm the upstream config still refers to make_dirs
 pkgname=chrony
 version=4.5
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--without-nss --enable-scfilter
  --with-sendmail=/usr/bin/sendmail"
@@ -13,9 +13,9 @@ conf_files="/etc/chrony.conf"
 short_desc="Versatile implementation of the Network Time Protocol (NTP)"
 maintainer="0x5c <dev@0x5c.io>"
 license="GPL-2.0-only"
-homepage="https://chrony.tuxfamily.org/"
-changelog="https://chrony.tuxfamily.org/news.html"
-distfiles="https://download.tuxfamily.org/chrony/${pkgname}-${version}.tar.gz"
+homepage="https://chrony-project.org/"
+changelog="https://gitlab.com/chrony/chrony/-/raw/master/NEWS"
+distfiles="https://chrony-project.org/releases/chrony-${version}.tar.gz"
 checksum=19fe1d9f4664d445a69a96c71e8fdb60bcd8df24c73d1386e02287f7366ad422
 system_accounts="chrony"
 chrony_homedir="/var/lib/chrony"

--- a/srcpkgs/chrony/update
+++ b/srcpkgs/chrony/update
@@ -1,1 +1,0 @@
-ignore="*oldcvs*"


### PR DESCRIPTION
The chrony project has moved from tuxfamily to chrony-project.org
The update file is not needed since no distfile matches that ignore pattern.

~~feedback needed:~~
- ~~Would a URL the NEWS file on Gitlab be prefered over the existing news page? 
   https://gitlab.com/chrony/chrony/-/raw/master/NEWS?ref_type=heads~~

- ~~Is pulling distfiles from gitlab preferable?~~

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
