### PR TITLE
New package: rsgain-3.5.2

### DIFF
--- a/srcpkgs/rsgain/template
+++ b/srcpkgs/rsgain/template
@@ -1,0 +1,19 @@
+# Template file for 'rsgain'
+pkgname=rsgain
+version=3.5.2
+revision=1
+build_style=cmake
+hostmakedepends="pkg-config"
+makedepends="ffmpeg6-devel taglib-devel libebur128-devel inih-devel fmt-devel"
+short_desc="ReplayGain 2.0 tagging utility"
+maintainer="sn0w <me@sn0w.cx>"
+license="BSD-2-Clause"
+homepage="https://github.com/complexlogic/rsgain"
+changelog="https://raw.githubusercontent.com/complexlogic/rsgain/master/CHANGELOG"
+distfiles="https://github.com/complexlogic/rsgain/archive/refs/tags/v${version}.tar.gz"
+checksum=c76ba0dfaafcaa3ceb71a3e5a1de128200d92f7895d8c2ad45360adefe5a103b
+
+post_install() {
+	vlicense LICENSE
+	vlicense LICENSE-CRCpp
+}


### PR DESCRIPTION
rsgain is a ReplayGain / EBU R 128 loudness normalization tool forked from the semi-abandoned loudgain.

this is another attempt to get it into void after the previous 3 PR's went stale and got auto-closed.

---

#### Testing the changes
- I tested the changes in this PR: **YES** (on `x86_64`, `aarch64{,-musl}`, and `armv6l{,-musl}`)

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64
- I built this PR locally for these architectures (all crossbuilds):
  - x86_64 
  - i686
  - aarch64-musl
  - aarch64
  - armv7l
  - armv7l-musl
  - armv6l
  - armv6l-musl