### PR TITLE
[rfc] wpa_supplicant: use capabilities in service to run as non-root

### DIFF
--- a/srcpkgs/wpa_supplicant/INSTALL.msg
+++ b/srcpkgs/wpa_supplicant/INSTALL.msg
@@ -1,0 +1,4 @@
+The runit service now uses Linux capabilities to run as non-root.
+If you edited `wpa_supplicant.conf` files, you must set
+	`control_interface_group=_wpas`
+there, so that the unprivileged daemon can function properly.

--- a/srcpkgs/wpa_supplicant/files/wpa_supplicant.conf
+++ b/srcpkgs/wpa_supplicant/files/wpa_supplicant.conf
@@ -1,7 +1,7 @@
 # Default configuration file for wpa_supplicant.conf(5).
 
 ctrl_interface=/run/wpa_supplicant
-ctrl_interface_group=wheel
+ctrl_interface_group=_wpas
 eapol_version=1
 ap_scan=1
 fast_reauth=1

--- a/srcpkgs/wpa_supplicant/files/wpa_supplicant/run
+++ b/srcpkgs/wpa_supplicant/files/wpa_supplicant/run
@@ -7,5 +7,14 @@ else
 	OPTS="${AUTO}"
 fi
 
+# automigrate
+chown -R _wpas:_wpas /etc/wpa_supplicant
+! [ -d /run/wpa_supplicant ] && install -m 700 -g _wpas -o _wpas -d /run/wpa_supplicant
+chown -R _wpas:_wpas /run/wpa_supplicant
+
 exec 2>&1
-exec wpa_supplicant ${OPTS}
+exec setpriv --reuid _wpas --regid _wpas --clear-groups \
+  --ambient-caps -all,+net_admin,+net_raw \
+  --inh-caps -all,+net_admin,+net_raw \
+  --bounding-set -all,+net_admin,+net_raw \
+  --no-new-privs -- wpa_supplicant ${OPTS}

