### PR TITLE
wine: make wow64 a buildoption

### DIFF
--- a/srcpkgs/wine/template
+++ b/srcpkgs/wine/template
@@ -19,11 +19,16 @@ checksum="24572f49cf3473fc9ef2a1ad1cddf511ce0ef43daa55413b4720a6c3e3c89ea6
 # NOTE: wine depends on specific versions of wine-mono and wine-gecko,
 # check for updates to these packages when updating wine
 
-build_options="mingw staging xshm"
+build_options="mingw staging xshm wow64"
 build_options_default="mingw xshm"
 desc_option_mingw="Use the MinGW cross compiler to build WinPE DLLs"
 desc_option_staging="Apply the wine-staging patchset"
 desc_option_xshm="Enable support for the X Shared Memory Extension"
+
+
+if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
+	build_options_default+=" wow64"
+fi
 
 lib32mode=full
 archs="i686* x86_64*"
@@ -74,7 +79,7 @@ if [ "$XBPS_LIBC" = "glibc" ]; then
 	hostmakedepends+=" prelink"
 fi
 
-if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
+if [ "${build_option_wow64}" ]; then
 	configure_args+=" --enable-archs=i386,x86_64"
 	makedepends+=" cross-i686-w64-mingw32"
 fi


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
