### PR TITLE
terragrunt: removed terraform dependency

### DIFF
--- a/srcpkgs/terragrunt/template
+++ b/srcpkgs/terragrunt/template
@@ -4,7 +4,6 @@ version=0.66.3
 revision=1
 build_style=go
 go_import_path="github.com/gruntwork-io/terragrunt"
-depends="terraform"
 short_desc="Thin wrapper for Terraform that provides extra tools"
 maintainer="Andrea Brancaleoni <abc@pompel.me>"
 license="MIT"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

As we have `opentofu` merged, we can remove `terraform` dependency from `terragrunt`. `terragrunt` can work with both `opentofu` and `terraform`, it even defaults to `opentofu` (at least on my machine).

@thypon, what do you think?