### PR TITLE
mbedtls: update to 3.6.2.

### DIFF
--- a/srcpkgs/mbedtls/template
+++ b/srcpkgs/mbedtls/template
@@ -1,8 +1,8 @@
 # Template file for 'mbedtls'
 pkgname=mbedtls
-version=3.6.0
+version=3.6.2
 revision=1
-_framework_ver=750634d3a51eb9d61b59fd5d801546927c946588
+_framework_ver=d9a70c758a5a511020240bbcc86f6d647d64fe96
 build_style=cmake
 configure_args="-DENABLE_TESTING=1 -DUSE_SHARED_MBEDTLS_LIBRARY=1"
 hostmakedepends="python3 perl"
@@ -13,8 +13,8 @@ homepage="https://tls.mbed.org/"
 changelog="https://raw.githubusercontent.com/ARMmbed/mbedtls/mbedtls-${version%.*}/ChangeLog"
 distfiles="https://github.com/ARMmbed/mbedtls/archive/refs/tags/v${version}.tar.gz
  https://github.com/Mbed-TLS/mbedtls-framework/archive/${_framework_ver}.tar.gz>framework-${_framework_ver}.tar.gz"
-checksum="32c500e73ee878e193e7d66bf5e4c34fb42bb968a6c9f9488aa466b16f6f3bff
- 4845b5ae123c036cf9ec9e0ff0478a24b2be95450fc36a0fb80e2748518b424f"
+checksum="f4a876b1f6921ad0aefb445f974ef62414d33928640b2c45555c5e64a196a1a8
+ d46acd6cb103d00d6e545631467e36363f6fc270b2c051be94d543eb0831393b"
 skip_extraction="framework-${_framework_ver}.tar.gz"
 
 post_extract() {


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

fixes broken TLS support in bctoolbox/linphone.

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
