### PR TITLE
ruby-tmuxinator: fix naming of completion file

### DIFF
--- a/srcpkgs/ruby-tmuxinator/template
+++ b/srcpkgs/ruby-tmuxinator/template
@@ -1,7 +1,7 @@
 # Template file for 'ruby-tmuxinator'
 pkgname=ruby-tmuxinator
 version=3.3.0
-revision=1
+revision=2
 build_style=gemspec
 depends="ruby-erubi>=1.7 ruby-thor>=1.3.0 ruby-xdg>=4.3.0 tmux"
 short_desc="Create and manage complex tmux sessions easily"
@@ -15,6 +15,6 @@ checksum=e15cf0d7fc8fc88b89adbeeebacd8061620c759da060b1bccf93bf8541679061
 post_install() {
 	vlicense LICENSE
 	for sh in bash fish zsh; do
-		vcompletion "completion/tmuxinator.${sh}" ${sh}
+		vcompletion "completion/tmuxinator.${sh}" ${sh} tmuxinator
 	done
 }

--- a/srcpkgs/zsh-completions/template
+++ b/srcpkgs/zsh-completions/template
@@ -1,7 +1,7 @@
 # Template file for 'zsh-completions'
 pkgname=zsh-completions
 version=0.35.0
-revision=1
+revision=2
 depends="zsh"
 short_desc="Additional completions for Zsh"
 maintainer="Alexander Gehrke <void@qwertyuiop.de>"
@@ -12,6 +12,7 @@ checksum=811bb4213622720872e08d6e0857f1dd7bc12ff7aa2099a170b76301a53f4fbe
 
 post_patch() {
 	rm -f src/_composer
+	rm -f src/_tmuxinator
 }
 
 do_install() {


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl
  - i686