### PR TITLE
tiff: fix cycle by disabling webp support by default

### DIFF
--- a/srcpkgs/tiff/template
+++ b/srcpkgs/tiff/template
@@ -1,17 +1,20 @@
 # Template file for 'tiff'
 pkgname=tiff
 version=4.6.0
-revision=2
+revision=3
 build_style=gnu-configure
 configure_args="--enable-cxx --without-x"
 makedepends="jbigkit-devel libjpeg-turbo-devel
- liblzma-devel libzstd-devel zlib-devel libwebp-devel"
+ liblzma-devel libzstd-devel zlib-devel $(vopt_if webp libwebp-devel)"
 short_desc="Library and tools for reading and writing TIFF data files"
 maintainer="skmpz <dem.procopiou@gmail.com>"
 license="libtiff"
 homepage="http://www.simplesystems.org/libtiff/"
 distfiles="https://download.osgeo.org/libtiff/tiff-${version}.tar.gz"
 checksum=88b3979e6d5c7e32b50d7ec72fb15af724f6ab2cbf7e10880c360a77e4b5d99a
+
+# Causes cyclic dependency with libwebp
+build_options="webp"
 
 if [ "$XBPS_CHECK_PKGS" ]; then
 	configure_args+=" --enable-tests"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
<!--
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
