### PR TITLE
socat: update to 1.8.0.1

### DIFF
--- a/srcpkgs/socat/template
+++ b/srcpkgs/socat/template
@@ -1,6 +1,6 @@
 # Template file for 'socat'
 pkgname=socat
-version=1.8.0.0
+version=1.8.0.1
 revision=1
 build_style=gnu-configure
 configure_args="--disable-libwrap --enable-fips
@@ -12,7 +12,7 @@ license="GPL-2.0-only"
 homepage="http://www.dest-unreach.org/socat/"
 changelog="http://www.dest-unreach.org/socat/CHANGES"
 distfiles="http://www.dest-unreach.org/socat/download/socat-${version}.tar.bz2"
-checksum=e1de683dd22ee0e3a6c6bbff269abe18ab0c9d7eb650204f125155b9005faca7
+checksum=6a283565db7cf86292c6f70504c58abb03e29888adeed5a6c5f3457e803c1b81
 
 case "$XBPS_TARGET_MACHINE" in
 	*-musl) CFLAGS="-D_LINUX_IF_ETHER_H"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**


#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl (crossbuilt)
  - aarch64 (crossbuilt)
  - x86_64-musl (crossbuilt)
  - armv6l-musl (crossbuilt)


#### Note
- As stated on the socat website, this "small" update fixes a couple of regressions in version 1.8.0.0.