### PR TITLE
ruby-addressable: update to 2.8.7

### DIFF
--- a/srcpkgs/ruby-addressable/template
+++ b/srcpkgs/ruby-addressable/template
@@ -1,11 +1,11 @@
 # Template file for 'ruby-addressable'
 pkgname=ruby-addressable
-version=2.7.0
-revision=8
+version=2.8.7
+revision=1
 build_style=gem
 depends="ruby-public_suffix>=2.0.2 ruby-public_suffix<5.0"
 short_desc="Replacement for Ruby's standard library URI implementation"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="Apache-2.0"
 homepage="https://github.com/sporkmonger/addressable"
-checksum=5e9b62fe1239091ea9b2893cd00ffe1bcbdd9371f4e1d35fac595c98c5856cbb
+checksum=462986537cf3735ab5f3c0f557f14155d778f4b43ea4f485a9deb9c8f7c58232


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **NO**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures :
  - i686-glibc

