### PR TITLE
Revert "llvm19: nocross (im sorry buildbot)"

### DIFF
--- a/srcpkgs/SPIRV-LLVM-Translator19/template
+++ b/srcpkgs/SPIRV-LLVM-Translator19/template
@@ -18,8 +18,6 @@ homepage="https://github.com/KhronosGroup/SPIRV-LLVM-Translator"
 distfiles="https://github.com/KhronosGroup/SPIRV-LLVM-Translator/archive/refs/tags/v${version}.tar.gz"
 checksum=7f6f7a1af0eb40910ddf3a7647d2186c8c5dc5a47945afa935aeec56bacf4336
 
-nocross="im sorry buildbot"
-
 alternatives="llvm-spirv:llvm-spirv:/usr/bin/llvm-spirv-${_llvm_ver}"
 
 post_install() {

--- a/srcpkgs/llvm19/template
+++ b/srcpkgs/llvm19/template
@@ -61,8 +61,6 @@ conflicts="llvm18>=0 llvm17>=0 llvm15>=0"
 lib32disabled=yes
 python_version=3
 
-nocross="im sorry buildbot"
-
 build_options="clang clang_tools_extra lld mlir libclc polly lldb flang bolt
  openmp libc libcxx libunwind offload lto graphviz full_debug"
 build_options_default="clang clang_tools_extra lld libclc polly lldb


### PR DESCRIPTION
This reverts commit a10c71946d28e5ad1869dc56405e302228441a81.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **NO**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->

[ci skip]