### PR TITLE
godot: switch from builtin embree to package

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -2477,8 +2477,7 @@ libanthygobject-1.0.so.5 ibus-anthy-1.5.6_1
 libtbbmalloc_proxy.so.2 tbb-4.3_1
 libtbbmalloc.so.2 tbb-4.3_1
 libtbb.so.12 tbb-2021.11.0_1
-libembree.so.3 embree-3.12.2_1
-libembree.so.2 embree-2.5.1_1
+libembree4.so.4 embree-4.3.3_1
 libgtkimageview.so.0 gtkimageview-1.6.4_1
 libgoocanvas-2.0.so.9 goocanvas-2.0.4_1
 libp8-platform.so.2 p8-platform-2.1.0.1_1

--- a/srcpkgs/godot/template
+++ b/srcpkgs/godot/template
@@ -1,12 +1,11 @@
 # Template file for 'godot'
 pkgname=godot
 version=4.3
-revision=2
+revision=3
 archs="x86_64* i686* aarch64* armv7* ppc64*"
 build_style=scons
-# Build currently fails with embree-4.X
 make_build_args="platform=linuxbsd target=editor progress=no production=yes
- lto=auto builtin_brotli=false builtin_embree=true builtin_enet=false
+ lto=auto builtin_brotli=false builtin_embree=false builtin_enet=false
  builtin_freetype=false builtin_graphite=false builtin_harfbuzz=false
  builtin_icu4c=false builtin_libogg=false builtin_libpng=false
  builtin_libtheora=false builtin_libvorbis=false builtin_libwebp=false
@@ -18,7 +17,7 @@ makedepends="alsa-lib-devel freetype-devel mesa glu-devel libXcursor-devel
  libpng-devel libwebp-devel libogg-devel libtheora-devel libvorbis-devel
  libenet-devel zlib-devel mbedtls-devel miniupnpc-devel pcre2-devel
  pulseaudio-devel graphite-devel harfbuzz-devel libzstd-devel
- speech-dispatcher-devel brotli-devel icu-devel"
+ speech-dispatcher-devel brotli-devel icu-devel embree-devel"
 depends="speech-dispatcher"
 short_desc="Multiplatform 2D and 3D engine"
 maintainer="dataCobra <datacobra@thinkbot.de>"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl
  - i686

Godot 4.3 supports embree version 4.x and so we can get rid of builtin embree.

Might need some more testing from different people.