### PR TITLE
ccache: update to 4.10.2.

### DIFF
--- a/srcpkgs/ccache/patches/ioctl.patch
+++ b/srcpkgs/ccache/patches/ioctl.patch
@@ -1,0 +1,18 @@
+musl uses an `int` instead of a `unsigend long` for the ioctl function
+prototype, contrary to glibc, since POSIX mandates the former. This
+causes a spurious error on ppc64le which can be silenced by casting to
+int explicitly.
+
+See https://www.openwall.com/lists/musl/2020/01/20/2
+
+diff -upr a/src/ccache/storage/local/LocalStorage.cpp b/src/ccache/storage/local/LocalStorage.cpp
+--- a/src/ccache/storage/local/LocalStorage.cpp	2024-06-30 20:46:01.000000000 +0200
++++ b/src/ccache/storage/local/LocalStorage.cpp	2024-07-03 16:29:39.073705276 +0200
+@@ -264,7 +264,7 @@ clone_file(const std::string& src, const
+     }
+   }
+ 
+-  if (ioctl(*dest_fd, FICLONE, *src_fd) != 0) {
++  if (ioctl(*dest_fd, (int)FICLONE, *src_fd) != 0) {
+     throw core::Error(strerror(errno));
+   }

--- a/srcpkgs/ccache/template
+++ b/srcpkgs/ccache/template
@@ -1,11 +1,11 @@
 # Template file for 'ccache'
 pkgname=ccache
-version=4.8.3
+version=4.10.2
 revision=1
 build_style=cmake
 configure_args="-DENABLE_TESTING=OFF -DREDIS_STORAGE_BACKEND=OFF
- -DENABLE_DOCUMENTATION=OFF"
-makedepends="libzstd-devel"
+ -DENABLE_DOCUMENTATION=OFF -DDEPS=LOCAL"
+makedepends="libzstd-devel xxHash-devel doctest-devel"
 short_desc="Fast C/C++ Compiler Cache"
 maintainer="Enno Boland <gottox@voidlinux.org>"
 license="GPL-3.0-or-later"
@@ -13,15 +13,21 @@ homepage="https://ccache.dev"
 changelog="https://ccache.dev/releasenotes.html"
 distfiles="https://github.com/ccache/ccache/releases/download/v${version}/ccache-${version}.tar.xz
  https://github.com/ccache/ccache/releases/download/v${version}/ccache-${version}-linux-x86_64.tar.xz"
-checksum="e47374c810b248cfca3665ee1d86c7c763ffd68d9944bc422d9c1872611f2b11
- 1021f6dc9641447524cc7bceb72f807f2d6502df118d69dc3f0f86cacf048e79"
+checksum="c0b85ddfc1a3e77b105ec9ada2d24aad617fa0b447c6a94d55890972810f0f5a
+ 80cab87bd510eca796467aee8e663c398239e0df1c4800a0b5dff11dca0b4f18"
+
 
 if [ -n "$XBPS_CHECK_PKGS" ]; then
+	makedepends+=" perl"
 	configure_args+=" -DENABLE_TESTING=ON"
 fi
 
 post_extract() {
 	mv ccache-${version}/* .
+}
+
+pre_check() {
+	export CC=/usr/bin/gcc
 }
 
 post_install() {


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl
  - i686