### PR TITLE
util-linux: backport fix for su(1)

### DIFF
--- a/srcpkgs/util-linux/patches/su-fix-use-after-free-in-run_shell.patch
+++ b/srcpkgs/util-linux/patches/su-fix-use-after-free-in-run_shell.patch
@@ -1,0 +1,49 @@
+From 4b2e6f5071a4c5beebbd9668d24dc05defc096d7 Mon Sep 17 00:00:00 2001
+From: Tanish Yadav <devtany@gmail.com>
+Date: Tue, 5 Mar 2024 00:51:41 +0530
+Subject: [PATCH] su: fix use after free in run_shell
+
+Do not free tmp for non login branch as basename may return a pointer to
+some part of it.
+
+[kzak@redhat.com: - improve coding style of the function]
+
+Signed-off-by: Tanish Yadav <devtany@gmail.com>
+Signed-off-by: Karel Zak <kzak@redhat.com>
+---
+ login-utils/su-common.c | 9 ++++-----
+ 1 file changed, 4 insertions(+), 5 deletions(-)
+
+diff --git a/login-utils/su-common.c b/login-utils/su-common.c
+index 242b6ce4e..9bc023196 100644
+--- a/login-utils/su-common.c
++++ b/login-utils/su-common.c
+@@ -835,13 +835,14 @@ static void run_shell(
+ 	size_t n_args = 1 + su->fast_startup + 2 * ! !command + n_additional_args + 1;
+ 	const char **args = xcalloc(n_args, sizeof *args);
+ 	size_t argno = 1;
++	char *tmp;
+ 
+ 	DBG(MISC, ul_debug("starting shell [shell=%s, command=\"%s\"%s%s]",
+ 				shell, command,
+ 				su->simulate_login ? " login" : "",
+ 				su->fast_startup ? " fast-start" : ""));
++	tmp = xstrdup(shell);
+ 
+-  char* tmp = xstrdup(shell);
+ 	if (su->simulate_login) {
+ 		char *arg0;
+ 		char *shell_basename;
+@@ -851,10 +852,8 @@ static void run_shell(
+ 		arg0[0] = '-';
+ 		strcpy(arg0 + 1, shell_basename);
+ 		args[0] = arg0;
+-	} else {
+-    args[0] = basename(tmp);
+-  }
+-  free(tmp);
++	} else
++		args[0] = basename(tmp);
+ 
+ 	if (su->fast_startup)
+ 		args[argno++] = "-f";

--- a/srcpkgs/util-linux/template
+++ b/srcpkgs/util-linux/template
@@ -2,7 +2,7 @@
 # Keep this package sync with util-linux-common
 pkgname=util-linux
 version=2.39.3
-revision=2
+revision=3
 build_style=gnu-configure
 configure_args="--exec-prefix=\${prefix} --enable-libuuid --disable-makeinstall-chown
  --enable-libblkid --enable-fsck --disable-rpath --enable-fs-paths-extra=/usr/sbin:/usr/bin


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
<br>

This is a backport for the [upstream fix](https://github.com/util-linux/util-linux/commit/4b2e6f5071a4c5beebbd9668d24dc05defc096d7). It was suggested by @classabbyamp at #50538