### PR TITLE
cloud-guest-utils: add core-service for resizing rootfs

### DIFF
--- a/srcpkgs/cloud-guest-utils/files/10-resize-root.sh
+++ b/srcpkgs/cloud-guest-utils/files/10-resize-root.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+. /etc/default/growpart
+
+if [ -n "$ENABLE_ROOT_GROWPART" ]; then
+	msg "Growing root partition"
+
+	rpart="$(findmnt -r -o SOURCE -v -n /)"
+	rnum="$(cat /sys/class/block/"${rpart##*/}"/partition)"
+	rdisk="${rpart%%"$rnum"}"
+	rdisk="${rdisk%p}"
+	rtype="$(blkid -o value -s TYPE "${rpart}")"
+
+	/usr/bin/growpart "$rdisk" "$rnum"
+
+	case "$rtype" in
+		ext*) resize2fs "$rpart" ;;
+		f2fs) resize.f2fs "$rpart" ;;
+		xfs) xfs_growfs -d "$rpart" ;;
+		*) msg_warn "Couldn't resize partition, partition type $rtype not supported" ;;
+	esac
+fi

--- a/srcpkgs/cloud-guest-utils/files/README.voidlinux
+++ b/srcpkgs/cloud-guest-utils/files/README.voidlinux
@@ -1,0 +1,2 @@
+This package provides a core service that can grow the root partition on boot.
+To enable it, uncomment the ENABLE_ROOT_GROWPART line in /etc/default/growpart.

--- a/srcpkgs/cloud-guest-utils/files/growpart.default
+++ b/srcpkgs/cloud-guest-utils/files/growpart.default
@@ -1,0 +1,3 @@
+# uncomment to enable growing the root partition on boot using growpart(1)
+# currently only ext*, f2fs, and xfs are supported
+#ENABLE_ROOT_GROWPART=yes

--- a/srcpkgs/cloud-guest-utils/template
+++ b/srcpkgs/cloud-guest-utils/template
@@ -1,7 +1,7 @@
 # Template file for 'cloud-guest-utils'
 pkgname=cloud-guest-utils
 version=0.33
-revision=1
+revision=2
 build_style=gnu-makefile
 depends="e2fsprogs util-linux gptfdisk"
 short_desc="Useful programs inside of a VM Guest"
@@ -11,6 +11,12 @@ homepage="https://github.com/canonical/cloud-utils/"
 changelog="https://github.com/canonical/cloud-utils/raw/main/ChangeLog"
 distfiles="https://github.com/canonical/cloud-utils/archive/refs/tags/$version.tar.gz"
 checksum=338770d637788466aacfcbcec17a8d0046f92a13cc3b25fce8fceadb02a7339f
+
+post_install() {
+	vdoc "${FILESDIR}"/README.voidlinux
+	vinstall "${FILESDIR}"/10-resize-root.sh 644 /etc/runit/core-services
+	vinstall "${FILESDIR}"/growpart.default 644 /etc/default growpart
+}
 
 cloud-utils-ec2metadata_package() {
 	short_desc="Script for retrieving AWS-EC2 Metadata"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES** (with mklive packer)

doesn't have deps on f2fs-tools or xfsprogs but `base-{container-full,system}` both do so probably not an issue
