### PR TITLE
coin3: update to 4.0.3.

### DIFF
--- a/srcpkgs/coin3/patches/no-cpack.patch
+++ b/srcpkgs/coin3/patches/no-cpack.patch
@@ -1,8 +1,0 @@
---- a/CMakeLists.txt
-+++ b/CMakeLists.txt
-@@ -815,4 +815,4 @@
- 
- # ############################################################################
- # New CPACK section, please see the README file inside cpack.d directory.
--add_subdirectory(cpack.d)
-+#add_subdirectory(cpack.d)

--- a/srcpkgs/coin3/template
+++ b/srcpkgs/coin3/template
@@ -1,7 +1,7 @@
 # Template file for 'coin3'
 pkgname=coin3
-version=4.0.0
-revision=2
+version=4.0.3
+revision=1
 build_style=cmake
 configure_args="-DCMAKE_INSTALL_INCLUDEDIR=include/Coin3
  -DCOIN_BUILD_TESTS=OFF -DCOIN_BUILD_DOCUMENTATION=ON"
@@ -11,8 +11,8 @@ short_desc="High-level 3D graphics toolkit"
 maintainer="yopito <pierre.bourgin@free.fr>"
 license="BSD-3-Clause"
 homepage="https://coin3d.github.io/"
-distfiles="https://github.com/coin3d/coin/archive/Coin-${version}.tar.gz"
-checksum=b00d2a8e9d962397cf9bf0d9baa81bcecfbd16eef675a98c792f5cf49eb6e805
+distfiles="https://github.com/coin3d/coin/archive/refs/tags/v${version}.tar.gz"
+checksum=086ecf84479e4bc59397568638488c2e6c08d8aa811779bab93cda5509f79d59
 
 CFLAGS=-DNDEBUG
 CXXFLAGS=-DNDEBUG

--- a/srcpkgs/coin3/update
+++ b/srcpkgs/coin3/update
@@ -1,1 +1,0 @@
-pattern="Coin-\K[\d.]+(?=\.tar)"


### PR DESCRIPTION
Fixes #41425 (FreeCAD crash on wayland)

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
