### PR TITLE
nvidia-container-toolkit: Add nvidia-cdi-hook as part of build to fix NVIDIA container support via CDI

### DIFF
--- a/srcpkgs/nvidia-container-toolkit/template
+++ b/srcpkgs/nvidia-container-toolkit/template
@@ -1,13 +1,14 @@
 # Template file for 'nvidia-container-toolkit'
 pkgname=nvidia-container-toolkit
 version=1.16.1
-revision=2
+revision=3
 archs="x86_64"
 build_style=go
 go_import_path=github.com/NVIDIA/nvidia-container-toolkit
 go_package="${go_import_path}/cmd/nvidia-container-runtime-hook
  ${go_import_path}/cmd/nvidia-container-runtime
- ${go_import_path}/cmd/nvidia-ctk"
+ ${go_import_path}/cmd/nvidia-ctk
+ ${go_import_path}/cmd/nvidia-cdi-hook"
 depends="libnvidia-container"
 short_desc="Build and run containers leveraging NVIDIA GPUs"
 maintainer="Quentin Freimanis <quentinfreimanis@gmail.com>"


### PR DESCRIPTION
Fixes the following error when trying to start a Podman container with an NVIDIA GPU attached:

```
Error: unable to start container: runc: runc create failed: unable to start container process: error during container init: error running hook #0: fork/exec /usr/bin/nvidia-cdi-hook: no such file or directory: OCI runtime attempted to invoke a command that was not found
```

And this warning when running `nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml`:

```
WARN[0000] Failed to locate nvidia-cdi-hook: pattern nvidia-cdi-hook not found
```

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
