### PR TITLE
SPIRV-LLVM-Translator: update to 18.1.3.

### DIFF
--- a/srcpkgs/SPIRV-LLVM-Translator/template
+++ b/srcpkgs/SPIRV-LLVM-Translator/template
@@ -1,24 +1,25 @@
 # Template file for 'SPIRV-LLVM-Translator'
 pkgname=SPIRV-LLVM-Translator
-version=18.1.2
+version=18.1.3
 revision=1
 build_style=cmake
-make_build_args="llvm-spirv"
 configure_args="-Wno-dev -DLLVM_LINK_LLVM_DYLIB=ON -DCMAKE_SKIP_RPATH=ON
  -DLLVM_SPIRV_INCLUDE_TESTS=OFF -DBUILD_SHARED_LIBS=ON
  -DLLVM_EXTERNAL_SPIRV_HEADERS_SOURCE_DIR=/usr"
 hostmakedepends="clang18 llvm18"
-makedepends="llvm18-devel SPIRV-Headers"
+makedepends="llvm18-devel SPIRV-Headers SPIRV-Tools-devel"
 short_desc="API and commands for processing SPIR-V modules"
 maintainer="Daniel Martinez <danielmartinez@cock.li>"
 license="NCSA"
 homepage="https://github.com/KhronosGroup/SPIRV-LLVM-Translator"
 distfiles="https://github.com/KhronosGroup/SPIRV-LLVM-Translator/archive/refs/tags/v${version}.tar.gz"
-checksum=4724372934041c8feb8bcafea1c9d086ab2de9f323599068943ef61ddb0bca51
+checksum=d896f35102c3ba9e16ead7b4db53b75e6131982cdb36a3324f17c68a43598759
+
+alternatives="llvm-spirv:llvm-spirv:/usr/bin/llvm-spirv-${version%.*.*}"
 
 post_install() {
+	mv ${DESTDIR}/usr/bin/llvm-spirv ${DESTDIR}/usr/bin/llvm-spirv-${version%.*.*}
 	vlicense LICENSE.TXT
-	vbin ${wrksrc}/${cmake_builddir}/tools/llvm-spirv/llvm-spirv
 }
 
 SPIRV-LLVM-Translator-devel_package() {


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl
  - i686
  - aarch64 (cross)
  - aarch64-musl (cross)
  - armv7l (cross)
  - arvm7l-musl (cross)
  - armv6l (cross)
  - armv6l-musl (cross)

Also creates alternatives group in preparation for allowing parallel installable translators linked to different llvm versions