### PR TITLE
spotify: add missing dependency

### DIFF
--- a/srcpkgs/spotify/template
+++ b/srcpkgs/spotify/template
@@ -1,12 +1,12 @@
 # Template file for 'spotify'
 pkgname=spotify
 version=1.2.47
-revision=1
+revision=2
 _subver=364.gf06e5cee
 archs="x86_64"
 create_wrksrc=yes
 hostmakedepends="libcurl"
-depends="libcurl"
+depends="libcurl libayatana-appindicator"
 short_desc="Proprietary music streaming client"
 maintainer="Stefan Mühlinghaus <jazzman@alphabreed.com>"
 license="custom:Proprietary"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)

Fixes: https://github.com/void-linux/void-packages/issues/52693
