### PR TITLE
scaleway-cli: update to 2.34.0.

### DIFF
--- a/srcpkgs/scaleway-cli/template
+++ b/srcpkgs/scaleway-cli/template
@@ -1,17 +1,20 @@
 # Template file for 'scaleway-cli'
 pkgname=scaleway-cli
-version=2.33.0
+version=2.34.0
 revision=1
 build_style=go
 go_import_path=github.com/scaleway/scaleway-cli/v2
 go_package=github.com/scaleway/scaleway-cli/v2/cmd/scw
 go_ldflags="-X main.Version=$version"
 short_desc="Interact with the Scaleway API from the command line"
-maintainer="Sébastien Pondichy<sebastien.pondichy@gmail.com>"
+maintainer="Sébastien Pondichy <sebastien.pondichy@gmail.com>"
 license="MIT"
 homepage="https://github.com/scaleway/scaleway-cli"
 distfiles="https://github.com/scaleway/scaleway-cli/archive/v${version}.tar.gz"
-checksum=cacf2f6bd749d14aae0ac2168197c3fd763b0e94d630fd07007c50bdce96a068
+checksum=ed2c62cffa0a68a4ed973a405eb190e42eb5a1aa3d021ad3729b1301f5646d70
+
+# Skip tests as they fail if SHELL=/bin/sh
+make_check="no"
 
 post_install() {
 	vdoc README.md README


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl
  - i686
  - armv7l
  - armv6l

#### Remark
I disabled the tests as they currently fail when the shell of the build user is set to /usr/bin/sh. I opened an issue uptream to fix this if possible --> https://github.com/scaleway/scaleway-cli/issues/4133
