### PR TITLE
gede: update to 2.19.3

### DIFF
--- a/srcpkgs/gede/template
+++ b/srcpkgs/gede/template
@@ -1,18 +1,18 @@
 # Template file for 'gede'
 pkgname=gede
-version=2.18.2
+version=2.19.3
 revision=1
 build_wrksrc=src
 build_style=qmake
 hostmakedepends="python3 qt5-qmake qt5-host-tools"
-makedepends="qt5-devel"
+makedepends="qt5-devel qt5-serialport-devel"
 depends="gdb ctags"
 short_desc="Graphical frontend (GUI) to GDB written in Qt"
 maintainer="Andrea Brancaleoni <abc@pompel.me>"
 license="BSD-2-Clause"
-homepage="http://acidron.com/gede"
+homepage="https://gede.dexar.se"
 distfiles="http://gede.dexar.se/uploads/source/${pkgname}-${version}.tar.xz"
-checksum=416ac31d5fb6b6b97ec0a2a26d68836be915444375d7a3b043a0e899a2a3dcb6
+checksum=f5f685c928207c3eed59eea532a958f136255767086ce907d1c37ab077de415d
 
 do_install() {
 	cd $wrksrc


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, **x86_64**

#### Comments

Changed homepage as the current one is dead (and gede.dexar.se straight up says "welcome to gede homepage")

Opened, ran against dolphin-emu. Nothing beyond that.