### PR TITLE
gnome-builder: update to 46.2.

### DIFF
--- a/srcpkgs/gnome-builder/template
+++ b/srcpkgs/gnome-builder/template
@@ -1,7 +1,7 @@
 # Template file for 'gnome-builder'
 pkgname=gnome-builder
-version=46.0
-revision=2
+version=46.2
+revision=1
 build_style=meson
 build_helper=qemu
 configure_args="-Dhelp=true -Dnetwork_tests=false"
@@ -24,5 +24,5 @@ homepage="https://wiki.gnome.org/Apps/Builder"
 #changelog="https://gitlab.gnome.org/GNOME/gnome-builder/-/raw/main/NEWS"
 changelog="https://gitlab.gnome.org/GNOME/gnome-builder/-/raw/gnome-builder-46/NEWS"
 distfiles="${GNOME_SITE}/gnome-builder/${version%.*}/gnome-builder-${version}.tar.xz"
-checksum=1a8e3937265552a2900fb83aa4079abcb1fda0aec15b6e79033b608f41ac3697
+checksum=0c857b89003b24787f2b1d2aae12d275a074c6684b48803b48c00276d9371963
 make_check_pre="xvfb-run"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
