### PR TITLE
ruby-tmuxinator: update to 3.3.2.

### DIFF
--- a/srcpkgs/ruby-tmuxinator/template
+++ b/srcpkgs/ruby-tmuxinator/template
@@ -1,6 +1,6 @@
 # Template file for 'ruby-tmuxinator'
 pkgname=ruby-tmuxinator
-version=3.3.1
+version=3.3.2
 revision=1
 build_style=gemspec
 depends="ruby-erubi>=1.7 ruby-thor>=1.3.0 ruby-xdg>=4.3.0 tmux"
@@ -10,7 +10,7 @@ license="MIT"
 homepage="https://github.com/tmuxinator/tmuxinator"
 changelog="https://raw.githubusercontent.com/tmuxinator/tmuxinator/master/CHANGELOG.md"
 distfiles="https://github.com/tmuxinator/tmuxinator/archive/refs/tags/v${version}.tar.gz"
-checksum=8b41f7c56b42ea13e37c99f4cd818a571859f473ae5acbed12f343a75e3fa1be
+checksum=8b5a8cc899f48772f2a8bace06ff463c57248ad9575a668326f1e60b7e9616f0
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl
  - i686
  - aarch64-musl (cross)
  - armv7l (cross)
