### PR TITLE
ffmpeg: strip static libs fix for i686-musl

### DIFF
--- a/srcpkgs/ffmpeg/template
+++ b/srcpkgs/ffmpeg/template
@@ -224,10 +224,11 @@ ffmpeg-devel_package() {
 	short_desc="Decoding, encoding and streaming software - development files"
 	conflicts="ffmpeg6-devel"
 	replaces="ffmpeg6-devel>=0"
-	if [ "$XBPS_TARGET_MACHINE" = "i686" ]; then
+	case "$XBPS_TARGET_MACHINE" in
+		i686*)
 		# /usr/bin/strip: error: the input file '/destdir//ffmpeg-devel-4.4.4/usr/lib/libavfilter.a(vf_atadenoise.o)' has no sections
-		nostrip_files="/usr/lib/libavfilter.a"
-	fi
+		nostrip_files="/usr/lib/libavfilter.a";;
+	esac
 
 	pkg_install() {
 		vmove usr/include


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture: x86_64-musl
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64
  - i686
  - i686-musl
  - aarch64
  - aarch64-musl
  - armv7l
  - armv7l-musl
