### PR TITLE
Update libdecor to 0.2.2 and gamescope to 3.14.23 

### DIFF
--- a/srcpkgs/gamescope/template
+++ b/srcpkgs/gamescope/template
@@ -1,19 +1,21 @@
 # Template file for 'gamescope'
 pkgname=gamescope
-version=3.14.2
+version=3.14.23
 revision=1
 _stb_hash=5736b15f7ea0ffb08dd38af21067c314d6a3aae9
-_vkroots_hash=d5ef31abc7cb5c69aee4bcb67b10dd543c1ff7ac
+_vkroots_hash=5106d8a0df95de66cc58dc1ea37e69c99afc9540
 _reshade_hash=9fdbea6892f9959fdc18095d035976c574b268b7
+_libliftoff_hash=8b08dc1c14fd019cc90ddabe34ad16596b0691f4
+_wlroots_hash=a5c9826e6d7d8b504b07d1c02425e6f62b020791
 build_style=meson
-configure_args="-Denable_openvr_support=false --force-fallback-for="
+configure_args="-Denable_openvr_support=false"
 hostmakedepends="glslang pkg-config wayland-devel"
 makedepends="pipewire-devel SPIRV-Headers libX11-devel
  libXdamage-devel libXcomposite-devel libXrender-devel libXxf86vm-devel
  libXtst-devel libXres-devel libdrm-devel vulkan-loader-devel wayland-protocols
- libxkbcommon-devel libcap-devel SDL2-devel hwids wlroots0.17-devel
- libliftoff-devel glm libXmu-devel libdisplay-info-devel benchmark-devel
- libavif-devel"
+ libxkbcommon-devel libcap-devel SDL2-devel hwids glm libXmu-devel
+ libdisplay-info-devel benchmark-devel libavif-devel xorg-server-xwayland
+ libei-devel libseat-devel libinput-devel pixman-devel xcb-util-wm-devel"
 depends="xorg-server-xwayland"
 short_desc="SteamOS session compositing window manager"
 maintainer="Dexter Gaon-Shatford <dexter.gaonshatford@gmail.com>"
@@ -22,25 +24,36 @@ homepage="https://github.com/ValveSoftware/gamescope"
 distfiles="https://github.com/ValveSoftware/gamescope/archive/refs/tags/${version}.tar.gz
  https://github.com/nothings/stb/archive/${_stb_hash}.tar.gz
  https://github.com/Joshua-Ashton/vkroots/archive/${_vkroots_hash}.tar.gz
- https://github.com/Joshua-Ashton/reshade/archive/${_reshade_hash}.tar.gz"
-checksum="91ed63557d3601723f1b1d554ea65a3850656a78bb7e32610330035160704836
+ https://github.com/Joshua-Ashton/reshade/archive/${_reshade_hash}.tar.gz
+ https://gitlab.freedesktop.org/emersion/libliftoff/-/archive/${_libliftoff_hash}/libliftoff-${_libliftoff_hash}.tar.gz
+ https://gitlab.freedesktop.org/emersion/wlroots/-/archive/${_wlroots_hash}/wlroots-${_wlroots_hash}.tar.gz"
+checksum="d384641fdea5941f5e91658f8dfb54e1913232300efde66764199549f6fa3af2
  d00921d49b06af62aa6bfb97c1b136bec661dd11dd4eecbcb0da1f6da7cedb4c
- b4eca5edca75355ea1443ad96fd59b0a407f6a2ce17ef5a8f9849c05fc10155f
- 165726ad21fbfc221c0363e40b597834068a416a11a1204ae2ac6d13ec161035"
+ 37b77586e91f7ebee70380dcddd73bf01ae4acef1053e6be41d0485ede022422
+ 165726ad21fbfc221c0363e40b597834068a416a11a1204ae2ac6d13ec161035
+ 8de28aee6f90f47b7fc7037dcd2360166197c0b5d2033f3afdbd34f2ea1bf216
+ f3f91b679114e565d94e87cd0c4c61444e48d7ef8a77cd101ef3081fd87f4726"
 skip_extraction="${_stb_hash}.tar.gz
  ${_vkroots_hash}.tar.gz
