### PR TITLE
New package: hacktv-2024.08.1

### DIFF
--- a/srcpkgs/hacktv/patches/Makefile.patch
+++ b/srcpkgs/hacktv/patches/Makefile.patch
@@ -1,0 +1,14 @@
+diff --git a/src/Makefile b/src/Makefile
+index 4938475e436..f6b3b210775 100644
+--- a/src/Makefile
++++ b/src/Makefile
+@@ -40,7 +40,8 @@ hacktv: $(OBJS)
+ 	@$(CC) $(CFLAGS) -MM $< -o $(@:.o=.d)
+ 
+ install:
+-	cp -f hacktv $(PREFIX)/usr/local/bin/
++	mkdir -p $(DESTDIR)$(PREFIX)/bin
++	cp -f hacktv $(DESTDIR)$(PREFIX)/bin/
+ 
+ clean:
+ 	rm -f *.o *.d hacktv hacktv.exe

--- a/srcpkgs/hacktv/template
+++ b/srcpkgs/hacktv/template
@@ -1,0 +1,16 @@
+# Template file for 'hacktv'
+pkgname=hacktv
+version=2024.08.1
+revision=1
+_commit="b5de3d2"
+build_wrksrc=src
+build_style=gnu-makefile
+make_use_env=yes
+hostmakedepends="pkg-config"
+makedepends="libhackrf-devel ffmpeg-devel"
+short_desc="Analogue TV transmitter for the HackRF"
+maintainer="Tor Morten Finnesand <tmfinnesand@gmail.com>"
+license="GPL-3.0-or-later"
+homepage="https://github.com/fsphil/hacktv"
+distfiles="${homepage}/archive/${_commit}.tar.gz"
+checksum=02cac020d9e7a52b40d44a55f7129939e9f15276d62aebefd702b1f68b71dc5e


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**


#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES (with note)**
 **Note:** The package requirements guide mentions not to use development branches as releases, however the hacktv project has no official releases tagged making this the only option.

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)


