### PR TITLE
Signal-Desktop: update to 7.28.0.

### DIFF
--- a/srcpkgs/Signal-Desktop/template
+++ b/srcpkgs/Signal-Desktop/template
@@ -1,6 +1,6 @@
 # Template file for 'Signal-Desktop'
 pkgname=Signal-Desktop
-version=7.26.0
+version=7.28.0
 revision=1
 # Signal officially only supports x86_64
 # x86_64-musl could potentially work based on the Alpine port:
@@ -14,7 +14,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="AGPL-3.0-only"
 homepage="https://github.com/signalapp/Signal-Desktop"
 distfiles="https://github.com/signalapp/Signal-Desktop/archive/v${version}.tar.gz"
-checksum=6a5b0706a3408bdd32cde70ff87fa01e5bc8ce780ec66a967b936ec16327c70d
+checksum=2d0d1f6bac0a12555b17ff9f6b97d874774fbe8c5bd28d8da629b2a13c7f9d37
 nostrip_files="signal-desktop"
 
 post_extract() {


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc

