### PR TITLE
svt-av1: 2.1.2

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -4293,8 +4293,7 @@ librttopo.so.1 librttopo-1.1.0_1
 libspatialite.so.7 libspatialite-5.0.1_1
 mod_spatialite.so.7 libspatialite-5.0.1_1
 libreadosm.so.1 readosm-1.1.0a_1
-libSvtAv1Enc.so.1 libsvt-av1-1.3.0_1
-libSvtAv1Dec.so.0 libsvt-av1-0.9.0_1
+libSvtAv1Enc.so.2 libsvt-av1-2.1.2_1
 libyascreen.so.0 yascreen-1.96_1
 libyyjson.so.0 yyjson-0.10.0_1
 librz_analysis.so.0.7 rizin-0.7.2_1

--- a/srcpkgs/ffmpeg/template
+++ b/srcpkgs/ffmpeg/template
@@ -2,7 +2,7 @@
 # audacity also needs to be bumped when a new ffmpeg version bumps libavformat's soname!
 pkgname=ffmpeg
 version=4.4.4
-revision=9
+revision=10
 build_style=meta
 short_desc="Decoding, encoding and streaming software (transitional dummy package)"
 maintainer="Orphaned <orphan@voidlinux.org>"
@@ -26,7 +26,7 @@ makedepends="zlib-devel bzip2-devel freetype-devel alsa-lib-devel libXfixes-deve
  $(vopt_if aom libaom-devel) $(vopt_if sndio sndio-devel)
  $(vopt_if dav1d libdav1d-devel) $(vopt_if zimg zimg-devel)
  $(vopt_if webp libwebp-devel) $(vopt_if sofa libmysofa-devel)
- $(vopt_if drm libdrm-devel) $(vopt_if svtav1 libsvt-av1-devel)
+ $(vopt_if drm libdrm-devel) libsvt-av1-devel
  $(vopt_if srt srt-devel) $(vopt_if rist librist-devel)
  $(vopt_if vulkan 'vulkan-loader-devel')
  $(vopt_if nvenc nv-codec-headers) $(vopt_if nvdec nv-codec-headers)"
@@ -34,7 +34,7 @@ makedepends="zlib-devel bzip2-devel freetype-devel alsa-lib-devel libXfixes-deve
 depends="ffmpeg6"
 
 build_options="x265 v4l2 vaapi vdpau vpx fdk_aac aom nvenc sndio pulseaudio
- dav1d zimg webp sofa vulkan drm svtav1 srt rist nvdec"
+ dav1d zimg webp sofa vulkan drm srt rist nvdec"
 build_options_default="x265 v4l2 vpx aom sndio pulseaudio dav1d webp vulkan drm srt rist"
 
 desc_option_srt="Enable support for SRT (Secure, Reliable, Transport)"
@@ -50,10 +50,6 @@ case "$XBPS_TARGET_MACHINE" in
 	ppc64*) build_options_default+=" vaapi vdpau";;
 	mips*) CFLAGS="-mnan=legacy";;
 esac
