### PR TITLE
nvidia: add nvidia-persistenced runit service

### DIFF
--- a/srcpkgs/nvidia/files/nvidia-persistenced-nodaemon
+++ b/srcpkgs/nvidia/files/nvidia-persistenced-nodaemon
@@ -1,0 +1,21 @@
+#!/bin/sh
+bin="nvidia-persistenced"
+rundir="/var/run/${bin}"
+pidfile="${rundir}/${bin}.pid"
+
+/usr/bin/${bin} ${@}
+exitcode=$?
+[ ${exitcode} -ne 0 ] && exit ${exitcode}
+
+# Allow the daemon some time to create its
+# PID file...
+sleep 1
+
+if [ -r "${pidfile}" ]; then
+    read procid < "${pidfile}"
+    waitpid -e ${procid}
+fi
+
+# We might have been signalled, so kill the
+# daemon...
+kill ${procid} || true

--- a/srcpkgs/nvidia/files/nvidia-persistenced/finish
+++ b/srcpkgs/nvidia/files/nvidia-persistenced/finish
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+piddir="/var/run/nvidia-persistenced"
+pidfile="${piddir}/nvidia-persistenced.pid"
+if [ -r ${pidfile} ]; then
+    pid=$(cat ${pidfile})
+    kill ${pid}
+    waitpid -t 1 -e ${pid}
+    rm -r ${piddir} || true
+fi

--- a/srcpkgs/nvidia/files/nvidia-persistenced/run
+++ b/srcpkgs/nvidia/files/nvidia-persistenced/run
@@ -1,0 +1,11 @@
+#!/bin/sh
+exec 2>&1
+
+[ -r conf ] && . ./conf
+
+user=_nvidiapersistenced
+
+install -o ${user} -m0755 -d /var/run/nvidia-persistenced
+
+exec chpst -u ${user} \
+    /usr/libexec/nvidia-persistenced-nodaemon ${OPTS}

--- a/srcpkgs/nvidia/template
+++ b/srcpkgs/nvidia/template
@@ -4,7 +4,7 @@ _desc="NVIDIA drivers for linux"
 
 pkgname=nvidia
 version=550.127.05
-revision=1
+revision=2
 maintainer="Andrew Benson <abenson+void@gmail.com>"
 license="custom:NVIDIA Proprietary"
 homepage="https://www.nvidia.com/en-us/drivers/unix/"
@@ -27,6 +27,7 @@ depends="nvidia-libs-${version}_${revision}
  nvidia-dkms-${version}_${revision}
  nvidia-firmware-${version}_${revision}"
 patch_args="-Np1 --directory=${XBPS_BUILDDIR}/${pkgname}-${version}/${_pkg}"
+system_accounts="_nvidiapersistenced"
 
 _install_libs() {
 	local libdir=$1
@@ -203,6 +204,8 @@ do_install() {
 	vbin nvidia-persistenced
 	gzip -d nvidia-persistenced.1.gz
 	vman nvidia-persistenced.1
+	vsv nvidia-persistenced
+	vinstall ${FILESDIR}/nvidia-persistenced-nodaemon 0755 usr/libexec
 
 	# nvidia-powerd
 	vbin nvidia-powerd


### PR DESCRIPTION
nvidia [recommends][1] the `nvidia-persistenced` daemon for driver persistence.

> NVIDIA [...] will focus all future development and bug fixes on
the daemon.

[1]: https://docs.nvidia.com/deploy/driver-persistence/index.html#persistence-daemon

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
#### Local build testing
- I built this PR locally for my native architecture, x86_64 glibc
