### PR TITLE
vimiv: rebuild to fix aarch64.

### DIFF
--- a/srcpkgs/vimiv/template
+++ b/srcpkgs/vimiv/template
@@ -1,7 +1,7 @@
 # Template file for 'vimiv'
 pkgname=vimiv
 version=0.9.1
-revision=8
+revision=9
 build_style=python3-module
 hostmakedepends="python3-setuptools python3-devel"
 makedepends="python3-devel"
@@ -13,6 +13,8 @@ homepage="http://karlch.github.io/vimiv/"
 distfiles="https://github.com/karlch/vimiv/archive/v${version}.tar.gz"
 checksum=7196341c41ad372f4d5d98bc96fba4aa55ad6e78d93afd617a62866bdaa6c087
 conf_files="/etc/vimiv/*"
+# Doesn't seem to impact the program
+make_check=no # ImportError: cannot import name '_image_enhance' from 'vimiv'
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)

I couldn't get tests to work and my C is down bad, so I'll skip those
tests.

Primary issue this PR is meant to fix is that vimiv is missing on
aarch64

- OK: https://repo-fastly.voidlinux.org/current/aarch64/vimiv-0.9.1_8.aarch64-musl.xbps
- NOT FOUND: https://repo-fastly.voidlinux.org/current/aarch64/vimiv-0.9.1_8.aarch64.xbps
