### PR TITLE
kodi: cleanup template, fix cross

### DIFF
--- a/srcpkgs/kodi/patches/cross-udfread.patch
+++ b/srcpkgs/kodi/patches/cross-udfread.patch
@@ -1,0 +1,31 @@
+--- a/cmake/modules/FindUdfread.cmake	2024-09-10 23:21:34.944300987 +0200
++++ -	2024-09-10 23:24:16.204142312 +0200
+@@ -43,12 +43,22 @@
+ 
+       set(UDFREAD_VERSION ${${MODULE}_VER})
+       set(BUILD_NAME udfread_build)
+-
+-      set(CONFIGURE_COMMAND autoreconf -vif &&
+-                            ./configure
+-                            --enable-static
+-                            --disable-shared
+-                            --prefix=${DEPENDS_PATH})
++      if(CMAKE_CROSSCOMPILING)
++        set(CONFIGURE_COMMAND autoreconf -vif &&
++                              ./configure
++                              --enable-static
++                              --disable-shared
++                              --prefix=${DEPENDS_PATH}
++                              --host=${XBPS_TRIPLET}
++                              --build=${XBPS_CROSS_TRIPLET}
++                              --target=${XBPS_CROSS_TRIPLET})
++      else()
++        set(CONFIGURE_COMMAND autoreconf -vif &&
++                              ./configure
++                              --enable-static
++                              --disable-shared
++                              --prefix=${DEPENDS_PATH})
++      endif()
+       set(BUILD_IN_SOURCE 1)
+ 
+       BUILD_DEP_TARGET()

--- a/srcpkgs/kodi/template
+++ b/srcpkgs/kodi/template
@@ -120,7 +120,7 @@ pre_configure() {
 			--prefix=/usr --with-toolchain=/usr --host=${XBPS_TRIPLET} \
 			--build=${XBPS_TRIPLET} --target=${XBPS_TRIPLET} --with-rendersystem=gl
 		cd ../..
-		for i in JsonSchemaBuilder TexturePacker; do
+		for i in JsonSchemaBuilder; do
 			msg_normal "Building native tool $i"
 			cd tools/depends/native/$i/src
 			./autogen.sh
@@ -133,22 +133,8 @@ pre_configure() {
 			cp -r tools/depends/native/$i/src/$i tools/$i
 			make -C tools/depends/native/$i distclean
 		done
-		configure_args+="
-		 -DWITH_JSONSCHEMABUILDER:PATH=$wrksrc/tools/JsonSchemaBuilder
-		 -DWITH_TEXTUREPACKER:PATH=$wrksrc/tools/TexturePacker"
-		# host = what we are on
-		# build = what tool to build with
-		# target = what this should run on and what repo it's in (same as build for cross)
-		configure_args=${configure_args/--host=${XBPS_CROSS_TRIPLET}/--host${XBPS_TRIPLET}}"
-		configure_args=${configure_args/--build=${XBPS_TRIPLET}/--build${XBPS_CROSS_TRIPLET}}"
-		configure_args+="--target=${XBPS_CROSS_TRIPLET}"
-	fi
-}
-
-post_configure() {
-	if [ "$CROSS_BUILD" ]; then
-		vsed -e "s|^  COMMAND.*udfread.*\./configure|& --host=${XBPS_TRIPLET} --build=${XBPS_CROSS_TRIPLET} --target=${XBPS_CROSS_TRIPLET}|" \
-		-i build/build.ninja
+		configure_args+=" -DWITH_JSONSCHEMABUILDER:PATH=$wrksrc/tools/JsonSchemaBuilder"
+		configure_args+=" -DXBPS_TRIPLET=${XBPS_TRIPLET} -DXBPS_CROSS_TRIPLET=${XBPS_CROSS_TRIPLET}"
 	fi
 }
 


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

Having TexturePacker once ought to be enough, we already depend on a host kodi and set `-DWITH_TEXTUREPACKER=<path>` for it.

The `--host`/`--build` configure_args had missing quotation marks, which resulted in having nonsense at the end. Removed them.

Replaced the `post_configure` `vsed` with a patch to the `FindUdfread.cmake`

#### Testing the changes
- I tested the changes in this PR: **YES**|**briefly**|**NO**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - armv7l-musl (cross)

