### PR TITLE
RFC: build-style/cmake: set -Wno-dev

### DIFF
--- a/common/build-style/cmake.sh
+++ b/common/build-style/cmake.sh
@@ -72,6 +72,9 @@ _EOF
 
 	cmake_args+=" -DCMAKE_INSTALL_SBINDIR:PATH=bin"
 
+	# https://cmake.org/cmake/help/latest/manual/cmake.1.html#cmdoption-cmake-Wno-dev
+	cmake_args+=" -Wno-dev"
+
 	export CMAKE_GENERATOR="${CMAKE_GENERATOR:-Ninja}"
 	# Remove -pipe: https://gitlab.kitware.com/cmake/cmake/issues/19590
 	CFLAGS="-DNDEBUG ${CFLAGS/ -pipe / }" CXXFLAGS="-DNDEBUG ${CXXFLAGS/ -pipe / }" \

--- a/srcpkgs/Lucene++/template
+++ b/srcpkgs/Lucene++/template
@@ -3,7 +3,6 @@ pkgname=Lucene++
 version=3.0.7
 revision=15
 build_style=cmake
-configure_args="-Wno-dev"
 makedepends="boost-devel gtest-devel"
 short_desc="C++ port of the popular text search engine"
 maintainer="Enno Boland <gottox@voidlinux.org>"

--- a/srcpkgs/intel-gmmlib/template
+++ b/srcpkgs/intel-gmmlib/template
@@ -12,7 +12,6 @@ build_style=cmake
 # intel-media-driver, which is wholly optional and installed only on
 # systems with supported CPUs, it doesn't make sense to change the
 # compilers flag in use.
-configure_args="-Wno-dev"
 short_desc="Intel Graphics Memory Management Library"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"


### PR DESCRIPTION
For most packages (maybe all?) we don't add any `CMakeLists.txt` files, so we don't need deprecation or policy warnings. The exceptions to this have the option to add `configure_args="-Wdev"` to opt-in to deprecation and policy warnings (please tell me about them so I can add them to this PR)

Note that this PR/RFC came about because I briefly considered adding `-Wno-dev` to LGOGDownloader's `configure_args` to silence this warning:
```
CMake Warning (dev) at CMakeLists.txt:17 (find_package):
  Policy CMP0167 is not set: The FindBoost module is removed.  Run "cmake
  --help-policy CMP0167" for policy details.  Use the cmake_policy command to
  set the policy and suppress this warning.

This warning is for project developers.  Use -Wno-dev to suppress it.
```
then I realized other packages likely issue similar warnings.

Cmake manual
https://cmake.org/cmake/help/latest/manual/cmake.1.html#cmdoption-cmake-Wno-dev
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

[ci skip]
<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
