### PR TITLE
New package: cyme-2.1.1.

### DIFF
--- a/srcpkgs/cyme/template
+++ b/srcpkgs/cyme/template
@@ -1,0 +1,26 @@
+# Template file for 'cyme'
+pkgname=cyme
+version=2.1.1
+revision=1
+build_style=cargo
+configure_args="--no-default-features --features=regex_icon,nusb,udevlib,udev_hwdb"
+hostmakedepends="pkg-config"
+makedepends="eudev-libudev-devel"
+short_desc="List system USB buses and devices"
+maintainer="klardotsh <josh@klar.sh>"
+license="GPL-3.0-or-later"
+homepage="https://github.com/tuna-f1sh/cyme"
+changelog="https://raw.githubusercontent.com/tuna-f1sh/cyme/main/CHANGELOG.md"
+distfiles="https://github.com/tuna-f1sh/cyme/archive/refs/tags/v${version}.tar.gz"
+checksum=a4259f3a77a9b01dc1e8968a184113d47e353c332520f9384cd8d90f5d88b7bb
+
+post_install() {
+	vcompletion doc/cyme.bash bash
+	vcompletion doc/_cyme zsh
+	vcompletion doc/cyme.fish fish
+
+	vman doc/cyme.1
+
+	vmkdir usr/share/examples/${pkgname}/
+	vcopy doc/cyme_example_config.json usr/share/examples/${pkgname}/config.json
+}


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

(I ran the binary plain, and saw my USB devices and their speeds enumerated. I then ran it as `cyme --lsusb` and saw similar output to the stock `lsusb`, so the "drop in replacement ish" mode seems sane too)

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**


<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
