### PR TITLE
llvm19: disable debug on 32bit build machines

### DIFF
--- a/srcpkgs/llvm19/template
+++ b/srcpkgs/llvm19/template
@@ -72,6 +72,10 @@ nocross="save the builders!"
 CFLAGS="-Wno-unused-command-line-argument"
 CXXFLAGS="-Wno-unused-command-line-argument"
 
+if [ "$XBPS_WORDSIZE" == "32" ]; then
+	nodebug=yes  # 32bit memory exhasted
+fi
+
 build_options="clang clang_tools_extra lld mlir libclc polly lldb flang bolt
  openmp libc libcxx libunwind offload llvm_spirv lto graphviz full_debug"
 build_options_default="clang clang_tools_extra lld mlir libclc polly lldb


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **NO**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->

[ci skip]