### PR TITLE
fmt: fix license

### DIFF
--- a/srcpkgs/fmt/template
+++ b/srcpkgs/fmt/template
@@ -6,7 +6,7 @@ build_style=cmake
 configure_args="-DBUILD_SHARED_LIBS=ON -DFMT_DOC=OFF -DFMT_TEST=OFF"
 short_desc="Modern formatting library"
 maintainer="skmpz <dem.procopiou@gmail.com>"
-license="BSD-2-Clause"
+license="MIT WITH fmt-exception"
 homepage="https://github.com/fmtlib/fmt"
 changelog="https://raw.githubusercontent.com/fmtlib/fmt/master/ChangeLog.rst"
 distfiles="https://github.com/fmtlib/fmt/archive/${version}.tar.gz"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

Inspired by https://github.com/mesonbuild/wrapdb/pull/1438

Related to #50183

xlint error is fixed by #51169

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
