### PR TITLE
python3-numpy: update to 2.1.0.

### DIFF
--- a/srcpkgs/flintlib/patches/2027.patch
+++ b/srcpkgs/flintlib/patches/2027.patch
@@ -1,0 +1,322 @@
+See: https://github.com/flintlib/flint/pull/2027
+
+From 1b93e73d00881be12e04b7f13e070214a3c9e1cc Mon Sep 17 00:00:00 2001
+From: Dima Pasechnik <dima@pasechnik.info>
+Date: Wed, 19 Jun 2024 22:16:34 +0100
+Subject: [PATCH] ensure C99 compliance in headers, as 'I' is reserved
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Note that the following code
+---- cut here: save as t.c
+---- cut here
+
+fails to compile with a suffciently new compiler, e.g. clang 16 or gcc 14.
+
+$ gcc -c t.c
+In file included from t.c:1:
+/usr/include/flint/mpoly.h:1319:43: error: expected ‘)’ before ‘__extension__’
+ 1319 | void mpoly_gcd_info_init(mpoly_gcd_info_t I, slong nvars);
+      |                                           ^
+In file included from /usr/include/flint/fmpz_types.h:15,
+                 from /usr/include/flint/fmpz_mod_types.h:15,
+                 from /usr/include/flint/mpoly_types.h:15,
+                 from /usr/include/flint/mpoly.h:23,
+                 from t.c:2:
+/usr/include/flint/mpoly.h:1319:46: error: expected ‘;’, ‘,’ or ‘)’ before ‘mp_limb_signed_t’
+ 1319 | void mpoly_gcd_info_init(mpoly_gcd_info_t I, slong nvars);
+
+...
+---
+ src/fft_small.h             |  6 +++---
+ src/fmpz_mod_mpoly_factor.h |  8 ++++----
+ src/fmpz_mpoly.h            |  2 +-
+ src/fmpz_mpoly_factor.h     | 18 +++++++++---------
+ src/fq_nmod_mpoly_factor.h  |  6 +++---
+ src/fq_zech_mpoly_factor.h  |  6 +++---
+ src/mpoly.h                 | 18 +++++++++---------
+ src/nmod_mpoly.h            |  4 ++--
+ src/nmod_mpoly_factor.h     |  6 +++---
+ 9 files changed, 37 insertions(+), 37 deletions(-)
+
+diff --git a/src/fft_small.h b/src/fft_small.h
+index 3f62f2e988..b7404f196d 100644
+--- a/src/fft_small.h
++++ b/src/fft_small.h
+@@ -242,10 +242,10 @@ FLINT_INLINE double sd_fft_ctx_get_fft_index(double* d, ulong i)
+ }
+ 
+ /* sd_fft.c */
+-void sd_fft_trunc(const sd_fft_lctx_t Q, ulong I, ulong S, ulong k, ulong j, ulong itrunc, ulong otrunc);
++void sd_fft_trunc(const sd_fft_lctx_t Q, ulong Iv, ulong S, ulong k, ulong j, ulong itrunc, ulong otrunc);
+ 
+ /* sd_ifft.c */
+-void sd_ifft_trunc(const sd_fft_lctx_t Q, ulong I, ulong S, ulong k, ulong j, ulong z, ulong n, int f);
++void sd_ifft_trunc(const sd_fft_lctx_t Q, ulong Iv, ulong S, ulong k, ulong j, ulong z, ulong n, int f);
+ 
+ /* sd_fft_ctx.c */
+ void sd_fft_ctx_clear(sd_fft_ctx_t Q);
+@@ -428,7 +428,7 @@ typedef struct {
+ 
+ typedef mpn_ctx_struct mpn_ctx_t[1];
+ 
+-void _convert_block(ulong* Xs, sd_fft_ctx_struct* Rffts, double* d, ulong dstride, ulong np, ulong I);
++void _convert_block(ulong* Xs, sd_fft_ctx_struct* Rffts, double* d, ulong dstride, ulong np, ulong Iv);
+ ulong flint_mpn_nbits(const ulong* a, ulong an);
+ int flint_mpn_cmp_ui_2exp(const ulong* a, ulong an, ulong b, ulong e);
+ unsigned char flint_mpn_add_inplace_c(ulong* z, ulong zn, ulong* a, ulong an, unsigned char cf);
+diff --git a/src/fmpz_mod_mpoly_factor.h b/src/fmpz_mod_mpoly_factor.h
+index 359fdd1e3d..460695dd23 100644
+--- a/src/fmpz_mod_mpoly_factor.h
++++ b/src/fmpz_mod_mpoly_factor.h
+@@ -1203,15 +1203,15 @@ typedef struct {
+ typedef fmpz_mod_mpoly_pfrac_struct fmpz_mod_mpoly_pfrac_t[1];
+ 
+ 
+-int fmpz_mod_mpoly_pfrac_init(fmpz_mod_mpoly_pfrac_t I,
++int fmpz_mod_mpoly_pfrac_init(fmpz_mod_mpoly_pfrac_t Iv,
+     flint_bitcnt_t bits, slong l, slong r, const fmpz_mod_mpoly_struct * betas,
+                           const fmpz * alpha, const fmpz_mod_mpoly_ctx_t ctx);
+ 
+-void fmpz_mod_mpoly_pfrac_clear(fmpz_mod_mpoly_pfrac_t I,
++void fmpz_mod_mpoly_pfrac_clear(fmpz_mod_mpoly_pfrac_t Iv,
+                                               const fmpz_mod_mpoly_ctx_t ctx);
+ 
+ int fmpz_mod_mpoly_pfrac(slong r, fmpz_mod_mpoly_t t, const slong * deg,
+-                     fmpz_mod_mpoly_pfrac_t I, const fmpz_mod_mpoly_ctx_t ctx);
++                     fmpz_mod_mpoly_pfrac_t Iv, const fmpz_mod_mpoly_ctx_t ctx);
+ 
+ int fmpz_mod_mpoly_hlift(slong m, fmpz_mod_mpoly_struct * f, slong r,
+             const fmpz * alpha, const fmpz_mod_mpoly_t A, const slong * degs,
+@@ -1290,7 +1290,7 @@ int fmpz_mod_mpolyn_gcd_brown_smprime(
+     fmpz_mod_mpolyn_t B,
+     slong var,
+     const fmpz_mod_mpoly_ctx_t ctx,
+-    const mpoly_gcd_info_t I,
++    const mpoly_gcd_info_t Iv,
+     fmpz_mod_poly_polyun_mpolyn_stack_t St);
+ 
+ int fmpz_mod_mpolyl_gcdp_zippel(
+diff --git a/src/fmpz_mpoly.h b/src/fmpz_mpoly.h
+index b7c9677915..4be3d05c56 100644
+--- a/src/fmpz_mpoly.h
++++ b/src/fmpz_mpoly.h
+@@ -1084,7 +1084,7 @@ void fmpz_mpoly_vec_randtest_not_zero(fmpz_mpoly_vec_t vec, flint_rand_t state,
+ 
+ void fmpz_mpoly_spoly(fmpz_mpoly_t res, const fmpz_mpoly_t f, const fmpz_mpoly_t g, const fmpz_mpoly_ctx_t ctx);
+ void fmpz_mpoly_vec_set_primitive_unique(fmpz_mpoly_vec_t G, const fmpz_mpoly_vec_t F, const fmpz_mpoly_ctx_t ctx);
+-void fmpz_mpoly_reduction_primitive_part(fmpz_mpoly_t res, const fmpz_mpoly_t f, const fmpz_mpoly_vec_t I, const fmpz_mpoly_ctx_t ctx);
++void fmpz_mpoly_reduction_primitive_part(fmpz_mpoly_t res, const fmpz_mpoly_t f, const fmpz_mpoly_vec_t Iv, const fmpz_mpoly_ctx_t ctx);
+ int fmpz_mpoly_vec_is_groebner(const fmpz_mpoly_vec_t G, const fmpz_mpoly_vec_t F, const fmpz_mpoly_ctx_t ctx);
+ void fmpz_mpoly_buchberger_naive(fmpz_mpoly_vec_t G, const fmpz_mpoly_vec_t F, const fmpz_mpoly_ctx_t ctx);
+ int fmpz_mpoly_buchberger_naive_with_limits(fmpz_mpoly_vec_t G, const fmpz_mpoly_vec_t F,
+diff --git a/src/fmpz_mpoly_factor.h b/src/fmpz_mpoly_factor.h
+index 0da7c1052b..a04ef8021e 100644
+--- a/src/fmpz_mpoly_factor.h
++++ b/src/fmpz_mpoly_factor.h
+@@ -298,11 +298,11 @@ void fmpz_mpoly_from_mpolyl_perm_inflate(fmpz_mpoly_t A,
+ 
+ int fmpz_mpolyl_gcd_brown(fmpz_mpoly_t G,
+         fmpz_mpoly_t Abar, fmpz_mpoly_t Bbar, fmpz_mpoly_t A, fmpz_mpoly_t B,
+-                         const fmpz_mpoly_ctx_t ctx, const mpoly_gcd_info_t I);
++                         const fmpz_mpoly_ctx_t ctx, const mpoly_gcd_info_t Iv);
+ 
+ int fmpz_mpolyl_gcd_brown_threaded_pool(fmpz_mpoly_t G,
+         fmpz_mpoly_t Abar, fmpz_mpoly_t Bbar, fmpz_mpoly_t A, fmpz_mpoly_t B,
+-                         const fmpz_mpoly_ctx_t ctx, const mpoly_gcd_info_t I,
++                         const fmpz_mpoly_ctx_t ctx, const mpoly_gcd_info_t Iv,
+                         const thread_pool_handle * handles, slong num_handles);
+ 
+ int fmpz_mpolyl_gcd_zippel(fmpz_mpoly_t G, fmpz_mpoly_t Abar,
+@@ -340,15 +340,15 @@ typedef struct {
+ 
+ typedef fmpz_poly_pfrac_struct fmpz_poly_pfrac_t[1];
+ 
+-void fmpz_poly_pfrac_init(fmpz_poly_pfrac_t I);
++void fmpz_poly_pfrac_init(fmpz_poly_pfrac_t Iv);
+ 
+-void fmpz_poly_pfrac_clear(fmpz_poly_pfrac_t I);
++void fmpz_poly_pfrac_clear(fmpz_poly_pfrac_t Iv);
+ 
+-int fmpz_poly_pfrac_precompute(fmpz_poly_pfrac_t I,
++int fmpz_poly_pfrac_precompute(fmpz_poly_pfrac_t Iv,
+                                           const fmpz_poly_struct * b, slong r);
+ 
+ int fmpz_poly_pfrac_precomp(fmpz_poly_struct * c,
+-                                     const fmpz_poly_t A, fmpz_poly_pfrac_t I);
++                                     const fmpz_poly_t A, fmpz_poly_pfrac_t Iv);
+ 
+ typedef struct {
+     flint_bitcnt_t bits;
+@@ -372,15 +372,15 @@ typedef struct {
+ 
+ typedef fmpz_mpoly_pfrac_struct fmpz_mpoly_pfrac_t[1];
+ 
+-int fmpz_mpoly_pfrac_init(fmpz_mpoly_pfrac_t I, flint_bitcnt_t bits,
++int fmpz_mpoly_pfrac_init(fmpz_mpoly_pfrac_t Iv, flint_bitcnt_t bits,
+                             slong r, slong w, const fmpz_mpoly_struct * betas,
+                                const fmpz * alpha, const fmpz_mpoly_ctx_t ctx);
+ 
+-void fmpz_mpoly_pfrac_clear(fmpz_mpoly_pfrac_t I,
++void fmpz_mpoly_pfrac_clear(fmpz_mpoly_pfrac_t Iv,
+                                                    const fmpz_mpoly_ctx_t ctx);
+ 
+ int fmpz_mpoly_pfrac(slong l, fmpz_mpoly_t t, const slong * degs,
+-                             fmpz_mpoly_pfrac_t I, const fmpz_mpoly_ctx_t ctx);
++                             fmpz_mpoly_pfrac_t Iv, const fmpz_mpoly_ctx_t ctx);
+ 
+ int fmpz_mpoly_hlift(slong m, fmpz_mpoly_struct * f, slong r,
+                 const fmpz * alpha, const fmpz_mpoly_t A, const slong * degs,
+diff --git a/src/fq_nmod_mpoly_factor.h b/src/fq_nmod_mpoly_factor.h
+index 6289d3f1c5..29caa99aa4 100644
+--- a/src/fq_nmod_mpoly_factor.h
++++ b/src/fq_nmod_mpoly_factor.h
+@@ -427,7 +427,7 @@ typedef fq_nmod_mpoly_pfrac_struct fq_nmod_mpoly_pfrac_t[1];
+ 
+ 
+ int fq_nmod_mpoly_pfrac_init(
+-    fq_nmod_mpoly_pfrac_t I,
++    fq_nmod_mpoly_pfrac_t Iv,
+     flint_bitcnt_t bits,
+     slong l, slong r,
+     const fq_nmod_mpoly_struct * betas,
+@@ -435,14 +435,14 @@ int fq_nmod_mpoly_pfrac_init(
+     const fq_nmod_mpoly_ctx_t ctx);
+ 
+ void fq_nmod_mpoly_pfrac_clear(
+-    fq_nmod_mpoly_pfrac_t I,
++    fq_nmod_mpoly_pfrac_t Iv,
+     const fq_nmod_mpoly_ctx_t ctx);
+ 
+ int fq_nmod_mpoly_pfrac(
+     slong r,
+     fq_nmod_mpoly_t t,
+     const slong * deg,
+-    fq_nmod_mpoly_pfrac_t I,
++    fq_nmod_mpoly_pfrac_t Iv,
+     const fq_nmod_mpoly_ctx_t ctx);
+ 
+ int fq_nmod_mpoly_hlift(
+diff --git a/src/fq_zech_mpoly_factor.h b/src/fq_zech_mpoly_factor.h
+index 06f31369f9..3d3c51419f 100644
+--- a/src/fq_zech_mpoly_factor.h
++++ b/src/fq_zech_mpoly_factor.h
+@@ -652,7 +652,7 @@ typedef fq_zech_mpoly_pfrac_struct fq_zech_mpoly_pfrac_t[1];
+ 
+ 
+ int fq_zech_mpoly_pfrac_init(
+-    fq_zech_mpoly_pfrac_t I,
++    fq_zech_mpoly_pfrac_t Iv,
+     flint_bitcnt_t bits,
+     slong l, slong r,
+     const fq_zech_mpoly_struct * betas,
+@@ -660,14 +660,14 @@ int fq_zech_mpoly_pfrac_init(
+     const fq_zech_mpoly_ctx_t ctx);
+ 
+ void fq_zech_mpoly_pfrac_clear(
+-    fq_zech_mpoly_pfrac_t I,
++    fq_zech_mpoly_pfrac_t Iv,
+     const fq_zech_mpoly_ctx_t ctx);
+ 
+ int fq_zech_mpoly_pfrac(
+     slong r,
+     fq_zech_mpoly_t t,
+     const slong * deg,
+-    fq_zech_mpoly_pfrac_t I,
++    fq_zech_mpoly_pfrac_t Iv,
+     const fq_zech_mpoly_ctx_t ctx);
+ 
+ int fq_zech_mpoly_hlift(
+diff --git a/src/mpoly.h b/src/mpoly.h
+index b0950e3a48..fe0ccbe7c4 100644
+--- a/src/mpoly.h
++++ b/src/mpoly.h
+@@ -1363,9 +1363,9 @@ typedef struct
+ 
+ typedef mpoly_gcd_info_struct mpoly_gcd_info_t[1];
+ 
+-void mpoly_gcd_info_init(mpoly_gcd_info_t I, slong nvars);
++void mpoly_gcd_info_init(mpoly_gcd_info_t Iv, slong nvars);
+ 
+-void mpoly_gcd_info_clear(mpoly_gcd_info_t I);
++void mpoly_gcd_info_clear(mpoly_gcd_info_t Iv);
+ 
+ void mpoly_gcd_info_limits(ulong * Amax_exp, ulong * Amin_exp,
+                        slong * Amax_exp_count, slong * Amin_exp_count,
+@@ -1378,25 +1378,25 @@ void mpoly_gcd_info_stride(ulong * strides,
+                              const ulong * Bmax_exp, const ulong * Bmin_exp,
+                                                        const mpoly_ctx_t mctx);
+ 
+-void mpoly_gcd_info_set_perm(mpoly_gcd_info_t I,
++void mpoly_gcd_info_set_perm(mpoly_gcd_info_t Iv,
+                          slong Alength, slong Blength, const mpoly_ctx_t mctx);
+ 
+-slong mpoly_gcd_info_get_brown_upper_limit(const mpoly_gcd_info_t I,
++slong mpoly_gcd_info_get_brown_upper_limit(const mpoly_gcd_info_t Iv,
+                                                        slong var, slong bound);
+ 
+-void mpoly_gcd_info_measure_hensel(mpoly_gcd_info_t I,
++void mpoly_gcd_info_measure_hensel(mpoly_gcd_info_t Iv,
+                          slong Alength, slong Blength, const mpoly_ctx_t mctx);
+ 
+-void mpoly_gcd_info_measure_brown(mpoly_gcd_info_t I,
++void mpoly_gcd_info_measure_brown(mpoly_gcd_info_t Iv,
+                          slong Alength, slong Blength, const mpoly_ctx_t mctx);
+ 
+-void mpoly_gcd_info_measure_bma(mpoly_gcd_info_t I,
++void mpoly_gcd_info_measure_bma(mpoly_gcd_info_t Iv,
+                          slong Alength, slong Blength, const mpoly_ctx_t mctx);
+ 
+-void mpoly_gcd_info_measure_zippel(mpoly_gcd_info_t I,
++void mpoly_gcd_info_measure_zippel(mpoly_gcd_info_t Iv,
+                          slong Alength, slong Blength, const mpoly_ctx_t mctx);
+ 
+-void mpoly_gcd_info_measure_zippel2(mpoly_gcd_info_t I,
++void mpoly_gcd_info_measure_zippel2(mpoly_gcd_info_t Iv,
+                          slong Alength, slong Blength, const mpoly_ctx_t mctx);
+ 
+ int mpoly_monomial_cofactors(fmpz * Abarexps, fmpz * Bbarexps,
+diff --git a/src/nmod_mpoly.h b/src/nmod_mpoly.h
+index 2a8136e6eb..716ac9669a 100644
+--- a/src/nmod_mpoly.h
++++ b/src/nmod_mpoly.h
+@@ -1619,13 +1619,13 @@ int nmod_mpolyn_gcd_brown_smprime_bivar(
+ int nmod_mpolyn_gcd_brown_smprime(nmod_mpolyn_t G,
+                                   nmod_mpolyn_t Abar, nmod_mpolyn_t Bbar,
+                                  nmod_mpolyn_t A, nmod_mpolyn_t B, slong var,
+-                         const nmod_mpoly_ctx_t ctx, const mpoly_gcd_info_t I,
++                         const nmod_mpoly_ctx_t ctx, const mpoly_gcd_info_t Iv,
+                                                          nmod_poly_stack_t Sp);
+ 
+ int nmod_mpolyn_gcd_brown_smprime_threaded_pool(nmod_mpolyn_t G,
+                                 nmod_mpolyn_t Abar, nmod_mpolyn_t Bbar,
+                                nmod_mpolyn_t A, nmod_mpolyn_t B, slong var,
+-                         const nmod_mpoly_ctx_t ctx, const mpoly_gcd_info_t I,
++                         const nmod_mpoly_ctx_t ctx, const mpoly_gcd_info_t Iv,
+                         const thread_pool_handle * handles, slong num_workers);
+ 
+ int nmod_mpolyn_gcd_brown_lgprime(nmod_mpolyn_t G,
+diff --git a/src/nmod_mpoly_factor.h b/src/nmod_mpoly_factor.h
+index a46afc860f..b16c802b9b 100644
+--- a/src/nmod_mpoly_factor.h
++++ b/src/nmod_mpoly_factor.h
+@@ -362,15 +362,15 @@ typedef struct {
+ typedef nmod_mpoly_pfrac_struct nmod_mpoly_pfrac_t[1];
+ 
+ 
+-int nmod_mpoly_pfrac_init(nmod_mpoly_pfrac_t I, flint_bitcnt_t bits,
++int nmod_mpoly_pfrac_init(nmod_mpoly_pfrac_t Iv, flint_bitcnt_t bits,
+                          slong l, slong r, const nmod_mpoly_struct * betas,
+                           const mp_limb_t * alpha, const nmod_mpoly_ctx_t ctx);
+ 
+-void nmod_mpoly_pfrac_clear(nmod_mpoly_pfrac_t I,
++void nmod_mpoly_pfrac_clear(nmod_mpoly_pfrac_t Iv,
+                                                    const nmod_mpoly_ctx_t ctx);
+ 
+ int nmod_mpoly_pfrac(slong r, nmod_mpoly_t t, const slong * deg,
+-                             nmod_mpoly_pfrac_t I, const nmod_mpoly_ctx_t ctx);
++                             nmod_mpoly_pfrac_t Iv, const nmod_mpoly_ctx_t ctx);
+ 
+ int nmod_mpoly_hlift(slong m, nmod_mpoly_struct * f, slong r,
+             const mp_limb_t * alpha, const nmod_mpoly_t A, const slong * degs,

--- a/srcpkgs/flintlib/template
+++ b/srcpkgs/flintlib/template
@@ -1,7 +1,7 @@
 # Template file for 'flintlib'
 pkgname=flintlib
 version=3.1.2
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--prefix=/usr --disable-arch $(vopt_with ntl)
  $(vopt_if openblas --with-blas-include=${XBPS_CROSS_BASE}/usr/include/openblas)"

--- a/srcpkgs/python3-numpy/template
+++ b/srcpkgs/python3-numpy/template
@@ -1,6 +1,6 @@
 # Template file for 'python3-numpy'
 pkgname=python3-numpy
-version=2.0.1
+version=2.1.0
 revision=1
 build_style=python3-pep517
 build_helper="meson qemu"
@@ -19,7 +19,7 @@ license="BSD-3-Clause"
 homepage="https://www.numpy.org/"
 changelog="https://github.com/numpy/numpy/releases"
 distfiles="${PYPI_SITE}/n/numpy/numpy-${version}.tar.gz"
-checksum=485b87235796410c3519a699cfe1faab097e509e90ebb05dcd098db2ae87e7b3
+checksum=7dc90da0081f7e1da49ec4e398ede6a8e9cc4f5ebe5f9e06b443ed889ee9aaa2
 alternatives="numpy:f2py:/usr/bin/f2py3"
 
 build_options="openblas"

--- a/srcpkgs/python3-scipy/template
+++ b/srcpkgs/python3-scipy/template
@@ -1,7 +1,7 @@
 # Template file for 'python3-scipy'
 pkgname=python3-scipy
-version=1.14.0
-revision=2
+version=1.14.1
+revision=1
 build_style=python3-pep517
 build_helper="meson numpy"
 # SciPy imposes strict and unnecessary restrictions on build dependencies
@@ -19,8 +19,9 @@ short_desc="Scientific library for Python3"
 maintainer="Andrew J. Hesford <ajh@sideband.org>"
 license="BSD-3-Clause"
 homepage="https://scipy.org/"
+changelog="https://github.com/scipy/scipy/releases"
 distfiles="${PYPI_SITE}/s/scipy/scipy-${version}.tar.gz"
-checksum=b5923f48cb840380f9854339176ef21763118a7300a88203ccd0bdd26e58527b
+checksum=5a275584e726026a5699459aa72f828a610821006228e841b94275c4a7c08417
 # must be tested from site dir of installed version (see dev.py:739)
 make_check_pre='eval env -C "${testdir}/${py3_sitelib}"'
 

--- a/srcpkgs/sagemath/patches/numpy_2.1a.patch
+++ b/srcpkgs/sagemath/patches/numpy_2.1a.patch
@@ -1,0 +1,28 @@
+commit 241dc39bd0ba1c056f88bee46a0345d59093eaff
+Author: Gonzalo Tornaría <tornaria@cmat.edu.uy>
+Date:   Mon Aug 19 23:25:32 2024 -0300
+
+    add copy parameter to numpy (needed for v2.1)
+
+diff --git a/src/sage/matrix/matrix1.pyx b/src/sage/matrix/matrix1.pyx
+index c38df5412f0..f587cef651a 100644
+--- a/src/sage/matrix/matrix1.pyx
++++ b/src/sage/matrix/matrix1.pyx
+@@ -671,7 +671,7 @@ cdef class Matrix(Matrix0):
+             entries = [[sib(v, 2) for v in row] for row in self.rows()]
+             return sib.name('matrix')(self.base_ring(), entries)
+ 
+-    def numpy(self, dtype=None):
++    def numpy(self, dtype=None, copy=True):
+         """
+         Return the Numpy matrix associated to this matrix.
+ 
+@@ -732,7 +732,7 @@ cdef class Matrix(Matrix0):
+             (3, 4)
+         """
+         import numpy
+-        A = numpy.matrix(self.list(), dtype=dtype)
++        A = numpy.matrix(self.list(), dtype=dtype, copy=copy)
+         return numpy.resize(A,(self.nrows(), self.ncols()))
+ 
+     # Define the magic "__array__" function so that numpy.array(m) can convert

--- a/srcpkgs/sagemath/patches/numpy_2.1b.patch
+++ b/srcpkgs/sagemath/patches/numpy_2.1b.patch
@@ -1,0 +1,229 @@
+commit 8b32fdb87725c1d67ffb51dadec1c331c7c35f3c
+Author: Gonzalo Tornaría <tornaria@cmat.edu.uy>
+Date:   Tue Aug 20 00:05:33 2024 -0300
+
+    silence np.set_printoptions (for numpy 2.1)
+
+diff --git a/src/sage/combinat/fully_packed_loop.py b/src/sage/combinat/fully_packed_loop.py
+index b3ebd206cd2..48866824224 100644
+--- a/src/sage/combinat/fully_packed_loop.py
++++ b/src/sage/combinat/fully_packed_loop.py
+@@ -68,7 +68,7 @@ def _make_color_list(n, colors=None, color_map=None, randomize=False):
+ 
+         sage: import numpy as np
+         sage: if int(np.version.short_version[0]) > 1:
+-        ....:     np.set_printoptions(legacy="1.25")
++        ....:     _token = np.set_printoptions(legacy="1.25")
+         sage: from sage.combinat.fully_packed_loop import _make_color_list
+         sage: _make_color_list(5)
+         sage: _make_color_list(5, ['blue', 'red'])
+diff --git a/src/sage/functions/special.py b/src/sage/functions/special.py
+index 2a03bb68f67..30b56722e66 100644
+--- a/src/sage/functions/special.py
++++ b/src/sage/functions/special.py
+@@ -219,7 +219,7 @@ class SphericalHarmonic(BuiltinFunction):
+         sage: from scipy.special import sph_harm  # NB: arguments x and y are swapped   # needs scipy
+         sage: import numpy as np                                                        # needs scipy
+         sage: if int(np.version.short_version[0]) > 1:                                  # needs scipy
+-        ....:     np.set_printoptions(legacy="1.25")                                    # needs scipy
++        ....:     _token = np.set_printoptions(legacy="1.25")                           # needs scipy
+         sage: sph_harm(1, 1, pi.n(), (pi/2).n())  # abs tol 1e-14                       # needs scipy sage.symbolic
+         (0.3454941494713355-4.231083042742082e-17j)
+ 
+diff --git a/src/sage/numerical/optimize.py b/src/sage/numerical/optimize.py
+index 7ae8ca4966f..4cba22efdba 100644
+--- a/src/sage/numerical/optimize.py
++++ b/src/sage/numerical/optimize.py
+@@ -385,7 +385,7 @@ def minimize(func, x0, gradient=None, hessian=None, algorithm="default",
+         ....:    return sum(100.0r*(x[1r:]-x[:-1r]**2.0r)**2.0r + (1r-x[:-1r])**2.0r)
+         sage: import numpy
+         sage: if int(numpy.version.short_version[0]) > 1:
+-        ....:     numpy.set_printoptions(legacy="1.25")
++        ....:     _token = numpy.set_printoptions(legacy="1.25")
+         sage: from numpy import zeros
+         sage: def rosen_der(x):
+         ....:    xm = x[1r:-1r]
+diff --git a/src/sage/plot/arrow.py b/src/sage/plot/arrow.py
+index 23e2517ca56..7375dcd5d1c 100644
+--- a/src/sage/plot/arrow.py
++++ b/src/sage/plot/arrow.py
+@@ -55,7 +55,7 @@ class CurveArrow(GraphicPrimitive):
+ 
+             sage: import numpy  # to ensure numpy 2.0 compatibility
+             sage: if int(numpy.version.short_version[0]) > 1:
+-            ....:     numpy.set_printoptions(legacy="1.25")
++            ....:     _token = numpy.set_printoptions(legacy="1.25")
+             sage: from sage.plot.arrow import CurveArrow
+             sage: b = CurveArrow(path=[[(0,0),(.5,.5),(1,0)],[(.5,1),(0,0)]],
+             ....:                options={})
+diff --git a/src/sage/plot/multigraphics.py b/src/sage/plot/multigraphics.py
+index 6be448f1e04..004594b77c4 100644
+--- a/src/sage/plot/multigraphics.py
++++ b/src/sage/plot/multigraphics.py
+@@ -786,7 +786,7 @@ class MultiGraphics(WithEqualityById, SageObject):
+             (0.2, 0.3, 0.4, 0.1)
+             sage: import numpy  # to ensure numpy 2.0 compatibility
+             sage: if int(numpy.version.short_version[0]) > 1:
+-            ....:     numpy.set_printoptions(legacy="1.25")
++            ....:     _token = numpy.set_printoptions(legacy="1.25")
+             sage: ax1.get_position().bounds  # tol 1.0e-13
+             (0.2, 0.3, 0.4000000000000001, 0.10000000000000003)
+ 
+@@ -1300,7 +1300,7 @@ class GraphicsArray(MultiGraphics):
+             sage: G = graphics_array([g1, g2])
+             sage: import numpy  # to ensure numpy 2.0 compatibility
+             sage: if int(numpy.version.short_version[0]) > 1:
+-            ....:     numpy.set_printoptions(legacy="1.25")
++            ....:     _token = numpy.set_printoptions(legacy="1.25")
+             sage: G.position(0)  # tol 5.0e-3
+             (0.025045451349937315,
+              0.03415488992713045,
+diff --git a/src/sage/plot/streamline_plot.py b/src/sage/plot/streamline_plot.py
+index d2cb11088c7..6d88517cc15 100644
+--- a/src/sage/plot/streamline_plot.py
++++ b/src/sage/plot/streamline_plot.py
+@@ -73,7 +73,7 @@ class StreamlinePlot(GraphicPrimitive):
+             sage: x, y = var('x y')
+             sage: import numpy  # to ensure numpy 2.0 compatibility
+             sage: if int(numpy.version.short_version[0]) > 1:
+-            ....:     numpy.set_printoptions(legacy="1.25")
++            ....:     _token = numpy.set_printoptions(legacy="1.25")
+             sage: d = streamline_plot((.01*x, x+y), (x,10,20), (y,10,20))[0].get_minmax_data()
+             sage: d['xmin']
+             10.0
+diff --git a/src/sage/rings/integer.pyx b/src/sage/rings/integer.pyx
+index 38c30f7627b..cfb8a5ff5f7 100644
+--- a/src/sage/rings/integer.pyx
++++ b/src/sage/rings/integer.pyx
+@@ -594,7 +594,7 @@ cdef class Integer(sage.structure.element.EuclideanDomainElement):
+ 
+             sage: import numpy                                                          # needs numpy
+             sage: if int(numpy.version.short_version[0]) > 1:                           # needs numpy
+-            ....:     numpy.set_printoptions(legacy="1.25")                             # needs numpy
++            ....:     _token = numpy.set_printoptions(legacy="1.25")                    # needs numpy
+             sage: numpy.int8('12') == 12                                                # needs numpy
+             True
+             sage: 12 == numpy.int8('12')                                                # needs numpy
+diff --git a/src/sage/rings/real_mpfi.pyx b/src/sage/rings/real_mpfi.pyx
+index 76fbfedab95..57de30c9d18 100644
+--- a/src/sage/rings/real_mpfi.pyx
++++ b/src/sage/rings/real_mpfi.pyx
+@@ -232,7 +232,7 @@ TESTS::
+ 
+     sage: import numpy                                                                  # needs numpy
+     sage: if int(numpy.version.short_version[0]) > 1:                                   # needs numpy
+-    ....:     numpy.set_printoptions(legacy="1.25")                                     # needs numpy
++    ....:     _token = numpy.set_printoptions(legacy="1.25")                            # needs numpy
+     sage: RIF(2) == numpy.int8('2')                                                     # needs numpy
+     True
+     sage: numpy.int8('2') == RIF(2)                                                     # needs numpy
+diff --git a/src/sage/schemes/elliptic_curves/period_lattice_region.pyx b/src/sage/schemes/elliptic_curves/period_lattice_region.pyx
+index 70ce616f92f..f604c6d3785 100644
+--- a/src/sage/schemes/elliptic_curves/period_lattice_region.pyx
++++ b/src/sage/schemes/elliptic_curves/period_lattice_region.pyx
+@@ -78,7 +78,7 @@ cdef class PeriodicRegion:
+ 
+             sage: import numpy as np
+             sage: if int(np.version.short_version[0]) > 1:
+-            ....:     np.set_printoptions(legacy="1.25")
++            ....:     _token = np.set_printoptions(legacy="1.25")
+             sage: from sage.schemes.elliptic_curves.period_lattice_region import PeriodicRegion
+             sage: data = np.zeros((4, 4))
+             sage: PeriodicRegion(CDF(2), CDF(2*I), data).is_empty()
+@@ -298,7 +298,7 @@ cdef class PeriodicRegion:
+ 
+             sage: import numpy as np
+             sage: if int(np.version.short_version[0]) > 1:
+-            ....:     np.set_printoptions(legacy="1.25")
++            ....:     _token = np.set_printoptions(legacy="1.25")
+             sage: from sage.schemes.elliptic_curves.period_lattice_region import PeriodicRegion
+             sage: data = np.zeros((10, 10))
+             sage: data[1:4,1:4] = True
+@@ -322,7 +322,7 @@ cdef class PeriodicRegion:
+ 
+             sage: import numpy as np
+             sage: if int(np.version.short_version[0]) > 1:
+-            ....:     np.set_printoptions(legacy="1.25")
++            ....:     _token = np.set_printoptions(legacy="1.25")
+             sage: from sage.schemes.elliptic_curves.period_lattice_region import PeriodicRegion
+             sage: data = np.zeros((4, 4))
+             sage: data[1,1] = True
+@@ -377,7 +377,7 @@ cdef class PeriodicRegion:
+ 
+             sage: import numpy as np
+             sage: if int(np.version.short_version[0]) > 1:
+-            ....:     np.set_printoptions(legacy="1.25")
++            ....:     _token = np.set_printoptions(legacy="1.25")
+             sage: from sage.schemes.elliptic_curves.period_lattice_region import PeriodicRegion
+ 
+             sage: data = np.zeros((20, 20))
+@@ -529,7 +529,7 @@ cdef class PeriodicRegion:
+ 
+             sage: import numpy as np
+             sage: if int(np.version.short_version[0]) > 1:
+-            ....:     np.set_printoptions(legacy="1.25")
++            ....:     _token = np.set_printoptions(legacy="1.25")
+             sage: from sage.schemes.elliptic_curves.period_lattice_region import PeriodicRegion
+             sage: data = np.zeros((4, 4))
+             sage: data[1, 1] = True
+diff --git a/src/sage/stats/basic_stats.py b/src/sage/stats/basic_stats.py
+index 6937f6cb410..fb296e00fb6 100644
+--- a/src/sage/stats/basic_stats.py
++++ b/src/sage/stats/basic_stats.py
+@@ -228,7 +228,7 @@ def std(v, bias=False):
+         sage: # needs numpy
+         sage: import numpy
+         sage: if int(numpy.version.short_version[0]) > 1:
+-        ....:     numpy.set_printoptions(legacy="1.25")
++        ....:     _token = numpy.set_printoptions(legacy="1.25")
+         sage: x = numpy.array([1,2,3,4,5])
+         sage: std(x, bias=False)
+         1.5811388300841898
+@@ -307,7 +307,7 @@ def variance(v, bias=False):
+         0.4897530450000000?
+         sage: import numpy                                                              # needs numpy
+         sage: if int(numpy.version.short_version[0]) > 1:                               # needs numpy
+-        ....:     numpy.set_printoptions(legacy="1.25")                                 # needs numpy
++        ....:     _token = numpy.set_printoptions(legacy="1.25")                        # needs numpy
+         sage: x = numpy.array([1,2,3,4,5])                                              # needs numpy
+         sage: variance(x, bias=False)                                                   # needs numpy
+         2.5
+diff --git a/src/sage/structure/coerce.pyx b/src/sage/structure/coerce.pyx
+index 955a256e9b4..e5ed6160b79 100644
+--- a/src/sage/structure/coerce.pyx
++++ b/src/sage/structure/coerce.pyx
+@@ -521,7 +521,7 @@ cdef class CoercionModel:
+ 
+         sage: import numpy                                                              # needs numpy
+         sage: if int(numpy.version.short_version[0]) > 1:                               # needs numpy
+-        ....:     numpy.set_printoptions(legacy="1.25")                                 # needs numpy
++        ....:     _token = numpy.set_printoptions(legacy="1.25")                        # needs numpy
+ 
+         sage: # needs sage.rings.real_mpfr
+         sage: x = polygen(RR)
+diff --git a/src/sage/symbolic/function.pyx b/src/sage/symbolic/function.pyx
+index cd89ad2a256..6fdf6d8ef23 100644
+--- a/src/sage/symbolic/function.pyx
++++ b/src/sage/symbolic/function.pyx
+@@ -965,7 +965,7 @@ cdef class BuiltinFunction(Function):
+ 
+             sage: import numpy                                                          # needs numpy
+             sage: if int(numpy.version.short_version[0]) > 1:                           # needs numpy
+-            ....:     numpy.set_printoptions(legacy="1.25")                             # needs numpy
++            ....:     _token = numpy.set_printoptions(legacy="1.25")                    # needs numpy
+ 
+             sage: sin(numpy.int32(0))                                                   # needs numpy
+             0.0
+diff --git a/src/sage/symbolic/ring.pyx b/src/sage/symbolic/ring.pyx
+index 5b007d9e5fd..4a096d317e7 100644
+--- a/src/sage/symbolic/ring.pyx
++++ b/src/sage/symbolic/ring.pyx
+@@ -1163,7 +1163,7 @@ cdef class NumpyToSRMorphism(Morphism):
+ 
+         sage: import numpy                                                              # needs numpy
+         sage: if int(numpy.version.short_version[0]) > 1:                               # needs numpy
+-        ....:     numpy.set_printoptions(legacy="1.25")                                 # needs numpy
++        ....:     _token = numpy.set_printoptions(legacy="1.25")                        # needs numpy
+         sage: f(x) = x^2
+         sage: f(numpy.int8('2'))                                                        # needs numpy
+         4

--- a/srcpkgs/sagemath/template
+++ b/srcpkgs/sagemath/template
@@ -1,7 +1,7 @@
 # Template file for 'sagemath'
 pkgname=sagemath
 version=10.4
-revision=2
+revision=3
 _pypi_version=${version/.beta/b}
 _pypi_version=${_pypi_version/.rc/rc}
 build_style=python3-pep517
@@ -25,7 +25,7 @@ depends="eclib-devel fflas-ffpack flintlib-devel gcc-fortran meson gd-devel
  python3-sympy python3-traitlets sage-data-combinatorial_designs
  python3-conway-polynomials sage-data-elliptic_curves sage-data-graphs
  sage-data-polytopes_db sympow tachyon threejs-sage"
-checkdepends="$depends pythran python3-Sphinx gdb"
+checkdepends="$depends python3-pytest pythran python3-Sphinx gdb"
 short_desc="Open source mathematics software"
 maintainer="Gonzalo Tornaría <tornaria@cmat.edu.uy>"
 license="GPL-2.0-or-later"


### PR DESCRIPTION
After the update, there's a conflict with flintlib headers which causes
trouble, for instance when building sagemath.

A patch to flintlib is included here (from https://github.com/flintlib/flint/pull/2027, already merged upstream).

@ahesford : I'm testing sagemath locally and here as well.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
