### PR TITLE
xfce4-panel-profiles: fix missing depends

### DIFF
--- a/srcpkgs/xfce4-panel-profiles/template
+++ b/srcpkgs/xfce4-panel-profiles/template
@@ -1,11 +1,11 @@
 # Template file for 'xfce4-panel-profiles'
 pkgname=xfce4-panel-profiles
 version=1.0.14
-revision=1
+revision=2
 build_style=configure
 configure_args="--prefix=/usr --python=python3"
 hostmakedepends="intltool tar"
-depends="xfce4-panel python3-gobject"
+depends="xfce4-panel python3-gobject python3-psutil"
 short_desc="Simple application to manage Xfce panel layouts"
 maintainer="Vinfall <neptuniahuai0tc@riseup.net>"
 license="GPL-3.0-only"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc

Solved this error in `.xsession-errors`, did not notice this before as I always have this dependency locally:
```python
Traceback (most recent call last):
  File "/usr/share/xfce4-panel-profiles/xfce4-panel-profiles/xfce4-panel-profiles.py", line 44, in <module>
    from panelconfig import PanelConfig
  File "/usr/share/xfce4-panel-profiles/xfce4-panel-profiles/panelconfig.py", line 19, in <module>
    import psutil
ModuleNotFoundError: No module named 'psutil'
```
