### PR TITLE
python3-starlette: update to 0.38.5

### DIFF
--- a/srcpkgs/python3-starlette/template
+++ b/srcpkgs/python3-starlette/template
@@ -1,6 +1,6 @@
 # Template file for 'python3-starlette'
 pkgname=python3-starlette
-version=0.38.2
+version=0.38.5
 revision=1
 build_style=python3-pep517
 hostmakedepends="hatchling"
@@ -10,7 +10,7 @@ maintainer="Emil Miler <em@0x45.cz>"
 license="BSD-3-Clause"
 homepage="https://github.com/encode/starlette"
 distfiles="${PYPI_SITE}/s/starlette/starlette-${version}.tar.gz"
-checksum=c7c0441065252160993a1a37cf2a73bb64d271b17303e0b0c1eb7191cfb12d75
+checksum=04a92830a9b6eb1442c766199d62260c3d4dc9c4f9188360626b1e0273cb7077
 # Many modules needed for testing are not available
 make_check=no
 


### PR DESCRIPTION
- I tested the changes in this PR: **NO**
- I built this PR locally for my native architecture, (x86_64-glibc)