### PR TITLE
Signal-Desktop: update to 7.18.0.

### DIFF
--- a/srcpkgs/Signal-Desktop/template
+++ b/srcpkgs/Signal-Desktop/template
@@ -1,7 +1,7 @@
 # Template file for 'Signal-Desktop'
 pkgname=Signal-Desktop
-version=7.17.0
-revision=2
+version=7.18.0
+revision=1
 # Signal officially only supports x86_64
 # x86_64-musl could potentially work based on the Alpine port:
 # https://git.alpinelinux.org/aports/tree/testing/signal-desktop
@@ -14,7 +14,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="AGPL-3.0-only"
 homepage="https://github.com/signalapp/Signal-Desktop"
 distfiles="https://github.com/signalapp/Signal-Desktop/archive/v${version}.tar.gz"
-checksum=50fc28498023966f4724d01103693cfafacded01600d3ba410d6e06e48cd0f0a
+checksum=bf725bd0adcec7194021cf011e81d4db7d9a57eebd33f1e795fe2f5c6e316ed7
 nostrip_files="signal-desktop"
 
 post_extract() {


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc