### PR TITLE
golangci-lint: update to 1.60.2

### DIFF
--- a/srcpkgs/golangci-lint/template
+++ b/srcpkgs/golangci-lint/template
@@ -1,7 +1,7 @@
 # Template file for 'golangci-lint'
 pkgname=golangci-lint
-version=1.60.1
-revision=2
+version=1.60.2
+revision=1
 build_style=go
 go_import_path="github.com/golangci/golangci-lint"
 go_package="./cmd/golangci-lint"
@@ -12,7 +12,7 @@ license="GPL-3.0-only"
 homepage="https://github.com/golangci/golangci-lint"
 changelog="https://raw.githubusercontent.com/golangci/golangci-lint/master/CHANGELOG.md"
 distfiles="https://github.com/golangci/golangci-lint/archive/v${version}.tar.gz"
-checksum=3ecb0d2fbbdbb7630eb847e1171f23f225ee7fd0327007ab76fb65af5a9ba7fe
+checksum=3c9b7e9edce898eee20077b4b60c2807783dfbe96038d0470f6f4ceaae889568
 
 # fix: collect2: fatal error: cannot find 'ld'
 export LDFLAGS="-fuse-ld=bfd"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64

#### Note
Void has got go 1.23.0 recently. For properly working with new compiler golangci-lint should be compiled with the same version -- 1.23.0 (generally the same or above). Check https://github.com/golangci/golangci-lint/issues/4837 I hope CI of Void Linux takes this rule in account.