### PR TITLE
[RFC] libgit2-1.8: switch from libssh2 to openssh

### DIFF
--- a/srcpkgs/libgit2-1.8/template
+++ b/srcpkgs/libgit2-1.8/template
@@ -1,11 +1,12 @@
 # Template file for 'libgit2-1.8'
 pkgname=libgit2-1.8
 version=1.8.4
-revision=1
+revision=2
 build_style=cmake
-configure_args="-DENABLE_REPRODUCIBLE_BUILDS=ON -DBUILD_CLI=OFF -DUSE_SSH=ON -DUSE_HTTP_PARSER=llhttp"
+configure_args="-DENABLE_REPRODUCIBLE_BUILDS=ON -DBUILD_CLI=OFF -DUSE_SSH=exec -DUSE_HTTP_PARSER=llhttp"
 hostmakedepends="python3 pkg-config"
-makedepends="zlib-devel openssl-devel llhttp-devel libssh2-devel"
+makedepends="zlib-devel openssl-devel llhttp-devel"
+depends=openssh
 short_desc="Git linkable library ${pkgname#libgit2-}"
 maintainer="tranzystorekk <tranzystorek.io@protonmail.com>"
 license="GPL-2.0-only WITH GCC-exception-2.0"


### PR DESCRIPTION
Switches newest libgit2 to invoke `openssh` from commandline for ssh git remotes etc.

Rationale:

- `git` also uses openssh under the hood
- parses ssh configuration files, making use of all openssh features

Note that since consistency is one of the goals here, I'd consider rebuilding any remaining non-rust packages to 1.8 a priority.