### PR TITLE
gnome-authenticator: fix crash when opening preferences

### DIFF
--- a/srcpkgs/gnome-authenticator/template
+++ b/srcpkgs/gnome-authenticator/template
@@ -1,14 +1,14 @@
 # Template file for 'gnome-authenticator'
 pkgname=gnome-authenticator
 version=4.4.0
-revision=1
+revision=2
 build_style=meson
 build_helper="rust"
 hostmakedepends="pkg-config gettext glib-devel itstool cargo desktop-file-utils
  gtk-update-icon-cache clang"
 makedepends="gtk4-devel libadwaita-devel libglib-devel libzbar-devel
  openssl-devel pipewire-devel rust-std"
-depends="gnome-keyring"
+depends="gnome-keyring gstreamer1-pipewire"
 short_desc="Two-factor authentication code generator for GNOME"
 maintainer="Enno Boland <gottox@voidlinux.org>"
 license="GPL-3.0-or-later"


### PR DESCRIPTION
Without a runtime dependency provided by the gstreamer1-pipewire package, gnome-authenticator crashes when opening the preferences menu (at least when running under pipewire). This is a significant issue because it prevents creating/restoring backups.

This is fixed by adding gstreamer1-pipewire as a dependency of the gnome-authenticator package.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

