### PR TITLE
python3-Cython: fix regression in cython 3.0.11.

### DIFF
--- a/srcpkgs/python3-Cython/patches/fix-regression.patch
+++ b/srcpkgs/python3-Cython/patches/fix-regression.patch
@@ -1,0 +1,17 @@
+Revert https://github.com/cython/cython/pull/6124 which causes a
+serious regression, e.g. sagemath FTBS with cython 3.0.11
+
+--- a/Cython/Compiler/Nodes.py
++++ b/Cython/Compiler/Nodes.py
+@@ -710,10 +710,8 @@ class CFuncDeclaratorNode(CDeclaratorNode):
+                 and not self.has_explicit_exc_clause
+                 and self.exception_check
+                 and visibility != 'extern'):
+-            # If function is already declared from pxd, the exception_check has already correct value.
+-            if not (self.declared_name() in env.entries and not in_pxd):
+-                self.exception_check = False
+             # implicit noexcept, with a warning
++            self.exception_check = False
+             warning(self.pos,
+                     "Implicit noexcept declaration is deprecated."
+                     " Function declaration should contain 'noexcept' keyword.",

--- a/srcpkgs/python3-Cython/template
+++ b/srcpkgs/python3-Cython/template
@@ -1,7 +1,7 @@
 # Template file for 'python3-Cython'
 pkgname=python3-Cython
 version=3.0.11
-revision=1
+revision=2
 build_style=python3-module
 hostmakedepends="python3-setuptools"
 makedepends="python3-devel"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

See: https://github.com/cython/cython/issues/6335

@ahesford

#### Testing the changes
- I tested the changes in this PR: **YES**

Without this, sagemath FTBS.

With this, sagemath builds and check (tested on x86_64).

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
