### PR TITLE
streamlink: update to 7.0.0

### DIFF
--- a/srcpkgs/streamlink/template
+++ b/srcpkgs/streamlink/template
@@ -1,23 +1,21 @@
 # Template file for 'streamlink'
 pkgname=streamlink
-version=6.11.0
+version=7.0.0
 revision=1
 build_style=python3-pep517
 hostmakedepends="python3-wheel python3-versioningit"
 depends="python3-lxml python3-pycryptodome python3-pycountry
  python3-pysocks python3-requests python3-websocket-client python3-isodate
  python3-urllib3 python3-certifi python3-typing_extensions python3-trio python3-trio-websocket"
-checkdepends="$depends python3-pytest python3-mock python3-requests-mock
- python3-freezegun"
+checkdepends="$depends python3-pytest python3-requests-mock python3-pytest-trio python3-freezegun"
 short_desc="Utility extracting streams from services, forked from livestreamer"
 maintainer="Tom Strausbaugh <tstrausbaugh@straustech.net>"
 license="BSD-2-Clause"
 homepage="https://streamlink.github.io/"
 changelog="https://raw.githubusercontent.com/streamlink/streamlink/master/CHANGELOG.md"
 distfiles="https://github.com/streamlink/streamlink/releases/download/$version/streamlink-$version.tar.gz"
-checksum=562e5d753ca109e1956207de4ac27c337ce6b99fbe7ed7203b945105ed5b2f86
+checksum=51a4062862e6795d694046ca6e70549d6d13583c640d1505966804b0e03feff2
 make_check_pre="env PYTHONPATH=src"
-make_check=ci-skip # some tests fail when running as root
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
Really just a version bump. No breaking changes from what I could see in release notes and no changes required to python libraries.

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl
  - aarch64-musl
  - aarch64
