### PR TITLE
rust-cargo-bloat: update to 0.12.1.

### DIFF
--- a/srcpkgs/rust-cargo-bloat/template
+++ b/srcpkgs/rust-cargo-bloat/template
@@ -1,6 +1,6 @@
 # Template file for 'rust-cargo-bloat'
 pkgname=rust-cargo-bloat
-version=0.12.0
+version=0.12.1
 revision=1
 build_style=cargo
 short_desc="Find out what takes most of the space in your executable"
@@ -9,7 +9,7 @@ license="MIT"
 homepage="https://crates.io/crates/cargo-bloat"
 changelog="https://raw.githubusercontent.com/RazrFalcon/cargo-bloat/master/CHANGELOG.md"
 distfiles="https://static.crates.io/crates/cargo-bloat/cargo-bloat-${version}.crate"
-checksum=6f4d37fce199c73cd6371fe792e848bcce8dbffb8d32fe7cb883e7af482bf74d
+checksum=56e2c483ab55e38021c2c701061e078cc6c28d563932cbdf6bc4efaa28ab117e
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture: **x86_64**