### PR TITLE
traceroute: update to 2.1.6.

### DIFF
--- a/srcpkgs/traceroute/template
+++ b/srcpkgs/traceroute/template
@@ -1,13 +1,13 @@
 # Template file for 'traceroute'
 pkgname=traceroute
-version=2.1.3
+version=2.1.6
 revision=1
 short_desc="Traces the route taken by packets over an IPv4/IPv6 network"
 maintainer="Enno Boland <gottox@voidlinux.org>"
 license="GPL-2.0-or-later, LGPL-2.1-or-later"
 homepage="https://traceroute.sourceforge.net"
 distfiles="${SOURCEFORGE_SITE}/traceroute/traceroute-${version}.tar.gz"
-checksum=05ebc7aba28a9100f9bbae54ceecbf75c82ccf46bdfce8b5d64806459a7e0412
+checksum=9ccef9cdb9d7a98ff7fbf93f79ebd0e48881664b525c4b232a0fcec7dcb9db5e
 
 alternatives="
  traceroute:traceroute:/usr/bin/linux-traceroute


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl
  - i686
  - aarch64
  - aarch64-musl
  - armv7l
