### PR TITLE
python3-keyring: update to 25.2.1.

### DIFF
--- a/srcpkgs/python3-keyring/template
+++ b/srcpkgs/python3-keyring/template
@@ -1,6 +1,6 @@
 # Template file for 'python3-keyring'
 pkgname=python3-keyring
-version=25.1.0
+version=25.2.1
 revision=1
 build_style=python3-pep517
 hostmakedepends="python3-wheel python3-setuptools_scm"
@@ -13,7 +13,7 @@ license="MIT"
 homepage="https://pypi.org/project/keyring/"
 changelog="https://raw.githubusercontent.com/jaraco/keyring/main/NEWS.rst"
 distfiles="${PYPI_SITE}/k/keyring/keyring-${version}.tar.gz"
-checksum=7230ea690525133f6ad536a9b5def74a4bd52642abe594761028fc044d7c7893
+checksum=daaffd42dbda25ddafb1ad5fec4024e5bbcfe424597ca1ca452b299861e49f1b
 
 pre_check() {
 	vsed -e '/addopts/d' -i pytest.ini


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture: **x86_64**