### PR TITLE
libavif: add missing libaom dependecy to -devel

### DIFF
--- a/srcpkgs/libavif/template
+++ b/srcpkgs/libavif/template
@@ -1,7 +1,7 @@
 # Template file for 'libavif'
 pkgname=libavif
 version=1.1.0
-revision=1
+revision=2
 build_style=cmake
 configure_args="-DAVIF_BUILD_APPS=ON -DAVIF_BUILD_GDK_PIXBUF=ON
  -DAVIF_LIBYUV=OFF -DAVIF_CODEC_AOM=SYSTEM
@@ -37,7 +37,7 @@ post_install() {
 
 libavif-devel_package() {
 	short_desc+=" - development files"
-	depends="${sourcepkg}>=${version}_${revision}"
+	depends="${sourcepkg}>=${version}_${revision} libaom-devel"
 	pkg_install() {
 		vmove usr/include
 		vmove "usr/lib/*.so"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

cc @leahneukirchen

`pkg-config` errors out for `libavif` otherwise because `libaom` is required

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
