### PR TITLE
rpcbind: update to 1.2.7

### DIFF
--- a/srcpkgs/rpcbind/template
+++ b/srcpkgs/rpcbind/template
@@ -1,6 +1,6 @@
 # Template file for 'rpcbind'
 pkgname=rpcbind
-version=1.2.6
+version=1.2.7
 revision=1
 build_style=gnu-configure
 configure_args="--enable-warmstarts --with-statedir=/run --with-rpcuser=rpc
@@ -12,7 +12,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="BSD-3-Clause"
 homepage="https://rpcbind.sourceforge.net"
 distfiles="${SOURCEFORGE_SITE}/${pkgname}/${pkgname}-${version}.tar.bz2"
-checksum=5613746489cae5ae23a443bb85c05a11741a5f12c8f55d2bb5e83b9defeee8de
+checksum=f6edf8cdf562aedd5d53b8bf93962d61623292bfc4d47eedd3f427d84d06f37e
 system_accounts="rpc"
 
 post_install() {


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**
Tested specifically with nfs4 and it works as expected.
<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture: x86_64-glibc
- I built this PR locally for these architectures:
  - i686
  - x86_64-musl
  - aarch64-{glibc,musl} (cross build)
  - armv7l (cross build)
  - armv6l-musl (cross build)

