### PR TITLE
miniupnp: Update homepage and distfiles

### DIFF
--- a/srcpkgs/libnatpmp/template
+++ b/srcpkgs/libnatpmp/template
@@ -7,9 +7,9 @@ make_use_env=y
 short_desc="Libraries for client side of NAT-PMP"
 maintainer="Đoàn Trần Công Danh <congdanhqx@gmail.com>"
 license="BSD-3-Clause"
-homepage="http://miniupnp.free.fr/libnatpmp.html"
-changelog="http://miniupnp.free.fr/files/changelog.php?file=libnatpmp-${version}.tar.gz"
-distfiles="http://miniupnp.free.fr/files/libnatpmp-${version}.tar.gz"
+homepage="https://miniupnp.tuxfamily.org/libnatpmp.html"
+changelog="https://miniupnp.tuxfamily.org/files/changelog.php?file=libnatpmp-${version}.tar.gz"
+distfiles="https://miniupnp.tuxfamily.org/files/libnatpmp-${version}.tar.gz"
 checksum=0684ed2c8406437e7519a1bd20ea83780db871b3a3a5d752311ba3e889dbfc70
 
 post_patch() {

--- a/srcpkgs/minissdpd/template
+++ b/srcpkgs/minissdpd/template
@@ -7,8 +7,8 @@ makedepends="libnfnetlink-devel"
 short_desc="MiniSSDP Daemon to speed up UPnP device discovery"
 maintainer="Duncaen <duncaen@voidlinux.org>"
 license="BSD-3-Clause"
-homepage="http://miniupnp.free.fr/minissdpd.html"
-distfiles="http://miniupnp.free.fr/files/minissdpd-${version}.tar.gz"
+homepage="https://miniupnp.tuxfamily.org/minissdpd.html"
+distfiles="https://miniupnp.tuxfamily.org/files/minissdpd-${version}.tar.gz"
 checksum=f4c2dea6a472e0a5cc9dca2dc4c1fc36ba5538eacf8d793825293251725546bd
 
 CFLAGS="-D_GNU_SOURCE"

--- a/srcpkgs/miniupnpc/template
+++ b/srcpkgs/miniupnpc/template
@@ -9,9 +9,9 @@ checkdepends="inetutils-ifconfig"
 short_desc="Small UPnP client library/tool to access Internet Gateway Devices"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="BSD-3-Clause"
-#changelog="http://miniupnp.free.fr/files/changelog.php?file=miniupnpc-${version}.tar.gz"
-homepage="http://miniupnp.free.fr"
-distfiles="http://miniupnp.free.fr/files/${pkgname}-${version}.tar.gz"
+#changelog="https://miniupnp.tuxfamily.org/files/changelog.php?file=miniupnpc-${version}.tar.gz"
+homepage="https://miniupnp.tuxfamily.org"
+distfiles="https://miniupnp.tuxfamily.org/files/${pkgname}-${version}.tar.gz"
 checksum=b0c3a27056840fd0ec9328a5a9bac3dc5e0ec6d2e8733349cf577b0aa1e70ac1
 
 post_install() {

--- a/srcpkgs/miniupnpd/template
+++ b/srcpkgs/miniupnpd/template
@@ -20,9 +20,9 @@ checkdepends="iproute2 which"
 short_desc="Lightweight UPnP IGD daemon"
 maintainer="Duncaen <duncaen@voidlinux.org>"
 license="BSD-3-Clause"
-homepage="http://miniupnp.free.fr"
-changelog="http://miniupnp.free.fr/files/changelog.php?file=miniupnpd-${version}.tar.gz"
-distfiles="http://miniupnp.free.fr/files/miniupnpd-${version}.tar.gz"
+homepage="https://miniupnp.tuxfamily.org"
+changelog="https://miniupnp.tuxfamily.org/files/changelog.php?file=miniupnpd-${version}.tar.gz"
+distfiles="https://miniupnp.tuxfamily.org/files/miniupnpd-${version}.tar.gz"
 checksum=fbdd5501039730f04a8420ea2f8f54b7df63f9f04cde2dc67fa7371e80477bbe
 
 if [ "$XBPS_TARGET_LIBC" = "musl" ]; then


### PR DESCRIPTION
Replace HTTP miniupnp.free.fr with HTTPS miniupnp.tuxfamily.org mirror

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)