### PR TITLE
mdadm: fix segfault on musl

### DIFF
--- a/srcpkgs/mdadm/patches/musl.patch
+++ b/srcpkgs/mdadm/patches/musl.patch
@@ -18,3 +18,13 @@
  #include	<signal.h>
  #include	<sys/signalfd.h>
  #include	<sys/wait.h>
+--- mdadm-4.3/Monitor.c
++++ mdadm-4.3/Monitor.c
+@@ -29,6 +29,7 @@
+ #include	<sys/wait.h>
+ #include	<limits.h>
+ #include	<syslog.h>
++#include	<libgen.h>
+ 
+ #define TASK_COMM_LEN 16
+ #define EVENT_NAME_MAX 32

--- a/srcpkgs/mdadm/template
+++ b/srcpkgs/mdadm/template
@@ -1,7 +1,7 @@
 # Template file for 'mdadm'
 pkgname=mdadm
 version=4.3
-revision=2
+revision=3
 hostmakedepends="pkg-config"
 makedepends="eudev-libudev-devel"
 short_desc="Tool for managing/monitoring Linux md device arrays"


### PR DESCRIPTION
The mdadm package installs a service that runs `mdadm --monitor --scan`, but that combination of flags segfaults on musl.

After reviewing the backtrace and checking the code, it is due to the code using the GNU `basename()` function instead of the  POSIX one, as noted in the VERSIONS section of basename(3). Due to this, the `basename()` function is not defined under musl and that crashes the program.

backtrace:

```
#0  0x00007ffff7fb3f88 in memchr (src=src@entry=0x55628e05, c=c@entry=0, n=n@entry=2147483647) at src/string/memchr.c:16
#1  0x00007ffff7fb4f56 in strnlen (s=s@entry=0x55628e05 <error: Cannot access memory at address 0x55628e05>, n=n@entry=2147483647)
    at src/string/strnlen.c:5
#2  0x00007ffff7faf31b in printf_core (f=f@entry=0x7fffffffe2e0, fmt=fmt@entry=0x5555555f5f6c "/dev/md/%s", ap=ap@entry=0x7fffffffe148, 
    nl_arg=nl_arg@entry=0x7fffffffe1e0, nl_type=nl_type@entry=0x7fffffffe160) at src/stdio/vfprintf.c:594
#3  0x00007ffff7faf4bb in vfprintf (f=f@entry=0x7fffffffe2e0, fmt=0x5555555f5f6c "/dev/md/%s", ap=<optimized out>) at src/stdio/vfprintf.c:683
#4  0x00007ffff7fb2513 in vsnprintf (s=<optimized out>, n=<optimized out>, fmt=<optimized out>, ap=ap@entry=0x7fffffffe3e8)
    at src/stdio/vsnprintf.c:54
#5  0x00007ffff7fac872 in snprintf (s=<optimized out>, n=<optimized out>, fmt=<optimized out>) at src/stdio/snprintf.c:9
#6  0x0000555555594bef in Monitor (devlist=0x0, mailaddr=0x555555628dc0 "root", alert_cmd=0x0, c=0x7fffffffe740, daemonise=0, oneshot=0, 
    dosyslog=0, pidfile=0x0, increments=20, share=1) at Monitor.c:256
#7  0x000055555555f407 in main (argc=3, argv=0x7fffffffebb8) at mdadm.c:1577
```

Monitor.c:256 refers to:

```c
  snprintf(st->devname, MD_NAME_MAX + sizeof(DEV_MD_DIR), DEV_MD_DIR "%s",
      basename(mdlist->devname));
```

And the compiler correctly warns (but doesn't error due to the template injecting `-Wno-error`) that:

```
Monitor.c: In function 'Monitor':
Monitor.c:257:34: warning: implicit declaration of function 'basename' [-Wimplicit-function-declaration]
  257 |                                  basename(mdlist->devname));
```

The patch imports the header that defines `basename()` under POSIX. A more correct fix would be to import it only if it's running under musl, so that the glibc version of the code isn't altered, but I don't know how to do that :) so instead I tested both on musl and glibc to ensure it didn't crash.

All of this is fixed on upstream mdadm, but they haven't released a new version yet :(

#### reproduction steps for the curious:

At least 1 md array must exist in order to hit the affected code. A temporal md array can be created using a loopback device for test purposes. Once created it must be referenced on the mdadm.conf file. With that done, the test will work.

```shell
# create a temp file to attach to the loopback device
dd if=/dev/zero of=/tmp/loopback_1 bs=10M count=100

# attach it
sudo losetup /dev/loop0 /tmp/loopback_1

# create the md array
sudo mdadm --create /dev/md55 --level=0 --raid-devices=1 --force /dev/loop0

# bootstrap mdadm.conf
cat <<EOT >> mdadm_test.conf
# mdadm.conf
#
# Please refer to mdadm.conf(5) for information about this file.
#

DEVICE partitions

# auto-create devices with the standard permissions
CREATE owner=root group=disk mode=0660 auto=yes

# automatically tag new arrays as belonging to the local system
HOMEHOST <system>

# instruct the monitoring daemon where to send mail alerts
MAILADDR root

# definitions of existing MD arrays
EOT
# add the reference to the array on the conf file
sudo mdadm --detail --scan >> mdadm_test.conf
```

then it can be tested with the following command, that segfaults on 4.3_2 under musl and works on 4.3_3:

```shell
sudo mdadm --monitor --config=./mdadm_test.conf --scan
```

test cleanup:

```
sudo mdadm --stop /dev/md55
sudo losetup -d /dev/loop0
rm /tmp/loopback_1
```

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-musl , x86_64-glibc

I guess I should ping @leahneukirchen as the pkg maintainer, if not let me know!