### PR TITLE
PrusaSlicer: don't build tests when unneeded

### DIFF
--- a/srcpkgs/PrusaSlicer/template
+++ b/srcpkgs/PrusaSlicer/template
@@ -21,6 +21,10 @@ checksum=e58278067b9d49a42dc9bb02b74307b3cb365bb737f28e246ca8c6f466095d6b
 
 CXXFLAGS="-D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64"
 
+if [ -z "${XBPS_CHECK_PKGS}" ]; then
+	configure_args+=" -DSLIC3R_BUILD_TESTS=OFF"
+fi
+
 post_extract() {
 	# Mark tests that fail on certain targets
 	case "$XBPS_TARGET_MACHINE" in


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
