### PR TITLE
mariadb: update to 11.4.2

### DIFF
--- a/srcpkgs/mariadb/INSTALL
+++ b/srcpkgs/mariadb/INSTALL
@@ -6,7 +6,7 @@ post)
 	chmod 700 usr/lib/mysql/plugin/auth_pam_tool_dir
 	chown mysql usr/lib/mysql/plugin/auth_pam_tool_dir
 	if [ "$UPDATE" = "no" ] &&  [ ! -f var/lib/mysql/mysql-bin.index ]; then
-		chpst -u mysql:mysql usr/bin/mysql_install_db --user=mysql --basedir=/usr \
+		chpst -u mysql:mysql usr/bin/mariadb-install-db --user=mysql --basedir=/usr \
 				--datadir=/var/lib/mysql --rpm --cross-bootstrap
 	fi
 	;;

--- a/srcpkgs/mariadb/template
+++ b/srcpkgs/mariadb/template
@@ -1,7 +1,7 @@
 # Template file for 'mariadb'
 pkgname=mariadb
-version=11.1.2
-revision=2
+version=11.4.2
+revision=1
 build_style=cmake
 build_helper=qemu
 configure_args="-DBUILD_CONFIG=mysql_release
@@ -27,7 +27,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-only"
 homepage="https://mariadb.com"
 distfiles="https://archive.mariadb.org/mariadb-${version}/source/mariadb-${version}.tar.gz"
-checksum=19a9e980e57fa332931f643b48ad7390528c889ff6ea8b0e16fd306aa3088238
+checksum=8c600e38adb899316c1cb11c68b87979668f4fb9d858000e347e6d8b7abe51b0
 lib32disabled=yes
 provides="mysql-${version}_${revision}"
 replaces="mysql>=0"


### PR DESCRIPTION
Changed the INSTALL script to use mariadb-install-db instead of 'mysql_install_db' since it's deprecated

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
#### Local build testing
- I built this PR locally for my native architecture, (x64-GLIBC)

