### PR TITLE
python3-pyinfra: update to 3.0.1

### DIFF
--- a/srcpkgs/python3-pyinfra/template
+++ b/srcpkgs/python3-pyinfra/template
@@ -1,12 +1,12 @@
 # Template file for 'python3-pyinfra'
 pkgname=python3-pyinfra
-version=2.9.2
+version=3.0.1
 revision=1
-build_style=python3-module
+build_style=python3-pep517
 hostmakedepends="python3-setuptools"
 depends="python3 python3-Jinja2 python3-click python3-colorama python3-dateutil
  python3-distro python3-docopt python3-gevent python3-paramiko python3-pywinrm
- python3-six python3-yaml"
+ python3-six python3-yaml python3-packaging python3-typeguard"
 checkdepends="${depends} python3-pytest python3-mock openssh"
 short_desc="Automate infrastructure super fast at massive scale"
 maintainer="Leah Neukirchen <leah@vuxu.org>"
@@ -14,11 +14,7 @@ license="MIT"
 homepage="https://pyinfra.com/"
 changelog="https://github.com/Fizzadar/pyinfra/blob/HEAD/CHANGELOG.md"
 distfiles="https://github.com/Fizzadar/pyinfra/archive/v${version}.tar.gz"
-checksum=10a4d7698f60ff142541d7e5c8173147b3613489c720899f3b92e278f2e95789
-
-post_extract() {
-	vsed -i -e '/configparser/d' setup.py  # is in Python 3.8
-}
+checksum=23cc2709d3979b71955541454889d19edf6077acef14826b7fd730bca6cc7273
 
 post_install() {
 	rm -r ${DESTDIR}/${py3_sitelib}/tests


### PR DESCRIPTION
- Switched the `build_style` to `python3-pep517` because of the deprecation warning.
- Updated the dependencies from `setup.py`.
- Tried installing the shell completions, but at least the bash completion hung most of the time.

#### Testing the changes
- I tested the changes in this PR: **briefly**
<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
