### PR TITLE
MangoHud: Adds missing multilib-32bit vulkan layer

### DIFF
--- a/srcpkgs/MangoHud/template
+++ b/srcpkgs/MangoHud/template
@@ -1,7 +1,7 @@
 # Template file for 'MangoHud'
 pkgname=MangoHud
 version=0.7.2
-revision=1
+revision=2
 build_style=meson
 configure_args="-Dwith_xnvctrl=disabled
  -Dwith_nvml=disabled -Duse_system_spdlog=enabled"
@@ -15,6 +15,7 @@ homepage="https://github.com/flightlessmango/MangoHud"
 distfiles="https://github.com/flightlessmango/MangoHud/releases/download/v${version}/MangoHud-v${version}-Source-DFSG.tar.xz"
 checksum=39d41ff564cd46b99a8514d35ff0cc1cd4ec5ab093347ca552bd7f7572a4064f
 python_version=3
+lib32files="/usr/share/vulkan/implicit_layer.d/MangoHud.x86.json"
 
 if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
 	configure_args+=" -Ddynamic_string_tokens=false"


### PR DESCRIPTION
Without this, using MangoHud-32bit on x86_64 hosts prevents some 32bit games from starting (E.g. Black Mesa). See [this issue][1] for details.

[1]: https://github.com/flightlessmango/MangoHud/issues/991

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
