### PR TITLE
Fix deprecated GitHub /downloads/ downloads

### DIFF
--- a/srcpkgs/mash/template
+++ b/srcpkgs/mash/template
@@ -4,7 +4,8 @@ version=0.2.0
 revision=9
 build_style=gnu-configure
 build_helper="gir"
-configure_args="--disable-static $(vopt_enable gir introspection)"
+configure_args="--disable-static $(vopt_enable gir introspection)
+ --enable-gtk-doc"
 hostmakedepends="automake glib-devel intltool libtool pkg-config
  $(vopt_if gir gobject-introspection) gtk-doc"
 makedepends="clutter-devel"
@@ -13,8 +14,9 @@ short_desc="Small library for using 3D models within a Clutter scene"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="LGPL-2.1-or-later"
 homepage="https://clutter-project.github.io/mash/"
-distfiles="https://github.com/downloads/clutter-project/mash/mash-${version}.tar.xz"
-checksum=fd4089e2974a1a57f9ba209a0a47924ed157da9fc9a3d65f68a6b9fdca353ccc
+distfiles="https://github.com/clutter-project/mash/archive/refs/tags/${version}.tar.gz"
+checksum=a5f91f0828c3c63a845800443ab347417cb34882db3b6672b42f6d68355ddab8
+nocross="Build system executes what it builds"
 
 build_options="gir"
 build_options_default="gir"
@@ -30,9 +32,7 @@ mash-devel_package() {
 		vmove usr/include
 		vmove usr/lib/pkgconfig
 		vmove usr/share/gtk-doc
-		if [ -z "$CROSS_BUILD" ]; then
-			vmove usr/share/gir-1.0
-		fi
+		vmove usr/share/gir-1.0
 		vmove usr/lib/*.so
 	}
 }

--- a/srcpkgs/pidgin-gpg/template
+++ b/srcpkgs/pidgin-gpg/template
@@ -9,5 +9,5 @@ short_desc="GnuPG plug-in for the Pidgin IM"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-3.0-or-later"
 homepage="http://github.com/segler-alex/Pidgin-GPG"
-distfiles="http://github.com/downloads/segler-alex/Pidgin-GPG/${pkgname}-${version}.tar.gz"
+distfiles="https://sources.voidlinux.org/pidgin-gpg-${version}/pidgin-gpg-${version}.tar.gz"
 checksum=736681cb25da31eb8ced96055d4150d649fe6ef6e523b6f65846c3446ac09a96

--- a/srcpkgs/pidgin-window-merge/template
+++ b/srcpkgs/pidgin-window-merge/template
@@ -9,5 +9,5 @@ short_desc="Pidgin plugin that merges the Buddy List and the conversation window
 maintainer="chinarulezzz <s.alex08@mail.ru>"
 license="GPL-3.0-or-later"
 homepage="https://github.com/dm0-/window_merge"
-distfiles="https://github.com/downloads/dm0-/window_merge/window_merge-${version}.tar.gz"
+distfiles="https://sources.voidlinux.org/pidgin-window-merge-${version}/window_merge-${version}.tar.gz"
 checksum=e890c829f8f074ca0bbf32a0bd3c9b8008802f2795d6f40a19756379e2ce6531

--- a/srcpkgs/wmfs/template
+++ b/srcpkgs/wmfs/template
@@ -11,7 +11,7 @@ short_desc="Window Manager From Scratch"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="BSD-3-Clause"
 homepage="https://github.com/xorg62/wmfs"
-distfiles="https://github.com/downloads/xorg62/wmfs/wmfs-${version}.tar.gz"
+distfiles="https://sources.voidlinux.org/wmfs-${version}/wmfs-${version}.tar.gz"
 checksum=c28b7cec28a6e3f2bc38a136fb1773bab8ec8f48c69ebe25c24192f96e782d64
 
 CFLAGS="-I${XBPS_CROSS_BASE}/usr/include/freetype2 -fcommon"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->
`mash`'s latest available tag is [`0.2.0`](https://github.com/clutter-project/mash/releases/tag/0.2.0), which is on par with Void linux's package

`wmfs` latest available tag is [`201003`](https://github.com/xorg62/wmfs/releases/tag/201003), which is `< 201104`

`pidgin-window-merge` doesn't have any tags or releases.

`pidgin-gpg`'s latest available tag is [`0.5`](https://github.com/segler-alex/Pidgin-GPG/releases/tag/0.5), which is `< 0.9` (`pidgin-gpg` appears to be a fork of some other project, releases `>=0.9` were created by the forker).

I personally believe that many of these projects deserve to be removed (at least `pidgin-window-merge` does, because it has no releases and therefore no longer meets quality requirements). I have not done so because you (Void maintainers) were reluctant to removing packages before.

The only remaining package using GitHub's deprecated `/downloads/` API is `xinput_calibrator`. I am having a discussion with maintainers about this: https://gitlab.freedesktop.org/xorg/app/xinput-calibrator/-/issues/85

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
