### PR TITLE
magic-wormhole: update to 0.15.0, add changelog

### DIFF
--- a/srcpkgs/magic-wormhole/template
+++ b/srcpkgs/magic-wormhole/template
@@ -1,6 +1,6 @@
 # Template file for 'magic-wormhole'
 pkgname=magic-wormhole
-version=0.14.0
+version=0.15.0
 revision=1
 build_style=python3-pep517
 hostmakedepends="python3 python3-build python3-setuptools python3-wheel"
@@ -11,8 +11,9 @@ short_desc="Get things from one computer to another, safely"
 maintainer="travankor <travankor@tuta.io>"
 license="MIT"
 homepage="https://magic-wormhole.readthedocs.io/en/latest/"
+changelog="https://raw.githubusercontent.com/magic-wormhole/magic-wormhole/master/NEWS.md"
 distfiles="https://github.com/warner/magic-wormhole/archive/${version}.tar.gz"
-checksum=6104ff2ce1223bf8fefc3a7a2a3bca0dddb86e008b21b6f47543dd74ab18db3c
+checksum=bc77b7280876ad0e9611498cdee1aebb3d0ec0a9236bf7356dc8967f2d6ce201
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
#### Local build testing
- I built this PR locally for my native architecture, (x86_64-musl)
---
Fixes breakage (ImportError crash) caused by the recent `python3-attrs` update (see magic-wormhole/magic-wormhole#492).

Cc: @travankor as the listed maintainer
Cc: @ahesford as the commiter of the attrs update
