### PR TITLE
libavif: fix usage of system codecs.

### DIFF
--- a/srcpkgs/libavif/template
+++ b/srcpkgs/libavif/template
@@ -1,12 +1,12 @@
 # Template file for 'libavif'
 pkgname=libavif
 version=1.1.1
-revision=1
+revision=2
 build_style=cmake
 configure_args="-DAVIF_BUILD_APPS=ON -DAVIF_BUILD_GDK_PIXBUF=ON
  -DAVIF_LIBYUV=OFF -DAVIF_CODEC_AOM=SYSTEM
- $(vopt_bool dav1d AVIF_CODEC_DAV1D) $(vopt_bool rav1e AVIF_CODEC_RAV1E)
- $(vopt_bool svt AVIF_CODEC_SVT)"
+ $(vopt_if dav1d -DAVIF_CODEC_DAV1D=SYSTEM) $(vopt_if rav1e -DAVIF_CODEC_RAV1E=SYSTEM)
+ $(vopt_if svt -DAVIF_CODEC_SVT=SYSTEM)"
 hostmakedepends="gdk-pixbuf-devel pkg-config"
 makedepends="gdk-pixbuf-devel libaom-devel libsharpyuv-devel
  libjpeg-turbo-devel libpng-devel zlib-devel


### PR DESCRIPTION
The options to enable additional codecs require either LOCAL for the vendored copy, or SYSTEM for the system libraries. Our version of libavif was getting built without any support for dav1d, rav1e or svt.

---

Noticed this when running `xbps-remove -o`.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES** (only at build time, and it does add the dependencies which were previously missing)