### PR TITLE
py-spy: update to 0.4.0.

### DIFF
--- a/srcpkgs/py-spy/template
+++ b/srcpkgs/py-spy/template
@@ -1,6 +1,6 @@
 # Template file for 'py-spy'
 pkgname=py-spy
-version=0.3.14
+version=0.4.0
 revision=1
 # musl archs can't compile remoteprocess
 archs="~*-musl"
@@ -13,16 +13,11 @@ maintainer="Wilson Birney <wpb@360scada.com>"
 license="MIT"
 homepage="https://github.com/benfred/py-spy"
 distfiles="https://github.com/benfred/py-spy/archive/refs/tags/v${version}.tar.gz"
-checksum=c01da8b74be0daba79781cfc125ffcd3df3a0d090157fe0081c71da2f6057905
+checksum=13a5c4b949947425670eedac05b6dd27edbc736b75f1587899efca1a7ef79ac3
 
 case "$XBPS_TARGET_MACHINE" in
 	ppc) broken="error[E0425]: cannot find function get_interp_head_offset in module pyruntime";;
 esac
-
-pre_build() {
-	# fixes the usage of yanked versions of crates
-	cargo update --package quick-xml@0.23.0 --precise 0.23.1
-}
 
 pre_check() {
 	rm -f tests/integration_test.rs


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
#### Notes
- Prior py-spy version 0.3.14 was incompatible with current void python version 3.12. py-spy 0.4.0 adds support for 3.12 (https://github.com/benfred/py-spy/releases/tag/v0.4.0)
- I removed a `pre_build` workaround that I believe is no longer needed.
- I tried re-enabling integration tests, but they hang at the end of the tests due to them leaving some zombie processes running. There'd need to be some patch to kill the processes after the tests end.