### PR TITLE
Update R to 4.4.1

### DIFF
--- a/srcpkgs/R/template
+++ b/srcpkgs/R/template
@@ -1,6 +1,6 @@
 # Template file for 'R'
 pkgname=R
-version=4.3.1
+version=4.4.1
 revision=1
 build_style=gnu-configure
 configure_args="--docdir=/usr/share/doc/R rdocdir=/usr/share/doc/R
@@ -23,7 +23,7 @@ license="GPL-2.0-or-later"
 homepage="https://www.r-project.org/"
 changelog="https://cran.r-project.org/doc/manuals/r-release/NEWS.html"
 distfiles="https://cran.r-project.org/src/base/R-4/${pkgname}-${version}.tar.gz"
-checksum=8dd0bf24f1023c6f618c3b317383d291b4a494f40d73b983ac22ffea99e4ba99
+checksum=b4cb675deaaeb7299d3b265d218cde43f192951ce5b89b7bb1a5148a36b2d94d
 nocross=yes
 shlib_provides="libR.so"
 # tests require texlive distribution


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

I built the package and am using it on my system right now. It seems to work well!

- I built this PR locally for my native architecture, (x86_64-musl)

xbps-src says
```
=> ERROR: R-4.4.1_1: cannot be cross compiled...
=> ERROR: R-4.4.1_1: yes
```
when I attempt to run a cross-compilation. I tried aarch64-musl and armv7l.