### PR TITLE
New package: libAnalitza-24.11.90, KAlgebra-24-11.90

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -4543,3 +4543,7 @@ libflashrom.so.1 flashrom-1.4.0_1
 libpyside6.so.6.7 libpyside6-6.7.2_1
 libpyside6qml.so.6.7 libpyside6-6.7.2_1
 libshiboken6.so.6.7 libshiboken6-6.7.2_1
+libAnalitza.so.9 libAnalitza-24.11.90_1
+libAnalitzaGui.so.9 libAnalitza-24.11.90_1
+libAnalitzaPlot.so.9 libAnalitza-24.11.90_1
+libAnalitzaWidgets.so.9 libAnalitza-24.11.90_1

--- a/srcpkgs/KAlgebra-doc
+++ b/srcpkgs/KAlgebra-doc
@@ -1,0 +1,1 @@
+KAlgebra

--- a/srcpkgs/KAlgebra/template
+++ b/srcpkgs/KAlgebra/template
@@ -1,0 +1,22 @@
+# Template file for 'KAlgebra'
+pkgname=KAlgebra
+version=24.11.90
+revision=1
+build_style=cmake
+hostmakedepends="extra-cmake-modules AppStream gettext kf6-kdoctools"
+makedepends="kf6-kio-devel libAnalitza-devel libplasma-devel qt6-webengine-devel kf6-kxmlgui-devel readline-devel"
+depends="kf6-kirigami kirigami-addons"
+short_desc="Graph Calculator"
+maintainer="Oscar Ronberg <oscar@oronberg.com>"
+license="GPL-2.0-or-later"
+homepage="https://apps.kde.org/kalgebra"
+distfiles="https://invent.kde.org/education/kalgebra/-/archive/v${version}/kalgebra-v${version}.tar.gz"
+checksum=553d265fbdaff8b282d0afc08de9d55d20d6b0675b66e2e2eea5fb828a8bbd33
+
+KAlgebra-doc_package() {
+	short_desc+=" - documentation"
+	pkg_install() {
+		vmkdir usr/share/doc/kalgebra
+		vcopy "doc/*" usr/share/doc/kalgebra
+	}
+}

--- a/srcpkgs/libAnalitza-devel
+++ b/srcpkgs/libAnalitza-devel
@@ -1,0 +1,1 @@
+libAnalitza

--- a/srcpkgs/libAnalitza/template
+++ b/srcpkgs/libAnalitza/template
@@ -1,0 +1,24 @@
+# Template file for 'libAnalitza'
+pkgname=libAnalitza
+version=24.11.90
+revision=1
+build_style=cmake
+configure_args="-DBUILD_TESTING=OFF -DKDE_INSTALL_QMLDIR=lib/qt6/qml"
+hostmakedepends="extra-cmake-modules eigen qt6-base qt6-tools qt6-declarative-host-tools"
+makedepends="kf6-kio-devel"
+short_desc="Mathematical features library"
+maintainer="Oscar Ronberg <oscar@oronberg.com>"
+license="GPL-2.0-or-later"
+homepage="https://invent.kde.org/education/analitza"
+distfiles="https://invent.kde.org/education/analitza/-/archive/v${version}/analitza-v${version}.tar.gz"
+checksum=7233c2e1fb8e47f608cd08a2abb4a7fbf21e829779a51f41411aba0db80260fa
+
+libAnalitza-devel_package() {
+	depends="${sourcepkg}>=${version}_${revision}"
+	short_desc+=" - development files"
+	pkg_install() {
+		vmove usr/include
+		vmove usr/lib/cmake
+		vmove "usr/lib/*.so"
+	}
+}


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)

***

I have attempted to build for armv6l however there is an issue of the build script attempting to run qmlcachegen which cannot be run on my x86_64 machine and gives the error `/usr/arm-linux-gnueabihf/usr/lib32/qt6/libexec/qmlcachegen: cannot execute binary file: Exec format error`, help sorting this issue out would be appreciated as I have no clue what to do for it.
