### PR TITLE
routinator: update to 0.14.0

### DIFF
--- a/srcpkgs/routinator/template
+++ b/srcpkgs/routinator/template
@@ -1,6 +1,6 @@
 # Template file for 'routinator'
 pkgname=routinator
-version=0.13.2
+version=0.14.0
 revision=1
 build_style=cargo
 depends="rsync"
@@ -11,7 +11,7 @@ homepage="https://routinator.docs.nlnetlabs.nl/"
 changelog="https://raw.githubusercontent.com/NLnetLabs/routinator/main/Changelog.md"
 distfiles="https://github.com/NLnetLabs/routinator/archive/v${version}.tar.gz"
 conf_files="/etc/routinator/routinator.conf"
-checksum=77c3b74b508caabf4c59387480cda18b222d817fd70328f8c73a8fb45a774108
+checksum=861e90f395344be19880485185df47e8fd258cc583b82be702af660b466955cb
 system_accounts="_routinator"
 _routinator_homedir="/var/lib/routinator"
 make_dirs="/var/lib/routinator 0755 _routinator _routinator"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc, x86_64-musl)
- I built this PR locally for these architectures:
  - aarch64-musl
  - armv7l
  - armv6l-musl