### PR TITLE
wireless-regdb: update to 2024.07.04

### DIFF
--- a/srcpkgs/wireless-regdb/template
+++ b/srcpkgs/wireless-regdb/template
@@ -1,13 +1,13 @@
 # Template file for 'wireless-regdb'
 pkgname=wireless-regdb
-version=2023.09.01
+version=2024.07.04
 revision=1
 short_desc="Regulatory database used by Linux"
 maintainer="Đoàn Trần Công Danh <congdanhqx@gmail.com>"
 license="ISC"
 homepage="https://wireless.wiki.kernel.org/en/developers/regulatory/wireless-regdb"
 distfiles="https://www.kernel.org/pub/software/network/wireless-regdb/wireless-regdb-${version}.tar.xz"
-checksum=26d4c2a727cc59239b84735aad856b7c7d0b04e30aa5c235c4f7f47f5f053491
+checksum=9832a14e1be24abff7be30dee3c9a1afb5fdfcf475a0d91aafef039f8d85f5eb
 replaces="crda>=0"
 
 post_patch() {


### PR DESCRIPTION
- I tested the changes in this PR: yes
- I built this PR locally for my native architecture, (x86_64-glibc)

cc @sgn I removed the `vsed`, not sure I understood why it's needed. Can you please review?