### PR TITLE
lite-xl: enable SDL renderer

### DIFF
--- a/srcpkgs/lite-xl/template
+++ b/srcpkgs/lite-xl/template
@@ -1,10 +1,10 @@
 # Template file for 'lite-xl'
 pkgname=lite-xl
 version=2.1.5
-revision=1
+revision=2
 archs="x86_64* i686* aarch64* arm*" # garbage software
 build_style=meson
-configure_args="-Duse_system_lua=true"
+configure_args="-Duse_system_lua=true -Drenderer=true"
 hostmakedepends="pkg-config lua54"
 makedepends="freetype-devel lua54-devel pcre2-devel SDL2-devel"
 short_desc="Lightweight text editor written in Lua"


### PR DESCRIPTION
Default one eats 100% cpu just from mouse movement.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**


#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC) amd64
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64 (cross)

