### PR TITLE
pstate-frequency: update to 3.15.1

### DIFF
--- a/srcpkgs/pstate-frequency/template
+++ b/srcpkgs/pstate-frequency/template
@@ -1,6 +1,6 @@
 # Template file for 'pstate-frequency'
 pkgname=pstate-frequency
-version=3.11.0
+version=3.15.1
 revision=1
 archs="i686* x86_64*"
 build_style=gnu-makefile
@@ -10,5 +10,5 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="https://pyamsoft.github.io/pstate-frequency/"
 distfiles="https://github.com/pyamsoft/pstate-frequency/archive/${version}.tar.gz"
-checksum=df232f57de91c6527958a89fc06010d8ed9bffd686f1f682ebf9ef30bd5078d4
+checksum=837e0a04135afc0b33a04023d5a1ee4fdd981cb0576834813d883a0cbd2e92c2
 conf_files="/etc/pstate-frequency.d/*.plan"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **NO**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures:
  - i686-glibc (crossbuild)
