### PR TITLE
ffmpeg6: absorb ffplay

### DIFF
--- a/srcpkgs/ffmpeg/template
+++ b/srcpkgs/ffmpeg/template
@@ -2,7 +2,7 @@
 # audacity also needs to be bumped when a new ffmpeg version bumps libavformat's soname!
 pkgname=ffmpeg
 version=4.4.4
-revision=8
+revision=9
 build_style=meta
 short_desc="Decoding, encoding and streaming software (transitional dummy package)"
 maintainer="Orphaned <orphan@voidlinux.org>"
@@ -237,10 +237,4 @@ ffmpeg-devel_package() {
 		vmove usr/share/ffmpeg/examples
 		vmove usr/share/man/man3
 	}
-}
-
-ffplay_package() {
-	short_desc="Simple video player using FFmpeg and SDL2 (transitional dummy package)"
-	build_style="meta"
-	depends="ffplay6"
 }

--- a/srcpkgs/ffmpeg6/patches/00001-vaapi_decode-multiple-slice-params-buffers.patch
+++ b/srcpkgs/ffmpeg6/patches/00001-vaapi_decode-multiple-slice-params-buffers.patch
@@ -1,0 +1,159 @@
+diff --git a/libavcodec/vaapi_av1.c b/libavcodec/vaapi_av1.c
+index d0339b2..6f33f03 100644
+--- a/libavcodec/vaapi_av1.c
++++ b/libavcodec/vaapi_av1.c
+@@ -421,7 +421,7 @@ static int vaapi_av1_decode_slice(AVCodecContext *avctx,
+             .tg_end            = s->tg_end,
+         };
+ 
+-        err = ff_vaapi_decode_make_slice_buffer(avctx, pic, &slice_param,
++        err = ff_vaapi_decode_make_slice_buffer(avctx, pic, &slice_param, 1,
+                                                 sizeof(VASliceParameterBufferAV1),
+                                                 buffer,
+                                                 size);
+diff --git a/libavcodec/vaapi_decode.c b/libavcodec/vaapi_decode.c
+index 134f10e..c6d90ac 100644
+--- a/libavcodec/vaapi_decode.c
++++ b/libavcodec/vaapi_decode.c
+@@ -61,6 +61,7 @@ int ff_vaapi_decode_make_param_buffer(AVCodecContext *avctx,
+ int ff_vaapi_decode_make_slice_buffer(AVCodecContext *avctx,
+                                       VAAPIDecodePicture *pic,
+                                       const void *params_data,
++				      int nb_params,
+                                       size_t params_size,
+                                       const void *slice_data,
+                                       size_t slice_size)
+@@ -89,7 +90,7 @@ int ff_vaapi_decode_make_slice_buffer(AVCodecContext *avctx,
+ 
+     vas = vaCreateBuffer(ctx->hwctx->display, ctx->va_context,
+                          VASliceParameterBufferType,
+-                         params_size, 1, (void*)params_data,
++                         params_size, nb_params, (void*)params_data,
+                          &pic->slice_buffers[index]);
+     if (vas != VA_STATUS_SUCCESS) {
+         av_log(avctx, AV_LOG_ERROR, "Failed to create slice "
+diff --git a/libavcodec/vaapi_decode.h b/libavcodec/vaapi_decode.h
+index 6beda14..22c8c54 100644
+--- a/libavcodec/vaapi_decode.h
++++ b/libavcodec/vaapi_decode.h
+@@ -73,6 +73,7 @@ int ff_vaapi_decode_make_param_buffer(AVCodecContext *avctx,
+ int ff_vaapi_decode_make_slice_buffer(AVCodecContext *avctx,
+                                       VAAPIDecodePicture *pic,
+                                       const void *params_data,
++				      int nb_params,
+                                       size_t params_size,
+                                       const void *slice_data,
+                                       size_t slice_size);
+diff --git a/libavcodec/vaapi_h264.c b/libavcodec/vaapi_h264.c
+index 9332aa6..0536ee8 100644
+--- a/libavcodec/vaapi_h264.c
++++ b/libavcodec/vaapi_h264.c
+@@ -375,7 +375,7 @@ static int vaapi_h264_decode_slice(AVCodecContext *avctx,
+                                        slice_param.chroma_offset_l1);
+ 
+     err = ff_vaapi_decode_make_slice_buffer(avctx, pic,
+-                                            &slice_param, sizeof(slice_param),
++                                            &slice_param, 1, sizeof(slice_param),
+                                             buffer, size);
+     if (err) {
+         ff_vaapi_decode_cancel(avctx, pic);
+diff --git a/libavcodec/vaapi_hevc.c b/libavcodec/vaapi_hevc.c
+index 20fb36a..6f022a7 100644
+--- a/libavcodec/vaapi_hevc.c
++++ b/libavcodec/vaapi_hevc.c
+@@ -305,7 +305,7 @@ static int vaapi_hevc_end_frame(AVCodecContext *avctx)
+     if (pic->last_size) {
+         last_slice_param->LongSliceFlags.fields.LastSliceOfPic = 1;
+         ret = ff_vaapi_decode_make_slice_buffer(avctx, &pic->pic,
+-                                                &pic->last_slice_param, slice_param_size,
++                                                &pic->last_slice_param, 1, slice_param_size,
+                                                 pic->last_buffer, pic->last_size);
+         if (ret < 0)
+             goto fail;
+@@ -423,7 +423,7 @@ static int vaapi_hevc_decode_slice(AVCodecContext *avctx,
+ 
+     if (!sh->first_slice_in_pic_flag) {
+         err = ff_vaapi_decode_make_slice_buffer(avctx, &pic->pic,
+-                                                &pic->last_slice_param, slice_param_size,
++                                                &pic->last_slice_param, 1, slice_param_size,
+                                                 pic->last_buffer, pic->last_size);
+         pic->last_buffer = NULL;
+         pic->last_size   = 0;
+diff --git a/libavcodec/vaapi_mjpeg.c b/libavcodec/vaapi_mjpeg.c
+index 8158211..3ee1663 100644
+--- a/libavcodec/vaapi_mjpeg.c
++++ b/libavcodec/vaapi_mjpeg.c
+@@ -131,7 +131,7 @@ static int vaapi_mjpeg_decode_slice(AVCodecContext *avctx,
+         sp.components[i].ac_table_selector  = s->ac_index[i];
+     }
+ 
+-    err = ff_vaapi_decode_make_slice_buffer(avctx, pic, &sp, sizeof(sp), buffer, size);
++    err = ff_vaapi_decode_make_slice_buffer(avctx, pic, &sp, 1, sizeof(sp), buffer, size);
+     if (err)
+         goto fail;
+ 
+diff --git a/libavcodec/vaapi_mpeg2.c b/libavcodec/vaapi_mpeg2.c
+index 5e2b889..8b37239 100644
+--- a/libavcodec/vaapi_mpeg2.c
++++ b/libavcodec/vaapi_mpeg2.c
+@@ -162,7 +162,7 @@ static int vaapi_mpeg2_decode_slice(AVCodecContext *avctx, const uint8_t *buffer
+     };
+ 
+     err = ff_vaapi_decode_make_slice_buffer(avctx, pic,
+-                                            &slice_param, sizeof(slice_param),
++                                            &slice_param, 1, sizeof(slice_param),
+                                             buffer, size);
+     if (err < 0) {
+         ff_vaapi_decode_cancel(avctx, pic);
+diff --git a/libavcodec/vaapi_mpeg4.c b/libavcodec/vaapi_mpeg4.c
+index 4e74e03..d2e1d15 100644
+--- a/libavcodec/vaapi_mpeg4.c
++++ b/libavcodec/vaapi_mpeg4.c
+@@ -169,7 +169,7 @@ static int vaapi_mpeg4_decode_slice(AVCodecContext *avctx, const uint8_t *buffer
+     };
+ 
+     err = ff_vaapi_decode_make_slice_buffer(avctx, pic,
+-                                            &slice_param, sizeof(slice_param),
++                                            &slice_param, 1, sizeof(slice_param),
+                                             buffer, size);
+     if (err < 0) {
+         ff_vaapi_decode_cancel(avctx, pic);
+diff --git a/libavcodec/vaapi_vc1.c b/libavcodec/vaapi_vc1.c
+index fb2132e..a4933c9 100644
+--- a/libavcodec/vaapi_vc1.c
++++ b/libavcodec/vaapi_vc1.c
+@@ -490,7 +490,7 @@ static int vaapi_vc1_decode_slice(AVCodecContext *avctx, const uint8_t *buffer,
+     };
+ 
+     err = ff_vaapi_decode_make_slice_buffer(avctx, pic,
+-                                            &slice_param, sizeof(slice_param),
++                                            &slice_param, 1, sizeof(slice_param),
+                                             buffer, size);
+     if (err < 0) {
+         ff_vaapi_decode_cancel(avctx, pic);
+diff --git a/libavcodec/vaapi_vp8.c b/libavcodec/vaapi_vp8.c
+index 5b18bf8..3c16e6d 100644
+--- a/libavcodec/vaapi_vp8.c
++++ b/libavcodec/vaapi_vp8.c
+@@ -209,7 +209,7 @@ static int vaapi_vp8_decode_slice(AVCodecContext *avctx,
+     for (i = 0; i < 8; i++)
+         sp.partition_size[i+1] = s->coeff_partition_size[i];
+ 
+-    err = ff_vaapi_decode_make_slice_buffer(avctx, pic, &sp, sizeof(sp), data, data_size);
++    err = ff_vaapi_decode_make_slice_buffer(avctx, pic, &sp, 1, sizeof(sp), data, data_size);
+     if (err)
+         goto fail;
+ 
+diff --git a/libavcodec/vaapi_vp9.c b/libavcodec/vaapi_vp9.c
+index 776382f..237f6c5 100644
+--- a/libavcodec/vaapi_vp9.c
++++ b/libavcodec/vaapi_vp9.c
+@@ -158,7 +158,7 @@ static int vaapi_vp9_decode_slice(AVCodecContext *avctx,
+     }
+ 
+     err = ff_vaapi_decode_make_slice_buffer(avctx, pic,
+-                                            &slice_param, sizeof(slice_param),
++                                            &slice_param, 1, sizeof(slice_param),
+                                             buffer, size);
+     if (err) {
+         ff_vaapi_decode_cancel(avctx, pic);

--- a/srcpkgs/ffmpeg6/patches/00002-lavc-vaapi_av1-Avoid-sending-the-same-slice-buffer-multiple-times.patch
+++ b/srcpkgs/ffmpeg6/patches/00002-lavc-vaapi_av1-Avoid-sending-the-same-slice-buffer-multiple-times.patch
@@ -1,0 +1,89 @@
+diff --git a/libavcodec/vaapi_av1.c b/libavcodec/vaapi_av1.c
+index d0339b2..c4b55cb 100644
+--- a/libavcodec/vaapi_av1.c
++++ b/libavcodec/vaapi_av1.c
+@@ -19,6 +19,7 @@
+  */
+ 
+ #include "libavutil/frame.h"
++#include "libavutil/mem.h"
+ #include "libavutil/pixdesc.h"
+ #include "hwconfig.h"
+ #include "vaapi_decode.h"
+@@ -43,6 +44,9 @@ typedef struct VAAPIAV1DecContext {
+     */
+     VAAPIAV1FrameRef ref_tab[AV1_NUM_REF_FRAMES];
+     AVFrame *tmp_frame;
++
++    int nb_slice_params;
++    VASliceParameterBufferAV1 *slice_params;
+ } VAAPIAV1DecContext;
+ 
+ static VASurfaceID vaapi_av1_surface_id(AV1Frame *vf)
+@@ -109,6 +113,8 @@ static int vaapi_av1_decode_uninit(AVCodecContext *avctx)
+         av_frame_free(&ctx->ref_tab[i].frame);
+     }
+ 
++    av_freep(&ctx->slice_params);
++
+     return ff_vaapi_decode_uninit(avctx);
+ }
+ 
+@@ -405,13 +411,24 @@ static int vaapi_av1_decode_slice(AVCodecContext *avctx,
+ {
+     const AV1DecContext *s = avctx->priv_data;
+     VAAPIDecodePicture *pic = s->cur_frame.hwaccel_picture_private;
+-    VASliceParameterBufferAV1 slice_param;
+-    int err = 0;
++    VAAPIAV1DecContext *ctx = avctx->internal->hwaccel_priv_data;
++    int err, nb_params;
++
++    nb_params = s->tg_end - s->tg_start + 1;
++    if (ctx->nb_slice_params < nb_params) {
++        ctx->slice_params = av_realloc_array(ctx->slice_params,
++                                             nb_params,
++                                             sizeof(*ctx->slice_params));
++        if (!ctx->slice_params) {
++            ctx->nb_slice_params = 0;
++            err = AVERROR(ENOMEM);
++            goto fail;
++        }
++        ctx->nb_slice_params = nb_params;
++    }
+ 
+     for (int i = s->tg_start; i <= s->tg_end; i++) {
+-        memset(&slice_param, 0, sizeof(VASliceParameterBufferAV1));
+-
+-        slice_param = (VASliceParameterBufferAV1) {
++	ctx->slice_params[i - s->tg_start] = (VASliceParameterBufferAV1) {
+             .slice_data_size   = s->tile_group_info[i].tile_size,
+             .slice_data_offset = s->tile_group_info[i].tile_offset,
+             .slice_data_flag   = VA_SLICE_DATA_FLAG_ALL,
+@@ -421,17 +438,19 @@ static int vaapi_av1_decode_slice(AVCodecContext *avctx,
+             .tg_end            = s->tg_end,
+         };
+ 
+-        err = ff_vaapi_decode_make_slice_buffer(avctx, pic, &slice_param, 1,
+-                                                sizeof(VASliceParameterBufferAV1),
+-                                                buffer,
+-                                                size);
+-        if (err) {
+-            ff_vaapi_decode_cancel(avctx, pic);
+-            return err;
+-        }
+     }
++    err = ff_vaapi_decode_make_slice_buffer(avctx, pic, ctx->slice_params, nb_params,
++                                            sizeof(VASliceParameterBufferAV1),
++                                            buffer,
++                                            size);
++    if (err)
++        goto fail;
+ 
+     return 0;
++
++fail:
++    ff_vaapi_decode_cancel(avctx, pic);
++    return err;
+ }
+ 
+ const AVHWAccel ff_av1_vaapi_hwaccel = {

--- a/srcpkgs/ffmpeg6/template
+++ b/srcpkgs/ffmpeg6/template
@@ -2,7 +2,7 @@
 # audacity also needs to be bumped when a new ffmpeg version bumps libavformat's soname!
 pkgname=ffmpeg6
 version=6.0.1
-revision=1
+revision=2
 hostmakedepends="pkg-config perl"
 makedepends="zlib-devel bzip2-devel freetype-devel alsa-lib-devel libXfixes-devel
  libXext-devel libXvMC-devel libxcb-devel lame-devel libtheora-devel
@@ -208,6 +208,12 @@ ffmpeg6-devel_package() {
 		vmove usr/share/ffmpeg/examples
 		vmove usr/share/man/man3
 	}
+}
+
+ffplay_package() {
+	short_desc="Simple video player using FFmpeg and SDL2"
+	build_style="meta"
+	depends="ffplay6"
 }
 
 ffplay6_package() {

--- a/srcpkgs/ffplay
+++ b/srcpkgs/ffplay
@@ -1,1 +1,1 @@
-ffmpeg
+ffmpeg6


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, **x86_64**

#### Comments

Move `ffplay` meta subpackage into `ffmpeg6`, which has `ffplay6`, which has the actual "ffplay" binary.

Upgrading to 6 had `ffplay` inside `ffmpeg`(4) as a meta transitional package. This broke updates for `ffmpeg6` being patched. see https://github.com/void-linux/void-packages/pull/51334