### PR TITLE
dhcpcd: update to 10.1.0

### DIFF
--- a/srcpkgs/dhcpcd/template
+++ b/srcpkgs/dhcpcd/template
@@ -1,6 +1,6 @@
 # Template file for 'dhcpcd'
 pkgname=dhcpcd
-version=10.0.10
+version=10.1.0
 revision=1
 build_style=configure
 make_check_target=test
@@ -15,7 +15,7 @@ license="BSD-2-Clause"
 homepage="https://roy.marples.name/projects/dhcpcd"
 changelog="https://github.com/NetworkConfiguration/dhcpcd/releases"
 distfiles="https://github.com/NetworkConfiguration/dhcpcd/archive/refs/tags/v${version}.tar.gz"
-checksum=3ea87ba6c37ec594620fbaa7f2f6bc1dd8893e0aa5db5c40f532b700d05fe03f
+checksum=e8a83208c2ff63a5a31d886f76bc717b4ec1938d18a2c8b88f328e710d2b515a
 lib32disabled=yes
 conf_files=/etc/dhcpcd.conf
 


### PR DESCRIPTION
DHCPCD v 10.0.10 was released with some very serious IPv6 bugs, causing IPv6 addresses to be deleted from interfaces before the lease expired: https://github.com/NetworkConfiguration/dhcpcd/compare/v10.0.10...v10.1.0

#### Testing the changes
- I tested the changes in this PR: **YES**


#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
