### PR TITLE
gtk4: update to 4.16.2

### DIFF
--- a/srcpkgs/gtk4/patches/remove-failing-tests.patch
+++ b/srcpkgs/gtk4/patches/remove-failing-tests.patch
@@ -1,0 +1,48 @@
+remove two failing doc-check tests: doc-check-gdk and doc-check-gtk,
+because some symbols and return values for them are not documented.
+
+diff --git a/docs/reference/gdk/meson.build b/docs/reference/gdk/meson.build
+index 89c8371a..1b5e9a50 100644
+--- a/docs/reference/gdk/meson.build
++++ b/docs/reference/gdk/meson.build
+@@ -29,18 +29,6 @@ if get_option('documentation')
+     install_dir: docs_dir,
+   )
+ 
+-  test('doc-check-gdk',
+-    gidocgen,
+-    args: [
+-      'check',
+-      '--config', gdk4_toml,
+-      '--add-include-path=@0@'.format(meson.current_build_dir() / '../../../gtk'),
+-      gdk_gir[0],
+-    ],
+-    depends: gdk_gir[0],
+-    suite: ['docs', 'failing'],
+-  )
+-
+   if x11_enabled
+     gdk4x11_toml = configure_file(
+       input: 'gdk4-x11.toml.in',
+diff --git a/docs/reference/gtk/meson.build b/docs/reference/gtk/meson.build
+index 70741afe..051dcca9 100644
+--- a/docs/reference/gtk/meson.build
++++ b/docs/reference/gtk/meson.build
+@@ -65,17 +65,6 @@ if get_option('documentation')
+     install_tag: 'doc',
+   )
+ 
+-  test('doc-check-gtk',
+-    gidocgen,
+-    args: [
+-      'check',
+-      '--config', gtk4_toml,
+-      '--add-include-path=@0@'.format(meson.current_build_dir() / '../../../gtk'),
+-      gtk_gir[0],
+-    ],
+-    depends: gtk_gir[0],
+-    suite: ['docs', 'failing'],
+-  )
+ endif
+ 
+ rst2man = find_program('rst2man', 'rst2man.py', required: get_option('man-pages'))

--- a/srcpkgs/gtk4/template
+++ b/srcpkgs/gtk4/template
@@ -1,7 +1,7 @@
 # Template file for 'gtk4'
 pkgname=gtk4
-version=4.14.4
-revision=2
+version=4.16.2
+revision=1
 build_style=meson
 build_helper="gir"
 configure_args="-Dman-pages=true -Ddocumentation=true -Dbuild-tests=false
@@ -31,9 +31,9 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="LGPL-2.1-or-later"
 homepage="https://www.gtk.org/"
 #changelog="https://gitlab.gnome.org/GNOME/gtk/-/raw/main/NEWS"
-changelog="https://gitlab.gnome.org/GNOME/gtk/-/raw/gtk-4-14/NEWS"
+changelog="https://gitlab.gnome.org/GNOME/gtk/-/raw/gtk-4-16/NEWS"
 distfiles="${GNOME_SITE}/gtk/${version%.*}/gtk-${version}.tar.xz"
-checksum=443518b97e8348f9f6430ac435b1010f9a6c5207f4dc6a7cd5d24e3820cee633
+checksum=34b624848e5de22a138b675ad6f39c0c7b9d67907c10e1fc7e5b03060e8d5437
 
 # Package build options
 build_options="broadway cloudproviders colord cups gir vulkan wayland x11 tracker"

--- a/srcpkgs/tracker/template
+++ b/srcpkgs/tracker/template
@@ -1,7 +1,7 @@
 # Template file for 'tracker'
 pkgname=tracker
 version=3.7.3
-revision=2
+revision=3
 build_style=meson
 build_helper="gir qemu"
 configure_args="-Ddocs=false -Dman=true -Dstemmer=disabled
@@ -14,8 +14,8 @@ checkdepends="dbus tar python3-gobject"
 short_desc="Personal search tool and storage system"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later, LGPL-2.1-or-later"
-homepage="https://wiki.gnome.org/Projects/Tracker"
-changelog="https://gitlab.gnome.org/GNOME/tracker/-/raw/master/NEWS"
+homepage="https://gitlab.gnome.org/GNOME/tinysparql"
+changelog="https://gitlab.gnome.org/GNOME/tinysparql/-/raw/master/NEWS"
 distfiles="${GNOME_SITE}/tracker/${version%.*}/tracker-${version}.tar.xz"
 checksum=ab3d4a50937e04c5ed7846f6dbb999e2909819402f389ca592ee6b77dd28d1f9
 make_check_pre="dbus-run-session"
@@ -44,7 +44,7 @@ post_patch() {
 }
 
 tracker-devel_package() {
-	depends="libtracker>=${version}_${revision} libglib-devel"
+	depends="libtracker>=${version}_${revision} libglib-devel sqlite-devel"
 	short_desc+=" - development files"
 	pkg_install() {
 		vmove usr/include


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86-64)


`mesa-24.2.2` (#51881) needs to be merged first. see the note below.
```
Note: This release changes the default GSK renderer to be Vulkan,
on Wayland. Other platforms still use ngl. The intent of this change
is to use the best available platform APIs. You can still override
the renderer choice using the GSK_RENDERER environment variable.

We believe that most of the problems reported with the new renderers
during the 4.13 and 4.15 development cycles have been addressed by now.

But the new renderers and dmabuf support are using graphics drivers
in different ways than the old gl renderer, and trigger new driver bugs.
Therefore, it is recommended to use the latest mesa release (24.2)
with the new renderers.
```

