### PR TITLE
python3-yattag: update to 1.16.0

### DIFF
--- a/srcpkgs/python3-yattag/template
+++ b/srcpkgs/python3-yattag/template
@@ -1,6 +1,6 @@
 # Template file for 'python3-yattag'
 pkgname=python3-yattag
-version=1.15.2
+version=1.16.0
 revision=1
 build_style=python3-module
 hostmakedepends="python3-setuptools"
@@ -10,4 +10,4 @@ maintainer="Emil Miler <em@0x45.cz>"
 license="LGPL-2.1-only"
 homepage="https://www.yattag.org/"
 distfiles="${PYPI_SITE}/y/yattag/yattag-${version}.tar.gz"
-checksum=aad9f540bd22dc503e5b5506cc47856facf081aa71fd35f727371b63e1e402bf
+checksum=0978247b9754d9f44e3703c64374ab9fa872d18de95ac5772fdfdd3c3f0d0706


### PR DESCRIPTION
- I tested the changes in this PR: **briefly**
- I built this PR locally for my native architecture, (x86_64-glibc)