### PR TITLE
fancontrol: fix run script

### DIFF
--- a/srcpkgs/lm_sensors/files/fancontrol/run
+++ b/srcpkgs/lm_sensors/files/fancontrol/run
@@ -1,5 +1,5 @@
 #!/bin/sh
 exec 2>&1
-[ -r conf ] && . conf
+[ -r conf ] && . ./conf
 [ ! -r ${CONF_FILE:-/etc/fancontrol} ] && exit 1
 exec /usr/bin/fancontrol ${CONF_FILE:-/etc/fancontrol}


### PR DESCRIPTION
The existing `run` script does not source `conf` correctly.
Tested on a Mellanox SN2700 running void (we provide our own `conf` which involves auto-generating the required config).
