### PR TITLE
kqtquickcharts: fix installation path (Fixes broken ktouch)

### DIFF
--- a/srcpkgs/kqtquickcharts/template
+++ b/srcpkgs/kqtquickcharts/template
@@ -1,12 +1,12 @@
 # Template file for 'kqtquickcharts'
 pkgname=kqtquickcharts
 version=24.05.1
-revision=1
+revision=2
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
- -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins
- -DKDE_INSTALL_QMLDIR=lib/qt6/qml
- -DECM_MKSPECS_INSTALL_DIR=/usr/lib/qt6/mkspecs/modules"
+configure_args="-DBUILD_TESTING=OFF -DKF5_HOST_TOOLING=/usr/lib/cmake
+ -DKDE_INSTALL_QTPLUGINDIR=lib/qt5/plugins
+ -DKDE_INSTALL_QMLDIR=lib/qt5/qml
+ -DECM_MKSPECS_INSTALL_DIR=/usr/lib/qt5/mkspecs/modules"
 hostmakedepends="extra-cmake-modules qt5-host-tools qt5-qmake"
 makedepends="qt5-declarative-devel"
 depends="qt5-quickcontrols2"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**


#### Local build testing
- I built this PR locally for my native architecture, (x6_64-GLIBC)


