### PR TITLE
cherrytree: update to 1.2.0

### DIFF
--- a/srcpkgs/cherrytree/template
+++ b/srcpkgs/cherrytree/template
@@ -1,6 +1,6 @@
 # Template file for 'cherrytree'
 pkgname=cherrytree
-version=1.1.4
+version=1.2.0
 revision=1
 build_style=cmake
 # Tests are built during the normal build process and require access to X server
@@ -8,7 +8,7 @@ configure_args="-DBUILD_TESTING=OFF"
 hostmakedepends="gettext glib-devel pkg-config python3"
 makedepends="fmt-devel fribidi-devel gtkmm-devel gtksourceviewmm-devel
  gspell-devel libcurl-devel libxml++-devel spdlog sqlite-devel uchardet-devel
- vte3-devel"
+ vte3-devel gtksourceview4-devel"
 depends="desktop-file-utils"
 short_desc="Hierarchial note taking application with syntax highlighting"
 maintainer="Orphaned <orphan@voidlinux.org>"
@@ -16,5 +16,5 @@ license="GPL-3.0-or-later"
 homepage="https://www.giuspen.com/cherrytree/"
 changelog="https://raw.githubusercontent.com/giuspen/cherrytree/master/changelog.txt"
 distfiles="https://github.com/giuspen/cherrytree/archive/refs/tags/v${version}.tar.gz"
-checksum=4440dd39fdd637b82cf3abac82389fe30f4da81a79f5d61ffcdd64748b24465b
+checksum=8d4e66b3c16e2362a4e98146e0bfe788803d9d54282392d44a917a3c74e9d32e
 make_check=no  # Tests are run during build step


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-musl)
- I built this PR locally for these architectures:
  - x86_64-glibc
  - i686
