### PR TITLE
incus: add control/t file for graceful shutdown

### DIFF
--- a/srcpkgs/incus/files/incus/control/t
+++ b/srcpkgs/incus/files/incus/control/t
@@ -1,0 +1,2 @@
+#!/bin/sh
+incus admin shutdown

--- a/srcpkgs/incus/template
+++ b/srcpkgs/incus/template
@@ -1,7 +1,7 @@
 # Template file for 'incus'
 pkgname=incus
 version=6.6.0
-revision=1
+revision=2
 build_style=go
 build_helper=qemu
 go_import_path=github.com/lxc/incus/v6


### PR DESCRIPTION
Incus interprets `SIGTERM` as a temporary shutdown of the incus daemon and leaves the instances running. `incus admin shutdown` starts a clean shutdown of all instances before exiting the incus daemon. This is important for system shutdown on an incus host.

**Note** I could add a time out to the incus shutdown command if that's desired.

#### Testing the changes
- I tested the changes in this PR: **YES** I've been running with this control file in my customized incus service since September 9th.


#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
   x86_64
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl 
  - (cross) aarch64-musl
  - (cross) armv7l
  - (cross) armv6l-musl
