### PR TITLE
btop: find our librocm_smi64.so.1.0

### DIFF
--- a/srcpkgs/btop/patches/ROCm-SMI.patch
+++ b/srcpkgs/btop/patches/ROCm-SMI.patch
@@ -1,0 +1,16 @@
+diff --git a/src/linux/btop_collect.cpp b/src/linux/btop_collect.cpp
+index 1799b0d..758fd46 100644
+--- a/src/linux/btop_collect.cpp
++++ b/src/linux/btop_collect.cpp
+@@ -1281,10 +1281,10 @@ namespace Gpu {
+ 
+ 			//? Try possible library paths and names for librocm_smi64.so
+ 			const array libRocAlts = {
++				"librocm_smi64.so.1.0", // void
+ 				"/opt/rocm/lib/librocm_smi64.so",
+ 				"librocm_smi64.so",
+ 				"librocm_smi64.so.5", // fedora
+-				"librocm_smi64.so.1.0", // debian
+ 				"librocm_smi64.so.6"
+ 			};
+ 

--- a/srcpkgs/btop/template
+++ b/srcpkgs/btop/template
@@ -1,7 +1,7 @@
 # Template file for 'btop'
 pkgname=btop
 version=1.4.0
-revision=1
+revision=2
 build_style=gnu-makefile
 hostmakedepends="lowdown"
 short_desc="Monitor of resources"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: ***briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl
  - i686
  - aarch64 (cross)
  - aarch64-musl (cross)
  - armv7l (cross)
  - armv7l-musl (cross)
  - armv6l (cross)
  - armv6l-musl (cross)

there's a bug with btop where it fails to dlopen our `librocm_smi64.so.1.0`, this patch fixes the issues and puts it at the top of the list.

https://github.com/aristocratos/btop/issues/774

