### PR TITLE
python3-passlib: fix pycompile warnings

### DIFF
--- a/srcpkgs/python3-passlib/patches/fix-invalid-escape-sequence.patch
+++ b/srcpkgs/python3-passlib/patches/fix-invalid-escape-sequence.patch
@@ -1,0 +1,139 @@
+Source: https://foss.heptapod.net/python-libs/passlib/-/issues/191
+--- a/passlib/_setup/stamp.py
++++ b/passlib/_setup/stamp.py
+@@ -55,7 +55,7 @@
+     #
+     path = os.path.join(base_dir, "passlib", "__init__.py")
+     content = _get_file(path)
+-    content, count = re.subn('(?m)^__version__\s*=.*$',
++    content, count = re.subn(r'(?m)^__version__\s*=.*$',
+                     '__version__ = ' + repr(version),
+                     content)
+     assert count == 1, "failed to replace version string"
+@@ -68,7 +68,7 @@
+     path = os.path.join(base_dir, "setup.py")
+     if os.path.exists(path):
+         content = _get_file(path)
+-        content, count = re.subn('(?m)^stamp_build\s*=.*$',
++        content, count = re.subn(r'(?m)^stamp_build\s*=.*$',
+                         'stamp_build = False', content)
+         assert count == 1, "failed to update 'stamp_build' flag"
+         _replace_file(path, content, dry_run=dry_run)
+--- a/passlib/tests/test_apache.py
++++ b/passlib/tests/test_apache.py
+@@ -207,7 +207,7 @@
+         self.assertRaises(ValueError, ht.set_password, "user:", "pass")
+ 
+         # test that legacy update() still works
+-        with self.assertWarningList("update\(\) is deprecated"):
++        with self.assertWarningList(r"update\(\) is deprecated"):
+             ht.update("user2", "test")
+         self.assertTrue(ht.check_password("user2", "test"))
+ 
+@@ -277,7 +277,7 @@
+         self.assertRaises(ValueError, ht.check_password, "user:", "pass")
+ 
+         # test that legacy verify() still works
+-        with self.assertWarningList(["verify\(\) is deprecated"]*2):
++        with self.assertWarningList([r"verify\(\) is deprecated"]*2):
+             self.assertTrue(ht.verify("user1", "pass1"))
+             self.assertFalse(ht.verify("user1", "pass2"))
+ 
+@@ -367,7 +367,7 @@
+         self.assertEqual(ht.get_hash("user4"), b"pass4")
+         self.assertEqual(ht.get_hash("user5"), None)
+ 
+-        with self.assertWarningList("find\(\) is deprecated"):
++        with self.assertWarningList(r"find\(\) is deprecated"):
+             self.assertEqual(ht.find("user4"), b"pass4")
+ 
+     def test_09_to_string(self):
+@@ -603,7 +603,7 @@
+         self.assertRaises(ValueError, ht.set_password, "user", "r"*256, "pass")
+ 
+         # test that legacy update() still works
+-        with self.assertWarningList("update\(\) is deprecated"):
++        with self.assertWarningList(r"update\(\) is deprecated"):
+             ht.update("user2", "realm2", "test")
+         self.assertTrue(ht.check_password("user2", "test"))
+ 
+@@ -637,7 +637,7 @@
+         self.assertIs(ht.check_password("user5", "pass5"), None)
+ 
+         # test that legacy verify() still works
+-        with self.assertWarningList(["verify\(\) is deprecated"]*2):
++        with self.assertWarningList([r"verify\(\) is deprecated"]*2):
+             self.assertTrue(ht.verify("user1", "realm", "pass1"))
+             self.assertFalse(ht.verify("user1", "realm", "pass2"))
+ 
+@@ -725,7 +725,7 @@
+         self.assertEqual(ht.get_hash("user4", "realm"), "ab7b5d5f28ccc7666315f508c7358519")
+         self.assertEqual(ht.get_hash("user5", "realm"), None)
+ 
+-        with self.assertWarningList("find\(\) is deprecated"):
++        with self.assertWarningList(r"find\(\) is deprecated"):
+             self.assertEqual(ht.find("user4", "realm"), "ab7b5d5f28ccc7666315f508c7358519")
+ 
+     def test_09_encodings(self):
+--- a/passlib/tests/test_context_deprecated.py
++++ b/passlib/tests/test_context_deprecated.py
+@@ -551,7 +551,7 @@
+                                 r"CryptContext\(\)\.replace\(\) has been deprecated.*")
+         warnings.filterwarnings("ignore",
+                                 r"The CryptContext ``policy`` keyword has been deprecated.*")
+-        warnings.filterwarnings("ignore", ".*(CryptPolicy|context\.policy).*(has|have) been deprecated.*")
++        warnings.filterwarnings("ignore", r".*(CryptPolicy|context\.policy).*(has|have) been deprecated.*")
+         warnings.filterwarnings("ignore",
+                                 r"the method.*hash_needs_update.*is deprecated")
+ 
+@@ -704,7 +704,7 @@
+         # silence some warnings
+         warnings.filterwarnings("ignore",
+                                 r"CryptContext\(\)\.replace\(\) has been deprecated")
+-        warnings.filterwarnings("ignore", ".*(CryptPolicy|context\.policy).*(has|have) been deprecated.*")
++        warnings.filterwarnings("ignore", r".*(CryptPolicy|context\.policy).*(has|have) been deprecated.*")
+ 
+     def test_kwd_constructor(self):
+         """test plain kwds"""
+--- a/passlib/tests/test_ext_django.py
++++ b/passlib/tests/test_ext_django.py
+@@ -913,7 +913,7 @@
+         # mess with User.set_password, make sure it's detected
+         orig = models.User.set_password
+         models.User.set_password = dummy
+-        with self.assertWarningList("another library has patched.*User\.set_password"):
++        with self.assertWarningList(r"another library has patched.*User\.set_password"):
+             adapter._manager.check_all()
+         models.User.set_password = orig
+ 
+--- a/passlib/tests/test_handlers.py
++++ b/passlib/tests/test_handlers.py
+@@ -1520,7 +1520,7 @@
+     filter_config_warnings = True # rounds too low, salt too small
+ 
+     platform_crypt_support = [
+-        ("freebsd(9|1\d)|linux", True),
++        (r"freebsd(9|1\d)|linux", True),
+         ("freebsd8", None),  # added in freebsd 8.3
+         ("freebsd|openbsd|netbsd|darwin", False),
+         ("solaris", None),  # depends on policy
+@@ -1758,7 +1758,7 @@
+ 
+     def test_90_special(self):
+         """test marker option & special behavior"""
+-        warnings.filterwarnings("ignore", "passing settings to .*.hash\(\) is deprecated")
++        warnings.filterwarnings("ignore", r"passing settings to .*.hash\(\) is deprecated")
+         handler = self.handler
+ 
+         # preserve hash if provided
+--- a/passlib/tests/test_utils.py
++++ b/passlib/tests/test_utils.py
+@@ -141,7 +141,7 @@
+     def test_generate_password(self):
+         """generate_password()"""
+         from passlib.utils import generate_password
+-        warnings.filterwarnings("ignore", "The function.*generate_password\(\) is deprecated")
++        warnings.filterwarnings("ignore", r"The function.*generate_password\(\) is deprecated")
+         self.assertEqual(len(generate_password(15)), 15)
+ 
+     def test_is_crypt_context(self):

--- a/srcpkgs/python3-passlib/template
+++ b/srcpkgs/python3-passlib/template
@@ -1,7 +1,7 @@
 # Template file for 'python3-passlib'
 pkgname=python3-passlib
 version=1.7.4
-revision=3
+revision=4
 build_style=python3-module
 hostmakedepends="python3-setuptools"
 depends="python3"


### PR DESCRIPTION
`python3-pycompile` produces a lot of `SyntaxWarning: invalid escape sequence`s. I personally find these really annoying, so I've been on a quest to fix all invalid escape sequences I could find and send the fixes upstream. I've been successful so far, although many of my fixes haven't been included in releases yet. But `python-libs/passlib` doesn't look like it will be fixing this anytime soon (see https://foss.heptapod.net/python-libs/passlib/-/issues/191) and the passlib warnings are by far the worst ones.

When installing the `python3-passlib` package, you'll be greeted by this:

```
...
Byte-compiling python3.12 code for module passlib...
usr/lib/python3.12/site-packages/passlib/_setup/stamp.py:58: SyntaxWarning: invalid escape sequence '\s'
  content, count = re.subn('(?m)^__version__\s*=.*$',
usr/lib/python3.12/site-packages/passlib/_setup/stamp.py:71: SyntaxWarning: invalid escape sequence '\s'
  content, count = re.subn('(?m)^stamp_build\s*=.*$',
usr/lib/python3.12/site-packages/passlib/tests/test_apache.py:210: SyntaxWarning: invalid escape sequence '\('
  with self.assertWarningList("update\(\) is deprecated"):
usr/lib/python3.12/site-packages/passlib/tests/test_apache.py:280: SyntaxWarning: invalid escape sequence '\('
  with self.assertWarningList(["verify\(\) is deprecated"]*2):
usr/lib/python3.12/site-packages/passlib/tests/test_apache.py:370: SyntaxWarning: invalid escape sequence '\('
  with self.assertWarningList("find\(\) is deprecated"):
usr/lib/python3.12/site-packages/passlib/tests/test_apache.py:606: SyntaxWarning: invalid escape sequence '\('
  with self.assertWarningList("update\(\) is deprecated"):
usr/lib/python3.12/site-packages/passlib/tests/test_apache.py:640: SyntaxWarning: invalid escape sequence '\('
  with self.assertWarningList(["verify\(\) is deprecated"]*2):
usr/lib/python3.12/site-packages/passlib/tests/test_apache.py:728: SyntaxWarning: invalid escape sequence '\('
  with self.assertWarningList("find\(\) is deprecated"):
usr/lib/python3.12/site-packages/passlib/tests/test_context_deprecated.py:554: SyntaxWarning: invalid escape sequence '\.'
  warnings.filterwarnings("ignore", ".*(CryptPolicy|context\.policy).*(has|have) been deprecated.*")
usr/lib/python3.12/site-packages/passlib/tests/test_context_deprecated.py:707: SyntaxWarning: invalid escape sequence '\.'
  warnings.filterwarnings("ignore", ".*(CryptPolicy|context\.policy).*(has|have) been deprecated.*")
usr/lib/python3.12/site-packages/passlib/tests/test_ext_django.py:916: SyntaxWarning: invalid escape sequence '\.'
  with self.assertWarningList("another library has patched.*User\.set_password"):
usr/lib/python3.12/site-packages/passlib/tests/test_handlers.py:1523: SyntaxWarning: invalid escape sequence '\d'
  ("freebsd(9|1\d)|linux", True),
usr/lib/python3.12/site-packages/passlib/tests/test_handlers.py:1761: SyntaxWarning: invalid escape sequence '\('
  warnings.filterwarnings("ignore", "passing settings to .*.hash\(\) is deprecated")
usr/lib/python3.12/site-packages/passlib/tests/test_utils.py:144: SyntaxWarning: invalid escape sequence '\('
  warnings.filterwarnings("ignore", "The function.*generate_password\(\) is deprecated")
usr/lib/python3.12/site-packages/passlib/_setup/stamp.py:58: SyntaxWarning: invalid escape sequence '\s'
  content, count = re.subn('(?m)^__version__\s*=.*$',
usr/lib/python3.12/site-packages/passlib/_setup/stamp.py:71: SyntaxWarning: invalid escape sequence '\s'
  content, count = re.subn('(?m)^stamp_build\s*=.*$',
usr/lib/python3.12/site-packages/passlib/tests/test_apache.py:210: SyntaxWarning: invalid escape sequence '\('
  with self.assertWarningList("update\(\) is deprecated"):
usr/lib/python3.12/site-packages/passlib/tests/test_apache.py:280: SyntaxWarning: invalid escape sequence '\('
  with self.assertWarningList(["verify\(\) is deprecated"]*2):
usr/lib/python3.12/site-packages/passlib/tests/test_apache.py:370: SyntaxWarning: invalid escape sequence '\('
  with self.assertWarningList("find\(\) is deprecated"):
usr/lib/python3.12/site-packages/passlib/tests/test_apache.py:606: SyntaxWarning: invalid escape sequence '\('
  with self.assertWarningList("update\(\) is deprecated"):
usr/lib/python3.12/site-packages/passlib/tests/test_apache.py:640: SyntaxWarning: invalid escape sequence '\('
  with self.assertWarningList(["verify\(\) is deprecated"]*2):
usr/lib/python3.12/site-packages/passlib/tests/test_apache.py:728: SyntaxWarning: invalid escape sequence '\('
  with self.assertWarningList("find\(\) is deprecated"):
usr/lib/python3.12/site-packages/passlib/tests/test_context_deprecated.py:554: SyntaxWarning: invalid escape sequence '\.'
  warnings.filterwarnings("ignore", ".*(CryptPolicy|context\.policy).*(has|have) been deprecated.*")
usr/lib/python3.12/site-packages/passlib/tests/test_context_deprecated.py:707: SyntaxWarning: invalid escape sequence '\.'
  warnings.filterwarnings("ignore", ".*(CryptPolicy|context\.policy).*(has|have) been deprecated.*")
usr/lib/python3.12/site-packages/passlib/tests/test_ext_django.py:916: SyntaxWarning: invalid escape sequence '\.'
  with self.assertWarningList("another library has patched.*User\.set_password"):
usr/lib/python3.12/site-packages/passlib/tests/test_handlers.py:1523: SyntaxWarning: invalid escape sequence '\d'
  ("freebsd(9|1\d)|linux", True),
usr/lib/python3.12/site-packages/passlib/tests/test_handlers.py:1761: SyntaxWarning: invalid escape sequence '\('
  warnings.filterwarnings("ignore", "passing settings to .*.hash\(\) is deprecated")
usr/lib/python3.12/site-packages/passlib/tests/test_utils.py:144: SyntaxWarning: invalid escape sequence '\('
  warnings.filterwarnings("ignore", "The function.*generate_password\(\) is deprecated")
...
```

The `pycompile` XBPS trigger calls `compileall` twice, which makes this twice as long.

This gets outputted every time `python3` gets updated.

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
