### PR TITLE
nextcloud-client: update to 3.14.0

### DIFF
--- a/srcpkgs/nextcloud-client/template
+++ b/srcpkgs/nextcloud-client/template
@@ -1,6 +1,6 @@
 # Template file for 'nextcloud-client'
 pkgname=nextcloud-client
-version=3.13.3
+version=3.14.0
 revision=1
 build_style=cmake
 configure_args="-DBUILD_UPDATER=NO -DBUILD_WITH_WEBENGINE=OFF -Wno-dev"
@@ -20,7 +20,7 @@ license="GPL-2.0-or-later"
 homepage="https://nextcloud.com/clients/"
 changelog="https://github.com/nextcloud/desktop/releases"
 distfiles="https://github.com/nextcloud/desktop/archive/v${version}.tar.gz"
-checksum=4f1b0ffae207a8ab29d10f9cb6d51e107263cf45d138234bd8be1554eb12661f
+checksum=6296db421df4fd0d8e9adfa8dc249974b314e9dabc00362b4a5e9e9425a09155
 # https://github.com/void-linux/void-packages/pull/33358#discussion_r724518549
 make_check=ci-skip
 

--- a/srcpkgs/nextcloud-client/template
+++ b/srcpkgs/nextcloud-client/template
@@ -1,6 +1,6 @@
 # Template file for 'nextcloud-client'
 pkgname=nextcloud-client
-version=3.14.1
+version=3.14.2
 revision=1
 build_style=cmake
 configure_args="-DBUILD_UPDATER=NO -DBUILD_WITH_WEBENGINE=OFF -Wno-dev"
@@ -27,7 +27,7 @@ license="GPL-2.0-or-later"
 homepage="https://nextcloud.com/clients/"
 changelog="https://github.com/nextcloud/desktop/releases"
 distfiles="https://github.com/nextcloud/desktop/archive/v${version}.tar.gz"
-checksum=83ddff511684c7b56a0a428c1a50630042a4c64d7b382d13b083509051cac8b9
+checksum=2b2209a47bc4011d7ddf50371138f4c7d8330079ab95d2859dd9b3df314520e4
 # https://github.com/void-linux/void-packages/pull/33358#discussion_r724518549
 make_check=ci-skip
 

--- a/srcpkgs/nextcloud-client/template
+++ b/srcpkgs/nextcloud-client/template
@@ -1,17 +1,24 @@
 # Template file for 'nextcloud-client'
 pkgname=nextcloud-client
-version=3.14.0
+version=3.14.1
 revision=1
 build_style=cmake
 configure_args="-DBUILD_UPDATER=NO -DBUILD_WITH_WEBENGINE=OFF -Wno-dev"
 hostmakedepends="pkg-config inkscape"
-makedepends="qt5-tools-devel qt5-declarative-devel qt5-webchannel-devel
- qt5-location-devel qtkeychain-qt5-devel sqlite-devel libcloudproviders-devel
- qt5-quickcontrols2-devel qt5-websockets-devel qt5-svg-devel karchive-devel
- qt5-plugin-mysql qt5-plugin-odbc qt5-plugin-pgsql qt5-plugin-sqlite qt5-plugin-tds
- $(vopt_if dolphin 'extra-cmake-modules kio-devel')
- $(vopt_if webengine 'qt5-webengine-devel')"
-depends="qt5-graphicaleffects kguiaddons"
+# makedepends="qt5-tools-devel qt5-declarative-devel qt5-webchannel-devel
+#  qt5-location-devel qtkeychain-qt5-devel sqlite-devel libcloudproviders-devel
+#  qt5-quickcontrols2-devel qt5-websockets-devel qt5-svg-devel karchive-devel
+#  qt5-plugin-mysql qt5-plugin-odbc qt5-plugin-pgsql qt5-plugin-sqlite qt5-plugin-tds
+#  $(vopt_if dolphin 'extra-cmake-modules kio-devel')
+#  $(vopt_if webengine 'qt5-webengine-devel')"
+# depends="qt5-graphicaleffects kguiaddons"
+makedepends="qt6-tools-devel qt6-webchannel-devel qt6-location-devel
+ qtkeychain-qt6-devel sqlite-devel libcloudproviders-devel
+ qt6-declarative-devel qt6-websockets-devel qt6-svg-devel kf6-karchive-devel
+ qt6-plugin-mysql qt6-plugin-odbc qt6-plugin-pgsql qt6-plugin-sqlite
+ $(vopt_if dolphin 'extra-cmake-modules kf6-kio-devel')
+ $(vopt_if webengine 'qt6-webengine-devel')"
+depends="qt6-qt5compat kguiaddons"
 checkdepends="cmocka-devel"
 conf_files="/etc/Nextcloud/sync-exclude.lst"
 short_desc="NextCloud Desktop client"
