### PR TITLE
GNS3 - update to 2.2.52

### DIFF
--- a/srcpkgs/gns3-gui/template
+++ b/srcpkgs/gns3-gui/template
@@ -1,6 +1,6 @@
 # Template file for 'gns3-gui'
 pkgname=gns3-gui
-version=2.2.49
+version=2.2.52
 revision=1
 build_style=python3-module
 hostmakedepends="python3-setuptools"
@@ -14,7 +14,7 @@ license="GPL-3.0-or-later"
 homepage="https://gns3.com"
 changelog="https://raw.githubusercontent.com/GNS3/gns3-gui/master/CHANGELOG"
 distfiles="https://github.com/GNS3/${pkgname}/archive/v${version}.tar.gz"
-checksum=360fe0eab33fe4f8b28bcecc77de7c9afa3da304c77cc4c5caf6339b982dd14e
+checksum=ff854f1403a99887c132daa210663c2b9b28ab5e8062500a8dc349e897b4c5c1
 
 
 post_patch() {

--- a/srcpkgs/gns3-server/template
+++ b/srcpkgs/gns3-server/template
@@ -1,6 +1,6 @@
 # Template file for 'gns3-server'
 pkgname=gns3-server
-version=2.2.49
+version=2.2.52
 revision=1
 build_style=python3-module
 hostmakedepends="python3-setuptools"
@@ -14,7 +14,7 @@ license="GPL-3.0-or-later"
 homepage="https://gns3.com"
 changelog="https://raw.githubusercontent.com/GNS3/gns3-server/master/CHANGELOG"
 distfiles="https://github.com/GNS3/gns3-server/archive/v${version}.tar.gz"
-checksum=4acd6b80293a2fef7c5c7c017643bf7925e6b2f3861f5f70cd55e2b7441f9762
+checksum=e4c1bfe7383033937fa1543f003ba659ce199d8757523b84acdd39becf8f9db0
 
 post_patch() {
 	# comment out requirements since versions are usually out of sync with Void packages


### PR DESCRIPTION
gns3-server: update to 2.2.52.
gns3-gui: update to 2.2.52.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
