### PR TITLE
python3-rapidfuzz: update to 3.10.0

### DIFF
--- a/srcpkgs/python3-rapidfuzz/patches/downgrade-scikit-build-core-ver.patch
+++ b/srcpkgs/python3-rapidfuzz/patches/downgrade-scikit-build-core-ver.patch
@@ -1,0 +1,12 @@
+diff --git a/pyproject.toml b/pyproject.toml
+index 7f5442efc..0aaffcae4 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -1,6 +1,6 @@
+ [build-system]
+ requires = [
+-    "scikit-build-core>=0.10.7"
++    "scikit-build-core>=0.10.6"
+ ]
+ build-backend = "scikit_build_core.build"
+ 

--- a/srcpkgs/python3-rapidfuzz/template
+++ b/srcpkgs/python3-rapidfuzz/template
@@ -1,9 +1,9 @@
 # Template file for 'python3-rapidfuzz'
 pkgname=python3-rapidfuzz
-version=3.9.7
+version=3.10.0
 revision=1
 build_style=python3-pep517
-hostmakedepends="cmake python3-scikit-build"
+hostmakedepends="python3-scikit-build-core ninja"
 makedepends="python3-devel rapidfuzz-cpp"
 depends="python3"
 checkdepends="python3-hypothesis python3-pandas python3-pytest"
@@ -13,7 +13,7 @@ license="MIT"
 homepage="https://github.com/maxbachmann/rapidfuzz"
 changelog="https://github.com/rapidfuzz/RapidFuzz/releases"
 distfiles="${PYPI_SITE}/r/rapidfuzz/rapidfuzz-${version}.tar.gz"
-checksum=f1c7296534c1afb6f495aa95871f14ccdc197c6db42965854e483100df313030
+checksum=6b62af27e65bb39276a66533655a2fa3c60a487b03935721c45b7809527979be
 
 export CMAKE_ARGS="-DPython_INCLUDE_DIR:PATH=${XBPS_CROSS_BASE}/${py3_inc}"
 


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86-64)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64