### PR TITLE
btrfs-progs: update to 6.9.2.

### DIFF
--- a/srcpkgs/btrfs-progs/template
+++ b/srcpkgs/btrfs-progs/template
@@ -1,11 +1,11 @@
 # Template file for 'btrfs-progs'
 pkgname=btrfs-progs
-version=6.5.1
+version=6.9.2
 revision=1
 build_style=gnu-configure
 make_check_target=test
 configure_args="--disable-backtrace --disable-python"
-hostmakedepends="pkgconf python3-Sphinx"
+hostmakedepends="pkgconf python3-Sphinx python3-sphinx_rtd_theme"
 makedepends="acl-devel libzstd-devel lzo-devel libblkid-devel libuuid-devel
  eudev-libudev-devel zlib-devel
  $(vopt_if e2fs 'e2fsprogs-devel') $(vopt_if reiserfs 'reiserfsprogs')"
@@ -15,7 +15,7 @@ license="GPL-2.0-only, LGPL-2.1-or-later"
 homepage="https://btrfs.wiki.kernel.org/index.php/Main_Page"
 changelog="https://raw.githubusercontent.com/kdave/btrfs-progs/master/CHANGES"
 distfiles="${KERNEL_SITE}/kernel/people/kdave/btrfs-progs/btrfs-progs-v${version}.tar.xz"
-checksum=dacbb28136e82586af802205263a428c3d1941778bc3fdc9b1b386ea12eb904e
+checksum=43865bb272dc0ab2585de3605434d81ba217578f0897bf700cd36c14ac40652a
 # Most of the tests depend on `mount` and `fallocate` commands, which are not
 # presented in chroot-util-linux
 make_check=no


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, x86_64-musl

