### PR TITLE
python3-googleapis-common-protos: update to 1.66.0

### DIFF
--- a/srcpkgs/python3-googleapis-common-protos/template
+++ b/srcpkgs/python3-googleapis-common-protos/template
@@ -1,7 +1,7 @@
 # Template file for 'python3-googleapis-common-protos'
 pkgname=python3-googleapis-common-protos
-version=1.58.0
-revision=2
+version=1.66.0
+revision=1
 build_style=python3-module
 hostmakedepends="python3-setuptools"
 depends="python3-protobuf"
@@ -11,8 +11,8 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="Apache-2.0"
 homepage="https://pypi.org/project/googleapis-common-protos/"
 changelog="https://raw.githubusercontent.com/googleapis/python-api-common-protos/v1.57.0/CHANGELOG.md"
-distfiles="${PYPI_SITE}/g/googleapis-common-protos/googleapis-common-protos-${version}.tar.gz"
-checksum=c727251ec025947d545184ba17e3578840fc3a24a0516a020479edab660457df
+distfiles="${PYPI_SITE}/g/googleapis_common_protos/googleapis_common_protos-${version}.tar.gz"
+checksum=c3e7b33d15fdca5374cc0a7346dd92ffa847425cc4ea941d970f13680052ec8c
 
 post_install() {
 	chmod -R +r "${DESTDIR}/${py3_sitelib}"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
