### PR TITLE
libjxl: add missing highway dependency to -devel

### DIFF
--- a/srcpkgs/libjxl/template
+++ b/srcpkgs/libjxl/template
@@ -1,7 +1,7 @@
 # Template file for 'libjxl'
 pkgname=libjxl
 version=0.10.3
-revision=1
+revision=2
 _testdata_hash=ff8d743aaba05b3014f17e5475e576242fa979fc
 build_style=cmake
 configure_args="-DJPEGXL_ENABLE_BENCHMARK=OFF -DJPEGXL_ENABLE_EXAMPLES=OFF
@@ -42,7 +42,7 @@ post_install() {
 
 libjxl-devel_package() {
 	short_desc+=" - development files"
-	depends="${sourcepkg}>=${version}_${revision} brotli-devel"
+	depends="${sourcepkg}>=${version}_${revision} highway-devel brotli-devel"
 	pkg_install() {
 		vmove usr/include
 		vmove "usr/lib/*.so"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

cc @joshuakraemer

`pkg-config` errors out for `libjxl` otherwise because `highway` is required

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
