### PR TITLE
nullmailer: bump to build with default log service

### DIFF
--- a/srcpkgs/nullmailer/template
+++ b/srcpkgs/nullmailer/template
@@ -1,7 +1,7 @@
 # Template file for 'nullmailer'
 pkgname=nullmailer
 version=2.2
-revision=2
+revision=3
 build_style=gnu-configure
 configure_args="--enable-tls"
 conf_files="/etc/nullmailer/*"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
