### PR TITLE
cmake-bootstrap: don't use ninja

### DIFF
--- a/srcpkgs/cmake-bootstrap/template
+++ b/srcpkgs/cmake-bootstrap/template
@@ -3,6 +3,7 @@ pkgname=cmake-bootstrap
 version=3.30.1
 revision=1
 build_style=cmake
+make_cmd="make" # using make to avoid a cycle: cmake-bootstrap -> ninja -> cmake-bootstrap
 configure_args="-DCMake_INSTALL_INFIX=libexec/xbps-src/
  -DCMAKE_SKIP_BOOTSTRAP_TEST=1 -DCMAKE_SKIP_RPATH=OFF
  -DCMAKE_USE_OPENSSL=OFF -DBUILD_CursesDialog=OFF -DBUILD_QtDialog=OFF
@@ -18,6 +19,8 @@ checksum=df9b3c53e3ce84c3c1b7c253e5ceff7d8d1f084ff0673d048f260e04ccb346e1
 repository="bootstrap"
 provides="cmake-${version}_1"
 
+export CMAKE_GENERATOR="Unix Makefiles"
+
 pre_configure() {
 	local f
 	rm -rf build
@@ -26,7 +29,7 @@ pre_configure() {
 	CC=$CC_FOR_BUILD CFLAGS="$CFLAGS_FOR_BUILD" \
 	CXX=$CXX_FOR_BUILD CXXFLAGS="$CXXFLAGS_FOR_BUILD" \
 	LD=$LD_FOR_BUILD LDFLAGS="$LDFLAGS_FOR_BUILD" \
-	../bootstrap --system-libs --generator=Ninja \
+	../bootstrap --system-libs --generator="Unix Makefiles" \
 		${XBPS_MAKEJOBS:+--parallel=$XBPS_MAKEJOBS}
 	# Make sure build directory is clean
 	for f in *; do


### PR DESCRIPTION
using ninja to build cmake-bootstrap causes a cycle

fixes #52351

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

cc @sgn
