### PR TITLE
New package: xfce4-panel-profiles-1.0.14

### DIFF
--- a/srcpkgs/xfce4-panel-profiles/template
+++ b/srcpkgs/xfce4-panel-profiles/template
@@ -1,0 +1,15 @@
+# Template file for 'xfce4-panel-profiles'
+pkgname=xfce4-panel-profiles
+version=1.0.14
+revision=1
+build_style=configure
+configure_args="--prefix=/usr --python=python3"
+hostmakedepends="intltool tar"
+depends="xfce4-panel python3-gobject"
+short_desc="Simple application to manage Xfce panel layouts"
+maintainer="Vinfall <neptuniahuai0tc@riseup.net>"
+license="GPL-3.0-only"
+homepage="https://docs.xfce.org/apps/xfce4-panel-profiles/start"
+changelog="https://gitlab.xfce.org/apps/xfce4-panel-profiles/-/raw/master/NEWS"
+distfiles="https://archive.xfce.org/src/apps/xfce4-panel-profiles/${version%.*}/xfce4-panel-profiles-${version}.tar.bz2"
+checksum=6d08354e8c44d4b0370150809c1ed601d09c8b488b68986477260609a78be3f9


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**


#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**


<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc

Adapted from #40454 and would close #40306. Version, license are updated. I hope I get changelog section right.

Also, regarding the request change in https://github.com/void-linux/void-packages/pull/40454#discussion_r1103340631, it does not work with a warning complaining about `--sysconfdir=/etc` as it's not defined in gnu-configure build-style (but I'm not sure how other packages using the same build style get away  with it even though they include this configure argument).
