### PR TITLE
libjpeg-turbo: update to 3.1.0, adopt.

### DIFF
--- a/srcpkgs/libjpeg-turbo/template
+++ b/srcpkgs/libjpeg-turbo/template
@@ -1,17 +1,17 @@
 # Template file for 'libjpeg-turbo'
 pkgname=libjpeg-turbo
-version=3.0.1
+version=3.1.0
 revision=1
 build_style=cmake
 configure_args="-DWITH_JPEG8=1"
 hostmakedepends="yasm"
 short_desc="Derivative of libjpeg which uses SIMD instructions"
-maintainer="Orphaned <orphan@voidlinux.org>"
+maintainer="Daniel Martinez <danielmartinez@cock.li>"
 license="IJG, BSD-3-Clause, Zlib"
 homepage="https://libjpeg-turbo.org/"
 changelog="https://raw.githubusercontent.com/libjpeg-turbo/libjpeg-turbo/main/ChangeLog.md"
-distfiles="${SOURCEFORGE_SITE}/libjpeg-turbo/libjpeg-turbo-${version}.tar.gz"
-checksum=22429507714ae147b3acacd299e82099fce5d9f456882fc28e252e4579ba2a75
+distfiles="https://github.com/libjpeg-turbo/libjpeg-turbo/releases/download/${version}/libjpeg-turbo-${version}.tar.gz"
+checksum=9564c72b1dfd1d6fe6274c5f95a8d989b59854575d4bbee44ade7bc17aa9bc93
 
 provides="jpeg-8_1"
 replaces="jpeg>=0"
@@ -19,11 +19,8 @@ replaces="jpeg>=0"
 post_install() {
 	vlicense LICENSE.md
 
-	vinstall jpegint.h 644 usr/include
-	vinstall transupp.h 644 usr/include
-
-	rm -r ${DESTDIR}/usr/share/doc \
-		  ${DESTDIR}/usr/bin/tjbench
+	vinstall src/jpegint.h 644 usr/include
+	vinstall src/transupp.h 644 usr/include
 }
 
 libjpeg-turbo-devel_package() {
@@ -35,6 +32,7 @@ libjpeg-turbo-devel_package() {
 		vmove usr/include
 		vmove "usr/lib/*.a"
 		vmove "usr/lib/*.so"
+		vmove usr/lib/cmake
 		vmove usr/lib/pkgconfig
 	}
 }


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl
  - i686
  - aarch64 (cross)
  - aarch64-musl (cross)
  - armv7l (cross)
  - armv7l-musl (cross)
  - armv6l (cross)
  - armv6l-musl (cross)

