### PR TITLE
include-what-you-use: update to 0.22.

### DIFF
--- a/srcpkgs/include-what-you-use/patches/remove_offload_openmp_test.patch
+++ b/srcpkgs/include-what-you-use/patches/remove_offload_openmp_test.patch
@@ -1,0 +1,53 @@
+From 1fad6361aedd19c44d5f1d85be01ba07299b3fb6 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Kim=20Gr=C3=A4sman?= <kim.grasman@gmail.com>
+Date: Sun, 7 Jul 2024 20:51:49 +0200
+Subject: [PATCH] Remove brittle offload_openmp driver testcase
+
+This testcase kind-of proved that our driver drops OpenMP/NVPTX jobs,
+but it was heavily dependent on the target environment.
+
+I'd only executed it on my own machine, and our CI environment, neither
+of which have any OpenMP toolchains installed.
+
+If such a toolchain _is_ installed the failure diagnostics will not
+match, and the test will fail.
+
+Since we don't have any control of the environment for these tests, and
+no way to isolate them, remove the test.
+---
+ tests/driver/offload_openmp.c | 26 --------------------------
+ 1 file changed, 26 deletions(-)
+ delete mode 100644 tests/driver/offload_openmp.c
+
+diff --git a/tests/driver/offload_openmp.c b/tests/driver/offload_openmp.c
+deleted file mode 100644
+index 2625369c9..000000000
+--- a/tests/driver/offload_openmp.c
++++ /dev/null
+@@ -1,26 +0,0 @@
+-//===--- offload_openmp.c - test input file for IWYU ----------------------===//
+-//
+-//                     The LLVM Compiler Infrastructure
+-//
+-// This file is distributed under the University of Illinois Open Source
+-// License. See LICENSE.TXT for details.
+-//
+-//===----------------------------------------------------------------------===//
+-
+-// Check that IWYU ignores the extra offload compiler job produced when
+-// compiling for OpenMP.
+-
+-// IWYU_ARGS: -fopenmp -fopenmp-targets=nvptx64 -nocudalib
+-
+-// This first diagnostic only happens because I don't have an nvptx64 toolchain
+-// on my machine -- this test should maybe be conditional on the presence of
+-// such a toolchain.
+-// IWYU~: Executable ".*" doesn't exist!; consider passing it via '-march'
+-
+-// IWYU~: ignoring offload job for device toolchain: openmp
+-
+-/**** IWYU_SUMMARY(0)
+-
+-(tests/driver/offload_openmp.c has correct #includes/fwd-decls)
+-
+-***** IWYU_SUMMARY */

--- a/srcpkgs/include-what-you-use/template
+++ b/srcpkgs/include-what-you-use/template
@@ -1,17 +1,17 @@
 # Template file for 'include-what-you-use'
 pkgname=include-what-you-use
-version=0.20
+version=0.22
 revision=1
 build_style=cmake
-configure_args="-DIWYU_LLVM_ROOT_PATH=${XBPS_CROSS_BASE}/usr "
+configure_args="-DIWYU_LLVM_ROOT_PATH=${XBPS_CROSS_BASE}/usr"
 hostmakedepends="python3"
-makedepends="clang clang-tools-extra llvm17-devel ncurses-devel zlib-devel"
+makedepends="llvm18-devel ncurses-devel zlib-devel"
 short_desc="Analyze #includes in C and C++ source files"
 maintainer="Leah Neukirchen <leah@vuxu.org>"
 license="NCSA"
 homepage="https://include-what-you-use.org/"
 distfiles="https://include-what-you-use.org/downloads/${pkgname}-${version}.src.tar.gz"
-checksum=75fce1e6485f280f8f13f4c2d090b11d2fd2102b50857507c8413a919b7af899
+checksum=859074b461ea4b8325a73418c207ca33b5e6566b08e6b587eb9164416569a6dd
 python_version=3
 
 post_install() {


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

I am not sure whether it would be more appropriate to update to version 0.21 instead. Version 0.21 depends on LLVM 17, which is the current "default" version on Void.

#### Testing the changes
- I tested the changes in this PR: **YES**

cc @leahneukirchen 

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
