### PR TITLE
bluez: update to 5.78.

### DIFF
--- a/srcpkgs/bluez/patches/disable-test-vcp.patch
+++ b/srcpkgs/bluez/patches/disable-test-vcp.patch
@@ -1,0 +1,24 @@
+From 1d5a2ec8eb96e9186aeb2826927057ddc7a9d0a6 Mon Sep 17 00:00:00 2001
+From: macmpi <16296055+macmpi@users.noreply.github.com>
+Date: Wed, 17 Jan 2024 09:34:28 +0100
+Subject: [PATCH] disable test_aics_unit_testcases
+
+fails on x86-64
+https://github.com/bluez/bluez/issues/726
+---
+ unit/test-vcp.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/unit/test-vcp.c b/unit/test-vcp.c
+index 6a61ea2c44..3886177758 100644
+--- a/unit/test-vcp.c
++++ b/unit/test-vcp.c
+@@ -2754,7 +2754,7 @@ int main(int argc, char *argv[])
+ 	tester_init(&argc, &argv);
+ 
+ 	test_vocs_unit_testcases();
+-	test_aics_unit_testcases();
++//	test_aics_unit_testcases(); test fails on x86-64
+ 
+ 	return tester_run();
+ }

--- a/srcpkgs/bluez/template
+++ b/srcpkgs/bluez/template
@@ -1,6 +1,6 @@
 # Template file for 'bluez'
 pkgname=bluez
-version=5.76
+version=5.78
 revision=1
 build_style=gnu-configure
 configure_args="--with-udevdir=/usr/lib/udev --disable-systemd
@@ -16,7 +16,7 @@ license="GPL-2.0-or-later, LGPL-2.1-or-later"
 homepage="http://www.bluez.org/"
 changelog="https://git.kernel.org/pub/scm/bluetooth/bluez.git/plain/ChangeLog"
 distfiles="${KERNEL_SITE}/bluetooth/bluez-${version}.tar.xz"
-checksum=55e2c645909ad82d833c42ce85ec20434e0ef0070941b1eab73facdd240bbd63
+checksum=830fed1915c5d375b8de0f5e6f45fcdea0dcc5ff5ffb3d31db6ed0f00d73c5e3
 conf_files="/etc/bluetooth/main.conf"
 system_groups="bluetooth"
 
@@ -44,6 +44,8 @@ post_install() {
 	vsv bluetoothd
 
 	vdoc ${FILESDIR}/README.voidlinux
+
+	rm ${DESTDIR}/etc/bluetooth/mesh-main.conf
 }
 
 libbluetooth_package() {


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl
  - i686
