### PR TITLE
xbps-src: improve update-check pattern for GitHub

### DIFF
--- a/common/xbps-src/shutils/update_check.sh
+++ b/common/xbps-src/shutils/update_check.sh
@@ -139,7 +139,7 @@ update_check() {
             *github.com*)
                 pkgurlname="$(printf %s "$url" | cut -d/ -f4,5)"
                 url="https://github.com/$pkgurlname/tags"
-                rx='/archive/refs/tags/(v?|\Q'"$pkgname"'\E[-_])?\K[\d.]+(?=\.tar\.gz")';;
+                rx='/archive/refs/tags/(\Q'"$pkgname"'\E|[-_v])*\K[\d.]+(?=\.tar\.gz")';;
             *//gitlab.*|*code.videolan.org*)
                 case "$url" in
                     */-/*) pkgurlname="$(printf %s "$url" | sed -e 's%/-/.*%%g; s%/$%%')";;


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

This one catches tags of the form `<pkgname>-v<major>.<minor>.<patch>` which would get through the previous one. And possibly some other cursed patterns. But maybe there's some unintended side effects. I did check it against quite a few packages but GH sources are far too many to do an exhaustive testing.