### PR TITLE
eza: update to 0.18.20

### DIFF
--- a/srcpkgs/eza/patches/downgrade-git2.patch
+++ b/srcpkgs/eza/patches/downgrade-git2.patch
@@ -1,0 +1,13 @@
+diff --git a/Cargo.toml b/Cargo.toml
+index b76d5c3..5cb3123 100644
+--- a/Cargo.toml
++++ b/Cargo.toml
+@@ -94,7 +94,7 @@ rayon = "1.10.0"
+ ansi-width = "0.1.0"
+ 
+ [dependencies.git2]
+-version = "0.19"
++version = "0.18"
+ optional = true
+ default-features = false
+ 

--- a/srcpkgs/eza/patches/fix-zsh-completions.patch
+++ b/srcpkgs/eza/patches/fix-zsh-completions.patch
@@ -1,0 +1,27 @@
+From 30d78ba5ce7fd2aabae174bcac106d6b202c6d31 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Martin=20Maty=C3=A1=C5=A1ek?= <martin.matyasek@gmail.com>
+Date: Thu, 27 Jun 2024 11:58:57 +0200
+Subject: [PATCH] fix(completions): fix missing line breaks in _eza
+
+Before this change the shell would report a parsing error, which was due
+to missing line breaks after the newly introduced symlinks flags. This
+commit fixes that issue.
+---
+ completions/zsh/_eza | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/completions/zsh/_eza b/completions/zsh/_eza
+index f672e0a59..67cf0284d 100644
+--- a/completions/zsh/_eza
++++ b/completions/zsh/_eza
+@@ -33,8 +33,8 @@ __eza() {
+         {-A,--almost-all}"[Equivalent to --all; included for compatibility with \'ls -A\']" \
+         {-d,--list-dirs}"[List directories like regular files]" \
+         {-D,--only-dirs}"[List only directories]" \
+-        --no-symlinks"[Do not show symbolic links]"
+-        --show-symlinks"[Explictly show symbolic links: for use with '--only-dirs'| '--only-files']"
++        --no-symlinks"[Do not show symbolic links]" \
++        --show-symlinks"[Explictly show symbolic links: for use with '--only-dirs'| '--only-files']" \
+         {-f,--only-files}"[List only files]" \
+         {-L,--level}"+[Limit the depth of recursion]" \
+         {-w,--width}"+[Limits column output of grid, 0 implies auto-width]" \

--- a/srcpkgs/eza/template
+++ b/srcpkgs/eza/template
@@ -1,6 +1,6 @@
 # Template file for 'eza'
 pkgname=eza
-version=0.18.18
+version=0.18.20
 revision=1
 build_style=cargo
 hostmakedepends="pkg-config"
@@ -11,14 +11,18 @@ license="MIT"
 homepage="https://eza.rocks"
 changelog="https://raw.githubusercontent.com/eza-community/eza/main/CHANGELOG.md"
 distfiles="https://github.com/eza-community/eza/archive/refs/tags/v${version}.tar.gz
-https://github.com/eza-community/eza/releases/download/v${version}/man-${version}.tar.gz"
-checksum="437ea76838fea2464b9592f1adef7df0412e27c9fc2a3e7ff47efcdfb17457f5
- 4ed46167bc31712fc25e46287743eec2870644feeb09241cd14a68b7d6527093"
+ https://github.com/eza-community/eza/releases/download/v${version}/man-${version}.tar.gz"
+checksum="f85a7c1a1859e4fb7913d9517bd5fd04714811562b631a71705077c5aceacd78
+ e376bfd7c8657cf9c8b0c1405543fed9142dd5222f1980b2c7e68309d163d23c"
 
 skip_extraction="man-${version}.tar.gz"
 
 post_extract() {
 	vsrcextract -C manpages --strip-components=3 man-${version}.tar.gz
+}
+
+post_patch() {
+	cargo update --package git2@0.19.0 --precise 0.18.3
 }
 
 post_install() {


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
