### PR TITLE
yazi: update to 0.3.3, fix missing ya binary

### DIFF
--- a/srcpkgs/yazi/template
+++ b/srcpkgs/yazi/template
@@ -1,9 +1,8 @@
 # Template file for 'yazi'
 pkgname=yazi
-version=0.3.2
+version=0.3.3
 revision=1
 build_style=cargo
-make_install_args="--path yazi-fm"
 hostmakedepends="pkg-config"
 makedepends="oniguruma-devel lua54-devel"
 depends="nerd-fonts-symbols-ttf"
@@ -13,13 +12,15 @@ license="MIT"
 homepage="https://yazi-rs.github.io"
 changelog="https://github.com/sxyazi/yazi/releases"
 distfiles="https://github.com/sxyazi/yazi/archive/refs/tags/v${version}.tar.gz"
-checksum=6aec4ed553670a47b3e5b34c161bb4356b1ebfac084b7354cd26052a81f971a4
+checksum=fe2a458808334fe20eff1ab0145c78d684d8736c9715e4c51bce54038607dc4e
 
 export VERGEN_GIT_SHA="${version}_${revision}"
 # enable the generation of shell auto completions
 export YAZI_GEN_COMPLETIONS=true
 
-post_install() {
+do_install() {
+	vbin target/${RUST_TARGET}/release/yazi
+	vbin target/${RUST_TARGET}/release/ya
 	vcompletion yazi-boot/completions/yazi.bash bash
 	vcompletion yazi-boot/completions/yazi.fish fish
 	vcompletion yazi-boot/completions/_yazi zsh


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc

closes https://github.com/void-linux/void-packages/issues/52176
closes https://github.com/void-linux/void-packages/pull/52116