### PR TITLE
efibootmgr: have efibootmgr scripts behave more like grub with kernel…

### DIFF
--- a/srcpkgs/efibootmgr/files/README.voidlinux
+++ b/srcpkgs/efibootmgr/files/README.voidlinux
@@ -13,7 +13,3 @@ but you always have to reconfigure the kernel:
 	(or any other kernel version)
 
 This is also required after the first installation of this package.
------------------------------------------------------------------------
-The bootorder itself is not changed, so your previous boot loader will
-stay enabled until you can edit the order in your firmware interface or
-using "efibootmgr -o <hexnum>"

--- a/srcpkgs/efibootmgr/files/kernel.d/efibootmgr.post-install
+++ b/srcpkgs/efibootmgr/files/kernel.d/efibootmgr.post-install
@@ -4,7 +4,7 @@
 #
 # Arguments passed to this script: $1 pkgname, $2 version.
 #
-PKGNAME="$1"
+# PKGNAME="$1"
 VERSION="$2"
 
 . "${ROOTDIR}/etc/default/efibootmgr-kernel-hook"
@@ -22,24 +22,5 @@ if [ "x${PART}" != x ]; then
 	args="$args -p $PART"
 fi
 
-# get major version, e.g. "4.8" for "linux4.8"
-major_version=$(echo $PKGNAME | cut -c 6-)
-
-# look for previous entry for this major kernel version
-existing_entry=$(efibootmgr | grep "Void Linux with kernel ${major_version}")
-
-# get the boot order
-# this is required because when in the next step the existing entry is removed,
-# it is also removed from the order so it needs to be restored later
-bootorder=$(efibootmgr |grep "BootOrder: " |cut -c 12-)
-
-# if existing, remove it
-if [ "$existing_entry" != "" ]; then
-  /etc/kernel.d/post-remove/50-efibootmgr $PKGNAME
-fi
-
-# create the new entry
-efibootmgr -qc $args -L "Void Linux with kernel ${major_version}" -l /vmlinuz-${VERSION} -u "${OPTIONS}"
-
-# restore the boot order
-efibootmgr -qo $bootorder
+# create new entry (new bootnum will be added to the start of bootorder)
+efibootmgr -qc $args -L "Void Linux with kernel ${VERSION}" -l /vmlinuz-${VERSION} -u "${OPTIONS}"

--- a/srcpkgs/efibootmgr/files/kernel.d/efibootmgr.post-remove
+++ b/srcpkgs/efibootmgr/files/kernel.d/efibootmgr.post-remove
@@ -4,18 +4,16 @@
 #
 # Arguments passed to this script: $1 pkgname, $2 version.
 #
-PKGNAME="$1"
+# PKGNAME="$1"
+VERSION="$2"
 
 . "${ROOTDIR}/etc/default/efibootmgr-kernel-hook"
 if [ "x${MODIFY_EFI_ENTRIES}" != x1 ]; then
 	exit 0
 fi
 
-# get major version, e.g. "4.8" for "linux4.8"
-major_version=$(echo $PKGNAME | cut -c 6-)
-
 # get hex number of the matching entry
-hexnum=$(efibootmgr | grep "Void Linux with kernel ${major_version}" | cut -c "5-8")
+hexnum=$(efibootmgr | grep "Void Linux with kernel ${VERSION}" | cut -c "5-8")
 
 # delete it
 [ "$hexnum" ] && efibootmgr -Bq -b $hexnum

--- a/srcpkgs/efibootmgr/template
+++ b/srcpkgs/efibootmgr/template
@@ -1,7 +1,7 @@
 # Template file for 'efibootmgr'
 pkgname=efibootmgr
 version=18
-revision=1
+revision=2
 hostmakedepends="pkg-config"
 makedepends="libefivar-devel popt-devel"
 short_desc="Tool to modify UEFI Firmware Boot Manager Variables"


### PR DESCRIPTION
… minor version entries, and allow vkpurge to function properly here

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)

efibootmgr.post-install only creates one boot entry for the latest kernel minor version of a major version; it removes the current boot entry and replaces it with the kernel that's been installed.  Additionally, efibootmgr.post-remove does nothing when called by vkpurge due to the "pkgname" that's passed to it.

This patch makes these scripts behave a little more like the related grub process in that you can easily boot from a previous kernel, as it simply adds a boot entry every time a kernel is installed.  In relation to this, efibootmgr.post-remove is also altered to allow vkpurge to do what one would expect, which is actually remove the related boot entry from EFI.

Please know this is my first commit on GitHub, so it's very possible something here is incorrect.