### PR TITLE
bcachefs-tools: update to 1.9.4. (With version 1.9.3 the 32bit build got fixed)

### DIFF
--- a/srcpkgs/bcachefs-tools/template
+++ b/srcpkgs/bcachefs-tools/template
@@ -1,7 +1,7 @@
 # Template file for 'bcachefs-tools'
 pkgname=bcachefs-tools
 reverts="24_1"
-version=1.9.2
+version=1.9.4
 revision=1
 build_style=gnu-makefile
 make_install_args="ROOT_SBINDIR=/usr/bin"
@@ -15,11 +15,7 @@ maintainer="Leah Neukirchen <leah@vuxu.org>"
 license="GPL-2.0-only"
 homepage="https://bcachefs.org/"
 distfiles="https://github.com/koverstreet/bcachefs-tools/archive/refs/tags/v${version}.tar.gz"
-checksum=4ebf1373216519f6851b9f2ea33bfd894c4effd4de4c20e665bb42c5fb8b4854
-
-if [ "$XBPS_TARGET_WORDSIZE" = "32" ]; then
-	broken="32-bit support is broken in upstream"
-fi
+checksum=735a715e4d38ff3ff581509b730deb1c092f34bfb91fe6a7da83c573871859d9
 
 export VERSION=v${version}
 export RUST_TARGET


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **NOT YET**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl
  - i686

Everyone who is using bcachefs is welcome to test this PR.