### PR TITLE
[RFC] adjust and note the kernel series each metapackage follows

### DIFF
--- a/srcpkgs/linux-lts/template
+++ b/srcpkgs/linux-lts/template
@@ -1,4 +1,5 @@
 # Template file for 'linux-lts'
+# this package should follow the second-latest LTS kernel listed on kernel.org
 pkgname=linux-lts
 version=6.1
 revision=1

--- a/srcpkgs/linux-mainline/template
+++ b/srcpkgs/linux-mainline/template
@@ -1,4 +1,5 @@
 # Template file for 'linux-mainline'
+# this package should follow the latest mainline kernel listed on kernel.org
 pkgname=linux-mainline
 version=6.11
 revision=1

--- a/srcpkgs/linux-stable-headers
+++ b/srcpkgs/linux-stable-headers
@@ -1,0 +1,1 @@
+linux-stable

--- a/srcpkgs/linux-stable/template
+++ b/srcpkgs/linux-stable/template
@@ -1,0 +1,16 @@
+# Template file for 'linux-stable'
+# this package should follow the latest stable kernel listed on kernel.org
+pkgname=linux-stable
+version=6.11
+revision=1
+build_style=meta
+depends="linux${version} linux-base"
+short_desc="Linux latest stable kernel meta package"
+maintainer="Leah Neukirchen <leah@vuxu.org>"
+license="Public Domain"
+homepage="http://www.voidlinux.org/"
+
+linux-stable-headers_package() {
+	short_desc="Linux latest stable kernel headers meta package"
+	depends="linux${version}-headers"
+}

--- a/srcpkgs/linux-stable/update
+++ b/srcpkgs/linux-stable/update
@@ -1,0 +1,2 @@
+site="https://www.kernel.org/feeds/kdist.xml"
+pattern="<title>\K\d+.\d+(?=: stable</title>)"

--- a/srcpkgs/linux/template
+++ b/srcpkgs/linux/template
@@ -1,5 +1,6 @@
 # Template file for 'linux'
-# this package should follow the latest LTS kernel listed on kernel.org
+# this package should follow the latest supported kernel
+# that supports common dkms modules like nvidia and zfs
 pkgname=linux
 version=6.6
 revision=1

--- a/srcpkgs/linux/template
+++ b/srcpkgs/linux/template
@@ -1,4 +1,5 @@
 # Template file for 'linux'
+# this package should follow the latest LTS kernel listed on kernel.org
 pkgname=linux
 version=6.6
 revision=1


### PR DESCRIPTION
The current kernel metapackage policy is:

- `linux-mainline`: follows the latest available kernel
- `linux`: follows the latest available kernel that supports popular dkms modules, like `zfs` and `nvidia`
- `linux-lts`: follows an LTS release and is behind `linux`

In recent times, kernels have been released and gone EOL faster than `zfs` can release build fixes, and `nvidia` in particular has had trouble with recent kernels, holding us back from bumping `linux` to 6.10 or 6.11. In the recent past, we've had `linux` point to a kernel that was already EOL (6.3 or 6.5), so we risked not getting backports for important fixes.

I propose the following changes:

- `linux-mainline`: no change
- `linux`: follows the latest LTS release
- `linux-lts`: follows the second-latest LTS release

This should help us keep `linux` on a supported kernel and provide a more reliable indicator for when we can update the default kernel series, I think.

@void-linux/pkg-committers, thoughts?
