### PR TITLE
octave: switch to qt6, fix cross-build

### DIFF
--- a/srcpkgs/GraphicsMagick/template
+++ b/srcpkgs/GraphicsMagick/template
@@ -1,6 +1,6 @@
 # Template file for 'GraphicsMagick'
 pkgname=GraphicsMagick
-version=1.3.40
+version=1.3.43
 revision=1
 build_style=gnu-configure
 configure_args="--with-quantum-depth=16 --with-gs-font-dir=/usr/share/fonts/Type1
@@ -14,12 +14,12 @@ makedepends="perl libjpeg-turbo-devel libpng-devel tiff-devel libwebp-devel
  ${_develdepends}"
 depends="ghostscript"
 short_desc="GraphicsMagick Image Processing System"
-maintainer="Orphaned <orphan@voidlinux.org>"
+maintainer="Gonzalo Tornaría <tornaria@cmat.edu.uy>"
 license="MIT"
 homepage="http://www.graphicsmagick.org/"
 changelog="https://sourceforge.net/p/graphicsmagick/code/ci/default/tree/NEWS.txt?format=raw"
-distfiles="${SOURCEFORGE_SITE}/graphicsmagick/graphicsmagick/${version}/${pkgname}-${version}.tar.gz"
-checksum=88ddbf76e1ced2ab6bcd743207ee308865de1afb4b645d460924dcc8bfc0ee85
+distfiles="${SOURCEFORGE_SITE}/graphicsmagick/graphicsmagick/${version}/${pkgname}-${version}.tar.xz"
+checksum=2b88580732cd7e409d9e22c6116238bef4ae06fcda11451bf33d259f9cbf399f
 keep_libtool_archives=yes
 
 post_install() {
@@ -45,7 +45,7 @@ libgraphicsmagick-devel_package() {
 		vmove "usr/lib/*.so"
 		vmove "usr/lib/*.la"
 		vmove "usr/share/man/man1/*-config.1"
-		vcopy ${wrksrc}/PerlMagick usr/share/doc/GraphicsMagick*/
+		vcopy PerlMagick usr/share/doc/GraphicsMagick/
 		vdoc "${FILESDIR}/README.voidlinux"
 	}
 }

--- a/srcpkgs/SuiteSparse/template
+++ b/srcpkgs/SuiteSparse/template
@@ -1,6 +1,6 @@
 # Template file for 'SuiteSparse'
 pkgname=SuiteSparse
-version=7.7.0
+version=7.8.1
 revision=1
 build_style=cmake
 hostmakedepends="cmake gcc-fortran"
@@ -12,7 +12,7 @@ license="custom:multiple"
 homepage="https://people.engr.tamu.edu/davis/suitesparse.html"
 changelog="https://raw.githubusercontent.com/DrTimothyAldenDavis/SuiteSparse/master/ChangeLog"
 distfiles="https://github.com/DrTimothyAldenDavis/SuiteSparse/archive/refs/tags/v${version}.tar.gz"
-checksum=529b067f5d80981f45ddf6766627b8fc5af619822f068f342aab776e683df4f3
+checksum=b645488ec0d9b02ebdbf27d9ae307f705de2b6133edb64617a72c7b4c6c3ff44
 
 build_options="openblas"
 

--- a/srcpkgs/octave/template
+++ b/srcpkgs/octave/template
@@ -1,13 +1,18 @@
 # Template file for 'octave'
 pkgname=octave
 version=9.2.0
-revision=1
+revision=2
 build_style=gnu-configure
+build_helper=qmake6
 configure_args="--disable-docs"
-hostmakedepends="perl gcc-fortran pkg-config"
+hostmakedepends="perl gcc-fortran pkg-config qt6-base qt6-tools"
 makedepends="pcre2-devel readline-devel libSM-devel libltdl-devel lcms2-devel
