### PR TITLE
keybase: update to 6.4.0.

### DIFF
--- a/srcpkgs/keybase/template
+++ b/srcpkgs/keybase/template
@@ -3,11 +3,12 @@ pkgname=keybase
 version=6.4.0
 revision=1
 build_style=go
-go_import_path="github.com/keybase/client"
-go_package="${go_import_path}/go/keybase
-${go_import_path}/go/kbfs/kbfsfuse
-${go_import_path}/go/kbfs/kbfsgit/git-remote-keybase
-${go_import_path}/go/kbfs/kbfstool ${go_import_path}/go/kbfs/redirector"
+build_wrksrc=go
+go_import_path="github.com/keybase/client/go"
+go_package="${go_import_path}/keybase
+${go_import_path}/kbfs/kbfsfuse
+${go_import_path}/kbfs/kbfsgit/git-remote-keybase
+${go_import_path}/kbfs/kbfstool ${go_import_path}/kbfs/redirector"
 go_build_tags="production"
 depends="gnupg>=2"
 short_desc="Client for keybase.io"

--- a/srcpkgs/keybase/template
+++ b/srcpkgs/keybase/template
@@ -1,7 +1,7 @@
 # Template file for 'keybase'
 pkgname=keybase
-version=5.8.1
-revision=5
+version=6.4.0
+revision=1
 build_style=go
 go_import_path="github.com/keybase/client"
 go_package="${go_import_path}/go/keybase
@@ -11,11 +11,11 @@ ${go_import_path}/go/kbfs/kbfstool ${go_import_path}/go/kbfs/redirector"
 go_build_tags="production"
 depends="gnupg>=2"
 short_desc="Client for keybase.io"
-maintainer="Toyam Cox <Vaelatern@voidlinux.org>"
+maintainer="Orphaned <orphan@voidlinux.org>"
 license="BSD-3-Clause"
 homepage="https://keybase.io/"
 distfiles="https://github.com/keybase/client/releases/download/v$version/keybase-v$version.tar.xz"
-checksum=5e89792105ce29420e92ebeaf8055db5e7d67de5e181f83f69904356ddeb8c71
+checksum=506916263f71a3ac8385228b3855d6ddb3f3168574179a0b10ab9867d18b0e3d
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
Hi, as discussed in #48036 (and encourage by @classabbyamp  to begin to work through them) I am attempting to start resolving breaking changes in updating the template for the keybase client. Unfortunately, I have no prior experience programming in Go. 

When attempting to package this new version of the Keybase client I get the error

```
=> ERROR: keybase-6.4.0_1: do_build: 'go install -p "$XBPS_MAKEJOBS" -v -tags "${go_build_tags}" -ldflags "${go_ldflags}" ${go_package}' exited with 1
=> ERROR:   in do_build() at common/build-style/go.sh:59
```

I think this is a permissions error but I'm not sure how to get more useful info from this error.

Any help majorly appreciated.
