### PR TITLE
shotcut: update to 25.01.25

### DIFF
--- a/srcpkgs/mlt7/template
+++ b/srcpkgs/mlt7/template
@@ -1,6 +1,6 @@
 # Template file for 'mlt7'
 pkgname=mlt7
-version=7.28.0
+version=7.30.0
 revision=1
 build_style=cmake
 configure_args="-DSWIG_PYTHON=ON -DMOD_QT6=ON"
@@ -16,7 +16,7 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-3.0-or-later, LGPL-2.1-or-later"
 homepage="https://mltframework.org/"
 distfiles="https://github.com/mltframework/mlt/archive/v${version}.tar.gz"
-checksum=25d7af70447c57f5aba80cd042b46fb69712ec9a993e8be4a6abe7ec46951271
+checksum=11b6ae978ce814a3d8a2c599b565ed27f691d23f4f7d712061f3d812bbc59d67
 
 if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
 	makedepends+=" musl-legacy-compat"

--- a/srcpkgs/shotcut/template
+++ b/srcpkgs/shotcut/template
@@ -1,6 +1,6 @@
 # Template file for 'shotcut'
 pkgname=shotcut
-version=24.06.26
+version=25.01.25
 revision=1
 build_style=cmake
 configure_args="-DSHOTCUT_VERSION=${version}"
@@ -15,6 +15,6 @@ license="GPL-3.0-or-later"
 homepage="https://www.shotcut.org"
 changelog="https://github.com/mltframework/shotcut/releases"
 distfiles="https://github.com/mltframework/shotcut/archive/v${version}.tar.gz"
-checksum=cd7a90228df954ad1e706940795abf9aff657c7686ce82092f009f9befec7e0b
+checksum=46a2befb45a719d81416b01dcb228ce27e97aa541b308570e5151738fe1b9677
 
 CXXFLAGS="-DHAVE_LOCALE_H=1 -DSHOTCUT_NOUPGRADE"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, **x86_64**
- cross **i686**

#### Comments

runs fine, exported quick video cut up with resize + no sound + normal sections

~~@Johnnynator~~ johnny orphaned between opening this and 25 update

updated mlt7 to 7.30, 32bit builds were bombing