### PR TITLE
qtile and dependencies: update

### DIFF
--- a/srcpkgs/python3-cairocffi/template
+++ b/srcpkgs/python3-cairocffi/template
@@ -1,7 +1,7 @@
 # Template file for 'python3-cairocffi'
 pkgname=python3-cairocffi
-version=1.6.1
-revision=2
+version=1.7.0
+revision=1
 build_style=python3-pep517
 make_check_args="--pyargs cairocffi"
 hostmakedepends="python3-setuptools python3-cffi python3-wheel
@@ -14,7 +14,7 @@ license="BSD-3-Clause"
 homepage="https://github.com/Kozea/cairocffi"
 changelog="https://raw.githubusercontent.com/Kozea/cairocffi/master/NEWS.rst"
 distfiles="${PYPI_SITE}/c/cairocffi/cairocffi-${version}.tar.gz"
-checksum=78e6bbe47357640c453d0be929fa49cd05cce2e1286f3d2a1ca9cbda7efdb8b7
+checksum=7761863603894305f3160eca68452f373433ca8745ab7dd445bd2c6ce50dcab7
 
 build_options=xcb
 case "$XBPS_MACHINE" in

--- a/srcpkgs/python3-pywayland/template
+++ b/srcpkgs/python3-pywayland/template
@@ -1,7 +1,7 @@
 # Template file for 'python3-pywayland'
 pkgname=python3-pywayland
-version=0.4.16
-revision=2
+version=0.4.17
+revision=1
 build_style=python3-module
 hostmakedepends="python3-setuptools wayland-protocols pkg-config
  python3-wheel python3-cffi wayland-devel"
@@ -12,5 +12,5 @@ maintainer="Đoàn Trần Công Danh <congdanhqx@gmail.com>"
 license="Apache-2.0"
 homepage="https://github.com/flacjacket/pywayland"
 distfiles="${PYPI_SITE}/p/pywayland/pywayland-${version}.tar.gz"
-checksum=aaa70c870b0ab365215f8e71505f73683c4ed15b1f3638433b1dc7344fe5b5dd
-make_check=no
+checksum=f7fd1902638c2f7a15ac07f31a3ef6895d3c160ca2601481ca82b2c61a23c657
+make_check=no # Need Wayland protocol files

--- a/srcpkgs/python3-pywlroots-0.16/update
+++ b/srcpkgs/python3-pywlroots-0.16/update
@@ -1,1 +1,0 @@
-pattern="[v_-]\K\Q${pkgname##*-}.\E.*(?=\.tar\.gz)"

--- a/srcpkgs/python3-pywlroots/template
+++ b/srcpkgs/python3-pywlroots/template
@@ -1,20 +1,19 @@
-# Template file for 'python3-pywlroots-0.16'
-pkgname=python3-pywlroots-0.16
-version=0.16.7
+# Template file for 'python3-pywlroots'
+pkgname=python3-pywlroots
+version=0.17.0
 revision=1
 build_style=python3-pep517
 hostmakedepends="python3-setuptools python3-cffi python3-pywayland python3-xkbcommon
