### PR TITLE
Revert: "mesa: update to 24.3.1." + Update to 24.2.8

### DIFF
--- a/srcpkgs/mesa/template
+++ b/srcpkgs/mesa/template
@@ -1,12 +1,13 @@
 # Template file for 'mesa'
 pkgname=mesa
-version=24.3.1
+reverts="24.3.1_1"
+version=24.2.8
 revision=1
 build_style=meson
 _llvmver=19
 #Disable LTO flag should be present, see https://gitlab.freedesktop.org/mesa/mesa/-/issues/6911
 configure_args="-Dglvnd=true -Dshared-glapi=enabled -Dgbm=enabled -Degl=enabled
- -Dosmesa=true -Dgles1=enabled -Dgles2=enabled -Dglx=dri
+ -Dosmesa=true -Dgles1=enabled -Dgles2=enabled -Dglx=dri -Ddri3=enabled
  -Dlmsensors=enabled -Dplatforms=x11$(vopt_if wayland ,wayland)
  -Dllvm=enabled -Db_lto=false -Dcpp_std=gnu++17"
 hostmakedepends="gettext flex pkg-config python3-Mako glslang llvm${_llvmver}
@@ -24,7 +25,7 @@ license="MIT, LGPL-2.1-or-later"
 homepage="https://www.mesa3d.org/"
 changelog="https://docs.mesa3d.org/relnotes.html"
 distfiles="https://mesa.freedesktop.org/archive/mesa-${version}.tar.xz"
-checksum=9c795900449ce5bc7c526ba0ab3532a22c3c951cab7e0dd9de5fcac41b0843af
+checksum=999d0a854f43864fc098266aaf25600ce7961318a1e2e358bff94a7f53580e30
 
 build_helper="qemu"
 build_options="wayland"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**


#### Local build testing
- I built this PR locally for my native architecture, (x64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x64-muslc
 
In response to https://github.com/void-linux/void-packages/issues/53434, my sincere apologies for the inconvenience. 
I should have tested the update with more hardware.
I think it's the wisest option we have for now.
I though took the liberty to update to the next minor version, this should fix the max amount of bugs we have with mesa globally.
