### PR TITLE
go: update to 1.23.3.

### DIFF
--- a/srcpkgs/go/template
+++ b/srcpkgs/go/template
@@ -1,6 +1,6 @@
 # Template file for 'go'
 pkgname=go
-version=1.23.2
+version=1.23.3
 revision=1
 create_wrksrc=yes
 build_wrksrc=go
@@ -12,7 +12,7 @@ license="BSD-3-Clause"
 homepage="https://go.dev/"
 changelog="https://go.dev/doc/devel/release.html"
 distfiles="https://go.dev/dl/go${version}.src.tar.gz"
-checksum=36930162a93df417d90bd22c6e14daff4705baac2b02418edda671cdfa9cd07f
+checksum=8d6a77332487557c6afa2421131b50f83db4ae3c579c3bc72e670ee1f6968599
 nostrip=yes
 noverifyrdeps=yes
 # on CI it tries to use `git submodule`, which is not part of chroot-git


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**


#### Local build testing
- I built this PR locally for my native architecture, (x86_64)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - aarch64
  - i686
  - i686-musl

@the-maldridge @classabbyamp


