### PR TITLE
New package: tinymist-0.11.32

### DIFF
--- a/srcpkgs/tinymist/template
+++ b/srcpkgs/tinymist/template
@@ -1,0 +1,16 @@
+# Template file for 'tinymist'
+pkgname=tinymist
+version=0.11.32
+revision=1
+build_style=cargo
+short_desc="Integrated language service for Typst"
+maintainer="Andrew Benson <abenson+void@gmail.com>"
+license="Apache-2.0"
+homepage="https://myriad-dreamin.github.io/tinymist/"
+distfiles="https://github.com/Myriad-Dreamin/tinymist/archive/refs/tags/v${version}.tar.gz"
+checksum=877d0c3722ac863d5f6f6469bd8b7b9a7ee461a2e4f50310ed0d42b795c1f182
+
+do_install() {
+	vbin target/${RUST_TARGET}/release/tinymist
+	vbin target/${RUST_TARGET}/release/typlite
+}


### PR DESCRIPTION

#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

#### Local build testing
```
SUMMARY
pkg       host         target        cross  result
tinymist  x86_64       x86_64        n      OK
tinymist  x86_64-musl  x86_64-musl   n      OK
tinymist  i686         i686          n      SKIPPED
tinymist  x86_64-musl  aarch64-musl  y      OK
tinymist  x86_64       aarch64       y      OK
tinymist  x86_64-musl  armv7l-musl   y      OK
tinymist  x86_64       armv7l        y      OK
tinymist  x86_64-musl  armv6l-musl   y      OK
tinymist  x86_64       armv6l        y      OK
```

One of the dependencies breaks on i686, I'll have to figure that out.