### PR TITLE
tmux: rebuild against ncurses-6.5

### DIFF
--- a/srcpkgs/tmux/template
+++ b/srcpkgs/tmux/template
@@ -1,7 +1,7 @@
 # Template file for 'tmux'
 pkgname=tmux
 version=3.4
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--enable-utempter --enable-sixel"
 hostmakedepends="byacc automake pkg-config"


### PR DESCRIPTION
Copying to the X11 clipboard from tmux has been failing since I updated to ncurses-6.5.

In ncurses 6.5, the `tparm` function fails if called with capability strings that do not come from the terminal description loaded by ncurses itself (see https://invisible-island.net/ncurses/announce.html#h4-fixes-library). This breaks tmux's use of terminfo overrides. Tmux 3.4 uses the new `tiparm_s` function (introduced in ncurses 6.5) to get around this, however this is only used if tmux is compiled against ncurses 6.5.

#### Testing the changes
- I tested the changes in this PR: **YES**

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
#### Local build testing
- I built this PR locally for my native architecture, x86_64
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl (crossbuild)
  - aarch64  (crossbuild)
  - armv6l-musl  (crossbuild)
  - armv6l  (crossbuild)
  - armv7l-musl  (crossbuild)
  - armv7l  (crossbuild)
  - x86_64-musl  (crossbuild)