-
-if [ "$XBPS_TARGET_WORDSIZE" != "32" ]; then
-	build_options_default+=" svtav1"
-fi
 
 _apply_patch() {
 	local args="$1" pname="$(basename $2)"
@@ -114,7 +110,7 @@ do_configure() {
 		--enable-libopus --enable-librtmp --enable-libjack \
 		$(vopt_if fdk_aac '--enable-nonfree --enable-libfdk-aac') \
 		--disable-libopencore_amrnb --disable-libopencore_amrwb \
-		--disable-libopenjpeg --enable-libbluray \
+		--disable-libopenjpeg --enable-libbluray --enable-libsvtav1 \
 		--enable-postproc --enable-opencl --enable-libvmaf ${_args} \
 		$(vopt_enable x265 libx265) \
 		$(vopt_enable v4l2 libv4l2) \
@@ -126,7 +122,6 @@ do_configure() {
 		$(vopt_enable sofa libmysofa) \
 		$(vopt_enable vulkan) \
 		$(vopt_enable drm libdrm) \
-		$(vopt_enable svtav1 libsvtav1) \
 		$(vopt_enable srt libsrt) \
 		$(vopt_enable rist librist) \
 		$(vopt_if nvenc '--enable-nvenc') \

--- a/srcpkgs/ffmpeg6/template
+++ b/srcpkgs/ffmpeg6/template
@@ -2,7 +2,7 @@
 # audacity also needs to be bumped when a new ffmpeg version bumps libavformat's soname!
 pkgname=ffmpeg6
 version=6.1.2
-revision=1
+revision=2
 hostmakedepends="pkg-config perl"
 makedepends="zlib-devel bzip2-devel freetype-devel alsa-lib-devel libXfixes-devel
  libXext-devel libXvMC-devel libxcb-devel lame-devel libtheora-devel
@@ -12,8 +12,7 @@ makedepends="zlib-devel bzip2-devel freetype-devel alsa-lib-devel libXfixes-deve
  libbs2b-devel libvidstab-devel vmaf-devel libbluray-devel pulseaudio-devel
  x265-devel v4l-utils-devel libvpx-devel libaom-devel libdav1d-devel
  libwebp-devel libdrm-devel srt-devel librist-devel vulkan-loader-devel
- zimg-devel libmysofa-devel
- $(vopt_if svtav1 libsvt-av1-devel) $(vopt_if vaapi libva-devel)
+ zimg-devel libmysofa-devel libsvt-av1-devel $(vopt_if vaapi libva-devel)
  $(vopt_if vdpau libvdpau-devel) $(vopt_if fdk_aac fdk-aac-devel)
  $(vopt_if onevpl oneVPL-devel) $(vopt_if nvcodec nv-codec-headers)"
 depends="ffplay6>=${version}_${revision}"
@@ -25,7 +24,7 @@ changelog="https://raw.githubusercontent.com/FFmpeg/FFmpeg/master/Changelog"
 distfiles="https://www.ffmpeg.org/releases/ffmpeg-${version}.tar.xz"
 checksum=3b624649725ecdc565c903ca6643d41f33bd49239922e45c9b1442c63dca4e38
 
-build_options="vaapi vdpau fdk_aac nvcodec svtav1 onevpl"
+build_options="vaapi vdpau fdk_aac nvcodec onevpl"
 desc_option_sofa="Enable support for AES SOFA"
 
 case "$XBPS_TARGET_MACHINE" in
@@ -40,10 +39,6 @@ case "$XBPS_TARGET_MACHINE" in
 	ppc64*) build_options_default+=" vaapi vdpau";;
 	mips*) CFLAGS="-mnan=legacy";;
 esac
-
-if [ "$XBPS_TARGET_WORDSIZE" != "32" ]; then
-	build_options_default+=" svtav1"
-fi
 
 _apply_patch() {
 	local args="$1" pname="$(basename $2)"
@@ -102,13 +97,12 @@ do_configure() {
 		--enable-libx265 --enable-libv4l2 --enable-libaom \
 		--enable-libbs2b --enable-libvidstab --enable-libdav1d \
 		--enable-libsrt --enable-librist --enable-libwebp \
-		--enable-vulkan --enable-libdrm \
+		--enable-vulkan --enable-libdrm --enable-libsvtav1 \
 		$(vopt_if fdk_aac '--enable-nonfree --enable-libfdk-aac') \
 		$(vopt_enable vaapi) $(vopt_enable vdpau) \
 		$(vopt_enable zimg libzimg) \
 		$(vopt_enable sofa libmysofa) \
 		$(vopt_enable onevpl libvpl) \
-		$(vopt_enable svtav1 libsvtav1) \
 		$(vopt_enable nvcodec nvenc) \
 		$(vopt_enable nvcodec nvdec)
 }

--- a/srcpkgs/handbrake/template
+++ b/srcpkgs/handbrake/template
@@ -1,7 +1,7 @@
 # Template file for 'handbrake'
 pkgname=handbrake
 version=1.6.1
-revision=2
+revision=3
 build_style=gnu-configure
 configure_args="--force --disable-gtk-update-checks --disable-df-fetch --harden
  $(vopt_enable fdk_aac fdk-aac) $(vopt_enable nvenc) $(vopt_enable qsv)"
@@ -12,8 +12,7 @@ makedepends="bzip2-devel ffmpeg6-devel gst-plugins-base1-devel gtk+3-devel
  jansson-devel lame-devel libass-devel libbluray-devel libdav1d-devel
  libdvdnav-devel libdvdread-devel libgudev-devel libnuma-devel
  libsamplerate-devel libtheora-devel libvorbis-devel libvpx-devel libxml2-devel
- opus-devel speex-devel x264-devel x265-devel zimg-devel
- $(vopt_if svt_av1 libsvt-av1-devel)
+ opus-devel speex-devel x264-devel x265-devel zimg-devel libsvt-av1-devel
  $(vopt_if fdk_aac fdk-aac-devel)
  $(vopt_if qsv 'libva-devel libdrm-devel oneVPL-devel')
  $(vopt_if nvenc nv-codec-headers)"
@@ -27,19 +26,15 @@ distfiles="https://github.com/HandBrake/HandBrake/releases/download/${version}/H
 checksum=94ccfe03db917a91650000c510f7fd53f844da19f19ad4b4be1b8f6bc31a8d4c
 nocross=yes
 
-build_options="fdk_aac nvenc svt_av1 qsv"
+build_options="fdk_aac nvenc qsv"
 
 case "$XBPS_TARGET_MACHINE" in
 	x86_64*)
 		CFLAGS="-msse"
-		build_options_default="nvenc svt_av1 qsv"
+		build_options_default="nvenc qsv"
 		;;
 	i686*)
 		CFLAGS="-msse"
