### PR TITLE
prometheus: update to 3.1.0.

### DIFF
--- a/srcpkgs/prometheus/template
+++ b/srcpkgs/prometheus/template
@@ -1,7 +1,7 @@
 # Template file for 'prometheus'
 pkgname=prometheus
-version=2.53.1
-revision=2
+version=3.1.0
+revision=1
 build_style=go
 go_import_path="github.com/prometheus/prometheus"
 go_package="github.com/prometheus/prometheus/cmd/prometheus github.com/prometheus/prometheus/cmd/promtool"
@@ -19,11 +19,15 @@ license="Apache-2.0, MIT"
 homepage="https://prometheus.io/"
 changelog="https://raw.githubusercontent.com/prometheus/prometheus/master/CHANGELOG.md"
 distfiles="https://github.com/prometheus/prometheus/archive/v${version}.tar.gz"
-checksum=6a36ad9fd6ce2813c78aab1da98d7725143bcb73e4fe1e2597c873537f7072af
+checksum=b23aefb9e0018788ea048fd1c0dbac945c4acf7b20a6ab0cf81bd3e717a2995f
 
 system_accounts="_prometheus"
 
 make_dirs="/var/lib/prometheus 700 _prometheus _prometheus"
+
+if [ "${XBPS_BUILD_ENVIRONMENT}" != "void-packages-ci" ]; then
+	make_check_args+=" -skip (TestQueryLog|TestDelayedCompaction)"
+fi
 
 pre_build() {
 	# Need to patch node fs to avoid using too many file descriptors
@@ -31,6 +35,12 @@ pre_build() {
 	echo "require('graceful-fs').gracefulify(require('fs'));" \
 		> "${wrksrc}/web/ui/use-graceful-fs.js"
 	export NODE_OPTIONS="--require ${wrksrc}/web/ui/use-graceful-fs.js"
+
+	# rollup doesn't support native i686, use wasm instead
+	if [ "$XBPS_TARGET_MACHINE" = "i686" ]; then
+		(cd web/ui && npm install --override rollup@npm:@rollup/wasm-node@latest)
+	fi
+
 	CGO_ENABLED=0 GOARCH= make assets assets-compress
 }
 
@@ -39,8 +49,6 @@ post_install() {
 	vmkdir etc/prometheus
 	vmkdir usr/share/doc/prometheus
 	vmkdir usr/share/examples/prometheus
-	vcopy consoles etc/prometheus
-	vcopy console_libraries etc/prometheus
 	vcopy documentation/examples/* usr/share/examples/prometheus/
 	vcopy documentation/examples/prometheus.yml etc/prometheus/
 	vcopy documentation/images usr/share/doc/prometheus/


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **Yes, running on my homelab**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)

#### Note

Although 3.x is available, Prometheus 2.55 or newer "required" for a major (3.x) upgrade, per migration guide (https://prometheus.io/docs/prometheus/3.0/migration/#tsdb-format-and-downgrade).
