### PR TITLE
geteltorito: update distfile and homepage URLs.

### DIFF
--- a/srcpkgs/geteltorito/template
+++ b/srcpkgs/geteltorito/template
@@ -1,13 +1,13 @@
 # Template file for 'geteltorito'
 pkgname=geteltorito
 version=0.6
-revision=2
+revision=3
 depends="perl"
 short_desc="El Torito boot image extractor"
 maintainer="0x5c <dev@0x5c.io>"
 license="GPL-2.0-only"
-homepage="https://userpages.uni-koblenz.de/~krienke/ftp/noarch/geteltorito"
-distfiles="https://userpages.uni-koblenz.de/~krienke/ftp/noarch/geteltorito/geteltorito-${version}.tar.gz"
+homepage="https://web.archive.org/web/20240118060107/https://userpages.uni-koblenz.de/~krienke/ftp/noarch/geteltorito"
+distfiles="https://web.archive.org/web/20240327193559if_/https://userpages.uni-koblenz.de/~krienke/ftp/noarch/geteltorito/geteltorito-${version}.tar.gz"
 checksum=bb4fab8d4bedee1250762940b9f5d20fc7ac29fb2b5e9767c6af0a0955aa6bbe
 
 do_install() {


### PR DESCRIPTION
uni-koblenz.de has removed the page and/or all userpages; now redirects to a network status page and instructions to setup campus VPN.

There is no clear new homepage and no new distfiles, so using archive.org for now. The archived version has the same checksum.

The last build of the package was so long ago that the distfile was never saved by distfiles.voidlinux.org

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**
<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
