### PR TITLE
python3-peewee: update to 3.17.6.

### DIFF
--- a/srcpkgs/python3-peewee/template
+++ b/srcpkgs/python3-peewee/template
@@ -1,6 +1,6 @@
 # Template file for 'python3-peewee'
 pkgname=python3-peewee
-version=3.17.5
+version=3.17.6
 revision=1
 build_style=python3-pep517
 hostmakedepends="python3-setuptools python3-wheel python3-Cython0.29"
@@ -12,7 +12,7 @@ license="MIT"
 homepage="https://github.com/coleifer/peewee"
 changelog="https://raw.githubusercontent.com/coleifer/peewee/master/CHANGELOG.md"
 distfiles="https://github.com/coleifer/peewee/archive/${version}.tar.gz"
-checksum=b2f365b8bf27a0a492cf577bf673b785f1a2ba14977d065cc933748a7137a1f0
+checksum=81c7c88f17141d653009f1ac63438b919dc3c86ce38f6dc06a0b9ff99e90cb62
 alternatives="peewee:pwiz:/usr/bin/pwiz.py3"
 make_check=no # tests require postgres instance
 


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-libc
