### PR TITLE
xpadneo: Fix dkms build for linux6.12

### DIFF
--- a/srcpkgs/xpadneo/patches/fix-xpadneo-dkms-linux-6.12.patch
+++ b/srcpkgs/xpadneo/patches/fix-xpadneo-dkms-linux-6.12.patch
@@ -1,0 +1,24 @@
+diff --git a/hid-xpadneo/src/hid-xpadneo.c b/hid-xpadneo/src/hid-xpadneo.c
+index 1a25631..c70b7cf 100644
+--- a/hid-xpadneo/src/hid-xpadneo.c
++++ b/hid-xpadneo/src/hid-xpadneo.c
+@@ -10,6 +10,7 @@
+ 
+ #include <linux/delay.h>
+ #include <linux/module.h>
++#include <linux/version.h>
+ 
+ #include "xpadneo.h"
+ 
+@@ -712,7 +713,11 @@ static int xpadneo_input_mapping(struct hid_device *hdev, struct hid_input *hi,
+ 	return MAP_AUTO;
+ }
+ 
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6,12,0)
+ static u8 *xpadneo_report_fixup(struct hid_device *hdev, u8 *rdesc, unsigned int *rsize)
++#else
++static const u8 *xpadneo_report_fixup(struct hid_device *hdev, u8 *rdesc, unsigned int *rsize)
++#endif
+ {
+ 	struct xpadneo_devdata *xdata = hid_get_drvdata(hdev);
+ 

--- a/srcpkgs/xpadneo/template
+++ b/srcpkgs/xpadneo/template
@@ -1,7 +1,7 @@
 # Template file for 'xpadneo'
 pkgname=xpadneo
 version=0.9.6
-revision=1
+revision=2
 depends="dkms bluez"
 short_desc="Bluetooth driver for Xbox One Wireless Controller"
 maintainer="Joshua Krämer <joshua@kraemer.link>"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**


#### Local build testing
- I built this PR locally for my native architecture, (x64-GlibC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - x64-MuslC

Ref: https://github.com/atar-axis/xpadneo/issues/498