### PR TITLE
New package: tuxedo-yt6801-1.0.29

### DIFF
--- a/srcpkgs/tuxedo-yt6801/template
+++ b/srcpkgs/tuxedo-yt6801/template
@@ -1,0 +1,21 @@
+# Template file for 'tuxedo-yt6801'
+pkgname=tuxedo-yt6801
+version=1.0.29
+revision=1
+_version=${version}tux1
+depends="dkms"
+short_desc="Driver for Motorcomm YT6801 ethernet controller"
+maintainer="newbluemoon <blaumolch@mailbox.org>"
+license="GPL-2.0-or-later"
+homepage="https://gitlab.com/tuxedocomputers/development/packages/tuxedo-yt6801"
+changelog="https://gitlab.com/tuxedocomputers/development/packages/tuxedo-yt6801/-/raw/main/debian/changelog"
+distfiles="https://gitlab.com/tuxedocomputers/development/packages/${pkgname}/-/archive/v${_version}/${pkgname}-v${_version}.tar.bz2"
+checksum=0dd84e1aed323cd13b84c24162f24b38ecdf489d09b02a8e66a479d7a1ddf578
+
+dkms_modules="tuxedo-yt6801 ${version}"
+
+do_install() {
+	vmkdir usr/src/${pkgname}-${version}
+	vcopy src/* usr/src/${pkgname}-${version}
+	vcopy debian/tuxedo-yt6801.dkms usr/src/${pkgname}-${version}/dkms.conf
+}


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**


<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)

Built for kernels 6.6 and 6.10, 6.12–6.14; running on 6.14.2 (built with gcc14)
