### PR TITLE
smpeg: update distfile url

### DIFF
--- a/srcpkgs/smpeg/template
+++ b/srcpkgs/smpeg/template
@@ -1,17 +1,22 @@
 # Template file for 'smpeg'
 pkgname=smpeg
 version=0.4.5
-revision=5
+revision=6
 build_style=gnu-configure
 configure_args="--with-sdl-prefix=${XBPS_CROSS_BASE}/usr --disable-gtk-player --disable-opengl-player"
 make_build_args="LDFLAGS+=-lstdc++"
+hostmakedepends="autoconf automake libtool"
 makedepends="SDL-devel"
 short_desc="SDL MPEG Player Library"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="LGPL-2.1-only"
 homepage="https://icculus.org/smpeg/"
-distfiles="ftp://slackware.oregonstate.edu/.1/vectorlinux/VL64-7.0/source/sourceVL/smpeg/${version}/src/smpeg-${version}.tar.gz"
-checksum=1839c12e88d5dbbc767a7b94eeab2aa3efe4f0eebb7eb7c7240270ba93689a2b
+distfiles="https://github.com/icculus/smpeg/archive/refs/tags/release_${version//./_}.tar.gz"
+checksum=e2e53bfd2e6401e2c29e5eb3929be0e8698bc9e4c9d731751f67e77b408f1f74
+
+pre_configure() {
+	./autogen.sh
+}
 
 post_install() {
 	# Remove unused stuff


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, x86_64
- I built this PR locally for these architectures (all crossbuilds):
  - aarch64{,-musl}
  - armv6l{,-musl}

---

the oregonstate.edu ftp server does not contain a vectorlinux mirror anymore, so the distfile link is broken.
while other mirrors of this exact file exist (for example at [nluug.nl](https://ftp.nluug.nl/os/Linux/distr/vectorlinux/VL64-7.0/source/sourceVL/smpeg/0.4.5/src) and [princeton.edu](https://mirror.math.princeton.edu/pub/vectorlinux/VL64-7.0/source/sourceVL/smpeg/0.4.5/src/)), it seems that icculus have moved the project from svn to github in late 2021, so i'd suggest just taking the sources from there directly.

the hash differs, but the sources are effectively unchanged.
it's mostly just the `.svn` litter being gone and auto{conf,make} files not being pregenerated anymore.