### PR TITLE
musikcube: update to 3.0.4

### DIFF
--- a/srcpkgs/musikcube/template
+++ b/srcpkgs/musikcube/template
@@ -1,7 +1,7 @@
 # Template file for 'musikcube'
 pkgname=musikcube
-version=3.0.2
-revision=2
+version=3.0.4
+revision=1
 build_style=cmake
 make_cmd=make
 configure_args="-DNO_NCURSESW=1"
@@ -17,7 +17,7 @@ license="BSD-3-Clause"
 homepage="https://musikcube.com/"
 changelog="https://raw.githubusercontent.com/clangen/musikcube/master/CHANGELOG.txt"
 distfiles="https://github.com/clangen/musikcube/archive/${version}.tar.gz"
-checksum=65f82db36d635bdbfd99f67d1d68c9e1aedf8e38efa627f303cf7971c306d063
+checksum=25bb95b8705d8c79bde447e7c7019372eea7eaed9d0268510278e7fcdb1378a5
 build_options="elogind"
 desc_option_elogind="Support MPRIS interface via elogind"
 build_options_default="elogind"


### PR DESCRIPTION
Simple update, things seemed to compile fine. It targets ffmpeg7 but works correctly with void ffmpeg. 

#### Testing the changes
- I tested the changes in this PR: **briefly**
- I've been listening to music both from local files, and from a remote musikcubed 
-  I've tested the built in pulseaudio and the pipewire plugin.





- I built this PR locally for my native architecture
 x86_64 
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl
  - (cross) aarch64-musl
  - (cross) armv7l
  - (cross) armv6l-musl

