### PR TITLE
docker-buildx: update to 0.15.1.

### DIFF
--- a/srcpkgs/docker-buildx/template
+++ b/srcpkgs/docker-buildx/template
@@ -1,6 +1,6 @@
 # Template file for 'docker-buildx'
 pkgname=docker-buildx
-version=0.14.1
+version=0.15.1
 revision=1
 build_style=go
 go_import_path="github.com/docker/buildx"
@@ -12,7 +12,7 @@ maintainer="Daniel Lewan <daniel@teddydd.me>"
 license="Apache-2.0"
 homepage="https://docs.docker.com/buildx/working-with-buildx/"
 distfiles="https://github.com/docker/buildx/archive/refs/tags/v${version}.tar.gz"
-checksum=01e39cc6d674e20547a62f52d80bc3cbd6c1cff6764d7869e182bdcdd49ac297
+checksum=af8a6733b166c7b7676348e7553b1abaa9e62b416827f1be790a8fe7ec21c8a9
 
 post_install() {
 	vmkdir usr/libexec/docker/cli-plugins


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
