### PR TITLE
common/build-style/cargo.sh: add make_build_args to build

### DIFF
--- a/common/build-style/cargo.sh
+++ b/common/build-style/cargo.sh
@@ -5,7 +5,8 @@
 do_build() {
 	: ${make_cmd:=cargo auditable}
 
-	${make_cmd} build --release --locked --target ${RUST_TARGET} ${configure_args}
+	${make_cmd} build --release --locked --target ${RUST_TARGET} \
+ 		${configure_args} ${make_build_args}
 }
 
 do_check() {


### PR DESCRIPTION
### Summary

I'm working on a template for a package that is not yet in the repository and I noticed that the `do_build` function from the `cargo` build-style is missing the `make_build_args` variable. I don't know whether this omission is intentional or not but seeing that both `do_check` and `do_install` have `make_check_args` and `make_install_args` respectively makes me think that it isn't intentional, let me know otherwise.

My use case for this is I need to add the `--package <spec>` option to the `cargo auditable build` action and I can't do that without manually rewriting the `do_build` function.

#### Testing the changes
- I tested the changes in this PR: **YES**

