### PR TITLE
strawberry: default to qt6

### DIFF
--- a/srcpkgs/strawberry/template
+++ b/srcpkgs/strawberry/template
@@ -1,13 +1,15 @@
 # Template file for 'strawberry'
 pkgname=strawberry
 version=1.1.1
-revision=1
+revision=2
 build_style=cmake
-hostmakedepends="pkg-config protobuf gettext"
+configure_args="-DBUILD_WITH_QT6=ON -DQT_HOST_PATH=/usr"
+hostmakedepends="pkg-config protobuf gettext qt6-base qt6-tools"
 makedepends="alsa-lib-devel boost-devel gnutls-devel fftw-devel
  chromaprint-devel gst-plugins-base1-devel libcdio-devel libgpod-devel
- libmtp-devel protobuf-devel pulseaudio-devel taglib-devel"
-depends="desktop-file-utils"
+ libmtp-devel protobuf-devel pulseaudio-devel taglib-devel qt6-base-devel
+ qt6-plugin-mysql qt6-plugin-odbc qt6-plugin-pgsql qt6-plugin-sqlite"
+depends="desktop-file-utils qt6-plugin-sqlite"
 short_desc="Audio player and music collection organizer"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-3.0-or-later"
@@ -15,19 +17,3 @@ homepage="https://www.strawberrymusicplayer.org/"
 changelog="https://raw.githubusercontent.com/strawberrymusicplayer/strawberry/master/Changelog"
 distfiles="https://files.strawberrymusicplayer.org/${pkgname}-${version}.tar.xz"
 checksum=ec0deff3c332aaa79dc9fb6dddd694480695cc6c97e7a7aba48e45cdde11f302
-
-build_options="qt6"
-
-if [ "$build_option_qt6" ]; then
-	configure_args="-DBUILD_WITH_QT6=ON -DQT_HOST_PATH=/usr"
-	hostmakedepends+=" qt6-base qt6-tools"
-	makedepends+=" qt6-base-devel qt6-plugin-mysql
-	 qt6-plugin-odbc qt6-plugin-pgsql qt6-plugin-sqlite"
-	depends+=" qt6-plugin-sqlite"
-else
-	hostmakedepends+=" qt5-host-tools qt5-devel"
-	makedepends+=" qt5-tools-devel qt5-plugin-mysql
-	 qt5-plugin-odbc qt5-plugin-pgsql qt5-plugin-sqlite
-	 qt5-plugin-tds qt5-x11extras-devel"
-	depends+=" qt5-plugin-sqlite"
-fi


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture: x86_64-glibc
- I built this PR locally for these architectures:
  - x86_64-musl: build
  - aarch64: cross build
  - aarch64-musl: cross build
  - armv7l: cross build
  - armv6l-musl: cross build
  - i686: cross build

Please advise whether `desc_option_qt6` should belong here or perhaps in _common/options.description_
