### PR TITLE
eclipse: update to 4.32 and add aarch64 support

### DIFF
--- a/srcpkgs/eclipse/template
+++ b/srcpkgs/eclipse/template
@@ -1,27 +1,38 @@
 # Template file for 'eclipse'
 pkgname=eclipse
-version=4.30.0
-revision=2
-#code name of version
-_release=2023-12
-archs="x86_64"
-depends="openjdk11 gtk+3 libwebkit2gtk41 libXtst
+version=4.32.0
+revision=1
+_release="2024-06"
+_jna_version="5.14.0.v20231211-1200"  # Found in distfiles at eclipse/plugins/com.sun.jna_<version#>/
+archs="x86_64 aarch64"
+depends="openjdk21 gtk+3 libwebkit2gtk41 libXtst
  hicolor-icon-theme desktop-file-utils"
 short_desc="IDE for Java and other languages"
 maintainer="mobinmob <mobinmob@disroot.org>"
 license="EPL-1.0"
 homepage="https://eclipse.org"
 make_dirs="/usr/lib/eclipse/dropins 0770 root users"
-_patch=R
-_edition=java
-_mirror="http://ftp-stud.fht-esslingen.de/pub/Mirrors/eclipse"
-distfiles="${_mirror}/technology/epp/downloads/release/${_release}/${_patch}/eclipse-${_edition}-${_release}-R-linux-gtk-x86_64.tar.gz"
-checksum=09fda3acd8da911b5e18efd6d7ca27784f440ccdd52f28bf94869f81f7e9ad47
 nopie=yes
 nostrip=yes
-allow_unknown_shlibs=yes # glibc sonames issue
 python_version=3
 
+distfiles="https://mirror.umd.edu/eclipse/technology/epp/downloads/release/${_release}/R/eclipse-java-${_release}-R-linux-gtk-${XBPS_TARGET_MACHINE%-*}.tar.gz"
+case ${XBPS_TARGET_MACHINE} in
+	x86_64)
+		checksum="7d77e3d0f226c9dda73d491a1af3aeec11807881e44e870a1fde2833f55df8b5"
+		;;
+	aarch64)
+		checksum="d046576e781722ca3c7d2f1bbd20cfc91182aded9d174fbac3295d43a1a11a6a"
+		;;
+esac
+
+# Skip JNA cross-platform binary components during dependency checks
+for _jna_arch in freebsd-x86-64 freebsd-x86 linux-aarch64 linux-armel \
+		linux-arm linux-loongarch64 linux-mips64el linux-ppc64le linux-ppc \
+		linux-riscv64 linux-s390x linux-x86-64 linux-x86 openbsd-x86-64 \
+		openbsd-x86 sunos-sparc sunos-sparcv9 sunos-x86-64 sunos-x86; do
+	skiprdeps+="/usr/lib/eclipse/plugins/com.sun.jna_${_jna_version}/com/sun/jna/${_jna_arch}/libjnidispatch.so "
+done
 
 do_install() {
 	vmkdir usr/lib/eclipse


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64.
- I built this PR locally for other architectures: aarch64 (xbuild, untested)

EDIT: thanks @classabbyamp for the assist fixing this one :3

Eclipse is shipping libs for all supported platforms in their tarballs now, and this was causing dependency problems. Deleting the offending libraries from the build dir fixes the issue.

~~Package builds successfully but cannot be installed:~~

~~eclipse-4.32.0_1: broken, unresolvable shlib `ld-linux-riscv64-lp64d.so.1'~~
~~Transaction aborted due to unresolved shlibs.~~

~~Requesting assistance resolving.~~