### PR TITLE
tuxedo-drivers: fix building on kernel 6.10

### DIFF
--- a/srcpkgs/tuxedo-drivers/patches/kernel6.10.patch
+++ b/srcpkgs/tuxedo-drivers/patches/kernel6.10.patch
@@ -1,0 +1,12 @@
+--- a/src/clevo_acpi.c
++++ b/src/clevo_acpi.c
+@@ -248,7 +248,9 @@ static const struct acpi_device_id clevo_acpi_device_ids[] = {
+ static struct acpi_driver clevo_acpi_driver = {
+ 	.name = DRIVER_NAME,
+ 	.class = DRIVER_NAME,
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 10, 0)
+ 	.owner = THIS_MODULE,
++#endif
+ 	.ids = clevo_acpi_device_ids,
+ 	.flags = ACPI_DRIVER_ALL_NOTIFY_EVENTS,
+ 	.ops = {

--- a/srcpkgs/tuxedo-drivers/template
+++ b/srcpkgs/tuxedo-drivers/template
@@ -1,7 +1,7 @@
 # Template file for 'tuxedo-drivers'
 pkgname=tuxedo-drivers
 version=4.6.1
-revision=1
+revision=2
 depends="dkms"
 short_desc="TUXEDO hardware drivers"
 maintainer="newbluemoon <blaumolch@mailbox.org>"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl
  - i686

@newbluemoon 

Added a patch from the AUR package which is maintained by a TuxedoComputers employee.