### PR TITLE
kodi-addon-pvr-hts: update to 21.2.5.

### DIFF
--- a/srcpkgs/kodi-addon-pvr-hts/template
+++ b/srcpkgs/kodi-addon-pvr-hts/template
@@ -1,8 +1,8 @@
 # Template file for 'kodi-addon-pvr-hts'
 pkgname=kodi-addon-pvr-hts
-version=19.0.6
+version=21.2.5
 revision=1
-_kodi_release=Matrix
+_kodi_release=Omega
 build_style=cmake
 makedepends="kodi-devel kodi-platform-devel p8-platform-devel"
 short_desc="Tvheadend HTSP client addon for Kodi"
@@ -10,7 +10,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="https://github.com/kodi-pvr/pvr.hts"
 distfiles="https://github.com/kodi-pvr/pvr.hts/archive/${version}-${_kodi_release}.tar.gz"
-checksum=990e5fd0757d48b86675aa124b77629e7fb2de6b27dcfd6f6ccc7ce181d04aeb
+checksum=c54c249a4c91091e47245b406210224aa4e3c5468497eb9cdeb09cd336cab4b2
 
 if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
 	makedepends+=" musl-legacy-compat"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
