### PR TITLE
PopCorn: avoid double runs, use snooze timefile

### DIFF
--- a/srcpkgs/PopCorn/files/popcorn/run
+++ b/srcpkgs/PopCorn/files/popcorn/run
@@ -6,5 +6,9 @@
 : ${PORT:=8001}
 
 exec 2>&1
-chpst -u _popcorn:_popcorn popcorn --server $SERVER --port $PORT
-exec chpst -u _popcorn:_popcorn snooze popcorn --server $SERVER --port $PORT
+
+[ ! -d /var/cache/popcorn ] && mkdir -p /var/cache/popcorn
+chown _popcorn:_popcorn /var/cache/popcorn
+
+exec chpst -u _popcorn:_popcorn snooze -s 1d -t /var/cache/popcorn/snooze -- sh -c \
+	"popcorn --server $SERVER --port $PORT; touch /var/cache/popcorn/snooze"

--- a/srcpkgs/PopCorn/template
+++ b/srcpkgs/PopCorn/template
@@ -1,7 +1,7 @@
 # Template file for 'PopCorn'
 pkgname=PopCorn
 version=0.4
-revision=11
+revision=12
 build_style=go
 go_import_path=github.com/the-maldridge/popcorn
 go_package="${go_import_path}/cmd/popcorn


### PR DESCRIPTION
as discussed on #xbps, current will run twice at the snooze time (snooze invocation, then the chpst invocation) and will always run at system start.  

new only runs at system start if haven't run in last day, and doesn't run twice when snooze fires.

#### Testing the changes
- I tested the changes in this PR: **YES** 

#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
x86_64
