### PR TITLE
firefox-esr: update to 115.12.0.

### DIFF
--- a/srcpkgs/firefox-esr/template
+++ b/srcpkgs/firefox-esr/template
@@ -4,15 +4,15 @@
 # After bumping this package, restore the depends of browsh
 #
 pkgname=firefox-esr
-version=115.0.2
-revision=2
+version=115.12.0
+revision=1
 build_helper="rust"
 short_desc="Mozilla Firefox web browser - Extended Support Release"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="MPL-2.0, GPL-2.0-or-later, LGPL-2.1-or-later"
 homepage="https://www.mozilla.org/firefox/"
 distfiles="${MOZILLA_SITE}/firefox/releases/${version}esr/source/firefox-${version}esr.source.tar.xz"
-checksum=45723c83ea7dc318ec50d67eebf834163b626ec3924a3131fecddfc7268a95f5
+checksum=b59e1625a0bb2f0565a737394f2bf8a7ce3171314b0d871bde533a101847a8ef
 
 lib32disabled=yes
 


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I did not cross-build this PR locally as it costs nearly a hour to finish a single build.

Just a minor update, everything works as far as I can tell.