### PR TITLE
sonic-visualiser: update to 5.2.1

### DIFF
--- a/common/build-helper/meson.sh
+++ b/common/build-helper/meson.sh
@@ -76,6 +76,8 @@ cat > "${XBPS_WRAPPERDIR}/meson/xbps_meson.cross" <<-EOF
 	cups-config = '${XBPS_CROSS_BASE}/usr/bin/cups-config'
 	qmake6 = 'qmake6'
 	qmake5 = 'qmake5'
+	moc = '/usr/lib/qt6/libexec/moc'
+	rcc = '/usr/lib/qt6/libexec/rcc'
 
 	[properties]
 	needs_exe_wrapper = true

--- a/srcpkgs/sonic-visualiser/patches/svcore-fix.patch
+++ b/srcpkgs/sonic-visualiser/patches/svcore-fix.patch
@@ -1,0 +1,67 @@
+from https://github.com/sonic-visualiser/sonic-visualiser/issues/112
+fixed in https://github.com/sonic-visualiser/svcore/commit/2dee776aad88060d41086c4fb0191ecb0bded86c
+
+diff --git a/data/model/EditableDenseThreeDimensionalModel.cpp b/data/model/EditableDenseThreeDimensionalModel.cpp
+index da5ff904..7a621631 100644
+--- a/svcore/data/model/EditableDenseThreeDimensionalModel.cpp
++++ b/svcore/data/model/EditableDenseThreeDimensionalModel.cpp
+@@ -458,10 +458,10 @@ EditableDenseThreeDimensionalModel::toXml(QTextStream &out,
+     Model::toXml
+         (out, indent,
+          QString("type=\"dense\" dimensions=\"3\" windowSize=\"%1\" yBinCount=\"%2\" minimum=\"%3\" maximum=\"%4\" dataset=\"%5\" startFrame=\"%6\" %7")
+-         .arg(m_resolution)
+-         .arg(m_yBinCount)
+-         .arg(m_minimum)
+-         .arg(m_maximum)
++         .arg(m_resolution.load())
++         .arg(m_yBinCount.load())
++         .arg(m_minimum.load())
++         .arg(m_maximum.load())
+          .arg(getExportId())
+          .arg(m_startFrame)
+          .arg(extraAttributes));
+diff --git a/data/model/NoteModel.h b/data/model/NoteModel.h
+index 8c3a421e..28e145c2 100644
+--- a/svcore/data/model/NoteModel.h
++++ b/svcore/data/model/NoteModel.h
+@@ -403,8 +403,8 @@ class NoteModel : public Model,
+              .arg(m_events.getExportId())
+              .arg(m_subtype == FLEXI_NOTE ? "flexinote" : "note")
+              .arg(m_valueQuantization)
+-             .arg(m_valueMinimum)
+-             .arg(m_valueMaximum)
++             .arg(m_valueMinimum.load())
++             .arg(m_valueMaximum.load())
+              .arg(encodeEntities(m_units))
+              .arg(extraAttributes));
+         
+diff --git a/data/model/RegionModel.h b/data/model/RegionModel.h
+index 916a0477..db021ae7 100644
+--- a/svcore/data/model/RegionModel.h
++++ b/svcore/data/model/RegionModel.h
+@@ -335,8 +335,8 @@ class RegionModel : public Model,
+              .arg(m_events.getExportId())
+              .arg("region")
+              .arg(m_valueQuantization)
+-             .arg(m_valueMinimum)
+-             .arg(m_valueMaximum)
++             .arg(m_valueMinimum.load())
++             .arg(m_valueMaximum.load())
+              .arg(encodeEntities(m_units))
+              .arg(extraAttributes));
+         
+diff --git a/data/model/SparseTimeValueModel.h b/data/model/SparseTimeValueModel.h
+index fe6e70cc..70335038 100644
+--- a/svcore/data/model/SparseTimeValueModel.h
++++ b/svcore/data/model/SparseTimeValueModel.h
+@@ -342,8 +342,8 @@ class SparseTimeValueModel : public Model,
+              .arg("true") // always true after model reaches 100% -
+                           // subsequent events are always notified
+              .arg(m_events.getExportId())
+-             .arg(m_valueMinimum)
+-             .arg(m_valueMaximum)
++             .arg(m_valueMinimum.load())
++             .arg(m_valueMaximum.load())
+              .arg(encodeEntities(m_units))
+              .arg(extraAttributes));
+         

--- a/srcpkgs/sonic-visualiser/template
+++ b/srcpkgs/sonic-visualiser/template
@@ -1,17 +1,18 @@
 # Template file for 'sonic-visualiser'
 pkgname=sonic-visualiser
-version=4.5.2
-revision=4
+version=5.2.1
+revision=1
 build_style=meson
-hostmakedepends="pkg-config capnproto-devel qt5-host-tools"
+hostmakedepends="pkg-config capnproto-devel qt6-base qt6-tools"
 makedepends="capnproto-devel jack-devel libfishsound-devel libid3tag-devel
- liblo-devel liblrdf-devel libmad-devel liboggz-devel libsamplerate-devel
- opusfile-devel portaudio-devel pulseaudio-devel qt5-svg-devel rubberband-devel
- speex-devel sord-devel vamp-plugin-sdk-devel"
+ liblo-devel liblrdf-devel libmad-devel liboggz-devel libopusenc-devel
+ libsamplerate-devel opusfile-devel portaudio-devel pulseaudio-devel
+ qt6-svg-devel rubberband-devel sord-devel speex-devel vamp-plugin-sdk-devel"
 short_desc="Viewing and analysing the contents of music audio files"
 maintainer="newbluemoon <blaumolch@mailbox.org>"
 license="GPL-2.0-or-later"
 homepage="https://www.sonicvisualiser.org/"
 changelog="https://raw.githubusercontent.com/sonic-visualiser/sonic-visualiser/default/CHANGELOG"
 distfiles="https://github.com/sonic-visualiser/sonic-visualiser/releases/download/sv_v${version}/sonic-visualiser-${version}.tar.gz"
-checksum=0816e1ba9e3f97af495ece2554186bccad1cf47090ff8a13f1d08322212db487
+checksum=2f338af0231e930539c5e5e04dac7c3384257866cc29fda112215f8c410898c9
+LDFLAGS+="-lopusenc"

--- a/srcpkgs/sonic-visualiser/update
+++ b/srcpkgs/sonic-visualiser/update
@@ -1,2 +1,1 @@
-site="https://code.soundsoftware.ac.uk/projects/sonic-visualiser/files"
-ignore="*pre*"
+pkgname=sv


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64 (cross)
  - armv7l (cross) --> fails on x86_64, succeedes on i686, see below
  - x86_64-musl
  - i686

There is a problem with 32-bit cross builds on a 64-bit host.
Meson detects Qt6 using pkg-config. However, the corresponding .pc files have
```
prefix=/usr
exec_prefix=${prefix}
bindir=${prefix}/lib32/qt6/bin
libexecdir=${prefix}/lib32/qt6/libexec
libdir=${prefix}/lib
includedir=${prefix}/include/qt6
```
i.e. they have `.../lib32/...` hard coded and so detection of the host tools fails when they are under `.../lib64/...`.

There are not much options to tweak this; using qmake instead of pkg-config yields the same error.

I think a clean solution would be adjusting Qt6’s .pc files to contain `.../lib/...` solely. There shouldn’t be a problem, because `lib32` and `lib64` are symlinks to `lib`, anyway. Everything else I can think of would be quite hacky. I don’t know if this is the only package having this problem; I searched for other templates, but didn’t find anything alike.

Any ideas/suggestions are very welcome :)