### PR TITLE
znc: update to 1.9.1.

### DIFF
--- a/srcpkgs/znc/template
+++ b/srcpkgs/znc/template
@@ -1,24 +1,20 @@
 # Template file for 'znc'
 pkgname=znc
-version=1.8.2
-revision=18
-build_style=gnu-configure
-configure_args="
- --enable-python
- --enable-perl
- --enable-tcl
- --enable-cyrus
- --with-tcl=$XBPS_CROSS_BASE/usr/lib"
-hostmakedepends="pkg-config perl tar"
+version=1.9.1
+revision=1
+build_style=cmake
+configure_args="-DWANT_PYTHON=YES -DWANT_PERL=YES -DWANT_TCL=YES
+ -DWANT_ARGON=YES -DWANT_I18N=YES"
+hostmakedepends="pkg-config perl gettext"
 makedepends="openssl-devel python3-devel tcl-devel libsasl-devel
- icu-devel zlib-devel perl"
+ icu-devel zlib-devel perl libargon2-devel boost-devel"
 short_desc="Advanced IRC Bouncer"
 maintainer="Duncaen <duncaen@voidlinux.org>"
 license="Apache-2.0"
 homepage="https://znc.in/"
 changelog="https://github.com/znc/znc/raw/master/ChangeLog.md"
 distfiles="https://znc.in/releases/${pkgname}-${version}.tar.gz"
-checksum=ff238aae3f2ae0e44e683c4aee17dc8e4fdd261ca9379d83b48a7d422488de0d
+checksum=e8a7cf80e19aad510b4e282eaf61b56bc30df88ea2e0f64fadcdd303c4894f3c
 
 system_accounts="znc"
 znc_homedir="/var/lib/znc"
@@ -37,6 +33,8 @@ pre_configure() {
 post_install() {
 	vsv znc
 	vdoc "${FILESDIR}/README.voidlinux"
+	vmkdir usr/lib/cmake/znc
+	mv "${DESTDIR}"/usr/share/znc/cmake/* "${DESTDIR}/usr/lib/cmake/znc"
 }
 
 znc-python3_package() {
@@ -75,5 +73,6 @@ znc-devel_package() {
 	pkg_install() {
 		vmove usr/include
 		vmove usr/lib/pkgconfig
+		vmove usr/lib/cmake
 	}
 }


### PR DESCRIPTION
fixes CVE-2024-39844

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**|**briefly**|**NO**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
