### PR TITLE
libcotp: update to 3.1.0

### DIFF
--- a/srcpkgs/libcotp/template
+++ b/srcpkgs/libcotp/template
@@ -1,6 +1,6 @@
 # Template file for 'libcotp'
 pkgname=libcotp
-version=3.0.0
+version=3.1.0
 revision=1
 build_style=cmake
 hostmakedepends="pkg-config"
@@ -10,7 +10,7 @@ maintainer="Emil Miler <em@0x45.cz>"
 license="Apache-2.0"
 homepage="https://github.com/paolostivanin/libcotp"
 distfiles="https://github.com/paolostivanin/libcotp/archive/refs/tags/v${version}.tar.gz"
-checksum=ff0b9ce208c4c6542a0f1e739cf31978fbf28848c573837c671a6cb7b56b2c12
+checksum=a48bbfd95b7ec12d23e4e2c4a017f8acddecc14bf10541ff144563cee044b39c
 
 libcotp-devel_package() {
 	depends="${sourcepkg}>=${version}_${revision}"


### PR DESCRIPTION
- I tested the changes in this PR: **briefly**
- I built this PR locally for my native architecture, (x86_64-glibc)