### PR TITLE
librsvg: update to 2.58.3.

### DIFF
--- a/srcpkgs/librsvg/template
+++ b/srcpkgs/librsvg/template
@@ -1,6 +1,6 @@
 # Template file for 'librsvg'
 pkgname=librsvg
-version=2.58.2
+version=2.58.3
 revision=1
 build_style=gnu-configure
 build_helper="gir rust"
@@ -12,10 +12,10 @@ makedepends="cairo-devel freetype-devel gdk-pixbuf-devel libcroco-devel
 short_desc="SVG library for GNOME"
 maintainer="Érico Nogueira <ericonr@disroot.org>"
 license="LGPL-2.1-or-later"
-homepage="https://wiki.gnome.org/Projects/LibRsvg"
+homepage="https://gitlab.gnome.org/GNOME/librsvg"
 changelog="https://gitlab.gnome.org/GNOME/librsvg/-/raw/librsvg-${version%.*}/NEWS"
 distfiles="${GNOME_SITE}/librsvg/${version%.*}/librsvg-${version}.tar.xz"
-checksum=18e9d70c08cf25f50d610d6d5af571561d67cf4179f962e04266475df6e2e224
+checksum=49f29a0a92f4c2d19a2cb41e96ab2fce7eb5bde41850c8a914fcf655e3110944
 
 # reference files are for specific pango and harfbuzz versions
 # the test suite isn't designed to be run by distros


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture: **x86_64**