### PR TITLE
font-sarasa-gothic: update to 1.0.14.

### DIFF
--- a/srcpkgs/font-sarasa-gothic/template
+++ b/srcpkgs/font-sarasa-gothic/template
@@ -1,14 +1,14 @@
 # Template file for 'font-sarasa-gothic'
 pkgname=font-sarasa-gothic
-version=0.40.3
+version=1.0.14
 revision=1
 depends="font-util"
 short_desc="CJK programming font based on Iosevka and Source Han Sans"
 maintainer="B. Wilson <x@wilsonb.com>"
 license="OFL-1.1"
 homepage="https://github.com/be5invis/Sarasa-Gothic"
-distfiles="https://github.com/be5invis/Sarasa-Gothic/releases/download/v${version}/sarasa-gothic-ttc-${version}.7z"
-checksum=9618ec9ac805117317e5bca9e74a91a07a17f67b8a72cac0a7a3460dd7d7a372
+distfiles="https://github.com/be5invis/Sarasa-Gothic/releases/download/v${version}/Sarasa-TTC-${version}.7z"
+checksum=66b23f2f613bd90b733ff6e316da6bef030e7228ebbb6bca1006c4892f7c39df
 font_dirs="/usr/share/fonts/TTF"
 
 do_install() {


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I did not build this PR locally for other architectures as it's a static font.

Still a minor update despite [Changes to File Naming Convention](https://github.com/be5invis/Sarasa-Gothic/issues/352). Originally I thought maybe it's a breaking change, but xbps is smart enough to detect the name change and old v0.x fonts are indeed removed from `/usr/share/fonts/TTF`.