### PR TITLE
moosefs: update to 4.56.6

### DIFF
--- a/srcpkgs/moosefs/patches/fix-musl.patch
+++ b/srcpkgs/moosefs/patches/fix-musl.patch
@@ -1,6 +1,6 @@
---- a/mfsclient/nbdmain.c	2020-06-08 08:19:08.422379805 +0200
-+++ b/mfsclient/nbdmain.c	2020-06-08 08:18:55.079380447 +0200
-@@ -39,6 +39,7 @@
+--- a/mfsclient/mfsbdev.c	2024-09-23 14:12:52.000000000 +0200
++++ b/mfsclient/mfsbdev.c	2024-11-15 10:29:23.666733778 +0100
+@@ -38,6 +38,7 @@
  #include <errno.h>
  #include <inttypes.h>
  #include <pthread.h>

--- a/srcpkgs/moosefs/template
+++ b/srcpkgs/moosefs/template
@@ -1,7 +1,7 @@
 # Template file for 'moosefs'
 pkgname=moosefs
-version=3.0.117
-revision=2
+version=4.56.6
+revision=1
 build_style=gnu-configure
 configure_args="--localstatedir=/var/lib --with-default-user=_mfs
  --with-default-group=_mfs"
@@ -12,7 +12,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-only"
 homepage="https://moosefs.com/"
 distfiles="https://ppa.moosefs.com/src/moosefs-${version}-1.tar.gz"
-checksum=d77947d0d8b699e2373926a1274ae81a9a8b24445c5ab986a1ec5e9203e3c3ba
+checksum=77cad891e38d33a9cfbaf25640e48a684f1650137cef8a86963673494444f7ed
 python_version=3
 system_accounts="_mfs"
 


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)
- I built this PR locally for these architectures (using crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl