### PR TITLE
gallery-dl: update to 1.28

### DIFF
--- a/srcpkgs/gallery-dl/template
+++ b/srcpkgs/gallery-dl/template
@@ -1,6 +1,6 @@
 # Template file for 'gallery-dl'
 pkgname=gallery-dl
-version=1.27.5
+version=1.28.1
 revision=1
 build_style=python3-module
 make_check_args="--ignore test/test_results.py"
@@ -13,7 +13,7 @@ license="GPL-2.0-only"
 homepage="https://github.com/mikf/gallery-dl"
 changelog="https://raw.githubusercontent.com/mikf/gallery-dl/master/CHANGELOG.md"
 distfiles="https://github.com/mikf/gallery-dl/archive/refs/tags/v${version}.tar.gz"
-checksum=f7fbf2321e98f79c8971de8bc44b059a976a44cb4f7dd19947affa9e76bc1484
+checksum=419377669f53f3815e1042a267373b6d5588c3ce7a2804c6841df19d433321d6
 
 pre_build() {
 	make man completion


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
