### PR TITLE
nv-codec-headers: update to 11.1.5.3.

### DIFF
--- a/srcpkgs/nv-codec-headers/template
+++ b/srcpkgs/nv-codec-headers/template
@@ -1,15 +1,15 @@
 # Template file for 'nv-codec-headers'
 pkgname=nv-codec-headers
 reverts="12.2.72.0_1"
-version=11.1.5.1
-revision=2
+version=11.1.5.3
+revision=1
 build_style=gnu-makefile
 short_desc="FFmpeg version of headers required to interface with Nvidias codec APIs"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
 homepage="http://git.videolan.org/?p=ffmpeg/nv-codec-headers.git"
 distfiles="https://github.com/FFmpeg/nv-codec-headers/archive/n${version}.tar.gz"
-checksum=d095fbd56aa93772471a323be0ebe65504a0f43f06c76a30b6d25da77b06ae9c
+checksum=7e7fe9ecd3cb517698a7dde7885935f8616d13c6382dfd722bf3652a985d7fe1
 
 post_install() {
 	sed -n '4,25p' include/ffnvcodec/nvEncodeAPI.h > LICENSE


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-musl)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl
  - i686

https://github.com/void-linux/void-packages/pull/50982

@zlice could you test ffmpeg with this version? Since it's still 11.x everything should be fine.
