### PR TITLE
python3-dnsrecon update (also add python3-loguru)

### DIFF
--- a/srcpkgs/python3-dnsrecon/template
+++ b/srcpkgs/python3-dnsrecon/template
@@ -1,16 +1,15 @@
 # Template file for 'python3-dnsrecon'
 pkgname=python3-dnsrecon
-version=1.2.0
+version=1.3.0
 revision=1
 build_style=python3-pep517
 make_check_args="-k not(test_zone_transfer)"
 hostmakedepends="python3-wheel"
-depends="python3 python3-netaddr python3-dnspython python3-lxml"
-checkdepends="${depends} python3-flake8 python3-pyflakes python3-pytest"
+depends="python3 python3-netaddr python3-dnspython python3-lxml python3-requests python3-loguru"
+checkdepends="${depends} python3-pytest"
 short_desc="DNS enumeration script"
 maintainer="Jason Elswick <jason@jasondavid.tv>"
 license="GPL-2.0-only"
 homepage="https://github.com/darkoperator/dnsrecon"
 distfiles="https://github.com/darkoperator/dnsrecon/archive/refs/tags/${version}.tar.gz"
-checksum=76fe1d5f776116060bec93b296874a8f81606de3a58b5f926d8a2fbada74fe8a
-make_check=no # requires python3-pytest >=8.0.0
+checksum=a59580f1dfb309965f6e1912b90bbc8c9ea965cc19939535094e80a3072af30c

--- a/srcpkgs/python3-loguru/template
+++ b/srcpkgs/python3-loguru/template
@@ -1,0 +1,17 @@
+# Template file for 'python3-loguru'
+pkgname=python3-loguru
+version=0.7.2
+revision=1
+build_style=python3-pep517
+hostmakedepends="python3-flit_core python3-setuptools"
+depends="python3"
+short_desc="Python logging made (stupidly) simple"
+maintainer="Jason Elswick <jason@jasondavid.us>"
+license="MIT"
+homepage="https://github.com/Delgan/loguru"
+distfiles="https://github.com/Delgan/loguru/archive/refs/tags/${version}.tar.gz"
+checksum=2b3517ef6941a3bb24ed108074194041b3de429d5d43fe9d51359f4abdd8bad5
+
+post_install() {
+	vlicense LICENSE
+}


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package (python3-loguru) conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-libc

The dependencies for dnsrecon have changed as of 1.3.0.
