### PR TITLE
openldap: update to 2.6.8, adopt

### DIFF
--- a/srcpkgs/openldap/template
+++ b/srcpkgs/openldap/template
@@ -1,7 +1,7 @@
 # Template file for 'openldap'
 pkgname=openldap
-version=2.6.6
-revision=3
+version=2.6.8
+revision=1
 build_style=gnu-configure
 configure_args="--prefix=/usr
  --libexecdir=/usr/libexec
@@ -18,11 +18,11 @@ makedepends="openssl-devel libsasl-devel db-devel libltdl-devel"
 depends="openldap-tools>=${version}_${revision}"
 conf_files="/etc/openldap/ldap.conf /etc/openldap/slapd.conf /etc/openldap/slapd.ldif"
 short_desc="OpenLDAP (Lightweight Directory Access Protocol)"
-maintainer="Orphaned <orphan@voidlinux.org>"
+maintainer="Klara Modin <klarasmodin@gmail.com>"
 license="OLDAP-2.0"
 homepage="http://www.openldap.org"
 distfiles="https://www.openldap.org/software/download/OpenLDAP/openldap-release/openldap-${version}.tgz"
-checksum=082e998cf542984d43634442dbe11da860759e510907152ea579bdc42fe39ea0
+checksum=48969323e94e3be3b03c6a132942dcba7ef8d545f2ad35401709019f696c3c4e
 
 system_accounts="ldap"
 ldap_homedir="/var/lib/openldap"


### PR DESCRIPTION
I have been using this package for long enough to feel confident in adopting it.

New since 2.6.6 (#48823 for 2.6.7 was not merged):
- fixes build for GCC 14
- a few OpenSSL 3 related fixes
- Other fixes can be seen at https://www.openldap.org/software/release/changes.html

#### Testing the changes
- I tested the changes in this PR: **YES**
- Have been using this version for the servers in my setup for a little over a week, no obvious issues

#### Local build testing
- I built this PR locally for my native architecture, (x86_64, x86_64-musl)
- I built this PR locally for these architectures:
  - aarch64-musl
  - armv7l
  - armv6l-musl
  - i686