### PR TITLE
common/build-helper/qemu: only install the relevant user emulator

### DIFF
--- a/common/build-helper/gir.sh
+++ b/common/build-helper/gir.sh
@@ -17,7 +17,7 @@ if [ "$build_option_gir" ] || [[ $build_options != *"gir"* ]]; then
 	if [ "$CROSS_BUILD" ]; then
 		# Required for running binaries produced from g-ir-compiler
 		# via g-ir-scanner-qemuwrapper
-		hostmakedepends+=" qemu-user"
+		hostmakedepends+=" qemu-user-${XBPS_TARGET_QEMU_MACHINE/x86_64/amd64}"
 
 		# Required for running the g-ir-scanner-lddwrapper
 		hostmakedepends+=" prelink-cross"

--- a/common/build-helper/qemu.sh
+++ b/common/build-helper/qemu.sh
@@ -1,8 +1,6 @@
 if [ "$CROSS_BUILD" ]; then
 	export QEMU_LD_PREFIX=${XBPS_CROSS_BASE}
-	if [[ $hostmakedepends != *"qemu-user"* ]]; then
-		hostmakedepends+=" qemu-user"
-	fi
+	hostmakedepends+=" qemu-user-${XBPS_TARGET_QEMU_MACHINE/x86_64/amd64}"
 fi
 
 vtargetrun() {

--- a/srcpkgs/aravis/template
+++ b/srcpkgs/aravis/template
@@ -3,9 +3,10 @@ pkgname=aravis
 version=0.8.33
 revision=1
 build_style=meson
+build_helper="gir"
 configure_args="-Ddocumentation=enabled"
-hostmakedepends="pkg-config gobject-introspection gi-docgen gettext"
-makedepends="gtk+3-devel glib-devel libusb-devel zlib-devel libxml2-devel
+hostmakedepends="pkg-config gobject-introspection gi-docgen gettext glib-devel"
+makedepends="gtk+3-devel libglib-devel libusb-devel zlib-devel libxml2-devel
  gstreamer1-devel gst-plugins-base1-devel gi-docgen"
 checkdepends="python3-gobject"
 short_desc="Vision utilities for genicam based cameras"
@@ -16,10 +17,6 @@ distfiles="${homepage}/archive/${version}.tar.gz"
 checksum=d70b125666b23ca4c0f8986fa0786a3d2b9efb7a56b558b703083cdfaa793f4e
 # Network test causes timeout in CI
 make_check=ci-skip
-
-if [ "$CROSS_BUILD" ]; then
-	hostmakedepends+=" glib-devel prelink-cross qemu-user"
-fi
 
 libaravis_package() {
 	short_desc="Vision library for genicam-based cameras"

--- a/srcpkgs/glib/template
+++ b/srcpkgs/glib/template
@@ -4,7 +4,7 @@ pkgname=glib
 version=2.80.3
 revision=1
 build_style=meson
-build_helper=qemu
+build_helper="qemu"
 # static version is necessary for qemu-user
 # also disable LTO, otherwise there are multiple failures when linking qemu
 configure_args="-Dman=true -Dselinux=disabled -Dintrospection=enabled

--- a/srcpkgs/gobject-introspection-bootstrap/template
+++ b/srcpkgs/gobject-introspection-bootstrap/template
@@ -7,6 +7,7 @@ pkgname=gobject-introspection-bootstrap
 version=1.80.1
 revision=2
 build_style=meson
+build_helper="qemu"
 configure_args="-Dbuild_introspection_data=false"
 pycompile_dirs="usr/lib/gobject-introspection/giscanner"
 hostmakedepends="flex pkg-config"
@@ -27,7 +28,7 @@ conflicts="libgirepository libgirepository-devel gobject-introspection"
 noverifyrdeps=yes
 
 if [ "$CROSS_BUILD" ]; then
-	hostmakedepends+=" gobject-introspection-bootstrap qemu-user prelink-cross"
+	hostmakedepends+=" gobject-introspection-bootstrap prelink-cross"
 	configure_args+=" -Dgi_cross_use_prebuilt_gi=true
 	 -Dgi_cross_binary_wrapper=/usr/bin/g-ir-scanner-qemuwrapper
 	 -Dgi_cross_ldd_wrapper=/usr/bin/g-ir-scanner-lddwrapper

--- a/srcpkgs/gobject-introspection/template
+++ b/srcpkgs/gobject-introspection/template
@@ -4,6 +4,7 @@ pkgname=gobject-introspection
 version=1.80.1
 revision=2
 build_style=meson
+build_helper="qemu"
 pycompile_dirs="usr/lib/gobject-introspection/giscanner"
 hostmakedepends="flex pkg-config"
 # won't run tests with cairo to avoid cyclical deps
@@ -20,7 +21,7 @@ checksum=a1df7c424e15bda1ab639c00e9051b9adf5cea1a9e512f8a603b53cd199bc6d8
 python_version=3
 
 if [ "$CROSS_BUILD" ]; then
-	hostmakedepends+=" gobject-introspection qemu-user prelink-cross"
+	hostmakedepends+=" gobject-introspection prelink-cross"
 	configure_args+=" -Dgi_cross_use_prebuilt_gi=true
 	 -Dgi_cross_binary_wrapper=/usr/bin/g-ir-scanner-qemuwrapper
 	 -Dgi_cross_ldd_wrapper=/usr/bin/g-ir-scanner-lddwrapper

--- a/srcpkgs/libgpg-error/template
+++ b/srcpkgs/libgpg-error/template
@@ -3,6 +3,7 @@ pkgname=libgpg-error
 version=1.49
 revision=1
 build_style=gnu-configure
+build_helper="qemu"
 configure_args="--enable-install-gpg-error-config"
 short_desc="Library for error values used by GnuPG component"
 maintainer="Orphaned <orphan@voidlinux.org>"
@@ -10,10 +11,6 @@ license="LGPL-2.1-or-later, GPL-2.0-or-later"
 homepage="https://www.gnupg.org"
 distfiles="https://www.gnupg.org/ftp/gcrypt/${pkgname}/${pkgname}-${version}.tar.bz2"
 checksum=8b79d54639dbf4abc08b5406fb2f37e669a2dec091dd024fb87dd367131c63a9
-
-if [ "$CROSS_BUILD" ]; then
-	hostmakedepends="qemu-user"
-fi
 
 post_install() {
 	rm -r ${DESTDIR}/usr/share/common-lisp

--- a/srcpkgs/libportal/template
+++ b/srcpkgs/libportal/template
@@ -3,6 +3,7 @@ pkgname=libportal
 version=0.7.1
 revision=1
 build_style=meson
+build_helper="gir"
 configure_args="$(vopt_bool gtk_doc docs) $(vopt_bool gir vapi)
  -Dbackend-gtk3=enabled -Dbackend-gtk4=enabled -Dbackend-qt5=enabled"
 hostmakedepends="pkg-config glib-devel gobject-introspection $(vopt_if gir vala)
@@ -20,10 +21,6 @@ make_check_pre="xvfb-run"
 
 build_options="gir gtk_doc"
 build_options_default="gir gtk_doc"
-
-if [ -n "$CROSS_BUILD" ]; then
-	hostmakedepends+=" qemu-user prelink-cross"
-fi
 
 libportal-devel_package() {
 	depends="libportal>=${version}_${revision} glib-devel"

--- a/srcpkgs/php8.2/template
+++ b/srcpkgs/php8.2/template
@@ -4,6 +4,7 @@ pkgname=php8.2
 version=8.2.22
 revision=1
 _php_version=8.2
+build_helper="qemu"
 hostmakedepends="bison pkg-config apache-devel"
 makedepends="apache-devel enchant2-devel freetds-devel freetype-devel gdbm-devel
  gmp-devel libcurl-devel libjpeg-turbo-devel libmariadbclient-devel
@@ -27,7 +28,7 @@ lib32disabled=yes
 
 if [ -n "$CROSS_BUILD" ]; then
 	# phar and pear need php to build
-	hostmakedepends+=" php${_php_version} qemu-user"
+	hostmakedepends+=" php${_php_version}"
 	CFLAGS+=" -DHAVE_LIBDL
 		 -DHAVE_DLOPEN
 		 -DHAVE_DLSYM

--- a/srcpkgs/php8.3/template
+++ b/srcpkgs/php8.3/template
@@ -4,6 +4,7 @@ pkgname=php8.3
 version=8.3.10
 revision=1
 _php_version=8.3
+build_helper="qemu"
 hostmakedepends="bison pkg-config apache-devel"
 makedepends="apache-devel enchant2-devel freetds-devel freetype-devel gdbm-devel
  gmp-devel libcurl-devel libjpeg-turbo-devel libmariadbclient-devel
@@ -27,7 +28,7 @@ lib32disabled=yes
 
 if [ -n "$CROSS_BUILD" ]; then
 	# phar and pear need php to build
-	hostmakedepends+=" php${_php_version} qemu-user"
+	hostmakedepends+=" php${_php_version}"
 	CFLAGS+=" -DHAVE_LIBDL
 		 -DHAVE_DLOPEN
 		 -DHAVE_DLSYM

--- a/srcpkgs/umockdev/template
+++ b/srcpkgs/umockdev/template
@@ -3,6 +3,7 @@ pkgname=umockdev
 version=0.17.13
 revision=1
 build_style=meson
+build_helper="gir"
 hostmakedepends="pkg-config vala"
 makedepends="vala-devel eudev-libudev-devel libpcap-devel gobject-introspection"
 checkdepends="eudev which gphoto2 libgudev-devel python3-gobject usbutils xz"
@@ -12,10 +13,6 @@ license="LGPL-2.1-or-later"
 homepage="https://github.com/martinpitt/umockdev"
 distfiles="https://github.com/martinpitt/umockdev/releases/download/${version}/umockdev-${version}.tar.xz"
 checksum=6c6ebf6e6209b6a49746e0d91a448d027b54271bab82ed70a132ecf294ca13cf
-
-if [ "$CROSS_BUILD" ]; then
-	hostmakedepends+=" gobject-introspection qemu-user"
-fi
 
 umockdev-devel_package() {
 	depends="umockdev>=${version}_${revision}"


### PR DESCRIPTION
now that the package is split, we don't have to install every emulator under the sun. also, clean up templates that explicitly hostmakedepend on qemu-user.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**|**briefly**|**NO**

