### PR TITLE
openssh: update to 9.8p1.

### DIFF
--- a/srcpkgs/openssh/patches/musl-connect.patch
+++ b/srcpkgs/openssh/patches/musl-connect.patch
@@ -1,0 +1,11 @@
+--- a/openbsd-compat/port-linux.c
++++ b/openbsd-compat/port-linux.c
+@@ -366,7 +366,7 @@
+ 		error_f("socket \"%s\": %s", path, strerror(errno));
+ 		goto out;
+ 	}
+-	if (connect(fd, &addr, sizeof(addr)) != 0) {
++	if (connect(fd, (const struct sockaddr *)&addr, sizeof(addr)) != 0) {
+ 		error_f("socket \"%s\" connect: %s", path, strerror(errno));
+ 		goto out;
+ 	}

--- a/srcpkgs/openssh/template
+++ b/srcpkgs/openssh/template
@@ -1,6 +1,6 @@
 # Template file for 'openssh'
 pkgname=openssh
-version=9.7p1
+version=9.8p1
 revision=1
 build_style=gnu-configure
 configure_args="--datadir=/usr/share/openssh
@@ -24,8 +24,9 @@ short_desc="OpenSSH free Secure Shell (SSH) client and server implementation"
 maintainer="Leah Neukirchen <leah@vuxu.org>"
 license="BSD-2-Clause, ISC"
 homepage="https://www.openssh.com"
+changelog="https://www.openssh.com/releasenotes.html"
 distfiles="https://ftp.openbsd.org/pub/OpenBSD/OpenSSH/portable/${pkgname}-${version}.tar.gz"
-checksum=490426f766d82a2763fcacd8d83ea3d70798750c7bd2aff2e57dc5660f773ffd
+checksum=dd8bd002a379b5d499dfb050dd1fa9af8029e80461f4bb6c523c49973f5a39f3
 conf_files="/etc/ssh/moduli /etc/ssh/ssh_config /etc/ssh/sshd_config /etc/pam.d/sshd"
 make_dirs="
  /var/chroot/ssh 0755 root root


### PR DESCRIPTION
fixes CVE-2024-6387

> OpenSSH plans to remove support for the DSA signature algorithm in early 2025. This release disables DSA by default at compile time.

do we reënable it?

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

