### PR TITLE
glibc: fix update check

### DIFF
--- a/srcpkgs/glibc/update
+++ b/srcpkgs/glibc/update
@@ -1,1 +1,0 @@
-pattern='\K[\d.]+(?= released)'


### PR DESCRIPTION
this way `update-check` works again