### PR TITLE
unrar: strip out native compilation flag

### DIFF
--- a/srcpkgs/unrar/template
+++ b/srcpkgs/unrar/template
@@ -1,7 +1,7 @@
 # Template file for 'unrar'
 pkgname=unrar
 version=7.0.9
-revision=1
+revision=2
 archs="x86_64* i686*"
 short_desc="Unarchiver for .rar files (non-free version)"
 maintainer="skmpz <dem.procopiou@gmail.com>"
@@ -12,13 +12,12 @@ checksum=505c13f9e4c54c01546f2e29b2fcc2d7fabc856a060b81e5cdfe6012a9198326
 repository=nonfree
 
 do_build() {
-	vsed -e 's/^\(CXXFLAGS\)=\(.*\)/\1+=\2/' \
+	vsed -e 's/^\(CXXFLAGS\)=-march=native \(.*\)/\1+=\2/' \
 		 -e 's/^\(LDFLAGS\)=\(.*\)/\1+=-lpthread \2/' \
 		 -i makefile
 	make CXX="$CXX" LD="$LD" STRIP=: -f makefile
-	# early install of unrar because makefile deletes unrar on lib creation
+	# early install of unrar because need to clean for lib creation
 	vbin unrar
-	# recompile for lib
 	make clean
 	make CXX="$CXX" LD="$LD" STRIP=: -f makefile lib
 }


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

This should get rid of the native compilation flag in the makefile script.

Not sure if it was included upstream by mistake, but it should be looked out for when new versions are released (ie revert this change if the flag gets removed again).