### PR TITLE
pmbootstrap: update to 3.0.0.

### DIFF
--- a/srcpkgs/pmbootstrap/template
+++ b/srcpkgs/pmbootstrap/template
@@ -1,15 +1,15 @@
 # Template file for 'pmbootstrap'
 pkgname=pmbootstrap
-version=2.3.1
+version=3.0.0
 revision=1
 build_style=python3-pep517
 hostmakedepends="python3-wheel"
-depends="git openssl python3"
+depends="git openssl python3 kpartx util-linux"
+checkdepends="python3-pytest ${depends}"
 short_desc="Package build and device flashing tool for postmarketOS"
 maintainer="Jami Kettunen <jami.kettunen@protonmail.com>"
 license="GPL-3.0-or-later"
 homepage="https://postmarketos.org"
-changelog="https://gitlab.com/postmarketOS/pmbootstrap/-/tags"
-distfiles="https://gitlab.com/postmarketOS/pmbootstrap/-/archive/${version}/pmbootstrap-${version}.tar.gz"
-checksum=aba09c0a27918dac4b07641339ccf86e6ec0d14d4602056dac44ec49af12c894
-make_check=no # tests require chroot
+changelog="https://gitlab.postmarketos.org/postmarketOS/pmbootstrap/-/tags"
+distfiles="https://gitlab.postmarketos.org/postmarketOS/pmbootstrap/-/archive/${version}/pmbootstrap-${version}.tar.gz"
+checksum=80bb9b105e9ddae07be8ac7b56299a50541ac4671e592544761fdbbbee5e09f4


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: YES

pmbootstrap --version

pmbootstrap init (for qemu)

pmbootstrap install (for qemu)

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl - cross compiled on x86_64
  - armv7l - cross compiled on x86_64
  - armv6l-musl - cross compiled on x86_64


Information about the gitlab migration changes that have been made in this PR. 
https://postmarketos.org/blog/2024/10/14/gitlab-migration/

Release notes for upgrade, tests should be re-enabled so let me know if I'm missing anything here to get them to run in the CI process. Thank you!

https://gitlab.postmarketos.org/postmarketOS/pmbootstrap/-/tags/3.0.0