### PR TITLE
highway: update to 1.2.0, build shared libs.

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -4518,3 +4518,4 @@ libKPim6MimeTreeParserWidgets.so.6 mimetreeparser-24.02.0_1
 libopenrazer.so.0 libopenrazer-0.2.0_1
 libstaroffice-0.0.so.0 libstaroffice-0.0.7_1
 libbox2d.so.2 box2d-2.4.1_1
+libhwy.so.1 highway-1.2.0_1

--- a/srcpkgs/highway-devel
+++ b/srcpkgs/highway-devel
@@ -1,0 +1,1 @@
+highway

--- a/srcpkgs/highway/template
+++ b/srcpkgs/highway/template
@@ -1,9 +1,9 @@
 # Template file for 'highway'
 pkgname=highway
-version=1.1.0
+version=1.2.0
 revision=1
 build_style=cmake
-configure_args="-DHWY_SYSTEM_GTEST=ON -DHWY_ENABLE_EXAMPLES=OFF"
+configure_args="-DHWY_SYSTEM_GTEST=ON -DHWY_ENABLE_EXAMPLES=OFF -DBUILD_SHARED_LIBS=ON"
 checkdepends="gtest-devel"
 short_desc="C++ library providing portable SIMD/vector intrinsics"
 maintainer="Joshua Krämer <joshua@kraemer.link>"
@@ -11,13 +11,23 @@ license="Apache-2.0"
 homepage="https://github.com/google/highway"
 changelog="https://raw.githubusercontent.com/google/highway/master/debian/changelog"
 distfiles="https://github.com/google/highway/archive/${version}.tar.gz"
-checksum=354a8b4539b588e70b98ec70844273e3f2741302c4c377bcc4e81b3d1866f7c9
+checksum=7e0be78b8318e8bdbf6fa545d2ecb4c90f947df03f7aadc42c1967f019e63343
 
 if [ -z "$XBPS_CHECK_PKGS" ]; then
 	configure_args+=" -DBUILD_TESTING=OFF"
 fi
 
-# Workaround for i686, requires GCC 13+
-# See: https://github.com/google/highway/issues/1488
-CFLAGS="-fexcess-precision=standard"
-CXXFLAGS="-fexcess-precision=standard"
+case "$XBPS_TARGET_MACHINE" in
+	i686*) configure_args+=" -DHWY_CMAKE_SSE2=ON";;
+esac
+
+highway-devel_package() {
+	depends="${sourcepkg}>=${version}_${revision}"
+	short_desc+=" - development files"
+	pkg_install() {
+		vmove usr/include
+		vmove usr/lib/cmake
+		vmove usr/lib/pkgconfig
+		vmove "usr/lib/*.so"
+	}
+}

--- a/srcpkgs/libjxl/template
+++ b/srcpkgs/libjxl/template
@@ -1,6 +1,6 @@
 # Template file for 'libjxl'
 pkgname=libjxl
-version=0.10.2
+version=0.10.3
 revision=1
 _testdata_hash=ff8d743aaba05b3014f17e5475e576242fa979fc
 build_style=cmake
@@ -8,7 +8,7 @@ configure_args="-DJPEGXL_ENABLE_BENCHMARK=OFF -DJPEGXL_ENABLE_EXAMPLES=OFF
  -DJPEGXL_ENABLE_SJPEG=OFF -DJPEGXL_ENABLE_PLUGINS=ON -DJPEGXL_VERSION=${version}
  -DJPEGXL_ENABLE_SKCMS=OFF"
 hostmakedepends="tar pkg-config asciidoc"
-makedepends="brotli-devel highway libpng-devel giflib-devel libjpeg-turbo-devel
+makedepends="brotli-devel highway-devel libpng-devel giflib-devel libjpeg-turbo-devel
  libopenexr-devel libwebp-devel gdk-pixbuf-devel gimp-devel lcms2-devel"
 checkdepends="gtest-devel xdg-utils"
 short_desc="JPEG XL image format reference implementation"
@@ -18,7 +18,7 @@ homepage="https://jpeg.org/jpegxl/"
 changelog="https://raw.githubusercontent.com/libjxl/libjxl/main/CHANGELOG.md"
 distfiles="https://github.com/libjxl/libjxl/archive/v${version}.tar.gz
  https://github.com/libjxl/testdata/archive/${_testdata_hash}.tar.gz>testdata-${_testdata_hash}.tar.gz"
-checksum="95e807f63143856dc4d161c071cca01115d2c6405b3d3209854ac6989dc6bb91
+checksum="e0191411cfcd927eebe5392d030fe4283fe27ba1685ab7265104936e0b4283a6
  9c45a108df32a002a69465df896d33acf77d97c88fb59dffa0dff5628370e96f"
 skip_extraction="testdata-${_testdata_hash}.tar.gz"
 
@@ -42,7 +42,7 @@ post_install() {
 
 libjxl-devel_package() {
 	short_desc+=" - development files"
-	depends="${sourcepkg}>=${version}_${revision} highway brotli-devel"
+	depends="${sourcepkg}>=${version}_${revision} brotli-devel"
 	pkg_install() {
 		vmove usr/include
 		vmove "usr/lib/*.so"


### PR DESCRIPTION
- **highway: update to 1.2.0, build shared libs**
- **libjxl: update to 0.10.3.**

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl
  - i686
  - aarch64 (cross)
  - aarch64-musl (cross)
  - armv7l (cross)
  - armv7l-musl (cross)
  - armv6l (cross)
  - armv6l-musl (cross)
