### PR TITLE
caddy: update to 2.8.4.

### DIFF
--- a/srcpkgs/caddy/template
+++ b/srcpkgs/caddy/template
@@ -1,11 +1,11 @@
 # Template file for 'caddy'
 pkgname=caddy
-version=2.7.6
+version=2.8.4
 revision=1
 build_style=go
 go_import_path=github.com/caddyserver/caddy/v2
 go_package="${go_import_path}/cmd/caddy"
-hostmakedepends="go1.20"
+hostmakedepends="go"
 depends="shared-mime-info"
 short_desc="Fast, cross-platform HTTP/2 web server with automatic HTTPS"
 maintainer="Orphaned <orphan@voidlinux.org>"
@@ -13,14 +13,13 @@ license="Apache-2.0"
 homepage="https://caddyserver.com"
 changelog="https://github.com/caddyserver/caddy/releases"
 distfiles="https://github.com/caddyserver/caddy/archive/v${version}.tar.gz"
-checksum=e1c524fc4f4bd2b0d39df51679d9d065bb811e381b7e4e51466ba39a0083e3ed
+checksum=5c2e95ad9e688a18dd9d9099c8c132331e01e0bebd401183e8d9123372cf4fcc
 
 system_accounts="caddy"
 caddy_homedir="/var/lib/caddy"
 caddy_descr="caddy daemon"
 
 conf_files="/etc/caddy/Caddyfile"
-export GOTOOLCHAIN=go1.20
 
 make_dirs="
 	/etc/caddy 0700 caddy caddy


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **yes**

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, aarch64 as well as aarch64-musl