### PR TITLE
chromium: update to 129.0.6668.58.

### DIFF
--- a/srcpkgs/chromium/files/chromium.sh
+++ b/srcpkgs/chromium/files/chromium.sh
@@ -2,4 +2,7 @@
 export CHROME_WRAPPER=/usr/lib/chromium/chromium
 export CHROME_DESKTOP=chromium.desktop
 CHROME_FLAGS="--enable-gpu-rasterization $CHROME_FLAGS"
-exec /usr/lib/chromium/chromium $CHROME_FLAGS "$@"
+case $(xbps-uhelper arch) in
+	*-musl) exec /usr/lib/chromium/chromium $CHROME_FLAGS --js-flags="--jitless --wasm_jitless" "$@";;
+	*) exec /usr/lib/chromium/chromium $CHROME_FLAGS "$@";;
+esac

--- a/srcpkgs/chromium/patches/sndio.patch
+++ b/srcpkgs/chromium/patches/sndio.patch
@@ -1,16 +1,14 @@
 diff -Naur chromium-83.0.4103.97.orig/media/BUILD.gn chromium-83.0.4103.97/media/BUILD.gn
---- a/media/BUILD.gn	2020-06-03 20:40:26.000000000 +0200
-+++ b/media/BUILD.gn	2021-06-13 17:32:28.510395975 +0200
-@@ -65,6 +65,9 @@
-       defines += [ "DLOPEN_PULSEAUDIO" ]
-     }
-   }
-+  if (use_sndio) {
-+    defines += [ "USE_SNDIO" ]
-+  }
-   if (use_cras) {
-     defines += [ "USE_CRAS" ]
-   }
+--- chromium-129.0.6668.58/media/BUILD.gn	2024-09-18 00:00:12.319230000 +0200
++++ -	2024-09-19 19:44:06.486438185 +0200
+@@ -66,6 +66,7 @@
+     "USE_CHROMEOS_PROTECTED_MEDIA=$use_chromeos_protected_media",
+     "USE_CRAS=$use_cras",
+     "USE_PROPRIETARY_CODECS=$proprietary_codecs",
++    "USE_SNDIO=$use_sndio",
+   ]
+ 
+   if (enable_library_cdms) {
 diff -Naur chromium-83.0.4103.97.orig/media/audio/BUILD.gn chromium-83.0.4103.97/media/audio/BUILD.gn
 --- a/media/audio/BUILD.gn	2020-06-03 20:39:37.000000000 +0200
 +++ b/media/audio/BUILD.gn	2020-06-13 17:32:28.511395969 +0200

--- a/srcpkgs/chromium/template
+++ b/srcpkgs/chromium/template
@@ -1,7 +1,7 @@
 # Template file for 'chromium'
 pkgname=chromium
 # See https://chromiumdash.appspot.com/releases?platform=Linux for the latest version
-version=128.0.6613.84
+version=129.0.6668.58
 revision=1
 archs="i686* x86_64* aarch64* armv7l*"
 hostmakedepends="
@@ -28,17 +28,18 @@ maintainer="Duncaen <duncaen@voidlinux.org>"
 license="BSD-3-Clause"
 homepage="https://www.chromium.org/"
 distfiles="https://commondatastorage.googleapis.com/chromium-browser-official/${pkgname}-${version}.tar.xz"
-checksum=9297c1e1dc9310534f6a48f90eacc2eac1d964ac3c827dc0798594e8a2742dc4
+checksum=eaf850183d32627ce0cde9f3d3f853bc11c217ef7f41540303214ed47803d96d
 
 lib32disabled=yes
 
-build_options="clang libcxx debug vaapi pulseaudio sndio pipewire lto"
+build_options="clang libcxx debug vaapi pulseaudio sndio pipewire lto drumbrake"
 build_options_default="clang libcxx vaapi pulseaudio pipewire"
 desc_option_clang="Use clang to build"
 desc_option_libcxx="Use bundled libc++"
 desc_option_debug="Build with debug symbols"
 desc_option_lto="Enable Link Time Optimization"
 desc_option_pipewire="Enable support for screen sharing for WebRTC via PipeWire"
+desc_option_drumbrake="WebAssembly Interpreter"
 
 if [ "$XBPS_LIBC" = musl ]; then
 	hostmakedepends+=" musl-legacy-compat"
@@ -47,6 +48,10 @@ fi
 if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
 	makedepends+=" musl-legacy-compat"
 fi
+
+case "$XBPS_TARGET_MACHINE" in
+	x86_64-musl|aarch64-musl) build_options_default+=" drumbrake";;
+esac
 
 if [ "$CROSS_BUILD" ]; then
 	hostmakedepends+=" libX11-devel libxcb-devel pciutils-devel libXext-devel libglvnd-devel
@@ -237,6 +242,8 @@ do_configure() {
 		"rtc_use_pipewire=$(vopt_if pipewire true false)"
 
 		"use_sndio=$(vopt_if sndio true false)"
+
+		"v8_enable_drumbrake=$(vopt_if drumbrake true false)"
 
 		# Always support proprietary codecs.
 		# Enable H.264 support in bundled ffmpeg.


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

Quickly tested on x86_64-musl with `--js-flags="--jitless --wasm_jitless"`, all the jits are still horribly broken on musl.

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, `x86_64. x86_64-musl`

#### Testing Repo
https://void.johnnynator.dev/dev/chromium/

[skip ci]
[ci skip]
