### PR TITLE
afl++: build with llvm18, add aarch64

### DIFF
--- a/srcpkgs/afl++/template
+++ b/srcpkgs/afl++/template
@@ -1,12 +1,12 @@
 # Template file for 'afl++'
 pkgname=afl++
 version=4.21c
-revision=1
-# x86 only currently
-archs="i686* x86_64*"
+revision=2
+archs="i686* x86_64* aarch64*"
+build_helper="qemu"
 build_style=gnu-makefile
 hostmakedepends="which"
-makedepends="clang gmp-devel lld llvm llvm17-devel python3-devel"
+makedepends="gmp-devel lld18 llvm18-devel python3-devel"
 short_desc="American fuzzy lop Plus Plus - a brute-force fuzzer"
 maintainer="Leah Neukirchen <leah@vuxu.org>"
 license="Apache-2.0"
@@ -18,7 +18,15 @@ replaces="afl>=0"
 
 nostrip_files="small_archive.a small_exec.elf"
 
-export LLVM_CONFIG=llvm-config
+if [ "$CROSS_BUILD" ]; then
+	export LLVM_CONFIG=${XBPS_CROSS_BASE}/usr/bin/llvm-config
+else
+	export LLVM_CONFIG=llvm-config
+fi
+
+case "$XBPS_TARGET_MACHINE" in
+	aarch64*) export AFL_NO_X86="YES" ;;
+esac
 
 post_install() {
 	# Test cases contain binary .../testcases/others/elf/small_exec.elf


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **NO**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc, aarch64-musl
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl
  - i686
  - aarch64 (cross + native)
  - aarch64-musl (cross + native)

@leahneukirchen 