### PR TITLE
python3-MyST-Parser: update to 3.0.1.

### DIFF
--- a/srcpkgs/python3-MyST-Parser/template
+++ b/srcpkgs/python3-MyST-Parser/template
@@ -1,6 +1,6 @@
 # Template file for 'python3-MyST-Parser'
 pkgname=python3-MyST-Parser
-version=2.0.0
+version=3.0.1
 revision=1
 build_style=python3-pep517
 hostmakedepends="python3-flit_core"
@@ -8,9 +8,9 @@ short_desc="Sphinx and Docutils extension to parse MyST"
 maintainer="Daniel Martinez <danielmartinez@cock.li>"
 license="MIT"
 homepage="https://myst-parser.readthedocs.io"
-changelog="https://raw.githubusercontent.com/executablebooks/MyST-Parser/v${version}/CHANGELOG.md"
+changelog="https://raw.githubusercontent.com/executablebooks/MyST-Parser/master/CHANGELOG.md"
 distfiles="https://github.com/executablebooks/MyST-Parser/archive/refs/tags/v${version}.tar.gz"
-checksum=6d03d257af6e7a4f336aaccd400e13537a85a0c260a58f95de51618c46b51579
+checksum=1686c63164d55db5f3e7ebea9a2c3a541f973f89b33a4e49390ef69ee89bd6a5
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl
  - i686
  - aarch64 (cross)
  - aarch64-musl (cross)
  - armv7l (cross)
  - armv7l-musl (cross)
  - armv6l (cross)
  - armv6l-musl (cross)
