### PR TITLE
zathura: import fix for 32-bit

### DIFF
--- a/srcpkgs/zathura/patches/fix_type_mismatch.patch
+++ b/srcpkgs/zathura/patches/fix_type_mismatch.patch
@@ -1,0 +1,24 @@
+From 0c344affeaaae5b1360d0958fb23b3481f63945c
+From: Adam Sampson <ats@offog.org>
+Date: Mon, 13 May 2024 01:07:10 +0100
+Subject: [PATCH] Fix type mismatch with g_ascii_string_to_unsigned
+
+The out_num argument is a guint64, which isn't the same as unsigned long
+on some platforms (e.g. AArch32 Linux).
+---
+ zathura/utils.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/zathura/utils.c b/zathura/utils.c
+index 2b3b39b3..bda6f86a 100644
+--- a/zathura/utils.c
++++ b/zathura/utils.c
+@@ -321,7 +321,7 @@ parse_first_page_column_list(const char* first_page_column_list, unsigned int* s
+   unsigned int* settings = g_malloc_n(length, sizeof(unsigned int));
+ 
+   for (unsigned int i=0; i<length; i++) {
+-    unsigned long column = 1;
++    guint64 column = 1;
+ 
+     if (g_ascii_string_to_unsigned(tokens[i], 10, 1, i+1, &column, NULL)) {
+       settings[i] = (unsigned int)column;

--- a/srcpkgs/zathura/template
+++ b/srcpkgs/zathura/template
@@ -1,7 +1,7 @@
 # Template file for 'zathura'
 pkgname=zathura
 version=0.5.6
-revision=1
+revision=2
 build_style=meson
 configure_args="-Dsynctex=enabled"
 hostmakedepends="pkg-config gettext python3-Sphinx desktop-file-utils


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

zathura-0.5.6 crashes with `*** stack smashing detected ***: terminated` on i686.  This brings in the upstream fix.

#### Testing the changes
- I tested the changes in this PR: **briefly**

Tested on i686

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
