### PR TITLE
dkms: update to 3.1.3.

### DIFF
--- a/srcpkgs/dkms/template
+++ b/srcpkgs/dkms/template
@@ -1,6 +1,6 @@
 # Template file for 'dkms'
 pkgname=dkms
-version=3.0.13
+version=3.1.4
 revision=1
 build_style=gnu-makefile
 make_build_args="all"
@@ -11,7 +11,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="https://github.com/dell/dkms"
 distfiles="https://github.com/dell/dkms/archive/v${version}.tar.gz"
-checksum=ceb5bbb89ece7310ee96952a56c926faa51c4486f7e5e43c8589585056e45bb5
+checksum=5b248af2e45c74af0f9e689bf8ae4a4d9f6ff577ac1ba8e71174e3c552c1d3ac
 # dkms does not create this directory, but needs it
 # https://github.com/void-linux/void-packages/issues/39066
 make_dirs="/var/lib/dkms 0755 root root"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl
  - i686
  - aarch64 (cross)
  - aarch64-musl (cross)
  - armv7l (cross)
