### PR TITLE
papirus-icon-theme: update to 20240501.

### DIFF
--- a/srcpkgs/papirus-icon-theme/template
+++ b/srcpkgs/papirus-icon-theme/template
@@ -1,13 +1,13 @@
 # Template file for 'papirus-icon-theme'
 pkgname=papirus-icon-theme
-version=20240201
+version=20240501
 revision=1
 short_desc="SVG icon theme for Linux, based on Paper Icon Set"
 maintainer="Giuseppe Fierro <gspe@ae-design.ws>"
 license="GPL-3.0-or-later"
 homepage="https://github.com/PapirusDevelopmentTeam/papirus-icon-theme"
 distfiles="https://github.com/PapirusDevelopmentTeam/papirus-icon-theme/archive/${version}.tar.gz"
-checksum=8ff3caded7862e5e6f531dbae54b213ff1cd3666d26f23357c6183173856f380
+checksum=c12a64963639afffc5c5425c4d8fd09e9d5510bbc4c408a1fec9a1d617c5089b
 
 do_install() {
 	vmkdir usr/share/icons


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, x86_64_glibc

It's probably not updated previously as [20240501](https://github.com/PapirusDevelopmentTeam/papirus-icon-theme/releases/tag/20240501) targets Plasma 6. As the transition is over it should be fine to upgrade.