### PR TITLE
xinput_calibrator: update to 0.8.0, fix distfile

### DIFF
--- a/srcpkgs/xinput_calibrator/patches/no-update-desktopdb.patch
+++ b/srcpkgs/xinput_calibrator/patches/no-update-desktopdb.patch
@@ -1,0 +1,11 @@
+Desktop database update is handled by update-desktopdb XBPS trigger already.
+--- a/meson.build
++++ b/meson.build
+@@ -110,7 +110,3 @@
+     'scripts/xinput_calibrator.xpm',
+     install_dir: get_option('datadir') / 'pixmaps'
+ )
+-
+-gnome.post_install(
+-    update_desktop_database: true,
+-)

--- a/srcpkgs/xinput_calibrator/template
+++ b/srcpkgs/xinput_calibrator/template
@@ -1,16 +1,16 @@
 # Template file for 'xinput_calibrator'
 pkgname=xinput_calibrator
-version=0.7.5
-revision=3
-build_style=gnu-configure
+version=0.8.0
+revision=1
+build_style=meson
 hostmakedepends="pkg-config"
 makedepends="libXrandr-devel libXi-devel"
 short_desc="Utility to calibrate X input devices"
 maintainer="Michael Aldridge <maldridge@voidlinux.org>"
 license="X11"
-homepage="http://www.freedesktop.org/wiki/Software/xinput_calibrator"
-distfiles="http://github.com/downloads/tias/xinput_calibrator/$pkgname-$version.tar.gz"
-checksum=baa4ddca49ec94c27ba4c715bfa26692fec1132103e927213c3169e475d3d971
+homepage="https://www.freedesktop.org/wiki/Software/xinput_calibrator"
+distfiles="https://xorg.freedesktop.org/archive/individual/app/xinput_calibrator-${version}.tar.xz"
+checksum=0508bf9705c0945f746b8c81bfc8d583a347dd067b58fa76b1aed4225e4b8b40
 
 post_install() {
 	vlicense COPYING LICENSE


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->
related to #52319

#### Testing the changes
- I tested the changes in this PR: **NO**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
