### PR TITLE
lv2: do not makedepend on gtk2

### DIFF
--- a/srcpkgs/lv2/template
+++ b/srcpkgs/lv2/template
@@ -1,10 +1,10 @@
 # Template file for 'lv2'
 pkgname=lv2
 version=1.18.10
-revision=1
+revision=2
 build_style=meson
 hostmakedepends="pkg-config"
-makedepends="libsndfile-devel gtk+-devel libsamplerate-devel"
+makedepends="libsndfile-devel libsamplerate-devel"
 short_desc="Plugin standard for audio systems"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="ISC"


### PR DESCRIPTION
Drop the dependence on `gtk`, see https://gitlab.com/lv2/lv2/-/issues/57

- I tested the changes in this PR: yes

@slimjimsoftware Can you also check this does not break audio in asahi?