### PR TITLE
sx: fix dead distfile

### DIFF
--- a/srcpkgs/sx/template
+++ b/srcpkgs/sx/template
@@ -1,6 +1,6 @@
 # Template file for 'sx'
 pkgname=sx
-version=3.0.0
+version=3.0
 revision=1
 build_style=gnu-makefile
 depends="xorg-server xauth"
@@ -9,7 +9,7 @@ maintainer="mustaqim <mustaqim@pm.me>"
 license="MIT"
 homepage="https://github.com/Earnestly/sx"
 distfiles="https://github.com/Earnestly/sx/archive/${version}.tar.gz"
-checksum=677b54292b63ec62628e9eef6faf9a019a9ca30ec6ff8509c005c81c4a2ad603
+checksum=69fd492e87f13a4d61565a0a9c42d1759dbd5f2eeb1ae9e460ab618a55878fae
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->
I have tried to figure out whether there is a major difference between versions 3.0 and 3.0.0, because the checksum differs. The original source is [thankfully cached in sources.voidlinux.org](https://sources.voidlinux.org/sx-3.0.0/3.0.0.tar.gz), so I was able to diff the two archives. Although the archives themselves are different, their contents seem to be identical, so it should be safe to use the 3.0.0 version.

I am not sure whether XBPS will register `3.0.0 -> 3.0` as an update or not, but I don't think it matters.

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
