### PR TITLE
New package: maliit-keyboard

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -4550,3 +4550,4 @@ libshiboken6.so.6.7 libshiboken6-6.7.2_1
 libopencore-amrnb.so.0 opencore-amr-0.1.6_1
 libopencore-amrwb.so.0 opencore-amr-0.1.6_1
 libilbc.so.3 libilbc-3.0.4_1
+libmaliit-plugins.so.2 maliit-keyboard-2.3.1_1

--- a/srcpkgs/maliit-framework-devel
+++ b/srcpkgs/maliit-framework-devel
@@ -1,0 +1,1 @@
+maliit-framework

--- a/srcpkgs/maliit-framework-doc
+++ b/srcpkgs/maliit-framework-doc
@@ -1,0 +1,1 @@
+maliit-framework

--- a/srcpkgs/maliit-framework-examples
+++ b/srcpkgs/maliit-framework-examples
@@ -1,0 +1,1 @@
+maliit-framework

--- a/srcpkgs/maliit-framework/template
+++ b/srcpkgs/maliit-framework/template
@@ -1,0 +1,49 @@
+# Template file for 'maliit-framework'
+pkgname=maliit-framework
+version=2.3.0
+revision=1
+build_style=cmake
+configure_args="-Denable-examples=ON
+ -Denable-tests=OFF
+ -Denable-dbus-activation=ON
+ -Denable-wayland-gtk=ON
+ -DWaylandScanner_EXECUTABLE=/usr/bin/wayland-scanner"
+hostmakedepends="doxygen gettext qt5-host-tools qt5-qmake qt5-wayland pkg-config
+ wayland-devel glib-devel"
+makedepends="libxcb-devel qt5-devel qt5-declarative-devel qt5-wayland-devel libglib-devel
+ wayland-devel wayland-protocols libxkbcommon-devel
+ libXdamage-devel libXcomposite-devel libXext-devel libXfixes-devel"
+short_desc="Core libraries of Maliit and server"
+maintainer="Hervy Qurrotul Ainur Rozi <hervyqa@proton.me>"
+license="LGPL-2.1-only"
+homepage="https://maliit.github.io"
+changelog="https://raw.githubusercontent.com/maliit/framework/master/NEWS"
+distfiles="https://github.com/maliit/framework/archive/refs/tags/${version}.tar.gz"
+checksum=bfc23919ac8b960243f85e8228ad7dfc28d557b52182a0b5a2a216a5c6a8057c
+
+maliit-framework-devel_package() {
+	depends="${sourcepkg}>=${version}_${revision}"
+	short_desc+=" - development files"
+	pkg_install() {
+		vmove usr/include
+		vmove usr/lib/pkgconfig
+		vmove usr/lib/qt5/mkspecs
+		vmove usr/lib/cmake
+		vmove "usr/lib/*.so"
+	}
+}
+
+maliit-framework-doc_package() {
+	short_desc+=" - documentation"
+	pkg_install() {
+		vmove usr/share/doc/maliit-framework
+		vmove usr/share/doc/maliit-framework-doc
+	}
+}
+
+maliit-framework-examples_package() {
+	short_desc+=" - examples"
+	pkg_install() {
+		vmove usr/bin/maliit-exampleapp-plainqt
+	}
+}

--- a/srcpkgs/maliit-keyboard-doc
+++ b/srcpkgs/maliit-keyboard-doc
@@ -1,0 +1,1 @@
+maliit-keyboard

--- a/srcpkgs/maliit-keyboard/template
+++ b/srcpkgs/maliit-keyboard/template
@@ -1,0 +1,35 @@
+# Template file for 'maliit-keyboard'
+pkgname=maliit-keyboard
+version=2.3.1
+revision=1
+build_style=cmake
+configure_args="-Denable-presage=OFF
+ -Denable-tests=OFF
+ -DWaylandScanner_EXECUTABLE=/usr/bin/wayland-scanner"
+hostmakedepends="gettext libpinyin pkg-config qt5-host-tools qt5-qmake"
+makedepends="$(vopt_if anthy anthy-unicode-devel)
+ $(vopt_if libpinyin libpinyin-devel) glib-devel hunspell-devel
+ libchewing-devel maliit-framework-devel qt5-declarative-devel
+ qt5-multimedia-devel qt5-quickcontrols2-devel"
+depends="hunspell maliit-framework qt5-graphicaleffects qt5-multimedia qt5-quickcontrols2"
+short_desc="Virtual keyboard based on Maliit framework"
+maintainer="Hervy Qurrotul Ainur Rozi <hervyqa@proton.me>"
+license="LGPL-2.1-only"
+homepage="https://maliit.github.io"
+changelog="https://raw.githubusercontent.com/maliit/keyboard/master/NEWS"
+distfiles="https://github.com/maliit/keyboard/archive/refs/tags/${version}.tar.gz"
+checksum=c3e1eb985b8ae7ce4e3e28412b7e797ff5db437ccd327e0d852a3c37f17fe456
+
+build_options="anthy libpinyin"
+build_options_default=""
+
+if [ -z "$CROSS_BUILD" ]; then
+	build_options_default+=" anthy libpinyin"
+fi
+
+maliit-keyboard-doc_package() {
+	short_desc+=" - documentation"
+	pkg_install() {
+		vmove usr/share/doc/maliit-keyboard
+	}
+}


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

Maybe fix: #49597

![Screenshot_20240904_123308](https://github.com/user-attachments/assets/f41f02ab-ba67-464e-97d1-846547650f4c)

#### Testing the changes
- I tested the changes in this PR: **YES**, but maliit virtual keyboard still not working. any advice @classabbyamp ?

```
Operating System: Void 
KDE Plasma Version: 6.1.4
KDE Frameworks Version: 6.5.0
Qt Version: 6.7.2
Kernel Version: 6.6.48_1 (64-bit)
Graphics Platform: Wayland
Processors: 12 × Intel® Core™ i5-10500H CPU @ 2.50GHz
Memory: 23.3 GiB of RAM
Graphics Processor: Mesa Intel® UHD Graphics
Manufacturer: Micro-Star International Co., Ltd.
Product Name: GF63 Thin 10UC
System Version: REV:1.0
```

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)