### PR TITLE
stig: update to 0.12.9a0

### DIFF
--- a/srcpkgs/stig/template
+++ b/srcpkgs/stig/template
@@ -1,6 +1,6 @@
 # Template file for 'stig'
 pkgname=stig
-version=0.12.8a0
+version=0.12.9a0
 revision=1
 build_style=python3-module
 hostmakedepends="python3-setuptools"
@@ -11,6 +11,7 @@ short_desc="TUI and CLI for the BitTorrent client Transmission"
 maintainer="Emil Miler <em@0x45.cz>"
 license="GPL-3.0-or-later"
 homepage="https://github.com/rndusr/stig"
+changelog="https://github.com/rndusr/stig/blob/master/CHANGELOG"
 distfiles="https://github.com/rndusr/stig/archive/v${version}.tar.gz"
-checksum=2c01f99988d8a536692e55bb22b7e0f265a213f70d85e70375771f002da88cbc
+checksum=1261a2546a4a6c4cd80718acc306c726241f00701443ce63a34b2b7e540adb84
 make_check=no # needs python3-asynctest which is not packaged


### PR DESCRIPTION
- I tested the changes in this PR: **briefly**
- I built this PR locally for my native architecture, (x86_64-glibc)