### PR TITLE
lsp-plugins: update to 1.2.19, enable cross build.

### DIFF
--- a/srcpkgs/lsp-plugins-gst
+++ b/srcpkgs/lsp-plugins-gst
@@ -1,0 +1,1 @@
+lsp-plugins

--- a/srcpkgs/lsp-plugins-vst3
+++ b/srcpkgs/lsp-plugins-vst3
@@ -1,0 +1,1 @@
+lsp-plugins

--- a/srcpkgs/lsp-plugins/patches/aarch64-atomic.patch
+++ b/srcpkgs/lsp-plugins/patches/aarch64-atomic.patch
@@ -1,0 +1,21 @@
+From 156be4d61c57d805745b85d7fadb781a4bc581b0 Mon Sep 17 00:00:00 2001
+From: Vladimir Sadovnikov <sadko4u@gmail.com>
+Date: Mon, 11 Nov 2024 14:50:21 +0300
+Subject: [PATCH] Fixed atomic operations for AArch64
+
+---
+ modules/lsp-common-lib/include/lsp-plug.in/common/arch/aarch64/atomic.h | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/modules/lsp-common-lib/include/lsp-plug.in/common/arch/aarch64/atomic.h b/modules/lsp-common-lib/include/lsp-plug.in/common/arch/aarch64/atomic.h
+index 388a869..2e6288e 100644
+--- a/modules/lsp-common-lib/include/lsp-plug.in/common/arch/aarch64/atomic.h
++++ b/modules/lsp-common-lib/include/lsp-plug.in/common/arch/aarch64/atomic.h
+@@ -203,6 +203,7 @@ namespace lsp
+     ATOMIC_SWAP_DEF(uint32_t, "", "w")
+     ATOMIC_SWAP_DEF(int64_t, "", "x")
+     ATOMIC_SWAP_DEF(uint64_t, "", "x")
++    ATOMIC_SWAP_DEF(void *, "", "x")
+ } /* namespace lsp */
+ 
+ #undef ATOMIC_SWAP_DEF

--- a/srcpkgs/lsp-plugins/patches/musl-locale.patch
+++ b/srcpkgs/lsp-plugins/patches/musl-locale.patch
@@ -1,0 +1,42 @@
+commit b670813cf0757f01ce0d863aad429b7342f29a3e
+Author: Daniel Martinez <danielmartinez@cock.li>
+Date:   Mon Oct 14 15:25:09 2024 -0400
+
+    Add checks around locales
+    
+    With musl libc, many of the locale macros are not defined, causing build
+    errors
+    
+    Check that the macros are defined before using them
+
+diff --git a/src/main/locale.cpp b/src/main/locale.cpp
+index 69ea619..ed84f5d 100644
+--- a/modules/lsp-common-lib/src/main/locale.cpp
++++ b/modules/lsp-common-lib/src/main/locale.cpp
+@@ -40,14 +40,24 @@ namespace lsp
+                 case LC_MONETARY:       flags   = LC_MONETARY_MASK; break;
+                 case LC_MESSAGES:       flags   = LC_MESSAGES_MASK; break;
+                 case LC_ALL:            flags   = LC_ALL_MASK; break;
+-        #if defined(PLATFORM_LINUX)
++        #if defined(LC_PAPER)
+                 case LC_PAPER:          flags   = LC_PAPER_MASK; break;
++        #endif
++        #if defined(LC_NAME)
+                 case LC_NAME:           flags   = LC_NAME_MASK; break;
++        #endif
++        #if defined(LC_ADDRESS)
+                 case LC_ADDRESS:        flags   = LC_ADDRESS_MASK; break;
++        #endif
++        #if defined(LC_TELEPHONE)
+                 case LC_TELEPHONE:      flags   = LC_TELEPHONE_MASK; break;
++        #endif
++        #if defined(LC_MEASUREMENT)
+                 case LC_MEASUREMENT:    flags   = LC_MEASUREMENT_MASK; break;
++        #endif
++        #if defined(LC_IDENTIFICATION)
+                 case LC_IDENTIFICATION: flags   = LC_IDENTIFICATION_MASK; break;
+-        #endif /* PLATFORM_LINUX */
++        #endif
+ 
+                 default:
+                     return INVALID_LOCALE;

--- a/srcpkgs/lsp-plugins/template
+++ b/srcpkgs/lsp-plugins/template
@@ -1,26 +1,55 @@
 # Template file for 'lsp-plugins'
 pkgname=lsp-plugins
