### PR TITLE
VirtualGL: add aarch64 to list of supported archs

### DIFF
--- a/srcpkgs/VirtualGL/template
+++ b/srcpkgs/VirtualGL/template
@@ -3,8 +3,8 @@ pkgname=VirtualGL
 version=2.6.2
 revision=4
 build_style=cmake
-configure_args="-DTJPEG_INCLUDE_DIR=/usr/include -DVGL_SYSTEMGLX=ON
- -DTJPEG_LIBRARY=/usr/lib/libturbojpeg.so
+configure_args="-DTJPEG_INCLUDE_DIR=${XBPS_CROSS_BASE}/usr/include -DVGL_SYSTEMGLX=ON
+ -DTJPEG_LIBRARY=${XBPS_CROSS_BASE}/usr/lib/libturbojpeg.so
  -DVGL_SYSTEMFLTK=ON -DVGL_USESSL=ON"
 makedepends="libXv-devel glu-devel libjpeg-turbo-devel MesaLib-devel
  libXtst-devel fltk-devel openssl-devel"
@@ -15,7 +15,7 @@ homepage="http://www.virtualgl.org/"
 distfiles="${SOURCEFORGE_SITE}/virtualgl/${version}/${pkgname}-${version}.tar.gz"
 checksum=79dff857862890215794509ac65826005625925d03bf0874a486d695aae6f859
 
-archs="i686* x86_64*"
+archs="i686* x86_64* aarch64*"
 
 post_install() {
 	mv ${DESTDIR}/usr/bin/{glxinfo,vglxinfo}


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
