### PR TITLE
Update: The-Powder-Toy to v98.2

### DIFF
--- a/srcpkgs/The-Powder-Toy/patches/luacpp.patch
+++ b/srcpkgs/The-Powder-Toy/patches/luacpp.patch
@@ -5,15 +5,13 @@ upstream Lua, but the normal .pc file works just fine.
 
 --- a/meson.build
 +++ b/meson.build
-@@ -108,9 +108,9 @@
- if uopt_lua == 'luajit'
- 	lua_opt_dep = [ use_tpt_libs != 'no' ? tpt_libs.get_variable('luajit_dep') : dependency('luajit', static: uopt_static == 'system') ]
- elif uopt_lua == 'lua5.2'
--	lua_opt_dep = [ use_tpt_libs != 'no' ? tpt_libs.get_variable('lua52_dep') : dependency('lua5.2-c++', static: uopt_static == 'system') ]
-+	lua_opt_dep = [ use_tpt_libs != 'no' ? tpt_libs.get_variable('lua52_dep') : dependency('lua5.2', static: uopt_static == 'system') ]
- elif uopt_lua == 'lua5.1'
--	lua_opt_dep = [ use_tpt_libs != 'no' ? tpt_libs.get_variable('lua51_dep') : dependency('lua5.1-c++', static: uopt_static == 'system') ]
-+	lua_opt_dep = [ use_tpt_libs != 'no' ? tpt_libs.get_variable('lua51_dep') : dependency('lua5.1', static: uopt_static == 'system') ]
- else
- 	lua_opt_dep = []
- endif
+@@ -157,7 +157,7 @@
+ if lua_variant == 'none'
+ 	lua_dep = []
+ elif lua_variant == 'lua5.1' or lua_variant == 'lua5.2'
+-	lua_dep = dependency(lua_variant + '-c++', static: is_static, required: false)
++	lua_dep = dependency(lua_variant, static: is_static, required: false)
+ 	if not lua_dep.found()
+ 		if not get_option('workaround_noncpp_lua')
+ 			error('your system @0@ is not compatible with C++, configure with -Dworkaround_noncpp_lua=true to disable this error'.format(lua_variant))
+

--- a/srcpkgs/The-Powder-Toy/template
+++ b/srcpkgs/The-Powder-Toy/template
@@ -1,19 +1,20 @@
 # Template file for 'The-Powder-Toy'
 pkgname=The-Powder-Toy
-version=96.2.350
+version=98.2.365
 revision=1
 build_style=meson
-configure_args="-Dx86_sse=sse2 -Dworkaround_gcc_no_pie=false
+configure_args="-Dx86_sse=sse2
  -Dlua=$(vopt_if luajit luajit lua5.1)"
 hostmakedepends="pkg-config"
-makedepends="SDL2-devel fftw-devel zlib-devel libcurl-devel
+makedepends="SDL2-devel fftw-devel zlib-devel libcurl-devel bzip2-devel
+ libpng-devel jsoncpp-devel
  $(vopt_if luajit LuaJIT-devel lua51-devel)"
 short_desc="Falling sand physics sandbox, simulates air pressure, velocity & heat"
 maintainer="0x5c <dev@0x5c.io>"
 license="GPL-3.0-or-later"
 homepage="https://powdertoy.co.uk/"
 distfiles="https://github.com/The-Powder-Toy/${pkgname}/archive/v${version}.tar.gz"
-checksum=d95cbadee22632687661e8fc488bd64405d81c0dca737e16420f26e93ea5bf58
+checksum=21900b6b022535d0e56126b023538cc4f44b64feceafb5640492618a42a60080
 
 build_options="luajit"
 
@@ -24,8 +25,8 @@ fi
 do_install() {
 	vbin build/powder
 	vdoc README.md
-	vinstall resources/powder.desktop 644 /usr/share/applications/
-	for size in 16 24 32 48 128 256 ; do
-		vinstall resources/icon/powder-${size}.png 644 /usr/share/icons/hicolor/${size}x${size}/apps powder.png
+	vinstall build/resources/powder.desktop 644 /usr/share/applications/
+	for size in 16 32 48; do
+		vinstall resources/generated_icons/icon_exe_${size}.png 644 /usr/share/icons/hicolor/${size}x${size}/apps powdertoy-powder.png
 	done
 }


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)

![image](https://github.com/user-attachments/assets/e02c5e5d-37c0-4059-b0ab-86f60373bf0d)

P.S: The void package is the only one on [repology](https://repology.org/project/powder-toy/versions) with the _capitalized kebab-case_ "The-Powder-Toy", and it was kinda tedious typing it every time I wanted to test the build. is there a way to rename it to "powdertoy" like on any other distro? 
