### PR TITLE
gamescope: update to 3.14.24.

### DIFF
--- a/srcpkgs/gamescope/patches/0001-Include-limits.h-in-Process.cpp.patch
+++ b/srcpkgs/gamescope/patches/0001-Include-limits.h-in-Process.cpp.patch
@@ -1,0 +1,20 @@
+From 6cff4b34ab52b8178e2f7b1268a7ef35f2fb908c Mon Sep 17 00:00:00 2001
+From: Dexter Gaon-Shatford <dexter@gaonshatford.ca>
+Date: Sat, 20 Jul 2024 23:31:32 -0400
+Subject: [PATCH] Include limits.h in Process.cpp
+
+Without this header, the PATH_MAX macro isn't defined when building
+against musl libc.
+---
+ src/Utils/Process.cpp | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/Utils/Process.cpp b/src/Utils/Process.cpp
+index 5688fb1..3f0d48c 100644
+--- a/src/Utils/Process.cpp
++++ b/src/Utils/Process.cpp
+@@ -27,0 +28 @@
++#include <limits.h>
+-- 
+2.45.2
+

--- a/srcpkgs/gamescope/template
+++ b/srcpkgs/gamescope/template
@@ -1,19 +1,23 @@
 # Template file for 'gamescope'
 pkgname=gamescope
-version=3.14.2
+version=3.14.24
 revision=1
 _stb_hash=5736b15f7ea0ffb08dd38af21067c314d6a3aae9
-_vkroots_hash=d5ef31abc7cb5c69aee4bcb67b10dd543c1ff7ac
-_reshade_hash=9fdbea6892f9959fdc18095d035976c574b268b7
+_vkroots_hash=5106d8a0df95de66cc58dc1ea37e69c99afc9540
+_reshade_hash=696b14cd6006ae9ca174e6164450619ace043283
+_spirv_hash=d790ced752b5bfc06b6988baadef6eb2d16bdf96
+_libdisplay_info_hash=8fbc366c7c56d584590db50fe5943b0f92b1f448
+_libliftoff_hash=8b08dc1c14fd019cc90ddabe34ad16596b0691f4
+_wlroots_hash=a5c9826e6d7d8b504b07d1c02425e6f62b020791
 build_style=meson
-configure_args="-Denable_openvr_support=false --force-fallback-for="
-hostmakedepends="glslang pkg-config wayland-devel"
+configure_args="-Denable_openvr_support=false"
+hostmakedepends="glslang pkg-config wayland-devel hwids"
 makedepends="pipewire-devel SPIRV-Headers libX11-devel
  libXdamage-devel libXcomposite-devel libXrender-devel libXxf86vm-devel
- libXtst-devel libXres-devel libdrm-devel vulkan-loader-devel wayland-protocols
- libxkbcommon-devel libcap-devel SDL2-devel hwids wlroots0.17-devel
- libliftoff-devel glm libXmu-devel libdisplay-info-devel benchmark-devel
- libavif-devel"
+ libXtst-devel libXres-devel libXmu-devel libdrm-devel vulkan-loader-devel
+ libxkbcommon-devel libcap-devel SDL2-devel glm benchmark-devel pixman-devel
+ libinput-devel libseat-devel libavif-devel libei-devel xcb-util-wm-devel
+ wayland-protocols xorg-server-xwayland"
 depends="xorg-server-xwayland"
 short_desc="SteamOS session compositing window manager"
 maintainer="Dexter Gaon-Shatford <dexter.gaonshatford@gmail.com>"
@@ -22,29 +26,70 @@ homepage="https://github.com/ValveSoftware/gamescope"
 distfiles="https://github.com/ValveSoftware/gamescope/archive/refs/tags/${version}.tar.gz
  https://github.com/nothings/stb/archive/${_stb_hash}.tar.gz
  https://github.com/Joshua-Ashton/vkroots/archive/${_vkroots_hash}.tar.gz
- https://github.com/Joshua-Ashton/reshade/archive/${_reshade_hash}.tar.gz"
-checksum="91ed63557d3601723f1b1d554ea65a3850656a78bb7e32610330035160704836
+ https://github.com/Joshua-Ashton/reshade/archive/${_reshade_hash}.tar.gz
+ https://github.com/KhronosGroup/SPIRV-Headers/archive/${_spirv_hash}.tar.gz
+ https://gitlab.freedesktop.org/emersion/libdisplay-info/-/archive/${_libdisplay_info_hash}/libdisplay-info-${_libdisplay_info_hash}.tar.gz
+ https://gitlab.freedesktop.org/emersion/libliftoff/-/archive/${_libliftoff_hash}/libliftoff-${_libliftoff_hash}.tar.gz
+ https://github.com/Joshua-Ashton/wlroots/archive/${_wlroots_hash}.tar.gz"
+checksum="429ef04aab9b3ca5cac76752f59e2219d8326010c0cd9533ad580f65f5bfd3a3
  d00921d49b06af62aa6bfb97c1b136bec661dd11dd4eecbcb0da1f6da7cedb4c
