### PR TITLE
mosquitto: move headers to devel pkg, fix deps

### DIFF
--- a/srcpkgs/mosquitto/template
+++ b/srcpkgs/mosquitto/template
@@ -1,7 +1,7 @@
 # Template file for 'mosquitto'
 pkgname=mosquitto
 version=2.0.18
-revision=1
+revision=2
 build_style=gnu-makefile
 make_build_args="WITH_WEBSOCKETS=yes WITH_BUNDLED_DEPS=no"
 make_install_args="prefix=/usr"
@@ -73,6 +73,7 @@ libmosquitto-devel_package() {
 	short_desc="MQTT version 3.1/3.1.1/5.0 client library - development files"
 	depends="libmosquitto-${version}_${revision}"
 	pkg_install() {
+		vmove usr/include/mqtt_protocol.h
 		vmove usr/include/mosquitto.h
 		vmove usr/include/mosquitto_plugin.h
 		vmove usr/include/mosquitto_broker.h
@@ -91,7 +92,7 @@ libmosquittopp_package() {
 
 libmosquittopp-devel_package() {
 	short_desc="MQTT version 3.1/3.1.1/5.0 C++ client library - development files"
-	depends="libmosquittopp-${version}_${revision}"
+	depends="libmosquittopp-${version}_${revision} libmosquitto-devel-${version}_${revision}"
 	pkg_install() {
 		vmove usr/include/mosquittopp.h
 		vmove usr/lib/libmosquittopp.so


### PR DESCRIPTION
mqtt_protocol.h was in the main package, not the devel

the C++ devel pkg needs to depend on the C devel pkg because one of its
headers includes mosquitto.h

#### Testing the changes
- I tested the changes in this PR: **briefly**
