### PR TITLE
New package: bashdb-5.0+1.1.2

### DIFF
--- a/srcpkgs/bashdb/patches/configure-bash-version.patch
+++ b/srcpkgs/bashdb/patches/configure-bash-version.patch
@@ -1,0 +1,12 @@
+Enable building with bash 5.1/5.2 - Remove with upstream release
+--- a/configure
++++ b/configure
+@@ -2790,7 +2790,7 @@ bash_major=`$SH_PROG -c 'echo ${BASH_VERSINFO[0]}'`
+ bash_minor=`$SH_PROG -c 'echo ${BASH_VERSINFO[1]}'`
+ bash_5_or_greater=no
+ case "${bash_major}.${bash_minor}" in
+-  '5.0' | '5.0')
++  '5.0' | '5.0' | '5.1' | '5.2')
+     bash_5_or_greater=yes
+     ;;
+   *)

--- a/srcpkgs/bashdb/patches/test-bash-rematch.patch
+++ b/srcpkgs/bashdb/patches/test-bash-rematch.patch
@@ -1,0 +1,13 @@
+Removes -r from expected "declare" result in bash-rematch test. Makes result consistent with current void-packages bash version.
+--- a/test/data/bash-rematch.right
++++ b/test/data/bash-rematch.right
+@@ -31,7 +31,7 @@
+ 8:	    echo "${!i} matches"
+  0: $BASH_REMATCH = 456
+ +eval typeset -p BASH_REMATCH
+-declare -ar BASH_REMATCH=([0]="456")
++declare -a BASH_REMATCH=([0]="456")
+ $? is 0
+ +c 
+ 456 matches
+

