### PR TITLE
dinit: update to 0.19.1.

### DIFF
--- a/srcpkgs/dinit/template
+++ b/srcpkgs/dinit/template
@@ -1,11 +1,11 @@
 # Template file for 'dinit'
 pkgname=dinit
-version=0.18.0
+version=0.19.1
 revision=1
 build_style=meson
 configure_args="
  -Ddinit-sbindir=/usr/bin
- -Dbuild-shutdown=disabled
+ -Dshutdown-prefix=dinit-
  -Dunit-tests=true
  -Digr-tests=true
  -Db_ndebug=false"
@@ -16,4 +16,10 @@ license="Apache-2.0"
 homepage="https://davmac.org/projects/dinit/"
 changelog="https://raw.githubusercontent.com/davmac314/dinit/master/NEWS"
 distfiles="https://github.com/davmac314/dinit/archive/v${version}.tar.gz"
-checksum=ec854903e93416b3f65e72009dcde4965869d8793e2314565484d94ede534e48
+checksum=e4ef40844ce64ca7476b9acba2adabdca49a2b59c97641a99e7d47904701a5f5
+
+post_install() {
+	vmkdir usr/share/doc/dinit
+	vcopy doc/linux/* usr/share/doc/dinit/
+	vdoc doc/getting_started.md
+}


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl
  - i686
  - aarch64 (cross)
  - aarch64-musl (cross)
  - armv7l (cross)

@dkwo, as the maintainer could you please take a look and give me feedback?

I've changed the configuration to enable shutdown but prefix everything with `dinit-`.

Also I added both Markdown files with the explanation for dinit as PID1 and user-init, aswell as copying the example services.
