### PR TITLE
qbittorrent: update to 5.0.1

### DIFF
--- a/srcpkgs/qbittorrent/template
+++ b/srcpkgs/qbittorrent/template
@@ -1,9 +1,9 @@
 # Template file for 'qbittorrent'
 pkgname=qbittorrent
-version=5.0.0
+version=5.0.1
 revision=1
 build_style=cmake
-configure_args="-DQT6=ON -DSYSTEMD=OFF -DGUI=ON -DWEBUI=OFF"
+configure_args="-DSYSTEMD=OFF -DGUI=ON -DWEBUI=OFF"
 hostmakedepends="pkg-config qt6-tools qt6-declarative-host-tools"
 makedepends="libtorrent-rasterbar-devel qt6-base-private-devel qt6-declarative-devel qt6-svg-devel"
 depends="qt6-svg"
@@ -13,7 +13,7 @@ license="GPL-2.0-or-later"
 homepage="https://www.qbittorrent.org/"
 changelog="https://www.qbittorrent.org/news.php"
 distfiles="${SOURCEFORGE_SITE}/qbittorrent/qbittorrent-${version}.tar.xz"
-checksum=623b0e29529ef0c041c5587494bfc1f81b068b3ea4318cefdc2296dcc6c7421d
+checksum=03435c292091cc953ff078da8fd224b9e45074842ea72caa82a4ead72b402e69
 CXXFLAGS=-std=gnu++17
 
 post_configure() { # qbittorrent-nox


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64 (cross)
  - armv7l-musl (cross)

Removed the `DQT6=ON` arg since it's unecessary, qbittorrent supports only Qt6 from 5.0.0 onwards.