### PR TITLE
new package: pam_uaccess

### DIFF
--- a/srcpkgs/elogind-uaccess
+++ b/srcpkgs/elogind-uaccess
@@ -1,0 +1,1 @@
+elogind

--- a/srcpkgs/elogind/template
+++ b/srcpkgs/elogind/template
@@ -1,7 +1,7 @@
 # Template file for 'elogind'
 pkgname=elogind
 version=252.9
-revision=2
+revision=3
 build_style=meson
 configure_args="-Dcgroup-controller=elogind -Ddefault-hierarchy=legacy
  -Ddefault-kill-user-processes=false -Dhalt-path=/usr/bin/halt
@@ -12,7 +12,7 @@ hostmakedepends="docbook-xsl glib-devel gperf gettext libxslt
  m4 pkg-config python3-Jinja2 shadow"
 makedepends="acl-devel eudev-libudev-devel libcap-devel
  libglib-devel libseccomp-devel pam-devel"
-depends="dbus"
+depends="dbus elogind-uaccess"
 short_desc="Standalone logind fork"
 maintainer="Enno Boland <gottox@voidlinux.org>"
 license="GPL-2.0-or-later, LGPL-2.0-or-later"
@@ -76,5 +76,12 @@ libelogind_package() {
 	short_desc+=" - elogind library"
 	pkg_install() {
 		 vmove "usr/lib/libelogind.so.*"
+	}
+}
+
+elogind-uaccess_package() {
+	short_desk+=" - uaccess rules"
+	pkg_install() {
+		vmove usr/lib/udev/rules.d/70-uaccess.rules
 	}
 }

--- a/srcpkgs/pam-base/files/system-login
+++ b/srcpkgs/pam-base/files/system-login
@@ -16,5 +16,6 @@ session    optional   pam_motd.so          motd=/etc/motd
 session    optional   pam_mail.so          dir=/var/mail standard quiet
 -session   optional   pam_turnstile.so
 -session   optional   pam_elogind.so
+-session   optional   pam_uaccess.so
 -session   optional   pam_dumb_runtime_dir.so
 session    required   pam_env.so

--- a/srcpkgs/pam-base/template
+++ b/srcpkgs/pam-base/template
@@ -1,7 +1,7 @@
 # Template file for 'pam-base'
 pkgname=pam-base
 version=0.4
-revision=3
+revision=4
 short_desc="PAM base configuration files"
 maintainer="Érico Nogueira <ericonr@disroot.org>"
 license="Public Domain"

--- a/srcpkgs/pam_uaccess/template
+++ b/srcpkgs/pam_uaccess/template
@@ -1,0 +1,19 @@
+# Template file for 'pam_uaccess'
+pkgname=pam_uaccess
+version=0
+revision=1
+_commit=54fbf043c63cc500b4850b0b4a12ea14078f2b53
+build_style=meson
+hostmakedepends="pkg-config"
+makedepends="acl-devel eudev-libudev-devel pam-devel"
+depends="elogind-uaccess"
+short_desc="PAM module that grants access to devices tagged uaccess"
+maintainer="dkwo <npiazza@disroot.org>"
+license="MIT"
+homepage="https://git.sr.ht/~kennylevinsen/pam_uaccess"
+distfiles="https://git.sr.ht/~kennylevinsen/pam_uaccess/archive/${_commit}.tar.gz"
+checksum=44986d6fb341a3ca4e98ad7410037d97b010bb6510ac20e3765693249a1dbc3d
+
+post_install() {
+	vlicense LICENSE
+}


### PR DESCRIPTION
From the author of `seatd`, this experimental PAM module grants access to devices tagged _uaccess_ in `udev` for the duration of the user session. Replaces `elogind`'s uaccess feature. Requires udev rules that set the uaccess tag, hence I split them from `elogind` package. I tested this locally, and it works for audio (i.e. I can access my audio card without being a member of audio group and without elogind). https://git.sr.ht/~kennylevinsen/pam_uaccess