### PR TITLE
octoxbps: update to 0.4.0 and add new dependency

### DIFF
--- a/srcpkgs/octoxbps/template
+++ b/srcpkgs/octoxbps/template
@@ -1,31 +1,27 @@
 # Template file for 'octoxbps'
 pkgname=octoxbps
-version=0.3.3
+version=0.4.0
 revision=1
 build_style=qmake
-hostmakedepends="qt5-qmake pkg-config qt5-host-tools"
-makedepends="qt5-declarative-devel qtermwidget-devel"
-depends="curl"
+build_helper=qmake6
+hostmakedepends="pkg-config qt6-tools qt6-base"
+makedepends=" qt6-declarative-devel qtermwidget-qt6-devel qt6-qt5compat-devel"
+depends="curl qt-sudo"
 short_desc="Qt-based XBPS front-end"
 maintainer="beefcurtains <beefcurtains@voidlinux.org>"
 license="GPL-2.0-or-later"
-homepage="https://tintaescura.com/projects/octopi/"
+homepage="https://tintaescura.com/projects/octoxbps/"
 changelog="https://raw.githubusercontent.com/aarnt/octoxbps/master/CHANGELOG"
 distfiles="https://github.com/aarnt/octoxbps/archive/v${version}.tar.gz"
-checksum=bf00fca7416b9ecad5e8c6e85d8e3215e8c4ef73c23a2b2c3cbe6773491ff4d5
+checksum=9c01d6a97511e3cecea32d094482e14b40ff3e1ede6576eb45a7e75dd8f39920
 
 post_configure() {
+	sed -i 's/usr\/local/usr/g' src/constants.h
 	local qmake_args
 	if [ "$CROSS_BUILD" ]; then
 		qmake_args="-qtconf ${wrksrc}/qt.conf"
 	fi
-	cd ${wrksrc}/notifier && qmake-qt5 ${configure_args} \
-		QMAKE_CC=$CC QMAKE_CXX=$CXX QMAKE_LINK=$CXX QMAKE_LINK_C=$CC \
-		QMAKE_CFLAGS="${CFLAGS}" \
-		QMAKE_CXXFLAGS="${CXXFLAGS}" \
-		QMAKE_LFLAGS="${LDFLAGS}" \
-		${qmake_args}
-	cd ${wrksrc}/sudo && qmake-qt5 ${configure_args} \
+	cd ${wrksrc}/notifier && qmake-qt6 ${configure_args} \
 		QMAKE_CC=$CC QMAKE_CXX=$CXX QMAKE_LINK=$CXX QMAKE_LINK_C=$CC \
 		QMAKE_CFLAGS="${CFLAGS}" \
 		QMAKE_CXXFLAGS="${CXXFLAGS}" \
@@ -34,13 +30,13 @@ post_configure() {
 }
 
 do_build() {
-	for _dir in ${wrksrc} ${wrksrc}/notifier ${wrksrc}/sudo; do
+	for _dir in ${wrksrc} ${wrksrc}/notifier; do
 		cd $_dir && make ${makejobs} ${make_build_args} ${make_build_target} CC="$CC" CXX="$CXX" LINK="$CXX"
 	done
 }
 
 do_install() {
-	for _dir in ${wrksrc} ${wrksrc}/notifier ${wrksrc}/sudo; do
+	for _dir in ${wrksrc} ${wrksrc}/notifier; do
 		cd $_dir && make INSTALL_ROOT=${DESTDIR} install
 	done
 }

--- a/srcpkgs/qt-sudo/template
+++ b/srcpkgs/qt-sudo/template
@@ -1,0 +1,14 @@
+# Template file for 'qt-sudo'
+pkgname=qt-sudo
+version=2.0.1
+revision=1
+build_style=qmake
+build_helper=qmake6
+hostmakedepends="qt6-base qt6-tools"
+makedepends="qt6-base-devel"
+short_desc="Clone of LXQt sudo tool, without LXQt libs"
+maintainer="toadwastoast <toadwastoast@proton.me>"
+license="GPL-2.0-or-later"
+homepage="https://github.com/aarnt/qt-sudo"
+distfiles="https://github.com/aarnt/qt-sudo/archive/v${version}.tar.gz"
+checksum=d97f38b37f2f8e4411506bed361090415a5617ebd794a9de7d9b4bb606ece3a1


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64 (cross)
  - armv7l-musl (cross)
  - armv6l (cross)

Had to package qt-sudo since it's now necessary on octoxbps.