### PR TITLE
texstudio: update to 4.8.4.

### DIFF
--- a/srcpkgs/texstudio/template
+++ b/srcpkgs/texstudio/template
@@ -1,25 +1,25 @@
 # Template file for 'texstudio'
 pkgname=texstudio
-version=4.5.2
-revision=2
+version=4.8.4
+revision=1
 build_style=cmake
 configure_args="$(vopt_bool multimedia TEXSTUDIO_ENABLE_MEDIAPLAYER)"
-hostmakedepends="pkg-config qt5-qmake qt5-host-tools"
-makedepends="qt5-webkit-devel qt5-svg-devel qt5-script-devel qt5-tools-devel
- kdeclarative-devel hunspell-devel quazip-devel
- $(vopt_if multimedia qt5-multimedia-devel)
- $(vopt_if poppler "poppler-qt5-devel poppler-cpp-devel")"
-depends="qt5-svg"
+hostmakedepends="pkg-config qt6-base"
+makedepends="qt6-svg-devel qt6-tools-devel qt6-qt5compat-devel
+ kf6-kdeclarative-devel hunspell-devel quazip-devel
+ $(vopt_if multimedia qt6-multimedia-devel)
+ $(vopt_if poppler "poppler-qt6-devel poppler-cpp-devel")"
+depends="qt6-svg"
 short_desc="Powerful Tex/LaTeX editor based on texmaker"
 maintainer="Piraty <mail@piraty.dev>"
 license="GPL-2.0-or-later"
 homepage="https://texstudio.org/"
 changelog="https://raw.githubusercontent.com/texstudio-org/texstudio/master/utilities/manual/CHANGELOG.txt"
 distfiles="https://github.com/texstudio-org/texstudio/archive/${version}.tar.gz"
-checksum=d43dd21a111aacf57e40b0ee27c94b9923f8fdbddec5bad919596abf9a03f3cf
+checksum=aec719cb21b788a41576375eeeba734600a54ff64130dd93f5d0da1efa37414c
 
 build_options="multimedia poppler"
-desc_option_phonon="build with qt5-multimedia (=media support for pdf preview)"
+desc_option_phonon="build with qt6-multimedia (=media support for pdf preview)"
 desc_option_poppler="build with poppler (=internal pdf preview)"
 
 build_options_default="multimedia poppler"


### PR DESCRIPTION
TeXstudio now uses Qt6.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
#### Local build testing
- I built this PR locally for my native architecture, (x86_64)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - armv6l (crossbuild)
