### PR TITLE
wine: fix staging patch scripts [ci skip]

### DIFF
--- a/srcpkgs/wine/template
+++ b/srcpkgs/wine/template
@@ -93,6 +93,7 @@ fi
 
 post_patch() {
 	if [ "${build_option_staging}" ]; then
+		export PATH="/usr/libexec/chroot-git:${PATH}"
 		"../wine-staging-${_pkgver}/staging/patchinstall.py" --all
 	fi
 }


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES** (but not staging)

#### Comments

https://github.com/void-linux/void-packages/pull/51541

https://bugs.winehq.org/show_bug.cgi?id=57016

Someone noticed in IRC that `staging` option doesn't build anymore. This seems to be related to `git` not being installed which is used in wine-staging's patching scripts. Not sure when that quit working but I guess no one here built staging in a while.