### PR TITLE
cross-x86_64-w64-mingw32: update to 12.0.0, build mingw32ucrt package

### DIFF
--- a/srcpkgs/cross-x86_64-w64-mingw32/template
+++ b/srcpkgs/cross-x86_64-w64-mingw32/template
@@ -1,13 +1,13 @@
 # Template file for 'cross-x86_64-w64-mingw32'
 pkgname=cross-x86_64-w64-mingw32
-version=10.0.0
+version=12.0.0
 revision=1
-_gcc_version=12.2.0
-_binutils_version=2.39
-_gmp_version=6.2.1
-_mpfr_version=4.1.0
-_mpc_version=1.2.1
-_isl_version=0.24
+_gcc_version=14.2.0
+_binutils_version=2.43
+_gmp_version=6.3.0
+_mpfr_version=4.2.1
+_mpc_version=1.3.1
+_isl_version=0.26
 _mingw_version="${version}"
 create_wrksrc=yes
 hostmakedepends="tar flex perl texinfo"
@@ -28,13 +28,13 @@ distfiles="
  ${GNU_SITE}/mpfr/mpfr-${_mpfr_version}.tar.xz
  ${SOURCEFORGE_SITE}/libisl/isl-${_isl_version}.tar.bz2
  ${SOURCEFORGE_SITE}/project/mingw-w64/mingw-w64/mingw-w64-release/mingw-w64-v${_mingw_version}.tar.bz2"
-checksum="645c25f563b8adc0a81dbd6a41cffbf4d37083a382e02d5d3df4f65c09516d00
- e549cf9cf3594a00e27b6589d4322d70e0720cdd213f39beb4181e06926230ff
- 17503d2c395dfcf106b622dc142683c1199431d095367c6aacba6eec30340459
- fd4829912cddd12f84181c3451cc752be224643e87fac497b69edddadc49b4f2
- 0c98a3f1732ff6ca4ea690552079da9c597872d30e96ec28414ee23c95558a7f
- fcf78dd9656c10eb8cf9fbd5f59a0b6b01386205fe1934b3b287a0a1898145c0
- ba6b430aed72c63a3768531f6a3ffc2b0fde2c57a3b251450dcf489a894f0894"
+checksum="b53606f443ac8f01d1d5fc9c39497f2af322d99e14cea5c0b4b124d630379365
+ a7b39bc69cbf9e25826c5a60ab26477001f7c08d85cec04bc0e29cabed6f3cc9
+ ab642492f5cf882b74aa0cb730cd410a81edcdbec895183ce930e706c1c759b8
+ a3c2b80201b89e68616f4ad30bc66aee4927c3ce50e33929ca819d5c43538898
+ 277807353a6726978996945af13e52829e3abd7a9a5b7fb2793894e18f1fcbb2
+ 5eac8664e9d67be6bd0bee5085d6840b8baf738c06814df47eaf4166d9776436
+ cc41898aac4b6e8dd5cffd7331b9d9515b912df4420a3a612b5ea2955bbeed2f"
 
 nocross=yes
 nopie=yes
