### PR TITLE
thunderbird: fix update-check

### DIFF
--- a/srcpkgs/thunderbird/update
+++ b/srcpkgs/thunderbird/update
@@ -1,2 +1,2 @@
-site="${MOZILLA_SITE}/${pkgname}/releases/"
-pattern="\">\K[0-9.]+(?=/</a>)"
+site="https://www.thunderbird.net/en-US/thunderbird/releases/atom.xml"
+pattern="Thunderbird \K[0-9.]+"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

Before that change, `./xbps-src update-check thunderbird` returned `125.0` as version. Apart from that the previously used mozilla site just redirected to thunderbird.net anyways.

cc @dataCobra 
