### PR TITLE
openimagedenoise: update to 2.3.1

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -3986,7 +3986,7 @@ libcaribou.so.0 libcaribou-0.4.21_3
 libtinyclipboard.so.1 tinyclipboard-16.01_1
 libcbor.so.0.11 libcbor-0.11.0_1
 libfido2.so.1 libfido2-1.6.0_2
-libOpenImageDenoise.so.1 openimagedenoise-1.3.0_1
+libOpenImageDenoise.so.2 openimagedenoise-2.3.1_1
 libcbang0.so cbang-1.6.0_3
 libblosc.so.1 c-blosc-1.17.1_1
 libopenvdb.so.9.0 openvdb-9.0.0_1

--- a/srcpkgs/openimagedenoise/template
+++ b/srcpkgs/openimagedenoise/template
@@ -1,7 +1,7 @@
 # Template file for 'openimagedenoise'
 pkgname=openimagedenoise
-version=1.4.3
-revision=2
+version=2.3.1
+revision=1
 archs="x86_64*"
 build_style=cmake
 hostmakedepends="ispc python3"
@@ -12,7 +12,7 @@ license="Apache-2.0"
 homepage="https://openimagedenoise.github.io"
 changelog="https://github.com/OpenImageDenoise/oidn/blob/master/CHANGELOG.md"
 distfiles="https://github.com/OpenImageDenoise/oidn/releases/download/v${version}/oidn-${version}.src.tar.gz"
-checksum=3276e252297ebad67a999298d8f0c30cfb221e166b166ae5c955d88b94ad062a
+checksum=225879b4225bfe015273f0372bf6e7a69d01030043c8aefa017196b41ecf8148
 
 do_check() {
 	build/oidnTest


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
