### PR TITLE
tmux: fix crash in SIXEL

### DIFF
--- a/srcpkgs/tmux/patches/sixelcrash.patch
+++ b/srcpkgs/tmux/patches/sixelcrash.patch
@@ -1,0 +1,76 @@
+From aa17f0e0c1c8b3f1d6fc8617613c74f07de66fae Mon Sep 17 00:00:00 2001
+From: Nicholas Marriott <nicholas.marriott@gmail.com>
+Date: Thu, 21 Mar 2024 11:37:09 +0000
+Subject: [PATCH] Fix crash if SIXEL colour register is invalid and remove
+ SIXEL images before reflow to avoid a different crash, from Anindya
+ Mukherjee.
+
+---
+ image-sixel.c  | 3 +++
+ input.c        | 2 +-
+ screen-write.c | 4 ++++
+ screen.c       | 6 +++---
+ 4 files changed, 11 insertions(+), 4 deletions(-)
+
+diff --git a/image-sixel.c b/image-sixel.c
+index 3396a22a7f..e23d17f902 100644
+--- a/image-sixel.c
++++ b/image-sixel.c
+@@ -489,6 +489,9 @@ sixel_print(struct sixel_image *si, struct sixel_image *map, size_t *size)
+ 		colours = si->colours;
+ 		ncolours = si->ncolours;
+ 	}
++
++	if (ncolours == 0)
++		return (NULL);
+ 	contains = xcalloc(1, ncolours);
+ 
+ 	len = 8192;
+diff --git a/input.c b/input.c
+index eb421b280e..e6016121ff 100644
+--- a/input.c
++++ b/input.c
+@@ -1839,7 +1839,7 @@ input_csi_dispatch_sm_private(struct input_ctx *ictx)
+ 
+ /* Handle CSI graphics SM. */
+ static void
+-input_csi_dispatch_sm_graphics(struct input_ctx *ictx)
++input_csi_dispatch_sm_graphics(__unused struct input_ctx *ictx)
+ {
+ #ifdef ENABLE_SIXEL
+ 	int	n, m, o;
+diff --git a/screen-write.c b/screen-write.c
+index 6892d04149..a732f093dc 100644
+--- a/screen-write.c
++++ b/screen-write.c
+@@ -2283,6 +2283,10 @@ screen_write_sixelimage(struct screen_write_ctx *ctx, struct sixel_image *si,
+ 		new = sixel_scale(si, 0, 0, 0, y - sy, sx, sy, 1);
+ 		sixel_free(si);
+ 		si = new;
++
++		/* Bail out if the image cannot be scaled. */
++		if (si == NULL)
++			return;
+ 		sixel_size_in_cells(si, &x, &y);
+ 	}
+ 
+diff --git a/screen.c b/screen.c
+index f73a850547..0eaf469886 100644
+--- a/screen.c
++++ b/screen.c
+@@ -308,12 +308,12 @@ screen_resize_cursor(struct screen *s, u_int sx, u_int sy, int reflow,
+ 	if (sy != screen_size_y(s))
+ 		screen_resize_y(s, sy, eat_empty, &cy);
+ 
+-	if (reflow) {
+ #ifdef ENABLE_SIXEL
+-		image_free_all(s);
++	image_free_all(s);
+ #endif
++
++	if (reflow)
+ 		screen_reflow(s, sx, &cx, &cy, cursor);
+-	}
+ 
+ 	if (cy >= s->grid->hsize) {
+ 		s->cx = cx;

--- a/srcpkgs/tmux/template
+++ b/srcpkgs/tmux/template
@@ -1,7 +1,7 @@
 # Template file for 'tmux'
 pkgname=tmux
 version=3.4
-revision=2
+revision=3
 build_style=gnu-configure
 configure_args="--enable-utempter --enable-sixel"
 hostmakedepends="byacc automake pkg-config"


### PR DESCRIPTION
Fixes crash in terminals that support SIXEL, for more info see https://github.com/tmux/tmux/issues/3983.

In order to avoid the crash without having to wait for the release of 3.5 this PR pathces v3.4 with tmux commit https://github.com/tmux/tmux/commit/aa17f0e0c1c8b3f1d6fc8617613c74f07de66fae

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**
