### PR TITLE
polychromatic: Add missing dependency

### DIFF
--- a/srcpkgs/polychromatic/template
+++ b/srcpkgs/polychromatic/template
@@ -1,17 +1,17 @@
 # Template file for 'polychromatic'
 pkgname=polychromatic
-version=0.9.1
-revision=2
+version=0.9.3
+revision=1
 build_style=meson
 hostmakedepends="ninja sassc which gettext"
 depends="python3-colorama python3-setproctitle python3-requests python3-colour
  python3-pyqt6-gui python3-pyqt6-devel-tools python3-pyqt6-printsupport
  python3-pyqt6-devel-tools python3-pyqt6-webengine python3-pyqt6-network
- python3-pyqt6-widgets python3-pyqt6-webchannel"
+ python3-pyqt6-widgets python3-pyqt6-webchannel python3-pyqt6-svg"
 short_desc="RGB lighting management software"
 maintainer="Martin Dimov <martin@dmarto.com>"
 license="GPL-3.0-or-later"
 homepage="https://polychromatic.app"
 changelog="https://github.com/polychromatic/polychromatic/raw/master/CHANGELOG"
 distfiles="https://github.com/polychromatic/polychromatic/archive/v${version}.tar.gz"
-checksum=651e5eebe7038356c99c4f8c3a6c04aa7d99236768c937863d8ddcebc44cfd5e
+checksum=8ec601bed283ff8c188d51066f7c761a3ff82bb72b0bafd6fd9b0c68329ab002


### PR DESCRIPTION
Problem:  `polychromatic-controller`  misses a dependency:
```
Traceback (most recent call last):
  File "/usr/bin/polychromatic-controller", line 36, in <module>
    import polychromatic.controller as controller
  File "/usr/lib/python3.12/site-packages/polychromatic/controller/__init__.py", line 1, in <module>
    from . import devices, effects, menubar, preferences, shared
  File "/usr/lib/python3.12/site-packages/polychromatic/controller/devices.py", line 27, in <module>
    from . import shared
  File "/usr/lib/python3.12/site-packages/polychromatic/controller/shared.py", line 17, in <module>
    from PyQt6.QtSvg import QSvgRenderer
ModuleNotFoundError: No module named 'PyQt6.QtSvg'
```

This adds the missing dependency which is requred for `polychromatic-controller` to work.

- I tested the changes in this PR: **briefly**