### PR TITLE
virtualbox-ose: update to 7.0.18

### DIFF
--- a/srcpkgs/virtualbox-ose/template
+++ b/srcpkgs/virtualbox-ose/template
@@ -1,14 +1,14 @@
 # Template file for 'virtualbox-ose'
 pkgname=virtualbox-ose
-version=7.0.12a
-revision=2
+version=7.0.18
+revision=1
 short_desc="General-purpose full virtualizer for x86 hardware"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-only, CDDL-1.0"
 homepage="https://www.virtualbox.org"
 changelog="https://www.virtualbox.org/wiki/Changelog"
 distfiles="http://download.virtualbox.org/virtualbox/${version%[a-z]*}/VirtualBox-${version}.tar.bz2"
-checksum=629261a711168c98d95180f14a8e6d814a71e9764f4657c4242e48cb24abb19e
+checksum=d999513533631674a024762668de999411d8197060c51e68c5faf0a2c0eea1a5
 
 nopie=yes
 lib32disabled=yes


### PR DESCRIPTION
I'm updating it as support to kernel 6.9 was added on [7.0.16](https://www.virtualbox.org/wiki/Changelog-7.0#v16).

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture: x86_64-libc