### PR TITLE
optipng: add changelog

### DIFF
--- a/srcpkgs/optipng/template
+++ b/srcpkgs/optipng/template
@@ -8,6 +8,7 @@ short_desc="Advanced PNG Optimizer"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="Zlib"
 homepage="https://optipng.sourceforge.net/"
+changelog="https://optipng.sourceforge.net/history.txt"
 distfiles="${SOURCEFORGE_SITE}/optipng/optipng-${version}.tar.gz"
 checksum=25a3bd68481f21502ccaa0f4c13f84dcf6b20338e4c4e8c51f2cefbd8513398c
 


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

`xchangelog` handles it fine, the file itself starts with non-printing characters* for some reason though:
![2024-05-28T22:53:50,555115731-04:00](https://github.com/void-linux/void-packages/assets/486393/19e58d7f-6976-4f15-b908-40f2bb494467)

*: byte sequence is `EF BB BF`
<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
