### PR TITLE
qtile: update to 0.27.0, python3-qtile-extras: update to 0.27.0 and python3-cairocffi: update to 1.7.1

### DIFF
--- a/srcpkgs/python3-cairocffi/template
+++ b/srcpkgs/python3-cairocffi/template
@@ -1,6 +1,6 @@
 # Template file for 'python3-cairocffi'
 pkgname=python3-cairocffi
-version=1.7.0
+version=1.7.1
 revision=1
 build_style=python3-pep517
 make_check_args="--pyargs cairocffi"
@@ -14,7 +14,7 @@ license="BSD-3-Clause"
 homepage="https://github.com/Kozea/cairocffi"
 changelog="https://raw.githubusercontent.com/Kozea/cairocffi/master/NEWS.rst"
 distfiles="${PYPI_SITE}/c/cairocffi/cairocffi-${version}.tar.gz"
-checksum=7761863603894305f3160eca68452f373433ca8745ab7dd445bd2c6ce50dcab7
+checksum=2e48ee864884ec4a3a34bfa8c9ab9999f688286eb714a15a43ec9d068c36557b
 
 build_options=xcb
 case "$XBPS_MACHINE" in

--- a/srcpkgs/python3-qtile-extras/template
+++ b/srcpkgs/python3-qtile-extras/template
@@ -1,6 +1,6 @@
 # Template file for 'python3-qtile-extras'
 pkgname=python3-qtile-extras
-version=0.26.0
+version=0.27.0
 revision=1
 build_style=python3-pep517
 makedepends="python3-wheel python3-setuptools_scm"
@@ -11,7 +11,7 @@ license="MIT"
 homepage="https://github.com/elParaguayo/qtile-extras"
 changelog="https://raw.githubusercontent.com/elParaguayo/qtile-extras/main/CHANGELOG"
 distfiles="${PYPI_SITE}/q/qtile-extras/qtile_extras-${version}.tar.gz"
-checksum=35a609bc8ad7e616b9cc692fc91a75ac9e16c2218d7689bdf65093bf38d384e7
+checksum=25038c48a1ebba472eeb66dc718da738d4526cb7bf669e519778bc7da8ebd18f
 # Tests require a lot of python modules that are not packaged
 make_check=no
 

--- a/srcpkgs/qtile/template
+++ b/srcpkgs/qtile/template
@@ -1,6 +1,6 @@
 # Template file for 'qtile'
 pkgname=qtile
-version=0.26.0
+version=0.27.0
 revision=1
 build_style=python3-pep517
 _wlroots=0.17
@@ -14,7 +14,7 @@ license="MIT"
 homepage="http://www.qtile.org/"
 changelog="https://raw.githubusercontent.com/qtile/qtile/master/CHANGELOG"
 distfiles="${PYPI_SITE}/q/qtile/qtile-${version}.tar.gz"
-checksum=2c806f94dbf67a8ce1e0cd3fa425b95e3fdc5258e28d766dfecd866a7f5806b5
+checksum=46a3069257abe1219cb1cf548be004f6cf400a143aaa00527e042b23ba3a8deb
 
 post_install() {
 	vinstall resources/qtile.desktop 644 usr/share/xsessions


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES** - except from qtile-wayland

#### Local build testing
- I built this PR locally for my native architecture, x86-64-LIBC