### PR TITLE
New package: radicle-1.0.0

### DIFF
--- a/srcpkgs/radicle-httpd/template
+++ b/srcpkgs/radicle-httpd/template
@@ -1,0 +1,27 @@
+# Template file for 'radicle-httpd'
+pkgname=radicle-httpd
+version=0.17.1
+revision=1
+build_wrksrc="radicle-httpd"
+build_style=cargo
+hostmakedepends="git pkg-config"
+makedepends="libgit2-1.8-devel"
+short_desc="HTTP API server for Radicle"
+maintainer="Leah Neukirchen <leah@vuxu.org>"
+license="MIT, Apache-2.0"
+homepage="https://app.radicle.xyz/nodes/ash.radicle.garden/rad:z4V1sjrXqjvFdnCUbxPFqd5p4DtH5"
+_gitrepo="https://seed.radicle.xyz/z4V1sjrXqjvFdnCUbxPFqd5p4DtH5.git"
+_gitrev="f815b2dbca9ae151d0fa5c597f870e418f57f134"
+
+do_fetch() {
+	rm -rf ${wrksrc}
+	git clone ${_gitrepo} ${wrksrc}
+	cd ${wrksrc}
+	git checkout ${_gitrev}
+}
+
+post_install() {
+	vlicense LICENSE-MIT
+}
+
+# We don't package the UI, as it requires configuration before "vite build".

--- a/srcpkgs/radicle/patches/rlim_t.patch
+++ b/srcpkgs/radicle/patches/rlim_t.patch
@@ -1,0 +1,19 @@
+diff --git a/radicle/src/io.rs b/radicle/src/io.rs
+index 8af88728..7e319ef4 100644
+--- a/radicle/src/io.rs
++++ b/radicle/src/io.rs
+@@ -1,12 +1,9 @@
+ use std::fmt;
+ use std::io;
+ 
+-use libc::{getrlimit, rlimit, setrlimit, RLIMIT_NOFILE};
++use libc::{getrlimit, rlim_t, rlimit, setrlimit, RLIMIT_NOFILE};
+ 
+-#[cfg(not(target_os = "freebsd"))]
+-type Int = u64;
+-#[cfg(target_os = "freebsd")]
+-type Int = i64;
++type Int = rlim_t;
+ 
+ /// Sets the open file limit to the given value, or the maximum allowed value.
+ pub fn set_file_limit<N>(n: N) -> io::Result<Int>

--- a/srcpkgs/radicle/template
+++ b/srcpkgs/radicle/template
@@ -1,0 +1,49 @@
+# Template file for 'radicle'
+pkgname=radicle
+version=1.0.0
+revision=1
+build_style=cargo
+make_build_args="--workspace"
+hostmakedepends="git ruby-asciidoctor pkg-config"
+makedepends="libgit2-1.8-devel"
+depends="git"
+short_desc="Peer-to-peer, local-first code collaboration stack built on Git"
+maintainer="Leah Neukirchen <leah@vuxu.org>"
+license="MIT, Apache-2.0"
+homepage="https://radicle.xyz/"
+_gitrepo="https://seed.radicle.xyz/z3gqcJUoA1n9HaHKufZs5FCSGazv5"
+_gitrev="d39ba83cfc7c7685548d18652fef039e25b19276"
+
+export RADICLE_VERSION=${version}
+
+do_fetch() {
+	rm -rf ${wrksrc}
+	git clone ${_gitrepo} ${wrksrc}
+	cd ${wrksrc}
+	git fetch origin ${_gitrev}
+	git checkout FETCH_HEAD
+}
+
+post_build() {
+	scripts/build-man-pages.sh . *.adoc
+}
+
+do_check() {
+	:
+}
+
+do_install() {
+	for crate in radicle-cli radicle-node radicle-remote-helper; do
+		cargo auditable install --target ${RUST_TARGET} \
+			--root="${DESTDIR}/usr" --offline --locked \
+			--path=${crate}
+	done
+
+	rm -f ${DESTDIR}/usr/.crates*
+
+	for f in *.1; do
+		vman $f
+	done
+
+	vlicense LICENSE-MIT
+}


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: YES

This package violates our general guidelines by checking out source code from Git in `do_build`.
I encouraged upstream to provide tarballs in the future.

The httpd doesn't include the JS frontend, as the frontend configuration leaks into the compiled JS.

Couldn't figure out why the tests break in CI yet, seems to be a confusion between build and release targets.

Closes #9791.
Closes #52170.