- glpk-devel SuiteSparse-devel rapidjson"
-depends="$(vopt_if gui qt5-plugin-sqlite) texinfo"
+ glpk-devel SuiteSparse-devel rapidjson arpack-ng-devel libsndfile-devel
+ portaudio-devel libcurl-devel fftw-devel libgraphicsmagick-devel
+ qt6-base-devel qt6-tools-devel qt6-qt5compat-devel qt6-plugin-sqlite
+ qscintilla-qt6-devel glu-devel fltk-devel fontconfig-devel freetype-devel
+ gl2ps-devel libgomp-devel libqhull-devel zlib-devel"
+depends="qt6-plugin-sqlite texinfo"
 checkdepends="zip unzip ghostscript gnuplot tar texinfo"
 short_desc="High-level language, primarily intended for numerical computations"
 maintainer="Gonzalo Tornaría <tornaria@cmat.edu.uy>"
@@ -16,9 +21,6 @@ homepage="https://octave.org/"
 changelog="http://hg.savannah.gnu.org/hgweb/octave/raw-file/default/etc/NEWS.${version%%.*}.md"
 distfiles="${GNU_SITE}/octave/octave-${version}.tar.gz"
 checksum=0636554b05996997e431caad4422c00386d2d7c68900472700fecf5ffeb7c991
-
-# avoid warnings due to egrep deprecation
-export EGREP="grep -E"
 
 # Use OpenBLAS on platforms where it is available and fallback to regular BLAS
 # on all others.
@@ -33,52 +35,9 @@ case "$XBPS_TARGET_MACHINE" in
 		;;
 esac
 
-
-# Package build options
-# TODO: some options are still missing, such as java, qrupdate
-build_options="
- arpack
- audio
- curl
- fftw3
- graphicsmagick
- gui
- hdf5
- imagemagick
- opengl
- openmp
- qhull
- zlib"
-
-vopt_conflict graphicsmagick imagemagick
-
-desc_option_arpack="Provides 'eigs' and 'svds' functions."
-desc_option_audio="Provides audiofile related functionality."
-desc_option_curl="Provides 'urlread' and 'urlwrite' functions and the 'ftp' class."
-desc_option_fftw3="Improves performance on discrete Fourier transforms."
-desc_option_gui="Graphical User Interface."
-desc_option_graphicsmagick="Provides 'imread' and 'imwrite' functions."
-desc_option_hdf5="Support for HDF data files."
-desc_option_imagemagick="Provides 'imread' and 'imwrite' functions."
-desc_option_qhull="Provides 'convhull{,n}', 'delaunay{,n}' and 'voronoi{,n}' functions."
-desc_option_openmp="Enable support for OpenMP SMP multi-threading"
-desc_option_zlib="Support for compressed data."
-
-build_options_default="
- arpack
- audio
- curl
- fftw3
- graphicsmagick
- gui
- opengl
- openmp
- qhull
- zlib"
-
 if [ -z "$CROSS_BUILD" ]; then
 	# hdf5 is nocross
-	build_options_default+=" hdf5"
+	makedepends+=" hdf5-devel"
 fi
 
 if [ -n "$CROSS_BUILD" ];then
@@ -87,20 +46,6 @@ if [ -n "$CROSS_BUILD" ];then
 	# even in 64 bit architectures
 	configure_args+=" ax_blas_integer_size=4"
 fi
-
-makedepends+="
- $(vopt_if arpack arpack-ng-devel)
- $(vopt_if audio 'libsndfile-devel portaudio-devel')
- $(vopt_if curl libcurl-devel)
- $(vopt_if fftw3 fftw-devel)
- $(vopt_if graphicsmagick libgraphicsmagick-devel)
- $(vopt_if gui 'qt5-devel qt5-plugin-sqlite qscintilla-qt5-devel qt5-tools-devel')
- $(vopt_if hdf5 hdf5-devel)
- $(vopt_if imagemagick libmagick-devel)
- $(vopt_if opengl "glu-devel fltk-devel fontconfig-devel freetype-devel gl2ps-devel")
- $(vopt_if openmp libgomp-devel)
- $(vopt_if qhull libqhull-devel)
- $(vopt_if zlib zlib-devel)"
 
 case "$XBPS_TARGET_MACHINE" in
 	ppc64*) ;;


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **NO**

I cross built the package for aarch64 before and after and the log shows clearly that qt5 was broken before and claims to be working now. But I don't have an aarch64 box to actually test if this fixes #51602.

Closes: #51602 (hopefully)

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
