### PR TITLE
libsoup3: update to 3.6.0

### DIFF
--- a/srcpkgs/libsoup3/template
+++ b/srcpkgs/libsoup3/template
@@ -1,6 +1,6 @@
 # Template file for 'libsoup3'
 pkgname=libsoup3
-version=3.4.2
+version=3.6.0
 revision=1
 build_style=meson
 build_helper="gir"
@@ -18,7 +18,7 @@ license="LGPL-2.1-or-later"
 homepage="https://wiki.gnome.org/Projects/libsoup"
 changelog="https://gitlab.gnome.org/GNOME/libsoup/-/raw/master/NEWS"
 distfiles="${GNOME_SITE}/libsoup/${version%.*}/libsoup-${version}.tar.xz"
-checksum=78c8fa37cb152d40ec8c4a148d6155e2f6947f3f1602a7cda3a31ad40f5ee2f3
+checksum=62959f791e8e8442f8c13cedac8c4919d78f9120d5bb5301be67a5e53318b4a3
 make_check=ci-skip # can not bind ports in CI
 
 # Package build options


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture: **x86_64-musl**
- I built this PR locally for these architectures:
  - x86_64
  - aarch64-musl
  - aarch64
  - i686
  - i686-musl
  - armv7l
  - armv7l-musl
  - armv6l
  - armv6l-musl

The builds are built the preferred way, i.e. match arch word size and libc in the build environments (for example, aarch64-musl in x86_64-musl, armv6l in i386, etc.).