### PR TITLE
e16: update to 1.0.30

### DIFF
--- a/srcpkgs/e16/template
+++ b/srcpkgs/e16/template
@@ -1,17 +1,17 @@
 # Template file for 'e16'
 pkgname=e16
-version=1.0.29
+version=1.0.30
 revision=1
 build_style=gnu-configure
 configure_args="--sysconfdir=/etc --enable-sound=alsa"
 hostmakedepends="pkg-config tar"
-makedepends="pango-devel libXinerama-devel libXrandr-devel imlib2-devel libXcomposite-devel libXdamage-devel alsa-lib-devel libsndfile-devel"
+makedepends="pango-devel libXinerama-devel libXrandr-devel imlib2-devel libXcomposite-devel libXdamage-devel alsa-lib-devel libsndfile-devel libXft-devel"
 short_desc="Enlightenment DR16 window manager"
 maintainer="Brihadeesh <brihadeesh@protonmail.com>"
 license="BSD-2-Clause"
 homepage="https://www.enlightenment.org/e16"
 distfiles="$SOURCEFORGE_SITE/enlightenment/${pkgname}-${version}.tar.gz"
-checksum=608e1405dc8d0c9aca7fc3d0ff6a7258ac94f3c5166e56d0316646d3c7df2289
+checksum=b8b7748a2c48c4c7c9758d9ad12b14f566d2bec38f2eda533e6d874f5ce9074c
 
 post_install() {
 	# install gnome and kde session scripts


### PR DESCRIPTION
Update e16 and also add the libXft dependency as it is mentioned on the e16 website and I noticed it was missing here. I can be convinced to remove it though if its not actually needed.

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl
