### PR TITLE
New package: artwiz-fonts-wl-2.0.0

### DIFF
--- a/srcpkgs/artwiz-fonts-wl/template
+++ b/srcpkgs/artwiz-fonts-wl/template
@@ -1,0 +1,24 @@
+# Template file for 'artwiz-fonts-wl'
+pkgname=artwiz-fonts-wl
+version=2.0.0
+revision=1
+create_wrksrc=yes
+makedepends="mkfontdir fontforge"
+short_desc="Small futuristic Unicode pixel fonts for X"
+maintainer="David H. Bronke <whitelynx@gmail.com>"
+license="GPL-2.0-or-later"
+homepage="https://github.com/whitelynx/artwiz-fonts-wl"
+distfiles="https://github.com/whitelynx/artwiz-fonts-wl/archive/refs/tags/${version}.tar.gz"
+checksum="ba875e24399c93a8aef9d25e28b34cc3dfe55c59fe3d5207e179314d94be3a2e"
+font_dirs="/usr/share/fonts/artwiz-fonts-wl"
+
+do_build() {
+	cd artwiz-fonts-wl-${version}
+	make otf
+}
+
+do_install() {
+	cd artwiz-fonts-wl-${version}
+	make DESTDIR=${DESTDIR} install-otf
+	vdoc README.md
+}


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**


#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

Advantages over the `artwiz-fonts` package:
- Full ISO/IEC 8859-1 encoding support, as well as Unicode-standard glyph names, for wider compatibility
- Fixes several issues with bold variants
- Installs as OTF fonts instead of legacy PCF fonts (meaning the fonts can be used on modern fontconfig-based apps easier)


#### Local build testing
- I built this PR locally for my native architecture, (x86_64)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl
  - i686