### PR TITLE
godot: use mbedtls2 package

### DIFF
--- a/srcpkgs/godot/template
+++ b/srcpkgs/godot/template
@@ -1,7 +1,7 @@
 # Template file for 'godot'
 pkgname=godot
 version=4.3
-revision=4
+revision=5
 archs="x86_64* i686* aarch64* armv7* ppc64*"
 build_style=scons
 make_build_args="platform=linuxbsd target=editor progress=no production=yes
@@ -10,12 +10,12 @@ make_build_args="platform=linuxbsd target=editor progress=no production=yes
  builtin_icu4c=false builtin_libogg=false builtin_libpng=false
  builtin_libtheora=false builtin_libvorbis=false builtin_libwebp=false
  builtin_mbedtls=false builtin_miniupnpc=false builtin_pcre2=false
- builtin_zlib=false builtin_zstd=false"
+ builtin_zlib=false builtin_zstd=false engine_update_check=false"
 hostmakedepends="pkg-config clang"
 makedepends="alsa-lib-devel freetype-devel mesa glu-devel libXcursor-devel
  libXi-devel libXinerama-devel libXrender-devel libXrandr-devel libX11-devel
  libpng-devel libwebp-devel libogg-devel libtheora-devel libvorbis-devel
- libenet-devel zlib-devel mbedtls-devel miniupnpc-devel pcre2-devel
+ libenet-devel zlib-devel mbedtls2-devel miniupnpc-devel pcre2-devel
  pulseaudio-devel graphite-devel harfbuzz-devel libzstd-devel
  speech-dispatcher-devel brotli-devel icu-devel"
 depends="speech-dispatcher"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl
  - i686

1. Fixing `mbedtls` with using `mbedtls2` version instead.
2. Remove update check feature.

This PR fixes: https://github.com/void-linux/void-packages/issues/52164.