### PR TITLE
brother-brscan4: update to 0.4.11

### DIFF
--- a/srcpkgs/brother-brscan4/INSTALL
+++ b/srcpkgs/brother-brscan4/INSTALL
@@ -1,9 +1,48 @@
+readonly opt_dir=/opt/brother/scanner/brscan4
+readonly etc_dir=/etc/opt/brother/scanner/brscan4
+
+# The config files are nominally "Brsane4.ini", "brsanenetdevice4.cfg",
+# and "models4/". Among these, only "brsanenetdevice4.cfg" is
+# potentially modified by the user.
+readonly config="brsanenetdevice4.cfg"
+
+readonly migrate_dir=/tmp
+readonly migrate_ext=brscan4.migrate
+
+# Packages with versions <= 0.4.9 used config files in "${etc_dir}/*".
+# However, "brsaneconfig4" expects to find them in "${opt_dir}/*" with
+# a symlink in "${etc_dir}/". If the non-symlink version of these is found,
+# it means it comes from those older packages and must be migrated.
+record_older_config()
+{
+	if [ -e "${etc_dir}/${config}" ] && [ ! -L "${etc_dir}/${config}" ]; then
+		cp "${etc_dir}/${config}" "${migrate_dir}/${config}.${migrate_ext}"
+	fi
+}
+
+# If the "record_older_config()" has created files for migrations
+# in ${migrate_dir} during the "pre" action, then they must be moved
+# into ${opt_dir} during the "post" action.
+# The config file, "brsanenetdevice4.cfg", provided by the package
+# is an empty file, so it can simply be overwritten by the user's file.
+use_older_config()
+{
+	# Is there any file to migrate?
+	if [ -f "${migrate_dir}/${config}.${migrate_ext}" ]; then
+		mv "${migrate_dir}/${config}.${migrate_ext}" "${opt_dir}/${config}"
+	fi
+}
+
 case "${ACTION}" in
-    post)
+pre)
+	record_older_config
+	;;
+post)
 	# Add brother driver to sane configuration
-	_SANE_CONF='/etc/sane.d/dll.conf'
-	if [ "$(grep brother4 ${_SANE_CONF})" = '' ]; then
-		echo brother4 >> ${_SANE_CONF}	
+	_SANE_CONF="/etc/sane.d/dll.conf"
+	if [ "$(grep brother4 ${_SANE_CONF})" = "" ]; then
+		echo brother4 >> "${_SANE_CONF}"
 	fi;
-    ;;
+	use_older_config
+	;;
 esac

--- a/srcpkgs/brother-brscan4/files/40-brother-brscan4-libsane-type1.rules
+++ b/srcpkgs/brother-brscan4/files/40-brother-brscan4-libsane-type1.rules
@@ -1,0 +1,18 @@
+ACTION!="add", GOTO="brother_mfp_end"
+SUBSYSTEM=="usb", GOTO="brother_mfp_udev_1"
+SUBSYSTEM!="usb_device", GOTO="brother_mfp_end"
+LABEL="brother_mfp_udev_1"
+# Comment out the SYSFS line for Void Linux. Else, in dmesg will be:
+#   ...udevd: unknown key 'SYSFS{idVendor}'...
+#SYSFS{idVendor}=="04f9", GOTO="brother_mfp_udev_2"
+ATTRS{idVendor}=="04f9", GOTO="brother_mfp_udev_2"
+GOTO="brother_mfp_end"
+LABEL="brother_mfp_udev_2"
+ATTRS{bInterfaceClass}!="0ff", GOTO="brother_mfp_end"
+ATTRS{bInterfaceSubClass}!="0ff", GOTO="brother_mfp_end"
+ATTRS{bInterfaceProtocol}!="0ff", GOTO="brother_mfp_end"
+#MODE="0666"
+#GROUP="scanner"
+ENV{libsane_matched}="yes"
+#SYMLINK+="scanner-%k"
+LABEL="brother_mfp_end"

