### PR TITLE
libtorrent-rasterbar-2.0.10 ,  qbittorrent-4.6.6 , remove libtorrent-rasterbar-python

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -2187,7 +2187,7 @@ libopenjpeg.so.5 libopenjpeg-1.5.2_1
 libopenpgl.so.0 openpgl-0.5.0_1
 liboping.so.0 liboping-1.8.0_1
 libloudmouth-1.so.0 loudmouth-1.5.3_12
-libtorrent-rasterbar.so.10 libtorrent-rasterbar-1.2.19_1
+libtorrent-rasterbar.so.2.0 libtorrent-rasterbar-2.0.10_1
 libcapstone.so.5 capstone-5.0.1_1
 libhavege.so.2 libhaveged-1.9.11_1
 libnih.so.1 libnih-1.0.3_1

--- a/srcpkgs/btfs/template
+++ b/srcpkgs/btfs/template
@@ -1,7 +1,7 @@
 # Template file for 'btfs'
 pkgname=btfs
 version=2.24
-revision=5
+revision=6
 build_style=gnu-configure
 hostmakedepends="automake pkg-config"
 makedepends="boost-devel fuse-devel libcurl-devel libtorrent-rasterbar-devel"

--- a/srcpkgs/libtorrent-rasterbar-python/template
+++ b/srcpkgs/libtorrent-rasterbar-python/template
@@ -1,9 +1,0 @@
-# Template file for 'libtorrent-rasterbar-python'
-pkgname=libtorrent-rasterbar-python
-version=1.2.2
-revision=1
-build_style=meta
-short_desc="Obsolete package: switch to libtorrent-rasterbar-python3"
-maintainer="Orphaned <orphan@voidlinux.org>"
-license="BSD-2-Clause"
-homepage="https://voidlinux.org/"

--- a/srcpkgs/libtorrent-rasterbar/template
+++ b/srcpkgs/libtorrent-rasterbar/template
@@ -1,7 +1,7 @@
 # Template file for 'libtorrent-rasterbar'
 # Breaks ABI/API without changing soname, revbump all dependants
 pkgname=libtorrent-rasterbar
-version=1.2.19
+version=2.0.10
 revision=1
 build_style=cmake
 configure_args="-Dbuild_examples=ON -Dbuild_tools=ON
@@ -13,7 +13,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="BSD-3-Clause"
 homepage="https://libtorrent.org/"
 distfiles="https://github.com/arvidn/libtorrent/releases/download/v${version}/${pkgname}-${version}.tar.gz"
-checksum=eee8e99548dc5eb5e643e49db9202f4f97112c032dba883dfdc8144af5b6e40e
+checksum=fc935b8c1daca5c0a4d304bff59e64e532be16bb877c012aea4bda73d9ca885d
 
 CXXFLAGS="-std=c++14"
 

--- a/srcpkgs/qbittorrent/template
+++ b/srcpkgs/qbittorrent/template
@@ -1,7 +1,7 @@
 # Template file for 'qbittorrent'
 pkgname=qbittorrent
-version=4.6.5
-revision=2
+version=4.6.6
+revision=1
 build_style=cmake
 configure_args="-DQT6=ON -DSYSTEMD=OFF -DGUI=ON -DWEBUI=OFF"
 hostmakedepends="pkg-config qt6-tools qt6-declarative-host-tools"
@@ -13,7 +13,7 @@ license="GPL-2.0-or-later"
 homepage="https://www.qbittorrent.org/"
 changelog="https://www.qbittorrent.org/news.php"
 distfiles="${SOURCEFORGE_SITE}/qbittorrent/qbittorrent-${version}.tar.xz"
-checksum=89cd79f58af4db346a9744e4bf61181c4bd40cce201b79a9f54ac31a8676e921
+checksum=437d5dc70c146aac45c263b335855826e279fad6da5c01c21db24152f18169d1
 CXXFLAGS=-std=gnu++17
 
 post_configure() { # qbittorrent-nox

--- a/srcpkgs/removed-packages/template
+++ b/srcpkgs/removed-packages/template
@@ -1,6 +1,6 @@
 # Template file for 'removed-packages'
 pkgname=removed-packages
-version=0.1.20240905
+version=0.1.20240909
 revision=1
 build_style=meta
 short_desc="Uninstalls packages removed from repository"
@@ -424,6 +424,7 @@ replaces="
  libspa-ffmpeg<=0.3.32_1
  libspotify-devel<=12.1.51_2
  libspotify<=12.1.51_2
+ libtorrent-rasterbar-python<=1.2.2_1
  libunique-devel<=3.0.2_11
  libunique1-devel<=1.1.6_12
  libunique1<=1.1.6_12


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->

ping @ericonr @slymattz @zen0bit 