### PR TITLE
New package: gnome-network-displays-0.96.0

### DIFF
--- a/srcpkgs/gnome-network-displays/template
+++ b/srcpkgs/gnome-network-displays/template
@@ -1,0 +1,17 @@
+# Template file for 'gnome-network-displays'
+pkgname=gnome-network-displays
+version=0.96.0
+revision=1
+build_style=meson
+hostmakedepends="desktop-file-utils gettext glib-devel gtk4-update-icon-cache
+ pkg-config"
+makedepends="NetworkManager-devel avahi-glib-libs-devel gst-rtsp-server-devel
+ libadwaita-devel libportal-gtk4-devel libsoup3-devel protobuf-c-devel
+ pulseaudio-devel"
+short_desc="Screencasting for GNOME"
+maintainer="chrysos349 <chrysostom349@gmail.com>"
+license="GPL-3.0-or-later"
+homepage="https://gitlab.gnome.org/GNOME/gnome-network-displays"
+changelog="https://gitlab.gnome.org/GNOME/gnome-network-displays/-/raw/master/NEWS"
+distfiles="${GNOME_SITE}/gnome-network-displays/${version%.*}/gnome-network-displays-${version}.tar.xz"
+checksum=3c1e44b1324710ede5fb8bb10598d85f9734c923e268cdc248760563deeaa497


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86-64)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl x
  - armv7l x 
  - armv6l-musl x