### PR TITLE
ghdl: don't remove src/ directory when installing

### DIFF
--- a/srcpkgs/ghdl/template
+++ b/srcpkgs/ghdl/template
@@ -7,7 +7,7 @@
 pkgname=ghdl
 reverts="20181129_1"
 version=4.1.0
-revision=1
+revision=2
 build_style=configure
 configure_args="--prefix=/usr --srcdir=.. --disable-werror"
 makedepends="zlib-devel"
@@ -73,11 +73,9 @@ do_install() {
 	# install whatever backends we have
 	if [ "$build_option_mcode" ]; then
 		make -C build_mcode DESTDIR=${DESTDIR} install
-		rm -rf ${DESTDIR}/usr/lib/ghdl/src
 	fi
 	if [ "$build_option_llvm" ]; then
 		make -C build_llvm DESTDIR=${DESTDIR} install
-		rm -rf ${DESTDIR}/usr/lib/ghdl/src
 	fi
 	# manpage is not installed by default
 	vman doc/ghdl.1


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (`x86_64-glibc`)

So, I think the last proper update for GHDL outside of it needing to compile for llvm>12 was #45643, and I'm not quite sure if they even tested this situation then, but the current template removes the `/usr/lib/ghdl/src` directory for seemingly no reason.

This means that any designs that use the standard ieee packages just... don't work, since all the definitions for those are in said `src/` directory:

```
$ ghdl -m -Wno-hide --workdir=. adder_8b_tb
adder_8b_tb.vhd:8:10:error: cannot load package "std_logic_1164"
use ieee.std_logic_1164.all;
```

Not removing this directory doesn't appear to affect anything--tested with both the llvm backend and the mcode backend, even installing both at once--and fixes all the issues with the ieee packages.