### PR TITLE
stig: update to 0.12.10a0

### DIFF
--- a/srcpkgs/stig/template
+++ b/srcpkgs/stig/template
@@ -1,6 +1,6 @@
 # Template file for 'stig'
 pkgname=stig
-version=0.12.9a0
+version=0.12.10a0
 revision=1
 build_style=python3-module
 hostmakedepends="python3-setuptools"
@@ -13,5 +13,5 @@ license="GPL-3.0-or-later"
 homepage="https://github.com/rndusr/stig"
 changelog="https://github.com/rndusr/stig/blob/master/CHANGELOG"
 distfiles="https://github.com/rndusr/stig/archive/v${version}.tar.gz"
-checksum=1261a2546a4a6c4cd80718acc306c726241f00701443ce63a34b2b7e540adb84
+checksum=69105ed6ae6a8bd4450d37516368318b1c069b78fe8734171694e729fee2dc56
 make_check=no # needs python3-asynctest which is not packaged


### PR DESCRIPTION
- I tested the changes in this PR: **briefly**
- I built this PR locally for my native architecture, (x86_64-glibc)