### PR TITLE
pax-utils: depend on python3-pyelftools

### DIFF
--- a/srcpkgs/pax-utils/template
+++ b/srcpkgs/pax-utils/template
@@ -1,10 +1,11 @@
 # Template file for 'pax-utils'
 pkgname=pax-utils
 version=1.3.8
-revision=1
+revision=2
 build_style=meson
 makedepends="libcap-devel"
-checkdepends="python3-pyelftools"
+depends="python3-pyelftools"
+checkdepends="${depends}"
 short_desc="PaX aware and related utilities for ELF binaries"
 maintainer="Leah Neukirchen <leah@vuxu.org>"
 license="GPL-2.0-only"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
<!--
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->

fixes:
```
lddtree /usr/bin/gcc
Traceback (most recent call last):
  File "/usr/bin/lddtree", line 64, in <module>
    from elftools.common import exceptions  # type: ignore
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ModuleNotFoundError: No module named 'elftools'
```
@leahneukirchen 