### PR TITLE
New package: rage-0.10.0

### DIFF
--- a/srcpkgs/rage/template
+++ b/srcpkgs/rage/template
@@ -1,0 +1,18 @@
+# Template file for 'rage'
+pkgname=rage
+version=0.11.1
+revision=1
+build_style=cargo
+make_install_args="--path rage"
+short_desc="Simple, modern and secure encryption tool, written in Rust"
+maintainer="Duncaen <duncaen@voidlinux.org>"
+license="MIT OR Apache-2.0"
+homepage="https://github.com/str4d/rage"
+distfiles="https://github.com/str4d/rage/archive/refs/tags/v${version}.tar.gz"
+checksum=b00559285c9fa5779b2908726d7a952cbf7cb629008e4c4c23a5c137c98f3f09
+
+conflicts="rage-player" # /usr/bin/rage
+
+post_install() {
+	vlicense LICENSE-MIT
+}


### PR DESCRIPTION
[rage](https://github.com/str4d/rage) is:
> A simple, secure and modern file encryption tool (and Rust library) with small explicit keys, no config options, and UNIX-style composability. 

It is also a rust implementation of [age](https://github.com/FiloSottile/age).

---

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
#### Local build testing
- I built this PR locally for my native architecture, x86_64
