### PR TITLE
rtl8812au-dkms update to 20210820_1

### DIFF
--- a/srcpkgs/rtl8812au-dkms/template
+++ b/srcpkgs/rtl8812au-dkms/template
@@ -1,16 +1,16 @@
 # Template file for 'rtl8812au-dkms'
 pkgname=rtl8812au-dkms
-version=20210629
-revision=5
+version=20210820
+revision=1
 _modver=5.13.6
-_gitrev=d4638de07724cf5c6ba7793920abf6d802311508
+_gitrev=c0efee9cd121d9f0c815d9771475f76339a8f7d3
 depends="dkms"
 short_desc="Realtek 8812AU USB WiFi driver (DKMS)"
-maintainer="Orphaned <orphan@voidlinux.org>"
+maintainer="Brian Olsen <bnolsen@gmail.com>"
 license="GPL-2.0-only"
 homepage="https://github.com/morrownr/8812au"
 distfiles="https://github.com/morrownr/8812au-${version}/archive/${_gitrev}.tar.gz"
-checksum=81c7538f29fe1483ef16aaa688eb9d4863da063fde29c18228d0d66559ba3b7d
+checksum=bfd887920a4bfc588b0b738e33caddcb63e57e37129a47c1e761cbab30d1fa9c
 dkms_modules="rtl8812au ${_modver}"
 
 case "$XBPS_TARGET_MACHINE" in


### PR DESCRIPTION
Allows building with 6.9.x

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: YES

Built and installed on my machine with 6.9.7_1, plugged in dongle and wifi worked.
copied package to another machine on network with 6.9.6_1, installed.  driver loaded but didn't associate with a station, rebooted to 6.9.7_1 and automatically initialized and connected.

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64
