### PR TITLE
godot: enable wayland support

### DIFF
--- a/srcpkgs/godot/template
+++ b/srcpkgs/godot/template
@@ -1,7 +1,7 @@
 # Template file for 'godot'
 pkgname=godot
 version=4.3
-revision=5
+revision=6
 archs="x86_64* i686* aarch64* armv7* ppc64*"
 build_style=scons
 make_build_args="platform=linuxbsd target=editor progress=no production=yes
@@ -10,14 +10,15 @@ make_build_args="platform=linuxbsd target=editor progress=no production=yes
  builtin_icu4c=false builtin_libogg=false builtin_libpng=false
  builtin_libtheora=false builtin_libvorbis=false builtin_libwebp=false
  builtin_mbedtls=false builtin_miniupnpc=false builtin_pcre2=false
- builtin_zlib=false builtin_zstd=false engine_update_check=false"
-hostmakedepends="pkg-config clang"
+ builtin_zlib=false builtin_zstd=false engine_update_check=false
+ x11=yes wayland=yes"
+hostmakedepends="pkg-config clang wayland-devel"
 makedepends="alsa-lib-devel freetype-devel mesa glu-devel libXcursor-devel
  libXi-devel libXinerama-devel libXrender-devel libXrandr-devel libX11-devel
  libpng-devel libwebp-devel libogg-devel libtheora-devel libvorbis-devel
  libenet-devel zlib-devel mbedtls2-devel miniupnpc-devel pcre2-devel
  pulseaudio-devel graphite-devel harfbuzz-devel libzstd-devel
- speech-dispatcher-devel brotli-devel icu-devel"
+ speech-dispatcher-devel brotli-devel icu-devel wayland-devel"
 depends="speech-dispatcher"
 short_desc="Multiplatform 2D and 3D engine"
 maintainer="dataCobra <datacobra@thinkbot.de>"


### PR DESCRIPTION
Godot 4.3 has added native support to wayland on its 4.3 release. This PR adds it on build time (the user still needs to enable it using [command line or on the Settings screen](https://godotengine.org/article/dev-snapshot-godot-4-3-dev-3/#wayland-support-for-linux)). 

This PR fixes #52200.

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture: x86_64-libc