### PR TITLE
python3-Faker: update to 29.0.0, adopt.

### DIFF
--- a/srcpkgs/python3-Faker/template
+++ b/srcpkgs/python3-Faker/template
@@ -1,18 +1,18 @@
 # Template file for 'python3-Faker'
 pkgname=python3-Faker
-version=26.2.0
+version=29.0.0
 revision=1
-build_style=python3-module
-hostmakedepends="python3-setuptools"
+build_style=python3-pep517
+hostmakedepends="python3-wheel python3-setuptools"
 depends="python3-dateutil"
-checkdepends="${depends} python3-freezegun python3-validators python3-Pillow python3-pytest"
+checkdepends="${depends} python3-freezegun python3-validators python3-Pillow python3-xmltodict python3-pytest"
 short_desc="Python package for generating fake data"
-maintainer="Orphaned <orphan@voidlinux.org>"
+maintainer="Vinfall <neptuniahuai0tc@riseup.net>"
 license="MIT"
 homepage="https://faker.readthedocs.io/en/master/"
 changelog="https://github.com/joke2k/faker/raw/master/CHANGELOG.md"
-distfiles="${PYPI_SITE}/F/Faker/Faker-${version}.tar.gz"
-checksum=81768de19012147521140f0d8bf5353e501ac42c1065d25e0cac455d3615c0a7
+distfiles="${PYPI_SITE}/f/faker/faker-${version}.tar.gz"
+checksum=34e89aec594cad9773431ca479ee95c7ce03dd9f22fda2524e2373b880a2fa77
 
 post_install() {
 	vlicense LICENSE.txt


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc

Notes:
- Tests are broken for a while, finally bothered me enough to do the fix
- I've been updating this for a while so maybe adopting it makes checking updates easier via `xcheckmypkgs`