### PR TITLE
skanpage: add kquickimageeditor to depends

### DIFF
--- a/srcpkgs/skanpage/template
+++ b/srcpkgs/skanpage/template
@@ -1,7 +1,7 @@
 # Template file for 'skanpage'
 pkgname=skanpage
 version=24.05.1
-revision=1
+revision=2
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins"
@@ -9,7 +9,7 @@ hostmakedepends="extra-cmake-modules gettext qt6-base qt6-tools kf6-kcoreaddons 
 makedepends="qt6-base-devel libksane6-devel kf6-kcoreaddons-devel kf6-ki18n-devel
  kf6-kirigami-devel kf6-kcrash-devel ksanecore6-devel kf6-kconfig-devel kf6-purpose-devel
  kf6-kxmlgui-devel kquickimageeditor-devel leptonica-devel tesseract-ocr-devel libgomp-devel qt6-pdf-devel"
-depends="kf6-kirigami kf6-qqc2-desktop-style"
+depends="kf6-kirigami kf6-qqc2-desktop-style kquickimageeditor"
 short_desc="Multi-page scanning application"
 maintainer="Enrico Belleri <idesmi@protonmail.com>"
 license="GPL-2.0-or-later"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

- I built this PR locally for my native architecture, (x86_64-glibc)

The problem: skanpage won't launch without explicitly installing kquickimageeditor. In terminal, skanpage shows the following error and the window never shows up 
`ATTENTION: default value of option vblank_mode overridden by environment.
QQmlApplicationEngine failed to load component
qrc:/qml/MainWindow.qml:361:26: Type ContentView unavailable
qrc:/qml/ContentView.qml:67:13: Type DocumentPage unavailable
qrc:/qml/DocumentPage.qml:14:1: module "org.kde.kquickimageeditor" is not installed` 

For context, you might want to see:
- https://github.com/KDE/skanpage/blob/master/.kde-ci.yml
- https://bugzilla.redhat.com/show_bug.cgi?id=2241499
- https://bugzilla.redhat.com/show_bug.cgi?id=2250337
- https://archlinux.org/packages/extra/x86_64/skanpage/

This has to be a runtime dependency as adding kquickimageeditor-devel to makedepends does not yield any positive results.

ping @Luciogi @sgn 