### PR TITLE
linphone

### DIFF
--- a/srcpkgs/bcmatroska2/template
+++ b/srcpkgs/bcmatroska2/template
@@ -1,6 +1,6 @@
 # Template file for 'bcmatroska2'
 pkgname=bcmatroska2
-version=5.3.69
+version=5.3.79
 revision=1
 build_style=cmake
 configure_args="-DBUILD_SHARED_LIBS=TRUE"
@@ -10,7 +10,7 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-only"
 homepage="https://gitlab.linphone.org/BC/public/bcmatroska2"
 distfiles="https://gitlab.linphone.org/BC/public/bcmatroska2/-/archive/${version}/bcmatroska2-${version}.tar.gz"
-checksum=89231f21841d7087c58619103d04d1fa32836d88571e3724e68c3488b0dc7aa8
+checksum=3f2cfaa97f6f5d4a22536008c40f0d23f8bc421c166cd59f0253b63c38113a21
 
 bcmatroska2-devel_package() {
 	depends="bcmatroska2-${version}_${revision}"

--- a/srcpkgs/bctoolbox/template
+++ b/srcpkgs/bctoolbox/template
@@ -1,6 +1,6 @@
 # Template file for 'bctoolbox'
 pkgname=bctoolbox
-version=5.3.77
+version=5.3.79
 revision=1
 build_style=cmake
 configure_args="-DENABLE_TESTS=ON -DENABLE_TESTS_COMPONENT=FALSE
@@ -12,7 +12,7 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-only"
 homepage="https://gitlab.linphone.org/BC/public/bctoolbox"
 distfiles="https://gitlab.linphone.org/BC/public/bctoolbox/-/archive/${version}/bctoolbox-${version}.tar.gz"
-checksum=bb0ce0da869e598512e20e69f734b5a86cb9713a5a7aa7071990274945e90cbe
+checksum=8293326971b5e7c3b0ef77e4f62653ecaf169af0c82d34acb1e26ff62c4e3801
 
 bctoolbox-devel_package() {
 	depends="bctoolbox-${version}_${revision}"

--- a/srcpkgs/belcard/template
+++ b/srcpkgs/belcard/template
@@ -1,6 +1,6 @@
 # Template file for 'belcard'
 pkgname=belcard
-version=5.3.77
+version=5.3.79
 revision=1
 build_style=cmake
 configure_args="-DBUILD_SHARED_LIBS=TRUE -DENABLE_UNIT_TESTS=FALSE"
@@ -10,7 +10,7 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-3.0-or-later"
 homepage="https://linphone.org"
 distfiles="https://gitlab.linphone.org/BC/public/belcard/-/archive/${version}/belcard-${version}.tar.gz"
-checksum=8fb598c19fbed0bc1853cee7b5c7867883f7d34e6eb8f69a73e050dc0ec2b11a
+checksum=ffa3f1d513de344566257547018b263eb80d3419e66178f5e542901798023b14
 
 belcard-devel_package() {
 	short_desc+=" - development files"

--- a/srcpkgs/belle-sip/template
+++ b/srcpkgs/belle-sip/template
@@ -1,6 +1,6 @@
 # Template file for 'belle-sip'
 pkgname=belle-sip
-version=5.3.77
+version=5.3.79
 revision=1
 build_style=cmake
 configure_args="-DENABLE_STRICT=OFF -DENABLE_UNIT_TESTS=NO -DCMAKE_SKIP_INSTALL_RPATH=ON
@@ -11,7 +11,7 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later"
 homepage="https://www.linphone.org"
 distfiles="https://gitlab.linphone.org/BC/public/belle-sip/-/archive/${version}/belle-sip-${version}.tar.gz"
-checksum=bf329eca5c0779ef929e2747e1e607fa8d53965f57ed1a5a59568c8bb3ac05b0
+checksum=df4a9ee5bb725cafc3fe286548e9475d4b22cdc3aafe0953bc60b45dd002ae61
 
 belle-sip-devel_package() {
 	depends="${sourcepkg}>=${version}_${revision}"

--- a/srcpkgs/belr/template
+++ b/srcpkgs/belr/template
@@ -1,6 +1,6 @@
 # Template file for 'belr'
 pkgname=belr
-version=5.3.77
+version=5.3.79
 revision=1
 build_style=cmake
 configure_args="-DBUILD_SHARED_LIBS=TRUE -DENABLE_UNIT_TESTS=FALSE"
@@ -10,7 +10,7 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-3.0-or-later"
 homepage="https://www.linphone.org"
 distfiles="https://gitlab.linphone.org/BC/public/belr/-/archive/${version}/belr-${version}.tar.gz"
-checksum=5fd453342e7f5ff741c6cc0f8f4dfaa35029668009de1517e172101a9b0c0e30
+checksum=16e4d3a309bfec5882a1880797624877bfb0954958c4cb67d62ad460ce14cd1a
 
 belr-devel_package() {
 	short_desc+=" - development files"

--- a/srcpkgs/bzrtp/template
+++ b/srcpkgs/bzrtp/template
@@ -1,6 +1,6 @@
 # Template file for 'bzrtp'
 pkgname=bzrtp
-version=5.3.77
+version=5.3.79
 revision=1
 build_style=cmake
 configure_args="-DENABLE_TESTS=FALSE -DBUILD_SHARED_LIBS=TRUE"
@@ -10,7 +10,7 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later"
 homepage="https://www.linphone.org"
 distfiles="https://gitlab.linphone.org/BC/public/bzrtp/-/archive/${version}/bzrtp-${version}.tar.gz"
-checksum=d2baf39269654869595ae5809b2ec9a35345f075c960f6306b30d8a172797ce9
+checksum=c1f1fec987257953d5c31ef3648a906932ee6a25f8c92d869dd94b41522b235b
 
 bzrtp-devel_package() {
 	depends="${makedepends} ${sourcepkg}>=${version}_${revision}"

--- a/srcpkgs/linphone-desktop/template
+++ b/srcpkgs/linphone-desktop/template
@@ -1,7 +1,7 @@
 # Template file for 'linphone-desktop'
 pkgname=linphone-desktop
 version=5.2.6
-revision=2
+revision=3
 build_wrksrc="linphone-app" # The root cmake is glue code for their vendored libs
 build_style=cmake
 cmake_builddir="build-cmake"
@@ -11,7 +11,8 @@ makedepends="bctoolbox-devel belcard-devel belle-sip-devel linphone-devel
  mediastreamer-devel qt5-declarative-devel qt5-quickcontrols2-devel
  qt5-svg-devel qt5-tools-devel qt5-webview-devel qt5-speech-devel
  qt5-multimedia-devel sonnet-devel"
-depends="qt5>=5.9_1 qt5-quickcontrols qt5-quickcontrols2 qt5-graphicaleffects"
+depends="qt5>=5.9_1 qt5-quickcontrols qt5-quickcontrols2 qt5-graphicaleffects
+ mediastreamer-plugin-msqogl"
 short_desc="Linphone qt desktop"
 maintainer="John <me@johnnynator.dev>"
 license="GPL-3.0-or-later"

--- a/srcpkgs/linphone/template
+++ b/srcpkgs/linphone/template
@@ -1,6 +1,6 @@
 # Template file for 'linphone'
 pkgname=linphone
-version=5.3.78
+version=5.3.79
 revision=1
 build_style="cmake"
 configure_args="-DBUILD_SHARED_LIBS=TRUE
@@ -20,7 +20,7 @@ maintainer="John <me@johnnynator.dev>"
 license="AGPL-3.0-or-later"
 homepage="https://www.linphone.org"
 distfiles="https://gitlab.linphone.org/BC/public/liblinphone/-/archive/${version}/liblinphone-${version}.tar.gz"
-checksum=74565d918b7089b64b3e05eeaca4f0f1c813058f075114ffd9e8b2c412f6da52
+checksum=d0351d454f5bee69d1c88e956a25c539782595a815070b59d965c3a6945e0de3
 
 pre_build() {
 	echo "#define MS2_GIT_VERSION=unknown" > coreapi/gitversion.h

--- a/srcpkgs/mediastreamer-plugin-msqogl
+++ b/srcpkgs/mediastreamer-plugin-msqogl
@@ -1,0 +1,1 @@
+mediastreamer

--- a/srcpkgs/mediastreamer/template
+++ b/srcpkgs/mediastreamer/template
@@ -1,24 +1,32 @@
 # Template file for 'mediastreamer'
 pkgname=mediastreamer
-version=5.3.78
+version=5.3.79
 revision=1
 build_style=cmake
-configure_args="-DENABLE_STRICT=0 -DENABLE_UNIT_TESTS=0 -DBUILD_SHARED_LIBS=TRUE"
-hostmakedepends="python3"
+configure_args="-DENABLE_STRICT=0 -DENABLE_UNIT_TESTS=0 -DBUILD_SHARED_LIBS=TRUE
+ -DENABLE_QT_GL=TRUE"
+hostmakedepends="python3 qt5-qmake qt5-host-tools"
 makedepends="bzrtp-devel ffmpeg-devel glew-devel libXv-devel libsrtp-devel
  libupnp-devel libvpx-devel mbedtls-devel opus-devel ortp-devel pulseaudio-devel
  libtheora-devel speex-devel v4l-utils-devel bcg729-devel bcmatroska2-devel libgsm-devel
- zxing-cpp-devel"
+ zxing-cpp-devel libaom-devel qt5-devel qt5-declarative-devel"
 short_desc="Powerful and lightweight streaming engine for voice/video telephony"
 maintainer="John <me@johnnynator.dev>"
 license="AGPL-3.0-or-later"
 homepage="https://www.linphone.org/technical-corner/mediastreamer2"
 distfiles="https://gitlab.linphone.org/BC/public/mediastreamer2/-/archive/${version}/mediastreamer2-${version}.tar.gz"
-checksum=d252b47310cc146eb8d4e00394452bc396a12e616d5448ec058fb80989d9c75f
+checksum=05fbdb71f4ad309458a20a93172451f0c6c26260107f6f5d60da2481f2711cc4
 
 post_install() {
 	vlicense LICENSE.txt
 	rm -r "${DESTDIR}/usr/include/OpenGL"
+}
+
+mediastreamer-plugin-msqogl_package() {
+	short_desc+=" - QT OpenGL Render Plugin"
+	pkg_install() {
+		vmove usr/lib/mediastreamer/plugins/libmsqogl.so
+	}
 }
 
 mediastreamer-devel_package() {

--- a/srcpkgs/ortp/template
+++ b/srcpkgs/ortp/template
@@ -1,6 +1,6 @@
 # Template file for 'ortp'
 pkgname=ortp
-version=5.3.77
+version=5.3.79
 revision=1
 build_style=cmake
 configure_args="-DBUILD_SHARED_LIBS=TRUE -DENABLE_UNIT_TESTS=OFF"
@@ -10,7 +10,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://www.linphone.org/technical-corner/ortp"
 distfiles="https://gitlab.linphone.org/BC/public/ortp/-/archive/${version}/ortp-${version}.tar.gz"
-checksum=0dde365930bb139dbc2fc817a59fbb67aa8509188c40d7afa848106322021511
+checksum=0444cd7a9e2d77e6fa3c0421b607e6afd73e37122f674e945de039b1637d06a8
 
 ortp-devel_package() {
 	depends="bctoolbox-devel ortp-${version}_${revision}"


### PR DESCRIPTION
- **bcmatroska2: update to 5.3.79.**
- **bctoolbox: update to 5.3.79.**
- **belcard: update to 5.3.79.**
- **belle-sip: update to 5.3.79.**
- **belr: update to 5.3.79.**
- **bzrtp: update to 5.3.79.**
- **linphone: update to 5.3.79.**
- **mediastreamer: update to 5.3.79.**
- **ortp: update to 5.3.79.**
- **linphone-desktop: add mising dep to mediastreamer-plugin-msqogl**

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**|**briefly**|**NO**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
