### PR TITLE
android-tools: update to 35.0.1.

### DIFF
--- a/srcpkgs/android-tools/template
+++ b/srcpkgs/android-tools/template
@@ -1,7 +1,7 @@
 # Template file for 'android-tools'
 pkgname=android-tools
-version=34.0.4
-revision=2
+version=35.0.1
+revision=1
 archs="armv* aarch64* x86_64* i686* ppc64le* riscv64*"
 build_style=cmake
 hostmakedepends="perl go protobuf pkg-config"
@@ -13,7 +13,7 @@ maintainer="John <me@johnnynator.dev>"
 license="Apache-2.0, ISC, GPL-2.0-only, MIT"
 homepage="https://developer.android.com/tools/help/adb.html"
 distfiles="https://github.com/nmeum/android-tools/releases/download/${version}/android-tools-${version}.tar.xz"
-checksum=7a22ff9cea81ff4f38f560687858e8f8fb733624412597e3cc1ab0262f8da3a1
+checksum=654030c7f96d25d7224cd6861fac14a043cf1d3980f40288cdfbe219f94ffaf9
 
 post_install() {
 	# zsh's built in works, while this one doesn't


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
