### PR TITLE
nasa-wallpaper: update to 2.1.1

### DIFF
--- a/srcpkgs/nasa-wallpaper/template
+++ b/srcpkgs/nasa-wallpaper/template
@@ -1,6 +1,6 @@
 # Template file for 'nasa-wallpaper'
 pkgname=nasa-wallpaper
-version=2.1.0
+version=2.1.1
 revision=1
 build_style="cargo"
 hostmakedepends="pkg-config"
@@ -10,4 +10,4 @@ maintainer="Emil Miler <em@0x45.cz>"
 license="Apache-2.0"
 homepage="https://github.com/davidpob99/nasa-wallpaper/"
 distfiles="https://github.com/davidpob99/nasa-wallpaper/archive/refs/tags/v${version}.tar.gz"
-checksum=a33947df6fca4681bbd8479a9121c5441e8d280388743b2a314c5be6e4c109d2
+checksum=0d104c25b94abe4707c7fcf0745a11692ade8b61946943abd5c6d0572ee44fbf


### PR DESCRIPTION
Simple version bump.

- I tested the changes in this PR: **briefly**
- I built this PR locally for my native architecture, (x86_64-glibc)
