### PR TITLE
New package: forgejo-9.0.0

### DIFF
--- a/srcpkgs/forgejo/INSTALL
+++ b/srcpkgs/forgejo/INSTALL
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+case "${ACTION}" in
+post)
+	chown _forgejo:_forgejo etc/forgejo/app.ini
+	;;
+esac

--- a/srcpkgs/forgejo/files/forgejo/run
+++ b/srcpkgs/forgejo/files/forgejo/run
@@ -1,0 +1,13 @@
+#!/bin/sh
+exec 2>&1
+
+# USER and HOME are needed because forgejo doesn't actually check the user it
+# runs as, but instead just grabs the variables from the variables.
+export USER=_forgejo
+export HOME=/var/lib/forgejo
+
+# forgejo needs to run from its home for SSH to work properly
+export FORGEJO_WORK_DIR="${HOME}"
+
+cd "${HOME}"
+exec chpst -u _forgejo:_forgejo forgejo web --config /etc/forgejo/app.ini 2>&1

--- a/srcpkgs/forgejo/patches/config.patch
+++ b/srcpkgs/forgejo/patches/config.patch
@@ -1,0 +1,173 @@
+diff --git a/custom/conf/app.example.ini b/custom/conf/app.example.ini
+index cdb7629887..b2c65063c0 100644
+--- a/custom/conf/app.example.ini
++++ b/custom/conf/app.example.ini
+@@ -51,11 +51,11 @@ APP_NAME = ; Forgejo: Beyond coding. We Forge.
+ ;APP_DISPLAY_NAME_FORMAT = {APP_NAME}: {APP_SLOGAN}
+ ;;
+ ;; RUN_USER will automatically detect the current user - but you can set it here change it if you run locally
+-RUN_USER = ; git
++RUN_USER = _forgejo
+ ;;
+ ;; Application run mode, affects performance and debugging: "dev" or "prod", default is "prod"
+ ;; Mode "dev" makes Gitea easier to develop and debug, values other than "dev" are treated as "prod" which is for production use.
+-;RUN_MODE = prod
++RUN_MODE = prod
+ ;;
+ ;; The working directory, see the comment of AppWorkPath above
+ ;WORK_PATH =
+@@ -125,7 +125,7 @@ RUN_USER = ; git
+ ;PER_WRITE_PER_KB_TIMEOUT = 30s
+ ;;
+ ;; Permission for unix socket
+-;UNIX_SOCKET_PERMISSION = 666
++UNIX_SOCKET_PERMISSION = 660
+ ;;
+ ;; Local (DMZ) URL for Gitea workers (such as SSH update) accessing web service. In
+ ;; most cases you do not need to change the default value. Alter it only if
+@@ -167,7 +167,7 @@ RUN_USER = ; git
+ ;SSH_LISTEN_PORT = %(SSH_PORT)s
+ ;;
+ ;; Root path of SSH directory, default is '~/.ssh', but you have to use '/home/git/.ssh'.
+-;SSH_ROOT_PATH =
++SSH_ROOT_PATH = /var/lib/forgejo/.ssh
+ ;;
+ ;; Gitea will create a authorized_keys file by default when it is not using the internal ssh server
+ ;; If you intend to use the AuthorizedKeysCommand functionality then you should turn this off.
+@@ -289,7 +289,7 @@ RUN_USER = ; git
+ ;;
+ ;; Root directory containing templates and static files.
+ ;; default is the path where Gitea is executed
+-;STATIC_ROOT_PATH = ; Will default to the built-in value _`StaticRootPath`_
++STATIC_ROOT_PATH = /var/lib/forgejo
+ ;;
+ ;; Default path for App data
+ ;APP_DATA_PATH = data ; relative paths will be made absolute with _`AppWorkPath`_
+@@ -355,10 +355,10 @@ RUN_USER = ; git
+ ;;
+ ;; MySQL Configuration
+ ;;
+-DB_TYPE = mysql
+-HOST = 127.0.0.1:3306 ; can use socket e.g. /var/run/mysqld/mysqld.sock
+-NAME = gitea
+-USER = root
++;DB_TYPE = mysql
++;HOST = 127.0.0.1:3306 ; can use socket e.g. /var/run/mysqld/mysqld.sock
++;NAME = gitea
++;USER = root
+ ;PASSWD = ;Use PASSWD = `your password` for quoting if you use special characters in the password.
+ ;SSL_MODE = false ; either "false" (default), "true", or "skip-verify"
+ ;CHARSET_COLLATION = ; Empty as default, Gitea will try to find a case-sensitive collation. Don't change it unless you clearly know what you need.
+@@ -379,8 +379,8 @@ USER = root
+ ;;
+ ;; SQLite Configuration
+ ;;
+-;DB_TYPE = sqlite3
+-;PATH= ; defaults to data/forgejo.db
++DB_TYPE = sqlite3
++PATH=/var/lib/forgejo/data/forgejo.db
+ ;SQLITE_TIMEOUT = ; Query timeout defaults to: 500
+ ;SQLITE_JOURNAL_MODE = ; defaults to sqlite database default (often DELETE), can be used to enable WAL mode. https://www.sqlite.org/pragma.html#pragma_journal_mode
+ ;;
+@@ -579,7 +579,7 @@ ENABLED = true
+ ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+ ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+ ;; Root path for the log files - defaults to %(GITEA_WORK_DIR)/log
+-;ROOT_PATH =
++ROOT_PATH = /var/log/forgejo
+ ;;
+ ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+ ;; Main Logger
+@@ -942,11 +942,11 @@ LEVEL = Info
+ ;GENERATOR_URL_TEMPLATE = https://img.shields.io/badge/{{.label}}-{{.text}}-{{.color}}
+ 
+ ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+-;[repository]
++[repository]
+ ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+ ;; Root path for storing all repository data. By default, it is set to %(APP_DATA_PATH)s/gitea-repositories.
+ ;; A relative path is interpreted as _`AppWorkPath`_/%(ROOT)s
+-;ROOT =
++ROOT = /var/lib/forgejo/repositories
+ ;;
+ ;; The script type this server supports. Usually this is `bash`, but some users report that only `sh` is available.
+ ;SCRIPT_TYPE = bash
+@@ -1048,16 +1048,16 @@ LEVEL = Info
+ 
+ ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+ ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+-;[repository.local]
++[repository.local]
+ ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+ ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+ ;;
+ ;; Path for local repository copy. Defaults to `tmp/local-repo` (content gets deleted on gitea restart)
+-;LOCAL_COPY_PATH = tmp/local-repo
++LOCAL_COPY_PATH = /var/lib/forgejo/tmp/local-repo
+ 
+ ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+ ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+-;[repository.upload]
++[repository.upload]
+ ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+ ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+ ;;
+@@ -1065,7 +1065,7 @@ LEVEL = Info
+ ;ENABLED = true
+ ;;
+ ;; Path for uploads. Defaults to `data/tmp/uploads` (content gets deleted on gitea restart)
+-;TEMP_PATH = data/tmp/uploads
++TEMP_PATH = /var/lib/forgejo/uploads
+ ;;
+ ;; Comma-separated list of allowed file extensions (`.zip`), mime types (`text/plain`) or wildcard type (`image/*`, `audio/*`, `video/*`). Empty value or `*/*` allows all types.
+ ;ALLOWED_TYPES =
+@@ -1433,7 +1433,7 @@ LEVEL = Info
+ 
+ ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+ ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+-;[indexer]
++[indexer]
+ ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+ ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+ ;;
+@@ -1444,7 +1444,7 @@ LEVEL = Info
+ ;ISSUE_INDEXER_TYPE = bleve
+ ;;
+ ;; Issue indexer storage path, available when ISSUE_INDEXER_TYPE is bleve
+-;ISSUE_INDEXER_PATH = indexers/issues.bleve ; Relative paths will be made absolute against _`AppWorkPath`_.
++ISSUE_INDEXER_PATH = /var/lib/forgejo/indexers/issues.bleve
+ ;;
+ ;; Issue indexer connection string, available when ISSUE_INDEXER_TYPE is elasticsearch (e.g. http://elastic:password@localhost:9200) or meilisearch (e.g. http://:apikey@localhost:7700)
+ ;ISSUE_INDEXER_CONN_STR =
+@@ -1959,7 +1959,7 @@ LEVEL = Info
+ ;; Url lookup for the minio bucket only available when STORAGE_TYPE is `minio`
+ ;; Available values: auto, dns, path
+ ;; If empty, it behaves the same as "auto" was set
+-;MINIO_BUCKET_LOOKUP = 
++;MINIO_BUCKET_LOOKUP =
+ ;;
+ ;; Minio location to create bucket only available when STORAGE_TYPE is `minio`
+ ;MINIO_LOCATION = us-east-1
+@@ -2637,11 +2637,11 @@ LEVEL = Info
+ ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+ ;; lfs storage will override storage
+ ;;
+-;[lfs]
++[lfs]
+ ;STORAGE_TYPE = local
+ ;;
+ ;; Where your lfs files reside, default is data/lfs.
+-;PATH = data/lfs
++PATH = /var/lib/forgejo/data/lfs
+ ;;
+ ;; override the minio base path if storage type is minio
+ ;MINIO_BASE_PATH = lfs/
+@@ -2680,7 +2680,7 @@ LEVEL = Info
+ ;; Url lookup for the minio bucket only available when STORAGE_TYPE is `minio`
+ ;; Available values: auto, dns, path
+ ;; If empty, it behaves the same as "auto" was set
+-;MINIO_BUCKET_LOOKUP = 
++;MINIO_BUCKET_LOOKUP =
+ ;;
+ ;; Minio location to create bucket only available when STORAGE_TYPE is `minio`
+ ;MINIO_LOCATION = us-east-1

--- a/srcpkgs/forgejo/template
+++ b/srcpkgs/forgejo/template
@@ -1,0 +1,70 @@
+# Template file for 'forgejo'
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# - [Installation from source](https://forgejo.org/docs/next/contributor/from-source)
+# - [Forgejo v9.0 is GPLv3+](https://codeberg.org/forgejo/forgejo/commit/94631c)
+
+homepage="https://forgejo.org"
+
+# https://github.com/void-linux/void-packages/blob/master/Manual.md#available_vars
+
+# Forgejo accepts contributions compatible with the GPLv3-or-later license.
+license="GPL-3.0-or-later"
+
+maintainer="Markus Heiser <markus.heiser@darmarit.de>"
+pkgname=forgejo
+# https://forgejo.org/docs/next/contributor/release/#release-cycle
+version=9.0.0
+revision=1
+_version="$(echo "${version}" | tr '.' '_')"
+short_desc="Forgejo is a self-hosted lightweight software forge"
+
+# go-bindata is from commit (dated in Oct 23, 2015):
+# - https://github.com/jteeuwen/go-bindata/commit/a0ff2567cf
+# - https://github.com/void-linux/void-packages/blob/059fd3968/srcpkgs/go-bindata/template#L5
+# go-bindata/go-bindata is more updated compared to jteeuwen/go-bindata
+# - https://github.com/go-bindata/go-bindata/releases
+
+hostmakedepends="go-bindata"
+makedepends="sqlite-devel pam-devel"
+depends="git git-lfs bash"
+
+distfiles="https://codeberg.org/forgejo/forgejo/releases/download/v${version}/forgejo-src-${version}.tar.gz"
+checksum=21364d6c1635711189f25da5dc343b3b28e8ade20a5f00202301ccc364adc1d2
+changelog="https://codeberg.org/forgejo/forgejo/src/branch/forgejo/RELEASE-NOTES.md#${_version}"
+
+# - https://github.com/void-linux/void-packages/blob/master/Manual.md#build-style-scripts
+# - https://github.com/void-linux/void-packages/blob/master/Manual.md#go-packages
+build_style=go
+go_ldflags=" -X main.Version=${version}"
+
+# forgejo is still module code.gitea.io/gitea
+go_import_path="code.gitea.io/gitea"
+
+# Follow forgejo default release build and enable pam support additionally
+go_build_tags="bindata timetzdata sqlite sqlite_unlock_notify pam"
+
+# https://github.com/void-linux/void-packages/blob/master/Manual.md#system-accounts
+system_accounts="_forgejo"
+_forgejo_homedir="/var/lib/forgejo"
+_forgejo_shell="/bin/bash" # Proper shell needed for ssh support
+
+make_dirs="\
+	/var/lib/forgejo 0750 _forgejo _forgejo
+	/var/log/forgejo 0755 _forgejo root
+"
+
+conf_files="/etc/forgejo/app.ini"
+
+# export BUILDDIR="${XBPS_BUILDDIR}/${pkgname}-${version}"
+
+do_install() {
+	# install code.gitea.io/gitea in /usr/bin/forgejo
+	vbin "${GOPATH}/bin/gitea" forgejo
+}
+
+post_install() {
+	# https://github.com/void-linux/void-packages/blob/master/Manual.md#global-functions
+	vsv forgejo
+	vinstall custom/conf/app.example.ini 0640 /etc/forgejo app.ini
+}

--- a/srcpkgs/forgejo/update
+++ b/srcpkgs/forgejo/update
@@ -1,0 +1,3 @@
+site="https://codeberg.org/forgejo/forgejo/tags"
+pattern='/forgejo/forgejo/archive/v\K[\d.]+(?=tar.gz)'
+ignore="*-dev"


### PR DESCRIPTION
Implemented with [4] and [5] under the pillow / but I have to note; this is my first PR to add a package --> be patient with me ;)

