### PR TITLE
PrismLauncher: remove SOURCE_DATE_EPOCH special handling

### DIFF
--- a/srcpkgs/PrismLauncher/template
+++ b/srcpkgs/PrismLauncher/template
@@ -26,11 +26,6 @@ case "$XBPS_TARGET_MACHINE" in
 esac
 
 pre_configure() {
-	local _date
-	if [ "$SOURCE_DATE_EPOCH" ]; then
-		_date="$(date --utc --date "@$SOURCE_DATE_EPOCH" "+%Y-%m-%d")"
-		configure_args+=" -DLauncher_BUILD_TIMESTAMP=${_date}"
-	fi
 	. /etc/profile.d/jdk.sh
 }
 


### PR DESCRIPTION
Since cmake version 3.8 it will automatically use SOURCE_DATE_EPOCH for the build timestamp.

https://cmake.org/cmake/help/latest/command/string.html#timestamp

#### Testing the changes
- I tested the changes in this PR: **NO**
