### PR TITLE
new package: niri 0.1.10.1

### DIFF
--- a/srcpkgs/niri/patches/remove-session.patch
+++ b/srcpkgs/niri/patches/remove-session.patch
@@ -1,0 +1,12 @@
+remove the niri-session, as that's a systemd-only binary. replace with niri --session which automatically adds envs.
+--
+--- a/resources/niri.desktop
++++ b/resources/niri.desktop
+@@ -1,6 +1,6 @@
+ [Desktop Entry]
+ Name=Niri
+ Comment=A scrollable-tiling Wayland compositor
+-Exec=niri-session
++Exec=/usr/bin/niri --session
+ Type=Application
+ DesktopNames=niri

--- a/srcpkgs/niri/template
+++ b/srcpkgs/niri/template
@@ -1,0 +1,21 @@
+# Template file for 'niri'
+pkgname=niri
+version=0.1.10.1
+revision=1
+build_style=cargo
+configure_args="--no-default-features --features xdp-gnome-screencast"
+hostmakedepends="pkg-config clang18-devel"
+makedepends="eudev-libudev-devel libxkbcommon-devel libinput-devel libgbm-devel
+ libdisplay-info-devel pipewire-devel pango-devel libseat-devel clang18-devel"
+short_desc="Scrollable-tiling Wayland compositor"
+maintainer="joetroll <joetroll@proton.me>"
+license="GPL-3.0-or-later"
+homepage="https://github.com/YaLTeR/niri"
+changelog="https://github.com/YaLTeR/niri/releases"
+distfiles="https://github.com/YaLTeR/niri/archive/refs/tags/v${version}.tar.gz"
+checksum=d8854830436a87215b0bc6a60b6d43f350d927a03a2798c75f0fbda228bac8d3
+
+post_install() {
+	vinstall resources/niri.desktop 644 usr/share/wayland-sessions
+	vinstall resources/niri-portals.conf 644 usr/share/xdg-desktop-portal
+}


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR:  **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)

contains templates for the niri window manager. i added extra rustflags for musl as it will not compile without those (cannot check if the actual musl checking part works as of now, but i've tested and it only compiles by adding those flags)

closes #48456 