### PR TITLE
apparmor: fix build on musl, enable python on cross-compile

### DIFF
--- a/srcpkgs/apparmor/template
+++ b/srcpkgs/apparmor/template
@@ -1,13 +1,15 @@
 # Template file for 'apparmor'
 pkgname=apparmor
 version=3.1.7
-revision=1
+revision=2
 build_wrksrc=libraries/libapparmor
 build_style=gnu-configure
 conf_files="/etc/apparmor.d/local/* /etc/apparmor/*"
 make_dirs="/etc/apparmor.d/disable 0755 root root"
+configure_args="$(vopt_with python) $(vopt_with perl)"
 hostmakedepends="bison flex gettext python3 which python3-setuptools pkg-config
- perl"
+ perl $(vopt_if python swig)"
+makedepends="$(vopt_if python python3-devel)"
 depends="runit-void-apparmor libapparmor-${version}_${revision} python3-notify2
  python3-psutil python3-dbus iproute2"
 checkdepends="dejagnu"
@@ -20,10 +22,20 @@ distfiles="https://launchpad.net/apparmor/${version%.*}/${version}/+download/app
 checksum=c6c161d6dbd99c2f10758ff347cbc6848223c7381f311de62522f22b0a16de64
 replaces="apparmor-vim>=0"
 
+# /usr/lib/perl5/core_perl/CORE/perl.h:3360:22: error: unknown type name 'off64_t';
+CFLAGS="-D_LARGEFILE64_SOURCE"
+CXXFLAGS="-D_LARGEFILE64_SOURCE"
+
+build_options="python perl"
+
+case "$XBPS_TARGET_MACHINE" in
+	x86_64*|aarch64*|i686*)
+		build_options_default+=" python"
+	;;
+esac
+
 if [ -z "$CROSS_BUILD" ]; then
-	configure_args="--with-perl --with-python"
-	hostmakedepends+=" swig"
-	makedepends="python3-devel"
+	build_options_default+=" perl"
 fi
 
 pre_build() {
@@ -55,7 +67,7 @@ post_install() {
 	make DESTDIR="${DESTDIR}" install -C profiles
 
 	# requires perl bindings not generated when cross-compiling
-	if [ "$CROSS_BUILD" ]; then
+	if [ -z "$build_option_perl" ]; then
 		rm -f ${DESTDIR}/usr/bin/aa-notify
 	fi
 
@@ -71,8 +83,10 @@ libapparmor_package() {
 	license="LGPL-2.1-only"
 	pkg_install() {
 		vmove "usr/lib/libapparmor.so*"
-		if [ -z "$CROSS_BUILD" ]; then
+		if [ "$build_option_perl" ]; then
 			vmove usr/lib/perl5
+		fi
+		if [ "$build_option_python" ]; then
 			vmove "${py3_sitelib}/LibAppArmor*"
 		fi
 		vmove usr/share/man/man2


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl
  - i686
  - aarch64 (native + cross)
  - aarch64-musl (native + cross)
  - armv7l (cross)
  - armv7l-musl (cross)
  - armv6l (cross)
  - armv6l-musl (cross)

