### PR TITLE
libbreeze-icons: split from breeze-icons

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -1949,7 +1949,7 @@ libQt6Xdg.so.4 libqtxdg-4.0.0_1
 libQt6XdgIconLoader.so.4 libqtxdg-4.0.0_1
 libqwt-qt5.so.6.2 qwt-6.2.0_2
 libqwt-qt6.so.6.2 qwt-qt6-6.2.0_2
-libKF6BreezeIcons.so.6 breeze-icons-6.3.0_1
+libKF6BreezeIcons.so.6 libbreeze-icons-6.3.0_2
 libKF6Archive.so.6 kf6-karchive-6.0.0_1
 libKF6Attica.so.6 kf6-attica-6.0.0_1
 libKF6AuthCore.so.6 kf6-kauth-6.0.0_1

--- a/srcpkgs/breeze-icons/template
+++ b/srcpkgs/breeze-icons/template
@@ -1,7 +1,7 @@
 # Template file for 'breeze-icons'
 pkgname=breeze-icons
 version=6.3.0
-revision=1
+revision=2
 build_style=cmake
 build_helper=qemu
 hostmakedepends="kcoreaddons extra-cmake-modules qt6-base qt6-tools
@@ -21,3 +21,19 @@ if [ -z "$CROSS_BUILD" ]; then
 else
 	configure_args="-DBINARY_ICONS_RESOURCE=OFF"
 fi
+
+libbreeze-icons_package() {
+	pkg_install() {
+		vmove "usr/lib/*.so.*"
+	}
+}
+
+libbreeze-icons-devel_package() {
+	depends="libbreeze-icons>=${version}_${revision}"
+	short_desc+=" - development files"
+	pkg_install() {
+		vmove usr/include
+		vmove usr/lib/cmake
+		vmove "usr/lib/*.so"
+	}
+}

--- a/srcpkgs/kf6-kiconthemes/template
+++ b/srcpkgs/kf6-kiconthemes/template
@@ -1,13 +1,13 @@
 # Template file for 'kf6-kiconthemes'
 pkgname=kf6-kiconthemes
 version=6.3.0
-revision=2
+revision=3
 build_style=cmake
 configure_args="-DKDE_INSTALL_QMLDIR=lib/qt6/qml
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins"
 hostmakedepends="extra-cmake-modules qt6-tools qt6-base
  qt6-declarative-host-tools gettext"
-makedepends="breeze-icons kf6-karchive-devel kf6-kcolorscheme-devel
+makedepends="libbreeze-icons-devel kf6-karchive-devel kf6-kcolorscheme-devel
  qt6-svg-devel kf6-kconfigwidgets-devel qt6-base-private-devel"
 short_desc="KDE Icon GUI utilities"
 maintainer="John <me@johnnynator.dev>"

--- a/srcpkgs/libbreeze-icons
+++ b/srcpkgs/libbreeze-icons
@@ -1,0 +1,1 @@
+breeze-icons

--- a/srcpkgs/libbreeze-icons-devel
+++ b/srcpkgs/libbreeze-icons-devel
@@ -1,0 +1,1 @@
+breeze-icons


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

kf6-kiconthemes is required by many packages and requires libKF6BreezeIcons.so.6. On the other hand I do ignorepkg breeze-icons for some time.
Split so they can be installed separately.

cc @Johnnynator 

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
