### PR TITLE
rootlesskit: update to 2.2.0.

### DIFF
--- a/srcpkgs/rootlesskit/template
+++ b/srcpkgs/rootlesskit/template
@@ -1,9 +1,9 @@
 # Template file for 'rootlesskit'
 pkgname=rootlesskit
-version=0.14.6
-revision=3
+version=2.2.0
+revision=1
 build_style=go
-go_import_path="github.com/rootless-containers/rootlesskit"
+go_import_path="github.com/rootless-containers/rootlesskit/v2"
 go_package="${go_import_path}/cmd/rootlesskit ${go_import_path}/cmd/rootlessctl
  ${go_import_path}/cmd/rootlesskit-docker-proxy"
 short_desc="Linux-native \"fake root\" for implementing rootless containers"
@@ -11,4 +11,4 @@ maintainer="Piotr Wójcik <chocimier@tlen.pl>"
 license="Apache-2.0"
 homepage="https://github.com/rootless-containers/rootlesskit"
 distfiles="https://github.com/rootless-containers/rootlesskit/archive/v${version}.tar.gz"
-checksum=e27e4249f12cca44fc6e15a27f214f30fcb5f15646c813a90b6788bd9f0cfd4b
+checksum=0075af5f14ea7ff5b1431ba30671d7c0e18e0e57453be58600293b283a9d8e2e


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
