### PR TITLE
kodi-addon-pvr-iptvsimple: update to 21.8.7.

### DIFF
--- a/srcpkgs/kodi-addon-pvr-iptvsimple/template
+++ b/srcpkgs/kodi-addon-pvr-iptvsimple/template
@@ -1,8 +1,8 @@
 # Template file for 'kodi-addon-pvr-iptvsimple'
 pkgname=kodi-addon-pvr-iptvsimple
-version=19.1.0
+version=21.8.7
 revision=1
-_kodi_release=Matrix
+_kodi_release=Omega
 build_style=cmake
 hostmakedepends="pkg-config"
 makedepends="kodi-devel kodi-platform-devel p8-platform-devel pugixml-devel
@@ -12,7 +12,7 @@ maintainer="Alexander Egorenkov <egorenar-dev@posteo.net>"
 license="GPL-2.0-or-later"
 homepage="https://github.com/kodi-pvr/pvr.iptvsimple"
 distfiles="https://github.com/kodi-pvr/pvr.iptvsimple/archive/${version}-${_kodi_release}.tar.gz"
-checksum=c92736b3f3c96fe36d7b20b329c82b47180260e3ed40fc456ef709572fad5fb0
+checksum=fb526d408b5a707c169399aa41e6a111045c4c78d28b4971f4e51ccf02930b4a
 
 if [ -n "${CROSS_BUILD}" ]; then
 	configure_args+=" -DCMAKE_MODULE_PATH=${XBPS_CROSS_BASE}/usr/share/kodi/cmake"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **NO**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
