### PR TITLE
cups: update to 2.4.10.

### DIFF
--- a/srcpkgs/cups/template
+++ b/srcpkgs/cups/template
@@ -1,7 +1,7 @@
 # Template file for 'cups'
 pkgname=cups
-version=2.4.7
-revision=5
+version=2.4.10
+revision=1
 build_style=gnu-configure
 make_install_args="BUILDROOT=${DESTDIR}"
 hostmakedepends="gnutls-devel pkg-config
@@ -11,10 +11,10 @@ makedepends="acl-devel gnutls-devel libpaper-devel libusb-devel pam-devel
 depends="xdg-utils"
 short_desc="Common Unix Printing System"
 maintainer="Orphaned <orphan@voidlinux.org>"
-license="Apache-2.0 WITH custom:GPL2-LGPL2-Exception, Zlib"
+license="Apache-2.0 WITH custom:GPL-2-LGPL-2-Exception, Zlib"
 homepage="https://github.com/OpenPrinting/cups"
 distfiles="https://github.com/OpenPrinting/cups/releases/download/v${version}/cups-${version}-source.tar.gz"
-checksum=dd54228dd903526428ce7e37961afaed230ad310788141da75cebaa08362cf6c
+checksum=d75757c2bc0f7a28b02ee4d52ca9e4b1aa1ba2affe16b985854f5336940e5ad7
 
 if [ "$XBPS_TARGET_LIBC" = "glibc" ]; then
 	makedepends+=" libxcrypt-devel"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES** (at least the fix in 2.4.8+ that is needed for a printer I was trying to use actually worked).

#### Local build testing
- I built this PR locally for my native architecture, x86_64
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv6l