### PR TITLE
kde5, kde5-baseapps: rename 

### DIFF
--- a/srcpkgs/kde-baseapps/template
+++ b/srcpkgs/kde-baseapps/template
@@ -1,13 +1,13 @@
-# Template file for 'kde5-baseapps'
-pkgname=kde5-baseapps
+# Template file for 'kde-baseapps'
+pkgname=kde-baseapps
 version=24.02.0
-revision=2
+revision=3
 build_style=meta
 depends="
 	dolphin>=${version}
 	kate>=${version}
 	konsole>=${version}"
-short_desc="KDE 5 base applications meta-package for Void Linux"
+short_desc="KDE base applications meta-package for Void Linux"
 maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-only"
 homepage="https://www.kde.org"
@@ -15,3 +15,9 @@ homepage="https://www.kde.org"
 if [ "$XBPS_WORDSIZE$XBPS_WORDSIZE" = "64$XBPS_TARGET_WORDSIZE" ]; then
 	depends+=" khelpcenter>=${version}"
 fi
+
+kde5-baseapps_package() {
+	build_style=meta
+	depends="${sourcepkg}>=${version}_${revision}"
+	short_desc+=" (transitional dummy package)"
+}

--- a/srcpkgs/kde-plasma/template
+++ b/srcpkgs/kde-plasma/template
@@ -1,7 +1,7 @@
-# Template file for 'kde5'
-pkgname=kde5
+# Template file for 'kde-plasma'
+pkgname=kde-plasma
 version=6.1.1
-revision=1
+revision=2
 build_style=meta
 depends="bluedevil>=${version}
  breeze-gtk>=${version}
@@ -32,3 +32,9 @@ short_desc="KDE Plasma Desktop meta-package for Void Linux"
 maintainer="John <me@johnnynator.dev>"
 license="Public Domain"
 homepage="https://kde.org/plasma-desktop"
+
+kde5_package() {
+	build_style=meta
+	depends="${sourcepkg}>=${version}_${revision}"
+	short_desc+=" (transitional dummy package)"
+}

--- a/srcpkgs/kde5
+++ b/srcpkgs/kde5
@@ -1,0 +1,1 @@
+kde-plasma

--- a/srcpkgs/kde5-baseapps
+++ b/srcpkgs/kde5-baseapps
@@ -1,0 +1,1 @@
+kde-baseapps


### PR DESCRIPTION
kde is now kde 6, so this is misleading

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

cc @johnnynator
