### PR TITLE
libwebp: fix -devel depends

### DIFF
--- a/srcpkgs/libwebp/template
+++ b/srcpkgs/libwebp/template
@@ -1,7 +1,7 @@
 # Template file for 'libwebp'
 pkgname=libwebp
 version=1.4.0
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--enable-libwebpmux --enable-libwebpdemux --enable-libwebpdecoder"
 hostmakedepends="pkg-config"
@@ -33,7 +33,7 @@ libwebp-tools_package() {
 }
 
 libwebp-devel_package() {
-	depends="${makedepends/libfreeglut-devel/} libsharpyuv-devel>=${version}_${revision} ${sourcepkg}>=${version}_${revision}"
+	depends="libsharpyuv-devel>=${version}_${revision} ${sourcepkg}>=${version}_${revision}"
 	short_desc+=" - development files"
 	pkg_install() {
 		vmove usr/include
@@ -52,6 +52,7 @@ libsharpyuv_package() {
 
 libsharpyuv-devel_package() {
 	short_desc="Library to expose libwebp's sharpyuv functionality - development files"
+	depends="libsharpyuv>=${version}_${revision}"
 	pkg_install() {
 		vmove usr/include/webp/sharpyuv
 		vmove usr/lib/pkgconfig/libsharpyuv.pc


### PR DESCRIPTION
makedepends are only used for the tools, not for the library
