### PR TITLE
scapy: update to 2.5.0

### DIFF
--- a/srcpkgs/scapy/template
+++ b/srcpkgs/scapy/template
@@ -1,7 +1,7 @@
 # Template file for 'scapy'
 pkgname=scapy
-version=2.4.5
-revision=4
+version=2.5.0
+revision=1
 build_style=python3-module
 hostmakedepends="python3-setuptools"
 depends="tcpdump python3"
@@ -10,7 +10,7 @@ maintainer="cipr3s <cipr3s@gmx.com>"
 license="GPL-2.0-only"
 homepage="https://scapy.net/"
 distfiles="${PYPI_SITE}/s/scapy/scapy-${version}.tar.gz"
-checksum=bc707e3604784496b6665a9e5b2a69c36cc9fb032af4864b29051531b24c8593
+checksum=5b260c2b754fd8d409ba83ee7aee294ecdbb2c235f9f78fe90bc11cb6e5debc2
 
 post_install() {
 	vdoc "${FILESDIR}/README.voidlinux"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, **x86_64**

#### Comments

got some error

```
Traceback (most recent call last):
  File "/tmp/./25s.py", line 4, in <module>
    from scapy.all import *
  File "/usr/lib/python3.12/site-packages/scapy/all.py", line 10, in <module>
    from scapy.base_classes import *
  File "/usr/lib/python3.12/site-packages/scapy/base_classes.py", line 32, in <module>
    from scapy.modules.six.moves import range
ModuleNotFoundError: No module named 'scapy.modules.six.moves'
```

realized it hasn't been updated in a while, works fine on 2.5.0