### PR TITLE
New package: vpl-gpu-rt-24.2.5

### DIFF
--- a/srcpkgs/vpl-gpu-rt-devel
+++ b/srcpkgs/vpl-gpu-rt-devel
@@ -1,0 +1,1 @@
+vpl-gpu-rt

--- a/srcpkgs/vpl-gpu-rt/template
+++ b/srcpkgs/vpl-gpu-rt/template
@@ -1,0 +1,27 @@
+# Template file for 'vpl-gpu-rt'
+pkgname=vpl-gpu-rt
+version=24.2.5
+revision=1
+archs="x86_64*"
+build_style=cmake
+configure_args="-Wno-dev -DCMAKE_BUILD_TYPE=Release"
+hostmakedepends="cmake pkg-config"
+makedepends="libdrm-devel libva-devel oneVPL-devel"
+short_desc="Runtime implementation of libvpl API for Intel GPUs"
+maintainer="zlice <zlice555@gmail.com>"
+license="MIT"
+homepage="https://github.com/intel/vpl-gpu-rt/"
+changelog="https://github.com/intel/vpl-gpu-rt/blob/main/CHANGELOG.md"
+distfiles="https://github.com/intel/vpl-gpu-rt/archive/refs/tags/intel-onevpl-${version}.tar.gz"
+checksum=ccb76812642d84d4d8a56d28df60ef6d450cbb09969a59ee6c4a819098617b5d
+
+post_install() {
+	vlicense LICENSE
+}
+
+vpl-gpu-rt-devel_package() {
+	short_desc+=" - development files"
+	pkg_install() {
+		vmove usr/lib/pkgconfig
+	}
+}


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**

#### Local build testing
- I built this PR locally for my native architecture, **x86_64** (only supports 64bit afaik)

#### Comments

Used with ffmpeg6 to test A770 av1 encode. Package should be kept in line with `intel-media-driver` I believe. Useless without vpl packages and ffmpeg6. Could be added to `intel-video-accel`