### PR TITLE
kodi-addon-inputstream-rtmp: update to 21.1.0.

### DIFF
--- a/srcpkgs/kodi-addon-inputstream-rtmp/template
+++ b/srcpkgs/kodi-addon-inputstream-rtmp/template
@@ -1,8 +1,8 @@
 # Template file for 'kodi-addon-inputstream-rtmp'
 pkgname=kodi-addon-inputstream-rtmp
-version=3.4.0
-revision=2
-_kodi_release=Matrix
+version=21.1.0
+revision=1
+_kodi_release=Omega
 build_style=cmake
 hostmakedepends="pkg-config"
 makedepends="kodi-devel kodi-platform-devel p8-platform-devel tinyxml-devel
@@ -12,7 +12,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="https://github.com/xbmc/inputstream.rtmp"
 distfiles="https://github.com/xbmc/inputstream.rtmp/archive/${version}-${_kodi_release}.tar.gz"
-checksum=efaaa9b07c18810582a3826df476fc36a2aac82be7512271545073c3f6cc0212
+checksum=193fabb14cd9d92baecf7319c50ba183bc6254385bf187fe2a726159134df2a9
 
 if [ -n "${CROSS_BUILD}" ]; then
 	configure_args+=" -DCMAKE_MODULE_PATH=${XBPS_CROSS_BASE}/usr/share/kodi/cmake"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **NO**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
