### PR TITLE
obs: change CMAKE_INSTALL_DATAROOTDIR to relative path

### DIFF
--- a/srcpkgs/obs/template
+++ b/srcpkgs/obs/template
@@ -1,11 +1,11 @@
 # Template file for 'obs'
 pkgname=obs
 version=30.2.3
-revision=1
+revision=2
 archs="i686* x86_64* ppc64le* aarch64* riscv64*"
 build_style=cmake
 configure_args="-DOBS_VERSION_OVERRIDE=${version} -DENABLE_JACK=ON
- -DCMAKE_INSTALL_DATAROOTDIR=/usr/share
+ -DCMAKE_INSTALL_DATAROOTDIR=share
  -DENABLE_VST=OFF -DENABLE_AJA=OFF -DCALM_DEPRECATION=ON
  -DENABLE_SCRIPTING_LUA=$(vopt_if luajit 'ON' 'OFF')
  -DENABLE_NATIVE_NVENC=OFF -DENABLE_QSV11=$(vopt_if 'ON' 'OFF')"


### PR DESCRIPTION
The absolute path results in obs trying to load plugin data from
/usr/usr/share which can't work for obvious reasons

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**|**briefly**|**NO**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
