### PR TITLE
python3-ansible-lint: update to 24.9.2; python3-ansible-compat: update to 24.9.1.

### DIFF
--- a/srcpkgs/python3-ansible-compat/template
+++ b/srcpkgs/python3-ansible-compat/template
@@ -1,16 +1,20 @@
 # Template file for 'python3-ansible-compat'
 pkgname=python3-ansible-compat
-version=4.1.10
+version=24.9.1
 revision=1
 build_style=python3-pep517
+# deselect unnecessary tests in venv
+make_check_args="--deselect test/test_runtime_scan_path.py::test_scan_sys_path[scanF-raises_not_foundT]
+ --deselect test/test_runtime_scan_path.py::test_scan_sys_path[scanT-raises_not_foundF]"
 hostmakedepends="python3-wheel python3-setuptools_scm"
-depends="python3-subprocess-tee python3-yaml"
+depends="ansible-core python3-jsonschema python3-subprocess-tee python3-yaml"
+checkdepends="${depends} python3-pytest python3-pytest-mock python3-cryptography"
 short_desc="Python package for working with various version of ansible"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
 homepage="https://github.com/ansible/ansible-compat"
-distfiles="${PYPI_SITE}/a/ansible-compat/ansible-compat-${version}.tar.gz"
-checksum=2be8c7b510d2e15eed1e9ef443209d67d9aec8f427026b88936d4535ff59863d
+distfiles="${PYPI_SITE}/a/ansible-compat/ansible_compat-${version}.tar.gz"
+checksum=9ff20245e1bd9de9b23a367902524ab0e11fbcfb741831996da5da5b60ab95df
 
 post_patch() {
 	export SETUPTOOLS_SCM_PRETEND_VERSION="${version}"

--- a/srcpkgs/python3-ansible-lint/template
+++ b/srcpkgs/python3-ansible-lint/template
@@ -1,12 +1,16 @@
 # Template file for 'python3-ansible-lint'
 pkgname=python3-ansible-lint
-version=6.22.1
+version=24.9.2
 revision=1
 build_style=python3-pep517
 hostmakedepends="python3-wheel python3-setuptools_scm"
 depends="python3-ansible-compat ansible-core black python3-filelock
- python3-jsonschema python3-packaging python3-yaml python3-rich
- python3-ruamel.yaml python3-wcmatch python3-yamllint"
+ python3-importlib_metadata python3-jsonschema python3-packaging
+ python3-pathspec python3-yaml python3-rich python3-ruamel.yaml
+ python3-subprocess-tee python3-wcmatch python3-yamllint"
+checkdepends="${depends} python3-jmespath python3-license-expression
+ python3-mypy python3-netaddr pylint
+ python3-pytest python3-pytest-mock python3-pytest-xdist"
 short_desc="Linter for Ansible files"
 maintainer="Orphaned <orphan@voidlinux.org>"
 # Note about licensing from upstream:
@@ -16,8 +20,8 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 # contributions made are accepted as being made under original MIT license.
 license="GPL-3.0-only"
 homepage="https://github.com/ansible/ansible-lint"
-distfiles="${PYPI_SITE}/a/ansible-lint/ansible-lint-${version}.tar.gz"
-checksum=d4a3116e0726b98ffbc253f35c5ede98bee546d72d9c363f65e6e79467784d15
+distfiles="${PYPI_SITE}/a/ansible-lint/ansible_lint-${version}.tar.gz"
+checksum=7cff6c5af10ef996b7c6010cbd48c91592764ae098f2b05408726899a1066a7f
 # cba anymore, the list of failing tests changes with every update
 make_check="no"
 


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **yes**

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc, x86_64-musl

#### Note

Basically a dep refresh, and I adapted template to fit the new upstream versioning scheme.
- ansible-lint
  - [requirements.in](https://github.com/ansible/ansible-lint/blob/v24.9.2/.config/requirements.in) & [requirements-test.in](https://github.com/ansible/ansible-lint/blob/v24.9.2/.config/requirements-test.in)
  - [large diff](https://github.com/ansible/ansible-lint/compare/v6.22.1...v24.9.2#diff-c339908dfbcdd2133009c338990a2cb3e73d9c32aa9cf41d3a4469d589e8a176)
  - like previous comment in template said, test suite does not work well, but most tests pass so it should be fine.

<details><summary>Test summary with `make_check=ci-skip`</summary>
<p>

```python
=========================== short test summary info ============================
FAILED .xbps-testdir/1727148759/usr/lib/python3.12/site-packages/ansiblelint/rules/loop_var_prefix.py::test_loop_var_prefix[fail]
FAILED .xbps-testdir/1727148759/usr/lib/python3.12/site-packages/ansiblelint/rules/loop_var_prefix.py::test_loop_var_prefix[pass]
FAILED test/test_file_utils.py::test_normpath_path[resolve-symlink] - Asserti...
FAILED test/rules/test_syntax_check.py::test_syntax_check_role - AssertionErr...
FAILED .xbps-testdir/1727148759/usr/lib/python3.12/site-packages/ansiblelint/rules/role_name.py::test_role_name_path[fail]
FAILED .xbps-testdir/1727148759/usr/lib/python3.12/site-packages/ansiblelint/rules/var_naming.py::test_var_naming_with_role_prefix_plays
FAILED test/test_include_miss_file_with_role.py::test_cases_warning_message
FAILED test/test_rules_collection.py::test_rules_id_format - AssertionError: ...
FAILED test/test_include_miss_file_with_role.py::test_cases_that_do_not_report[inplace]
FAILED test/test_skip_inside_yaml.py::test_role_tasks_with_block - assert 1 == 4
FAILED test/test_runner.py::test_include_wrong_syntax[3] - assert 45 == 2
FAILED test/test_include_miss_file_with_role.py::test_cases_that_do_not_report[relative]
FAILED test/test_schemas.py::test_spdx - Failed: SPDX license list inside gal...
FAILED test/test_app.py::test_generate_ignore - AssertionError: assert 'vars....
FAILED test/test_transformer.py::test_transformer[multiline_msg_with_indent_indicator]
FAILED test/test_transformer.py::test_transformer[strings] - assert '---\n# M...
FAILED test/test_transformer.py::test_transformer[no_jinja_when] - assert 64 ...
FAILED test/test_task_includes.py::test_included_tasks[role_with_task_inclusions]
FAILED test/test_yaml_utils.py::test_fmt[13] - AssertionError: assert '---\nW...
FAILED test/test_main.py::test_call_from_outside_venv[normal] - FileNotFoundE...
FAILED test/test_main.py::test_call_from_outside_venv[isolated] - FileNotFoun...
FAILED test/test_main.py::test_nodeps[1] - FileNotFoundError: [Errno 2] No su...
FAILED test/test_main.py::test_nodeps[2] - FileNotFoundError: [Errno 2] No su...
FAILED test/test_main.py::test_broken_ansible_cfg - FileNotFoundError: [Errno...
ERROR .xbps-testdir/1727149049/usr/lib/python3.12/site-packages/ansiblelint/rules
ERROR .xbps-testdir/1727149049/usr/lib/python3.12/site-packages/ansiblelint/rules
ERROR .xbps-testdir/1727149049/usr/lib/python3.12/site-packages/ansiblelint/rules
ERROR .xbps-testdir/1727149049/usr/lib/python3.12/site-packages/ansiblelint/rules
ERROR .xbps-testdir/1727149049/usr/lib/python3.12/site-packages/ansiblelint/rules
ERROR .xbps-testdir/1727149049/usr/lib/python3.12/site-packages/ansiblelint/rules
ERROR .xbps-testdir/1727149049/usr/lib/python3.12/site-packages/ansiblelint/rules
ERROR .xbps-testdir/1727151241/usr/lib/python3.12/site-packages/ansiblelint/rules
ERROR .xbps-testdir/1727151241/usr/lib/python3.12/site-packages/ansiblelint/rules
ERROR .xbps-testdir/1727151241/usr/lib/python3.12/site-packages/ansiblelint/rules
ERROR .xbps-testdir/1727151241/usr/lib/python3.12/site-packages/ansiblelint/rules
ERROR .xbps-testdir/1727151241/usr/lib/python3.12/site-packages/ansiblelint/rules
ERROR .xbps-testdir/1727151241/usr/lib/python3.12/site-packages/ansiblelint/rules
ERROR .xbps-testdir/1727151241/usr/lib/python3.12/site-packages/ansiblelint/rules
ERROR .xbps-testdir/1727149049/usr/lib/python3.12/site-packages/ansiblelint/rules
ERROR .xbps-testdir/1727151241/usr/lib/python3.12/site-packages/ansiblelint/rules
ERROR src/ansiblelint/rules - ValueError: Plugin already registered under a d...
ERROR src/ansiblelint/rules - ValueError: Plugin already registered under a d...
ERROR src/ansiblelint/rules - ValueError: Plugin already registered under a d...
ERROR src/ansiblelint/rules - ValueError: Plugin already registered under a d...
ERROR src/ansiblelint/rules - ValueError: Plugin already registered under a d...
ERROR src/ansiblelint/rules - ValueError: Plugin already registered under a d...
ERROR src/ansiblelint/rules - ValueError: Plugin already registered under a d...
ERROR src/ansiblelint/rules - ValueError: Plugin already registered under a d...
============= 24 failed, 869 passed, 24 errors in 87.10s (0:01:27) =============
=> ERROR: python3-ansible-lint-24.9.2_1: do_check: 'PATH="${testdir}/usr/bin:${PATH}" PYTHONPATH="${testdir}/${py3_sitelib}" PY_IGNORE_IMPORTMISMATCH=1 ${make_check_pre} pytest3 ${testjobs} ${make_check_args} ${make_check_target}' exited with 1        
=> ERROR:   in do_check() at common/build-style/python3-pep517.sh:36 
```

</p>
</details> 

- ansible-compat
  - [requirements.in](https://github.com/ansible/ansible-compat/blob/v24.9.1/.config/requirements.in) & [requirements-test.in](https://github.com/ansible/ansible-compat/blob/v24.9.1/.config/requirements-test.in)
  - [large diff](https://github.com/ansible/ansible-compat/compare/v4.1.10...v24.9.1#diff-6738f408eb17f7b7773b9565b5623db4664203921d2a78acead5f39cc0621dca)
  - this one is well tested

<details><summary>Test log</summary>
<p>

```python
=> xbps-src: updating repositories for host (x86_64)...
[*] Updating repository `https://repo-default.voidlinux.org/current/bootstrap/x86_64-repodata' ...
[*] Updating repository `https://repo-default.voidlinux.org/current/x86_64-repodata' ...
[*] Updating repository `https://repo-default.voidlinux.org/current/nonfree/x86_64-repodata' ...
[*] Updating repository `https://repo-default.voidlinux.org/current/debug/x86_64-repodata' ...
[*] Updating repository `https://repo-default.voidlinux.org/current/multilib/bootstrap/x86_64-repodata' ...
[*] Updating repository `https://repo-default.voidlinux.org/current/multilib/x86_64-repodata' ...
[*] Updating repository `https://repo-default.voidlinux.org/current/multilib/nonfree/x86_64-repodata' ...
=> xbps-src: updating software in / masterdir...
=> xbps-src: cleaning up / masterdir...
=> python3-ansible-compat-24.9.1_1: removing autodeps, please wait...
=> python3-ansible-compat-24.9.1_1: building with [python3-pep517] [python3] for x86_64...
   [host] python3-wheel-0.44.0_1: found (https://repo-default.voidlinux.org/current)
   [host] python3-setuptools_scm-8.1.0_1: found (https://repo-default.voidlinux.org/current)
   [host] python3-build-1.2.2_1: found (https://repo-default.voidlinux.org/current)
   [host] python3-installer-0.7.0_2: found (https://repo-default.voidlinux.org/current)
   [check] ansible-core-2.17.4_1: found (https://repo-default.voidlinux.org/current)
   [check] python3-jsonschema-4.23.0_1: found (https://repo-default.voidlinux.org/current)
   [check] python3-subprocess-tee-0.4.1_2: found (https://repo-default.voidlinux.org/current)
   [check] python3-yaml-6.0.2_1: found (https://repo-default.voidlinux.org/current)
   [check] python3-pytest-8.3.1_1: found (https://repo-default.voidlinux.org/current)
   [check] python3-pytest-mock-3.14.0_1: found (https://repo-default.voidlinux.org/current)
   [runtime] ansible-core-2.17.4_1: found (https://repo-default.voidlinux.org/current)
   [runtime] python3-jsonschema-4.23.0_1: found (https://repo-default.voidlinux.org/current)
   [runtime] python3-subprocess-tee-0.4.1_2: found (https://repo-default.voidlinux.org/current)
   [runtime] python3-yaml-6.0.2_1: found (https://repo-default.voidlinux.org/current)
=> python3-ansible-compat-24.9.1_1: installing host dependencies: python3-wheel-0.44.0_1 python3-setuptools_scm-8.1.0_1 python3-build-1.2.2_1 python3-installer-0.7.0_2 ansible-core-2.17.4_1 python3-jsonschema-4.23.0_1 python3-subprocess-tee-0.4.1_2 python3-yaml-6.0.2_1 python3-pytest-8.3.1_1 python3-pytest-mock-3.14.0_1 ...
=> python3-ansible-compat-24.9.1_1: running do_check ...
============================= test session starts ==============================
platform linux -- Python 3.12.6, pytest-8.3.1, pluggy-1.5.0
rootdir: /builddir/python3-ansible-compat-24.9.1
configfile: pyproject.toml
testpaths: test
plugins: mock-3.14.0
collected 108 items

test/test_api.py .                                                       [  0%]
test/test_config.py ..........                                           [ 10%]
test/test_configuration_example.py .                                     [ 11%]
test/test_loaders.py .                                                   [ 12%]
test/test_prerun.py .                                                    [ 12%]
test/test_runtime.py ................................................... [ 60%]
...................................                                      [ 92%]
test/test_runtime_example.py .                                           [ 93%]
test/test_runtime_scan_path.py ..                                        [ 95%]
test/test_schema.py ...                                                  [ 98%]
test/test_types.py .                                                     [ 99%]
test/test_version.py .                                                   [100%]

======================= 108 passed in 152.97s (0:02:32) ========================
```

</p>
</details> 
