### PR TITLE
nushell: update to 0.98.0

### DIFF
--- a/srcpkgs/nushell/template
+++ b/srcpkgs/nushell/template
@@ -1,6 +1,6 @@
 # Template file for 'nushell'
 pkgname=nushell
-version=0.97.1
+version=0.98.0
 revision=1
 build_style=cargo
 hostmakedepends="pkg-config"
@@ -12,7 +12,7 @@ license="MIT"
 homepage="https://www.nushell.sh/"
 changelog="https://www.nushell.sh/blog/"
 distfiles="https://github.com/nushell/nushell/archive/refs/tags/${version}.tar.gz"
-checksum=e605d5a7f104b7f2bf99197ca2f34a4a68f68cc12ecab41f606113e6a65b67b1
+checksum=c77fd63c4a5f2d35f7dcbb3e9bd76dfaa23acc6bc21fb1de4e7a4a94dc458839
 register_shell="/usr/bin/nu"
 # all tests fail with argument --target
 make_check=no


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**
(Installed and ran it as shell, works as expected)


#### Local build testing
- I built this PR locally for my native architecture, (x86-64-musl)
- I built this PR locally for these architectures:
  - i686
  - x86_64-glibc

