### PR TITLE
sqlcipher: update to 4.6.1

### DIFF
--- a/srcpkgs/sqlcipher/template
+++ b/srcpkgs/sqlcipher/template
@@ -1,7 +1,7 @@
 # Template file for 'sqlcipher'
 pkgname=sqlcipher
-version=4.3.0
-revision=4
+version=4.6.1
+revision=1
 build_style=gnu-configure
 configure_args="--enable-tempstore=yes"
 hostmakedepends="tcl"
@@ -12,12 +12,12 @@ license="BSD-3-Clause"
 homepage="https://www.zetetic.net/sqlcipher/"
 changelog="https://raw.githubusercontent.com/sqlcipher/sqlcipher/v${version}/CHANGELOG.md"
 distfiles="https://github.com/${pkgname}/${pkgname}/archive/v${version}.tar.gz"
-checksum=fccb37e440ada898902b294d02cde7af9e8706b185d77ed9f6f4d5b18b4c305f
+checksum=d8f9afcbc2f4b55e316ca4ada4425daf3d0b4aab25f45e11a802ae422b9f53a3
 
 CFLAGS="-DSQLITE_HAS_CODEC"
 
 post_install() {
-	vlicense LICENSE
+	vlicense LICENSE.md
 }
 
 sqlcipher-devel_package() {


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, x86_64
- I crossbuilded this PR locally for these architectures:
  - armv7l
  - armv6l-musl
  - aarch64-musl