-		build_options_default="nvenc"
-		;;
-	*)
-		build_options_default="svt_av1"
 		;;
 esac
 
@@ -50,11 +45,6 @@ pre_configure() {
 		x265 zimg svt-av1 libvpl; do
 	    vsed -i "/MODULES += contrib\/${module}/d" make/include/main.defs
 	done
-	if [[ "$XBPS_TARGET_MACHINE" = "i686"* ]] ; then
-		vsed -e 's/-lSvtAv1Enc //g' -i gtk/configure.ac
-		vsed -e 's/ SvtAv1Enc//g' -i test/module.defs
-		vsed -e 's/ SvtAv1Enc//g' -i libhb/module.defs
-	fi
 }
 
 pre_build() {

--- a/srcpkgs/svt-av1/template
+++ b/srcpkgs/svt-av1/template
@@ -1,6 +1,6 @@
 # Template file for 'svt-av1'
 pkgname=svt-av1
-version=1.7.0
+version=2.1.2
 revision=1
 build_style=cmake
 configure_args="-DSVT_AV1_LTO=ON"
@@ -10,20 +10,15 @@ license="BSD-3-Clause-Clear"
 homepage="https://gitlab.com/AOMediaCodec/SVT-AV1"
 changelog="https://gitlab.com/AOMediaCodec/SVT-AV1/-/raw/master/CHANGELOG.md"
 distfiles="https://gitlab.com/AOMediaCodec/SVT-AV1/-/archive/v${version}/SVT-AV1-v${version}.tar.gz"
-checksum=ce0973584f1a187aa4abf63f509ff8464397120878e322a3153f87e9c161fc4f
+checksum=65e90af18f31f8c8d2e9febf909a7d61f36172536abb25a7089f152210847cd9
 
 case "$XBPS_TARGET_MACHINE" in
 	i686* | x86_64*) hostmakedepends="nasm"
 esac
 
-if [ "$XBPS_TARGET_WORDSIZE" = "32" ]; then
-	broken="32-bit is not supported"
-fi
-
 libsvt-av1_package() {
 	short_desc+=" - library files"
 	pkg_install() {
-		vmove "usr/lib/libSvtAv1Dec.so.*"
 		vmove "usr/lib/libSvtAv1Enc.so.*"
 		vlicense LICENSE.md
 	}


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

- I built this PR locally for my native architecture, **x86_64**

- cross builds: **i686**, **aarch64-musl**


#### Comments

After 2.1.0 they removed the decoder library. I guess most just use other libs https://gitlab.com/AOMediaCodec/SVT-AV1/-/issues/2182

Out of date, also fixes 32bit build, remove svt use flag in ffmpeg, and handbrake 32bit builds with it for https://github.com/void-linux/void-packages/pull/51706