### PR TITLE
leocad: update to 23.03

### DIFF
--- a/srcpkgs/leocad/template
+++ b/srcpkgs/leocad/template
@@ -1,8 +1,8 @@
 # Template file for 'leocad'
 pkgname=leocad
-version=21.06
+version=23.03
 revision=1
-_lib_version=20.03
+_lib_version=23.06
 create_wrksrc=yes
 build_style=qmake
 configure_args="DISABLE_UPDATE_CHECK=1"
@@ -14,8 +14,8 @@ license="GPL-2.0-only, CC-BY-2.0"
 homepage="http://leocad.org"
 distfiles="https://github.com/leozide/leocad/archive/v${version}.tar.gz
  https://github.com/leozide/leocad/releases/download/v${version}/Library-${_lib_version}.zip"
-checksum="bd28c47f920fa1bc458b6e5f476b93ccc1aa40e30158a3dd2397368cc3d79099
- 88d6d28b3a494a15ae63e984c1e732e28362fabc2e145ffab828fed2eb5e3632"
+checksum="69a45c60898ed07d8cf7e714442b201b0da3adc073287170eb6f46901e4604ce
+ ef29c1e0fc989c9e9894072f43ae0030a5274c0cdcc831bc6c206bbe059f449b"
 
 post_extract() {
 	mv leocad-${version}/* .


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures:
  - x96_64-musl
