### PR TITLE
New package: lxqt-wayland-session-0.1.1

### DIFF
--- a/srcpkgs/lxqt-wayland-session/template
+++ b/srcpkgs/lxqt-wayland-session/template
@@ -1,0 +1,21 @@
+# Template file for 'lxqt-wayland-session'
+pkgname=lxqt-wayland-session
+version=0.1.1
+revision=1
+build_style=cmake
+hostmakedepends="pkg-config qt6-base qt6-tools lxqt-build-tools
+ xdg-user-dirs perl"
+makedepends="liblxqt-devel"
+depends="lxqt-session labwc"
+short_desc="Files needed for the LXQt Wayland Session"
+maintainer="toadwastoast <toadwastoast@proton.me>"
+license="LGPL-2.1-only, GPL-2.0-only, GPL-3.0-only, GPL-3.0-or-later,
+ BSD-3-Clause, CC-BY-SA-4.0, MIT"
+homepage="https://github.com/lxqt/lxqt-wayland-session"
+distfiles="https://github.com/lxqt/lxqt-wayland-session/archive/${version}.tar.gz"
+checksum=50f27f5ca49de5b9d5bf54abf05d70ab30dbe9a36516db2d84e6872f97d13324
+
+post_install() {
+	vlicense LICENSE.BSD
+	vlicense LICENSE.MIT
+}


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl (cross)
  - armv6l (cross)
  
 Tested with labwc, wayfire and kwin_wayland.
 
 I added labwc as a dependency since it's the wayland equivalent to openbox. It's also needed for the initial session settings to show up if no wayland compositor for LXQt is set.