### PR TITLE
dracut: allow disabling of kernel.d hook

### DIFF
--- a/srcpkgs/dracut/files/dracut-hook.confd
+++ b/srcpkgs/dracut/files/dracut-hook.confd
@@ -1,0 +1,2 @@
+#Uncomment and set the following option to 0 if you don't want dracut to generate the initramfs automatically. This makes sense if dracut-uefi is used.
+#CREATE_INITRAMFS=1

--- a/srcpkgs/dracut/files/kernel-hook-postinst
+++ b/srcpkgs/dracut/files/kernel-hook-postinst
@@ -7,6 +7,11 @@
 PKGNAME="$1"
 VERSION="$2"
 
+. "${ROOTDIR}/etc/default/dracut-hook"
+if [ ! -z "${CREATE_INITRAMFS}" ]; then
+	exit 0
+fi
+
 if [ ! -x usr/bin/dracut ]; then
 	exit 0
 fi

--- a/srcpkgs/dracut/template
+++ b/srcpkgs/dracut/template
@@ -1,10 +1,10 @@
 # Template file for 'dracut'
 pkgname=dracut
 version=105
-revision=1
+revision=2
 build_style=configure
 configure_args="--prefix=/usr --sysconfdir=/etc"
-conf_files="/etc/dracut.conf"
+conf_files="/etc/dracut.conf /etc/default/dracut-hook"
 hostmakedepends="pkg-config asciidoc"
 makedepends="libkmod-devel"
 depends="bash coreutils cpio eudev gzip kmod>=3.7 kpartx util-linux"
@@ -41,6 +41,7 @@ post_install() {
 	# kernel hooks.
 	vinstall ${FILESDIR}/kernel-hook-postinst 755 usr/libexec/dracut
 	vinstall ${FILESDIR}/kernel-hook-postrm 755 usr/libexec/dracut
+	vinstall ${FILESDIR}/dracut-hook.confd 644 etc/default dracut-hook
 
 	# We don't need the systemd stuff.
 	rm -r ${DESTDIR}/usr/lib/dracut/modules.d/*systemd*


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)