### PR TITLE
libvirt(-python3): update to 10.10.0.

### DIFF
--- a/srcpkgs/libvirt-python3/template
+++ b/srcpkgs/libvirt-python3/template
@@ -1,6 +1,6 @@
 # Template file for 'libvirt-python3'
 pkgname=libvirt-python3
-version=10.5.0
+version=10.10.0
 revision=1
 build_style=python3-module
 hostmakedepends="pkg-config python3-devel python3-setuptools libvirt-devel
@@ -13,7 +13,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="LGPL-2.1-or-later"
 homepage="https://pypi.org/project/libvirt-python/"
 distfiles="https://libvirt.org/sources/python/libvirt-python-${version}.tar.gz"
-checksum=785023500f58d3e8e829af98647d43eee97e517aacc9d9e7ded43594ea52d032
+checksum=8acf6dcfb33a03ed92f9440cb1a0b8d3fc53fb23bba2e76ceedeb8bfb5327557
 
 do_check() {
 	PYTHONPATH="$(cd build/lib.* && pwd)" pytest

--- a/srcpkgs/libvirt/template
+++ b/srcpkgs/libvirt/template
@@ -1,6 +1,6 @@
 # Template file for 'libvirt'
 pkgname=libvirt
-version=10.5.0
+version=10.10.0
 revision=1
 build_style=meson
 configure_args="-Dqemu_user=libvirt -Dqemu_group=libvirt -Drunstatedir=/run
@@ -11,8 +11,9 @@ hostmakedepends="automake dnsmasq docbook-xsl gettext gettext-devel iptables
 makedepends="readline-devel libcap-ng-devel attr-devel gnutls-devel
  libsasl-devel libcurl-devel libpcap-devel libxml2-devel libparted-devel
  device-mapper-devel eudev-libudev-devel libblkid-devel libpciaccess-devel
- avahi-libs-devel polkit-devel yajl-devel jansson-devel python3-devel
- libssh2-devel fuse-devel libtirpc-devel libapparmor-devel"
+ avahi-libs-devel polkit-devel jansson-devel python3-devel libssh2-devel
+ fuse-devel libtirpc-devel libapparmor-devel json-c-devel bash-completion
+ libssh-devel acl-devel libaudit-devel libnuma-devel"
 depends="iptables dnsmasq"
 short_desc="Virtualization API for controlling virtualization engines"
 maintainer="Orphaned <orphan@voidlinux.org>"
@@ -20,27 +21,18 @@ license="LGPL-2.1-or-later"
 homepage="https://libvirt.org"
 changelog="https://raw.githubusercontent.com/libvirt/libvirt/master/NEWS.rst"
 distfiles="https://libvirt.org/sources/libvirt-${version}.tar.xz"
-checksum=8e853a9c91c9029b9019cf5fdf2b5fea36d501d563e43254efc20e12c00557e8
-# At least one test times out on CI but works locally
-make_check=ci-skip
-
-# FIX https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=701649
-system_accounts="libvirt"
-libvirt_groups="disk,kvm"
+checksum=e1bd7bd31b7c0d0ae073dec050bb5b0232b3e4adebdc58ea82fe8b366c765796
 
 case "$XBPS_TARGET_MACHINE" in
-	i686*) makedepends+=" libnuma-devel" ;;
-	x86_64*) makedepends+=" libnuma-devel xen-devel" ;;
+	x86_64*) makedepends+=" xen-devel " ;;
 	*) ;;
 esac
 
 case "$XBPS_TARGET_MACHINE" in
 	*-musl) ;;
 	*)
-		# LTO apparently causes the linker to confuse the glibc symbol
-		# xdr_int64_t with that provided by libtirpc, causing a crash.
-		# https://gitlab.com/libvirt/libvirt/-/issues/92
-		configure_args+=" -Db_lto=false"
+		# glusterfs is currently broken with musl-libc
+		makedepends+=" glusterfs-devel "
 		;;
 esac
 
@@ -72,6 +64,12 @@ post_patch() {
 }
 
 pre_build() {
+	# Remove specific tests because they timeout on CI build
+	if [ "$XBPS_BUILD_ENVIRONMENT" = "void-packages-ci" ]; then
+		vsed -i "tests/meson.build" -e "/{ 'name': 'virshtest',/d"
+		vsed -i "tests/meson.build" -e "/{ 'name': 'commandtest' },/d"
+	fi
+
 	# racey custom targets; prevent parallelism issues
 	ninja -C build \
 		src/remote/lxc_protocol.h \


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl
  - i686
  - aarch64 (cross)
  - armv7l (cross)

Cleanup and refactor of the whole template.

Also added a few packages to makedepends for additional features and removed one dependency as it is no longer needed.

Enable and modify testing to work in CI.
