### PR TITLE
font-awesome6: update to 6.7.1

### DIFF
--- a/srcpkgs/font-awesome6/template
+++ b/srcpkgs/font-awesome6/template
@@ -1,6 +1,6 @@
 # Template file for 'font-awesome6'
 pkgname=font-awesome6
-version=6.6.0
+version=6.7.1
 revision=1
 hostmakedepends="font-util"
 short_desc="Iconic SVG, font, and CSS toolkit - desktop fonts"
@@ -9,7 +9,7 @@ license="OFL-1.1"
 homepage="https://fontawesome.com/"
 changelog="https://fontawesome.com/docs/changelog/"
 distfiles="https://github.com/FortAwesome/Font-Awesome/releases/download/${version}/fontawesome-free-${version}-desktop.zip"
-checksum=8cde9bf442f218ee330844263ee35403ff466a1afbbd11ab170523f3cd09067c
+checksum=3118838d8d0aa88b8c9a5e132f8a195a3f1b23895ae66c61dc6746f9ceef80da
 font_dirs="/usr/share/fonts/OTF"
 
 do_install() {


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures:
  - x86_64-musl

~~As font-awesome 4.x series is marked as EOL,
I have transited it to font-awesome6~~
<br/>

@mobinmob could you please review the changes??
And thanks for your time!!