### PR TITLE
updates rio to v0.1.17

### DIFF
--- a/srcpkgs/rio/template
+++ b/srcpkgs/rio/template
@@ -1,6 +1,6 @@
 # Template file for 'rio'
 pkgname=rio
-version=0.1.16
+version=0.1.17
 revision=1
 build_style=cargo
 build_wrksrc="frontends/rioterm"
@@ -13,7 +13,7 @@ license="MIT"
 homepage="https://raphamorim.io/rio/"
 changelog="https://raw.githubusercontent.com/raphamorim/rio/main/CHANGELOG.md"
 distfiles="https://github.com/raphamorim/rio/archive/refs/tags/v${version}.tar.gz"
-checksum=5311753404c4475751a514305e4dbb75c565f386e5ccf66d8238f135c1cd786f
+checksum=2e17a8775a5463f4ad96e55b90468561b08636d8d260bb295770aef930168000
 
 post_install() {
 	vinstall ${wrksrc}/misc/logo.svg 644 usr/share/icons/hicolor/scalable/apps rio.svg


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly** (on my own system, amd64 gnu libc)

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
