### PR TITLE
chirp: update to 20240706.

### DIFF
--- a/srcpkgs/chirp/template
+++ b/srcpkgs/chirp/template
@@ -1,14 +1,14 @@
 # Template file for 'chirp'
 pkgname=chirp
-version=20230911
-revision=3
+version=20240706
+revision=1
 build_style=python3-pep517
 hostmakedepends="python3-setuptools python3-wheel"
-depends="python3-six wxPython python3-pyserial python3-future python3-requests
+depends="python3-six wxPython python3-pyserial python3-requests
  python3-suds python3-yattag"
 short_desc="Open-source tool for programming amateur radios"
 maintainer="Emil Miler <em@0x45.cz>"
 license="GPL-3.0-or-later"
 homepage="https://chirp.danplanet.com/projects/chirp/wiki/Home"
 distfiles="https://trac.chirp.danplanet.com/chirp_next/next-${version}/chirp-${version}.tar.gz"
-checksum=948cfd8972626d9311ff4c1f3227d7965709462af2af38e5e7fd47cb7e79c36c
+checksum=09c097307d8aeb29339552a4c1ef272b657779b78c4b3a4c68175609ec8c9b0e


### PR DESCRIPTION
The currently-packaged version of chirp is broken due to python3.12's removal of `imp`. The latest version resolves that (and no longer depends on `python3-future`)

cc @realcharmer 

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
<!--
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
