### PR TITLE
amberol: update to 2024.1

### DIFF
--- a/srcpkgs/amberol/template
+++ b/srcpkgs/amberol/template
@@ -1,11 +1,11 @@
 # Template file for 'amberol'
 pkgname=amberol
-version=0.10.3
+version=2024.1
 revision=1
 build_style=meson
 build_helper=rust
 hostmakedepends="cargo desktop-file-utils gettext m4 pkg-config glib-devel
- gtk-update-icon-cache"
+ gtk4-update-icon-cache"
 makedepends="libadwaita-devel rust-std"
 depends="gst-plugins-good1 xdg-desktop-portal"
 short_desc="Small and simple sound and music player"
@@ -14,12 +14,12 @@ license="GPL-3.0-or-later"
 homepage="https://gitlab.gnome.org/World/amberol"
 changelog="https://gitlab.gnome.org/World/amberol/-/raw/main/CHANGES.md"
 distfiles="https://gitlab.gnome.org/World/amberol/-/archive/${version}/${pkgname}-${version}.tar.gz"
-checksum=52372ec6f5ba066409e8dfc4a62fdb2c57e79f83a809cf295ff0e040eebb233b
+checksum=2be110f5a5781fc4d11abf8686335e055866ce6df40562ed5eabab16916faceb
 
 post_patch() {
 	if [ "$CROSS_BUILD" ]; then
 		vsed -i src/meson.build \
-			-e "s%rust_target /%'${RUST_TARGET}' / rust_target /%"
+			-e "s%rust_target /%'${RUST_TARGET}' / &%"
 
 		vsed -i meson.build \
 			-e "/'libdir': get_option('libdir'),/d" \


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86-64)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64