### PR TITLE
gst-rtsp-server: update to 1.24.8.

### DIFF
--- a/srcpkgs/gst-rtsp-server/template
+++ b/srcpkgs/gst-rtsp-server/template
@@ -1,6 +1,6 @@
 # Template file for 'gst-rtsp-server'
 pkgname=gst-rtsp-server
-version=1.24.6
+version=1.24.8
 revision=1
 build_style=meson
 build_helper=gir
@@ -14,7 +14,7 @@ license="LGPL-2.1-or-later"
 homepage="https://gstreamer.freedesktop.org"
 changelog="https://gstreamer.freedesktop.org/releases/${version%.*}/#${version}"
 distfiles="https://gstreamer.freedesktop.org/src/gst-rtsp-server/gst-rtsp-server-${version}.tar.xz"
-checksum=b0bdda26173f13f5521c829367963824a74fd0ce8f52bcab674d7e727f74e93c
+checksum=84ed2b34b8f581a418d8ab8eff7657635fcf83c8960f27065c6c47e52836ed02
 
 gst-rtsp-server-devel_package() {
 	depends="${sourcepkg}>=${version}_${revision} gst-plugins-base1-devel"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES
<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)
<!--
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
