### PR TITLE
New package: pizauth

### DIFF
--- a/srcpkgs/pizauth/template
+++ b/srcpkgs/pizauth/template
@@ -1,0 +1,28 @@
+# Template file for 'pizauth'
+pkgname=pizauth
+version=1.0.7
+revision=1
+build_style=cargo
+configure_args="--all-features"
+short_desc="Command-line OAuth2 authentication daemon"
+maintainer="dkwo <npiazza@disroot.org>"
+license="MIT AND Apache-2.0"
+homepage="https://tratt.net/laurie/src/pizauth/"
+distfiles="https://github.com/ltratt/pizauth/archive/refs/tags/pizauth-${version}.tar.gz"
+checksum=24ae38cb00694281301c196e1d57b861bb539878d548e043d885735c3d3254f4
+
+if [ "$XBPS_TARGET_LIBC" = "glibc" ] && [ "$XBPS_TARGET_WORDSIZE" = "32" ]; then
+	broken="boot-time crate fails"
+fi
+
+do_install() {
+	vbin target/${RUST_TARGET}/release/pizauth
+
+	vlicense LICENSE-MIT
+	vlicense LICENSE-APACHE
+
+	vman pizauth.1
+	vman pizauth.conf.5
+	vsconf examples/pizauth.conf
+	vcompletion share/bash/completion.bash bash
+}


### PR DESCRIPTION
This is a command-line OAuth2 authentication daemon that could be a nice alternative to `mutt_oauth2.py`.

- I tested the changes in this PR: tested with google and microsoft, as well as my user dinit service at https://github.com/dkwo/dotfiles/tree/master/private_dot_config/private_dinit.d
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): yes
- I built this PR locally for my native architectures, `x86_64-glibc` and `aarch64-glibc`