### PR TITLE
x265: update to 3.6

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -1952,7 +1952,7 @@ libQt5TextToSpeech.so.5 qt5-speech-5.15.2_3
 libQt5Bodymovin.so.5 qt5-lottie-5.15.2_3
 libQt5WebKit.so.5 qt5-webkit-5.6.0_1
 libQt5WebKitWidgets.so.5 qt5-webkit-5.6.0_1
-libx265.so.199 x265-3.5_1
+libx265.so.209 x265-3.6_1
 libQt6Xdg.so.4 libqtxdg-4.0.0_1
 libQt6XdgIconLoader.so.4 libqtxdg-4.0.0_1
 libqwt-qt5.so.6.2 qwt-6.2.0_2

--- a/srcpkgs/avidemux/template
+++ b/srcpkgs/avidemux/template
@@ -1,7 +1,7 @@
 # Template file for 'avidemux'
 pkgname=avidemux
 version=2.8.1
-revision=1
+revision=2
 # Can't be compiled for aarch64, arm* or mips*
 archs="x86_64* i686*"
 hostmakedepends="cmake pkg-config qt5-host-tools qt5-devel tar yasm"

--- a/srcpkgs/baresip/template
+++ b/srcpkgs/baresip/template
@@ -1,7 +1,7 @@
 # Template file for 'baresip'
 pkgname=baresip
 version=3.14.0
-revision=2
+revision=3
 build_style=cmake
 hostmakedepends="pkg-config glib-devel"
 makedepends="libgsm-devel libpng-devel openssl-devel libsndfile-devel

--- a/srcpkgs/digikam/template
+++ b/srcpkgs/digikam/template
@@ -1,7 +1,7 @@
 # Template file for 'digikam'
 pkgname=digikam
 version=8.4.0
-revision=2
+revision=3
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins -DBUILD_WITH_QT6=ON

--- a/srcpkgs/ffmpeg/template
+++ b/srcpkgs/ffmpeg/template
@@ -2,7 +2,7 @@
 # audacity also needs to be bumped when a new ffmpeg version bumps libavformat's soname!
 pkgname=ffmpeg
 version=4.4.4
-revision=8
+revision=9
 build_style=meta
 short_desc="Decoding, encoding and streaming software (transitional dummy package)"
 maintainer="Orphaned <orphan@voidlinux.org>"

--- a/srcpkgs/ffmpeg6/template
+++ b/srcpkgs/ffmpeg6/template
@@ -2,7 +2,7 @@
 # audacity also needs to be bumped when a new ffmpeg version bumps libavformat's soname!
 pkgname=ffmpeg6
 version=6.0.1
-revision=2
+revision=3
 hostmakedepends="pkg-config perl"
 makedepends="zlib-devel bzip2-devel freetype-devel alsa-lib-devel libXfixes-devel
  libXext-devel libXvMC-devel libxcb-devel lame-devel libtheora-devel

--- a/srcpkgs/gimp/template
+++ b/srcpkgs/gimp/template
@@ -1,7 +1,7 @@
 # Template file for 'gimp'
 pkgname=gimp
 version=2.10.38
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--disable-check-update --datadir=/usr/share --disable-python"
 hostmakedepends="automake gegl gettext-devel glib-devel gtk+-devel intltool

--- a/srcpkgs/gst-plugins-bad1/template
+++ b/srcpkgs/gst-plugins-bad1/template
@@ -1,7 +1,7 @@
 # Template file for 'gst-plugins-bad1'
 pkgname=gst-plugins-bad1
 version=1.24.6
-revision=1
+revision=2
 build_helper="gir"
 build_style=meson
 configure_args="-Dpackage-origin=https://voidlinux.org -Ddoc=disabled

--- a/srcpkgs/handbrake/template
+++ b/srcpkgs/handbrake/template
@@ -1,7 +1,7 @@
 # Template file for 'handbrake'
 pkgname=handbrake
 version=1.6.1
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--force --disable-gtk-update-checks --disable-df-fetch --harden
  $(vopt_enable fdk_aac fdk-aac) $(vopt_enable nvenc) $(vopt_enable qsv)"
@@ -12,7 +12,8 @@ makedepends="bzip2-devel ffmpeg6-devel gst-plugins-base1-devel gtk+3-devel
  jansson-devel lame-devel libass-devel libbluray-devel libdav1d-devel
  libdvdnav-devel libdvdread-devel libgudev-devel libnuma-devel
  libsamplerate-devel libtheora-devel libvorbis-devel libvpx-devel libxml2-devel
