### PR TITLE
incus: fix check script

### DIFF
--- a/srcpkgs/incus/files/incus-user/check
+++ b/srcpkgs/incus/files/incus-user/check
@@ -1,3 +1,2 @@
 #!/bin/sh
-exec 2>&1
-exec incus config show >/dev/null
+exec incus config show >/dev/null 2>&1

--- a/srcpkgs/incus/template
+++ b/srcpkgs/incus/template
@@ -1,7 +1,7 @@
 # Template file for 'incus'
 pkgname=incus
 version=6.3.0
-revision=2
+revision=3
 build_style=go
 build_helper=qemu
 go_import_path=github.com/lxc/incus/v6


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Reason for making it
The line `exec 2>&1` in the beginning of `incus-user/check` would stop the execution of the script right there, and would return a non-zero value, making `sv restart incus-user` show a timeout (after 7 seconds), like this:

```
-bash-5.2# sv start incus-user
timeout: run: incus-user: (pid 9181) 7s
```

Placing `2>&1` at the right point, the execution of `sv restart incus-user` is like this:

```
-bash-5.2# sv restart incus-user
ok: run: incus-user: (pid 9370) 0s
```

...in less than a second.