### PR TITLE
common/build-style/zig-build.sh: add --verbose flag

### DIFF
--- a/common/build-style/zig-build.sh
+++ b/common/build-style/zig-build.sh
@@ -36,6 +36,7 @@ do_build() {
 		--global-cache-dir /host/zig \
 		--libc xbps_zig_libc.txt \
 		--release=safe \
+		--verbose \
 		-Dtarget="${zig_target}" -Dcpu="${zig_cpu}" \
 		install \
 		${configure_args}


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

ATM, the only way to inspect what zig does during build is the `--verbose` flag, especially since it displays most build info in a TUI style that only works in a tty.

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
