### PR TITLE
sysstat: fix sensors support

### DIFF
--- a/srcpkgs/sysstat/template
+++ b/srcpkgs/sysstat/template
@@ -1,12 +1,13 @@
 # Template file for 'sysstat'
 pkgname=sysstat
 version=12.7.6
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--enable-copy-only --disable-file-attr
- --with-systemdsystemunitdir= --enable-install-cron"
+ --with-systemdsystemunitdir= --enable-install-cron --enable-sensors"
 conf_files="/etc/default/sysstat /etc/default/sysstat.ioconf"
 hostmakedepends="pkg-config gettext"
+makedepends="libsensors-devel"
 depends="lm_sensors"
 short_desc="Collection of performance monitoring tools"
 maintainer="Leah Neukirchen <leah@vuxu.org>"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->
Prior to this change the `sar` command would not show temperature values.  When running `sar -m TEMP` the following message would be displayed:
```
Requested activities not available in file /var/log/sa/sa30
```

After this change and running the following commands `sar` reported temperature values.
```
sudo rm /var/log/sa/sa30
sudo /usr/lib/sa/sa1 1 1
sudo /usr/lib/sa/sa1 1 1
sar -m TEMP
```

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-glibc
