### PR TITLE
ocaml: fix for i686-musl packaging

### DIFF
--- a/srcpkgs/ocaml/template
+++ b/srcpkgs/ocaml/template
@@ -14,6 +14,13 @@ distfiles="https://github.com/ocaml/ocaml/archive/refs/tags/${version}.tar.gz"
 checksum=48554abfd530fcdaa08f23f801b699e4f74c320ddf7d0bd56b0e8c24e55fc911
 nocross=yes
 
+case "${XBPS_TARGET_MACHINE}" in
+	i686-musl)
+		nopie_files="/usr/bin/ocamlrun /usr/bin/ocamlrund
+		 /usr/bin/ocamlruni /usr/bin/ocamlyacc"
+		;;
+esac
+
 export ASPP="cc -c"
 
 post_install() {


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture: x86_64-musl
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64
  - i686-musl
  - i686
 
Can't crossbuild this package to other arches, only native building is supported, so I just tested these.
