### PR TITLE
webrtc-audio-processing: fix for i686-musl build

### DIFF
--- a/srcpkgs/webrtc-audio-processing/template
+++ b/srcpkgs/webrtc-audio-processing/template
@@ -13,7 +13,7 @@ distfiles="${FREEDESKTOP_SITE}/pulseaudio/webrtc-audio-processing/webrtc-audio-p
 checksum=95552fc17faa0202133707bbb3727e8c2cf64d4266fe31bfdb2298d769c1db75
 
 # Upstream issue: https://gitlab.freedesktop.org/pulseaudio/webrtc-audio-processing/-/issues/5
-if [ "$XBPS_MACHINE" = "i686" ]; then
+if [[ "$XBPS_TARGET_MACHINE" = "i686"* ]]; then
 	CXXFLAGS="-DPFFFT_SIMD_DISABLE=1"
 	CFLAGS="-DPFFFT_SIMD_DISABLE=1"
 fi


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture: x86_64-musl, i686-musl (with `-A i686-musl`)
- I built this PR locally for these architectures:
  - x86_64 (`-A x86_64` on x86_64-musl)
  - i686 (`-A i686` on x86_64-musl)
  - aarch64 (`-A x86_64 -a aarch64` on x86_64-musl)
  - aarch64-musl (`-A x86_64-musl -a aarch64-musl` on x86_64-musl)
  - armv7l (`-A i686 -a armv7l` on x86_64-musl)
  - armv7l-musl (`-A i686-musl -a armv7l-musl` on x86_64-musl)

PS: Sorry for the new PR, I messed something up when squashing.