### PR TITLE
xorg-video-drivers: prune dependencies

### DIFF
--- a/srcpkgs/xorg-video-drivers/template
+++ b/srcpkgs/xorg-video-drivers/template
@@ -1,7 +1,7 @@
 # Template file for 'xorg-video-drivers'
 pkgname=xorg-video-drivers
 version=7.6
-revision=22
+revision=23
 build_style=meta
 depends="xf86-video-fbdev xf86-video-dummy"
 short_desc="X.org video drivers meta-package"
@@ -10,17 +10,10 @@ license="CC0-1.0"
 homepage="http://www.voidlinux.org"
 
 case "$XBPS_TARGET_MACHINE" in
-	i686*|x86_64*)
-		depends+=" xf86-video-vesa"
-		depends+=" xf86-video-intel"
-		depends+=" xf86-video-vmware"
-		;;
+	i686*|x86_64*) depends+=" xf86-video-vesa xf86-video-vmware" ;;
 esac
 
 case "$XBPS_TARGET_MACHINE" in
-	armv[56]*|mips*) ;;
-	*)
-		depends+=" xf86-video-ati xf86-video-amdgpu"
-		depends+=" xf86-video-nouveau"
-		;;
+	armv[56]*|aarch64*|mips*) ;;
+	*) depends+=" xf86-video-ati xf86-video-amdgpu xf86-video-nouveau" ;;
 esac


### PR DESCRIPTION
xf86-video-intel is generally not recommended anymore

fixes #28864

on aarch64, it's probably very uncommon to have amd/nvidia gpu

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

