### PR TITLE
u-boot-menu: update to 0.3

### DIFF
--- a/srcpkgs/u-boot-menu/files/kernel.d/extlinux
+++ b/srcpkgs/u-boot-menu/files/kernel.d/extlinux
@@ -7,18 +7,19 @@ header() {
 }
 
 get_bootpath() {
-	echo ${1} | sed "s#${BOOTPART}/#/#"
+	echo "${1}" | sed "s#${BOOTPART}/#/#"
 }
 
 add_kernel() {
-	ver=${1}
-	kernel=$(get_bootpath "/boot/vmlinux-${ver}")
+	ver="${1}"
+	suffix="${2}"
+	kernel=$(get_bootpath "/boot/vmlinu${suffix}-${ver}")
 	initrd=$(get_bootpath "/boot/initramfs-${ver}.img")
 	devicetreedir=$(get_bootpath "/boot/dtbs/dtbs-${ver}")
 	fdt=$(get_bootpath "/boot/dtbs/dtbs-${ver}/${DTBPATH}")
 	cmdline="${CMDLINE}"
 
-	printf "LABEL entry%s\n" "${ENTRY}" >> "${OUTFILE}"
+	printf "\nLABEL entry%s\n" "${ENTRY}" >> "${OUTFILE}"
 	printf "\tMENU LABEL Void Linux Version %s\n" "${ver}" >> "${OUTFILE}"
 	printf "\tLINUX %s\n" "${kernel}" >> "${OUTFILE}"
 	if [ -e "${BOOTPART}/${initrd}" ]; then
@@ -27,17 +28,18 @@ add_kernel() {
 	if [ -n "${USE_DEVICETREEDIR}" ]; then
 		printf "\tDEVICETREEDIR %s\n" "${devicetreedir}" >> "${OUTFILE}"
 	elif [ -n "${DTBPATH}" ] && [ -e "${BOOTPART}/${fdt}" ]; then
-		printf "\tFDT %s\n" ${fdt} >> "${OUTFILE}"
+		printf "\tFDT %s\n" "${fdt}" >> "${OUTFILE}"
 	fi
 	if [ -n "${cmdline}" ]; then
 		printf "\tAPPEND %s\n" "${cmdline}" >> "${OUTFILE}"
 	fi
-	ENTRY=$(expr ${ENTRY} + 1)
+
+	ENTRY=$((ENTRY + 1))
 }
 
 main() {
 	if [ ! -d /boot/extlinux ]; then
-		rm ${OUTFILE}
+		rm "${OUTFILE}"
 		exit 0
 	fi
 
@@ -52,15 +54,19 @@ main() {
 	header
 
 	for kernel in $(ls /boot/vmlinu[xz]-* | sort -rV); do
-		ver=$(echo ${kernel} | sed "s#/boot/vmlinu[xz]-\(.*\)#\\1#")
+		ver=$(echo "${kernel}" | sed "s#/boot/vmlinu[xz]-\(.*\)#\\1#")
+		suffix=$(echo "${kernel}" | sed "s#/boot/vmlinu\([xz]\).*#\\1#")
 		echo "Add kernel ${ver}"
-		add_kernel ${ver}
+		add_kernel "${ver}" "${suffix}"
 	done
-	mv ${OUTFILE} /boot/extlinux/extlinux.conf
+
+	mv "${OUTFILE}" /boot/extlinux/extlinux.conf
 }
 
 CONF=/etc/default/extlinux
 OUTFILE=$(mktemp)
 BOOTPART=$(df -P /boot | tail -1 | awk '{ print $6 }')
 ENTRY=0
+TIMEOUT=10
+
 main

--- a/srcpkgs/u-boot-menu/template
+++ b/srcpkgs/u-boot-menu/template
@@ -1,7 +1,7 @@
 # Template file for 'u-boot-menu'
 pkgname=u-boot-menu
-version=0.2
-revision=3
+version=0.3
+revision=1
 conf_files="/etc/default/extlinux"
 short_desc="Create an u-boot menu with currently available kernels"
 maintainer="Remi Pommarel <repk@triplefau.lt>"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Changes
- correct LINUX entry suffix
- default TIMEOUT if CONF is not present
- fixed warnings according to `shellcheck -s sh`
