### PR TITLE
Add Option to use Distfiles Mirror as a Fallback

### DIFF
--- a/etc/defaults.conf
+++ b/etc/defaults.conf
@@ -165,3 +165,8 @@ XBPS_SUCMD="sudo /bin/sh -c"
 # This can also be set or exported as a regular environment variable.
 #
 #XBPS_UPDATE_CHECK_VERBOSE=yes
+
+# [OPTIONAL]
+# Use this mirror as a fallback for when the distfiles specified in the template are not found.
+#
+#XBPS_DISTFILES_FALLBACK="https://sources.voidlinux.org/"

--- a/xbps-src
+++ b/xbps-src
@@ -343,10 +343,11 @@ read_pkg() {
 }
 
 setup_distfiles_mirror() {
+    local mirror_list="$1"
     local mirror scheme path
 
     # Scheme file:// mirror locations only work with uchroot
-    for mirror in $XBPS_DISTFILES_MIRROR; do
+    for mirror in $mirror_list; do
         scheme="file"
         if [[ "$mirror" == *://* ]]; then
             scheme="${mirror%%://*}"
@@ -696,7 +697,7 @@ export XBPS_SHUTILSDIR XBPS_CROSSPFDIR XBPS_TRIGGERSDIR \
     XBPS_LIBEXECDIR XBPS_DISTDIR XBPS_DISTFILES_MIRROR XBPS_ALLOW_RESTRICTED \
     XBPS_USE_GIT_COMMIT_DATE XBPS_PKG_COMPTYPE XBPS_REPO_COMPTYPE \
     XBPS_BUILDHELPERDIR XBPS_USE_BUILD_MTIME XBPS_BUILD_ENVIRONMENT \
-    XBPS_PRESERVE_PKGS XBPS_IGNORE_BROKENNESS
+    XBPS_PRESERVE_PKGS XBPS_IGNORE_BROKENNESS XBPS_DISTFILES_FALLBACK
 
 for i in REPOSITORY DESTDIR BUILDDIR SRCDISTDIR; do
     eval val="\$XBPS_$i"
@@ -760,7 +761,10 @@ done
 if [ -z "$IN_CHROOT" ]; then
     trap 'exit_func' INT TERM
     if [ -n "$XBPS_DISTFILES_MIRROR" ]; then
-        setup_distfiles_mirror
+        setup_distfiles_mirror "$XBPS_DISTFILES_MIRROR"
+    fi
+    if [ -n "$XBPS_DISTFILES_FALLBACK" ]; then
+        setup_distfiles_mirror "$XBPS_DISTFILES_FALLBACK"
     fi
 fi
 


### PR DESCRIPTION
This adds an optional configuration to add a fallback distfiles mirror

The idea is that normally, distfiles should be fetched from the urls in the template. However, occasionally the urls have rotted, or are simply own temporarily, in which case the fetch will fail. A workaround to this has been to use the XBPS_DISTFILES_MIRROR option, however the downside to this is that it costs bandwidth, and 99% of the time isn't needed.

This adds the $XBPS_DISTFILES_FALLBACK option, which can be set to an addiontional list of mirrors which will be attempted after both $XBPS_DISTFILES_MIRROR, and the urls in the template have failed to fetch the distfiles

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
