### PR TITLE
ruby-tmuxinator: not working because of wrong dependency

### DIFF
--- a/srcpkgs/ruby-erubi/template
+++ b/srcpkgs/ruby-erubi/template
@@ -1,0 +1,14 @@
+# Template file for 'ruby-erubi'
+pkgname=ruby-erubi
+version=1.12.0
+revision=1
+build_style=gem
+short_desc="ERB template engine for ruby"
+maintainer="dataCobra <datacobra@thinkbot.de>"
+license="MIT"
+homepage="https://github.com/jeremyevans/erubi"
+checksum=27bedb74dfb1e04ff60674975e182d8ca787f2224f2e8143268c7696f42e4723
+
+post_install() {
+	vlicense MIT-LICENSE
+}

--- a/srcpkgs/ruby-tmuxinator/template
+++ b/srcpkgs/ruby-tmuxinator/template
@@ -1,9 +1,9 @@
 # Template file for 'ruby-tmuxinator'
 pkgname=ruby-tmuxinator
 version=3.2.1
-revision=1
+revision=2
 build_style=gemspec
-depends="ruby-erubis>=2.6 ruby-thor>=1.3.0 ruby-xdg>=4.3.0 tmux"
+depends="ruby-erubi>=1.7 ruby-thor>=1.3.0 ruby-xdg>=4.3.0 tmux"
 short_desc="Create and manage complex tmux sessions easily"
 maintainer="dataCobra <datacobra@thinkbot.de>"
 license="MIT"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl
  - i686

After the last PR I forgot to change the dependency from ruby-erubis to ruby-erubi.

With this PR tmuxinator is finally working.