### PR TITLE
yq-go: update to 4.44.3.

### DIFF
--- a/srcpkgs/yq-go/template
+++ b/srcpkgs/yq-go/template
@@ -1,19 +1,22 @@
 # Template file for 'yq-go'
 pkgname=yq-go
-version=4.44.2
-revision=2
+version=4.44.3
+revision=1
 build_style=go
 go_import_path=github.com/mikefarah/yq/v4
 short_desc="Command-line YAML, JSON, XML, CSV, TOML and properties processor"
-maintainer="Orphaned <orphan@voidlinux.org>"
+maintainer="icp <pangolin@vivaldi.net>"
 license="MIT"
-homepage="https://github.com/mikefarah/yq"
+homepage="https://mikefarah.gitbook.io/yq"
 changelog="https://raw.githubusercontent.com/mikefarah/yq/master/release_notes.txt"
 distfiles="https://github.com/mikefarah/yq/archive/refs/tags/v${version}.tar.gz"
-checksum=eb741c2d41351537aa42d563d0fccf16b3195c352b33e0ef111fd448232da911
+checksum=ea950f5622480fc0ff3708c52589426a737cd4ec887a52922a74efa1be8f2fbf
+
+alternatives="yq:yq:/usr/bin/yq-go"
 
 do_check() {
-	go test -v
+	# https://github.com/mikefarah/yq/blob/master/scripts/test.sh
+	go test $(go list ./... | grep -v -E 'examples' | grep -v -E 'test')
 }
 
 post_install() {


### PR DESCRIPTION
Register as an alternative for `yq`; adopt.

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture: **x86_64**