### PR TITLE
New package: dtrace-utils-2.0.2

### DIFF
--- a/srcpkgs/cross-bpf-binutils/template
+++ b/srcpkgs/cross-bpf-binutils/template
@@ -1,0 +1,37 @@
+# Template file for 'cross-bpf-binutils'
+_triplet=bpf
+_pkgname=binutils
+pkgname=cross-${_triplet}-${_pkgname}
+version=2.44
+revision=1
+build_style=gnu-configure
+configure_args="
+ --disable-nls
+ --enable-deterministic-archives
+ --enable-interwork
+ --enable-ld
+ --enable-multilib
+ --host=${XBPS_CROSS_TRIPLET}
+ --prefix=/usr
+ --target=${_triplet}
+ --with-gnu-as
+ --with-gnu-ld
+ --with-sysroot=/usr/${_triplet}
+ --with-system-zlib
+ --without-isl
+"
+hostmakedepends="autoconf automake bison flex perl"
+makedepends="zlib-devel"
+depends="binutils-doc"
+short_desc="GNU binary utilities"
+maintainer="Leah Neukirchen <leah@vuxu.org>"
+license="GPL-3.0-or-later"
+homepage="https://www.gnu.org/software/binutils/"
+distfiles="${GNU_SITE}/${_pkgname}/${_pkgname}-${version}.tar.xz"
+checksum=ce2017e059d63e67ddb9240e9d4ec49c2893605035cd60e92ad53177f4377237
+nocross=yes
+
+post_install() {
+	rm -f ${DESTDIR}/usr/lib/bfd-plugins/libdep.*
+	rm -fr ${DESTDIR}/usr/share/info
+}

--- a/srcpkgs/cross-bpf-gcc/template
+++ b/srcpkgs/cross-bpf-gcc/template
@@ -1,0 +1,79 @@
+# Template file for 'cross-${_triplet}-gcc'
+_triplet=bpf
+_pkgname=gcc
+pkgname=cross-${_triplet}-gcc
+version=14.2.1+20250405
+revision=1
+_patchver="${version%+*}"
+_minorver="${version%.*}"
+_majorver="${_minorver%.*}"
+build_wrksrc=build
+build_style=gnu-configure
+make_build_args="INHIBIT_LIBC_CFLAGS='-DUSE_TM_CLONE_REGISTRY=0'"
+hostmakedepends="autoconf automake cross-bpf-binutils bison flex
+ perl tar texinfo"
+makedepends="gmp-devel isl-devel libmpc-devel mpfr-devel zlib-devel"
+short_desc="GNU Compiler Collection"
+maintainer="Leah Neukirchen <leah@vuxu.org>"
+license="GFDL-1.2-or-later, GPL-3.0-or-later, LGPL-2.1-or-later"
+homepage="https://gcc.gnu.org"
+distfiles="https://gcc.gnu.org/pub/gcc/snapshots/${_majorver}-${version#*+}/gcc-${_majorver}-${version#*+}.tar.xz"
+checksum=9a84b0947d8fb18197eef3fce8e255e30a61f7f382cebb961b1705c1d99214a3
+nocross=yes
+nopie=yes
+nostrip_files="libgcc.a libgcov.a"
+
+if [ "$XBPS_TARGET_WORDSIZE" != 64 ]; then
+	broken="https://api.travis-ci.org/v3/job/717355887/log.txt"
+fi
+
+export CFLAGS_FOR_TARGET="-g -Os -ffunction-sections -fdata-sections"
+export CXXFLAGS_FOR_TARGET="-g -Os -ffunction-sections -fdata-sections"
+
+post_extract() {
+	mkdir -p build
+}
+
+do_configure() {
+	../configure \
+		--disable-decimal-float \
+		--disable-fixincludes\
+		--disable-libffi \
+		--disable-libgomp \
+		--disable-libmudflap \
+		--disable-libquadmath \
+		--disable-libssp \
+		--disable-libstdcxx-pch \
+		--disable-libstdc__-v3 \
+		--disable-nls \
+		--disable-shared \
+		--disable-threads \
+		--disable-tls \
+		--disable-werror \
+		--disable-gcov \
+		--enable-__cxa_atexit \
+		--enable-c99 \
+		--enable-interwork \
+		--enable-languages=c \
+		--enable-long-long \
+		--enable-plugins \
+		--host=${XBPS_CROSS_TRIPLET} \
+		--libdir=/usr/lib \
+		--libexecdir=/usr/lib \
+		--prefix=/usr \
+		--target=${_triplet} \
+		--with-gnu-as \
+		--with-gnu-ld \
+		--with-headers=/usr/${_triplet}/include \
+		--with-host-libstdcxx='-static-libgcc -Wl,-Bstatic,-lstdc++,-Bdynamic -lm' \
+		--with-libelf \
+		--with-native-system-header-dir=/include \
+		--with-python-dir=share/gcc-${_triplet} \
+		--with-sysroot=/usr/${_triplet} \
+		--with-system-zlib
+}
+
+post_install() {
+	rm -fr ${DESTDIR}/usr/share/{info,man/man7}
+	rm -fr ${DESTDIR}/usr/lib/libcc1.*
+}

--- a/srcpkgs/dtrace-utils/patches/configure.patch
+++ b/srcpkgs/dtrace-utils/patches/configure.patch
@@ -1,0 +1,11 @@
+--- a/configure
++++ b/configure
+@@ -173,7 +173,7 @@
+         HAVE_BPFV3=*) write_config_var BPFV3 "$option";;
+         HAVE_BPFMASM=*) write_config_var BPFMASM "$option";;
+         *) echo "Unknown option $option" >&2
+-           exit 1;;
++           ;;
+     esac
+ done
+ 

--- a/srcpkgs/dtrace-utils/template
+++ b/srcpkgs/dtrace-utils/template
@@ -1,0 +1,29 @@
+# Template file for 'dtrace-utils'
+pkgname=dtrace-utils
+version=2.0.2
+revision=1
+archs="~*-musl" # ld.so internals, other glibc specifics
+build_style=gnu-configure
+hostmakedepends="cross-bpf-binutils cross-bpf-gcc flex libgomp-devel pkg-config
+ shadow"
+makedepends="binutils-devel elfutils-devel fuse-devel libbpf-devel libpcap-devel
+ libpfm4-devel valgrind-devel"
+short_desc="Linux version of the DTrace tracing tool"
+maintainer="Leah Neukirchen <leah@vuxu.org>"
+license="UPL-1.0"
+homepage="https://github.com/oracle/dtrace-utils"
+distfiles="https://github.com/oracle/dtrace-utils/archive/refs/tags/${version}.tar.gz"
+checksum=0636546b8286d67de0e41148f5c73cf8f4339f5989da3113442eb51421bc4916
+nostrip_files="bpf_dlib.o libdtrace.so.2.0.0"
+make_check=no  # needs root
+nocross=yes # mkoffsets
+conflicts="systemtap>=0"
+
+export BPFC="bpf-gcc"
+export BPFLD="bpf-ld"
+
+post_install() {
+	rm ${DESTDIR}/usr/share/doc/dtrace-*/showUSDT
+	mv ${DESTDIR}/lib64/* ${DESTDIR}/usr/lib/
+	rmdir ${DESTDIR}/lib64
+}


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

This is WIP.

Issues to fix before merging:
- binutils needs to be at least 2.42 because of a PIE linking bug: 
https://sourceware.org/bugzilla/show_bug.cgi?id=31047
- bpf-binutils must be not newer than 2.41 unless we move bpf-gcc to 14.x

#### Testing the changes
- I tested the changes in this PR: **YES**|**briefly**|**NO**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
