### PR TITLE
[RFC] Manual.md: use SPDX expressions for license=

### DIFF
--- a/Manual.md
+++ b/Manual.md
@@ -439,7 +439,12 @@ The list of mandatory variables for a template:
 - <a id="var_license"></a>
 `license` A string matching the license's [SPDX Short identifier](https://spdx.org/licenses),
 `Public Domain`, or string prefixed with `custom:` for other licenses.
-Multiple licenses should be separated by commas, Example: `GPL-3.0-or-later, custom:Hugware`.
+Multiple licenses should be listed as an
+[SPDX license expression](https://spdx.github.io/spdx-spec/v3.0/annexes/SPDX-license-expressions/)
+(examples: `MIT OR Apache-2.0`, `MIT AND (LGPL-2.1-or-later OR BSD-3-Clause)`).
+Usage of `AND`, `OR`, `WITH`, and `()` are supported by xlint. The legacy
+comma-separated format should be converted when encountered (example:
+`GPL-3.0-or-later, custom:Hugware`).
 
   Empty meta-packages that don't include any files
   and thus have and require no license should use


### PR DESCRIPTION
see also:
- https://github.com/void-linux/void-packages/issues/48303
- https://github.com/void-linux/void-packages/issues/11240

xlint supports parsing this since leahneukirchen/xtools#322

SPDX expressions are more expressive and accurate than the comma-separated format, and WITH has already been usable for a long time.

I propose that existing multi-licence strings be changed in batches (if someone wants to spend the time) or as templates are modified.

@void-linux/pkg-committers

there are also a few `qt6-*` packages that already use this notation