### PR TITLE
opera: update to 110.0.5130.66

### DIFF
--- a/srcpkgs/opera/template
+++ b/srcpkgs/opera/template
@@ -1,6 +1,6 @@
 # Template file for 'opera'
 pkgname=opera
-version=107.0.5045.36
+version=110.0.5130.66
 revision=1
 archs="x86_64"
 create_wrksrc=yes
@@ -10,7 +10,7 @@ maintainer="mobinmob <mobinmob@disroot.org>"
 license="custom:Proprietary"
 homepage="https://www.opera.com/computer"
 distfiles="https://get.geo.opera.com/pub/opera/desktop/${version}/linux/opera-stable_${version}_amd64.rpm"
-checksum=019f4ccb2c379490834005c94e167f9cb2900900826ed2dd5b2144d5af503efe
+checksum=7f327a061cf847a00ae0ee51ae043cfffb92ae9214446137b6a0e33b3cb6c3a9
 repository="nonfree"
 nostrip=yes
 


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->
@mobinmob 
#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
