### PR TITLE
sord: add pcre2 dependency to build sord_validate

### DIFF
--- a/srcpkgs/sord/template
+++ b/srcpkgs/sord/template
@@ -1,10 +1,10 @@
 # Template file for 'sord'
 pkgname=sord
 version=0.16.16
-revision=1
+revision=2
 build_style=meson
 hostmakedepends="pkg-config"
-makedepends="serd-devel pcre-devel zix-devel"
+makedepends="serd-devel pcre-devel zix-devel pcre2-devel"
 short_desc="Lightweight C library for storing RDF data in memory"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="ISC"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
#### Local build testing
- I built this PR locally for my native architecture, (x86_glibc)

[sord_validate](https://lv2plug.in/pages/validating-lv2-data.html) is useful tool to ensure that .ttl side of lv2 sound plugins will work properly. In current state it hasn't been building due to missing pcre2-devel.
