### PR TITLE
mit-krb5: update to 1.21.3, adopt

### DIFF
--- a/srcpkgs/mit-krb5/template
+++ b/srcpkgs/mit-krb5/template
@@ -2,8 +2,8 @@
 # if there is a bump in .so version,
 # also update srcpkgs/libgssglue/files/gssapi_mech.conf
 pkgname=mit-krb5
-version=1.21.2
-revision=3
+version=1.21.3
+revision=1
 _distver=$(echo $version | cut -d. -f-2)
 build_style=gnu-configure
 configure_args="--sbindir=/usr/bin --disable-rpath --with-system-et
@@ -13,11 +13,11 @@ hostmakedepends="e2fsprogs-devel flex perl pkg-config"
 makedepends="e2fsprogs-devel db-devel $(vopt_if ldap libldap-devel)
  $(vopt_if lmdb lmdb-devel)"
 short_desc="MIT Kerberos 5 implementation"
-maintainer="Orphaned <orphan@voidlinux.org>"
+maintainer="Klara Modin <klarasmodin@gmail.com>"
 license="MIT"
 homepage="http://web.mit.edu/kerberos"
 distfiles="http://kerberos.org/dist/krb5/${_distver}/krb5-${version}.tar.gz"
-checksum=9560941a9d843c0243a71b17a7ac6fe31c7cebb5bce3983db79e52ae7e850491
+checksum=b7a4cd5ead67fb08b980b21abd150ff7217e85ea320c9ed0c6dadd304840ad35
 build_options="ldap lmdb"
 build_options_default="ldap"
 desc_option_lmdb="Enable LMDB database backend"


### PR DESCRIPTION
I use this package together with openldap which I adopted recently.

One thing I would like to do with this package when I have the time is to convert the build options to separate subpackages instead which would make them easier to use without rebuilding locally.
Another thing to look at is that currently the package uses the Berkely DB library from the distro, which in the build instructions at https://web.mit.edu/kerberos/krb5-latest/doc/build/options2configure.html is marked as unsupported. This could perhaps also be resolved by recommending to use the LMDB backend instead which I believe does not have this problem.

Relevant changes:
- Fix vulnerabilities in GSS message token handling [CVE-2024-37370, CVE-2024-37371].
- Fix a potential bad pointer free in krb5_cccol_have_contents()

#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64, x86_64-musl)
- I built this PR locally for these architectures:
  - aarch64-musl
  - armv7l
  - armv6l-musl
  - i686