### PR TITLE
helix: specify installation runtime path explicitly

### DIFF
--- a/srcpkgs/helix/template
+++ b/srcpkgs/helix/template
@@ -1,7 +1,7 @@
 # Template file for 'helix'
 pkgname=helix
 version=24.07
-revision=1
+revision=2
 build_style=cargo
 make_install_args="--path helix-term"
 short_desc="Post-modern modal text editor"
@@ -22,6 +22,8 @@ esac
 # See https://github.com/helix-editor/helix/pull/7320
 export PATH="$PATH:/usr/libexec/chroot-git"
 
+export HELIX_DEFAULT_RUNTIME=/usr/lib/helix/runtime
+
 post_install() {
 	rm runtime/grammars/.gitkeep
 	rm runtime/themes/README.md
@@ -37,6 +39,4 @@ post_install() {
 
 	vmkdir usr/lib/helix
 	vcopy runtime usr/lib/helix
-	mv ${DESTDIR}/usr/bin/hx ${DESTDIR}/usr/lib/helix/
-	ln -s /usr/lib/helix/hx ${DESTDIR}/usr/bin/
 }


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
