### PR TITLE
Signal-Desktop: update to 7.34.0

### DIFF
--- a/srcpkgs/Signal-Desktop/template
+++ b/srcpkgs/Signal-Desktop/template
@@ -1,6 +1,6 @@
 # Template file for 'Signal-Desktop'
 pkgname=Signal-Desktop
-version=7.32.0
+version=7.34.0
 revision=1
 # Signal officially only supports x86_64
 # x86_64-musl could potentially work based on the Alpine port:
@@ -14,7 +14,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="AGPL-3.0-only"
 homepage="https://github.com/signalapp/Signal-Desktop"
 distfiles="https://github.com/signalapp/Signal-Desktop/archive/v${version}.tar.gz"
-checksum=e6d51ff1b90bd39090057cdee56476e074e8708e021294cd5ed6b865cb5e3c4a
+checksum=0119578e90afc4e3421682beef0cc6cbe373f13126fad40568a08492d4088a28
 nostrip_files="signal-desktop"
 
 post_extract() {
@@ -63,11 +63,6 @@ do_install() {
 	ln -s /usr/lib/signal-desktop/signal-desktop ${DESTDIR}/usr/bin/
 
 	vinstall signal-desktop.desktop 644 usr/share/applications
-
-	vmkdir usr/share/icons/hicolor
-	for size in 16 32 256; do
-		vinstall images/icon_${size}.png 644 usr/share/icons/hicolor/${size}x${size}/apps/ signal-desktop.png
-	done
 
 	vlicense LICENSE
 }


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)

As the the new package do not have hicolor icons present I have modified the post_extract script.
Please correct me if I'm wrong