### PR TITLE
New package: intel-media-driver-nonfree-24.3.4

### DIFF
--- a/srcpkgs/intel-media-driver-nonfree
+++ b/srcpkgs/intel-media-driver-nonfree
@@ -1,0 +1,1 @@
+intel-media-driver

--- a/srcpkgs/intel-media-driver/template
+++ b/srcpkgs/intel-media-driver/template
@@ -18,12 +18,54 @@ checksum=58978f9ee4981532e60be2f2768673b1f3825db09971ebb98fbd7e8819cab6eb
 build_options="nonfree"
 desc_option_nonfree="Enable nonfree kernels"
 
-post_install() {
-	vlicense LICENSE.md
+post_configure() {
+	(
+		configure_args="${configure_args/KERNELS=OFF/KERNELS=ON}"
+		cmake_builddir="nonfree-build"
+		do_configure
+	)
 }
 
+post_build() {
+	(
+		DESTDIR=${DESTDIR/${pkgname}/${pkgname}-nonfree}
+		cmake_builddir="nonfree-build"
+		do_build
+	)
+}
+
+# for some reason, lib installs to lib64 instead of symlinking?
+# wildcard for libigfxcmrt.so did not work - use direct name to unlink
+# or else it gets detected as a conflict of the main (free) package
+post_install() {
+	vlicense LICENSE.md
+	(
+		DESTDIR=${DESTDIR/${pkgname}/${pkgname}-nonfree}
+		cmake_builddir="nonfree-build"
+		do_install
+		unlink ${DESTDIR}/usr/lib64/libigfxcmrt.so
+	)
+}
+
+intel-media-driver-nonfree_package() {
+	short_desc+=" - nonfree codecs"
+	provides="intel-media-driver-${version}_${revision}"
+	conflicts="intel-media-driver>=0"
+	repository=nonfree
+	pkg_install() {
+		DESTDIR="${pkgname}-${version}"
+		vlicense LICENSE.md
+		mv ${PKGDESTDIR}/usr/lib64/* ${PKGDESTDIR}/usr/lib/
+		rmdir ${PKGDESTDIR}/usr/lib64
+		rm -f ${PKGDESTDIR}/usr/lib/lib
+		rm -rf ${PKGDESTDIR}/usr/include
+		rm -rf ${PKGDESTDIR}/usr/lib/pkgconfig
+	}
+}
+
+# devel files are the same for nonfree package
 intel-media-driver-devel_package() {
-	depends="${makedepends} ${sourcepkg}-${version}_${revision}"
+	depends="${makedepends} ${sourcepkg}>=${version}_${revision}"
 	short_desc+=" - development files"
 	pkg_install() {
 		vmove usr/include


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, **x86_64**
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - **x86_64-musl**

#### Comments

Add a `nonfree` package for `intel-media-driver`. This builds twice, similar to conky, and adds support for nonfree codecs to the repos (such as AV1 decode on Intel Arc A770 / DG2).

I'm unsure why `lib` and `lib64` are mixed up for the `-nonfree` subpackage. If anyone can tell me why or how to get rid of the hacky workaround rm/ln, let me know.

The `-devel` packages are the same files, so I went with `replace` and `intel-media-driver-nonfree` installs fine when you already have `intel-media-driver` and `intel-media-driver-devel` installed.

Could possibly add a `intel-video-accel-nonfree`.