### PR TITLE
node_exporter: update to 1.8.2.

### DIFF
--- a/srcpkgs/node_exporter/template
+++ b/srcpkgs/node_exporter/template
@@ -1,7 +1,7 @@
 # Template file for 'node_exporter'
 pkgname=node_exporter
-version=1.3.1
-revision=4
+version=1.8.2
+revision=1
 build_style=go
 go_import_path="github.com/prometheus/node_exporter"
 go_ldflags="-X ${go_import_path}/version.Version=${version}
@@ -14,7 +14,7 @@ license="Apache-2.0"
 homepage="https://prometheus.io/"
 changelog="https://raw.githubusercontent.com/prometheus/node_exporter/master/CHANGELOG.md"
 distfiles="https://github.com/prometheus/node_exporter/archive/v${version}.tar.gz"
-checksum=66856b6b8953e094c46d7dd5aabd32801375cf4d13d9fe388e320cbaeaff573a
+checksum=f615c70be816550498dd6a505391dbed1a896705eff842628de13a1fa7654e8f
 
 system_accounts="_node_exporter"
 


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **Yes, testing it about a day on my homelab**.

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)

#### Note

In the future, will be needed to drop the runit collector flag, per https://github.com/prometheus/node_exporter/commit/180879e1c4bb0b9430d46ff3936850007dc78774