Initial settings are taken from [1] and [2], compilation options are taken from [3].

- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

- I tested the changes in this PR: **YES**::

      $ xlint forgejo

      $ ./xbps-src update-check forgejo
      forgejo-9.0.0 -> forgejo-9.0.1.
      forgejo-9.0.0 -> forgejo-9.0.2.

- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds)::

      $ ./xbps-src clean
      $ ./xbps-src pkg forgejo
      $ ./xbps-src pkg -a armv7hf-musl forgejo  # cross build
      $ ./xbps-src pkg -a armv6l-musl forgejo   # cross build

      $ xi -f forgejo
      $ sudo ln -s /etc/sv/forgejo /var/service/

      $ xdg-open http://localhost:3000/
      ...
      $ xbps-remove -vfy forgejo


----

[1] https://forgejo.org/docs/latest/admin/config-cheat-sheet/
[2] https://forgejo.org/docs/latest/admin/installation-binary/
[3] https://forgejo.org/docs/next/contributor/from-source/#installation-from-source
[4] https://xbps-src-tutorials.github.io/packaging/j4-dmenu-desktop.html
[5] https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md

----

`version`:
- https://forgejo.org/docs/next/contributor/release/#release-cycle

`build_style` and `go_ldflags`:
- https://github.com/void-linux/void-packages/blob/master/Manual.md#build-style-scripts
- https://github.com/void-linux/void-packages/blob/master/Manual.md#go-packages

