### PR TITLE
libarchive: update to 3.7.5

### DIFF
--- a/srcpkgs/libarchive/template
+++ b/srcpkgs/libarchive/template
@@ -1,6 +1,6 @@
 # Template file for 'libarchive'
 pkgname=libarchive
-version=3.7.4
+version=3.7.5
 revision=1
 bootstrap=yes
 build_style=gnu-configure
@@ -18,7 +18,7 @@ license="BSD-2-Clause"
 homepage="https://www.libarchive.org/"
 changelog="https://github.com/libarchive/libarchive/releases"
 distfiles="https://github.com/libarchive/libarchive/releases/download/v${version}/libarchive-${version}.tar.xz"
-checksum=f887755c434a736a609cbd28d87ddbfbe9d6a3bb5b703c22c02f6af80a802735
+checksum=ca74ff8f99dd40ab8a8274424d10a12a7ec3f4428dd35aee9fdda8bdb861b570
 
 build_options="acl expat lzo lz4 ssl zstd"
 build_options_default="acl ssl lz4 zstd"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**
- **NOTE**: Currently investigating the test failure on i686-glibc.
  - Currently awaiting upstream on verifying https://github.com/libarchive/libarchive/issues/2329, once a patch is available I'll add it to this PR

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc