### PR TITLE
catch2: update to 3.6.0.

### DIFF
--- a/srcpkgs/catch2/template
+++ b/srcpkgs/catch2/template
@@ -1,6 +1,6 @@
 # Template file for 'catch2'
 pkgname=catch2
-version=3.4.0
+version=3.6.0
 revision=1
 build_style=cmake
 configure_args="-DCATCH_USE_VALGRIND=OFF -DCATCH_BUILD_TESTING=ON
@@ -13,7 +13,7 @@ maintainer="Louis Dupré Bertoni <contact@louisdb.xyz>"
 license="BSL-1.0"
 homepage="https://github.com/catchorg/Catch2"
 distfiles="https://github.com/catchorg/Catch2/archive/v${version}/catch2-v${version}.tar.gz"
-checksum=122928b814b75717316c71af69bd2b43387643ba076a6ec16e7882bfb2dfacbb
+checksum=485932259a75c7c6b72d4b874242c489ea5155d17efa345eb8cc72159f49f356
 
 post_install() {
 	vlicense LICENSE.txt


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - aarch64