### PR TITLE
aerc: run the full test suite

### DIFF
--- a/srcpkgs/aerc/template
+++ b/srcpkgs/aerc/template
@@ -21,3 +21,7 @@ post_install() {
 	make PREFIX=/usr DESTDIR=${DESTDIR} install
 	vlicense LICENSE
 }
+
+do_check() {
+	make ${makejobs} tests
+}


### PR DESCRIPTION
With 2991ed7a16f6 ("musl: backport patch to fix fgetws") merged, the
tests of the included filters written in C no longer fail on musl and
can thus be enabled.

---

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
#### Local build testing
- I built this PR locally for my native architecture, (x86_64-musl)
