### PR TITLE
ruby-backports: update to 3.25.0

### DIFF
--- a/srcpkgs/ruby-backports/template
+++ b/srcpkgs/ruby-backports/template
@@ -1,13 +1,13 @@
 # Template file for 'ruby-backports'
 pkgname=ruby-backports
-version=3.15.0
-revision=7
+version=3.25.0
+revision=1
 build_style=gem
 short_desc="Essential backports that enable many of the nice features of Ruby"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
 homepage="https://github.com/marcandre/backports"
-checksum=c23ad4b8b3637992f34c41256b46d49dc49a3725f1df78de42469deb43749f31
+checksum=c44a1fc0b99195d1834f748079a994d905e1e5dfc8a54baa549cffe1497d220d
 
 post_install() {
 	vlicense LICENSE.txt


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **NO**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures:
  - i686-glibc

