### PR TITLE
qtav: remove for digikam 8.0.0+

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -3028,8 +3028,6 @@ libCGAL.so.13 cgal-4.10_1
 libCGAL_Core.so.13 cgal-4.10_1
 libCGAL_ImageIO.so.14 cgal-4.14_1
 libqscintilla2_qt5.so.15 qscintilla-qt5-2.11_1
-libQtAVWidgets.so.1 qtav-1.12.0_1
-libQtAV.so.1 qtav-1.12.0_1
 liblxpanel.so.0 lxpanel-0.9.3_1
 libuim.so.8 uim-1.8.6_1
 libuim-scm.so.0 uim-1.8.6_1

--- a/srcpkgs/digikam/template
+++ b/srcpkgs/digikam/template
@@ -1,7 +1,7 @@
 # Template file for 'digikam'
 pkgname=digikam
 version=8.3.0
-revision=2
+revision=3
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins -DBUILD_WITH_QT6=ON
@@ -15,7 +15,7 @@ makedepends="qt6-base-private-devel libjpeg-turbo-devel qt6-scxml-devel
  kf6-solid-devel kf6-ki18n-devel kf6-kio-devel kf6-kiconthemes-devel
  kf6-knotifyconfig-devel kf6-knotifications-devel kf6-threadweaver-devel
  akonadi-contacts-devel libksane6-devel kf6-kcalendarcore-devel tiff-devel
- lcms2-devel qtav libopencv-devel liblqr-devel libgphoto2-devel qt6-webengine-devel
+ lcms2-devel libopencv-devel liblqr-devel libgphoto2-devel qt6-webengine-devel
  lensfun-devel eigen jasper-devel MesaLib-devel glu-devel qt6-webchannel-devel
  kf6-kconfigwidgets-devel kf6-kwidgetsaddons-devel libheif-devel qt6-networkauth-devel
  libmagick-devel"

--- a/srcpkgs/removed-packages/template
+++ b/srcpkgs/removed-packages/template
@@ -660,6 +660,7 @@ replaces="
  python3-txacme<=0.9.3_3
  qimageblitz<=0.0.6_4
  qqc2-desktop-style<=5.115.0_1
+ qtav<=1.13.0_2
  qt-designer-devel<=4.8.7_29
  qt-designer-libs<=4.8.7_29
  qt-designer<=4.8.7_29


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, **x86_64**
- I built this PR locally for these architectures (if supported. mark crossbuilds):
 - **x86_64-musl**

#### Comments

Part of ffmpeg6 migration. digikam will need revbump for opencv-4.7.0 and ffmpeg6 