### PR TITLE
update: libdecor to 0.2.2

### DIFF
--- a/srcpkgs/libdecor/template
+++ b/srcpkgs/libdecor/template
@@ -1,18 +1,18 @@
 # Template file for 'libdecor'
 pkgname=libdecor
-version=0.1.1
+version=0.2.2
 revision=1
 build_style=meson
 configure_args="-Ddemo=false $(vopt_feature dbus dbus)"
 hostmakedepends="pkg-config wayland-devel"
 makedepends="wayland-devel wayland-protocols pango-devel
- $(vopt_if dbus dbus-devel)"
+ $(vopt_if dbus dbus-devel) gtk+3-devel"
 short_desc="Client-side decorations library for Wayland client"
 maintainer="Arda Demir <ddmirarda@gmail.com>"
 license="MIT"
 homepage="https://gitlab.gnome.org/jadahl/libdecor"
-distfiles="https://gitlab.gnome.org/jadahl/libdecor/-/archive/${version}/libdecor-${version}.tar.gz"
-checksum=82adece5baeb6194292b0d1a91b4b3d10da41115f352a5e6c5844b20b88a0512
+distfiles="https://gitlab.freedesktop.org/libdecor/libdecor/-/archive/${version}/libdecor-${version}.tar.gz"
+checksum=40a1d8be07d8b1f66e8fb98a1f4a84549ca6bf992407198a5055952be80a8525
 
 build_options="dbus"
 build_options_default="dbus"


### PR DESCRIPTION
# Update libdecor

Update to the libdecor version as newer versions of gamescope will crash on the current version package with Void Linux. I've tested the new version locally on glibc and it seems to work fine on the apps I've tested it on that being steam, SDL2 and gamescope 3.14.23(Not the packaged version of gamescope). 

Also tested with gamescope 3.14.2 and it still works fine also though I am unsure if that version has the wayland backend that  uses libdecor.
#### Testing the changes
- I tested the changes in this PR: YES

Tested on Gamescope, SDL, and steam

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
