### PR TITLE
gnome-calculator: update to 46.1.

### DIFF
--- a/srcpkgs/gnome-calculator/template
+++ b/srcpkgs/gnome-calculator/template
@@ -1,6 +1,6 @@
 # Template file for 'gnome-calculator'
 pkgname=gnome-calculator
-version=46.0
+version=46.1
 revision=1
 build_style=meson
 build_helper="gir"
@@ -16,4 +16,4 @@ homepage="https://wiki.gnome.org/Apps/Calculator"
 changelog="https://gitlab.gnome.org/GNOME/gnome-calculator/-/raw/gnome-46/NEWS"
 #changelog="https://gitlab.gnome.org/GNOME/gnome-calculator/-/raw/master/NEWS"
 distfiles="${GNOME_SITE}/gnome-calculator/${version%%.*}/gnome-calculator-${version}.tar.xz"
-checksum=44694fda6b6233923f5c10a48d02d2cf5724e011a8a85789074c953101f33bf1
+checksum=2d36750a73890086122cf3f0c83e68517891585615165306fa1596a918668247


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):

