### PR TITLE
add dejavu-fonts-ttf as a dependency for river

### DIFF
--- a/srcpkgs/river/template
+++ b/srcpkgs/river/template
@@ -1,14 +1,14 @@
 # Template file for 'river'
 pkgname=river
 version=0.3.5
-revision=1
+revision=2
 archs="~i686* ~armv6l* ~armv7l*"
 build_style=zig-build
 configure_args="$(vopt_if xwayland -Dxwayland) -Dpie"
 hostmakedepends="pkg-config wayland-devel scdoc"
 makedepends="wlroots0.18-devel libevdev-devel pixman-devel
  wayland-protocols libxkbcommon-devel wayland-devel"
-depends="$(vopt_if xwayland xorg-server-xwayland)"
+depends="dejavu-fonts-ttf $(vopt_if xwayland xorg-server-xwayland)"
 short_desc="Dynamic tiling Wayland compositor"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-3.0-only"


### PR DESCRIPTION
I could not get [river](https://github.com/riverwm/river) to run on a bare-bones Void setup, while I was able to do it on my [regular setup](https://github.com/myterminal/dotfiles). After trial and error to pin point the exact additional package that it needed to work, I found that it needs [dejavu-fonts-ttf](https://github.com/void-linux/void-packages/tree/master/srcpkgs/dejavu-fonts-ttf) installed as well.

#### Testing the changes
- I tested the changes in this PR: **YES**
