### PR TITLE
beets: update to 2.2.0.

### DIFF
--- a/srcpkgs/beets/template
+++ b/srcpkgs/beets/template
@@ -1,27 +1,35 @@
 # Template file for 'beets'
 pkgname=beets
-version=2.0.0
-revision=2
-build_style=python3-module
-hostmakedepends="python3-setuptools"
+version=2.2.0
+revision=1
+build_style=python3-pep517
+# tests requires unpackaged librosa, pytest-flask
+make_check_args="--ignore=test/plugins/test_autobpm.py
+ --ignore=test/plugins/test_aura.py"
+hostmakedepends="python3-poetry-core python3-Sphinx"
 depends="python3-munkres python3-musicbrainzngs python3-Unidecode python3-yaml
- python3-jellyfish python3-mediafile python3-confuse python3-typing_extensions"
+ python3-jellyfish python3-mediafile python3-confuse python3-platformdirs"
 checkdepends="$depends python3-BeautifulSoup4 python3-Flask python3-mock
  python3-pylast python3-pytest python3-pytest-cov python3-mpd2 python3-xdg
  python3-responses python3-requests-oauthlib python3-reflink python3-rarfile
- python3-discogs_client python3-py7zr"
+ python3-discogs_client python3-py7zr python3-typing_extensions
+ python3-dateutil python3-gobject gstreamer1 ffmpeg"
 short_desc="Media library management system for obsessive-compulsive music geeks"
 maintainer="Joel Beckmeyer <joel@beckmeyer.us>"
 license="MIT"
 homepage="https://beets.io"
 changelog="https://raw.githubusercontent.com/beetbox/beets/master/docs/changelog.rst"
-distfiles="${PYPI_SITE}/b/${pkgname}/${pkgname}-${version}.tar.gz"
-checksum=3b1172b5bc3729e33a6ea4689f7d0236682bf828c67196b6a260f0389cb1f8cf
+distfiles="${PYPI_SITE}/b/${pkgname}/${pkgname}-${version}.tar.gz
+ https://raw.githubusercontent.com/beetbox/beets/refs/tags/v${version}/extra/_beet"
+checksum="cc0a277f530844575e3374021f316da16bf78ed514963c1ab1597168a8d4c715
+ 74675a1171809b4190bc1d734931a1ba12cba13083521b50a008cdaaa738736e"
+skip_extraction="_beet"
 make_check=ci-skip # tests don't work as root
 
 post_install() {
 	vman man/beet.1
 	vman man/beetsconfig.5
 	vlicense LICENSE
-	vcompletion extra/_beet zsh beet
+	# https://github.com/beetbox/beets/issues/5531
+	vcompletion $XBPS_SRCDISTDIR/$pkgname-$version/_beet zsh beet
 }

--- a/srcpkgs/python3-discogs_client/template
+++ b/srcpkgs/python3-discogs_client/template
@@ -1,20 +1,18 @@
 # Template file for 'python3-discogs_client'
 pkgname=python3-discogs_client
-version=2.2.2
-revision=7
+version=2.7.1
+revision=1
 build_style=python3-module
 hostmakedepends="python3-setuptools"
 depends="python3-requests python3-six python3-oauthlib"
 short_desc="Official Discogs API client for Python3"
-maintainer="Georg Schabel <gescha@posteo.de>"
+maintainer="Joel Beckmeyer <joel@beckmeyer.us>"
 license="BSD-2-Clause"
-homepage="https://github.com/discogs/discogs_client"
-distfiles="${PYPI_SITE}/d/discogs-client/discogs-client-${version}.tar.gz
- https://raw.githubusercontent.com/discogs/discogs_client/master/LICENSE"
-checksum="aeae43fb9281e27c580d1bcd484e6c309f4f3a05af3908016ee3363786ef43d8
- 1af62aeddccb57134218ddbdc67d0473524ca736703d7cce01db59b2e07da542"
-skip_extraction="LICENSE"
+homepage="https://github.com/joalla/discogs_client"
+changelog="https://github.com/joalla/discogs_client/releases"
+distfiles="${PYPI_SITE}/p/python3-discogs-client/python3_discogs_client-${version}.tar.gz"
+checksum=f2453582f5d044ea5847d27cfe56473179e51c9a836913b46db803c20ae598f9
 
 post_install() {
-	vlicense ${XBPS_SRCDISTDIR}/${pkgname}-${version}/LICENSE
+	vlicense LICENSE
 }


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->

[`discogs-client`](https://pypi.org/project/discogs-client/) is unmaintained,
but `beets` depends on the fork
[`python3-discogs-client`](https://pypi.org/project/python3-discogs-client/).
Since no other packages use this dependency, I have just updated our
`python3-discogs_client` to be the maintained fork.
