### PR TITLE
New package: python3-pdm-2.18.2 and dependencies

### DIFF
--- a/srcpkgs/python3-dep-logic/template
+++ b/srcpkgs/python3-dep-logic/template
@@ -1,0 +1,16 @@
+# Template file for 'python3-dep-logic'
+
+pkgname=python3-dep-logic
+version=0.4.6
+revision=1
+build_style=python3-pep517
+hostmakedepends="python3 python3-build python3-packaging python3-pdm-backend"
+short_desc="Python dependency specifications supporting logical operations"
+maintainer="Komeil Parseh <ahmdparsh129@gmail.com>"
+license="Apache-2.0"
+homepage="https://github.com/pdm-project/dep-logic"
+distfiles="https://github.com/pdm-project/dep-logic/archive/refs/tags/${version}.tar.gz"
+checksum="d61805145b7dcdccc9bc325eac21791459d30907f3e0288be4f720c5a67bba7f"
+
+# Specify fallback version to avoid SCM detection issues
+export PDM_BUILD_SCM_VERSION="${version}"

--- a/srcpkgs/python3-findpython/template
+++ b/srcpkgs/python3-findpython/template
@@ -1,0 +1,20 @@
+# Template file for 'python3-findpython'
+pkgname=python3-findpython
+version=0.6.1
+revision=1
+build_style=python3-pep517
+hostmakedepends="python3 python3-build python3-packaging python3-pdm-backend"
+short_desc="A utility to find python versions on your system"
+maintainer="Komeil Parseh <ahmdparsh129@gmail.com>"
+license="MIT"
+homepage="https://github.com/frostming/findpython"
+changelog="https://raw.githubusercontent.com/pdm-project/pdm/main/CHANGELOG.md"
+distfiles="https://github.com/frostming/findpython/archive/refs/tags/${version}.tar.gz"
+checksum="4a2e7a6ee983423315b334b88071130caa417a249d43784878c93f877e3882ad"
+
+# Specify fallback version to avoid SCM detection issues
+export PDM_BUILD_SCM_VERSION="${version}"
+
+post_install() {
+	vlicense LICENSE
+}

--- a/srcpkgs/python3-pbs-installer/template
+++ b/srcpkgs/python3-pbs-installer/template
@@ -1,0 +1,21 @@
+# Template file for 'python3-pbs-installer'
+pkgname=python3-pbs-installer
+version=2024.09.09
+revision=1
+build_style=python3-pep517
+hostmakedepends="python3 python3-build python3-packaging python3-pdm-backend"
+depends="python3-httpx python3-zstandard"
+short_desc="pbs-installer"
+maintainer="Komeil Parseh <ahmdparsh129@gmail.com>"
+license="MIT"
+homepage="https://github.com/frostming/pbs-installer"
+changelog="https://raw.githubusercontent.com/pdm-project/pdm/main/CHANGELOG.md"
+distfiles="https://github.com/frostming/pbs-installer/archive/refs/tags/${version}.tar.gz"
+checksum="50b8f89fe88d23c3141ff7c6d185ddd4246aa3b80cf75c94621f2529adf65a32"
+
+# Specify fallback version to avoid SCM detection issues
+export PDM_BUILD_SCM_VERSION="${version}"
+
+post_install() {
+	vlicense LICENSE
+}

--- a/srcpkgs/python3-pdm-build-locked/template
+++ b/srcpkgs/python3-pdm-build-locked/template
@@ -1,0 +1,16 @@
+# Template file for 'python3-pdm-build-locked'
+pkgname=python3-pdm-build-locked
+version=0.3.3
+revision=1
+build_style=python3-pep517
+hostmakedepends="python3 python3-build python3-packaging python3-pdm-backend"
+short_desc="pdm-build-locked is a pdm plugin to publish locked dependencies as optional-dependencies"
+maintainer="Komeil Parseh <ahmdparsh129@gmail.com>"
+license="MIT"
+homepage="https://pdm-build-locked.readthedocs.io/"
+distfiles="${PYPI_SITE}/p/pdm_build_locked/pdm_build_locked-${version}.tar.gz"
+checksum="b784135abf62b93ce0a11332ee24723a2699b7f266fddb7950a5b70c93df6214"
+
+post_install() {
+	vlicense LICENSE
+}

