### PR TITLE
poppler: update to 24.12.0

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -351,7 +351,7 @@ libMagickCore-7.Q16HDRI.so.10 libmagick-7.1.0.10_1
 libMagickWand-7.Q16HDRI.so.10 libmagick-7.1.0.10_1
 libMagick++-7.Q16HDRI.so.5 libmagick-7.0.11.1_1
 libltdl.so.7 libltdl-2.2.6_1
-libpoppler.so.140 libpoppler-24.08.0_1
+libpoppler.so.144 libpoppler-24.12.0_1
 libpoppler-glib.so.8 poppler-glib-0.18.2_1
 libpoppler-cpp.so.1 poppler-cpp-24.08.0_1
 libpoppler-qt5.so.1 poppler-qt5-0.31.0_1

--- a/srcpkgs/poppler-qt5/template
+++ b/srcpkgs/poppler-qt5/template
@@ -4,7 +4,7 @@
 # IT IS SPLIT TO AVOID A CYCLIC DEPENDENCY: qt5 -> cups -> poppler -> qt5.
 #
 pkgname=poppler-qt5
-version=24.08.0
+version=24.12.0
 revision=1
 build_style=cmake
 configure_args="-DENABLE_UNSTABLE_API_ABI_HEADERS=ON -DENABLE_GLIB=OFF
@@ -21,7 +21,7 @@ license="GPL-2.0-or-later, GPL-3.0-or-later"
 homepage="https://poppler.freedesktop.org"
 changelog="https://gitlab.freedesktop.org/poppler/poppler/-/raw/master/NEWS"
 distfiles="https://poppler.freedesktop.org/poppler-${version}.tar.xz"
-checksum=97453fbddf0c9a9eafa0ea45ac710d3d49bcf23a62e864585385d3c0b4403174
+checksum=1cf374c3146f3f685d9257701bf0c2866c61d6c202c14d1f5c01a1f3a089028a
 # fails to find a bunch of files
 make_check=no
 

--- a/srcpkgs/poppler/template
+++ b/srcpkgs/poppler/template
@@ -2,7 +2,7 @@
 #
 # THIS PKG MUST BE SYNCHRONIZED WITH "srcpkgs/poppler-qt5".
 pkgname=poppler
-version=24.08.0
+version=24.12.0
 revision=1
 _testVersion=ff3133cdb6cb496ee1d2c3231bfa35006a5e8410
 create_wrksrc=yes
@@ -24,7 +24,7 @@ homepage="https://poppler.freedesktop.org"
 changelog="https://gitlab.freedesktop.org/poppler/poppler/-/raw/master/NEWS"
 distfiles="https://poppler.freedesktop.org/poppler-${version}.tar.xz
  https://gitlab.freedesktop.org/poppler/test/-/archive/${_testVersion}/test-${_testVersion}.tar.gz"
-checksum="97453fbddf0c9a9eafa0ea45ac710d3d49bcf23a62e864585385d3c0b4403174
+checksum="1cf374c3146f3f685d9257701bf0c2866c61d6c202c14d1f5c01a1f3a089028a
  98a06e7dd7619fe20bfd99505a31993dbe40517678d81278e6395a30a40f03bf"
 
 build_options="gir boost"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**
- [x] poppler builds for x86_64-{glibc,musl} and i686; it also cross-compiles for aarch64-glibc
- [x] poppler-qt5 builds for x86_64-{glibc,musl} and i686; it also cross-compiles for aarch64-glibc


**Rebuilding all the packages that depend on poppler...:**
- [x] calligra: x86_64-{glibc,musl}
- [x] fim: x86_64-{glibc,musl}, aarch64-glibc (cross build)
- [ ] inkscape: x86_64-{glibc,musl}, aarch64-glibc (cross build)
- [x] ipe: x86_64-{glibc,musl} [nocross var set so no cross builds
- [x] kitinerary: x86_64-{glibc,musl}, aarch64-glibc (cross build)
- [x] libreoffice: x86_64-glibc, aarch64-glibc (cross build)
- [x] pdf2djvu: x86_64-{glibc,musl}, aarch64-glibc (cross build)
- [ ] scribus: x86_64-{glibc,musl}, aarch64-glibc (cross build)
- [x] efl: x86_64-{glibc,musl}, aarch64-glibc (cross build)
- [x] extractpdfmark: x86_64-{glibc,musl}, aarch64-glibc (cross build)
- [x] libcupsfilters: x86_64-{glibc,musl}, aarch64-glibc (cross build)
- [x] pdfgrep: x86_64-{glibc,musl}, aarch64-glibc (cross build)