### PR TITLE
cropgui: update to 0.8, adopt.

### DIFF
--- a/srcpkgs/cropgui/template
+++ b/srcpkgs/cropgui/template
@@ -1,15 +1,15 @@
 # Template file for 'cropgui'
 pkgname=cropgui
-version=0.6
-revision=2
+version=0.8
+revision=1
 hostmakedepends="which python3-setuptools"
 depends="python3-Pillow python3-gobject libjpeg-turbo-tools ImageMagick exiftool gtk+3"
 short_desc="Gtk frontend for lossless cropping of jpeg images"
-maintainer="Orphaned <orphan@voidlinux.org>"
+maintainer="Eloi Torrents <eloitor@duck.com>"
 license="GPL-2.0-or-later"
 homepage="https://github.com/jepler/cropgui"
 distfiles="https://github.com/jepler/cropgui/archive/v${version}.tar.gz"
-checksum=154b88c01f365505bf509537d01695fc72986cc0cc4d8ef6d6bf40bc0c5b4f53
+checksum=8c874ccf12aab918fe3998360e18f58af1a84ca42014ab84bca1e8592e122930
 python_version=3
 
 do_install() {


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)


The current version has this bug, and this PR solves it:

```
/usr/bin/cropgui:33: DeprecationWarning: 'imghdr' is deprecated and slated for removal in Python 3.13
  import imghdr
Traceback (most recent call last):
  File "/usr/bin/cropgui", line 223, in <module>
    wa = display.get_primary_monitor().get_workarea()
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'get_workarea'

/usr/bin/cropgui:45: PyGTKDeprecationWarning: Using positional arguments with the GObject constructor has been deprecated. Please specify keyword(s) for "parent, flags, message_type, buttons, message_format" or use a class specific constructor. See: https://wiki.gnome.org/PyGObject/InitializerDeprecations
  m = gtk.MessageDialog(w,
/usr/bin/cropgui:45: PyGTKDeprecationWarning: The keyword(s) "message_format" have been deprecated in favor of "text" respectively. See: https://wiki.gnome.org/PyGObject/InitializerDeprecations
  m = gtk.MessageDialog(w,
/usr/bin/cropgui:45: PyGTKDeprecationWarning: The "flags" argument for dialog construction is deprecated. Please use initializer keywords: modal=True and/or destroy_with_parent=True. See: https://wiki.gnome.org/PyGObject/InitializerDeprecations
  m = gtk.MessageDialog(w,
```

