### PR TITLE
heisenbridge: update to 1.15.0

### DIFF
--- a/srcpkgs/heisenbridge/template
+++ b/srcpkgs/heisenbridge/template
@@ -1,10 +1,10 @@
 # Template file for 'heisenbridge'
 pkgname=heisenbridge
-version=1.14.6
+version=1.15.0
 revision=1
 build_style=python3-module
 hostmakedepends="python3-setuptools"
-depends="python3-irc python3-ruamel.yaml python3-mautrix python3-socks python3-aiohttp"
+depends="python3-irc python3-ruamel.yaml python3-mautrix python3-socks python3-aiohttp python3-async-timeout"
 checkdepends="$depends python3-pytest"
 short_desc="Bouncer-style Matrix IRC bridge"
 maintainer="Luca Matei Pintilie <luca@lucamatei.com>"
@@ -13,7 +13,7 @@ homepage="https://github.com/hifi/heisenbridge"
 changelog="https://github.com/hifi/heisenbridge/releases"
 # distfiles="https://github.com/hifi/heisenbridge/releases/download/v$version/heisenbridge-$version.tar.gz"
 distfiles="https://github.com/hifi/heisenbridge/archive/refs/tags/v$version.tar.gz"
-checksum=0372a06055147f0402035897f6782bce9a24df0d290b8c054d24b33ba81d27da
+checksum=29cfd803450ee7ca3aa2c20feb36e010a1499e6153f01819519b11760b883d0d
 
 post_install() {
 	vsv heisenbridge


### PR DESCRIPTION
Note: also adds a missing runtime dependency.

#### Testing the changes
- I tested the changes in this PR: YES

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - armv6l
  - armv6l-musl