### PR TITLE
New package: dotnet-sdk-8.0.7.

### DIFF
--- a/srcpkgs/aspnetcore-runtime
+++ b/srcpkgs/aspnetcore-runtime
@@ -1,0 +1,1 @@
+dotnet-sdk

--- a/srcpkgs/dotnet-runtime
+++ b/srcpkgs/dotnet-runtime
@@ -1,0 +1,1 @@
+dotnet-sdk

--- a/srcpkgs/dotnet-sdk/patches/sdk_telemetry-output.patch
+++ b/srcpkgs/dotnet-sdk/patches/sdk_telemetry-output.patch
@@ -1,0 +1,33 @@
+From 20472f229151ca848196a1d3276d9685cad662a0 Mon Sep 17 00:00:00 2001
+From: Luca Matei Pintilie <luca@lucamatei.com>
+Date: Thu, 6 Jul 2023 21:02:59 +0200
+Subject: [PATCH] SDK telemetry optout
+
+Disables telemetry by default.
+
+Patch copied from Alpine Linux
+and authored by Antoine Martin <dev@ayakael.net>
+---
+ src/sdk/src/Cli/dotnet/Program.cs | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/src/sdk/src/Cli/dotnet/Program.cs b/src/sdk/src/Cli/dotnet/Program.cs
+index 32a9f4ccc6..ac3f5fd293 100644
+--- a/src/sdk/src/Cli/dotnet/Program.cs
++++ b/src/sdk/src/Cli/dotnet/Program.cs
+@@ -27,6 +27,12 @@ public class Program
+ 
+         public static int Main(string[] args)
+         {
++            // opt out of telemetry by default if the env var is unset
++            string telemetryValue = Environment.GetEnvironmentVariable("DOTNET_CLI_TELEMETRY_OPTOUT");
++            if (String.IsNullOrEmpty(telemetryValue))
++            {
++                Environment.SetEnvironmentVariable("DOTNET_CLI_TELEMETRY_OPTOUT", "1");
++            }
+             using AutomaticEncodingRestorer _ = new();
+ 
+             // Setting output encoding is not available on those platforms
+-- 
+2.41.0
+

--- a/srcpkgs/dotnet-sdk/template
+++ b/srcpkgs/dotnet-sdk/template
@@ -1,0 +1,74 @@
+# Template file for 'dotnet-sdk'
+pkgname=dotnet-sdk
+version=8.0.7
+revision=1
+archs="x86_64"
+hostmakedepends="curl python3 clang cmake tar jq"
+makedepends="llvm18 mit-krb5-devel lttng-ust-devel icu-devel"
+depends="icu-libs"
+short_desc=".NET is the free framework for building apps and powerful services"
+maintainer="Luca Matei Pintilie <luca@lucamatei.com>"
+license="MIT"
+homepage="https://dotnet.microsoft.com/en-us/"
+changelog="https://github.com/dotnet/dotnet/releases/"
+distfiles="https://github.com/dotnet/dotnet/archive/refs/tags/v${version}.tar.gz
+ https://github.com/dotnet/dotnet/releases/download/v${version}/release.json"
+checksum="c190bd7ee6b4ec26681ce4d36118f2e74f6cae8256604bbb6f24b6d42a3df57c
+ 65dbc9c82c7b9fddaa815339173d369aeae7e3b1664daa86184609bb58d0e1e0"
+skip_extraction="release.json"
+
+# Private stuff used throughout below
+_libbase="/usr/lib/dotnet"
+_binbase="/usr/bin/dotnet"
+_rid="x64"
+_releasepath="$XBPS_SRCDISTDIR/$pkgname-$version/release.json"
+
+pre_build() {
+	bash ./prep.sh
+}
+
+do_build() {
+	PATH="/usr/libexec/chroot-git:${PATH}"
+	DOTNET_CLI_TELEMETRY_OPTOUT=1
+	bash ./build.sh \
+		--clean-while-building \
+		--online \
+		--source-repository "$(jq -r .sourceRepository "${_releasepath}")" \
+		--source-version "$(jq -r .sourceVersion "${_releasepath}")"
+}
+
+do_install() {
+	mkdir -p "${DESTDIR}${_libbase}"
+	tar xvf "artifacts/${_rid}/Release/dotnet-sdk-$(jq -r .sdkVersion "${_releasepath}")-void-${_rid}.tar.gz" -C "${DESTDIR}${_libbase}"
+	mkdir -p "${DESTDIR}/usr/bin"
+	ln -s "$_libbase/dotnet" "$DESTDIR$_binbase"
+	mkdir -p "$DESTDIR/etc/dotnet"
+	echo "$_libbase" > "$DESTDIR/etc/dotnet/install_location"
+}
+
+post_install() {
+	vlicense "LICENSE.TXT"
+	vlicense "THIRD-PARTY-NOTICES.txt"
+}
+
+dotnet-runtime_package() {
+	short_desc+=" - runtime"
+	depends="icu-libs"
+	pkg_install() {
+		mkdir -p "${PKGDESTDIR}${_libbase}"
+		tar xvf "artifacts/${_rid}/Release/dotnet-runtime-${version}-void-${_rid}.tar.gz" -C "${PKGDESTDIR}${_libbase}"
+		mkdir -p "${PKGDESTDIR}/usr/bin"
+		ln -s "$_libbase/dotnet" "$PKGDESTDIR$_binbase"
+		mkdir -p "$PKGDESTDIR/etc/dotnet"
+		echo "$_libbase" > "$PKGDESTDIR/etc/dotnet/install_location"
+	}
+}
+
+aspnetcore-runtime_package() {
+	short_desc+=" - aspnetcore-runtime"
+	depends="dotnet-runtime>=${version}_${revision}"
+	pkg_install() {
+		mkdir -p "${PKGDESTDIR}${_libbase}"
+		tar xvf "artifacts/${_rid}/Release/aspnetcore-runtime-${version}-void-${_rid}.tar.gz" -C "${PKGDESTDIR}${_libbase}"
+	}
+}


### PR DESCRIPTION
[ci skip]
#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)

Inspired by arch linux's package
https://gitlab.archlinux.org/archlinux/packaging/packages/dotnet-core/-/blob/main/PKGBUILD

Missing a couple subpackages, but should be a starting point.

A couple TODOs or stuff that are less than ideal:
- [ ] Downloading happens during do_configure and assets are not cached
- [ ] Only x86_64-glibc is supported, as I couldn't get it to work on
  musl due to some weird error.
- [ ] No test suite
