### PR TITLE
gnome-mahjongg: update to 47.0

### DIFF
--- a/srcpkgs/gnome-mahjongg/template
+++ b/srcpkgs/gnome-mahjongg/template
@@ -1,10 +1,10 @@
 # Template file for 'gnome-mahjongg'
 pkgname=gnome-mahjongg
-version=3.40.1
+version=47.0
 revision=1
 build_style=meson
 hostmakedepends="gettext glib-devel itstool pkg-config vala
- gtk4-update-icon-cache"
+ gtk4-update-icon-cache desktop-file-utils"
 makedepends="librsvg-devel libadwaita-devel"
 short_desc="GNOME Mahjongg solitaire game"
 maintainer="Orphaned <orphan@voidlinux.org>"
@@ -12,4 +12,4 @@ license="GPL-2.0-or-later"
 homepage="https://wiki.gnome.org/Apps/Mahjongg"
 changelog="https://gitlab.gnome.org/GNOME/gnome-mahjongg/-/raw/master/NEWS"
 distfiles="${GNOME_SITE}/${pkgname}/${version%.*}/${pkgname}-${version}.tar.xz"
-checksum=8ed54eecade36b08336906fd8e6c902a0d6f7bbbbb67653c23956a6b631223f6
+checksum=58f157f0bc5ec71ab8da35dce7e73ca2e8192c5b2f219167a926930b971da49b


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, x86_64
- I built this PR locally for these architectures :
  - armv7l
  - armv6l-musl
  - aarch64-musl

#### Notes
Added desktop-file-utils because of this new requirement :
> Program update-desktop-database found: NO
>
> meson.build:40:6: ERROR: Program 'update-desktop-database' not found or not executable


