### PR TITLE
discord: update to 0.0.55.

### DIFF
--- a/srcpkgs/discord/template
+++ b/srcpkgs/discord/template
@@ -1,6 +1,6 @@
 # Template file for 'discord'
 pkgname=discord
-version=0.0.54
+version=0.0.55
 revision=1
 archs="x86_64"
 depends="alsa-lib dbus-glib gtk+3 libnotify nss libXtst libcxx libatomic
@@ -10,7 +10,7 @@ maintainer="Ryan Conwell <ryanconwell@protonmail.com>"
 license="custom:Proprietary"
 homepage="https://discord.com"
 distfiles="https://dl.discordapp.net/apps/linux/${version}/discord-${version}.tar.gz"
-checksum=aee6a8b7327e76fa8d515fdee31a49d6ba2b1a20b8226e7b0524a275d3fc645f
+checksum=afc6901ccb80b916566d67fae6651f903617f8e6868f6321e4b3538a319e4f9d
 repository=nonfree
 restricted=yes
 nopie=yes


### PR DESCRIPTION
- I tested the changes in this PR: YES

- I built this PR locally for my native architecture, x64-glibc
