### PR TITLE
ndhc: update to 20240524.

### DIFF
--- a/srcpkgs/ndhc/patches/ldflags.patch
+++ b/srcpkgs/ndhc/patches/ldflags.patch
@@ -1,0 +1,11 @@
+--- a/Makefile
++++ b/Makefile
+@@ -9,7 +9,7 @@ CPPFLAGS += $(INCL)
+ all: ragel ndhc
+ 
+ ndhc: $(NDHC_OBJS)
+-	$(CC) $(CFLAGS) $(INCL) -o $@ $^
++	$(CC) $(CFLAGS) $(INCL) -o $@ $^ $(LDFLAGS)
+ 
+ -include $(NDHC_DEP)
+ 

--- a/srcpkgs/ndhc/template
+++ b/srcpkgs/ndhc/template
@@ -1,6 +1,6 @@
 # Template file for 'ndhc'
 pkgname=ndhc
-version=20220308
+version=20240524
 revision=1
 _dashversion="${version:0:4}-${version:4:2}-${version:6:2}"
 build_style=gnu-makefile
@@ -12,8 +12,8 @@ short_desc="Privilege-seperated secure DHCPv4 client"
 maintainer="Duncaen <duncaen@voidlinux.org>"
 license="MIT"
 homepage="https://github.com/niklata/ndhc"
-distfiles="https://github.com/niklata/ndhc/archive/v${_dashversion}.tar.gz"
-checksum=30f595b7c1cc2e60599b8c6aa82e0b1ee4ef2243a67fcebf812b60746db7de4d
+distfiles="https://github.com/niklata/ndhc/archive/refs/tags/v${_dashversion}.tar.gz"
+checksum=4612e1b01e65e3c64b39e39d8e67e46e571ed651b33e3087d6c0d257cd25644c
 
 export CFLAGS="-std=gnu99 -D_GNU_SOURCE -DNK_USE_CAPABILITY"
 


### PR DESCRIPTION
Patch Makefile to respect LDFLAGS, which has the extra benefit of fixing the static build option.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->

cc: @Duncaen 
