### PR TITLE
qemu-user: Make qemu-user-* binaries static

### DIFF
--- a/srcpkgs/qemu-user/template
+++ b/srcpkgs/qemu-user/template
@@ -2,10 +2,10 @@
 # This package should be updated together with qemu
 pkgname=qemu-user
 version=9.1.0
-revision=1
+revision=2
 build_style=meta
 configure_args="--prefix=/usr --sysconfdir=/etc --libexecdir=/usr/libexec
- --enable-linux-user --disable-system
+ --enable-linux-user --disable-system --static
  -Dkvm=disabled -Dpng=disabled -Dvirtfs=disabled -Dfdt=disabled -Dseccomp=disabled
  -Dtools=disabled"
 hostmakedepends="meson flex glib-devel pkg-config perl"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

It seems that https://github.com/void-linux/void-packages/issues/51804 breaks [void-mklive](https://github.com/void-linux/void-mklive).  With this change I was able to run `mkrootfs.sh aarch64` without errors.  With the current `qemu-user-static` package it complained about missing files when reconfiguring `base-files`.  Apparently the `--static` parameter wasn't included in the new `qemu-user` package.  There may be other flags that need to be updated too.

Error:
```
base-files: configuring ...
ERROR: base-files: [configure] INSTALL script failed to execute the post ACTION: No such file or directory
Failed to reconfigure `base-files': No such file or directory
chroot: failed to run command ‘sh’: No such file or directory
chroot: failed to run command ‘sh’: No such file or directory
Setting the default root password ('voidlinux')
chroot: failed to run command ‘sh’: No such file or directory
chroot: failed to run command ‘sh’: No such file or directory
FATAL: Could not set default credentials
```

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
