### PR TITLE
cpuset: update to 1.6.2 for python3.12

### DIFF
--- a/srcpkgs/cpuset/template
+++ b/srcpkgs/cpuset/template
@@ -1,17 +1,15 @@
 # Template file for 'cpuset'
 pkgname=cpuset
-version=1.6
-revision=6
+version=1.6.2
+revision=1
 build_style=python3-module
-pycompile_module="cpuset"
 hostmakedepends="python3-setuptools"
-depends="python3-future"
 short_desc="Wrapper to make kernel cpusets facilities easier to use"
 maintainer="Simon Zelazny <zelazny@mailbox.org>"
 license="GPL-2.0-only"
-homepage="https://github.com/lpechacek/cpuset"
-distfiles="https://github.com/lpechacek/cpuset/archive/v${version}.tar.gz"
-checksum=61702a7ad9acb9f0ff30abd37cc74dbae52095f265a89aacee99f42a61ac2512
+homepage="https://github.com/SUSE/cpuset"
+distfiles="https://github.com/SUSE/cpuset/archive/refs/tags/v${version}.tar.gz"
+checksum=298187d07830c0308a35bbdc57daef22743f6300af1da5e780b45c7579ebf78b
 
 post_extract() {
 	sed -i 's|share/doc/packages/cpuset|share/doc/cpuset|' setup.py


### PR DESCRIPTION
- upstream has migrated to new repo / ownership; updated accordingly
- removed dependency on python3-future per upstream's changes
- should fix failing python3 check in #46170

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl (xbuild)
  - i686 (xbuild)
  - armv6l (xbuild)
