### PR TITLE
OpenRCT2: update to 0.4.14.

### DIFF
--- a/srcpkgs/OpenRCT2/template
+++ b/srcpkgs/OpenRCT2/template
@@ -2,11 +2,11 @@
 # based on https://raw.githubusercontent.com/AluisioASG/void-packages/openrct2/srcpkgs/OpenRCT2/template
 # and https://github.com/void-linux/void-packages/issues/1014#issuecomment-417372421
 pkgname=OpenRCT2
-version=0.4.13
+version=0.4.14
 revision=1
 # versions pulled from https://raw.githubusercontent.com/OpenRCT2/OpenRCT2/v${version}/CMakeLists.txt
 _objects_version=1.4.7
-_titles_version=0.4.6
+_titles_version=0.4.14
 _replays_version=0.0.79
 _opensfx_version=1.0.5
 _openmsx_version=1.6
@@ -40,12 +40,12 @@ distfiles="https://github.com/OpenRCT2/OpenRCT2/archive/v${version}.tar.gz
  https://github.com/OpenRCT2/OpenMusic/releases/download/v${_openmsx_version}/openmusic.zip>openmusic-${_openmsx_version}.zip
  https://github.com/OpenRCT2/replays/releases/download/v${_replays_version}/replays.zip>replays-${_replays_version}.zip
  https://github.com/OpenRCT2/title-sequences/releases/download/v${_titles_version}/title-sequences.zip>title-sequences-${_titles_version}.zip"
-checksum="b15c424300c0a056cb6498e4e5d5d8762fbc532ca1ab3feabc1a97a5dff23b28
+checksum="a6645c0c5fcdd4e1e9bdbe90a97d1674a7b9ed5c5e8b803339b4fe4886368ad2
  003c7d8a68a2461ac27204a361ffe6eab66e3aff262755b9830c97ce36d6fb65
  a952148be164c128e4fd3aea96822e5f051edd9a0b1f2c84de7f7628ce3b2e18
  f097d3a4ccd39f7546f97db3ecb1b8be73648f53b7a7595b86cccbdc1a7557e4
  045da1df8697e2d33ff33b34008f22e7698280aa4639afd1b1fc3c590d5e9956
- 24a189cdaf1f78fb6d6caede8f1ab3cedf8ab9f819cd2260a09b2cce4c710d98"
+ 140df714e806fed411cc49763e7f16b0fcf2a487a57001d1e50fce8f9148a9f3"
 skip_extraction="objects-${_objects_version}.zip
  opensound-${_opensfx_version}.zip
  openmusic-${_openmsx_version}.zip


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly** (the game launches to title screen still, on `x86_64-musl`. that's the extent of today's testing)

Almost exactly 1hr after upstream release... probably my fastest package bump, by luck of having checked my GitHub feed this afternoon :smiley: 
