### PR TITLE
pmars: change upstream to site that should work with builders

### DIFF
--- a/srcpkgs/pmars/template
+++ b/srcpkgs/pmars/template
@@ -6,10 +6,9 @@ makedepends="libX11-devel"
 short_desc="Reference implementation of Corewar game"
 maintainer="Robert Lowry <bobertlo@gmail.com>"
 license="GPL-2.0-or-later"
-homepage="https://corewar.co.uk/pmars.htm"
-distfiles="https://corewar.co.uk/pmars/pmars-${version}.zip"
+homepage="http://www.koth.org/pmars/"
+distfiles="http://www.koth.org/pmars/pmars-${version}.zip"
 checksum=26c2860ee5906b5e90262ce18d511c8cc395ee6f6796e99631b1910bd0a84c4c
-broken="upstream is dead"
 
 do_build() {
 	make -C src CC="${CC}"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
-->
