### PR TITLE
dool: depend on python3

### DIFF
--- a/srcpkgs/dool/template
+++ b/srcpkgs/dool/template
@@ -1,8 +1,9 @@
 # Template file for 'dool'
 pkgname=dool
 version=1.3.2
-revision=1
+revision=2
 makedepends="python3"
+depends="python3"
 short_desc="Versatile tool for generating system resource statistics"
 maintainer="Leah Neukirchen <leah@vuxu.org>"
 license="GPL-2.0-or-later"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

---
Fixes:
```sh
$ dool
zsh: /usr/bin/dool: bad interpreter: /usr/bin/python3: no such file or directory
```