### PR TITLE
ostree: fix flatpak error (fixes #52273)

### DIFF
--- a/srcpkgs/flatpak/template
+++ b/srcpkgs/flatpak/template
@@ -1,7 +1,7 @@
 # Template file for 'flatpak'
 pkgname=flatpak
 version=1.15.10
-revision=1
+revision=2
 build_style=meson
 build_helper="gir"
 configure_args="

--- a/srcpkgs/ostree/patches/fix-ostree-flatpak.patch
+++ b/srcpkgs/ostree/patches/fix-ostree-flatpak.patch
@@ -1,0 +1,39 @@
+diff --git a/src/libostree/ostree-fetcher-curl.c b/src/libostree/ostree-fetcher-curl.c
+index e9b9672..26ba6ca 100644
+--- a/src/libostree/ostree-fetcher-curl.c
++++ b/src/libostree/ostree-fetcher-curl.c
+@@ -78,6 +78,7 @@ struct OstreeFetcher
+   struct curl_slist *extra_headers;
+   int tmpdir_dfd;
+   bool force_anonymous;
++  bool finalizing; // Set if we're in the process of teardown
+   char *custom_user_agent;
+   guint32 opt_low_speed_limit;
+   guint32 opt_low_speed_time;
+@@ -180,6 +181,15 @@ _ostree_fetcher_finalize (GObject *object)
+ {
+   OstreeFetcher *self = OSTREE_FETCHER (object);
+ 
++  // Because curl_multi_cleanup may invoke callbacks, we effectively have
++  // some circular references going on here. See discussion in
++  // https://github.com/curl/curl/issues/14860
++  // Basically what we do is make most callbacks libcurl may invoke into no-ops when
++  // we detect we're finalizing. The data structures are owned by this object and
++  // not by the callbacks, and will be destroyed below. Note that
++  // e.g. g_hash_table_unref() may itself invoke callbacks, which is where
++  // some data is cleaned up.
++  self->finalizing = true;
+   curl_multi_cleanup (self->multi);
+   g_free (self->remote_name);
+   g_free (self->tls_ca_db_path);
+@@ -528,6 +538,10 @@ sock_cb (CURL *easy, curl_socket_t s, int what, void *cbp, void *sockp)
+   OstreeFetcher *fetcher = cbp;
+   SockInfo *fdp = (SockInfo *)sockp;
+ 
++  // We do nothing if we're in the process of teardown; see below.
++  if (fetcher->finalizing)
++    return 0;
++
+   if (what == CURL_POLL_REMOVE)
+     {
+       if (!g_hash_table_remove (fetcher->sockets, fdp))

--- a/srcpkgs/ostree/template
+++ b/srcpkgs/ostree/template
@@ -1,7 +1,7 @@
 # Template file for 'ostree'
 pkgname=ostree
 version=2024.3
-revision=1
+revision=2
 build_style=gnu-configure
 build_helper="gir"
 configure_args="


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**



#### Local build testing
- I built this PR locally for my native architecture, (x64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x64-musl

source of the patch: https://github.com/ostreedev/ostree/pull/3307

Fixes https://github.com/void-linux/void-packages/issues/52273

Peace. :v: 