### PR TITLE
libcaca: update to 0.99.beta20

### DIFF
--- a/srcpkgs/libcaca/template
+++ b/srcpkgs/libcaca/template
@@ -1,7 +1,7 @@
 # Template file for 'libcaca'
 pkgname=libcaca
-version=0.99.beta19
-revision=13
+version=0.99.beta20
+revision=1
 build_style=gnu-configure
 configure_args="$(vopt_enable x11)"
 hostmakedepends="libtool automake pkg-config"
@@ -11,12 +11,11 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="WTFPL"
 homepage="http://caca.zoy.org/wiki/libcaca"
 distfiles="https://github.com/cacalabs/libcaca/archive/v${version}.tar.gz"
-checksum=7ed29a00cc7f017424d8b2994f001f137ed5bc4441987b711d78c6734fdf3493
+checksum="3edb8763a8f888ed4d4b85b3a056e81c840d5d27f79bdebc0b991688b23084f2"
 
 build_options="x11 opengl"
 
 pre_configure() {
-	vsed -i -e 's,AM_CONFIG_HEADER,AC_CONFIG_HEADERS,' configure.ac
 	autoreconf -fi
 }
 


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture: x86_64-musl
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64
  - aarch64
  - aarch64-musl
  - i686
  - i686-musl
  - armv7
  - armv7l-musl

There is no need for the `vsed` part in `pre_configure()`, it has been corrected upstream.
