### PR TITLE
pinfo: fix showing of man pages

### DIFF
--- a/srcpkgs/pinfo/patches/36.patch
+++ b/srcpkgs/pinfo/patches/36.patch
@@ -1,0 +1,57 @@
+From 032dbfc4bf9ff45719de64d251244ab1307db17c Mon Sep 17 00:00:00 2001
+From: "David H. Bronke" <whitelynx@gmail.com>
+Date: Sun, 9 Jun 2024 12:12:05 +0200
+Subject: [PATCH 1/2] Fall back to running man without -W since some
+ implementations don't allow that
+
+Fixes #12.
+
+Change courtesy of loreb: https://github.com/baszoetekouw/pinfo/issues/12#issuecomment-884322986
+---
+ src/manual.c | 10 ++++++++--
+ 1 file changed, 8 insertions(+), 2 deletions(-)
+
+diff --git a/src/manual.c b/src/manual.c
+index 5f058ff..791df32 100644
+--- a/src/manual.c
++++ b/src/manual.c
+@@ -186,8 +186,14 @@ set_initial_history(char *name)
+ 		pathFile = popen(buf, "r");
+ 		if (fgets(buf, sizeof(buf), pathFile)==NULL)
+ 		{
+-			fprintf(stderr, "Error executing command '%s'\n", buf);
+-			exit(1);
++			/* Try without -W */
++			snprintf(buf, sizeof(buf), "man -w %s %s", ManOptions, name);
++			pathFile = popen(buf, "r");
++			if (fgets(buf, sizeof(buf), pathFile)==NULL)
++			{
++				fprintf(stderr, "Error executing command '%s'\n", buf);
++				exit(1);
++			}
+ 		}
+ 		pclose(pathFile);
+ 		/* buf will be of the form "/usr/share/man/man1/sleep.1.gz". We
+
+From c3722aa478420b6671ed932503e06886e04d4287 Mon Sep 17 00:00:00 2001
+From: "David H. Bronke" <whitelynx@gmail.com>
+Date: Sat, 29 Jun 2024 14:55:46 +0200
+Subject: [PATCH 2/2] fix(src/manual.c): close pathFile before reopening
+
+Suggested by @xaizek
+---
+ src/manual.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/manual.c b/src/manual.c
+index 791df32..bb730ee 100644
+--- a/src/manual.c
++++ b/src/manual.c
+@@ -186,6 +186,7 @@ set_initial_history(char *name)
+ 		pathFile = popen(buf, "r");
+ 		if (fgets(buf, sizeof(buf), pathFile)==NULL)
+ 		{
++			pclose(pathFile);
+ 			/* Try without -W */
+ 			snprintf(buf, sizeof(buf), "man -w %s %s", ManOptions, name);
+ 			pathFile = popen(buf, "r");

--- a/srcpkgs/pinfo/template
+++ b/srcpkgs/pinfo/template
@@ -1,7 +1,7 @@
 # Template file for 'pinfo'
 pkgname=pinfo
 version=0.6.13
-revision=2
+revision=3
 build_style=gnu-configure
 hostmakedepends="automake gettext gettext-devel tar texinfo"
 makedepends="ncurses-devel"


### PR DESCRIPTION
To show a man page (e.g. when there is no info file) this program uses
`man -w -W <name>` but option `-W` is unsupported by our `man(1)`.

This results in:

    $ pinfo man
    man: BADARG: bad command line argument: -W man
    Error executing command 'man -w -W  man'

and the terminal is left in a broken state.

Fix by applying this PR: https://github.com/baszoetekouw/pinfo/pull/36

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