- ${_reshade_hash}.tar.gz"
+ ${_reshade_hash}.tar.gz
+ libliftoff-${_libliftoff_hash}.tar.gz
+ wlroots-${_wlroots_hash}.tar.gz"
 
 post_extract() {
 	vsrcextract -C subprojects/stb "${_stb_hash}.tar.gz"
 	cp subprojects/packagefiles/stb/meson.build subprojects/stb
 	vsrcextract -C subprojects/vkroots "${_vkroots_hash}.tar.gz"
+	vsrcextract -C subprojects/libliftoff "libliftoff-${_libliftoff_hash}.tar.gz"
+	vsrcextract -C subprojects/wlroots "wlroots-${_wlroots_hash}.tar.gz"
 	vsrcextract -C src/reshade "${_reshade_hash}.tar.gz"
 }
 
 post_patch() {
 	# Use system SPIRV headers rather than gamescope's vendored headers
 	vsed -i src/meson.build -e "s|../thirdparty/SPIRV-Headers/include/spirv/unified1|${XBPS_CROSS_BASE}/usr/include/spirv/unified1|"
+	# Disable werror in libliftoff due to their test files having numerous warnings mistakes.
+	vsed -i subprojects/libliftoff/meson.build -e "s|'werror=true'|'werror=false'|"
+	vsed -i subprojects/wlroots/meson.build -e "s|'werror=true'|'werror=false'|"
 }
 
 post_install() {

--- a/srcpkgs/libdecor/template
+++ b/srcpkgs/libdecor/template
@@ -1,18 +1,18 @@
 # Template file for 'libdecor'
 pkgname=libdecor
-version=0.1.1
+version=0.2.2
 revision=1
 build_style=meson
 configure_args="-Ddemo=false $(vopt_feature dbus dbus)"
 hostmakedepends="pkg-config wayland-devel"
 makedepends="wayland-devel wayland-protocols pango-devel
- $(vopt_if dbus dbus-devel)"
+ $(vopt_if dbus dbus-devel) gtk+3-devel"
 short_desc="Client-side decorations library for Wayland client"
 maintainer="Arda Demir <ddmirarda@gmail.com>"
 license="MIT"
 homepage="https://gitlab.gnome.org/jadahl/libdecor"
-distfiles="https://gitlab.gnome.org/jadahl/libdecor/-/archive/${version}/libdecor-${version}.tar.gz"
-checksum=82adece5baeb6194292b0d1a91b4b3d10da41115f352a5e6c5844b20b88a0512
+distfiles="https://gitlab.freedesktop.org/libdecor/libdecor/-/archive/${version}/libdecor-${version}.tar.gz"
+checksum=40a1d8be07d8b1f66e8fb98a1f4a84549ca6bf992407198a5055952be80a8525
 
 build_options="dbus"
 build_options_default="dbus"


### PR DESCRIPTION
# Update libdecor and gamescope
I've updated gamescope and libdecor(as new gamescope needs it). This is because I was having issues with the version packaged with Void being the camera in games spinning uncontrollably.

Notes about this update in this time Gamescope has moved to using tagged versions of wlroots and libliftoff so for that purpose I've changed the gamescope build template to pull in the commits that gamescope is looking for and updated the dependencies of gamescope(removed wlroots and libliftoff as they are now built in) and added things such as libinput which used to be pulled in by wlroots.

The disabling "Werror" on libliftoff and wlroots was needed as both of them make use of code that can produce warnings based on compiler version. and the version of GCC shipped in void triggers those warnings. However these warnings are due to unused variables and not anything that is likely to cause major issue.

Please let me know if these would be accepted as is or if you would require me to make any adjustments.
## Summary of changes

libdecor 0.1.1 -> 0.2.2
gamescope 3.14.2 -> 3.14.23
#### Testing the changes

I tested the changes in this PR: Briefly(Would love to get more people to test on more games)

I attempted to get 3.14.24 to work however was experiencing crashing issues to do with the pointer leaving the gamescope window/surface. So feel back to 3.14.23 (I've tested on the games I have access to Warcraft 3, WoW, Command and Conquer 95-Tib sun)

I've also tested some SDL2 and steam games as I am aware that steam and SDL2 both also pull in libdecor and they also seemed to work fine.
#### Local build testing
I built this PR locally for my native architecture, (x86_64-glibc)
I've not tested on any other arch's as I do not have access to hardware.

ps. this is my first time packaging anything please let me know if I've made a mistake or misunderstood the system :3

Thanks
Cat
