### PR TITLE
kernel-libc-headers: fix for riscv

### DIFF
--- a/srcpkgs/kernel-libc-headers/template
+++ b/srcpkgs/kernel-libc-headers/template
@@ -20,6 +20,7 @@ case "$XBPS_TARGET_MACHINE" in
 	aarch64*) _arch="arm64";;
 	mips*) _arch="mips";;
 	ppc*) _arch="powerpc";;
+	riscv*) _arch="riscv";;
 	*) msg_error "$pkgname: unknown architecture.\n";;
 esac
 


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for these architectures:
  - riscv64 (cross)
  - riscv64 (native)