### PR TITLE
flatpak: add missing -devel packages to depends

### DIFF
--- a/srcpkgs/flatpak/template
+++ b/srcpkgs/flatpak/template
@@ -1,7 +1,7 @@
 # Template file for 'flatpak'
 pkgname=flatpak
 version=1.15.9
-revision=1
+revision=2
 build_style=meson
 build_helper="gir"
 configure_args="
@@ -49,7 +49,7 @@ flatpak-devel_package() {
 	short_desc+=" - development files"
 	depends="${sourcepkg}>=${version}_${revision} libglib-devel libostree-devel
 	 libcurl-devel libarchive-devel json-glib-devel dconf-devel libseccomp-devel
-	 gpgme-devel polkit-devel"
+	 gpgme-devel polkit-devel libxml2-devel libXau-devel"
 	pkg_install() {
 		vmove usr/include
 		vmove usr/lib/pkgconfig


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
<!--
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->

This add missing `libxml2-devel` an `libXau-devel` dependencies to `flatpak-devel` to satisfy pkg-config
