### PR TITLE
New package: cloud-utils-0.33.

### DIFF
--- a/srcpkgs/cloud-guest-utils/template
+++ b/srcpkgs/cloud-guest-utils/template
@@ -1,0 +1,42 @@
+# Template file for 'cloud-guest-utils'
+pkgname=cloud-guest-utils
+version=0.33
+revision=1
+build_style=gnu-makefile
+depends="e2fsprogs util-linux gptfdisk"
+short_desc="Useful programs inside of a VM Guest"
+maintainer="Michael Aldridge <maldridge@voidlinux.org>"
+license="GPL-3.0-only"
+homepage="https://github.com/canonical/cloud-utils/"
+changelog="https://github.com/canonical/cloud-utils/raw/main/ChangeLog"
+distfiles="https://github.com/canonical/cloud-utils/archive/refs/tags/$version.tar.gz"
+checksum=338770d637788466aacfcbcec17a8d0046f92a13cc3b25fce8fceadb02a7339f
+
+cloud-utils-ec2metadata_package() {
+	short_desc="Script for retrieving AWS-EC2 Metadata"
+	depends="python3"
+	pkg_install() {
+		vmove usr/bin/ec2metadata
+	}
+}
+
+cloud-image-utils_package() {
+	short_desc="Useful programs for dealing with cloud images"
+	depends="python3 e2fsprogs qemu wget file zisofs-tools geteltorito cdrtools"
+	pkg_install() {
+		vmove usr/bin/cloud-localds
+		vmove usr/bin/resize-part-image
+		vmove usr/bin/ubuntu-cloudimg-query
+		vmove usr/bin/write-mime-multipart
+		vmove usr/bin/mount-image-callback
+		vmove usr/share/man/man1/cloud-localds.1
+		vmove usr/share/man/man1/resize-part-image.1
+		vmove usr/share/man/man1/write-mime-multipart.1
+	}
+}
+
+cloud-utils_package() {
+	short_desc="Meta package of cloud-guest-utils and cloud-image-utils"
+	depends="${sourcepkg}>=${version}_${revision} cloud-image-utils>=${version}-${revision}"
+	build_style=meta
+}

--- a/srcpkgs/cloud-image-utils
+++ b/srcpkgs/cloud-image-utils
@@ -1,0 +1,1 @@
+cloud-guest-utils

--- a/srcpkgs/cloud-utils
+++ b/srcpkgs/cloud-utils
@@ -1,0 +1,1 @@
+cloud-guest-utils

--- a/srcpkgs/cloud-utils-ec2metadata
+++ b/srcpkgs/cloud-utils-ec2metadata
@@ -1,0 +1,1 @@
+cloud-guest-utils


### PR DESCRIPTION
This is a pile of shell scripts and python scripts, but they're annoying to obtain if we don't package them.  The most important one in this bundle is growpart.
