### PR TITLE
New package: iamb-0.0.10

### DIFF
--- a/srcpkgs/iamb/template
+++ b/srcpkgs/iamb/template
@@ -1,0 +1,24 @@
+# Template file for 'iamb'
+pkgname=iamb
+version=0.0.10
+revision=1
+build_style=cargo
+configure_args="--no-default-features --features=native-tls,desktop"
+hostmakedepends="pkg-config"
+makedepends="openssl-devel sqlite-devel oniguruma-devel"
+short_desc="Terminal-based client for Matrix for the Vim addict"
+maintainer="Felix Van der Jeugt <felixvdj+github@posteo.be>"
+license="Apache-2.0"
+homepage="https://iamb.chat"
+changelog="https://github.com/ulyssa/iamb/releases"
+distfiles="https://github.com/ulyssa/iamb/archive/refs/tags/v${version}.tar.gz"
+checksum=f628cfbd9eba9e8881902b970e9432fec815044ec9bea901a8562ea3ef8f4615
+
+post_install() {
+	vinstall iamb.desktop 644 usr/share/applications
+	vinstall config.example.toml 644 usr/share/examples/iamb config.toml
+	vinstall docs/iamb.svg 644 usr/share/icons/hicolor/scalable/apps
+	vinstall docs/iamb.metainfo.xml 644 usr/share/metainfo
+	vman docs/iamb.1
+	vman docs/iamb.5
+}


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**. Well, mostly. It's still 0.0.10, but it has had releases since march 2023.