### PR TITLE
fastfetch: update to 2.21.3

### DIFF
--- a/srcpkgs/fastfetch/template
+++ b/srcpkgs/fastfetch/template
@@ -1,6 +1,6 @@
 # Template file for 'fastfetch'
 pkgname=fastfetch
-version=2.21.1
+version=2.21.3
 revision=1
 build_style=cmake
 configure_args="-DENABLE_SYSTEM_YYJSON=ON"
@@ -14,7 +14,7 @@ license="MIT"
 homepage="https://github.com/fastfetch-cli/fastfetch"
 changelog="https://github.com/fastfetch-cli/fastfetch/raw/dev/CHANGELOG.md"
 distfiles="https://github.com/fastfetch-cli/fastfetch/archive/refs/tags/${version}.tar.gz"
-checksum=67afc33bc1ad321cecf9e4c6f22b09d85020d0beacb10c31008d1111a6a72b70
+checksum=cec1f126ade7a5ef971901b1cdbe79f5864523d7a0a92732991619485d13e2e7
 
 if [ -n "$XBPS_CHECK_PKGS" ]; then
 	configure_args+=" -DBUILD_TESTS=ON"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture: x86_64-musl
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64
  - aarch64
  - aarch64-musl
  - i686
  - armv7l
  - armv7l-musl
