### PR TITLE
Revert "llvm19: nocross (save the builders!)"

### DIFF
--- a/srcpkgs/llvm19/template
+++ b/srcpkgs/llvm19/template
@@ -67,9 +67,7 @@ skip_extraction=${_spirv_version}.tar.gz
 conflicts="llvm18>=0 llvm17>=0 llvm15>=0"
 lib32disabled=yes
 python_version=3
-if [ "$XBPS_TARGET_MACHINE" != aarch64 ]; then
-	nocross="save the builders!"
-fi
+nocross="save the builders!"
 
 CFLAGS="-Wno-unused-command-line-argument"
 CXXFLAGS="-Wno-unused-command-line-argument"

--- a/srcpkgs/llvm19/template
+++ b/srcpkgs/llvm19/template
@@ -67,7 +67,6 @@ skip_extraction=${_spirv_version}.tar.gz
 conflicts="llvm18>=0 llvm17>=0 llvm15>=0"
 lib32disabled=yes
 python_version=3
-nocross="save the builders!"
 
 CFLAGS="-Wno-unused-command-line-argument"
 CXXFLAGS="-Wno-unused-command-line-argument"


### PR DESCRIPTION
This reverts commit a7bd3bcfecdc02f77161f14654ba2bc02f31a215.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **NO**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->

do not merge until build is done on x86_64 and x86_64-musl

[ci skip]