### PR TITLE
qarma: update for qt6

### DIFF
--- a/srcpkgs/qarma/template
+++ b/srcpkgs/qarma/template
@@ -1,16 +1,17 @@
 # Template file for 'qarma'
 pkgname=qarma
 version=t1
-revision=2
+revision=3
+_commit=c623e0679e4bdaa17505f2a76d2b35cc66caf598
 build_style=qmake
-hostmakedepends="qt5-qmake qt5-host-tools"
-makedepends="qt5-x11extras-devel"
+hostmakedepends="qt6-base"
+makedepends="qt6-base-devel qt6-widgets"
 short_desc="Tool to create dialog boxes, based on Qt"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-only"
 homepage="https://github.com/luebking/qarma"
-distfiles="https://github.com/luebking/qarma/archive/${version}.tar.gz"
-checksum=ebce381d2884e4109998bc4a966f1eb08cc549b2725b0f4c5525b30849754794
+distfiles="https://github.com/luebking/qarma/archive/${_commit}.tar.gz"
+checksum=40fb41ee39e685b376d30acc5820cd51af503eaa4de0684ba5a4a85fc71b00a1
 replaces="zenity>=0"
 provides="zenity-${version}_${revision}"
 


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, **x86_64**

#### Comments

The last issue about a new release is from 2019 and I don't see one coming any time soon, so I used a commit to compile for qt6.