- python3-wheel python3-devel wlroots${pkgname##*-}-devel"
-makedepends="python3-devel python3-cffi wlroots${pkgname##*-}-devel"
+ python3-wheel python3-devel wlroots${version%.*}-devel"
+makedepends="python3-devel python3-cffi wlroots${version%.*}-devel"
 depends="python3-pywayland python3-xkbcommon python3-cffi"
-short_desc="Python binding to the wlroots ${pkgname##*-} using cffi"
+short_desc="Python binding to the wlroots library using cffi"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
 homepage="https://github.com/flacjacket/pywlroots"
 distfiles="${PYPI_SITE}/p/pywlroots/pywlroots-${version}.tar.gz"
-checksum=cdf8dc5d0097cac1be24cc34d18112fc6424ff28c71fd90292c6fd4a566df70a
-conflicts="python3-pywlroots-0.15>=0"
-replaces="python3-pywlroots-0.15>=0"
+checksum=72cb2be14048c0cbc89ccf1b57863013a9977fd51248c300ccc72001e7c43dbb
+replaces="python3-pywlroots-0.15>=0 python3-pywlroots-0.16>=0"
 
 pre_build() {
 	[ "$CROSS_BUILD" ] || return 0

--- a/srcpkgs/python3-pywlroots/update
+++ b/srcpkgs/python3-pywlroots/update
@@ -1,0 +1,1 @@
+pattern="[v_-]\K\Q${version%.*}.\E.*(?=\.tar\.gz)"

--- a/srcpkgs/python3-qtile-extras/template
+++ b/srcpkgs/python3-qtile-extras/template
@@ -1,6 +1,6 @@
 # Template file for 'python3-qtile-extras'
 pkgname=python3-qtile-extras
-version=0.25.0
+version=0.26.0
 revision=1
 build_style=python3-pep517
 makedepends="python3-wheel python3-setuptools_scm"
@@ -10,8 +10,8 @@ maintainer="Bartek Stalewski <ftpd@insomniac.pl>"
 license="MIT"
 homepage="https://github.com/elParaguayo/qtile-extras"
 changelog="https://raw.githubusercontent.com/elParaguayo/qtile-extras/main/CHANGELOG"
-distfiles="${PYPI_SITE}/q/qtile-extras/qtile-extras-${version}.tar.gz"
-checksum=0e945de4685bf9431d44779fd29a1e7661dd1c46f3bf34f51dffb4a50c89b317
+distfiles="${PYPI_SITE}/q/qtile-extras/qtile_extras-${version}.tar.gz"
+checksum=35a609bc8ad7e616b9cc692fc91a75ac9e16c2218d7689bdf65093bf38d384e7
 # Tests require a lot of python modules that are not packaged
 make_check=no
 

--- a/srcpkgs/qtile/template
+++ b/srcpkgs/qtile/template
@@ -1,11 +1,11 @@
 # Template file for 'qtile'
 pkgname=qtile
-version=0.25.0
+version=0.26.0
 revision=1
 build_style=python3-pep517
-_wlroots=0.16
+_wlroots=0.17
 hostmakedepends="python3-setuptools_scm python3-cairocffi python3-xcffib python3-wheel
- pkg-config python3-pywlroots-${_wlroots} python3-pywayland python3-xkbcommon"
+ pkg-config python3-pywlroots python3-pywayland python3-xkbcommon"
 makedepends="python3-devel libffi-devel pulseaudio-devel wlroots${_wlroots}-devel"
 depends="python3-cairocffi python3-xcffib pango gdk-pixbuf"
 short_desc="Full-featured tiling window manager written and configured in Python"
@@ -14,7 +14,7 @@ license="MIT"
 homepage="http://www.qtile.org/"
 changelog="https://raw.githubusercontent.com/qtile/qtile/master/CHANGELOG"
 distfiles="${PYPI_SITE}/q/qtile/qtile-${version}.tar.gz"
-checksum=cc7b80cfa0e7037242a610563f53dac315c1ef1538efb801fec99073e363fc11
+checksum=2c806f94dbf67a8ce1e0cd3fa425b95e3fdc5258e28d766dfecd866a7f5806b5
 
 post_install() {
 	vinstall resources/qtile.desktop 644 usr/share/xsessions
@@ -24,7 +24,7 @@ post_install() {
 
 qtile-wayland_package() {
 	depends="${sourcepkg}>=${version}_${revision}
-	 python3-pywlroots-${_wlroots} python3-pywayland python3-xkbcommon"
+	 python3-pywlroots python3-pywayland python3-xkbcommon"
 	pkg_install() {
 		vmove ${py3_sitelib}/libqtile/backend/wayland
 		vmove usr/share/wayland-sessions


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**
Except the Wayland packages since I'm using xorg.

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**
The new package is requirement to run Qtile on Wayland.

#### Local build testing
- I built this PR locally for my native architecture, x86-64-LIBC