### PR TITLE
Signal-Desktop: update to 7.24.1.

### DIFF
--- a/srcpkgs/Signal-Desktop/template
+++ b/srcpkgs/Signal-Desktop/template
@@ -1,6 +1,6 @@
 # Template file for 'Signal-Desktop'
 pkgname=Signal-Desktop
-version=7.21.0
+version=7.24.1
 revision=1
 # Signal officially only supports x86_64
 # x86_64-musl could potentially work based on the Alpine port:
@@ -14,7 +14,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="AGPL-3.0-only"
 homepage="https://github.com/signalapp/Signal-Desktop"
 distfiles="https://github.com/signalapp/Signal-Desktop/archive/v${version}.tar.gz"
-checksum=4506a3639685dd191f713d70ed3c6624a77cafe8fd6ff3f113b340d2cd337526
+checksum=e71ef8d89b79fc7322053c6511dfc2bef7a1160bd4214326961f964e5de2350d
 nostrip_files="signal-desktop"
 
 post_extract() {
@@ -23,15 +23,21 @@ post_extract() {
 
 	vsed 's/"node": ".*"/"node": ">=20.0.0"/' -i package.json
 
-	npm install -g yarn
-	# Dependencies have to be installed before applying patch
-	yarn install --ignore-engines --frozen-lockfile
+	# Install dependencies for sticker-creator
+	npm --prefix ./sticker-creator/ install
+
+	# Install dependencies for signal-desktop
+	npm install --ignore-engines
 }
 
 do_build() {
-	yarn generate
-	yarn build-release
+	# Build the sticker creator
+	npm --prefix ./sticker-creator/ run build
 
+	# Build signal-desktop
+	npm run build
+
+	# Extract the generated .desktop file
 	bsdtar xOf release/signal-desktop_*.deb data.tar.xz | \
 		bsdtar xO ./usr/share/applications/signal-desktop.desktop > signal-desktop.desktop
 	vsed -i -e 's/\/opt\/Signal\///' signal-desktop.desktop


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc


Using `yarn` to build the package resulted in many errors, so I decided to use `npm` instead (I copied the commands from the way Arch Linux does it). I also added a desktop that I copied from `/usr/share/applications`, since I got a build error saying that it was not found without it.

This still needs some testing,
People who might know about this more than me, any suggestions are welcome. Thanks