### PR TITLE
btop: update to 1.4.0

### DIFF
--- a/srcpkgs/btop/template
+++ b/srcpkgs/btop/template
@@ -1,12 +1,13 @@
 # Template file for 'btop'
 pkgname=btop
-version=1.3.2
+version=1.4.0
 revision=1
 build_style=gnu-makefile
+hostmakedepends="lowdown"
 short_desc="Monitor of resources"
 maintainer="RunningDroid <runningdroid@zoho.com>"
 license="Apache-2.0"
 homepage="https://github.com/aristocratos/btop"
 changelog="https://raw.githubusercontent.com/aristocratos/btop/main/CHANGELOG.md"
 distfiles="https://github.com/aristocratos/btop/archive/refs/tags/v${version}.tar.gz"
-checksum=331d18488b1dc7f06cfa12cff909230816a24c57790ba3e8224b117e3f0ae03e
+checksum=ac0d2371bf69d5136de7e9470c6fb286cbee2e16b4c7a6d2cd48a14796e86650


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-musl)
- I built this PR locally for these architectures:
  - x86_64-glibc
  - i686
