### PR TITLE
newsboat: update to 2.36.

### DIFF
--- a/srcpkgs/newsboat/template
+++ b/srcpkgs/newsboat/template
@@ -1,6 +1,6 @@
 # Template file for 'newsboat'
 pkgname=newsboat
-version=2.35
+version=2.36
 revision=1
 build_style=configure
 build_helper="rust"
@@ -17,7 +17,7 @@ license="MIT"
 homepage="https://newsboat.org/"
 changelog="https://raw.githubusercontent.com/newsboat/newsboat/master/CHANGELOG.md"
 distfiles="https://newsboat.org/releases/${version}/newsboat-${version}.tar.xz"
-checksum=f4f003f6ca38e44c0fef01fb6bc8c5ba6b53589c7c87db7b0cc2284e018db6c4
+checksum=61a67a397cc9df7fbb7d73bb156e89e5b4a2b31fc9360e1e7384e710a2cf037a
 python_version=3
 
 # tests fail when run by superuser


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
