### PR TITLE
libarchive: update to 3.7.6

### DIFF
--- a/srcpkgs/libarchive/template
+++ b/srcpkgs/libarchive/template
@@ -1,6 +1,6 @@
 # Template file for 'libarchive'
 pkgname=libarchive
-version=3.7.4
+version=3.7.6
 revision=1
 bootstrap=yes
 build_style=gnu-configure
@@ -18,7 +18,7 @@ license="BSD-2-Clause"
 homepage="https://www.libarchive.org/"
 changelog="https://github.com/libarchive/libarchive/releases"
 distfiles="https://github.com/libarchive/libarchive/releases/download/v${version}/libarchive-${version}.tar.xz"
-checksum=f887755c434a736a609cbd28d87ddbfbe9d6a3bb5b703c22c02f6af80a802735
+checksum=0a2efdcb185da2eb1e7cd8421434cb9a6119f72417a13335cca378d476fd3ba0
 
 build_options="acl expat lzo lz4 ssl zstd"
 build_options_default="acl ssl lz4 zstd"


### PR DESCRIPTION
supersedes #52212 as 3.7.6 got fixes for the i686 test failure and I was able to validate them by running the test suite locally.

#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, x86-64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - i686-glibc