### PR TITLE
xmlto: update to 0.0.29

### DIFF
--- a/srcpkgs/xmlto/template
+++ b/srcpkgs/xmlto/template
@@ -1,15 +1,19 @@
 # Template file for 'xmlto'
 pkgname=xmlto
-version=0.0.28
-revision=2
+version=0.0.29
+revision=1
 build_style=gnu-configure
 # Requires bash!
 configure_args="ac_cv_path_BASH=/bin/bash"
-hostmakedepends="libxslt docbook-xsl"
-depends="bash ${hostmakedepends}"
+hostmakedepends="autoconf automake libxslt docbook-xsl"
+depends="bash libxslt docbook-xsl"
 short_desc="Tool to help transform XML documents into other formats"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later"
-homepage="http://cyberelk.net/tim/software/xmlto/"
-distfiles="http://anduin.linuxfromscratch.org/BLFS/xmlto/xmlto-${version}.tar.bz2"
-checksum=1130df3a7957eb9f6f0d29e4aa1c75732a7dfb6d639be013859b5c7ec5421276
+homepage="https://pagure.io/xmlto/"
+distfiles="https://pagure.io/xmlto/archive/${version}/xmlto-${version}.tar.gz"
+checksum=40504db68718385a4eaa9154a28f59e51e59d006d1aa14f5bc9d6fded1d6017a
+
+pre_configure() {
+	autoreconf -fi
+}


### PR DESCRIPTION
As indicated on the cyberelk website, the project was moved to Fedora pagure. This also has a newer release with fixes for gcc 14.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
