### PR TITLE
workrave: update to 1.10.52

### DIFF
--- a/srcpkgs/workrave/template
+++ b/srcpkgs/workrave/template
@@ -1,11 +1,11 @@
 # Template file for 'workrave'
 pkgname=workrave
-version=1.10.45
+version=1.10.52
 revision=1
 _realversion="${version//./_}"
 build_style=gnu-configure
 build_helper="gir"
-configure_args="--disable-static --disable-gnome --disable-gsettings
+configure_args="--disable-static --disable-gsettings
  $(vopt_enable pulseaudio pulse)"
 hostmakedepends="automake autoconf-archive gettext-devel intltool python3-Jinja2
 pkg-config python3-cheetah3 libtool"
@@ -14,9 +14,9 @@ makedepends="boost-devel gtkmm-devel libSM-devel libXtst-devel libXScrnSaver-dev
 short_desc="Program that assists in the recovery and prevention of RSI"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-3.0-or-later"
-homepage="http://www.workrave.org/"
+homepage="https://www.workrave.org/"
 distfiles="https://github.com/rcaelers/${pkgname}/archive/v${_realversion}.tar.gz"
-checksum=b9c8d1aaae16ca55c98d361a392f879a306a4ecf6db28663a7e96d0c205dabc0
+checksum=e33e70cd0401a83aa0e4e319e117911b937df9d832cc9310c3e86bb3062f16f7
 
 build_options="pulseaudio"
 


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl
  - i686
  - aarch64

I didn't see any reason to have GNOME disabled, so I removed that flag. If there's some good reason that I'm missing, let me know.