--- a/srcpkgs/wpa_supplicant/patches/unsurprising-ext-password.patch
+++ b/srcpkgs/wpa_supplicant/patches/unsurprising-ext-password.patch
@@ -1,0 +1,66 @@
+From e5ac0dd1af48e085bb824082ef3b64afba673ded Mon Sep 17 00:00:00 2001
+From: rnhmjoj <rnhmjoj@inventati.org>
+Date: Wed, 18 Sep 2024 13:43:44 +0200
+Subject: [PATCH] ext_password_file: do not use wpa_config_get_line
+To: hostap@lists.infradead.org
+
+The file-based backed of the ext_password framework uses
+`wpa_config_get_line` to read the passwords line-by-line from a file.
+This function is meant to parse a single line from the
+wpa_supplicant.conf file, so it handles whitespace, quotes and other
+characters specially.
+
+Its behavior, however, it's not compatible with the rest of the
+ext_password framework implementation. For example, if a passphrase
+contains a `#` character it must be quoted to prevent parsing the
+remaining characters as an inline comment, but the code handling the
+external password in `wpa_supplicant_get_psk` does not handle quotes.
+The result is that either it will hash the enclosing quotes, producing a
+wrong PSK, or if the passphrase is long enough, fail the length check.
+As a consequence, some passphrases are impossible to input correctly.
+
+To solve this and other issues, this patch changes the behaviour of the
+`ext_password_file_get` function (which was not documented in details,
+at least w.r.t. special characters) to simply treat all characters
+literally: including trailing whitespaces (except CR and LF), `#` for
+inline comments, etc. Empty lines and full-line comments are still
+supported.
+
+Signed-off-by: Michele Guerini Rocco <rnhmjoj@inventati.org>
+---
+ src/utils/ext_password_file.c | 12 ++++++++++--
+ 1 file changed, 10 insertions(+), 2 deletions(-)
+
+diff --git a/src/utils/ext_password_file.c b/src/utils/ext_password_file.c
+index 4bb0095f3..f631ff15c 100644
+--- a/src/utils/ext_password_file.c
++++ b/src/utils/ext_password_file.c
+@@ -9,7 +9,6 @@
+ #include "includes.h"
+ 
+ #include "utils/common.h"
+-#include "utils/config.h"
+ #include "ext_password_i.h"
+ 
+ 
+@@ -97,7 +96,16 @@ static struct wpabuf * ext_password_file_get(void *ctx, const char *name)
+ 
+ 	wpa_printf(MSG_DEBUG, "EXT PW FILE: get(%s)", name);
+ 
+-	while (wpa_config_get_line(buf, sizeof(buf), f, &line, &pos)) {
++	while ((pos = fgets(buf, sizeof(buf), f))) {
++		line++;
++
++		/* Strip newline characters */
++		pos[strcspn(pos, "\r\n")] = 0;
++
++		/* Skip comments and empty lines */
++		if (*pos == '#' || *pos == '\0')
++		  continue;
++
+ 		char *sep = os_strchr(pos, '=');
+ 
+ 		if (!sep) {
+-- 
+2.44.1
+

--- a/srcpkgs/wpa_supplicant/template
+++ b/srcpkgs/wpa_supplicant/template
@@ -20,6 +20,7 @@ make_check=no # has no test suite
 build_options="dbus readline"
 build_options_default="dbus readline"
 conf_files="/etc/${pkgname}/${pkgname}.conf"
+system_accounts="_wpas"
 
 pre_build() {
 	cp -f ${FILESDIR}/config .config

--- a/srcpkgs/wpa_supplicant/template
+++ b/srcpkgs/wpa_supplicant/template
@@ -1,22 +1,27 @@
 # Template file for 'wpa_supplicant'
 pkgname=wpa_supplicant
 version=2.11
-revision=1
+revision=2
 build_wrksrc="${pkgname}"
+build_style=gnu-makefile
+make_build_args="V=1 BINDIR=/usr/bin"
+make_install_args="BINDIR=/usr/bin"
+make_use_env=true
 hostmakedepends="pkg-config"
-makedepends="libnl3-devel openssl-devel $(vopt_if dbus dbus-devel) $(vopt_if readline readline-devel)"
+makedepends="libnl3-devel openssl-devel $(vopt_if dbus dbus-devel)
+ $(vopt_if readline readline-devel)"
 short_desc="WPA/WPA2/IEEE 802.1X Supplicant"
 maintainer="Enno Boland <gottox@voidlinux.org>"
 license="BSD-3-Clause"
 homepage="http://w1.fi/wpa_supplicant/"
 distfiles="http://w1.fi/releases/${pkgname}-${version}.tar.gz"
 checksum=912ea06f74e30a8e36fbb68064d6cdff218d8d591db0fc5d75dee6c81ac7fc0a
+make_check=no # has no test suite
 build_options="dbus readline"
 build_options_default="dbus readline"
 conf_files="/etc/${pkgname}/${pkgname}.conf"
 
 pre_build() {
-	vsed -e 's|/usr/local|$(PREFIX)|g' -i Makefile
 	cp -f ${FILESDIR}/config .config
 
 	if [ "$build_option_dbus" ]; then
@@ -31,14 +36,7 @@ pre_build() {
 	fi
 }
 
-do_build() {
-	export CFLAGS+=" $(pkg-config --cflags libnl-3.0) $CPPFLAGS"
-	make ${makejobs} V=1 PREFIX=/usr BINDIR=/usr/bin
-}
-
-do_install() {
-	make PREFIX=/usr BINDIR=/usr/bin DESTDIR=${DESTDIR} install
-
+post_install() {
 	if [ "$build_option_dbus" ]; then
 		install -d ${DESTDIR}/usr/share/dbus-1/system-services
 		install -m644 dbus/*.service ${DESTDIR}/usr/share/dbus-1/system-services/


### PR DESCRIPTION
The capabilities are the ones recommended in upstream README. They recommend to set them on the executable, but it seems safer to set them in the service.

- I tested the changes in this PR: yes, but only using the runit service. I.e., did not test other potential consumers of wpa_supplicant, like network manager or wpa_cli. 
- I built this PR locally for my native architecture, (x86_64-glibc)

Added a patch to the external file function, which is now upstream.