-version=1.2.14
-revision=2
+version=1.2.19
+revision=1
 build_style=gnu-makefile
 make_use_env=yes
 make_build_args="VERBOSE=0"
 hostmakedepends="pkg-config php lv2"
 makedepends="lv2 libglvnd-devel jack-devel libsndfile-devel
- libXrandr-devel cairo-devel freetype-devel"
+ libXrandr-devel cairo-devel freetype-devel gst-plugins-base1-devel"
 depends="lsp-plugins-libs lsp-plugins-xdg
- lsp-plugins-clap lsp-plugins-ladspa lsp-plugins-lv2 lsp-plugins-vst2"
+ lsp-plugins-clap lsp-plugins-ladspa lsp-plugins-lv2 lsp-plugins-vst2
+ lsp-plugins-gst lsp-plugins-vst3"
 short_desc="Collection of open-source audio plugins for studios"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-3.0-or-later"
 homepage="https://lsp-plug.in/"
 changelog="https://raw.githubusercontent.com/sadko4u/lsp-plugins/master/CHANGELOG"
 distfiles="https://github.com/sadko4u/lsp-plugins/releases/download/$version/lsp-plugins-src-${version}.tar.gz"
-checksum=1a3359ee8b8a82971bd7e9eeabe43f58ce6b4a4793d85fb16f97b100e4edee9a
-nocross="Build system doesn't support cross-compilation properly"
+checksum=f0536d790fada3d896670683b71a2916a7bef55a2395f314370015535ec8d959
+
+if [ "$CROSS_BUILD" ]; then
+	hostmakedepends+=" ${makedepends}"
+fi
 
 do_configure() {
-	make LD="$CXX" PREFIX=/usr config
+	_configure_args=(
+	 PREFIX=/usr
+	 LD="$CXX"
+	 ARCHITECTURE="$XBPS_TARGET_MACHINE"
+	 ARCHITECTURE_CFLAGS="$CFLAGS"
+	 ARCHITECTURE_CXXFLAGS="$CXXFLAGS"
+	 ARCHITECTURE_LDFLAGS="$LDFLAGS"
+	 HOST_CC=cc
+	 HOST_CXX=c++
+	 HOST_LD=c++
+	)
+	if [ "$CROSS_BUILD" ]; then
+		_configure_args+=(
+		 CROSS_COMPILE=1
+		 HOST_ARCHITECTURE_CFLAGS="$XBPS_CFLAGS"
+		 HOST_ARCHITECTURE_CXXFLAGS="$XBPS_CXXFLAGS"
+		 HOST_ARCHITECTURE_LDFLAGS="$XBPS_LDFLAGS"
+		)
+	else
+		_configure_args+=(
+		 HOST_ARCHITECTURE_CFLAGS="$CFLAGS"
+		 HOST_ARCHITECTURE_CXXFLAGS="$CXXFLAGS"
+		 HOST_ARCHITECTURE_LDFLAGS="$LDFLAGS"
+		)
+	fi
+	make config "${_configure_args[@]}"
 }
 
 lsp-plugins-libs_package() {
@@ -70,6 +99,23 @@ lsp-plugins-vst2_package() {
 	depends="${sourcepkg}-libs>=${version}_${revision}"
 	pkg_install() {
 		vmove usr/lib/vst
+	}
+}
+
+lsp-plugins-gst_package() {
+	short_desc+=" - gst plugins"
+	depends="${sourcepkg}-libs>=${version}_${revision}"
+	pkg_install() {
+		vmove usr/lib/gstreamer-1.0
+		vmove usr/lib/lsp-plugins/liblsp-plugins-gstreamer*.so
+	}
+}
+
+lsp-plugins-vst3_package() {
+	short_desc+=" - vst3 plugins"
+	depends="${sourcepkg}-libs>=${version}_${revision}"
+	pkg_install() {
+		vmove usr/lib/vst3
 	}
 }
 


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl
  - i686
  - aarch64 (cross)
  - aarch64-musl (cross)
  - armv7l (cross)
  - armv7l-musl (cross)
  - armv6l (cross)
  - armv6l-musl (cross)

patch submitted upstream: https://github.com/lsp-plugins/lsp-common-lib/pull/1

Also relevant for: https://github.com/void-linux/void-packages/pull/39796

