### PR TITLE
New package: doggo-1.0.4

### DIFF
--- a/srcpkgs/doggo/template
+++ b/srcpkgs/doggo/template
@@ -1,0 +1,14 @@
+# Template file for 'doggo'
+pkgname=doggo
+version=1.0.4
+revision=1
+build_style=go
+go_import_path=github.com/mr-karan/doggo
+go_package="${go_import_path}/cmd/doggo"
+go_ldflags="-X main.Version=${version}"
+short_desc="Command-line DNS client for humans"
+maintainer="klardotsh <josh@klar.sh>"
+license="GPL-3.0-only"
+homepage="https://github.com/mr-karan/doggo"
+distfiles="https://github.com/mr-karan/doggo/archive/refs/tags/v${version}.tar.gz"
+checksum=d7b8c742680332b172ad64e4d625449537c89e2607b7d7fd83a34fdd737c039f


### PR DESCRIPTION
Resolves #36949 (given `dog` itself is unmaintained, but this is a maintained semi-equivalent, as discussed in the thread).

The upstream README alludes to the MIT license, which is incorrect. The license in the repo is indeed GPL-3.0. I did not see an "or later" clause on a quick skim, so went with the `-only` SPDF.

#### Testing the changes
- I tested the changes in this PR: **briefly**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-musl)