### PR TITLE
cowsql: update to 1.15.6

### DIFF
--- a/srcpkgs/cowsql/template
+++ b/srcpkgs/cowsql/template
@@ -1,6 +1,6 @@
 # Template file for 'cowsql'
 pkgname=cowsql
-version=1.15.4
+version=1.15.6
 revision=1
 build_style=gnu-configure
 configure_args="--enable-example"
@@ -11,7 +11,7 @@ maintainer="dkwo <npiazza@disroot.org>"
 license="custom:LGPL-3.0-only-linking-exception"
 homepage="https://github.com/cowsql/cowsql"
 distfiles="https://github.com/cowsql/cowsql/archive/refs/tags/v${version}.tar.gz"
-checksum=f37ac775e8165ccf5cee4c981672072ac11e8d23c25c92e94bd25a299d170668
+checksum=723f7f8ede3bcb19c10a6c85c18a23ee34c6874cb4cf104c434bd69d6a916882
 
 pre_configure() {
 	autoreconf -fi


### PR DESCRIPTION
I was subject to the "Incus crash with vfsDatabaseRead" bug (https://github.com/lxc/incus/issues/665) on my Void machine; upgrading cowsql to [v1.15.6](https://github.com/cowsql/cowsql/releases/tag/v1.15.6) fixed the bug (currently using incus 6.2 thanks to #50251).

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-musl