### PR TITLE
winusb: Use pkexec instead of gksudo for privilege escalation

### DIFF
--- a/srcpkgs/winusb/patches/support-PolicyKit.patch
+++ b/srcpkgs/winusb/patches/support-PolicyKit.patch
@@ -1,0 +1,11 @@
+--- a/src/MainPanel.cpp	2024-05-29 02:25:33.973355791 -0300
++++ b/src/MainPanel.cpp	2024-05-29 03:02:00.747154122 -0300
+@@ -240,7 +240,7 @@
+             iso = m_dvdDriveDevList.at(m_dvdDriveList->GetSelection());
+         }
+ 
+-        PipeManager pipe(std::string("gksudo --description 'WinUSB' -- sh -c 'winusb --noColor --forGui --format \"") + iso + "\" \"" + device + "\" 2>&1'");
++        PipeManager pipe(std::string("pkexec --description 'WinUSB' -- sh -c 'winusb --noColor --forGui --format \"") + iso + "\" \"" + device + "\" 2>&1'");
+ 
+         wxProgressDialog *dialog = new wxProgressDialog(_("Installing..."), _("Please wait..."), 100, GetParent(), wxPD_APP_MODAL | wxPD_SMOOTH | wxPD_CAN_ABORT);
+ 

--- a/srcpkgs/winusb/template
+++ b/srcpkgs/winusb/template
@@ -1,15 +1,15 @@
 # Template file for 'winusb'
 pkgname=winusb
 version=1.0.11
-revision=11
+revision=12
 archs="i686* x86_64*"
 build_style=gnu-configure
 configure_args="--with-wx-config=wx-config-gtk3"
 hostmakedepends="pkg-config"
 makedepends="wxWidgets-gtk3-devel ntfs-3g libparted-devel
  desktop-file-utils hicolor-icon-theme"
-short_desc="Simple tool to create your own usb stick windows installer"
 depends="desktop-file-utils hicolor-icon-theme parted ntfs-3g"
+short_desc="Simple tool to create your own usb stick windows installer"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-3.0-or-later"
 homepage="http://en.congelli.eu/prog_info_winusb.html"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
