### PR TITLE
New package: fnm-1.37.1

### DIFF
--- a/srcpkgs/fnm/files/fnm.sh
+++ b/srcpkgs/fnm/files/fnm.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+if [ "$(xbps-uhelper arch)" = "x86_64-musl" ]; then
+    export FNM_NODE_DIST_MIRROR=https://unofficial-builds.nodejs.org/download/release
+    export FNM_ARCH=x64-musl
+fi

--- a/srcpkgs/fnm/template
+++ b/srcpkgs/fnm/template
@@ -1,0 +1,36 @@
+# Template file for 'fnm'
+pkgname=fnm
+version=1.37.1
+revision=1
+# Upstream only supports these architectures
+archs="x86_64* aarch64 armv7l"
+build_style=cargo
+build_helper=qemu
+hostmakedepends="pkg-config"
+makedepends="libzstd-devel"
+short_desc="Fast and simple Node.js version manager, built in Rust"
+maintainer="Vinfall <neptuniahuai0tc@riseup.net>"
+license="GPL-3.0-only"
+homepage="https://github.com/Schniz/fnm"
+changelog="https://raw.githubusercontent.com/Schniz/fnm/master/CHANGELOG.md"
+distfiles="https://github.com/Schniz/fnm/archive/refs/tags/v${version}.tar.gz"
+checksum=56a170304ab281439a71e541c4db878848c3a891078ae3c2dcc84017cd0306b4
+
+do_check() {
+	# NOTE: downloader::tests are ignored as musl requires env to work
+	cargo test --target ${RUST_TARGET} --workspace --locked -- \
+		    --skip shell::infer::unix::tests::test_get_process_info \
+		    --skip downloader::tests::test_installing_node_12 \
+		    --skip downloader::tests::test_installing_npm
+}
+
+post_install() {
+	# only needed on musl
+	if [ "$XBPS_TARGET_MACHINE" = "x86_64-musl" ]; then
+		vinstall ${FILESDIR}/fnm.sh 644 etc/profile.d
+	fi
+	for shell in bash fish zsh; do
+		vtargetrun ${DESTDIR}/usr/bin/fnm completions --shell ${shell} > fnm.${shell}
+		vcompletion fnm.${shell} ${shell}
+	done
+}


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**


#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**


<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc

This is updated from #49718, and a few notes:
- As node.js does not have native musl build, fnm would expose environment variables and use unofficial builds on x86_64-musl (it is how upstream supports x86_64-musl), I don't know if it's allowed on Void.
- Also, as patching during build time is a bit troublesome, I chose to only include fnm.sh in `/etc/profile.d/` on x86_64-musl instead. Please correct me if `[ "$XBPS_TARGET_MACHINE" = "x86_64-musl" ]` is not the right way to do this.