### PR TITLE
kodi-addon-pvr-zattoo: update to 21.0.4.

### DIFF
--- a/srcpkgs/kodi-addon-pvr-zattoo/template
+++ b/srcpkgs/kodi-addon-pvr-zattoo/template
@@ -1,8 +1,8 @@
 # Template file for 'kodi-addon-pvr-zattoo'
 pkgname=kodi-addon-pvr-zattoo
-version=19.7.16
+version=21.0.4
 revision=1
-_kodi_release=Matrix
+_kodi_release=Omega
 build_style=cmake
 hostmakedepends="pkg-config"
 makedepends="kodi-devel kodi-platform-devel p8-platform-devel rapidjson
@@ -13,7 +13,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-only"
 homepage="https://github.com/rbuehlma/pvr.zattoo"
 distfiles="https://github.com/rbuehlma/pvr.zattoo/archive/${version}-${_kodi_release}.tar.gz"
-checksum=ac09db721e51b47f1ca7f4c2201833dbcd69040fd19b09c194fa7491ff4dad41
+checksum=7e1fab309232e7115efa0868c8c3c13c2e7639628ef8bc59a93bf4aa82a3b20d
 
 if [ -n "${CROSS_BUILD}" ]; then
 	configure_args+=" -DCMAKE_MODULE_PATH=${XBPS_CROSS_BASE}/usr/share/kodi/cmake"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **NO**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
