### PR TITLE
perl-namespace-autoclean: update to 0.31

### DIFF
--- a/srcpkgs/perl-namespace-autoclean/template
+++ b/srcpkgs/perl-namespace-autoclean/template
@@ -1,15 +1,15 @@
 # Template file for 'perl-namespace-autoclean'
 pkgname=perl-namespace-autoclean
-version=0.29
-revision=2
+version=0.31
+revision=1
 build_style=perl-module
 hostmakedepends="perl"
-makedepends="${hostmakedepends} perl-Sub-Identify perl-namespace-clean perl-B-Hooks-EndOfScope"
+makedepends="perl perl-namespace-clean perl-B-Hooks-EndOfScope"
 depends="${makedepends}"
-checkdepends="perl-Test-Needs"
+checkdepends="perl-Moo perl-Sub-Name perl-Test-Needs"
 short_desc="Keep imports out of your namespace"
 maintainer="newbluemoon <blaumolch@mailbox.org>"
 license="Artistic-1.0-Perl, GPL-1.0-or-later"
 homepage="https://metacpan.org/release/namespace-autoclean"
 distfiles="${CPAN_SITE}/namespace/${pkgname/perl-/}-$version.tar.gz"
-checksum=45ebd8e64a54a86f88d8e01ae55212967c8aa8fed57e814085def7608ac65804
+checksum=d3b32c82e1d2caa9d58b8c8075965240e6cab66ab9350bd6f6bea4ca07e938d6


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

- I built this PR locally for my native architecture, (x86_64)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64 (cross)
  - armv7l-musl (cross)
  - x86_64-musl
  - i686