### PR TITLE
screen: fix socket dir and utmp

### DIFF
--- a/srcpkgs/screen/patches/fix-musl.patch
+++ b/srcpkgs/screen/patches/fix-musl.patch
@@ -1,0 +1,10 @@
+--- a/utmp.c
++++ b/utmp.c
+@@ -30,6 +30,7 @@
+ 
+ #include "utmp.h"
+ 
++#include <signal.h>
+ #include <sys/types.h>
+ #include <sys/stat.h>
+ #include <fcntl.h>

--- a/srcpkgs/screen/template
+++ b/srcpkgs/screen/template
@@ -1,12 +1,9 @@
 # Template file for 'screen'
 pkgname=screen
 version=5.0.0
-revision=1
+revision=2
 build_style=gnu-configure
-configure_args="--with-sys-screenrc=/etc/screenrc --enable-pam
- --enable-colors256 --enable-rxvt_osc --enable-telnet
- --enable-use-locale --with-socket-dir=/run/screens --with-pty-group=5"
-hostmakedepends="automake"
+configure_args="--enable-telnet --enable-utmp --enable-socket-dir=/run/screens"
 makedepends="libutempter-devel ncurses-devel pam-devel"
 conf_files="/etc/screenrc /etc/skel/.screenrc"
 short_desc="GNU screen manager with VT100/ANSI terminal emulation"
@@ -15,16 +12,13 @@ license="GPL-3.0-or-later"
 homepage="http://www.gnu.org/s/screen/"
 distfiles="${GNU_SITE}/$pkgname/$pkgname-$version.tar.gz"
 checksum=f04a39d00a0e5c7c86a55338808903082ad5df4d73df1a2fd3425976aed94971
+make_check=no  # check is broken in 5.0.0
 
 build_options="multiuser"
 
 if [ "$XBPS_TARGET_LIBC" = "glibc" ]; then
 	makedepends+=" libxcrypt-devel"
 fi
-
-pre_configure() {
-	./autogen.sh
-}
 
 post_install() {
 	vinstall etc/etcscreenrc 0644 etc screenrc


### PR DESCRIPTION
This adjusts configure changes necessary for 5.0.0

- Use `/run/screens/S-<USER>` for socket dir as before; the default `$HOME/.screen` is not nice when home is shared.
- Enable UTMP so screen sessions show up (used to be enabled by default in 4.9.1)
- Other minor cleanup in the configure args
- No need to run autogen.sh
- skip check which are broken (https://savannah.gnu.org/bugs/?66416)

@leahneukirchen

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
