### PR TITLE
netavark: update to 1.12.2, aardvark-dns: update to 1.12.2.

### DIFF
--- a/srcpkgs/aardvark-dns/template
+++ b/srcpkgs/aardvark-dns/template
@@ -1,6 +1,6 @@
 # Template file for 'aardvark-dns'
 pkgname=aardvark-dns
-version=1.10.0
+version=1.12.2
 revision=1
 build_style=cargo
 short_desc="Authoritative dns server for A/AAAA container records"
@@ -9,7 +9,7 @@ license="Apache-2.0"
 homepage="https://github.com/containers/aardvark-dns"
 changelog="https://raw.githubusercontent.com/containers/aardvark-dns/main/RELEASE_NOTES.md"
 distfiles="https://github.com/containers/aardvark-dns/archive/refs/tags/v${version}.tar.gz"
-checksum=b3e77b3ff4eb40f010c78ca00762761e8c639c47e1cb67686d1eb7f522fbc81e
+checksum=19317d97525c19135b31f76101b9c13bf2b009cecfc11f467b2ab30fb2641867
 
 post_install() {
 	vmkdir usr/libexec/podman

--- a/srcpkgs/netavark/template
+++ b/srcpkgs/netavark/template
@@ -1,6 +1,6 @@
 # Template file for 'netavark'
 pkgname=netavark
-version=1.10.3
+version=1.12.2
 revision=1
 build_style=cargo
 hostmakedepends="mandown protobuf"
@@ -10,7 +10,7 @@ license="Apache-2.0"
 homepage="https://github.com/containers/netavark"
 changelog="https://raw.githubusercontent.com/containers/netavark/main/RELEASE_NOTES.md"
 distfiles="https://github.com/containers/netavark/archive/refs/tags/v${version}.tar.gz"
-checksum=fdc3010cb221f0fcef0302f57ef6f4d9168a61f9606238a3e1ed4d2e348257b7
+checksum=d1e5a7e65b825724fd084b0162084d9b61db8cda1dad26de8a07be1bd6891dbc
 # needs unshare which cannot be used in CI
 make_check=ci-skip
 


### PR DESCRIPTION
- **netavark: update to 1.12.2.**
- **aardvark-dns: update to 1.12.2.**

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
