### PR TITLE
python3-openssl: update to 24.2.1

### DIFF
--- a/srcpkgs/python3-openssl/template
+++ b/srcpkgs/python3-openssl/template
@@ -1,20 +1,26 @@
 # Template file for 'python3-openssl'
 pkgname=python3-openssl
-version=24.0.0
+version=24.2.1
 revision=1
 build_style=python3-module
+# disabled tests require pytest-rerunfailures which isn't packaged
+make_check_args="
+ --deselect tests/test_crypto.py::TestX509::test_gmtime_adj_notBefore
+ --deselect tests/test_crypto.py::TestX509::test_gmtime_adj_notAfter
+ --deselect tests/test_ssl.py::TestContext::test_set_cipher_list_no_cipher_match"
 hostmakedepends="python3-setuptools"
 depends="python3-cryptography"
-checkdepends="python3-pytest $depends python3-flaky python3-pretend"
+checkdepends="python3-pytest $depends python3-flaky python3-pretend
+ python3-pytest-xdist"
 short_desc="Python3 interface to the OpenSSL library"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="Apache-2.0"
 homepage="https://pyopenssl.org/"
 changelog="https://raw.githubusercontent.com/pyca/pyopenssl/master/CHANGELOG.rst"
-distfiles="${PYPI_SITE}/p/pyOpenSSL/pyOpenSSL-${version}.tar.gz"
-checksum=6aa33039a93fffa4563e655b61d11364d01264be8ccb49906101e02a334530bf
+distfiles="${PYPI_SITE}/p/pyOpenSSL/pyopenssl-${version}.tar.gz"
+checksum=4247f0dbe3748d560dcbb2ff3ea01af0f9a1a001ef5f7c4c647956ed8cbf0e95
 
 if [ "$XBPS_TARGET_WORDSIZE" = "32" ]; then
 	# https://github.com/pyca/pyopenssl/issues/974
-	make_check_args="-k not(test_verify_with_time)"
+	make_check_args+=" -k not(test_verify_with_time)"
 fi


### PR DESCRIPTION
closes #51438 

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86-64)