### PR TITLE
rednotebook: update to 2.35

### DIFF
--- a/srcpkgs/rednotebook/template
+++ b/srcpkgs/rednotebook/template
@@ -1,6 +1,6 @@
 # Template file for 'rednotebook'
 pkgname=rednotebook
-version=2.33
+version=2.35
 revision=1
 build_style=python3-module
 hostmakedepends="python3-setuptools gettext"
@@ -13,4 +13,4 @@ license="GPL-2.0-or-later"
 homepage="https://rednotebook.sourceforge.io"
 changelog="https://raw.githubusercontent.com/jendrikseipp/rednotebook/master/CHANGELOG.md"
 distfiles="https://github.com/jendrikseipp/rednotebook/archive/v${version}.tar.gz"
-checksum=a17952459ad0cc84ae17bdf7e2ae48bbb41b2f12471cbfbc6d780b37194fab2d
+checksum=a30ffde30b2bc746e66ac24f580615a78d68c97fa4853d98a55f9344b8b33742


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**
#### Local build testing
- I built this PR locally for my native architecture, (x86_64-musl)
- I built this PR locally for these architectures:
  - x86_64-glibc
  - i686