--- a/srcpkgs/brother-brscan4/files/README.voidlinux
+++ b/srcpkgs/brother-brscan4/files/README.voidlinux
@@ -1,3 +1,9 @@
 In order to access networked scanners and multifunctionals, the SANE backend 
 must be configured using 'brsaneconfig4'.
-See http://support.brother.com/g/s/id/linux/en/instruction_scn1b.html
+
+They can be added like:
+# brsaneconfig4 -a name=<name>    model=<model>      ip=<ip_address>
+# brsaneconfig4 -a name=myscanner model=DCP-L8410CDW ip=192.168.1.50
+
+Diagnosie with:
+$ brsaneconfig4 -d

--- a/srcpkgs/brother-brscan4/template
+++ b/srcpkgs/brother-brscan4/template
@@ -1,6 +1,6 @@
 # Template file for 'brother-brscan4'
 pkgname=brother-brscan4
-version=0.4.9
+version=0.4.11
 revision=1
 archs="i686 x86_64"
 depends="sane"
@@ -11,9 +11,9 @@ homepage="https://support.brother.com/"
 repository="nonfree"
 nopie=yes
 _mylibrary="libsane-brother4.so.1.0.7"
-conf_files="/etc/opt/brother/scanner/brscan4/Brsane4.ini
- /etc/opt/brother/scanner/brscan4/brsanenetdevice4.cfg
- /etc/opt/brother/scanner/brscan4/models4/*.ini"
+conf_files="/opt/brother/scanner/brscan4/Brsane4.ini
+ /opt/brother/scanner/brscan4/brsanenetdevice4.cfg
+ /opt/brother/scanner/brscan4/models4/*.ini"
 
 # The license was removed by Brother - we vendor it.
 # distfiles="http://www.brother.com/agreement/English_sane/agree.html>LICENSE.html"
@@ -21,24 +21,44 @@ conf_files="/etc/opt/brother/scanner/brscan4/Brsane4.ini
 
 if [ "$XBPS_TARGET_MACHINE" = "x86_64" ]; then
 	_rpmpkgid="1.x86_64"
-	distfiles="https://download.brother.com/welcome/dlf006648/brscan4-${version}-${_rpmpkgid}.rpm"
-	checksum="0d0af0f3f299a94d32b275f4714c72407ee679dd9e27eac050d6728cd728ac89"
+	distfiles="https://download.brother.com/welcome/dlf105203/brscan4-${version}-${_rpmpkgid}.rpm"
+	checksum="7d7dcbe8349ae4d4ab816e4551017f2f1fd9fd6bf3f4f3c570fbd9576248dd9f"
 	_rpmlibdir="usr/lib64"
 else
 	_rpmpkgid="1.i386"
-	distfiles="https://download.brother.com/welcome/dlf006647/brscan4-${version}-${_rpmpkgid}.rpm"
-	checksum="73bcbcc661a05000375266369fc6e22a980cc956ac7f92926ff42516f92845f8"
+	distfiles="https://download.brother.com/welcome/dlf105202/brscan4-${version}-${_rpmpkgid}.rpm"
+	checksum="8bd395b8a25a385eb4a5e2770d4b10b17735203006b7a90a6879a0ef69e5fe4d"
 	_rpmlibdir="usr/lib"
 fi
 
 do_install() {
 	# binary package makes a fine mess of things, and installs stuff in very
-	# unwieldly locations. Some of this cannot be avoided.
+	# unwieldy locations. Some of this cannot be avoided.
+	#
+	# The query command, "brsaneconfig4 -q", only works under these conditions:
+	#
+	# 1. The "brsaneconfig4" binary must be in /opt/brother/scanner/brscan4/.
+	#    We can still make a symlink in /usr/bin/, but we cannot copy it there.
+	#
+	# 2. The configuration files must reside in /opt/brother/scanner/bscan4/.
+	#    And their symlink must be in /etc/opt/brother/scanner/brscan4/.
+
 
 	# deb package installs 64-bit libraries in /usr/lib64; fix this
 	vinstall ./${_rpmlibdir}/sane/${_mylibrary} 755 usr/lib/sane
 	ln -sf /usr/lib/sane/${_mylibrary} ${DESTDIR}/usr/lib/sane/$(echo ${_mylibrary} | sed -e 's/\.[0-9]\.[0-9]$//')
 	ln -sf /usr/lib/sane/${_mylibrary} ${DESTDIR}/usr/lib/sane/$(echo ${_mylibrary} | sed -e 's/\.[0-9]\.[0-9]\.[0-9]$//')
+
+	vinstall ${FILESDIR}/40-brother-brscan4-libsane-type1.rules 644 usr/lib/udev/rules.d
+
+	vmkdir opt/brother/scanner/brscan4 755
+	vcopy  opt/brother/scanner/brscan4/models4 opt/brother/scanner/brscan4
+
+	vinstall opt/brother/scanner/brscan4/Brsane4.ini          644 opt/brother/scanner/brscan4
+	vinstall opt/brother/scanner/brscan4/brsanenetdevice4.cfg 644 opt/brother/scanner/brscan4
+	vinstall opt/brother/scanner/brscan4/brscan_cnetconfig    755 opt/brother/scanner/brscan4
+	vinstall opt/brother/scanner/brscan4/brscan_gnetconfig    755 opt/brother/scanner/brscan4
+	vinstall opt/brother/scanner/brscan4/brsaneconfig4        755 opt/brother/scanner/brscan4
 
 	# The binary library has hard-coded paths to
 	#
@@ -46,23 +66,18 @@ do_install() {
 	#
 	# This is very unfortunate, but cannot be avoided without the source to
 	# recompile the binary - which is not available.
-	#
-	# The deb package then goes ahead and installs symlinks to the actual
-	# files in /opt/brother/scanner/brscan4. Limit the mess by actually
-	# installing these files to /etc/opt/brother/scanner/brscan4 so there
-	# are no configuration files in /opt
-
 	vmkdir etc/opt/brother/scanner/brscan4 755
-	vinstall opt/brother/scanner/brscan4/Brsane4.ini 644 etc/opt/brother/scanner/brscan4
-	vinstall opt/brother/scanner/brscan4/brsanenetdevice4.cfg 644 etc/opt/brother/scanner/brscan4
-	vcopy opt/brother/scanner/brscan4/models4 etc/opt/brother/scanner/brscan4
+	for link in Brsane4.ini brsanenetdevice4.cfg models4/; do
+		ln -sf /opt/brother/scanner/brscan4/${link} ${DESTDIR}/etc/opt/brother/scanner/brscan4/
+	done
 
 	# Install the licenses.
 	vlicense ${FILESDIR}/agree.html LICENSE.html
 	vlicense opt/brother/scanner/brscan4/doc/brscan4/readme.txt # Independent JPEG blurb.
 
 	# config helper - installed by the deb package as a symlink.
-	vbin opt/brother/scanner/brscan4/brsaneconfig4
+	vmkdir usr/bin 755
+	ln -sf /opt/brother/scanner/brscan4/brsaneconfig4 ${DESTDIR}/usr/bin/brsaneconfig4
 
 	# The only file in the deb package that has *not* been installed is a
 	# setup script to modify the SANE configuration. This will be performed


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, `x86_64-glibc`

```
Along the way, I have also made the package template look closer
to brother-brscan5. That practically means:

- Adding symlink in /etc/opt/... to configuration files in /opt/...
- Handle udev rule

Also, I have updated the README.voidlinux (URL mentioned in there was
not valid anymore) AND added brscan_{c,g}netconfig files to the
package. Else, "brsaneconfig4" would complain when adding a new device.
```