@@ -78,17 +78,25 @@ _mingw_headers() {
 	_target=$1
 	_sysroot="/usr/${_target}"
 	_builddir=${wrksrc}/"build-mingw-headers-${_target}"
+	_configure_args=" "
 
 	msg_normal "Building MinGW headers: ${_target}\n"
 
 	mkdir -p ${_builddir} && cd ${_builddir}
+
+	if [ "${_target##*-}" == "mingw32ucrt" ]; then
+		_configure_args+=" --with-default-msvcrt=ucrt"
+	else
+		_configure_args+=" --with-default-msvcrt=msvcrt"
+	fi
 
 	../mingw-w64-v${_mingw_version}/mingw-w64-headers/configure \
 		--prefix=${_sysroot} \
 		--host=${_target} \
 		--disable-werror \
 		--enable-secure-api \
-		--enable-sdk=all
+		--enable-sdk=all \
+		${_configure_args}
 
 	make ${makejobs} && make install
 
@@ -139,9 +147,11 @@ _mingw_crt_build() {
 	msg_normal "Building MinGW CRT: ${_target}\n"
 
 	if [ ${_target} == "i686-w64-mingw32" ]; then
-		_crt_configure_args="--disable-lib64 --enable-lib32"
+		_crt_configure_args="--disable-lib64 --enable-lib32 --with-default-msvcrt=msvcrt"
 	elif [ ${_target} == "x86_64-w64-mingw32" ]; then
-		_crt_configure_args="--disable-lib32 --enable-lib64"
+		_crt_configure_args="--disable-lib32 --enable-lib64 --with-default-msvcrt=msvcrt"
+	elif [ ${_target} == "x86_64-w64-mingw32ucrt" ]; then
+		_crt_configure_args="--disable-lib32 --enable-lib64 --with-default-msvcrt=ucrt"
 	fi
 
 	mkdir -p ${_builddir} && cd ${_builddir}
@@ -219,6 +229,7 @@ _build_cross() {
 }
 
 do_build() {
+	(_build_cross "x86_64-w64-mingw32ucrt")
 	(_build_cross "x86_64-w64-mingw32")
 	(_build_cross "i686-w64-mingw32")
 }
@@ -258,6 +269,7 @@ _clean_cross() {
 }
 
 do_clean() {
+	(_clean_cross "x86_64-w64-mingw32ucrt")
 	(_clean_cross "x86_64-w64-mingw32")
 	(_clean_cross "i686-w64-mingw32")
 }
@@ -303,5 +315,35 @@ cross-i686-w64-mingw32-crt_package() {
 	lib32disabled=yes
 	pkg_install() {
 		DESTDIR="$PKGDESTDIR" _install_crt "i686-w64-mingw32"
+	}
+}
+
+cross-x86_64-w64-mingw32ucrt_package() {
+	short_desc="Cross toolchain for Win32 (GCC ${_gcc_version})"
+	depends="cross-x86_64-w64-mingw32ucrt-crt-${version}_${revision}"
+	nopie=yes
+	nodebug=yes
+	noverifyrdeps=yes
+	noshlibprovides=yes
+	lib32disabled=yes
+	nostrip_files="libgcc.a libgcc_eh.a libgcc_s.a libgcov.a
+	 libatomic.a libatomic.dll.a libquadmath.a libquadmath.dll.a
+	 libssp.a libssp.dll.a libssp_nonshared.a
+	 libstdc++.a libstdc++.dll.a libstdc++fs.a libsupc++.a"
+	pkg_install() {
+		DESTDIR="$PKGDESTDIR" _install_toolchain "x86_64-w64-mingw32ucrt"
+	}
+}
+
+cross-x86_64-w64-mingw32ucrt-crt_package() {
+	short_desc="CRT for Win32 cross toolchain"
+	nopie=yes
+	nodebug=yes
+	nostrip=yes
+	noverifyrdeps=yes
+	noshlibprovides=yes
+	lib32disabled=yes
+	pkg_install() {
+		DESTDIR="$PKGDESTDIR" _install_crt "x86_64-w64-mingw32ucrt"
 	}
 }

--- a/srcpkgs/cross-x86_64-w64-mingw32ucrt
+++ b/srcpkgs/cross-x86_64-w64-mingw32ucrt
@@ -1,0 +1,1 @@
+cross-x86_64-w64-mingw32

--- a/srcpkgs/cross-x86_64-w64-mingw32ucrt-crt
+++ b/srcpkgs/cross-x86_64-w64-mingw32ucrt-crt
@@ -1,0 +1,1 @@
+cross-x86_64-w64-mingw32


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

Updates mingw to 12.0.0: https://sourceforge.net/p/mingw-w64/mailman/message/58776404/

Adds `cross-x86_64-w64-mingw32ucrt`: https://www.msys2.org/docs/environments/#msvcrt-vs-ucrt

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
