### PR TITLE
dnsdist: update to 1.9.6

### DIFF
--- a/srcpkgs/dnsdist/template
+++ b/srcpkgs/dnsdist/template
@@ -1,6 +1,6 @@
 # Template file for 'dnsdist'
 pkgname=dnsdist
-version=1.9.5
+version=1.9.6
 revision=1
 build_style=gnu-configure
 configure_args="--with-pic --with-gnu-ld --with-libsodium --with-re2
@@ -18,7 +18,7 @@ license="GPL-2.0-only"
 homepage="https://dnsdist.org/"
 changelog="https://dnsdist.org/changelog.html"
 distfiles="https://downloads.powerdns.com/releases/${pkgname}-${version}.tar.bz2"
-checksum=4aee9088de5edaeff2a4104f3ea669605ae3e92e5dab9006c725f7775f6d254c
+checksum=f6c48d95525693fea6bd9422f3fdf69a77c75b06f02ed14ff0f42072f72082c9
 
 system_accounts="_dnsdist"
 


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**|**briefly**|**NO**

#### Local build testing
- I built this PR locally for my native architecture, x86-64-musl
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