--- a/srcpkgs/bashdb/patches/test-bug-loc-pygments.patch
+++ b/srcpkgs/bashdb/patches/test-bug-loc-pygments.patch
@@ -1,0 +1,44 @@
+Makes expected color codes of bug-loc test results consistent with current void-packages python3-Pygments version.
+--- a/test/data/bug-loc.right
++++ b/test/data/bug-loc.right
+@@ -1,26 +1,26 @@
+ (bug-loc.sh:5):
+-5:	[31mdirname[39;49;00m=[33m${[39;49;00m[31mBASH_SOURCE[39;49;00m%/*[33m}[39;49;00m   [37m# equivalent to dirname($0)[39;49;00m
++5:	[31mdirname[39;49;00m=[33m${[39;49;00m[31mBASH_SOURCE[39;49;00m%/*[33m}[39;49;00m[37m   [39;49;00m[37m# equivalent to dirname($0)[39;49;00m
+ +# Test to see that we read in files that mentioned in breakpoints
+ +# but we don't step into.
+-+step
+++step 
+ (bug-loc.sh:6):
+-6:	[36msource[39;49;00m [33m${[39;49;00m[31mdirname[39;49;00m[33m}[39;49;00m/library.sh
+-+step
++6:	[36msource[39;49;00m[37m [39;49;00m[33m${[39;49;00m[31mdirname[39;49;00m[33m}[39;49;00m/library.sh[37m[39;49;00m
+++step 
+ (bug-loc.sh:7):
+-7:	[36mecho[39;49;00m [33m'script line 7'[39;49;00m
+-+step
++7:	[36mecho[39;49;00m[37m [39;49;00m[33m'script line 7'[39;49;00m[37m[39;49;00m
+++step 
+ script line 7
+ (bug-loc.sh:8):
+-8:	library-function
+-+step
++8:	library-function[37m[39;49;00m
+++step 
+ (library.sh:1):
+-1:	library-function() {
+-+step
++1:	library-function()[37m [39;49;00m{[37m[39;49;00m
+++step 
+ (library.sh:2):
+-2:	  [36mecho[39;49;00m [33m'library line 2 in library-function'[39;49;00m
+-+step
++2:	[37m  [39;49;00m[36mecho[39;49;00m[37m [39;49;00m[33m'library line 2 in library-function'[39;49;00m[37m[39;49;00m
+++step 
+ library line 2 in library-function
+ (bug-loc.sh:11):
+-11:	[36mecho[39;49;00m [33m'script line 11'[39;49;00m
+-+quit
++11:	[36mecho[39;49;00m[37m [39;49;00m[33m'script line 11'[39;49;00m[37m[39;49;00m
+++quit 
+ bashdb: That's all, folks...

--- a/srcpkgs/bashdb/patches/test-cmd-info-variables-abs_top_srcdir.patch
+++ b/srcpkgs/bashdb/patches/test-cmd-info-variables-abs_top_srcdir.patch
@@ -1,0 +1,17 @@
+Adds missing @abs_top_srcdir@ to test-cmd-info-variables.sh.in
+--- a/test/unit/test-cmd-info-variables.sh.in
++++ b/test/unit/test-cmd-info-variables.sh.in
+@@ -32,11 +32,11 @@
+     # FIXME try -x -i, and no options. try invalid opts
+ }
+ 
+-if [ '/src/external-vcs/sourceforge/bashdb' = '' ] ; then
++if [ '@abs_top_srcdir@' = '' ] ; then
+   echo "Something is wrong: abs_top_srcdir is not set."
+  exit 1
+ fi
+-abs_top_srcdir=/src/external-vcs/sourceforge/bashdb
++abs_top_srcdir=@abs_top_srcdir@
+ # Make sure $abs_top_src has a trailing slash
+ abs_top_srcdir=${abs_top_srcdir%%/}/
+ . ${abs_top_srcdir}test/unit/helper.sh

--- a/srcpkgs/bashdb/patches/test-settrace-pygments.patch
+++ b/srcpkgs/bashdb/patches/test-settrace-pygments.patch
@@ -1,0 +1,10 @@
+Makes expected color codes of settrace test results consistent with current void-packages python3-Pygments version.
+--- a/test/data/settrace.right
++++ b/test/data/settrace.right
+@@ -1,5 +1,5 @@
+ (settrace.sh:6):
+-6:	  _Dbg_debugger; :
++6:	[37m  [39;49;00m_Dbg_debugger;[37m [39;49;00m:[37m[39;49;00m
+ +# Test set_trace call.
+ +where
+ ->0 in file `settrace.sh' at line 6

--- a/srcpkgs/bashdb/template
+++ b/srcpkgs/bashdb/template
@@ -1,0 +1,14 @@
+# Template file for 'bashdb'
+pkgname=bashdb
+version=5.0+1.1.2
+revision=1
+build_style=gnu-configure
+depends="python3-Pygments"
+checkdepends="python3-Pygments"
+short_desc="Gdb-like debugger for bash"
+maintainer="Zachary Hanham <z@zmhanham.com>"
+license="GPL-2.0-only"
+homepage="https://bashdb.sourceforge.net/"
+distfiles="${SOURCEFORGE_SITE}/${pkgname}/${pkgname}-${version//+/-}.tar.gz"
+checksum=1cd5508007bb6b377977010de8c8aea9208e1417c56b30d102ffffd9d8afb0ca
+python_version=3


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl

#### Notes

- The upstream version is "5.0-1.1.2", but due to void's version naming rules not allowing for dashes, I changed the "-" to a "+"
- It is worth noting that the upstream is currently only released to support up to bash version 5.0, not including the current void-packages bash 5.2. However, bashdb still works just fine in bash 5.2, and this has not stopped other repos from packaging bashdb with patches applied to allow building for 5.2 (see `configure-bash-version.patch`). For instance, nixpkgs and gentoo are both on bash 5.2 and both package bashdb.
- Several other patches had to be made to get certain tests to pass, these seem benign and are likely due to version differences.
- There is a missing test in the packaged distribution (`test-file-with-spaces`), see https://sourceforge.net/p/bashdb/bugs/52. Gentoo deals with this by hosting the missing test files, and copying them in, see here: https://gitweb.gentoo.org/repo/gentoo.git/tree/app-shells/bashdb/bashdb-5.0.1.1.2.ebuild#n24. Personally I think it is fine to just skip this test, but I would be willing to add a similar fix to the gentoo one if it is deemed valuable. I'm unsure where to put the missing files exactly if I were to, add them via patches??
- A few unit tests are marked as failing, specifically `test_alias`, `test_cmd_info_variables`, and `test_get_source_line` Check still exits successfully without needing to disable these tests. I had spent some time trying to fix these but I gave up after some time. It is strange though because I can get them to pass if I run them individually (except `test_alias`), but some tests seem to depend on other tests running prior. That is, the results of each test are not idempotent of each other. I understand if this is unacceptable, but I'm reaching the extent of my ability to debug these.