### PR TITLE
libclc: use libclc alternatives group

### DIFF
--- a/srcpkgs/libclc/template
+++ b/srcpkgs/libclc/template
@@ -1,7 +1,7 @@
 # Template file for 'libclc'
 pkgname=libclc
 version=18.1.8
-revision=2
+revision=3
 build_style=cmake
 # disable clspv (failing tests, we don't ship it)
 configure_args="-DCMAKE_INSTALL_PREFIX=/usr/lib/llvm/18/ -DCMAKE_BUILD_TYPE=Release
@@ -17,9 +17,9 @@ checksum=905bd59e9f810d6bd0ae6874725a8f8a3c91cb416199c03f2b98b57437cfb32e
 replaces="libclc-git>=0"
 
 alternatives="
- clc:/usr/share/clc:/usr/lib/llvm/18/share/clc
- clc:/usr/include/clc:/usr/lib/llvm/18/include/clc
- clc:/usr/share/pkgconfig/libclc.pc:/usr/lib/llvm/18/share/pkgconfig/libclc.pc
+ libclc:/usr/share/clc:/usr/lib/llvm/18/share/clc
+ libclc:/usr/include/clc:/usr/lib/llvm/18/include/clc
+ libclc:/usr/share/pkgconfig/libclc.pc:/usr/lib/llvm/18/share/pkgconfig/libclc.pc
 "
 
 do_configure() {


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
