### PR TITLE
incus: update to 6.6; reverse dependency.

### DIFF
--- a/srcpkgs/incus/files/README.voidlinux
+++ b/srcpkgs/incus/files/README.voidlinux
@@ -1,6 +1,6 @@
 Users wishing to interact with incus system daemons should belong to
-the `_incus-admin` and `_incus` groups. The root user should also be
-assigned a range of subordinate user and group IDs to be mapped in
+either the `_incus-admin` or `_incus` group. The root user should also
+be assigned a range of subordinate user and group IDs to be mapped in
 containers. For example, the command
 
 	usermod --add-subuids 1000000-1065535 \

--- a/srcpkgs/incus/template
+++ b/srcpkgs/incus/template
@@ -1,6 +1,6 @@
 # Template file for 'incus'
 pkgname=incus
-version=6.5.0
+version=6.6.0
 revision=1
 build_style=go
 build_helper=qemu
@@ -11,13 +11,14 @@ make_check_args="-skip TestConvertNetworkConfig"
 hostmakedepends="pkg-config"
 makedepends="lxc-devel acl-devel cowsql-devel raft-devel
  libcap-devel libuv-devel sqlite-devel eudev-libudev-devel"
-depends="lxc acl acl-progs rsync squashfs-tools xz dnsmasq iptables attr-progs"
+depends="lxc acl acl-progs rsync squashfs-tools xz dnsmasq iptables attr-progs
+ ${pkgname}-client-${version}_${revision}"
 short_desc="Powerful system container and virtual machine manager"
 maintainer="dkwo <npiazza@disroot.org>"
 license="Apache-2.0"
 homepage="https://linuxcontainers.org/incus"
 distfiles="https://github.com/lxc/incus/archive/refs/tags/v${version}.tar.gz"
-checksum=aabc762bdcfe210b777e6b78e40150c9ffbc798aa39c8b4ba55812dac3ada0ec
+checksum=0274f6258591a3189737812228722d5c7b0cc57deb5edd0f65750d3323210394
 system_groups="_incus-admin _incus"
 make_dirs="
  /var/lib/incus 0755 root root
@@ -38,6 +39,7 @@ post_install() {
 		vinstall "${f}" 700 usr/libexec/incus && rm "${f}"
 	done
 	vsv incus
+	vsv incus-user
 
 	# avoid conflict with lxd, lxd-lts
 	mv ${DESTDIR}/usr/bin/{fuidshift,fuidshift-incus}
@@ -57,10 +59,8 @@ post_install() {
 
 incus-client_package() {
 	short_desc+=" - client"
-	depends="${sourcepkg}>=${version}_${revision}"
 	pkg_install() {
 		vmove usr/bin/incus
-		vsv incus-user
 		for shell in bash fish zsh; do
 			vcompletion scripts/${shell}-completion ${shell} incus
 		done


### PR DESCRIPTION
incus-client is intended to be installed without the daemon to use to control remove incus servers. incus the daemon can't me used without the client, at least to authorize another client's to access the API.

I moved incus-user to the daemon package because it's a daemon and not part of the client.

readme: I also removed the information about subuid and subgid because void sets these up out of the box.

readme: I changed "and" to "or" because the two groups grant you access to the daemons in different privelege levels.


#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture:
x86_64-glibc
- I built this PR locally for these architectures:
x86_64-musl
(cross) aarch64-musl 
(cross) armv7l
(cross) armv6l-musl

