### PR TITLE
biblioteq: update to 2024.06.30.

### DIFF
--- a/srcpkgs/biblioteq/template
+++ b/srcpkgs/biblioteq/template
@@ -1,43 +1,76 @@
 # Template file for 'biblioteq'
 pkgname=biblioteq
-version=2020.01.01
+version=2024.06.30
 revision=1
 build_style=qmake
-configure_args="-o Makefile"
-hostmakedepends="qt5-qmake qt5-host-tools"
-makedepends="libpqxx-devel qt5-devel poppler-cpp-devel poppler-qt5-devel
+build_helper=qmake6
+hostmakedepends="qt6-tools qt6-base"
+makedepends="libpqxx-devel qt6-base-devel poppler-cpp-devel poppler-qt6-devel
  sqlite-devel yaz-devel"
-depends="qt5-plugin-sqlite"
+depends="qt6-plugin-sqlite"
 short_desc="Professional cataloging and library management suite"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="BSD-3-Clause"
 homepage="https://textbrowser.github.io/biblioteq/"
 distfiles="https://github.com/textbrowser/biblioteq/archive/${version}.tar.gz"
-checksum=e07ffccbee4e1f34a93ab3d9277c393669091b8a957c648bbcce65159f9e0d86
+checksum=1265bcc448b1fb29871c72daf441804657822de63cd66a61d293c18a1c8cf426
 
+_qt_version=6
 conf_files="/etc/biblioteq.conf"
 
+# Set the appropriate build helper and dependencies based on architecture
 case "$XBPS_TARGET_MACHINE" in
-	arm*) configure_args+=" biblioteq.arm.pro" ;;
-	*) configure_args+=" biblioteq.pro" ;;
+	arm*|aarch64*)
+		configure_file="biblioteq.arm.pro"
+		_qt_version=5
+		;;
+	ppc*)
+		configure_file="biblioteq.powerpc.pro"
+		_qt_version=5
+		;;
+	*) configure_file="biblioteq.pro" ;;
 esac
+
+if [ "$_qt_version" -eq 5 ]; then
+	build_helper=qmake
+	hostmakedepends="qt5-qmake qt5-host-tools"
+	makedepends="libpqxx-devel qt5-devel poppler-cpp-devel poppler-qt5-devel
+	 sqlite-devel yaz-devel"
+	depends="qt5-plugin-sqlite"
+fi
+
 
 
 pre_configure() {
-	sed -i -e 's|biblioteq.conf|/etc/biblioteq.conf|' \
-		-e 's/-mtune=native//' -e 's/-Werror//' biblioteq.arm.pro
+	configure_args="-o Makefile ${configure_file}"
+	vsed -i "${configure_file}" -e "s|biblioteq.conf|/etc/biblioteq.conf|"
 
-	sed -i -e 's|biblioteq.conf|/etc/biblioteq.conf|' \
-		-e 's/-mtune=generic//' -e 's/-Werror//' biblioteq.pro
+	if [ "$_qt_version" -eq 6 ]; then
+		vsed -i "${configure_file}" -e "s|QT_MAJOR_VERSION|${_qt_version}|g"
+	fi
+	# Set paths for cross-compiling without export
+	if [ "$CROSS_BUILD" ]; then
+		vsed -i -e "s|/usr/include|${XBPS_CROSS_BASE}/usr/include|g" "${configure_file}"
+	fi
+}
+
+post_build() {
+	vsed -i Distributions/biblioteq.desktop \
+		-e "s|Exec=/opt/biblioteq/biblioteq.sh|Exec=biblioteq|" \
+		-e "s|Icon=/opt/biblioteq/book.png|Icon=biblioteq.png|" \
+		-e "s|MimeType=text/html;/text/xml;application/xhtml_xml;|MimeType=text/html;text/xml;application/xhtml+xml;|"
 }
 
 do_install() {
-	## Translations must be in the same directory as BiblioteQ (executable)
+	# Translations must be in the same directory as BiblioteQ (executable)
 	vinstall BiblioteQ 755 usr/lib/BiblioteQ
 	vcopy Translations usr/lib/BiblioteQ
-	vinstall Icons/book.png 644 usr/share/icons
+
+	vinstall Icons/book.png 644 /usr/share/pixmaps/ biblioteq.png
+	vinstall Distributions/biblioteq.desktop 644 /usr/share/applications/
 	vconf biblioteq.conf
 	vlicense LICENSE
+
 	vmkdir usr/bin
 	ln -s /usr/lib/BiblioteQ/BiblioteQ ${DESTDIR}/usr/bin/biblioteq
 }


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures using specific masterdirs:
  - x86_64-musl
  - i686
- I built this PR locally for these architectures (crossbuilds):
  - aarch64
  - aarch64-musl
  - armv7l
  - armv7l-musl
  - armv6l
  - armv6l-musl

#### Migration to Qt6 for x86_64 and i686
I have migrated the BiblioteQ package to use Qt6 for x86_64 (both musl and glibc) and i686 architectures. The ARM builds remain on Qt5, and I have also added configuration support for PPC, although I have not tested the migration on architectures other than my own.