### PR TITLE
carapace: update to 1.0.5.

### DIFF
--- a/srcpkgs/carapace/template
+++ b/srcpkgs/carapace/template
@@ -1,6 +1,6 @@
 # Template file for 'carapace'
 pkgname=carapace
-version=1.0.4
+version=1.0.5
 revision=1
 build_style=go
 go_import_path=github.com/carapace-sh/carapace-bin
@@ -13,7 +13,7 @@ license="MIT"
 homepage="https://carapace.sh/"
 changelog="https://carapace-sh.github.io/carapace-bin/release_notes.html"
 distfiles="https://github.com/carapace-sh/carapace-bin/archive/refs/tags/v${version}.tar.gz"
-checksum=745bf9cbbfc205ddc42c8a09b7a05534be792672ed9dc97bd670f74973438e1b
+checksum=25555206b1b5350cba3567463cb2c5b87c43fad20d4e8200ab78d49371c0b4db
 
 pre_build() {
 	CGO_ENABLED=0 GOARCH= go generate ./cmd/...


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture: **x86_64**