--- a/srcpkgs/python3-pdm/template
+++ b/srcpkgs/python3-pdm/template
@@ -1,0 +1,21 @@
+# Template file for 'python3-pdm'
+pkgname=python3-pdm
+version=2.18.2
+revision=1
+build_style=python3-pep517
+hostmakedepends="python3 python3-build python3-packaging python3-pdm-backend python3-pdm-build-locked"
+depends="python3-blinker python3-dep-logic python3-dotenv python3-filelock python3-findpython python3-httpx python3-installer python3-msgpack python3-pbs-installer python3-pyproject-hooks python3-resolvelib python3-rich python3-shellingham python3-tomli python3-tomlkit python3-virtualenv"
+short_desc="A modern Python package and dependency manager supporting the latest PEP standards"
+maintainer="Komeil Parseh <ahmdparsh129@gmail.com>"
+license="MIT"
+homepage="https://pdm-project.org/"
+changelog="https://raw.githubusercontent.com/pdm-project/pdm/main/CHANGELOG.md"
+distfiles="${PYPI_SITE}/p/pdm/pdm-${version}.tar.gz"
+checksum="6d93a18d52edca056fafed7b262fe48ddc61984dabf73eb9365ad61a90caebb6"
+
+# Specify fallback version to avoid SCM detection issues
+export PDM_BUILD_SCM_VERSION="${version}"
+
+post_install() {
+	vlicense LICENSE
+}

--- a/srcpkgs/python3-unearth/template
+++ b/srcpkgs/python3-unearth/template
@@ -1,0 +1,20 @@
+# Template file for 'python3-unearth'
+pkgname=python3-unearth
+version=0.17.2
+revision=1
+build_style=python3-pep517
+hostmakedepends="python3 python3-build python3-packaging python3-pdm-backend"
+depends="python3-httpx"
+short_desc="A utility to fetch and download python packages"
+maintainer="Komeil Parseh <ahmdparsh129@gmail.com>"
+license="MIT"
+homepage="https://github.com/frostming/unearth"
+distfiles="https://github.com/frostming/unearth/archive/refs/tags/${version}.tar.gz"
+checksum="1144b78ad1e33b659cee68b74fb0de4ae0be71e27f1afd0fdaaf60d974d60bcd"
+
+# Specify fallback version to avoid SCM detection issues
+export PDM_BUILD_SCM_VERSION="${version}"
+
+post_install() {
+	vlicense LICENSE
+}


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->
### python3-pdm

This PR introduces the [`pdm`](https://github.com/pdm-project/pdm) Python package manager and its necessary dependencies to the Void Linux package repository. Pdm provides a flexible and efficient way to manage Python projects.

**Included packages:**

* [**python3-pdm-2.18.2:**](https://github.com/pdm-project/pdm) The core pdm package
* [**python3-pdm-build-locked-0.3.3:**](https://github.com/pdm-project/pdm-build-locked) is a pdm plugin to publish locked dependencies as optional-dependencies
* [**python3-pbs-installer-2024.09.09:**](https://github.com/frostming/pbs-installer) A utility for installing packages
* [**python3-findpython-0.6.1:**](https://github.com/frostming/findpython) A utility to find python versions on your system.
* [**python3-dep-logic-0.4.6:**](https://github.com/pdm-project/dep-logic) Python dependency specifications supporting logical operations 
* [**python3-unearth-0.17.2:**](https://github.com/frostming/unearth)  A utility to fetch and download python packages 

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [pac<!-- Uncomment relevant sections and delete options which are not applicable -->

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, aarch64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl


#### This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->

