### PR TITLE
onefetch: update to 2.22.0

### DIFF
--- a/srcpkgs/onefetch/template
+++ b/srcpkgs/onefetch/template
@@ -1,8 +1,9 @@
 # Template file for 'onefetch'
 pkgname=onefetch
-version=2.21.0
+version=2.22.0
 revision=1
 build_style=cargo
+build_helper=qemu
 make_check_args="-- --skip info::tests::test_style_subtitle"
 hostmakedepends="pkg-config"
 makedepends="zlib-devel libzstd-devel"
@@ -13,7 +14,7 @@ license="MIT"
 homepage="https://onefetch.dev"
 changelog="https://github.com/o2sh/onefetch/raw/main/CHANGELOG.md"
 distfiles="https://github.com/o2sh/onefetch/archive/refs/tags/${version}.tar.gz"
-checksum=a035bc44ef0c04a330b409e08ee61ac8a66a56cb672f87a824d4c0349989eaf2
+checksum=1741516c628bb70b432285aa78439c4acfeb5df19e48b8d85dba5f71336e190b
 
 if [ "$XBPS_TARGET_ENDIAN" = "be" ]; then
 	broken="exr crate unimplemented for BE"
@@ -26,4 +27,13 @@ pre_build() {
 
 post_install() {
 	vlicense LICENSE.md
+
+	local _onefetch=${DESTDIR}/usr/bin/onefetch
+
+	vman docs/onefetch.1
+
+	for _shell in bash fish zsh; do
+		vtargetrun ${_onefetch} --generate ${_shell} > onefetch.${_shell}
+		vcompletion onefetch.${_shell} ${_shell}
+	done
 }


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**


#### Local build testing
- I built this PR locally for my native architecture, (x86_64-musl)
- I built this PR locally for these architectures:
  - i686
  - x86_64-glibc