### PR TITLE
wiki-tui: update time-rs for rust 1.80

### DIFF
--- a/srcpkgs/wiki-tui/template
+++ b/srcpkgs/wiki-tui/template
@@ -1,7 +1,7 @@
 # Template file for 'wiki-tui'
 pkgname=wiki-tui
 version=0.8.2
-revision=2
+revision=3
 build_style=cargo
 hostmakedepends="pkg-config"
 makedepends="openssl-devel"
@@ -12,6 +12,10 @@ homepage="https://builditluc.github.io/wiki-tui/"
 changelog="https://github.com/Builditluc/wiki-tui/raw/main/CHANGELOG.md"
 distfiles="https://github.com/Builditluc/wiki-tui/archive/refs/tags/v${version}.tar.gz"
 checksum=408bc8eb928e3a9b8d0c59ac2aa160c101b1e978e1a95eb751585f54087dfe62
+
+post_patch() {
+	cargo update --package time@0.3.22 --precise 0.3.35
+}
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)

For #51458

Future versions of this package appear not to depend on `time-rs`.