### PR TITLE
python3-keyring: update to 25.4.1.

### DIFF
--- a/srcpkgs/python3-keyring/template
+++ b/srcpkgs/python3-keyring/template
@@ -1,6 +1,6 @@
 # Template file for 'python3-keyring'
 pkgname=python3-keyring
-version=25.3.0
+version=25.4.1
 revision=1
 build_style=python3-pep517
 hostmakedepends="python3-wheel python3-setuptools_scm"
@@ -13,7 +13,7 @@ license="MIT"
 homepage="https://pypi.org/project/keyring/"
 changelog="https://raw.githubusercontent.com/jaraco/keyring/main/NEWS.rst"
 distfiles="${PYPI_SITE}/k/keyring/keyring-${version}.tar.gz"
-checksum=8d85a1ea5d6db8515b59e1c5d1d1678b03cf7fc8b8dcfb1651e8c4a524eb42ef
+checksum=b07ebc55f3e8ed86ac81dd31ef14e81ace9dd9c3d4b5d77a6e9a2016d0d71a1b
 
 pre_check() {
 	vsed -e '/addopts/d' -i pytest.ini


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture: **x86_64**