### PR TITLE
tree-sitter: update to 0.24.3, revbump of neovim, emacs, rizin.

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -4196,7 +4196,7 @@ libsword-1.8.1.so libsword-1.8.1_6
 libgivaro.so.9 givaro-4.1.1_1
 liblinbox.so.0 linbox-1.6.3_1
 libpari-gmp-tls.so.8 pari-2.15.0_1
-libtree-sitter.so.0 tree-sitter-0.19.0_1
+libtree-sitter.so.0.24 tree-sitter-0.24.3_1
 libplanarity.so.0 planarity-3.0.1.1_1
 libgap.so.9 gap-4.13.0_1
 libgtkdatabox.so.1 gtkdatabox3-1.0.0_1

--- a/srcpkgs/emacs/template
+++ b/srcpkgs/emacs/template
@@ -1,7 +1,7 @@
 # Template file for 'emacs'
 pkgname=emacs
 version=29.4
-revision=1
+revision=2
 create_wrksrc=required
 build_style=gnu-configure
 configure_args="--with-file-notification=inotify --with-modules

--- a/srcpkgs/neovim/template
+++ b/srcpkgs/neovim/template
@@ -1,7 +1,7 @@
 # Template file for 'neovim'
 pkgname=neovim
 version=0.10.2
-revision=1
+revision=2
 # as per https://github.com/neovim/neovim/blob/master/cmake.deps/deps.txt
 _treesitter_c_version=0.21.3
 _treesitter_lua_version=0.1.0

--- a/srcpkgs/rizin/template
+++ b/srcpkgs/rizin/template
@@ -3,7 +3,7 @@
 # Rebuild cutter on update
 pkgname=rizin
 version=0.7.3
-revision=1
+revision=2
 build_style=meson
 configure_args="-D use_sys_capstone=enabled -D use_capstone_version=v5
  -D use_sys_magic=enabled -D use_sys_libzip=enabled -D use_sys_zlib=enabled

--- a/srcpkgs/tree-sitter/template
+++ b/srcpkgs/tree-sitter/template
@@ -1,6 +1,6 @@
 # Template file for 'tree-sitter'
 pkgname=tree-sitter
-version=0.22.6
+version=0.24.3
 revision=1
 build_style=cargo
 make_install_args="--path=cli"
@@ -10,7 +10,7 @@ license="MIT"
 homepage="https://tree-sitter.github.io"
 changelog="https://raw.githubusercontent.com/tree-sitter/tree-sitter/master/CHANGELOG.md"
 distfiles="https://github.com/tree-sitter/tree-sitter/archive/refs/tags/v${version}.tar.gz"
-checksum=e2b687f74358ab6404730b7fb1a1ced7ddb3780202d37595ecd7b20a8f41861f
+checksum=0a8d0cf8e09caba22ed0d8439f7fa1e3d8453800038e43ccad1f34ef29537da1
 make_check=no # tests require generating fixtures from remote repositories
 
 post_build() {


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-musl)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl
  - i686
