### PR TITLE
leftwm: update to 0.5.1.

### DIFF
--- a/srcpkgs/leftwm/patches/fix_32bit_builds.patch
+++ b/srcpkgs/leftwm/patches/fix_32bit_builds.patch
@@ -1,0 +1,24 @@
+From 75257283248c99347089225befee851e2d6e2895 Mon Sep 17 00:00:00 2001
+From: Adrian <github@eskaan.de>
+Date: Mon, 1 Jan 2024 07:55:18 +0100
+Subject: [PATCH] Fix the 32 bit builds by changing a type cast (#1202)
+
+`i64::from` was replaced by a direct `as` type cast.
+
+Tested on i686-unknown-linux-gnu
+---
+ display-servers/xlib-display-server/src/xwrap/setters.rs | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/display-servers/xlib-display-server/src/xwrap/setters.rs b/display-servers/xlib-display-server/src/xwrap/setters.rs
+index f0cb569ed..efd4034b7 100644
+--- a/display-servers/xlib-display-server/src/xwrap/setters.rs
++++ b/display-servers/xlib-display-server/src/xwrap/setters.rs
+@@ -94,7 +94,7 @@ impl XWrap {
+ 
+     /// Sets a desktop property.
+     pub fn set_desktop_prop(&self, data: &[u32], atom: c_ulong) {
+-        let x_data: Vec<c_long> = data.iter().map(|x| i64::from(*x)).collect();
++        let x_data: Vec<c_long> = data.iter().map(|x| *x as c_long).collect();
+         self.replace_property_long(self.root, atom, xlib::XA_CARDINAL, &x_data);
+     }

--- a/srcpkgs/leftwm/template
+++ b/srcpkgs/leftwm/template
@@ -1,6 +1,6 @@
 # Template file for 'leftwm'
 pkgname=leftwm
-version=0.4.2
+version=0.5.1
 revision=1
 build_style=cargo
 configure_args="--no-default-features --features lefthk,sys-log"
@@ -12,7 +12,11 @@ license="MIT"
 homepage="https://github.com/leftwm/leftwm"
 changelog="https://raw.githubusercontent.com/leftwm/leftwm/main/CHANGELOG"
 distfiles="https://github.com/leftwm/leftwm/archive/refs/tags/${version}.tar.gz"
-checksum=97a86b2966d20fd56237905fd90692a873e979759831f6030da2db9d5dc11f2b
+checksum=3c8ab0fdbfe205b33ad7ae108d3a604bdd22663458bf803e0a3a4a924aad963a
+
+post_patch() {
+	cargo update --package time@0.3.30 --precise 0.3.36
+}
 
 do_install() {
 	vdoc README.md


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**


#### Local build testing
- I built this PR locally for my native architecture, x86_64
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - armv7l
 
#### Additional info
There is already a PR #48571 open since months to update leftwm to the same version but I prefered to open a new one based on a more recent version of the repository.

2 issues encountered during the build

- as in the original PR, leftwm does not compile on 32 bit architecture due to a small bug in the code. The patch `fix_32bit_builds.patch` fixes that based on upstream commit
- new issue, one of the leftwm dependencies (time crate) does not compile in the version defined in the project using rust 1.80. The second patch `cargo_update_time.patch` fixes this and I also opened an [issue](https://github.com/leftwm/leftwm/issues/1272) upstream to request a fix and a new release.


