### PR TITLE
python3-rapidfuzz: update to 3.9.3

### DIFF
--- a/srcpkgs/python3-rapidfuzz/template
+++ b/srcpkgs/python3-rapidfuzz/template
@@ -1,6 +1,6 @@
 # Template file for 'python3-rapidfuzz'
 pkgname=python3-rapidfuzz
-version=3.9.1
+version=3.9.3
 revision=1
 build_style=python3-pep517
 hostmakedepends="cmake python3-scikit-build"
@@ -13,7 +13,7 @@ license="MIT"
 homepage="https://github.com/maxbachmann/rapidfuzz"
 changelog="https://github.com/rapidfuzz/RapidFuzz/releases"
 distfiles="${PYPI_SITE}/r/rapidfuzz/rapidfuzz-${version}.tar.gz"
-checksum=a42eb645241f39a59c45a7fc15e3faf61886bff3a4a22263fd0f7cfb90e91b7f
+checksum=b398ea66e8ed50451bce5997c430197d5e4b06ac4aa74602717f792d8d8d06e2
 
 export CMAKE_ARGS="-DPython_INCLUDE_DIR:PATH=${XBPS_CROSS_BASE}/${py3_inc}"
 


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86-64)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64