### PR TITLE
python3-uvicorn: update to 0.30.6

### DIFF
--- a/srcpkgs/python3-uvicorn/template
+++ b/srcpkgs/python3-uvicorn/template
@@ -1,6 +1,6 @@
 # Template file for 'python3-uvicorn'
 pkgname=python3-uvicorn
-version=0.30.1
+version=0.30.6
 revision=1
 build_style=python3-pep517
 hostmakedepends="hatchling"
@@ -11,7 +11,7 @@ license="BSD-3-Clause"
 homepage="https://www.uvicorn.org/"
 changelog="https://github.com/encode/uvicorn/blob/master/CHANGELOG.md"
 distfiles="${PYPI_SITE}/u/uvicorn/uvicorn-${version}.tar.gz"
-checksum=d46cd8e0fd80240baffbcd9ec1012a712938754afcf81bce56c024c1656aece8
+checksum=4b15decdda1e72be08209e860a1e10e92439ad5b97cf44cc945fcbee66fc5788
 
 post_install() {
 	vlicense LICENSE.md


### PR DESCRIPTION
- I tested the changes in this PR: **briefly**
- I built this PR locally for my native architecture, (x86_64-glibc)