### PR TITLE
fastfetch: update to 2.27.1

### DIFF
--- a/srcpkgs/fastfetch/template
+++ b/srcpkgs/fastfetch/template
@@ -1,6 +1,6 @@
 # Template file for 'fastfetch'
 pkgname=fastfetch
-version=2.26.1
+version=2.27.1
 revision=1
 build_style=cmake
 configure_args="-DENABLE_SYSTEM_YYJSON=ON"
@@ -14,7 +14,7 @@ license="MIT"
 homepage="https://github.com/fastfetch-cli/fastfetch"
 changelog="https://github.com/fastfetch-cli/fastfetch/raw/dev/CHANGELOG.md"
 distfiles="https://github.com/fastfetch-cli/fastfetch/archive/refs/tags/${version}.tar.gz"
-checksum=4320d1c304df6880e8c944e6a36340d12a3340477be40b2ead42be308a7fcdaf
+checksum=de12f8cdb52bc1f123aa9b37813f009eeb09f15cbf43b033693c2936716e2626
 
 if [ -n "$XBPS_CHECK_PKGS" ]; then
 	configure_args+=" -DBUILD_TESTS=ON"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-musl)
- I built this PR locally for these architectures:
  - x86_64-glibc
  - i686

@classabbyamp could you please review the changes and thanks for your time