### PR TITLE
python3-openpyxl: update to 3.1.3.

### DIFF
--- a/srcpkgs/python3-openpyxl/template
+++ b/srcpkgs/python3-openpyxl/template
@@ -1,17 +1,18 @@
 # Template file for 'python3-openpyxl'
 pkgname=python3-openpyxl
-version=3.1.2
-revision=2
+version=3.1.3
+revision=1
 build_style=python3-module
 hostmakedepends="python3-setuptools"
 depends="python3-et-xmlfile"
 checkdepends="python3-pytest python3-lxml python3-Pillow $depends"
-short_desc="Python library to read/write Excel 2007 xlsx/xlsm files"
+short_desc="Python library to read/write Excel 2010 xlsx/xlsm files"
 maintainer="yopito <pierre.bourgin@free.fr>"
 license="MIT"
 homepage="https://openpyxl.readthedocs.io/"
+changelog="https://openpyxl.readthedocs.io/en/stable/changes.html"
 distfiles="https://foss.heptapod.net/openpyxl/openpyxl/-/archive/${version}/openpyxl-${version}.tar.bz2"
-checksum=421e13e7004f6fee7cf84c1b9fa738615bf409ff2b57e2227be75452f7608c12
+checksum=cea16c469bbd31859bfae71f82bb479bd27bf95dfce30f519e12f6d62f86df23
 
 post_install() {
 	vlicense LICENCE.rst


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc

Notes:
- Mostly bugfixes according to [changelog](https://openpyxl.readthedocs.io/en/stable/changes.html#id1). Checks passed locally.
- Adjusted template a bit.
- BTW, it's also an optional dep for visidata to read from XLSX files (see [setup.py](https://github.com/saulpw/visidata/blob/v3.0.2/setup.py)), but as visidata template seems to miss a lot of extra deps, I'm not adding it explicitly.