### PR TITLE
Wayfire 0.9.0

### DIFF
--- a/srcpkgs/wayfire-plugins-extra/template
+++ b/srcpkgs/wayfire-plugins-extra/template
@@ -1,6 +1,6 @@
 # Template file for 'wayfire-plugins-extra'
 pkgname=wayfire-plugins-extra
-version=0.8.1
+version=0.9.0
 revision=1
 build_style=meson
 hostmakedepends="pkg-config wayland-devel"
@@ -11,7 +11,7 @@ maintainer="Érico Nogueira <ericonr@disroot.org>"
 license="MIT"
 homepage="https://wayfire.org/"
 distfiles="https://github.com/WayfireWM/wayfire-plugins-extra/archive/refs/tags/v${version}.tar.gz"
-checksum=22931376eebb93092828e2fb192facf097de4dc99c8766732f7cabc4e5175feb
+checksum=5fd08387fb02ce541b7f9dfbeefbbef9cd19b2c88347517f40afab4da54b83bf
 
 post_install() {
 	vlicense LICENSE

--- a/srcpkgs/wayfire/template
+++ b/srcpkgs/wayfire/template
@@ -1,26 +1,19 @@
 # Template file for 'wayfire'
 pkgname=wayfire
-version=0.8.1
-revision=2
-_utils_commit=15f8e16721585ae3eaf278ba71d7064237eb23f5
-_touch_commit=8974eb0f6a65464b63dd03b842795cb441fb6403
+version=0.9.0
+revision=1
 build_style=meson
 configure_args="-Dprint_trace=false"
 hostmakedepends="pkg-config wayland-devel"
 makedepends="wf-config-devel wlroots0.17-devel cairo-devel pango-devel json-c++
- $(vopt_if image 'libjpeg-turbo-devel libpng-devel')"
+ libgomp-devel $(vopt_if image 'libjpeg-turbo-devel libpng-devel')"
 depends="xorg-server-xwayland"
 short_desc="3D wayland compositor"
 maintainer="Érico Nogueira <ericonr@disroot.org>"
 license="MIT"
 homepage="https://wayfire.org"
-distfiles="https://github.com/WayfireWM/wayfire/archive/refs/tags/v${version}.tar.gz
- https://github.com/WayfireWM/wf-utils/archive/${_utils_commit}.tar.gz
- https://github.com/WayfireWM/wf-touch/archive/${_touch_commit}.tar.gz"
-checksum="04f43df21167db15d266f7e01085b111680d57779ebc27a410201f995b33c6df
- 5f0a0f523b29bd73e0f11d63079315d3a0a3c3cae6ce9b557e0433e25b5a0d92
- 09061c8a4d3d964e8dcfd1a7b97f7dc43d0fc30743b0993585439c6923ce422f"
-skip_extraction="${_utils_commit}.tar.gz ${_touch_commit}.tar.gz"
+distfiles="https://github.com/WayfireWM/wayfire/releases/download/v${version}/wayfire-${version}.tar.xz"
+checksum=dd0c9c08b8a72a2d8c3317c8be6c42b17a493c25abab1d02ac09c24eaa95229d
 
 # Optimization for nested STL calls
 CXXFLAGS="-O3"
@@ -33,11 +26,6 @@ desc_option_image="Enable JPEG and PNG support"
 if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
 	makedepends+=" libexecinfo-devel"
 fi
-
-post_extract() {
-	vsrcextract -C subprojects/wf-utils "${_utils_commit}.tar.gz"
-	vsrcextract -C subprojects/wf-touch "${_touch_commit}.tar.gz"
-}
 
 post_install() {
 	vlicense LICENSE

--- a/srcpkgs/wcm/template
+++ b/srcpkgs/wcm/template
@@ -1,6 +1,6 @@
 # Template file for 'wcm'
 pkgname=wcm
-version=0.8.0
+version=0.9.0
 revision=1
 build_style=meson
 configure_args="-Denable_wdisplays=false"
@@ -11,7 +11,7 @@ maintainer="Érico Nogueira <ericonr@disroot.org>"
 license="MIT"
 homepage="https://wayfire.org/"
 distfiles="https://github.com/WayfireWM/wcm/archive/v${version}.tar.gz"
-checksum=24000f5d037dc03eed9eaf2803987db5e02c1776bbe7c56b9c95c5942f65938f
+checksum=35205c165b83ac387235b0415f58f0e80a8975421de23250c7cb70c471aeee87
 
 post_install() {
 	vlicense LICENSE

--- a/srcpkgs/wf-config/template
+++ b/srcpkgs/wf-config/template
@@ -1,6 +1,6 @@
 # Template file for 'wf-config'
 pkgname=wf-config
-version=0.8.0
+version=0.9.0
 revision=1
 build_style=meson
 hostmakedepends="pkg-config"
@@ -10,7 +10,7 @@ maintainer="Young Jin Park <youngjinpark20@gmail.com>"
 license="MIT"
 homepage="https://wayfire.org"
 distfiles="https://github.com/WayfireWM/wf-config/archive/v${version}.tar.gz"
-checksum=5b69ab8886e2b0e9c5bffa65c5c676c2848fbcc0e67201886a5f2fdd354e25fb
+checksum=973a47795d3397d281d89c561903867f691c9fe8c3d141ba887afd12902c790d
 
 post_install() {
 	vlicense LICENSE

--- a/srcpkgs/wf-recorder/template
+++ b/srcpkgs/wf-recorder/template
@@ -1,11 +1,11 @@
 # Template file for 'wf-recorder'
 pkgname=wf-recorder
 version=0.5.0
-revision=1
+revision=2
 build_style=meson
 hostmakedepends="pkg-config scdoc wayland-devel"
-makedepends="wayland-protocols wayland-devel ffmpeg6-devel libgbm-devel x264-devel
- pulseaudio-devel libdrm-devel"
+makedepends="wayland-protocols wayland-devel libgbm-devel libdrm-devel
+ ffmpeg6-devel x264-devel pulseaudio-devel pipewire-devel"
 short_desc="Screen recorder for wlroots-based compositors"
 maintainer="Jony <maybe-one-day-ubermensch@protonmail.com>"
 license="MIT"

--- a/srcpkgs/wf-shell/template
+++ b/srcpkgs/wf-shell/template
@@ -1,18 +1,18 @@
 # Template file for 'wf-shell'
 pkgname=wf-shell
-version=0.8.1
+version=0.9.0
 revision=1
 build_style=meson
 build_helper="gir"
-hostmakedepends="gobject-introspection pkg-config wayland-devel"
+hostmakedepends="gobject-introspection pkg-config wayland-devel glib-devel"
 makedepends="alsa-lib-devel pulseaudio-devel gtkmm-devel wayfire-devel
- gtk+3-devel gtk-layer-shell-devel libdbusmenu-gtk3-devel"
+ gtk-layer-shell-devel libdbusmenu-gtk3-devel"
 short_desc="Wayfire shell with GTK-based panel and background client"
 maintainer="Young Jin Park <youngjinpark20@gmail.com>"
 license="MIT"
 homepage="https://wayfire.org"
 distfiles="https://github.com/WayfireWM/wf-shell/releases/download/v${version}/wf-shell-${version}.tar.xz"
-checksum=c54cb0685f55fa44a62c55b1b64f81630b787b0e67813486ae85921fb5f79b38
+checksum=c8ac529b9fa6a4f65bd430140394b6b6a486c7b2def6c22b811396612ba94bb4
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**, but want to daily drive it for a bit first.

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->

I don't know what caused the gvc config error in wf-shell, so accepting suggestions... A more complete log (their meson assumes libpulse found means gvc was found, that's why the error at the bottom happens):

```
Executing subproject gvc

gvc| Project name: gvc
gvc| Project version: undefined
gvc| C compiler for the host machine: cc (gcc 13.2.0 "cc (GCC) 13.2.0")
gvc| C linker for the host machine: cc ld.bfd 2.41
gvc| Build-time dependency glib-2.0 found: YES 2.82.1
gvc| Program /usr/bin/glib-mkenums found: NO

gvc| subprojects/gvc/meson.build:30:21: Exception: Dependency 'glib-2.0' tool variable 'glib_mkenums' contains erroneous value: '/usr/bin/glib-mkenums'

gvc| This is a distributor issue -- please report it to your glib-2.0 provider.

Subproject subprojects/gvc is buildable: NO (disabling)

Executing subproject wayland-logout

wayland-logout| Project name: wayland-logout
wayland-logout| Project version: 1.0
wayland-logout| C compiler for the host machine: cc (gcc 13.2.0 "cc (GCC) 13.2.0")
wayland-logout| C linker for the host machine: cc ld.bfd 2.41
wayland-logout| Build targets in project: 1
wayland-logout| Subproject wayland-logout finished.


meson.build:31:18: ERROR: Subproject "subprojects/gvc" disabled can't get_variable on it.

A full log can be found at /builddir/wf-shell-0.9.0/build/meson-logs/meson-log.txt
=> ERROR: wf-shell-0.9.0_1: do_configure: '${meson_cmd} setup --prefix=/usr --libdir=/usr/lib${XBPS_TARGET_WORDSIZE} --libexecdir=/usr/libexec --bindir=/usr/bin --sbindir=/usr/bin --includedir=/usr/include --datadir=/usr/share --mandir=/usr/share/man --infodir=/usr/share/info --localedir=/usr/share/locale --sysconfdir=/etc --localstatedir=/var --sharedstatedir=/var/lib --buildtype=plain --auto-features=auto --wrap-mode=nodownload -Db_lto=true -Db_ndebug=true -Db_staticpic=true ${configure_args} . ${meson_builddir}' exited with 1
=> ERROR:   in do_configure() at common/build-style/meson.sh:23
```