### PR TITLE
mate-panel: fix strftime on musl

### DIFF
--- a/srcpkgs/mate-panel/patches/musl-strftime.patch
+++ b/srcpkgs/mate-panel/patches/musl-strftime.patch
@@ -1,0 +1,40 @@
+--- a/applets/clock/clock-location-tile.c
++++ b/applets/clock/clock-location-tile.c
+@@ -434,7 +434,7 @@ format_time (struct tm   *now,
+                          * weekday differs from the weekday at the location
+                          * (the %A expands to the weekday). The %p expands to
+                          * am/pm. */
+-                        format = _("%l:%M <small>%p (%A)</small>");
++                        format = _("%_I:%M <small>%p (%A)</small>");
+                 }
+                 else {
+                         /* Translators: This is a strftime format string.
+@@ -451,7 +451,7 @@ format_time (struct tm   *now,
+                          * It is used to display the time in 12-hours format
+                          * (eg, like in the US: 8:10 am). The %p expands to
+                          * am/pm. */
+-                        format = _("%l:%M <small>%p</small>");
++                        format = _("%_I:%M <small>%p</small>");
+                 }
+                 else {
+                         /* Translators: This is a strftime format string.
+@@ -497,7 +497,7 @@ convert_time_to_str (time_t now, ClockFo
+                  * It is used to display the time in 12-hours format (eg, like
+                  * in the US: 8:10 am). The %p expands to am/pm.
+                  */
+-                format = _("%l:%M %p");
++                format = _("%_I:%M %p");
+         }
+         else {
+                 /* Translators: This is a strftime format string.
+--- a/applets/clock/clock.c
++++ b/applets/clock/clock.c
+@@ -458,7 +458,7 @@ get_updated_timeformat (ClockData *cd)
+                 /* Translators: This is a strftime format string.
+                  * It is used to display the time in 12-hours format (eg, like
+                  * in the US: 8:10 am). The %p expands to am/pm. */
+-                time_format = cd->showseconds ? _("%l:%M:%S %p") : _("%l:%M %p");
++                time_format = cd->showseconds ? _("%_I:%M:%S %p") : _("%_I:%M %p");
+         else
+                 /* Translators: This is a strftime format string.
+                  * It is used to display the time in 24-hours format (eg, like

--- a/srcpkgs/mate-panel/template
+++ b/srcpkgs/mate-panel/template
@@ -1,7 +1,7 @@
 # Template file for 'mate-panel'
 pkgname=mate-panel
 version=1.28.2
-revision=1
+revision=2
 build_style=gnu-configure
 build_helper="gir"
 configure_args="--disable-static --disable-schemas-compile


### PR DESCRIPTION
Fix: #52494

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**|**briefly**|**NO**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
