### PR TITLE
syncthingtray: depend on qt6-plugin-tls-openssl

### DIFF
--- a/srcpkgs/syncthingtray/template
+++ b/srcpkgs/syncthingtray/template
@@ -1,7 +1,7 @@
 # Template file for 'syncthingtray'
 pkgname=syncthingtray
 version=1.5.5
-revision=1
+revision=2
 build_style=cmake
 configure_args="-DBUILTIN_TRANSLATIONS=ON -DSYSTEMD_SUPPORT=OFF
  -DBUILD_SHARED_LIBS=ON -DQT_PACKAGE_PREFIX=Qt6 -DKF_PACKAGE_PREFIX=KF6"
@@ -9,7 +9,7 @@ hostmakedepends="pkg-config qt6-tools qt6-base extra-cmake-modules"
 makedepends="cpp-utilities-devel qtutilities-devel qtforkawesome-devel boost-devel
  qt6-base-devel qt6-declarative-devel qt6-svg-devel libplasma-devel kf6-kconfig-devel
  kf6-kio-devel"
-depends="syncthing"
+depends="syncthing qt6-plugin-tls-openssl"
 checkdepends="syncthing iproute2"
 short_desc="Tray application for Syncthing"
 maintainer="classabbyamp <void@placeviolette.net>"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

fixes error:
`Unable to load certificate "/home/$USER/.local/state/syncthing/https-cert.pem" when restoring settings`

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->

@classabbyamp 
