### PR TITLE
mesa: add riscv target

### DIFF
--- a/srcpkgs/mesa/template
+++ b/srcpkgs/mesa/template
@@ -33,7 +33,7 @@ build_options_default="wayland"
 # especially on big endian it's all kinds of broken, and e.g. on
 # 32-bit powerpc it does not work at all, so fall back to softpipe
 case "$XBPS_TARGET_MACHINE" in
-	i686*|x86_64*|aarch64*|ppc64le*|arm*) ;;
+	i686*|x86_64*|aarch64*|ppc64le*|arm*|riscv64*) ;;
 	*) configure_args+=" -Ddraw-use-llvm=false" ;;
 esac
 

--- a/srcpkgs/xorg-video-drivers/template
+++ b/srcpkgs/xorg-video-drivers/template
@@ -14,6 +14,6 @@ case "$XBPS_TARGET_MACHINE" in
 esac
 
 case "$XBPS_TARGET_MACHINE" in
-	armv[56]*|aarch64*|mips*) ;;
+	armv[56]*|aarch64*|mips*|riscv*) ;;
 	*) depends+=" xf86-video-ati xf86-video-amdgpu xf86-video-nouveau" ;;
 esac


### PR DESCRIPTION
llvmpipe works on riscv64

after this patch (along with #53049) it will be able to start a graphical desktop on a risc-v machine.

#### Testing the changes
- I tested the changes in this PR: **YES** (ran glxinfo, glxgears, alacritty, firefox correctly)

#### Local build testing
- I built this PR locally for these architectures:
  - riscv64-glibc (cross)

[ci skip]