### PR TITLE
vaultwarden: update to 1.32.5.

### DIFF
--- a/srcpkgs/vaultwarden/template
+++ b/srcpkgs/vaultwarden/template
@@ -1,6 +1,6 @@
 # Template file for 'vaultwarden'
 pkgname=vaultwarden
-version=1.32.4
+version=1.32.5
 revision=1
 build_style=cargo
 configure_args="--features sqlite,mysql,postgresql"
@@ -13,7 +13,7 @@ license="AGPL-3.0-only"
 homepage="https://github.com/dani-garcia/vaultwarden"
 changelog="https://github.com/dani-garcia/vaultwarden/releases"
 distfiles="https://github.com/dani-garcia/vaultwarden/archive/${version}.tar.gz"
-checksum=7cf9a5c7356df42b0da318a446bf576c2aa340581ec4c729f1cb616754cf66ad
+checksum=305b195e464cd831abc31112aec9dad634b44323069cfe3dc675ede41a3a42d9
 
 system_accounts="_vaultwarden"
 _vaultwarden_homedir="/var/lib/vaultwarden"
@@ -24,6 +24,7 @@ make_dirs="/var/lib/vaultwarden 0750 _vaultwarden _vaultwarden"
 # https://github.com/dani-garcia/vaultwarden/issues/4320
 if [ "$XBPS_TARGET_MACHINE" = "i686" ]; then
 	export CARGO_PROFILE_RELEASE_LTO=thin
+	export CARGO_PROFILE_RELEASE_CODEGEN_UNITS=16
 fi
 
 post_install() {


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->

[Upstream says to update promptly due to a CVE](https://github.com/dani-garcia/vaultwarden/releases/tag/1.32.5):
>  This release further fixed some CVE Reports reported by a third party security auditor and we recommend everybody to update to the latest version as soon as possible. The contents of these reports will be disclosed publicly in the future.
