### PR TITLE
android-studio: add missing dep for emulator

### DIFF
--- a/srcpkgs/android-studio/template
+++ b/srcpkgs/android-studio/template
@@ -1,9 +1,10 @@
 # Template file for 'android-studio'
 pkgname=android-studio
 version=2024.2.1.9
-revision=1
+revision=2
 archs="x86_64"
 hostmakedepends="tar"
+depends="libbsd"
 short_desc="Official Android IDE"
 maintainer="Bnyro <bnyro@tutanota.com>"
 license="Apache-2.0"


### PR DESCRIPTION
Running the android emulator using the `emulator` executable located in the `Sdk/emulator` directory without `libbsd` being installed leads to the following error:

```
INFO    | Android emulator version 35.2.10.0 (build_id 12414864) (CL:N/A)
INFO    | Graphics backend: gfxstream
INFO    | Found systemPath /home/meator/Android/Sdk/system-images/android-34/google_apis_playstore/x86_64/
/home/meator/Android/Sdk/emulator/qemu/linux-x86_64/qemu-system-x86_64: error while loading shared libraries: libbsd.so.0: cannot open shared object file: No such file or directory
```

This is hard to debug and diagnose, because the common way of running Android emulators, through Android Studio's Device Manager, prints a generic error message:

![ksnip_20241206-103011](https://github.com/user-attachments/assets/187c781c-047e-47e8-9a21-d1934b0e1010)

The best solution would be to unvendor qemu and use Void's one, but that would be difficult (I assume).

cc @Bnyro

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
