### PR TITLE
ffmpeg6: qt5-webengine and qt6-pdf(webengine) [ci skip]

### DIFF
--- a/srcpkgs/qt5-webengine/patches/chromium-media-filters-cpp14.patch
+++ b/srcpkgs/qt5-webengine/patches/chromium-media-filters-cpp14.patch
@@ -1,0 +1,11 @@
+--- a/src/3rdparty/chromium/media/filters/BUILD.gn	2023-02-27 13:32:59.000000000 -0500
++++ b/src/3rdparty/chromium/media/filters/BUILD.gn	2023-04-02 17:21:39.204066384 -0400
+@@ -96,6 +96,8 @@
+     "//ui/gfx/geometry:geometry",
+   ]
+ 
++  cflags_cc = [ "-std=c++14" ]
++
+   libs = []
+ 
+   if (proprietary_codecs) {

--- a/srcpkgs/qt5-webengine/patches/ffmepg5.patch
+++ b/srcpkgs/qt5-webengine/patches/ffmepg5.patch
@@ -1,0 +1,179 @@
+--- a/src/3rdparty/chromium/media/filters/ffmpeg_demuxer.cc	2023-04-02 16:50:57.732547446 -0400
++++ b/src/3rdparty/chromium/media/filters/ffmpeg_demuxer.cc	2023-04-02 16:50:09.486478995 -0400
+@@ -57,6 +57,8 @@
+ 
+ namespace {
+ 
++constexpr int64_t kRelativeTsBase = static_cast<int64_t>(0x7ffeffffffffffff);
++
+ void SetAVStreamDiscard(AVStream* stream, AVDiscard discard) {
+   DCHECK(stream);
+   stream->discard = discard;
+@@ -90,24 +92,12 @@
+ 
+ static base::TimeDelta ExtractStartTime(AVStream* stream) {
+   // The default start time is zero.
+-  base::TimeDelta start_time;
++  base::TimeDelta start_time = kNoTimestamp;
+ 
+   // First try to use  the |start_time| value as is.
+   if (stream->start_time != kNoFFmpegTimestamp)
+     start_time = ConvertFromTimeBase(stream->time_base, stream->start_time);
+ 
+-  // Next try to use the first DTS value, for codecs where we know PTS == DTS
+-  // (excludes all H26x codecs). The start time must be returned in PTS.
+-  if (stream->first_dts != kNoFFmpegTimestamp &&
+-      stream->codecpar->codec_id != AV_CODEC_ID_HEVC &&
+-      stream->codecpar->codec_id != AV_CODEC_ID_H264 &&
+-      stream->codecpar->codec_id != AV_CODEC_ID_MPEG4) {
+-    const base::TimeDelta first_pts =
+-        ConvertFromTimeBase(stream->time_base, stream->first_dts);
+-    if (first_pts < start_time)
+-      start_time = first_pts;
+-  }
+-
+   return start_time;
+ }
+ 
+@@ -408,11 +398,11 @@
+   scoped_refptr<DecoderBuffer> buffer;
+ 
+   if (type() == DemuxerStream::TEXT) {
+-    int id_size = 0;
++    size_t id_size = 0;
+     uint8_t* id_data = av_packet_get_side_data(
+         packet.get(), AV_PKT_DATA_WEBVTT_IDENTIFIER, &id_size);
+ 
+-    int settings_size = 0;
++    size_t settings_size = 0;
+     uint8_t* settings_data = av_packet_get_side_data(
+         packet.get(), AV_PKT_DATA_WEBVTT_SETTINGS, &settings_size);
+ 
+@@ -424,7 +414,7 @@
+     buffer = DecoderBuffer::CopyFrom(packet->data, packet->size,
+                                      side_data.data(), side_data.size());
+   } else {
+-    int side_data_size = 0;
++    size_t side_data_size = 0;
+     uint8_t* side_data = av_packet_get_side_data(
+         packet.get(), AV_PKT_DATA_MATROSKA_BLOCKADDITIONAL, &side_data_size);
+ 
+@@ -485,7 +475,7 @@
+                                        packet->size - data_offset);
+     }
+ 
+-    int skip_samples_size = 0;
++    size_t skip_samples_size = 0;
+     const uint32_t* skip_samples_ptr =
+         reinterpret_cast<const uint32_t*>(av_packet_get_side_data(
+             packet.get(), AV_PKT_DATA_SKIP_SAMPLES, &skip_samples_size));
+@@ -1587,6 +1577,8 @@
+   for (const auto& stream : streams_) {
+     if (!stream || stream->IsEnabled() != enabled)
+       continue;
++    if (stream->av_stream()->start_time == AV_NOPTS_VALUE)
++      continue;
+     if (!lowest_start_time_stream ||
+         stream->start_time() < lowest_start_time_stream->start_time()) {
+       lowest_start_time_stream = stream.get();
+@@ -1604,6 +1596,8 @@
+     if (stream && stream->type() == DemuxerStream::VIDEO &&
+         stream->IsEnabled()) {
+       video_stream = stream.get();
++      if (stream->av_stream()->start_time == AV_NOPTS_VALUE)
++        continue;
+       if (video_stream->start_time() <= seek_time) {
+         return video_stream;
+       }
+diff -Naurp qtwebengine-5.15.10.orig/src/3rdparty/chromium/media/ffmpeg/ffmpeg_common.h qtwebengine-5.15.10/src/3rdparty/chromium/media/ffmpeg/ffmpeg_common.h
+--- a/src/3rdparty/chromium/media/ffmpeg/ffmpeg_common.h	2022-05-23 06:38:40.000000000 -0500
++++ b/src/3rdparty/chromium/media/ffmpeg/ffmpeg_common.h	2022-07-11 22:12:47.917192788 -0500
+@@ -29,6 +29,7 @@ extern "C" {
+ #include <libavformat/avformat.h>
+ #include <libavformat/avio.h>
+ #include <libavutil/avutil.h>
++#include <libavutil/channel_layout.h>
+ #include <libavutil/imgutils.h>
+ #include <libavutil/log.h>
+ #include <libavutil/mastering_display_metadata.h>
+diff -Naurp qtwebengine-5.15.10.orig/src/3rdparty/chromium/media/filters/audio_file_reader.cc qtwebengine-5.15.10/src/3rdparty/chromium/media/filters/audio_file_reader.cc
+--- a/src/3rdparty/chromium/media/filters/audio_file_reader.cc	2022-05-23 06:38:40.000000000 -0500
++++ b/src/3rdparty/chromium/media/filters/audio_file_reader.cc	2022-07-11 22:12:47.917192788 -0500
+@@ -85,7 +85,7 @@ bool AudioFileReader::OpenDemuxer() {
+ }
+ 
+ bool AudioFileReader::OpenDecoder() {
+-  AVCodec* codec = avcodec_find_decoder(codec_context_->codec_id);
++  const AVCodec* codec = avcodec_find_decoder(codec_context_->codec_id);
+   if (codec) {
+     // MP3 decodes to S16P which we don't support, tell it to use S16 instead.
+     if (codec_context_->sample_fmt == AV_SAMPLE_FMT_S16P)
+diff -Naurp qtwebengine-5.15.10.orig/src/3rdparty/chromium/media/filters/ffmpeg_audio_decoder.cc qtwebengine-5.15.10/src/3rdparty/chromium/media/filters/ffmpeg_audio_decoder.cc
+--- a/src/3rdparty/chromium/media/filters/ffmpeg_audio_decoder.cc	2022-05-23 06:38:40.000000000 -0500
++++ b/src/3rdparty/chromium/media/filters/ffmpeg_audio_decoder.cc	2022-07-11 22:12:47.917192788 -0500
+@@ -329,7 +329,7 @@ bool FFmpegAudioDecoder::ConfigureDecode
+     }
+   }
+ 
+-  AVCodec* codec = avcodec_find_decoder(codec_context_->codec_id);
++  const AVCodec* codec = avcodec_find_decoder(codec_context_->codec_id);
+   if (!codec ||
+       avcodec_open2(codec_context_.get(), codec, &codec_options) < 0) {
+     DLOG(ERROR) << "Could not initialize audio decoder: "
+diff -Naurp qtwebengine-5.15.10.orig/src/3rdparty/chromium/media/filters/ffmpeg_glue.cc qtwebengine-5.15.10/src/3rdparty/chromium/media/filters/ffmpeg_glue.cc
+--- a/src/3rdparty/chromium/media/filters/ffmpeg_glue.cc	2022-05-23 06:38:40.000000000 -0500
++++ b/src/3rdparty/chromium/media/filters/ffmpeg_glue.cc	2022-07-11 22:12:47.918192779 -0500
+@@ -59,7 +59,6 @@ static int64_t AVIOSeekOperation(void* o
+ }
+ 
+ void FFmpegGlue::InitializeFFmpeg() {
+-  av_register_all();
+ }
+ 
+ static void LogContainer(bool is_local_file,
+@@ -95,9 +94,6 @@ FFmpegGlue::FFmpegGlue(FFmpegURLProtocol
+   // Enable fast, but inaccurate seeks for MP3.
+   format_context_->flags |= AVFMT_FLAG_FAST_SEEK;
+ 
+-  // Ensures we can read out various metadata bits like vp8 alpha.
+-  format_context_->flags |= AVFMT_FLAG_KEEP_SIDE_DATA;
+-
+   // Ensures format parsing errors will bail out. From an audit on 11/2017, all
+   // instances were real failures. Solves bugs like http://crbug.com/710791.
+   format_context_->error_recognition |= AV_EF_EXPLODE;
+diff -Naurp qtwebengine-5.15.10.orig/src/3rdparty/chromium/media/filters/ffmpeg_video_decoder.cc qtwebengine-5.15.10/src/3rdparty/chromium/media/filters/ffmpeg_video_decoder.cc
+--- a/src/3rdparty/chromium/media/filters/ffmpeg_video_decoder.cc	2022-05-23 06:38:40.000000000 -0500
++++ b/src/3rdparty/chromium/media/filters/ffmpeg_video_decoder.cc	2022-07-11 22:12:47.918192779 -0500
+@@ -391,7 +391,7 @@ bool FFmpegVideoDecoder::ConfigureDecode
+   if (decode_nalus_)
+     codec_context_->flags2 |= AV_CODEC_FLAG2_CHUNKS;
+ 
+-  AVCodec* codec = avcodec_find_decoder(codec_context_->codec_id);
++  const AVCodec* codec = avcodec_find_decoder(codec_context_->codec_id);
+   if (!codec || avcodec_open2(codec_context_.get(), codec, NULL) < 0) {
+     ReleaseFFmpegResources();
+     return false;
+diff -Naurp qtwebengine-5.15.10.orig/src/3rdparty/chromium/media/filters/media_file_checker.cc qtwebengine-5.15.10/src/3rdparty/chromium/media/filters/media_file_checker.cc
+--- a/src/3rdparty/chromium/media/filters/media_file_checker.cc	2022-05-23 06:38:40.000000000 -0500
++++ b/src/3rdparty/chromium/media/filters/media_file_checker.cc	2022-07-11 22:12:47.918192779 -0500
+@@ -68,7 +68,7 @@ bool MediaFileChecker::Start(base::TimeD
+       auto context = AVStreamToAVCodecContext(format_context->streams[i]);
+       if (!context)
+         continue;
+-      AVCodec* codec = avcodec_find_decoder(cp->codec_id);
++      const AVCodec* codec = avcodec_find_decoder(cp->codec_id);
+       if (codec && avcodec_open2(context.get(), codec, nullptr) >= 0) {
+         auto loop = std::make_unique<FFmpegDecodingLoop>(context.get());
+         stream_contexts[i] = {std::move(context), std::move(loop)};
+diff -Naurp qtwebengine-5.15.10.orig/src/3rdparty/chromium/third_party/webrtc/modules/video_coding/codecs/h264/h264_decoder_impl.cc qtwebengine-5.15.10/src/3rdparty/chromium/third_party/webrtc/modules/video_coding/codecs/h264/h264_decoder_impl.cc
+--- a/src/3rdparty/chromium/third_party/webrtc/modules/video_coding/codecs/h264/h264_decoder_impl.cc	2022-05-23 06:38:40.000000000 -0500
++++ b/src/3rdparty/chromium/third_party/webrtc/modules/video_coding/codecs/h264/h264_decoder_impl.cc	2022-07-11 22:12:47.918192779 -0500
+@@ -203,7 +203,7 @@ int32_t H264DecoderImpl::InitDecode(cons
+   // a pointer |this|.
+   av_context_->opaque = this;
+ 
+-  AVCodec* codec = avcodec_find_decoder(av_context_->codec_id);
++  const AVCodec* codec = avcodec_find_decoder(av_context_->codec_id);
+   if (!codec) {
+     // This is an indication that FFmpeg has not been initialized or it has not
+     // been compiled/initialized with the correct set of codecs.

--- a/srcpkgs/qt5-webengine/patches/string.patch
+++ b/srcpkgs/qt5-webengine/patches/string.patch
@@ -1,0 +1,12 @@
+--- a/src/3rdparty/chromium/gpu/command_buffer/service/program_manager.cc	2023-11-09 06:32:20.000000000 -0500
++++ b/src/3rdparty/chromium/gpu/command_buffer/service/program_manager.cc	2024-07-05 09:41:50.248682928 -0400
+@@ -620,7 +620,7 @@
+       output += hashed_name;
+   }
+ 
+-  return output + input.as_string();
++  return output + std::string(input);
+ }
+ 
+ void Program::UpdateLogInfo() {
+

--- a/srcpkgs/qt5-webengine/template
+++ b/srcpkgs/qt5-webengine/template
@@ -1,14 +1,14 @@
 # Template file for 'qt5-webengine'
 pkgname=qt5-webengine
 version=5.15.16
-revision=1
+revision=2
 _version="${version}-lts"
 _chromium_commit=207c2ac45ca3386d153770c6b0d2ea2ec21ca880
 archs="x86_64* i686* armv[67]* ppc64* aarch64*"
 create_wrksrc=yes
 build_style=qmake
 configure_args="--
- -webengine-icu -webengine-ffmpeg -webengine-opus -webengine-webp
+ -webengine-icu -system-ffmpeg -webengine-opus -webengine-webp
  -webengine-pepper-plugins -webengine-printing-and-pdf -webengine-proprietary-codecs
  -webengine-pulseaudio -webengine-spellchecker -webengine-webrtc -webengine-geolocation
  -webengine-kerberos -no-webengine-embedded-build $(vopt_if sndio '' '-no')-webengine-sndio
@@ -19,7 +19,7 @@ hostmakedepends="qt5-qmake gperf ninja qt5-host-tools flex pkg-config nodejs
  libjpeg-turbo-devel libpng-devel libwebp-devel freetype-devel
  harfbuzz-devel"
 makedepends="qt5-webchannel-devel qt5-location-devel qt5-tools-devel qt5-devel
- qt5-declarative-devel libevent-devel snappy-devel icu-devel ffmpeg-devel
+ qt5-declarative-devel libevent-devel snappy-devel icu-devel ffmpeg6-devel
  libwebp-devel opus-devel cups-devel nss-devel minizip-devel libxslt-devel
  libvpx-devel re2-devel libXtst-devel libXcursor-devel libXcomposite-devel
  jsoncpp-devel harfbuzz-devel lcms2-devel protobuf-devel pulseaudio-devel

--- a/srcpkgs/qt6-pdf/template
+++ b/srcpkgs/qt6-pdf/template
@@ -1,7 +1,7 @@
 # Template file for 'qt6-pdf'
 pkgname=qt6-pdf
 version=6.7.2
-revision=1
+revision=2
 build_style=cmake
 configure_args="-DQT_FEATURE_qtpdf_build=ON
  -DQT_FEATURE_qtpdf_widgets_build=ON
@@ -12,7 +12,7 @@ hostmakedepends="qt6-base-devel perl pkg-config nodejs python3-html5lib
  qt6-declarative-host-tools gperf bison flex nss-devel"
 makedepends="qt6-base-private-devel qt6-declarative-private-devel
  qt6-svg-devel zlib-devel
- pciutils-devel opus-devel libxslt-devel libxml2-devel ffmpeg-devel
+ pciutils-devel opus-devel libxslt-devel libxml2-devel ffmpeg6-devel
  lcms2-devel libwebp-devel icu-devel re2-devel snappy-devel libevent-devel
  libvpx-devel minizip-devel tiff-devel libpng-devel harfbuzz-devel
  freetype-devel libjpeg-turbo-devel nss-devel libxshmfence-devel"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing - !! TBD !!
- I built this PR locally for my native architecture, **x86_86**
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - **aarch64-musl**
  - **aarch64-musl**
  - **aarch64-musl**

#### Comments

Part of ffmpeg6 left overs https://github.com/void-linux/void-packages/issues/51522

Tested before on old branch with ffmpeg6 as main 'ffmpeg' package. Konqueror and other qt programs seemed fine.

Can build these later today/tonight since they take hours. May be fine without the qt5-webengine string patch.

(side note: pyside2 and shiboken2 compiled fine for me this morning)