### PR TITLE
android-file-transfer-linux: update to 4.3, split cli and libs

### DIFF
--- a/srcpkgs/android-file-transfer-linux-cli
+++ b/srcpkgs/android-file-transfer-linux-cli
@@ -1,0 +1,1 @@
+android-file-transfer-linux

--- a/srcpkgs/android-file-transfer-linux-libs
+++ b/srcpkgs/android-file-transfer-linux-libs
@@ -1,0 +1,1 @@
+android-file-transfer-linux

--- a/srcpkgs/android-file-transfer-linux/template
+++ b/srcpkgs/android-file-transfer-linux/template
@@ -1,16 +1,30 @@
 # Template file for 'android-file-transfer-linux'
 pkgname=android-file-transfer-linux
-version=4.2
-revision=4
+version=4.3
+revision=1
 build_style=cmake
 configure_args="-DBUILD_SHARED_LIB=1"
 hostmakedepends="qt5-qmake qt5-host-tools ninja pkg-config"
 makedepends="file-devel fuse-devel qt5-devel readline-devel
  qt5-tools-devel"
-depends="qt5-svg"
+depends="qt5-svg android-file-transfer-linux-cli android-file-transfer-linux-libs"
 short_desc="Android File Transfer for Linux"
 maintainer="Toyam Cox <Vaelatern@voidlinux.org>"
 license="LGPL-2.1-or-later"
 homepage="https://github.com/whoozle/android-file-transfer-linux"
 distfiles="https://github.com/whoozle/android-file-transfer-linux/archive/v${version}.tar.gz"
-checksum=cc607d68e8a18273c9b56975a70a0e68fbdf9d5b903b2727a345a605ff48a19f
+checksum=8ff658630fc820a7ca0b70025aa47d235b7fb64f5cb6a72ca76a7acbf3435128
+
+android-file-transfer-linux-libs_package() {
+	short_desc+=" - library"
+	pkg_install() {
+		vmove usr/lib/*
+	}
+}
+
+android-file-transfer-linux-cli_package() {
+	short_desc+=" - cli tools"
+	pkg_install() {
+		vmove usr/bin/aft-mtp-*
+	}
+}


### PR DESCRIPTION
- I tested the changes in this PR: yes
- I built this PR locally for my native architecture, (x86_64-glibc)

cc @Vaelatern 

This is so that we don't have to bring in gui stuff to use cli tools.