@@ -20,13 +27,13 @@ license="GPL-2.0-or-later"
 homepage="https://nextcloud.com/clients/"
 changelog="https://github.com/nextcloud/desktop/releases"
 distfiles="https://github.com/nextcloud/desktop/archive/v${version}.tar.gz"
-checksum=6296db421df4fd0d8e9adfa8dc249974b314e9dabc00362b4a5e9e9425a09155
+checksum=83ddff511684c7b56a0a428c1a50630042a4c64d7b382d13b083509051cac8b9
 # https://github.com/void-linux/void-packages/pull/33358#discussion_r724518549
 make_check=ci-skip
 
 build_options="dolphin webengine"
 desc_option_dolphin="Build KDE dolphin support"
-desc_option_webengine="Build Qt5 WebEngine support"
+desc_option_webengine="Build Qt6 WebEngine support"
 build_options_default="dolphin"
 
 if [ "$XBPS_TARGET_ENDIAN" = "le" ]; then
@@ -36,7 +43,8 @@ if [ "$XBPS_TARGET_ENDIAN" = "le" ]; then
 fi
 
 if [ "$CROSS_BUILD" ]; then
-	hostmakedepends+=" qt5-qmake qt5-host-tools qt5-tools"
+	# hostmakedepends+=" qt5-qmake qt5-host-tools qt5-tools"
+	hostmakedepends+=" qt6-tools qt6-declarative-host-tools"
 	# provides desktoptojson
 	hostmakedepends+=" $(vopt_if dolphin 'kcoreaddons')"
 fi
@@ -76,7 +84,7 @@ nextcloud-client-dolphin_package() {
 	depends="nextcloud-client>=${version}_${revision}"
 	pkg_install() {
 		vmove usr/lib/libnextclouddolphinpluginhelper.so
-		vmove usr/lib/qt5
+		vmove usr/lib/qt6
 	}
 }
 

--- a/srcpkgs/nextcloud-client/template
+++ b/srcpkgs/nextcloud-client/template
@@ -1,6 +1,6 @@
 # Template file for 'nextcloud-client'
 pkgname=nextcloud-client
-version=3.14.2
+version=3.14.3
 revision=1
 build_style=cmake
 configure_args="-DBUILD_UPDATER=NO -DBUILD_WITH_WEBENGINE=OFF -Wno-dev"
@@ -27,7 +27,7 @@ license="GPL-2.0-or-later"
 homepage="https://nextcloud.com/clients/"
 changelog="https://github.com/nextcloud/desktop/releases"
 distfiles="https://github.com/nextcloud/desktop/archive/v${version}.tar.gz"
-checksum=2b2209a47bc4011d7ddf50371138f4c7d8330079ab95d2859dd9b3df314520e4
+checksum=9b09b82f1ebf08b9c4df2ef2c94a735978f1219418bbf81af4fb89ad94cfa634
 # https://github.com/void-linux/void-packages/pull/33358#discussion_r724518549
 make_check=ci-skip
 


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **TBD**

#### Local build testing
- I built this PR locally for my native architecture: ~x86_64-libc~ WIP
- I built this PR locally for these architectures:
  - ~armv7l (crossbuilds)~ WIP

libpulseaudio-16.1_1: broken, unresolvable shlib `libwebrtc_audio_processing.so.1'
edit: ALSO it is using qt6 by default now, will evaluate changes to include it on this update