### PR TITLE
krita: update to 5.2.6

### DIFF
--- a/srcpkgs/krita/template
+++ b/srcpkgs/krita/template
@@ -1,7 +1,7 @@
 # Template file for 'krita'
 pkgname=krita
-version=5.2.3
-revision=2
+version=5.2.6
+revision=1
 build_style=cmake
 configure_args="-Wno-dev -DBUILD_TESTING=OFF -DENABLE_UPDATERS=OFF"
 hostmakedepends="extra-cmake-modules gettext pkg-config python3
@@ -17,13 +17,13 @@ makedepends="karchive-devel kconfig-devel kwidgetsaddons-devel kcompletion-devel
  libopenjpeg2-devel qt5-plugin-mysql qt5-plugin-sqlite qt5-plugin-odbc
  qt5-plugin-pgsql qt5-plugin-tds libwebp-devel libmypaint-devel libjxl-devel
  libkdcraw5-devel immer zug lager libunibreak-devel mlt7-devel xsimd"
-depends="qt5-plugin-sqlite"
+depends="qt5-plugin-sqlite python3-PyQt5"
 short_desc="Painting and image editing program"
 maintainer="John <me@johnnynator.dev>"
 license="GPL-3.0-only"
 homepage="https://krita.org/"
 distfiles="${KDE_SITE}/krita/${version}/krita-${version}.tar.xz"
-checksum=cf78ddb39700c92928cf14d7611b8ef3870d8f5b83ef590d43e218bec5dafd54
+checksum=7a9be2c782a87b349e2267bda74ecc43381a085b639b5b2b91da1c56f977de59
 python_version=3
 replaces="calligra-krita>=0"
 # FIXME


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - armv7l-musl (cross)
  - aarch64 (cross)

I added `python3-PyQt5` to `depends` since it's necessary for the krita python plugin manager to work and for dockers like the quick settings docker to show up.

@Johnnynator may you please review this PR? Thanks.