### PR TITLE
[RFC] build-style/cargo.sh: set profile to release only if not specified

### DIFF
--- a/common/build-style/cargo.sh
+++ b/common/build-style/cargo.sh
@@ -5,13 +5,17 @@
 do_build() {
 	: ${make_cmd:=cargo auditable}
 
-	${make_cmd} build --release --locked --target ${RUST_TARGET} ${configure_args}
+	if ! [[ ${configure_args} =~ .*--profile([[:space:]]|=).* ]]; then
+		configure_args+=" --profile=release"
+	fi
+
+	${make_cmd} build --locked --target ${RUST_TARGET} ${configure_args}
 }
 
 do_check() {
 	: ${make_cmd:=cargo auditable}
 
-	${make_check_pre} ${make_cmd} test --release --locked --target ${RUST_TARGET} \
+	${make_check_pre} ${make_cmd} test --locked --target ${RUST_TARGET} \
 		${configure_args} ${make_check_args}
 }
 

--- a/srcpkgs/vaultwarden/template
+++ b/srcpkgs/vaultwarden/template
@@ -1,24 +1,29 @@
 # Template file for 'vaultwarden'
 pkgname=vaultwarden
-version=1.30.5
+version=1.31.0
 revision=1
 build_style=cargo
 configure_args="--features sqlite,mysql,postgresql"
 hostmakedepends="pkg-config"
 makedepends="openssl-devel libmysqlclient-devel postgresql-libs-devel
- sqlite-devel"
+ sqlite-devel zlib-devel"
 short_desc="Unofficial Bitwarden compatible server written in Rust"
 maintainer="Joel Beckmeyer <joel@beckmeyer.us>"
 license="AGPL-3.0-only"
 homepage="https://github.com/dani-garcia/vaultwarden"
 changelog="https://github.com/dani-garcia/vaultwarden/releases"
 distfiles="https://github.com/dani-garcia/vaultwarden/archive/${version}.tar.gz"
-checksum=6a5b1792fc53e94445033390f594dd1075390bf1339daa54ae92569ca902391d
+checksum=c5859e406596aa3a57666442867b9a3ec77106bf02af31b751599a5c5a1772a9
 
 system_accounts="_vaultwarden"
 _vaultwarden_homedir="/var/lib/vaultwarden"
 
 make_dirs="/var/lib/vaultwarden 0750 _vaultwarden _vaultwarden"
+
+# fails on i686, see https://github.com/dani-garcia/vaultwarden/issues/4320
+if [ "$XBPS_TARGET_MACHINE" = "i686" ]; then
+	configure_args+=" --profile=release-low"
+fi
 
 post_install() {
 	vsconf .env.template vaultwarden.conf


### PR DESCRIPTION
Currently `build_style=cargo` is hardcoded to build the `release` profile [(`--release` and  `--profile=release` are equivalent).](https://doc.rust-lang.org/cargo/reference/profiles.html#release)

This means that templates wishing to use a different profile have to vendor `do_build` and `do_check` if they need to customize the profile (see https://github.com/void-linux/void-packages/pull/51188).

With this change, the build_style checks `configure_args` for custom profiles before setting release by default.

I don't need think there are any other templates in repo currently that would use this.

[ci skip]