### PR TITLE
python3-Faker: update to 33.1.0.

### DIFF
--- a/srcpkgs/python3-Faker/template
+++ b/srcpkgs/python3-Faker/template
@@ -1,6 +1,6 @@
 # Template file for 'python3-Faker'
 pkgname=python3-Faker
-version=33.0.0
+version=33.1.0
 revision=1
 build_style=python3-pep517
 hostmakedepends="python3-wheel python3-setuptools"
@@ -13,7 +13,7 @@ license="MIT"
 homepage="https://faker.readthedocs.io/en/master/"
 changelog="https://github.com/joke2k/faker/raw/master/CHANGELOG.md"
 distfiles="${PYPI_SITE}/f/faker/faker-${version}.tar.gz"
-checksum=9b01019c1ddaf2253ca2308c0472116e993f4ad8fc9905f82fa965e0c6f932e9
+checksum=1c925fc0e86a51fc46648b504078c88d0cd48da1da2595c4e712841cab43a1e4
 
 post_install() {
 	vlicense LICENSE.txt


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc

This version brings Python 3.13 support btw, just before 3.13.1 on Dec 3 per [PEP 719](https://peps.python.org/pep-0719/).