- opus-devel speex-devel x264-devel x265-devel zimg-devel libsvt-av1-devel
+ opus-devel speex-devel x264-devel x265-devel zimg-devel
+ $(vopt_if svt_av1 libsvt-av1-devel)
  $(vopt_if fdk_aac fdk-aac-devel)
  $(vopt_if qsv 'libva-devel libdrm-devel oneVPL-devel')
  $(vopt_if nvenc nv-codec-headers)"
@@ -26,12 +27,19 @@ distfiles="https://github.com/HandBrake/HandBrake/releases/download/${version}/H
 checksum=94ccfe03db917a91650000c510f7fd53f844da19f19ad4b4be1b8f6bc31a8d4c
 nocross=yes
 
-build_options="fdk_aac nvenc qsv"
+build_options="fdk_aac nvenc svt_av1 qsv"
 
 case "$XBPS_TARGET_MACHINE" in
-	x86_64*|i686*)
+	x86_64*)
 		CFLAGS="-msse"
-		build_options_default="nvenc qsv"
+		build_options_default="nvenc svt_av1 qsv"
+		;;
+	i686*)
+		CFLAGS="-msse"
+		build_options_default="nvenc"
+		;;
+	*)
+		build_options_default="svt_av1"
 		;;
 esac
 
@@ -42,6 +50,11 @@ pre_configure() {
 		x265 zimg svt-av1 libvpl; do
 	    vsed -i "/MODULES += contrib\/${module}/d" make/include/main.defs
 	done
+	if [[ "$XBPS_TARGET_MACHINE" = "i686"* ]] ; then
+		vsed -e 's/-lSvtAv1Enc //g' -i gtk/configure.ac
+		vsed -e 's/ SvtAv1Enc//g' -i test/module.defs
+		vsed -e 's/ SvtAv1Enc//g' -i libhb/module.defs
+	fi
 }
 
 pre_build() {

--- a/srcpkgs/libheif/template
+++ b/srcpkgs/libheif/template
@@ -1,7 +1,7 @@
 # Template file for 'libheif'
 pkgname=libheif
 version=1.17.5
-revision=1
+revision=2
 build_style=cmake
 makedepends="libjpeg-turbo-devel libpng-devel libde265-devel x265-devel
  libaom-devel"

--- a/srcpkgs/vlc/template
+++ b/srcpkgs/vlc/template
@@ -1,7 +1,7 @@
 # Template file for 'vlc'
 pkgname=vlc
 version=3.0.21
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--disable-gme --disable-libtar --enable-jack
  --enable-live555 --disable-fluidsynth --enable-dvdread

--- a/srcpkgs/x265/patches/handbrake-ambientlight.patch
+++ b/srcpkgs/x265/patches/handbrake-ambientlight.patch
@@ -1,0 +1,115 @@
+diff --git a/source/common/param.cpp b/source/common/param.cpp
+index 8c32fafa2..0b56235c9 100755
+--- a/source/common/param.cpp
++++ b/source/common/param.cpp
+@@ -378,6 +378,7 @@ void x265_param_default(x265_param* param)
+     param->preferredTransferCharacteristics = -1;
+     param->pictureStructure = -1;
+     param->bEmitCLL = 1;
++    param->bEmitAmbientViewingEnvironment = 0;
+ 
+     param->bEnableFrameDuplication = 0;
+     param->dupThreshold = 70;
+@@ -1880,6 +1881,7 @@ int x265_check_params(x265_param* param)
+                      || param->bEmitIDRRecoverySEI
+                    || !!param->interlaceMode
+                      || param->preferredTransferCharacteristics > 1
++                     || param->bEmitAmbientViewingEnvironment
+                      || param->toneMapFile
+                      || param->naluFile);
+ 
+@@ -2766,6 +2768,10 @@ void x265_copy_params(x265_param* dst, x265_param* src)
+     dst->bEmitCLL = src->bEmitCLL;
+     dst->maxCLL = src->maxCLL;
+     dst->maxFALL = src->maxFALL;
++    dst->ambientIlluminance = src->ambientIlluminance;
++    dst->ambientLightX = src->ambientLightX;
++    dst->ambientLightY = src->ambientLightY;
++    dst->bEmitAmbientViewingEnvironment = src->bEmitAmbientViewingEnvironment;
+     dst->log2MaxPocLsb = src->log2MaxPocLsb;
+     dst->bEmitVUIHRDInfo = src->bEmitVUIHRDInfo;
+     dst->bEmitVUITimingInfo = src->bEmitVUITimingInfo;
+diff --git a/source/encoder/encoder.cpp b/source/encoder/encoder.cpp
+index 5950f87e9..545283474 100644
+--- a/source/encoder/encoder.cpp
++++ b/source/encoder/encoder.cpp
+@@ -3276,6 +3276,15 @@ void Encoder::getStreamHeaders(NALList& list, Entropy& sbacCoder, Bitstream& bs)
+         }
+     }
+ 
++    if (m_param->bEmitAmbientViewingEnvironment)
++    {
++        SEIAmbientViewingEnvironment ambientsei;
++        ambientsei.ambientIlluminance = m_param->ambientIlluminance;
++        ambientsei.ambientLightX = m_param->ambientLightX;
++        ambientsei.ambientLightY = m_param->ambientLightY;
++        ambientsei.writeSEImessages(bs, m_sps, NAL_UNIT_PREFIX_SEI, list, m_param->bSingleSeiNal);
++    }
++
+     if (m_param->bEmitInfoSEI)
+     {
+         char *opts = x265_param2string(m_param, m_sps.conformanceWindow.rightOffset, m_sps.conformanceWindow.bottomOffset);
+diff --git a/source/encoder/sei.h b/source/encoder/sei.h
+index 03e210639..712e4efb4 100644
+--- a/source/encoder/sei.h
++++ b/source/encoder/sei.h
+@@ -242,6 +242,25 @@ public:
+     }
+ };
+ 
++class SEIAmbientViewingEnvironment : public SEI
++{
++public:
++    SEIAmbientViewingEnvironment()
++    {
++        m_payloadType = AMBIENT_VIEWING_ENVIRONMENT;
++        m_payloadSize = 8;
++    }
++    uint32_t ambientIlluminance;
++    uint16_t ambientLightX;
++    uint16_t ambientLightY;
++    void writeSEI(const SPS&)
++    {
++        WRITE_CODE(ambientIlluminance, 32, "ambient_illuminance");
++        WRITE_CODE(ambientLightX,      16, "ambient_light_x");
++        WRITE_CODE(ambientLightY,      16, "ambient_light_y");
++    }
++};
++
+ class SEIDecodedPictureHash : public SEI
+ {
+ public:
+diff --git a/source/x265.h b/source/x265.h
+index 9f3abd9d9..b6a4d3fe1 100644
+--- a/source/x265.h
++++ b/source/x265.h
+@@ -371,6 +371,7 @@ typedef enum
+     MASTERING_DISPLAY_INFO               = 137,
+     CONTENT_LIGHT_LEVEL_INFO             = 144,
+     ALTERNATIVE_TRANSFER_CHARACTERISTICS = 147,
++    AMBIENT_VIEWING_ENVIRONMENT          = 148,
+ } SEIPayloadType;
+ 
+ typedef struct x265_sei_payload
+@@ -1903,6 +1904,11 @@ typedef struct x265_param
+      * value to that value. */
+     uint16_t maxLuma;
+ 
++    /* ISO/IEC 23008-2:2017, D.2.39 ambient viewing environment SEI message */
++    uint32_t ambientIlluminance;
++    uint16_t ambientLightX;
++    uint16_t ambientLightY;
++
+     /* Maximum of the picture order count */
+     int log2MaxPocLsb;
+ 
+@@ -2114,6 +2120,9 @@ typedef struct x265_param
+     /*Emit content light level info SEI*/
+     int         bEmitCLL;
+ 
++    /* Emit ambient viewing environment SEI */
++    int         bEmitAmbientViewingEnvironment;
++
+     /*
+     * Signals picture structure SEI timing message for every frame
+     * picture structure 7 is signalled for frame doubling

--- a/srcpkgs/x265/template
+++ b/srcpkgs/x265/template
@@ -1,8 +1,7 @@
 # Template file for 'x265'
 pkgname=x265
-version=3.5
+version=3.6
 revision=1
-_commit="f0c1022b6be1"
 build_wrksrc=source
 build_style=cmake
 configure_args="-DENABLE_PIC=1"
@@ -12,7 +11,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="http://x265.org/"
 distfiles="https://bitbucket.org/multicoreware/x265_git/get/${version}.tar.gz"
-checksum=5ca3403c08de4716719575ec56c686b1eb55b078c0fe50a064dcf1ac20af1618
+checksum=206329b9599c78d06969a1b7b7bb939f7c99a459ab283b2e93f76854bd34ca7b
 
 build_options="altivec assembly"
 


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, **x86_64**
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - **aarch64-musl**

#### Comments

Part #51478 - handbrake 1.8.1 needs newer x265 with some 'ambient light' patches, newer [libvpl](https://github.com/void-linux/void-packages/pull/51496) (this PR conflicts revbumps with libvpl) and ffmpeg6.0 down patches

When I forgot to update shlibs, xbps-src mentioned `digikam` needing a revbump? Not quite sure why as I don't see x265-devel in the template but I bumped anyway.