### PR TITLE
New package: vfio-isolate

### DIFF
--- a/srcpkgs/cpuset/template
+++ b/srcpkgs/cpuset/template
@@ -1,17 +1,15 @@
 # Template file for 'cpuset'
 pkgname=cpuset
-version=1.6
-revision=6
+version=1.6.2
+revision=1
 build_style=python3-module
-pycompile_module="cpuset"
 hostmakedepends="python3-setuptools"
-depends="python3-future"
 short_desc="Wrapper to make kernel cpusets facilities easier to use"
 maintainer="Simon Zelazny <zelazny@mailbox.org>"
 license="GPL-2.0-only"
-homepage="https://github.com/lpechacek/cpuset"
-distfiles="https://github.com/lpechacek/cpuset/archive/v${version}.tar.gz"
-checksum=61702a7ad9acb9f0ff30abd37cc74dbae52095f265a89aacee99f42a61ac2512
+homepage="https://github.com/SUSE/cpuset"
+distfiles="https://github.com/SUSE/cpuset/archive/refs/tags/v${version}.tar.gz"
+checksum=298187d07830c0308a35bbdc57daef22743f6300af1da5e780b45c7579ebf78b
 
 post_extract() {
 	sed -i 's|share/doc/packages/cpuset|share/doc/cpuset|' setup.py

--- a/srcpkgs/vfio-isolate/template
+++ b/srcpkgs/vfio-isolate/template
@@ -1,0 +1,17 @@
+# Template file for 'vfio-isolate'
+pkgname=vfio-isolate
+version=0.5.2
+revision=1
+build_style=python3-module
+hostmakedepends="python3-setuptools"
+depends="cpuset"
+short_desc="CLI CPU isolation utility for vfio virtual machines"
+maintainer="Jadyn Brammer <jadyn@brammer.social>"
+license="MIT"
+homepage="https://github.com/spheenik/vfio-isolate"
+distfiles="${PYPI_SITE}/v/vfio-isolate/vfio-isolate-${version}.tar.gz"
+checksum=fbad511d8ae24b4423341dba2da1c49171382184c5980133a013d82ae8953a5a
+
+post_install() {
+	vlicense LICENSE
+}


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

Justification: System
vfio-isolate needs to run as root and depends on the existing system package 'cpuset'.

#### Local build testing
- I built this PR locally for my native architecture, x86_64
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl (xbuild)
  - i686 (xbuild)
