### PR TITLE
gimp: reenable avif/heic

### DIFF
--- a/srcpkgs/gimp/patches/libheif-1.18-compat.patch
+++ b/srcpkgs/gimp/patches/libheif-1.18-compat.patch
@@ -1,0 +1,20 @@
+--- a/configure.ac	2024-08-29 18:28:19.457012043 -0500
++++ b/configure.ac	2024-08-29 18:28:29.154953488 -0500
+@@ -1843,13 +1843,13 @@
+ can_import_avif=no
+ can_export_avif=no
+ if test "x$have_libheif" = xyes; then
+-  can_import_heic=`$PKG_CONFIG --variable=builtin_h265_decoder libheif`
+-  can_export_heic=`$PKG_CONFIG --variable=builtin_h265_encoder libheif`
++  can_import_heic=yes
++  can_export_heic=yes
+   if test "x$can_import_heic" = xyes; then
+     MIME_TYPES="$MIME_TYPES;image/heif;image/heic"
+   fi
+-  can_import_avif=`$PKG_CONFIG --variable=builtin_avif_decoder libheif`
+-  can_export_avif=`$PKG_CONFIG --variable=builtin_avif_encoder libheif`
++  can_import_avif=yes
++  can_export_avif=yes
+   if test "x$can_import_avif" = xyes; then
+     MIME_TYPES="$MIME_TYPES;image/avif"
+   fi

--- a/srcpkgs/gimp/template
+++ b/srcpkgs/gimp/template
@@ -1,7 +1,7 @@
 # Template file for 'gimp'
 pkgname=gimp
 version=2.10.38
-revision=2
+revision=3
 build_style=gnu-configure
 configure_args="--disable-check-update --datadir=/usr/share --disable-python"
 hostmakedepends="automake gegl gettext-devel glib-devel gtk+-devel intltool


### PR DESCRIPTION
libheif commit cf0d89c6e0809427427583290547a7757428cf5a removes the definitions for the `builtin_h265_decoder`, `builtin_h265_encoder`, `builtin_avif_decoder`, and `builtin_avif_encoder` pkg-config variables. This commit is included in libheif 1.80.0 and newer. gimp 2.10.38 depends on these pkg-config variables in its autoconf morass, and as a result is built without support for importing or exporting avif and heic. This commit "fixes" this by forcefully setting these feature detection flags to "yes" if any version of libheif is present. Technically this logic should only apply to libheif 1.80.0 and above, but I don't think there's really any good reason to bother with that additional complication for a patch meant specifically for compiling gimp in a rolling release distribution.

Some links:
 - <https://www.github.com/strukturag/libheif/issues/758>
 - <https://gitlab.gnome.org/GNOME/gimp/-/issues/9080>

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)

