### PR TITLE
libedit: update to 20240808.3.1.

### DIFF
--- a/srcpkgs/libedit/template
+++ b/srcpkgs/libedit/template
@@ -1,6 +1,6 @@
 # Template file for 'libedit'
 pkgname=libedit
-version=20240517.3.1
+version=20240808.3.1
 revision=1
 build_style=gnu-configure
 # only check if man support nroff format
@@ -12,12 +12,10 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="BSD-3-Clause"
 homepage="https://www.thrysoee.dk/editline/"
 distfiles="https://www.thrysoee.dk/editline/libedit-${version%%.*}-${version#*.}.tar.gz"
-checksum=3a489097bb4115495f3bd85ae782852b7097c556d9500088d74b6fa38dbd12ff
+checksum=5f0573349d77c4a48967191cdd6634dd7aa5f6398c6a57fe037cc02696d6099f
 
 post_install() {
 	vlicense COPYING
-	# history.3 conflicts with readline-devel
-	rm ${DESTDIR}/usr/share/man/man3/history.3
 }
 
 libedit-devel_package() {


### PR DESCRIPTION
Manpage links were renamed to el_*
e.g. history.3 is now el_history.3

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
