### PR TITLE
nasa-wallpaper: update to 2.1.0, adopt

### DIFF
--- a/srcpkgs/nasa-wallpaper/template
+++ b/srcpkgs/nasa-wallpaper/template
@@ -1,19 +1,13 @@
 # Template file for 'nasa-wallpaper'
 pkgname=nasa-wallpaper
-version=2.0
-revision=5
+version=2.1.0
+revision=1
 build_style="cargo"
 hostmakedepends="pkg-config"
 makedepends="openssl-devel"
 short_desc="Change your desktop background with a NASA image"
-maintainer="Orphaned <orphan@voidlinux.org>"
+maintainer="Emil Miler <em@0x45.cz>"
 license="Apache-2.0"
 homepage="https://github.com/davidpob99/nasa-wallpaper/"
-distfiles="https://github.com/davidpob99/nasa-wallpaper/archive/v${version}.tar.gz"
-checksum=5bdf85cabc954069f7188f32c5579a6d47aae1781bc438bead7d7a0af335f5f8
-
-post_patch() {
-	# Upstream does not ship a lockfile yet:
-	# https://github.com/davidpob99/nasa-wallpaper/issues/12
-	cargo generate-lockfile
-}
+distfiles="https://github.com/davidpob99/nasa-wallpaper/archive/refs/tags/v${version}.tar.gz"
+checksum=a33947df6fca4681bbd8479a9121c5441e8d280388743b2a314c5be6e4c109d2


### PR DESCRIPTION
- I tested the changes in this PR: **YES**
- I built this PR locally for my native architecture, (x86_64-glibc)