### PR TITLE
python3-peewee: update to 3.17.8.

### DIFF
--- a/srcpkgs/python3-peewee/template
+++ b/srcpkgs/python3-peewee/template
@@ -1,6 +1,6 @@
 # Template file for 'python3-peewee'
 pkgname=python3-peewee
-version=3.17.7
+version=3.17.8
 revision=1
 build_style=python3-pep517
 hostmakedepends="python3-setuptools python3-wheel python3-Cython0.29"
@@ -12,7 +12,7 @@ license="MIT"
 homepage="https://github.com/coleifer/peewee"
 changelog="https://raw.githubusercontent.com/coleifer/peewee/master/CHANGELOG.md"
 distfiles="https://github.com/coleifer/peewee/archive/${version}.tar.gz"
-checksum=c9b02f2191357093a400433b01d51ec545aaa78357e68975843f4b349d1cd303
+checksum=92131e0c8b69fd66234f5d60ceaa7e9daadd337a2f9fcc12bb2d3886e3e985d8
 alternatives="peewee:pwiz:/usr/bin/pwiz.py3"
 make_check=no # tests require postgres instance
 


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-libc
