### PR TITLE
python3-isort: update to 5.13.2.

### DIFF
--- a/srcpkgs/python3-isort/template
+++ b/srcpkgs/python3-isort/template
@@ -1,7 +1,7 @@
 # Template file for 'python3-isort'
 pkgname=python3-isort
-version=5.12.0
-revision=2
+version=5.13.2
+revision=1
 build_style=python3-pep517
 hostmakedepends="python3-poetry-core"
 depends="python3"
@@ -13,7 +13,7 @@ license="MIT"
 homepage="https://github.com/PyCQA/isort"
 changelog="https://raw.githubusercontent.com/PyCQA/isort/main/CHANGELOG.md"
 distfiles="${PYPI_SITE}/i/isort/isort-${version}.tar.gz"
-checksum=8bef7dde241278824a6d83f44a544709b065191b95b6e50894bdc722fcba0504
+checksum=48fdfcb9face5d58a4f6dde2e72a1fb8dcaf8ab26f95ab49fab84c2ddefb0109
 conflicts="python-isort>=0"
 make_check=no # FIXME
 


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, **x86_64**
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl
