### PR TITLE
Komikku: update to 1.68.0, adopt.

### DIFF
--- a/srcpkgs/Komikku/template
+++ b/srcpkgs/Komikku/template
@@ -1,20 +1,25 @@
 # Template file for 'Komikku'
 pkgname=Komikku
-version=1.21.1
-revision=3
+version=1.68.0
+revision=1
 build_style=meson
-hostmakedepends="gettext glib-devel gobject-introspection pkg-config
- desktop-file-utils gtk-update-icon-cache"
+build_helper=gir
+hostmakedepends="gettext glib-devel pkg-config desktop-file-utils
+ gtk-update-icon-cache blueprint-compiler"
 makedepends="gtk4-devel libadwaita-devel"
 depends="gtk4 libadwaita libnotify libsecret python3-BeautifulSoup4 python3-Brotli
  python3-Pillow python3-Unidecode python3-requests python3-dateparser
  python3-gobject python3-keyring python3-lxml python3-magic python3-rarfile
  python3-natsort python3-pure-protobuf python3-emoji libwebkitgtk60
- python3-piexif"
+ python3-piexif python3-colorthief python3-pillow_heif"
 checkdepends="appstream-glib desktop-file-utils"
 short_desc="Online/offline manga reader for GNOME"
-maintainer="Orphaned <orphan@voidlinux.org>"
+maintainer="fanyx <fanyx@posteo.net>"
 license="GPL-3.0-or-later"
-homepage="https://gitlab.com/valos/Komikku"
-distfiles="https://gitlab.com/valos/Komikku/-/archive/v${version}/Komikku-v${version}.tar.gz"
-checksum=303919974aa860b542e486d0321149a882f3f667309b2216899ea5f1633c860f
+homepage="https://codeberg.org/valos/Komikku"
+distfiles="https://codeberg.org/valos/Komikku/archive/v${version}.tar.gz"
+checksum=d6db52db72da5d4c35b81b8e17ab9154cea7b8e03f96be2f4802cea6fbc3c692
+
+if [ "$CROSS_BUILD" ]; then
+	export GI_TYPELIB_PATH="${XBPS_CROSS_BASE}/usr/lib/girepository-1.0"
+fi

--- a/srcpkgs/python3-colorthief/template
+++ b/srcpkgs/python3-colorthief/template
@@ -1,0 +1,18 @@
+# Template file for 'python3-colorthief'
+pkgname=python3-colorthief
+version=0.2.1
+revision=1
+build_style=python3-module
+hostmakedepends="python3-setuptools"
+depends="python3-Pillow"
+short_desc="Python module for grabbing the color palette from an image"
+maintainer="fanyx <fanyx@posteo.net>"
+license="BSD-3-Clause"
+homepage="https://github.com/fengsp/color-thief-py"
+distfiles="${PYPI_SITE}/c/colorthief/colorthief-${version}.tar.gz"
+checksum=079cb0c95bdd669c4643e2f7494de13b0b6029d5cdbe2d74d5d3c3386bd57221
+make_check=no # no tests
+
+post_install() {
+	vlicense LICENSE
+}


### PR DESCRIPTION
Komikku migrated to codeberg.

#### Merge first:
- https://github.com/void-linux/void-packages/pull/50777

Ty @chrysos349

#### Testing the changes
- I tested the changes in this PR: **yes**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
