### PR TITLE
coq: install coqide-server

### DIFF
--- a/srcpkgs/coq/template
+++ b/srcpkgs/coq/template
@@ -1,7 +1,7 @@
 # Template file for 'coq'
 pkgname=coq
 version=8.19.2
-revision=1
+revision=2
 hostmakedepends="dune ocaml ocaml-findlib ocaml-num ocaml-zarith"
 depends="ocaml-findlib"
 checkdepends="python3 rsync time"
@@ -33,7 +33,7 @@ do_build() {
 }
 
 do_install() {
-	dune install coq-core coq-stdlib --prefix=/usr --destdir="$DESTDIR" \
+	dune install coq-core coq-stdlib coqide-server --prefix=/usr --destdir="$DESTDIR" \
 		--mandir=/usr/share/man --docdir=/usr/share/doc
 }
 


### PR DESCRIPTION
- I tested the changes in this PR: **YES**
- I built this PR locally for my native architecture, x86_64

Since https://github.com/void-linux/void-packages/commit/a69760e180448c31998369902b8524f476548f76, `coqide-server` is being built, but not installed. 

"`coqide-server` provides the `coqidetop` language server, an implementation of Coq's XML protocol which allows clients to interact with Coq in a structured way". It is essential to use Coq with an external editor such as [Coqtail](https://github.com/whonore/Coqtail) in vim.