### PR TITLE
New package: oils-for-unix-0.28.0

### DIFF
--- a/srcpkgs/oils-for-unix/template
+++ b/srcpkgs/oils-for-unix/template
@@ -1,0 +1,34 @@
+# Template file for 'oils-for-unix'
+pkgname=oils-for-unix
+version=0.28.0
+revision=1
+build_style=gnu-configure
+configure_args="$(vopt_with readline) --readline=$XBPS_CROSS_BASE"
+makedepends="$(vopt_if readline readline-devel)"
+short_desc="New unix shell with JSON-compatible structured data"
+maintainer="meator <meator.dev@gmail.com>"
+license="Apache-2.0"
+homepage="https://oils.pub/"
+distfiles="https://oils.pub/download/oils-for-unix-${version}.tar.gz"
+checksum=266d14b16d90d4a07fe774881eafa0ecdbbc8411cf1c75f8b6e256370b668e35
+register_shell="/usr/bin/osh /usr/bin/ysh"
+conflicts="oil"
+
+build_options="readline"
+build_options_default="readline"
+
+do_build() {
+	# OILS_PARALLEL_BUILD affects only the first (largest) TU,
+	# everything else is build sequentially.
+	if [ "$XBPS_MAKEJOBS" -eq 1 ]; then
+		export OILS_PARALLEL_BUILD=0
+	else
+		export OILS_PARALLEL_BUILD=1
+	fi
+	_build/oils.sh --cxx "$CXX"
+}
+
+do_install() {
+	# Build dir embeds the compiler name in it.
+	DESTDIR="$DESTDIR" ./install _bin/$CXX-opt-sh/oils-for-unix
+}


### PR DESCRIPTION
closes #51951

#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