- b4eca5edca75355ea1443ad96fd59b0a407f6a2ce17ef5a8f9849c05fc10155f
- 165726ad21fbfc221c0363e40b597834068a416a11a1204ae2ac6d13ec161035"
+ 37b77586e91f7ebee70380dcddd73bf01ae4acef1053e6be41d0485ede022422
+ 3aa6feda7773cc8ffa8fb012fe95e6207c776101e29198d0e0d34a0c5e339f6a
+ 90141b3f6261dba643fe546d56b4539e61fe40e307c5c3b9985ea9fa0622ac3f
+ 4f8b35850ba72fc1abdb9ea72af3aa2328a5e95176f779cb3ac3ee3512dfacf8
+ 8de28aee6f90f47b7fc7037dcd2360166197c0b5d2033f3afdbd34f2ea1bf216
+ f3f91b679114e565d94e87cd0c4c61444e48d7ef8a77cd101ef3081fd87f4726"
 skip_extraction="${_stb_hash}.tar.gz
  ${_vkroots_hash}.tar.gz
- ${_reshade_hash}.tar.gz"
+ ${_reshade_hash}.tar.gz
+ ${_spirv_hash}.tar.gz
+ libdisplay-info-${_libdisplay_info_hash}.tar.gz
+ libliftoff-${_libliftoff_hash}.tar.gz
+ ${_wlroots_hash}.tar.gz"
+
+# wlroots and libliftoff fail to build because of these warnings
+CFLAGS="-Wno-error=unused-variable
+ -Wno-error=unused-but-set-variable
+ -Wno-error=unused-result"
+
+if [ "$XBPS_CHECK_PKGS" ]; then
+	# The libliftoff test suite checks for NDEBUG and fails if it is defined,
+	# even if all other tests would pass
+	CFLAGS+=" -UNDEBUG"
+fi
 
 post_extract() {
 	vsrcextract -C subprojects/stb "${_stb_hash}.tar.gz"
 	cp subprojects/packagefiles/stb/meson.build subprojects/stb
 	vsrcextract -C subprojects/vkroots "${_vkroots_hash}.tar.gz"
 	vsrcextract -C src/reshade "${_reshade_hash}.tar.gz"
+	vsrcextract -C thirdparty/SPIRV-Headers "${_spirv_hash}.tar.gz"
+	vsrcextract -C subprojects/libdisplay-info "libdisplay-info-${_libdisplay_info_hash}.tar.gz"
+	vsrcextract -C subprojects/libliftoff "libliftoff-${_libliftoff_hash}.tar.gz"
+	vsrcextract -C subprojects/wlroots "${_wlroots_hash}.tar.gz"
 }
 
 post_patch() {
-	# Use system SPIRV headers rather than gamescope's vendored headers
-	vsed -i src/meson.build -e "s|../thirdparty/SPIRV-Headers/include/spirv/unified1|${XBPS_CROSS_BASE}/usr/include/spirv/unified1|"
+	# libdisplay-info tests require currently unpackaged edid-decode
+	vsed -i subprojects/libdisplay-info/meson.build -e "s/subdir('test')//"
 }
 
 post_install() {
 	vlicense LICENSE
-	rm ${DESTDIR}/usr/lib/pkgconfig/vkroots.pc
+
 	rm ${DESTDIR}/usr/include/vkroots.h
+	rm ${DESTDIR}/usr/lib/pkgconfig/vkroots.pc
+
+	rm ${DESTDIR}/usr/include/libliftoff.h
+	rm ${DESTDIR}/usr/lib/pkgconfig/libliftoff.pc
+	rm ${DESTDIR}/usr/lib/libliftoff.a
+
+	rm -r ${DESTDIR}/usr/include/wlr
+	rm ${DESTDIR}/usr/lib/pkgconfig/wlroots.pc
+	rm ${DESTDIR}/usr/lib/libwlroots.a
+
+	rm ${DESTDIR}/usr/bin/di-edid-decode
+	rm -r ${DESTDIR}/usr/include/libdisplay-info
+	rm ${DESTDIR}/usr/lib/pkgconfig/display-info.pc
+	rm ${DESTDIR}/usr/lib/libdisplay-info.a
 }


### PR DESCRIPTION
Gamescope upstream has made it very clear that they explicitly want distros to use their vendored dependencies, not system packages. This commit respects all their vendored dependencies.

This PR depends on #51341 as the latest gamescope depends on a newer version of libdecor than is currently packaged.

Thanks to @CaitCatDev for starting off the updated template. I've made some corrections to the dependencies and set `-Wno-error` specifically for the warnings that were causing problems building libliftoff and wlroots rather than turning off werror entirely.

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)