### PR TITLE
pimcommon: depend on qt6-plugin-networkinformation

### DIFF
--- a/srcpkgs/pimcommon/template
+++ b/srcpkgs/pimcommon/template
@@ -1,7 +1,7 @@
 # Template file for 'pimcommon'
 pkgname=pimcommon
 version=24.08.1
-revision=1
+revision=2
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins
@@ -18,6 +18,7 @@ makedepends="kf6-ktextwidgets-devel kf6-kcmutils-devel kf6-karchive-devel
  kf6-kxmlgui-devel kf6-purpose-devel kmime6-devel libkdepim-devel kimap-devel
  kpimtextedit-devel ktextaddons-devel kf6-akonadi-devel akonadi-contacts-devel
  kldap-devel akonadi-search-devel"
+depends="qt6-plugin-networkinformation"
 short_desc="Common libraries for KDE PIM"
 maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later, LGPL-2.1-or-later"


### PR DESCRIPTION
Needed for the runtme network reachability check.

Further investigation needed on why qt6-network segfaults without this
(instead of only having missing functionality)
