### PR TITLE
svt-av1: update to 2.2.1.

### DIFF
--- a/srcpkgs/svt-av1/template
+++ b/srcpkgs/svt-av1/template
@@ -1,6 +1,6 @@
 # Template file for 'svt-av1'
 pkgname=svt-av1
-version=2.1.2
+version=2.2.1
 revision=1
 build_style=cmake
 configure_args="-DSVT_AV1_LTO=ON"
@@ -10,7 +10,7 @@ license="BSD-3-Clause-Clear"
 homepage="https://gitlab.com/AOMediaCodec/SVT-AV1"
 changelog="https://gitlab.com/AOMediaCodec/SVT-AV1/-/raw/master/CHANGELOG.md"
 distfiles="https://gitlab.com/AOMediaCodec/SVT-AV1/-/archive/v${version}/SVT-AV1-v${version}.tar.gz"
-checksum=65e90af18f31f8c8d2e9febf909a7d61f36172536abb25a7089f152210847cd9
+checksum=d02b54685542de0236bce4be1b50912aba68aff997c43b350d84a518df0cf4e5
 
 case "$XBPS_TARGET_MACHINE" in
 	i686* | x86_64*) hostmakedepends="nasm"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly** (encoded one video using ffmpeg and SvtAv1EncApp using mostly standard settings)

#### Local build testing
- I built this PR locally for my native architecture, (`x86_64-glibc`)
- I built this PR locally for these architectures:
  - `armv6l-glibc` (crossbuild)
  - `i686-glibc`
