### PR TITLE
os-prober: update to 1.83

### DIFF
--- a/srcpkgs/os-prober/template
+++ b/srcpkgs/os-prober/template
@@ -1,6 +1,6 @@
 # Template file for 'os-prober'
 pkgname=os-prober
-version=1.81
+version=1.83
 revision=1
 build_style=gnu-makefile
 make_dirs="/var/lib/os-prober 0755 root root"
@@ -8,8 +8,9 @@ short_desc="Utility to detect other OSes on a set of drives"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="https://packages.debian.org/sid/os-prober"
+changelog="https://metadata.ftp-master.debian.org/changelogs/main/o/os-prober/unstable_changelog"
 distfiles="${DEBIAN_SITE}/main/o/${pkgname}/${pkgname}_${version}.tar.xz"
-checksum=2fd928ec86538227711e2adf49cfd6a1ef74f6bb3555c5dad4e0425ccd978883
+checksum=8c82d5084c2b6f8935f6633612f18d16d04a0deffd6b99c264985fb7204140a6
 
 case "$XBPS_TARGET_MACHINE" in
 	i686*|x86_64*) _ARCH="x86";;


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, x86_64
- I crossbuilded this PR locally for these architectures:
  - armv7l
  - armv6l-musl
  - aarch64-musl