### PR TITLE
c-ares: Update to 1.30.0, apply new download link

### DIFF
--- a/srcpkgs/c-ares/template
+++ b/srcpkgs/c-ares/template
@@ -1,6 +1,6 @@
 # Template file for 'c-ares'
 pkgname=c-ares
-version=1.29.0
+version=1.30.0
 revision=1
 build_style=gnu-configure
 checkdepends="iana-etc"
@@ -9,8 +9,8 @@ maintainer="Duncaen <duncaen@voidlinux.org>"
 license="MIT"
 homepage="https://c-ares.haxx.se/"
 changelog="https://c-ares.haxx.se/changelog.html"
-distfiles="https://c-ares.haxx.se/download/c-ares-${version}.tar.gz"
-checksum=0b89fa425b825c4c7bc708494f374ae69340e4d1fdc64523bdbb2750bfc02ea7
+distfiles="https://github.com/c-ares/c-ares/releases/download/v${version}/c-ares-${version}.tar.gz"
+checksum=4fea312112021bcef081203b1ea020109842feb58cd8a36a3d3f7e0d8bc1138c
 make_check=ci-skip # segfaults only on CI
 
 post_install() {


### PR DESCRIPTION
c-ares' new version is 1.30.0, and the current 1.29.0 doesn't build due to a now-missing download link. Fix both problems at once to get the package building again.

I've tested these changes on several architectures for glibc and musl.

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - (cross) i686
  - (cross) i686-musl
  - (cross) mips-musl
  - (cross) ppc
  - ppc
  - (cross) armv6l-musl
  - (cross) armv6l
  - (cross) aarch64-musl
  - (cross) aarch64