### PR TITLE
scaleway-cli: update to 2.33.0, adopt.

### DIFF
--- a/srcpkgs/scaleway-cli/template
+++ b/srcpkgs/scaleway-cli/template
@@ -1,17 +1,17 @@
 # Template file for 'scaleway-cli'
 pkgname=scaleway-cli
-version=2.32.1
-revision=2
+version=2.33.0
+revision=1
 build_style=go
 go_import_path=github.com/scaleway/scaleway-cli/v2
 go_package=github.com/scaleway/scaleway-cli/v2/cmd/scw
 go_ldflags="-X main.Version=$version"
 short_desc="Interact with the Scaleway API from the command line"
-maintainer="Orphaned <orphan@voidlinux.org>"
+maintainer="Sébastien Pondichy<sebastien.pondichy@gmail.com>"
 license="MIT"
 homepage="https://github.com/scaleway/scaleway-cli"
 distfiles="https://github.com/scaleway/scaleway-cli/archive/v${version}.tar.gz"
-checksum=4b2bfe7b39dcb259f27d5e4eaae4ffc55f31fb9cf6ff1869c7783c5d75c66eb6
+checksum=cacf2f6bd749d14aae0ac2168197c3fd763b0e94d630fd07007c50bdce96a068
 
 post_install() {
 	vdoc README.md README


### PR DESCRIPTION
 I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - i686
  - x86_64-musl
  - armv7l
