### PR TITLE
stress: move to new upstream

### DIFF
--- a/srcpkgs/stress/template
+++ b/srcpkgs/stress/template
@@ -1,14 +1,14 @@
 # Template file for 'stress'
 pkgname=stress
 version=1.0.7
-revision=1
+revision=2
 build_style=gnu-configure
 hostmakedepends="automake"
 short_desc="Deliberately simple workload generator for POSIX systems"
 maintainer="Leah Neukirchen <leah@vuxu.org>"
 license="GPL-2.0-or-later"
-homepage="https://packages.debian.org/sid/stress"
-distfiles="${DEBIAN_SITE}/main/s/stress/stress_${version}.orig.tar.gz"
+homepage="https://github.com/resurrecting-open-source-projects/stress"
+distfiles="https://github.com/resurrecting-open-source-projects/stress/archive/${version}.tar.gz"
 checksum=cdaa56671506133e2ed8e1e318d793c2a21c4a00adc53f31ffdef1ece8ace0b1
 
 pre_configure() {


### PR DESCRIPTION
Changed to the upstream that Debian uses, instead of the Debian package.

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-musl)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - armv6l-musl
