### PR TITLE
spotify: update to 1.2.48.

### DIFF
--- a/srcpkgs/spotify/template
+++ b/srcpkgs/spotify/template
@@ -1,8 +1,8 @@
 # Template file for 'spotify'
 pkgname=spotify
-version=1.2.47
-revision=2
-_subver=364.gf06e5cee
+version=1.2.48
+revision=1
+_subver=405.gf2c48e6f
 archs="x86_64"
 create_wrksrc=yes
 hostmakedepends="libcurl"
@@ -12,7 +12,7 @@ maintainer="Stefan Mühlinghaus <jazzman@alphabreed.com>"
 license="custom:Proprietary"
 homepage="https://www.spotify.com"
 distfiles="http://repository.spotify.com/pool/non-free/s/spotify-client/spotify-client_${version}.${_subver}_amd64.deb"
-checksum=65405a1346884600e5a1a350bc0bcfb17f822432031d45ae11c3eeea3236c8fa
+checksum=9c0e845624e3e5b528d5ffe07888892502555261446e3f747908cc355dff0752
 repository=nonfree
 restricted=yes
 nostrip=yes


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)

This also fixes the creation of the `explicit_filter.restore` file.
