### PR TITLE
linux-lts: upgrade to 6.6

### DIFF
--- a/srcpkgs/linux-lts/template
+++ b/srcpkgs/linux-lts/template
@@ -1,6 +1,6 @@
 # Template file for 'linux-lts'
 pkgname=linux-lts
-version=6.1
+version=6.6
 revision=1
 build_style=meta
 depends="linux${version} linux-base"


### PR DESCRIPTION
6.6 has been the current LTS release since last October and is supported until the same date as 6.1 (December 2026): https://www.kernel.org/category/releases.html. Note that 6.6 is the same as the kernel used by linux (in base-system) so this should already be quite well tested in the wild.

#### Testing the changes
- I tested the changes in this PR: **NO**