### PR TITLE
rawtherapee: remove tcmalloc to fix crash on aarch64-musl

### DIFF
--- a/srcpkgs/rawtherapee/template
+++ b/srcpkgs/rawtherapee/template
@@ -1,15 +1,12 @@
 # Template file for 'rawtherapee'
 pkgname=rawtherapee
 version=5.10
-revision=2
+revision=3
 build_style=cmake
-configure_args="-DCACHE_NAME_SUFFIX=\"\"
- -DWITH_LTO=ON
- -DENABLE_TCMALLOC=ON"
+configure_args="-DCACHE_NAME_SUFFIX=\"\" -DWITH_LTO=ON"
 hostmakedepends="pkg-config"
 makedepends="fftw-devel gtkmm-devel lensfun-devel
- libcanberra-devel libgomp-devel libiptcdata-devel librsvg-devel
- exiv2-devel gperftools-devel"
+ libcanberra-devel libgomp-devel libiptcdata-devel librsvg-devel exiv2-devel"
 depends="desktop-file-utils hicolor-icon-theme"
 short_desc="Free RAW converter and digital photo processing software"
 maintainer="Daniel Martinez <danielmartinez@cock.li>"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

The application fails to start on my aarch64-musl device. I discovered that this is likely caused by tcmalloc.

Using tcmalloc doesn't seem to make a significant difference on other platforms, and its not enabled by default `CMakeLists.txt` so I think its best to remove it on all platforms

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc, aarch64-musl
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl
  - i686
  - aarch64 (native + cross)
  - aarch64-musl (native + cross)
  - armv7l (cross)
  - armv7l-musl (cross)
  - armv6l (cross)
  - armv6l-musl (cross)

