### PR TITLE
thefuck: move setuptools to depends

### DIFF
--- a/srcpkgs/thefuck/template
+++ b/srcpkgs/thefuck/template
@@ -3,9 +3,9 @@ pkgname=thefuck
 version=3.32
 revision=4
 build_style=python3-module
-hostmakedepends="python3-setuptools"
+hostmakedepends=""
 depends="python3-colorama python3-decorator python3-psutil python3-pyte
- python3-requests"
+ python3-requests python3-setuptools"
 checkdepends="python3-pytest-mock $depends"
 short_desc="Magnificent app which corrects your previous console command"
 maintainer="Orphaned <orphan@voidlinux.org>"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **NO**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
