### PR TITLE
fdupes: update to 2.3.2

### DIFF
--- a/srcpkgs/fdupes/template
+++ b/srcpkgs/fdupes/template
@@ -1,16 +1,16 @@
 # Template file for 'fdupes'
 pkgname=fdupes
-version=2.2.1
+version=2.3.2
 revision=1
 build_style=gnu-configure
-makedepends="ncurses-devel pcre2-devel"
+makedepends="ncurses-devel pcre2-devel sqlite-devel"
 short_desc="Identify or delete duplicate files within specified directories"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
 homepage="https://github.com/adrianlopezroche/fdupes"
 changelog="https://raw.githubusercontent.com/adrianlopezroche/fdupes/master/CHANGES"
 distfiles="https://github.com/adrianlopezroche/fdupes/releases/download/v${version}/fdupes-${version}.tar.gz"
-checksum=846bb79ca3f0157856aa93ed50b49217feb68e1b35226193b6bc578be0c5698d
+checksum=808d8decbe7fa41cab407ae4b7c14bfc27b8cb62227540c3dcb6caf980592ac7
 
 post_install() {
 	vlicense README


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture: **x86_64-musl**
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64
  - aarch64
  - aarch64-musl
  - i686
  - i686-musl
  - armv7l
  - armv7l-musl
  - armv6l
  - armv6l-musl
  - armv5te
  - armv5te-musl
