### PR TITLE
[PR on HOLD] New package: python3-pynitrokey-0.4.50 with a bunch of dependencies

### DIFF
--- a/srcpkgs/libusbsio-python3
+++ b/srcpkgs/libusbsio-python3
@@ -1,0 +1,1 @@
+libusbsio

--- a/srcpkgs/libusbsio/template
+++ b/srcpkgs/libusbsio/template
@@ -1,0 +1,66 @@
+# Template file for 'libusbsio'
+pkgname=libusbsio
+version=2.1.11
+revision=1
+build_style=gnu-makefile
+hostmakedepends="pkg-config python3-setuptools python3-installer python3-wheel python3-build tar"
+makedepends="eudev-libudev-devel hidapi-devel libusb-devel"
+short_desc="Library for USB-HID communication over SPI, I2C or GPIO"
+maintainer="Mateusz Sylwestrzak <slymattz@gmail.com>"
+license="BSD-3-Clause"
+homepage="https://www.nxp.com/design/software/development-software/library-for-windows-macos-and-ubuntu-linux:LIBUSBSIO"
+distfiles="https://www.nxp.com/downloads/en/libraries/libusbsio-${version}-src.zip"
+checksum=b854d4ecbaab19c33cb1e77f59eec2442f67acc8911705ccaf838f7547449dae
+
+post_extract() {
+	# remove precompiled binaries
+	rm -r bin/*
+	# extract the python tarball
+	cd "python/dist"
+	tar xvzf "libusbsio-${version}.tar.gz"
+	# remove prebuilt shared libs
+	rm -r libusbsio-${version}/libusbsio/bin/*
+
+	if [ "$CROSS_BUILD" ]; then
+		vsed -i -e "s/gcc/$CC/" -e "s/g++/$CXX/" \
+			"${wrksrc}/makefile"
+	fi
+}
+
+post_patch() {
+	# fix Exception encountered: LIBUSBSIO_Exception("LIBUSBSIO: DLL path invalid './libusbsio.so'.")
+	vsed -i -e 's|dfltdir = "linux_" + platform.machine()|dfltdir = "/usr/lib"|g' \
+		"python/dist/libusbsio-${version}/libusbsio/libusbsio.py"
+}
+
+do_build() {
+	make # libusbsio
+
+	# build python bindings
+	cd "python/dist/libusbsio-${version}"
+
+	python3 -m build --no-isolation --wheel \
+		${make_build_args} ${make_build_target}
+}
+
+do_install() {
+	local _architecture="${XBPS_MACHINE%%-*}"
+	vmkdir "usr/lib"
+	vinstall "bin/linux_${_architecture}/libusbsio.so" 755 "usr/lib/" # install the freshly compiled library
+
+	# install python bindings
+	python3 -m installer --destdir ${DESTDIR} \
+		${make_install_args} "python/dist/libusbsio-${version}/dist/libusbsio-$version-py3-none-any.whl"
+}
+
+post_install() {
+	vlicense LICENSE.txt
+}
+
+libusbsio-python3_package() {
+	short_desc+=" - Python3 bindings"
+	depends="python3 libusbsio"
+	pkg_install() {
+		vmove usr/lib/python3*
+	}
+}

--- a/srcpkgs/python3-argparse-addons/template
+++ b/srcpkgs/python3-argparse-addons/template
@@ -1,0 +1,17 @@
+# Template file for 'python3-argparse-addons'
+pkgname=python3-argparse-addons
+version=0.12.0
+revision=1
+build_style=python3-pep517
+hostmakedepends="python3-setuptools python3-wheel"
+depends="python3"
+short_desc="Additional Python argparse types and actions"
+maintainer="Mateusz Sylwestrzak <slymattz@gmail.com>"
+license="MIT"
+homepage="https://github.com/eerimoq/argparse_addons"
+distfiles="${PYPI_SITE}/a/argparse_addons/argparse_addons-${version}.tar.gz"
+checksum=6322a0dcd706887e76308d23136d5b86da0eab75a282dc6496701d1210b460af
+
+post_install() {
+	vlicense LICENSE
+}

--- a/srcpkgs/python3-astunparse/template
+++ b/srcpkgs/python3-astunparse/template
@@ -1,0 +1,13 @@
+# Template file for 'python3-astunparse'
+pkgname=python3-astunparse
+version=1.6.3
+revision=1
+build_style=python3-pep517
+hostmakedepends="python3-wheel python3-setuptools"
+depends="python3-six"
+short_desc="AST unparser for Python"
+maintainer="Mateusz Sylwestrzak <slymattz@gmail.com>"
+license="Python-2.0"
+homepage="https://github.com/simonpercivall/astunparse"
+distfiles="${PYPI_SITE}/a/astunparse/astunparse-${version}.tar.gz"
+checksum=5ad93a8456f0d084c3456d059fd9a92cce667963232cbf763eac3bc5b7940872

--- a/srcpkgs/python3-bincopy/template
+++ b/srcpkgs/python3-bincopy/template
@@ -1,0 +1,17 @@
+# Template file for 'python3-bincopy'
+pkgname=python3-bincopy
+version=20.0.0
+revision=1
+build_style=python3-pep517
+hostmakedepends="python3-setuptools"
+depends="python3-argparse-addons python3-humanfriendly python3-pyelftools"
+short_desc="Mangling of various file formats that conveys binary information"
+maintainer="Mateusz Sylwestrzak <slymattz@gmail.com>"
+license="MIT"
+homepage="https://github.com/eerimoq/bincopy"
+distfiles="${PYPI_SITE}/b/bincopy/bincopy-${version}.tar.gz"
+checksum=14cfb4cf97227bf2b1f5b85623df4c767ad219afdc9fe0732dd2cfdff446afdf
+
+post_install() {
+	vlicense LICENSE
+}

--- a/srcpkgs/python3-click-aliases/template
+++ b/srcpkgs/python3-click-aliases/template
@@ -1,0 +1,17 @@
+# Template file for 'python3-click-aliases'
+pkgname=python3-click-aliases
+version=1.0.4
+revision=1
+build_style=python3-pep517
+hostmakedepends="python3-poetry-core python3-wheel"
+depends="python3-click"
+short_desc="Enable aliases for Click"
+maintainer="Mateusz Sylwestrzak <slymattz@gmail.com>"
+license="MIT"
+homepage="https://github.com/click-contrib/click-aliases"
+distfiles="${PYPI_SITE}/c/click_aliases/click_aliases-${version}.tar.gz"
+checksum=384313c5dc4c4bd64d9eadaff39ad91352747e8cdfd2f95d504d914c01eb4eda
+
+post_install() {
+	vlicense LICENSE
+}

--- a/srcpkgs/python3-click-command-tree/template
+++ b/srcpkgs/python3-click-command-tree/template
@@ -1,0 +1,17 @@
+# Template file for 'python3-click-command-tree'
+pkgname=python3-click-command-tree
+version=1.2.0
+revision=1
+build_style=python3-pep517
+hostmakedepends="python3-wheel python3-setuptools"
+depends="python3-click"
+short_desc="Click plugin to show the command tree of your CLI"
+maintainer="Mateusz Sylwestrzak <slymattz@gmail.com>"
+license="MIT"
+homepage="https://github.com/whwright/click-command-tree"
+distfiles="${PYPI_SITE}/c/click_command_tree/click_command_tree-${version}.tar.gz"
+checksum=3e7f5db9f3eccc2eccab40f7979355efe6d5123c958b748dee9c242a38364d6c
+
+post_install() {
+	vlicense LICENSE
+}

--- a/srcpkgs/python3-click-option-group/template
+++ b/srcpkgs/python3-click-option-group/template
@@ -1,0 +1,17 @@
+# Template file for 'python3-click-option-group'
+pkgname=python3-click-option-group
+version=0.5.6
+revision=1
+build_style=python3-pep517
+hostmakedepends="python3-wheel python3-setuptools"
+depends="python3-click"
+short_desc="Option groups missing in Click"
+maintainer="Mateusz Sylwestrzak <slymattz@gmail.com>"
+license="BSD-3-Clause"
+homepage="https://github.com/click-contrib/click-option-group"
+distfiles="${PYPI_SITE}/c/click-option-group/click-option-group-${version}.tar.gz"
+checksum=97d06703873518cc5038509443742b25069a3c7562d1ea72ff08bfadde1ce777
+
+post_install() {
+	vlicense LICENSE
+}

--- a/srcpkgs/python3-cmsis-pack-manager/patches/python-cmsis-pack-manager-0.5.3-update_maturin.patch
+++ b/srcpkgs/python3-cmsis-pack-manager/patches/python-cmsis-pack-manager-0.5.3-update_maturin.patch
@@ -1,0 +1,120 @@
+From 5d9fd7a54169f770d69b1931ddbbe1020a8355e2 Mon Sep 17 00:00:00 2001
+From: David Runge <dave@sleepmap.de>
+Date: Fri, 1 Dec 2023 12:44:59 +0100
+Subject: [PATCH 1/3] Update maturin build requirement to >=1,<2
+
+Signed-off-by: David Runge <dave@sleepmap.de>
+---
+ pyproject.toml | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/pyproject.toml b/pyproject.toml
+index 20898079b..348237db1 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -1,6 +1,6 @@
+ [build-system]
+ requires = [
+-    "maturin>=0.13,<0.15",
++    "maturin>=1,<2",
+     "cffi",
+ ]
+ build-backend = "maturin"
+
+From 01d911c729adb2a0e8c73aa3ed49ace91ff68acb Mon Sep 17 00:00:00 2001
+From: David Runge <dave@sleepmap.de>
+Date: Fri, 1 Dec 2023 12:49:28 +0100
+Subject: [PATCH 2/3] Add pytest configuration options to pyproject.toml
+
+Signed-off-by: David Runge <dave@sleepmap.de>
+---
+ pyproject.toml | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/pyproject.toml b/pyproject.toml
+index 348237db1..d5e801067 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -60,3 +60,6 @@ Changelog = "https://github.com/pyocd/cmsis-pack-manager/releases"
+
+ [tool.maturin]
+ bindings = "cffi"
++
++[tool.pytest.ini_options]
++python_files = "tests/*.py"
+
+From 74600aa37ab421bcb78ddacb690019080170b2d5 Mon Sep 17 00:00:00 2001
+From: David Runge <dave@sleepmap.de>
+Date: Fri, 1 Dec 2023 12:51:06 +0100
+Subject: [PATCH 3/3] Remove unneeded setup.cfg file
+
+All configuration is done in pyproject.toml
+
+Signed-off-by: David Runge <dave@sleepmap.de>
+---
+ setup.cfg | 56 -------------------------------------------------------
+ 1 file changed, 56 deletions(-)
+ delete mode 100644 setup.cfg
+
+diff --git a/setup.cfg b/setup.cfg
+deleted file mode 100644
+index 0b054b5cd..000000000
+--- a/setup.cfg
++++ /dev/null
+@@ -1,56 +0,0 @@
+-[metadata]
+-name = cmsis-pack-manager
+-description = Python manager for CMSIS-Pack index and cache with fast Rust backend
+-long_description = file: README.md
+-long_description_content_type = text/markdown
+-url = https://github.com/pyocd/cmsis-pack-manager
+-maintainer = Mathias Brossard, Chris Reed
+-maintainer_email = mathias.brossard@arm.com, flit@me.com
+-license = Apache 2.0
+-license_file = LICENSE
+-classifiers =
+-    Development Status :: 4 - Beta
+-    Intended Audience :: Developers
+-    License :: OSI Approved :: Apache Software License
+-    Operating System :: MacOS
+-    Operating System :: Microsoft :: Windows
+-    Operating System :: POSIX
+-    Operating System :: Unix
+-    Programming Language :: Python
+-    Programming Language :: Python :: 3.6
+-    Programming Language :: Python :: 3.7
+-    Programming Language :: Python :: 3.8
+-    Programming Language :: Python :: 3.9
+-    Programming Language :: Python :: 3.10
+-    Programming Language :: Python :: 3.11
+-    Topic :: Software Development
+-    Topic :: Software Development :: Debuggers
+-    Topic :: Software Development :: Embedded Systems
+-    Topic :: Utilities
+-project_urls =
+-    Documentation = https://github.com/pyocd/cmsis-pack-manager/
+-    Bug Tracker = https://github.com/pyocd/cmsis-pack-manager/issues
+-    Discussions = https://github.com/pyocd/cmsis-pack-manager/discussions
+-    Changelog = https://github.com/pyocd/cmsis-pack-manager/releases
+-
+-[options]
+-packages = find:
+-install_requires =
+-    appdirs>=1.4,<2.0
+-    pyyaml>=6.0,<7.0
+-python_requires = >=3.6
+-include_package_data = True
+-zip_safe = False
+-
+-[options.extras_require]
+-test =
+-    pytest>=6.0
+-    hypothesis
+-    jinja2
+-
+-[options.entry_points]
+-console_scripts =
+-    pack-manager = cmsis_pack_manager.pack_manager:main
+-
+-[tool:pytest]
+-python_files = tests/*.py

--- a/srcpkgs/python3-cmsis-pack-manager/template
+++ b/srcpkgs/python3-cmsis-pack-manager/template
@@ -1,0 +1,20 @@
+# Template file for 'python3-cmsis-pack-manager'
+pkgname=python3-cmsis-pack-manager
+version=0.5.3
+revision=1
+archs="x86_64* i686*"
+build_style=python3-pep517
+build_helper="rust"
+hostmakedepends="python3-wheel maturin cargo"
+makedepends="python3-cffi"
+depends="python3-appdirs python3-yaml python3-cffi"
+short_desc="Python manager for CMSIS-Pack index and cache with fast Rust backend"
+maintainer="Mateusz Sylwestrzak <slymattz@gmail.com>"
+license="Apache-2.0"
+homepage="https://github.com/pyocd/cmsis-pack-manager"
+distfiles="https://github.com/pyocd/cmsis-pack-manager/archive/refs/tags/v${version}.tar.gz" # pypi version won't pull rust crates
+checksum=77230b0d39248aaa059c6e2f35cc8beb4f62fd821d1bf495a7e23443feac5071
+
+pre_build() {
+	cargo update # https://github.com/rust-lang/rust/issues/127343
+}

--- a/srcpkgs/python3-commentjson/template
+++ b/srcpkgs/python3-commentjson/template
@@ -1,0 +1,17 @@
+# Template file for 'python3-commentjson'
+pkgname=python3-commentjson
+version=0.9.0
+revision=1
+build_style=python3-pep517
+hostmakedepends="python3-wheel python3-setuptools"
+depends="python3-lark-parser"
+short_desc="Add Python and JavaScript style comments in your JSON files"
+maintainer="Mateusz Sylwestrzak <slymattz@gmail.com>"
+license="MIT"
+homepage="https://github.com/vaidik/commentjson"
+distfiles="${PYPI_SITE}/c/commentjson/commentjson-${version}.tar.gz"
+checksum=42f9f231d97d93aff3286a4dc0de39bfd91ae823d1d9eba9fa901fe0c7113dd4
+
+post_install() {
+	vlicense LICENSE.rst
+}

--- a/srcpkgs/python3-deepmerge/template
+++ b/srcpkgs/python3-deepmerge/template
@@ -1,0 +1,17 @@
+# Template file for 'python3-deepmerge'
+pkgname=python3-deepmerge
+version=1.1.1
+revision=1
+build_style=python3-pep517
+hostmakedepends="python3-wheel python-setuptools python3-setuptools_scm"
+depends="python3"
+short_desc="Deep merging tool for Python core data structures"
+maintainer="Mateusz Sylwestrzak <slymattz@gmail.com>"
+license="MIT"
+homepage="https://github.com/toumorokoshi/deepmerge"
+distfiles="${PYPI_SITE}/d/deepmerge/deepmerge-${version}.tar.gz"
+checksum=53a489dc9449636e480a784359ae2aab3191748c920649551c8e378622f0eca4
+
+post_install() {
+	vlicense LICENSE
+}

--- a/srcpkgs/python3-fire/template
+++ b/srcpkgs/python3-fire/template
@@ -1,0 +1,13 @@
+# Template file for 'python3-fire'
+pkgname=python3-fire
+version=0.6.0
+revision=1
+build_style=python3-pep517
+hostmakedepends="python3-flit_core python3-wheel"
+depends="python3-six python3-termcolor"
+short_desc="Library for automatically generating command line interfaces"
+maintainer="Mateusz Sylwestrzak <slymattz@gmail.com>"
+license="Apache-2.0"
+homepage="https://github.com/google/python-fire"
+distfiles="${PYPI_SITE}/f/fire/fire-${version}.tar.gz"
+checksum=54ec5b996ecdd3c0309c800324a0703d6da512241bc73b553db959d98de0aa66

--- a/srcpkgs/python3-hexdump/template
+++ b/srcpkgs/python3-hexdump/template
@@ -1,0 +1,13 @@
+# Template file for 'python3-hexdump'
+pkgname=python3-hexdump
+version=3.3
+revision=1
+build_style=python3-pep517
+hostmakedepends="python3-wheel python3-setuptools"
+depends="python3"
+short_desc="Library and tool to work with hex and binary data"
+maintainer="Mateusz Sylwestrzak <slymattz@gmail.com>"
+license="Public Domain"
+homepage="https://pypi.org/project/hexdump"
+distfiles="${PYPI_SITE}/h/hexdump/hexdump-${version}.zip"
+checksum=d781a43b0c16ace3f9366aade73e8ad3a7bd5137d58f0b45ab2d3f54876f20db

--- a/srcpkgs/python3-humanfriendly/template
+++ b/srcpkgs/python3-humanfriendly/template
@@ -1,0 +1,17 @@
+# Template file for 'python3-humanfriendly'
+pkgname=python3-humanfriendly
+version=10.0
+revision=1
+build_style=python3-pep517
+hostmakedepends="python3-wheel python3-setuptools"
+depends="python3"
+short_desc="Human friendly input/output for text interfaces using Python"
+maintainer="Mateusz Sylwestrzak <slymattz@gmail.com>"
+license="MIT"
+homepage="https://github.com/xolox/python-humanfriendly"
+distfiles="${PYPI_SITE}/h/humanfriendly/humanfriendly-${version}.tar.gz"
+checksum=6b0b831ce8f15f7300721aa49829fc4e83921a9a301cc7f606be6686a2288ddc
+
+post_install() {
+	vlicense LICENSE.txt
+}

--- a/srcpkgs/python3-importlib_resources/template
+++ b/srcpkgs/python3-importlib_resources/template
@@ -1,0 +1,13 @@
+# Template file for 'python3-importlib_resources'
+pkgname=python3-importlib_resources
+version=6.4.4
+revision=1
+build_style=python3-pep517
+hostmakedepends="python3-wheel python3-setuptools python3-setuptools_scm"
+depends="python3"
+short_desc="Backport of the importlib.resources module"
+maintainer="Mateusz Sylwestrzak <slymattz@gmail.com>"
+license="Apache-2.0"
+homepage="https://github.com/python/importlib_resources"
+distfiles="${PYPI_SITE}/i/importlib_resources/importlib_resources-${version}.tar.gz"
+checksum=20600c8b7361938dc0bb2d5ec0297802e575df486f5a544fa414da65e13721f7

--- a/srcpkgs/python3-intelhex/template
+++ b/srcpkgs/python3-intelhex/template
@@ -1,0 +1,17 @@
+# Template file for 'python3-intelhex'
+pkgname=python3-intelhex
+version=2.3.0
+revision=1
+build_style=python3-module
+hostmakedepends="python3-setuptools"
+depends="python3"
+short_desc="Python library for Intel HEX files manipulations"
+maintainer="Mateusz Sylwestrzak <slymattz@gmail.com>"
+license="MIT"
+homepage="https://github.com/python-intelhex/intelhex"
+distfiles="${PYPI_SITE}/i/intelhex/intelhex-${version}.tar.gz"
+checksum=892b7361a719f4945237da8ccf754e9513db32f5628852785aea108dcd250093
+
+post_install() {
+	vlicense LICENSE.txt
+}

--- a/srcpkgs/python3-lark-parser/template
+++ b/srcpkgs/python3-lark-parser/template
@@ -1,0 +1,17 @@
+# Template file for 'python3-lark-parser'
+pkgname=python3-lark-parser
+version=1.2.2
+revision=1
+build_style=python3-pep517
+hostmakedepends="python3-wheel python3-setuptools"
+depends="python3-typing_extensions"
+short_desc="Modern parsing library"
+maintainer="Mateusz Sylwestrzak <slymattz@gmail.com>"
+license="MIT"
+homepage="https://github.com/lark-parser/lark"
+distfiles="https://github.com/lark-parser/lark/archive/refs/tags/${version}.tar.gz"
+checksum=472a686b2cf8034938e9fd5df98afd09ae8781e837bfd74abb18d161cc504a82
+
+post_install() {
+	vlicense LICENSE
+}

--- a/srcpkgs/python3-nethsm-sdk-py/template
+++ b/srcpkgs/python3-nethsm-sdk-py/template
@@ -1,0 +1,13 @@
+# Template file for 'python3-nethsm-sdk-py'
+pkgname=python3-nethsm-sdk-py
+version=1.2.1
+revision=1
+build_style=python3-pep517
+hostmakedepends="python3-flit_core"
+depends="python3-certifi python3-cryptography python3-dateutil python3-typing_extensions python3-urllib3"
+short_desc="Python Library to manage NetHSM(s)"
+maintainer="Mateusz Sylwestrzak <slymattz@gmail.com>"
+license="Apache-2.0"
+homepage="https://github.com/Nitrokey/nethsm-sdk-py"
+distfiles="https://github.com/Nitrokey/nethsm-sdk-py/archive/refs/tags/v${version}.tar.gz"
+checksum=b2f7ae0aa3606386a7d7d1dbfbe0d01513b05626af3a38abbecaf6def10a39cd

--- a/srcpkgs/python3-nkdfu/template
+++ b/srcpkgs/python3-nkdfu/template
@@ -1,0 +1,13 @@
+# Template file for 'python3-nkdfu'
+pkgname=python3-nkdfu
+version=0.2
+revision=1
+build_style=python3-pep517
+hostmakedepends="python3-flit_core"
+depends="python3-fire python3-intelhex python3-usb python3-tqdm"
+short_desc="DFU tool for updating Nitrokeys' firmware"
+maintainer="Mateusz Sylwestrzak <slymattz@gmail.com>"
+license="GPL-2.0-only"
+homepage="https://github.com/Nitrokey/nkdfu"
+distfiles="https://github.com/Nitrokey/nkdfu/archive/refs/tags/v${version}.tar.gz"
+checksum=b9cd3e383a7e97372bdf26852f314014ac73a77c5f09b3c5a9426350a4af4713

--- a/srcpkgs/python3-oscrypto/template
+++ b/srcpkgs/python3-oscrypto/template
@@ -1,0 +1,17 @@
+# Template file for 'python3-oscrypto'
+pkgname=python3-oscrypto
+version=1.3.0
+revision=1
+build_style=python3-pep517
+hostmakedepends="python3-setuptools python3-wheel"
+depends="libssl3 libcrypto3 python3-asn1crypto"
+short_desc="Compiler-free Python crypto library backed by the OS"
+maintainer="Mateusz Sylwestrzak <slymattz@gmail.com>"
+license="MIT"
+homepage="https://github.com/wbond/oscrypto"
+distfiles="${PYPI_SITE}/o/oscrypto/oscrypto-${version}.tar.gz"
+checksum=6f5fef59cb5b3708321db7cca56aed8ad7e662853351e7991fcf60ec606d47a4
+
+post_install() {
+	vlicense LICENSE
+}

--- a/srcpkgs/python3-pylink-square/template
+++ b/srcpkgs/python3-pylink-square/template
@@ -1,0 +1,13 @@
+# Template file for 'python3-pylink-square'
+pkgname=python3-pylink-square
+version=1.2.1
+revision=1
+build_style=python3-pep517
+hostmakedepends="python3-wheel python3-setuptools"
+depends="python3-psutil python3-six"
+short_desc="Python interface for the SEGGER J-Link"
+maintainer="Mateusz Sylwestrzak <slymattz@gmail.com>"
+license="Apache-2.0"
+homepage="https://github.com/Square/pylink"
+distfiles="${PYPI_SITE}/p/pylink-square/pylink_square-${version}.tar.gz"
+checksum=4b84b5fd1c22546189324e0ac6c716eb67a90bf7c18dfe50450924a4055bc348

--- a/srcpkgs/python3-pynitrokey/template
+++ b/srcpkgs/python3-pynitrokey/template
@@ -1,0 +1,23 @@
+# Template file for 'python3-pynitrokey'
+pkgname=python3-pynitrokey
+version=0.4.50
+revision=1
+build_style=python3-pep517
+make_build_args="--skip-dependency-check"
+hostmakedepends="python3-wheel python3-flit_core"
+depends="python3-click python3-click-aliases python3-cryptography
+ python3-dateutil python3-ecdsa python3-fido2 python3-frozendict
+ python3-intelhex python3-libusb1 python3-nethsm-sdk-py python3-nkdfu
+ python3-protobuf python3-pyserial python3-requests python3-semver
+ python3-spsdk python3-tlv8 python3-tqdm python3-typing_extensions
+ python3-urllib3 python3-packaging libnitrokey" # libnitrokey is required for udev rules
+short_desc="Python Library for Nitrokey devices"
+maintainer="Mateusz Sylwestrzak <slymattz@gmail.com>"
+license="Apache-2.0, MIT"
+homepage="https://github.com/Nitrokey/pynitrokey"
+distfiles="https://github.com/Nitrokey/pynitrokey/archive/refs/tags/v${version}.tar.gz"
+checksum=2e32caf7b6fc0dc91be453afabbc6d061324c6a1836db4293cfeeffd80508d34
+
+post_install() {
+	vlicense LICENSE-MIT
+}

--- a/srcpkgs/python3-pyocd/template
+++ b/srcpkgs/python3-pyocd/template
@@ -1,0 +1,17 @@
+# Template file for 'python3-pyocd'
+pkgname=python3-pyocd
+version=0.36.0
+revision=1
+build_style=python3-pep517
+hostmakedepends="python3-wheel python3-setuptools python3-setuptools_scm"
+depends="capstone-python3 python3-cmsis-pack-manager python3-colorama
+ python3-pyelftools python3-importlib_metadata python3-importlib_resources
+ python3-intelhex python3-intervaltree python3-lark-parser python3-natsort
+ python3-oletools python3-pyelftools python3-pylink-square python3-usb
+ python3-cattrs python3-six python3-typing_extensions"
+short_desc="Programming and debugging Arm Cortex-M microcontrollers"
+maintainer="Mateusz Sylwestrzak <slymattz@gmail.com>"
+license="Apache-2.0"
+homepage="https://github.com/pyocd/pyOCD"
+distfiles="${PYPI_SITE}/p/pyocd/pyocd-${version}.tar.gz"
+checksum=937782acc9daff054d50fb7c6f788cd94a84f80f0b85f25aacab99dc98228648

--- a/srcpkgs/python3-sly/template
+++ b/srcpkgs/python3-sly/template
@@ -1,0 +1,17 @@
+# Template file for 'python3-sly'
+pkgname=python3-sly
+version=1.5
+revision=1
+build_style=python3-pep517
+hostmakedepends="python3-wheel python3-setuptools"
+depends="python3"
+short_desc="Python implementation of lax and yacc"
+maintainer="Mateusz Sylwestrzak <slymattz@gmail.com>"
+license="BSD-3-Clause"
+homepage="https://github.com/dabeaz/sly"
+distfiles="https://github.com/dabeaz/sly/archive/refs/tags/${version}.tar.gz"
+checksum=d1a5708df747e414276816321b305cef02481ab5b435be07cc08d8835fea4c2b
+
+post_install() {
+	vlicense LICENSE
+}

--- a/srcpkgs/python3-spsdk/template
+++ b/srcpkgs/python3-spsdk/template
@@ -1,0 +1,26 @@
+# Template file for 'python3-spsdk'
+pkgname=python3-spsdk
+version=2.2.1
+revision=1
+build_style=python3-pep517
+hostmakedepends="python3-setuptools python3-setuptools_scm"
+depends="pcsclite python3-asn1crypto python3-astunparse python3-bincopy
+ python3-bitstring python3-click python3-click-command-tree
+ python3-click-option-group python3-cmsis-pack-manager python3-colorama
+ python3-commentjson python3-crcmod python3-cryptography python3-deepmerge
+ python3-colorama python3-crcmod python3-cryptography python3-deepmerge
+ python3-fastjsonschema python3-hexdump python3-Jinja2 libusbsio-python3
+ python3-oscrypto python3-oscrypto python3-platformdirs
+ python3-pycryptodome python3-pylink-square python3-pyocd python3-pyscard
+ python3-pyserial python3-requests python3-ruamel.yaml python3-sly
+ python3-typing_extensions"
+short_desc="Open Source Secure Provisioning SDK for NXP MCU/MPU"
+maintainer="Mateusz Sylwestrzak <slymattz@gmail.com>"
+license="BSD-3-Clause"
+homepage="https://github.com/nxp-mcuxpresso/spsdk"
+distfiles="${PYPI_SITE}/s/spsdk/spsdk-${version}.tar.gz"
+checksum=3c2a69e68842192a5a0f407a3433f018350f7e983772ccd56acf91b4e6e67687
+
+post_install() {
+	vlicense LICENSE
+}

--- a/srcpkgs/python3-tlv8/template
+++ b/srcpkgs/python3-tlv8/template
@@ -1,0 +1,13 @@
+# Template file for 'python3-tlv8'
+pkgname=python3-tlv8
+version=0.10.0
+revision=1
+build_style=python3-pep517
+hostmakedepends="python3-setuptools"
+depends="python3"
+short_desc="Module to handle type-length-value (TLV)"
+maintainer="Mateusz Sylwestrzak <slymattz@gmail.com>"
+license="Apache-2.0"
+homepage="https://github.com/jlusiardi/tlv8_python"
+distfiles="${PYPI_SITE}/t/tlv8/tlv8-${version}.tar.gz"
+checksum=7930a590267b809952272ac2a27ee81b99ec5191fa2eba08050e0daee4262684


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->
#### UPDATE on this PR
Although this PR works totally fine, pynitrokey 0.5.0 is just around the corner. Long story short, it replaces libusbsio dependency with hidapi. It also removes the need for spsdk which is a bulky dep pulling lots of deps including the non-portable cmsis-pack-manager. These changes upstream will certainly simplify the packaging/updating process.

In my opinion, **this PR can be put on hold**. I've already packaged 0.5.0-rc1 and will create a PR when it gets released.

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture: x86_64-glibc

#### About two problematic packages:
- _libusbsio_ has been fixed with a simple sed command proposed by zlice.
- _python3-cmsis-pack-manager_: I've had no success building it for arches other than x86_64 and i686. Upstream documentation says "[Cross-compilation may be an option but has not been sufficiently investigated.](https://github.com/pyocd/pyOCD/blob/main/docs/installing_on_non_x86.md#cmsis-pack-manager)". I've tried to use:
```
build_helper=rust
(...)
rustup-init -y
source "/host/cargo/env"
rustup target add aarch64-unknown-linux-gnu
(...)
cargo build --release --target=aarch64-unknown-linux-gnu
```
Still it fails for aarch64 so the other archs are likely to be affected, too. For the record, I get:
`error: toolchain 'stable-x86_64-unknown-linux-gnu' does not contain component 'rustc' for target 'aarch64-unknown-linux-gnu'` If anybody can think of something to make it work, I'd appreciate a comment.

Native compilation is also bound to fail since "[wheels are not available for non-x86 systems](https://github.com/pyocd/pyOCD/blob/main/docs/installing_on_non_x86.md#cmsis-pack-manager)" That's why I'm keeping the _archs_ line in the template and not setting the var _broken_ for $CROSS_BUILD.