### PR TITLE
mise: update to 2024.11.1

### DIFF
--- a/srcpkgs/mise/template
+++ b/srcpkgs/mise/template
@@ -1,6 +1,6 @@
 # Template file for 'mise'
 pkgname=mise
-version=2024.10.13
+version=2024.11.1
 revision=1
 build_style=cargo
 make_check_args="-- --skip cli --skip runtime_symlinks::tests::test_list_symlinks"
@@ -12,7 +12,7 @@ license="MIT"
 homepage="https://github.com/jdx/mise"
 changelog="https://github.com/jdx/mise/releases"
 distfiles="https://github.com/jdx/mise/archive/v${version}.tar.gz>${pkgname}-${version}.tar.gz"
-checksum=e25023b573dbf8f2df2a5fb6372ad82bcf2a2abff6b1f5ceb1922c936099a3a4
+checksum=82eee2693af7d0ecb59873f8d90defa4a08c641586ccc6baae200e883c467a44
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc