### PR TITLE
New package: fyi-1.0.4

### DIFF
--- a/srcpkgs/fyi/template
+++ b/srcpkgs/fyi/template
@@ -1,0 +1,21 @@
+# Template file for 'fyi'
+pkgname=fyi
+version=1.0.4
+revision=1
+build_style=meson
+hostmakedepends="pkg-config scdoc"
+makedepends="dbus-devel"
+short_desc="Command line utility to send desktop notifications"
+maintainer="icp <pangolin@vivaldi.net>"
+license="MIT"
+homepage="https://codeberg.org/dnkl/fyi"
+changelog="https://codeberg.org/dnkl/fyi/raw/branch/master/CHANGELOG.md"
+distfiles="https://codeberg.org/dnkl/fyi/archive/${version}.tar.gz"
+checksum=6d196b4725df02dba39ca736c0f5b485f6a204a98f68de6bbe8155bdc1e56d24
+
+post_install() {
+	rm -r "${DESTDIR}/usr/share/doc"
+
+	vlicense LICENSE
+	vdoc README.md
+}


### PR DESCRIPTION
#### Description
[FYI](https://codeberg.org/dnkl/fyi) is a command line utility to send desktop notifications to the user via a notification daemon implementing XDG desktop notifications.

#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

#### Local build testing
- I built this PR locally for my native architecture: **x86_64**