### PR TITLE
iproute2: update to 6.10.0.

### DIFF
--- a/srcpkgs/iproute2/template
+++ b/srcpkgs/iproute2/template
@@ -1,6 +1,6 @@
 # Template file for 'iproute2'
 pkgname=iproute2
-version=6.7.0
+version=6.10.0
 revision=1
 build_style=configure
 make_install_args="SBINDIR=/usr/bin"
@@ -12,7 +12,7 @@ maintainer="Enno Boland <gottox@voidlinux.org>"
 license="GPL-2.0-only"
 homepage="https://wiki.linuxfoundation.org/networking/iproute2"
 distfiles="${KERNEL_SITE}/utils/net/iproute2/iproute2-${version}.tar.xz"
-checksum=ff942dd9828d7d1f867f61fe72ce433078c31e5d8e4a78e20f02cb5892e8841d
+checksum=91a62f82737b44905a00fa803369c447d549e914e9a2a4018fdd75b1d54e8dce
 # Requires unshare, which is not provided by chroot-util-linux.
 make_check=no
 
@@ -31,13 +31,4 @@ post_install() {
 	vmkdir etc
 	vcopy etc/iproute2 etc
 	rm -r ${DESTDIR}/usr/share/man/man3
-}
-
-iproute2-tc-ipt_package() {
-	short_desc+=" - tc(8) IPtables support"
-	pkg_install() {
-		# m_ipt.so is symlinked to m_xt.so
-		vmove usr/lib/tc/m_ipt.so
-		vmove usr/lib/tc/m_xt.so
-	}
 }

--- a/srcpkgs/removed-packages/template
+++ b/srcpkgs/removed-packages/template
@@ -1,6 +1,6 @@
 # Template file for 'removed-packages'
 pkgname=removed-packages
-version=0.1.20240807
+version=0.1.20240825
 revision=1
 build_style=meta
 short_desc="Uninstalls packages removed from repository"
@@ -300,6 +300,7 @@ replaces="
  ilmbase-devel<=2.4.2_2
  ilmbase<=2.4.2_2
  ioquake3-rpi<=20130506_2
+ iproute2-tc-ipt<=6.7.0
  isl16<=0.16_2
  js<=1.8.5_11
  julia<=1.6.1_2


### PR DESCRIPTION
Support for ipt and xt in tc was removed in v6.8.0
https://git.kernel.org/pub/scm/network/iproute2/iproute2.git/commit/?id=45dc10463dd5a51eef944b110a4f046feb1b46db

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
