### PR TITLE
vscode: remove deprecated --unity-launch flag from desktop file

### DIFF
--- a/srcpkgs/vscode/patches/fix_dir.patch
+++ b/srcpkgs/vscode/patches/fix_dir.patch
@@ -33,7 +33,7 @@ index 4c939a2fab8..1f94f5fccfb 100755
  Comment=Code Editing. Redefined.
  GenericName=Text Editor
 -Exec=@@EXEC@@ %F
-+Exec=/usr/lib/@@NAME@@/bin/@@NAME@@ --unity-launch %F
++Exec=/usr/lib/@@NAME@@/bin/@@NAME@@ %F
  Icon=@@ICON@@
  Type=Application
  StartupNotify=false

--- a/srcpkgs/vscode/template
+++ b/srcpkgs/vscode/template
@@ -1,7 +1,7 @@
 # Template file for 'vscode'
 pkgname=vscode
 version=1.90.0
-revision=1
+revision=2
 _electronver=24.3.0
 _npmver=8.6.0
 hostmakedepends="pkg-config python3 python3-setuptools nodejs yarn tar git ripgrep"


### PR DESCRIPTION
VSCode has [deprecated the --unity-launch flag](https://github.com/microsoft/vscode/issues/202545) and its presence was breaking the "Open with Code" context menu option.

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc

Closes #50682