### PR TITLE
libnvidia-container, nvidia-container-toolkit: update to 1.13.5

### DIFF
--- a/srcpkgs/libnvidia-container/template
+++ b/srcpkgs/libnvidia-container/template
@@ -1,6 +1,6 @@
 # Template file for 'libnvidia-container'
 pkgname=libnvidia-container
-version=1.11.0
+version=1.13.5
 revision=1
 archs="x86_64"
 hostmakedepends="tar xz curl bmake groff m4 pkg-config which go"
@@ -10,7 +10,7 @@ maintainer="Quentin Freimanis <quentinfreimanis@gmail.com>"
 license="Apache-2.0"
 homepage="https://github.com/NVIDIA/libnvidia-container"
 distfiles="https://github.com/NVIDIA/libnvidia-container/archive/v${version}.tar.gz"
-checksum=ff09fa96615d26b2484588bbd5a8e435fa9c2d931838c3de48c990892960d6b7
+checksum=431522239d71728d2840b2f048d0a0733c3e6ad7a209bdf21c7d17c0aa661657
 
 do_build() {
 	make dist prefix=/usr REVISION=${version}

--- a/srcpkgs/nvidia-container-toolkit/template
+++ b/srcpkgs/nvidia-container-toolkit/template
@@ -1,7 +1,7 @@
 # Template file for 'nvidia-container-toolkit'
 pkgname=nvidia-container-toolkit
-version=1.11.0
-revision=3
+version=1.13.5
+revision=1
 archs="x86_64"
 build_style=go
 go_import_path=github.com/NVIDIA/nvidia-container-toolkit
@@ -14,7 +14,7 @@ maintainer="Quentin Freimanis <quentinfreimanis@gmail.com>"
 license="Apache-2.0"
 homepage="https://github.com/NVIDIA/nvidia-container-toolkit/"
 distfiles="https://github.com/NVIDIA/nvidia-container-toolkit/archive/v${version}.tar.gz"
-checksum=016e20b3a1a59409da131817d84b9fc56eab72d3f69a9797bbf960f73c9e5262
+checksum=2e95a89ca3ab95528df4bf32c5e0c8333e283e0465b9636458282c3d49a1b1da
 
 post_install() {
 	ln -sf /usr/bin/nvidia-container-runtime-hook ${DESTDIR}/usr/bin/${pkgname}


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)

#### Note
- 1.13.5 was the latest version I could build
- I am not the official maintainer. I had to update this for pure necessity to work with podman and nvidia