### PR TITLE
New package: supervisor-4.2.5

### DIFF
--- a/srcpkgs/supervisor/template
+++ b/srcpkgs/supervisor/template
@@ -1,0 +1,19 @@
+# Template file for 'supervisor'
+pkgname=supervisor
+version=4.2.5
+revision=1
+build_style=python3-module
+hostmakedepends="python3-setuptools"
+depends="python3"
+checkdepends="python3-pytest"
+short_desc="Client/server system to monitor and control processes"
+maintainer="Sumit Khanna <sumit@penguindreams.org>"
+license="custom: repoze"
+homepage="http://supervisord.org/"
+changelog="https://raw.githubusercontent.com/carpedm20/emoji/master/CHANGES.md"
+distfiles="https://github.com/Supervisor/supervisor/archive/refs/tags/${version}.tar.gz"
+checksum=d612a48684cf41ea7ce8cdc559eaa4bf9cbaa4687c5aac3f355c6d2df4e4f170
+
+post_install() {
+	vlicense LICENSES.txt
+}


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): I think so. I ran the linter and I think I got everything in the guide. This is my first package though.

### License

The license is a derivative of ZPL (which is BSD compatible) called repoze, so I put it in as custom. On Gentoo it's licensed as "repoze ZPL BSD HPND GPL-2"

