### PR TITLE
Fix discord package template for version 0.0.72

### DIFF
--- a/srcpkgs/discord/template
+++ b/srcpkgs/discord/template
@@ -1,6 +1,6 @@
 # Template file for 'discord'
 pkgname=discord
-version=0.0.71
+version=0.0.72
 revision=1
 archs="x86_64"
 depends="alsa-lib dbus-glib gtk+3 libnotify nss libXtst libcxx libatomic
@@ -10,7 +10,7 @@ maintainer="Ryan Conwell <ryanconwell@protonmail.com>"
 license="custom:Proprietary"
 homepage="https://discord.com"
 distfiles="https://dl.discordapp.net/apps/linux/${version}/discord-${version}.tar.gz"
-checksum=3cc71abe05212fc735605696b28a1939b0daec03cca820f521acac103e5f59a7
+checksum=200be5c6cea811d3bffea556c07d1c04911b0f1c8f2c6e871f098e82a3334515
 repository=nonfree
 restricted=yes
 nopie=yes


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**|**briefly**|**NO**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->



This update modifies the template for the discord package to version 0.0.72. The following changes were made:

   -  Version Bump: The version field has been updated from 0.0.71 to 0.0.72 to reflect the new Discord release.
   - Distfiles Update: The distfiles URL was modified to point to the correct source file for the new version (discord-0.0.72.tar.gz).
   - Checksum Update: The checksum field was updated to ensure that the downloaded file is correctly validated with the new SHA256 hash.

The rest of the installation process remains the same, ensuring that the package installs its necessary files (e.g., binaries, resources, and libraries) in the appropriate locations.