### PR TITLE
kmod: update to 33.

### DIFF
--- a/srcpkgs/kmod/template
+++ b/srcpkgs/kmod/template
@@ -1,10 +1,10 @@
 # Template file for 'kmod'
 pkgname=kmod
-version=31
+version=33
 revision=1
 build_style=gnu-configure
 configure_args="--with-zlib --with-xz --with-zstd"
-hostmakedepends="pkg-config"
+hostmakedepends="pkg-config scdoc"
 makedepends="zlib-devel liblzma-devel libzstd-devel"
 make_dirs="
  /etc/depmod.d 0755 root root
@@ -16,7 +16,7 @@ maintainer="Enno Boland <gottox@voidlinux.org>"
 license="GPL-2.0-or-later, LGPL-2.1-or-later"
 homepage="https://git.kernel.org/pub/scm/utils/kernel/kmod/kmod.git"
 distfiles="${KERNEL_SITE}/utils/kernel/kmod/kmod-${version}.tar.xz"
-checksum=f5a6949043cc72c001b728d8c218609c5a15f3c33d75614b78c79418fcf00d80
+checksum=dc768b3155172091f56dc69430b5481f2d76ecd9ccb54ead8c2540dbcf5ea9bc
 make_check=no # needs access to /lib/modules/$(uname -r)/build
 
 post_install() {


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl
  - i686
  - aarch64
  - armv7l
