### PR TITLE
common: move handling of rdeps, shlib-provides, shlib-requires files

### DIFF
--- a/common/hooks/do-pkg/00-gen-pkg.sh
+++ b/common/hooks/do-pkg/00-gen-pkg.sh
@@ -34,14 +34,14 @@ genpkg() {
 	cd $pkgdir
 
 	_preserve=${preserve:+-p}
-	if [ -s ${PKGDESTDIR}/rdeps ]; then
-		_deps="$(<${PKGDESTDIR}/rdeps)"
+	if [ -s ${XBPS_STATEDIR}/${pkgname}-rdeps ]; then
+		_deps="$(<${XBPS_STATEDIR}/${pkgname}-rdeps)"
 	fi
-	if [ -s ${PKGDESTDIR}/shlib-provides ]; then
-		_shprovides="$(<${PKGDESTDIR}/shlib-provides)"
+	if [ -s ${XBPS_STATEDIR}/${pkgname}-shlib-provides ]; then
+		_shprovides="$(<${XBPS_STATEDIR}/${pkgname}-shlib-provides)"
 	fi
-	if [ -s ${PKGDESTDIR}/shlib-requires ]; then
-		_shrequires="$(<${PKGDESTDIR}/shlib-requires)"
+	if [ -s ${XBPS_STATEDIR}/${pkgname}-shlib-requires ]; then
+		_shrequires="$(<${XBPS_STATEDIR}/${pkgname}-shlib-requires)"
 	fi
 	if [ -s ${XBPS_STATEDIR}/gitrev ]; then
 		_gitrevs="$(<${XBPS_STATEDIR}/gitrev)"

--- a/common/hooks/post-install/06-strip-and-debug-pkgs.sh
+++ b/common/hooks/post-install/06-strip-and-debug-pkgs.sh
@@ -51,7 +51,7 @@ create_debug_pkg() {
 		msg_red "$pkgver: failed to create debug pkg\n"
 		return 1
 	fi
-	printf "${pkgver} " >> ${_destdir}/rdeps
+	printf "${pkgver} " >> ${XBPS_STATEDIR}/${pkgname}-dbg-rdeps
 	rmdir --ignore-fail-on-non-empty "${PKGDESTDIR}/usr/lib" 2>/dev/null
 	return 0
 }

--- a/common/hooks/post-install/98-shlib-provides.sh
+++ b/common/hooks/post-install/98-shlib-provides.sh
@@ -50,8 +50,8 @@ collect_sonames() {
 		echo "$f" >> ${_tmpfile}
 	done
 	if [ -s "${_tmpfile}" ]; then
-		tr '\n' ' ' < "${_tmpfile}" > ${_destdir}/shlib-provides
-		echo >> ${_destdir}/shlib-provides
+		tr '\n' ' ' < "${_tmpfile}" > "${XBPS_STATEDIR}/${pkgname}-shlib-provides"
+		echo >> "${XBPS_STATEDIR}/${pkgname}-shlib-provides"
 		if [ "$_mainpkg" ]; then
 			cp "${_tmpfile}" "${_shlib_dir}/${pkgname}.soname"
 		fi

--- a/common/hooks/pre-pkg/04-generate-runtime-deps.sh
+++ b/common/hooks/pre-pkg/04-generate-runtime-deps.sh
@@ -41,7 +41,7 @@ store_pkgdestdir_rundeps() {
                     _curdep="${_curdep}>=0"
                 fi
                 printf "%s " "${_curdep}"
-            done > "${PKGDESTDIR}/rdeps"
+            done > "${XBPS_STATEDIR}/${pkgname}-rdeps"
         fi
 }
 
@@ -149,6 +149,6 @@ hook() {
     store_pkgdestdir_rundeps
 
     if [ -n "${sorequires}" ]; then
-        echo "${sorequires}" | xargs -n1 | sort | xargs > ${PKGDESTDIR}/shlib-requires
+        echo "${sorequires}" | xargs -n1 | sort | xargs > ${XBPS_STATEDIR}/${pkgname}-shlib-requires
     fi
 }

--- a/common/hooks/pre-pkg/05-generate-32bit-runtime-deps.sh
+++ b/common/hooks/pre-pkg/05-generate-32bit-runtime-deps.sh
@@ -19,13 +19,13 @@ hook() {
 	# 32bit dependencies.
 	trap - ERR
 
-	: > ${destdir32}/rdeps
+	: > ${XBPS_STATEDIR}/${pkgname}-32bit-rdeps
 
-	if [ -s "$PKGDESTDIR/rdeps" ]; then
+	if [ -s "${XBPS_STATEDIR}/${pkgname}-rdeps" ]; then
 		if [ -n "$lib32depends" ]; then
 			_deps="${lib32depends}"
 		else
-			_deps="$(<${PKGDESTDIR}/rdeps)"
+			_deps="$(<${XBPS_STATEDIR}/${pkgname}-rdeps)"
 		fi
 		for f in ${_deps}; do
 			unset found pkgn pkgv _shprovides
@@ -43,7 +43,7 @@ hook() {
 			# If dependency is a development pkg switch it to 32bit.
 			if [[ $pkgn == *-devel ]]; then
 				echo "   RDEP: $f -> ${pkgn}-32bit${pkgv} (development)"
-				printf "${pkgn}-32bit${pkgv} " >> ${destdir32}/rdeps
+				printf "${pkgn}-32bit${pkgv} " >> ${XBPS_STATEDIR}/${pkgname}-32bit-rdeps
 				continue
 			fi
 			# If dependency does not have "shlib-provides" do not
@@ -60,20 +60,20 @@ hook() {
 				_shprovides="$($XBPS_QUERY_CMD -R --property=shlib-provides "$pkgn")"
 				if [ -n "${_shprovides}" ]; then
 					echo "   RDEP: $f -> ${pkgn}-32bit${pkgv} (shlib-provides)"
-					printf "${pkgn}-32bit${pkgv} " >> ${destdir32}/rdeps
+					printf "${pkgn}-32bit${pkgv} " >> ${XBPS_STATEDIR}/${pkgname}-32bit-rdeps
 				else
 					echo "   RDEP: $f -> ${pkgn}${pkgv} (no shlib-provides)"
-					printf "${pkgn}${pkgv} " >> ${destdir32}/rdeps
+					printf "${pkgn}${pkgv} " >> ${XBPS_STATEDIR}/${pkgname}-32bit-rdeps
 				fi
 			else
-				if [ -s ${XBPS_DESTDIR}/${pkgn}-${version}/shlib-provides ]; then
+				if [ -s "${XBPS_STATEDIR}/${pkgn}-shlib-provides" ]; then
 					# Dependency is a subpkg; check if it provides any shlib
 					# and convert to 32bit if true.
 					echo "   RDEP: $f -> ${pkgn}-32bit${pkgv} (subpkg, shlib-provides)"
-					printf "${pkgn}-32bit${pkgv} " >> ${destdir32}/rdeps
+					printf "${pkgn}-32bit${pkgv} " >> ${XBPS_STATEDIR}/${pkgname}-32bit-rdeps
 				else
 					echo "   RDEP: $f -> ${pkgn}${pkgv} (subpkg, no shlib-provides)"
-					printf "${pkgn}${pkgv} " >> ${destdir32}/rdeps
+					printf "${pkgn}${pkgv} " >> ${XBPS_STATEDIR}/${pkgname}-32bit-rdeps
 				fi
 			fi
 		done
@@ -81,7 +81,7 @@ hook() {
 	# If it's a development pkg add a dependency to the 64bit pkg.
 	if [[ $pkgn == *-devel ]]; then
 		echo "   RDEP: ${pkgver}"
-		printf "${pkgver} " >> ${destdir32}/rdeps
+		printf "${pkgver} " >> ${XBPS_STATEDIR}/${pkgname}-32bit-rdeps
 	fi
-	printf "\n" >> ${destdir32}/rdeps
+	printf "\n" >> ${XBPS_STATEDIR}/${pkgname}-32bit-rdeps
 }

--- a/common/hooks/pre-pkg/99-pkglint.sh
+++ b/common/hooks/pre-pkg/99-pkglint.sh
@@ -170,11 +170,11 @@ hook() {
 	fi
 
 	# Check for missing shlibs and SONAME bumps.
-	if [ ! -s "${PKGDESTDIR}/shlib-provides" ]; then
+	if [ ! -s "${XBPS_STATEDIR}/${pkgname}-shlib-provides" ]; then
 		return 0
 	fi
 
-	for filename in $(<${PKGDESTDIR}/shlib-provides); do
+	for filename in $(<"${XBPS_STATEDIR}/${pkgname}-shlib-provides"); do
 		rev=${filename#*.so.}
 		libname=${filename%.so*}
 		_shlib=$(echo "$libname"|sed -E 's|\+|\\+|g')

--- a/common/hooks/pre-pkg/999-collected-rdeps.sh
+++ b/common/hooks/pre-pkg/999-collected-rdeps.sh
@@ -1,7 +1,7 @@
 # This hook displays resolved dependencies for a pkg.
 
 hook() {
-	if [ -e $PKGDESTDIR/rdeps ]; then
-		echo "   $(cat $PKGDESTDIR/rdeps)"
+	if [ -e "${XBPS_STATEDIR}/${pkgname}-rdeps" ]; then
+		echo "   $(cat "${XBPS_STATEDIR}/${pkgname}-rdeps")"
 	fi
 }

--- a/common/xbps-src/shutils/show.sh
+++ b/common/xbps-src/shutils/show.sh
@@ -62,7 +62,7 @@ show_pkg_var() {
 }
 
 show_pkg_deps() {
-    [ -f "${PKGDESTDIR}/rdeps" ] && cat ${PKGDESTDIR}/rdeps
+    [ -f "${XBPS_STATEDIR}/${pkgname}-rdeps" ] && cat "${XBPS_STATEDIR}/${pkgname}-rdeps"
 }
 
 show_pkg_files() {
@@ -155,9 +155,9 @@ show_pkg_build_options() {
 }
 
 show_pkg_shlib_provides() {
-    [ -f "${PKGDESTDIR}/shlib-provides" ] && cat ${PKGDESTDIR}/shlib-provides
+    [ -f "${XBPS_STATEDIR}/${pkgname}-shlib-provides" ] && cat "${XBPS_STATEDIR}/${pkgname}-shlib-provides"
 }
 
 show_pkg_shlib_requires() {
-    [ -f "${PKGDESTDIR}/shlib-requires" ] && cat ${PKGDESTDIR}/shlib-requires
+    [ -f "${XBPS_STATEDIR}/${pkgname}-shlib-requires" ] && cat "${XBPS_STATEDIR}/${pkgname}-shlib-requires"
 }


### PR DESCRIPTION
to `XBPS_STATEDIR`. There's no need for them to pollute `PKGDESTDIR`. Keep `INSTALL.msg`/`REMOVE.msg` handling as-is for now because it's a little more complex. Keep the pkglints for these files because xbps still ignores them.

#### Testing the changes
- I tested the changes in this PR: **YES**

