### PR TITLE
gopass: run tests, remove useless path, build as pie

### DIFF
--- a/srcpkgs/gopass/template
+++ b/srcpkgs/gopass/template
@@ -1,11 +1,12 @@
 # Template file for 'gopass'
 pkgname=gopass
 version=1.15.13
-revision=1
+revision=2
 build_style=go
 go_import_path=github.com/gopasspw/gopass
-go_package="${go_import_path} ${go_import_path}/cmd/..."
+go_package="${go_import_path}"
 depends="gnupg>=2 git"
+checkdepends="gnupg git age"
 short_desc="Slightly more awesome standard unix password manager for teams"
 maintainer="Felipe Nogueira <contato.fnog@gmail.com>"
 license="MIT"
@@ -13,6 +14,11 @@ homepage="https://www.gopass.pw/"
 changelog="https://raw.githubusercontent.com/gopasspw/gopass/master/CHANGELOG.md"
 distfiles="https://github.com/gopasspw/gopass/archive/refs/tags/v${version}.tar.gz"
 checksum=8f7ee347f517bf66a7d0760e7a5ed6c948d66737559bd04fa8da594801ed9b4f
+export GOFLAGS="-buildmode=pie"
+
+do_check() {
+	GOPASS_BINARY=${GOPATH}/bin/gopass go test -v ./tests
+}
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
- I tested the changes in this PR: yes
- I built this PR locally for my native architecture, (x86_64-glibc)

run tests
disable unexistent path (otherwise it produces a warning)
build as pie (as it's done in the upstream makefile)

cc @fnogcps 