### PR TITLE
papis: update to 0.13.

### DIFF
--- a/srcpkgs/papis/template
+++ b/srcpkgs/papis/template
@@ -1,7 +1,7 @@
 # Template file for 'papis'
 pkgname=papis
 version=0.13
-revision=2
+revision=3
 build_style=python3-module
 make_check_target="papis tests"
 hostmakedepends="python3-setuptools"
@@ -9,7 +9,8 @@ depends="python3-requests python3-yaml python3-chardet python3-BeautifulSoup4
  python3-colorama python3-click python3-slugify python3-prompt_toolkit
  python3-tqdm python3-Pygments python3-stevedore python3-parsing
  python3-filetype python3-bibtexparser python3-habanero python3-arxiv2bib
- python3-isbnlib python3-lxml python3-doi python3-dominate python3-Whoosh"
+ python3-isbnlib python3-lxml python3-doi python3-dominate python3-Whoosh
+ python3-typing_extensions"
 checkdepends="${depends} python3-typing_extensions python3-pytest-cov"
 short_desc="Command-line based document and bibliography manager"
 maintainer="xaltsc <xaltsc@protonmail.ch>"


### PR DESCRIPTION
Not really an update, just to add a missing dependency, `python3-typing_extensions`.


#### Testing the changes
- I tested the changes in this PR: **YES**

