### PR TITLE
New packages: python3-debugpy-1.8.9, python3-untangle-1.2.1

### DIFF
--- a/srcpkgs/python3-debugpy/patches/fix_pythonpath_test.patch
+++ b/srcpkgs/python3-debugpy/patches/fix_pythonpath_test.patch
@@ -1,0 +1,11 @@
+Fix importing of debugpy in test_nodebug
+--- a/tests/debug/session.py
++++ b/tests/debug/session.py
+@@ -704,6 +704,7 @@ class Session(object):
+         if "PYTHONPATH" in self.config.env:
+             # If specified, launcher will use it in lieu of PYTHONPATH it inherited
+             # from the adapter when spawning debuggee, so we need to adjust again.
++            self.config.env.prepend_to("PYTHONPATH", os.environ["PYTHONPATH"])
+             self.config.env.prepend_to("PYTHONPATH", DEBUGGEE_PYTHONPATH.strpath)
+ 
+         # Adapter is going to start listening for server and spawn the launcher at

--- a/srcpkgs/python3-debugpy/patches/skip_attach_pid_test.patch
+++ b/srcpkgs/python3-debugpy/patches/skip_attach_pid_test.patch
@@ -1,0 +1,24 @@
+Disable attach_pid tests because they are flaky, they are disabled by default in MacOS and Windows anyways.
+--- a/tests/debug/runners.py
++++ b/tests/debug/runners.py
+@@ -163,7 +163,7 @@ def _attach_common_config(session, target, cwd):
+ @_runner
+ @contextlib.contextmanager
+ def attach_pid(session, target, cwd=None, wait=True):
+-    if wait and not sys.platform.startswith("linux"):
++    if wait:
+         pytest.skip("https://github.com/microsoft/ptvsd/issues/1926")
+ 
+     log.info("Attaching {0} to {1} by PID.", session, target)
+--- a/tests/debugpy/test_attach.py
++++ b/tests/debugpy/test_attach.py
+@@ -153,8 +153,7 @@ def test_reattach(pyfile, target, run):
+ 
+ 
+ @pytest.mark.parametrize("pid_type", ["int", "str"])
+-@pytest.mark.skipif(
+-    not sys.platform.startswith("linux"),
++@pytest.mark.skip(
+     reason="https://github.com/microsoft/debugpy/issues/311",
+ )
+ @pytest.mark.flaky(retries=2, delay=1)

--- a/srcpkgs/python3-debugpy/patches/skip_django_tests.patch
+++ b/srcpkgs/python3-debugpy/patches/skip_django_tests.patch
@@ -1,0 +1,35 @@
+Skip django tests as it is not in void-packages
+--- a/tests/debugpy/test_django.py
++++ b/tests/debugpy/test_django.py
+@@ -45,6 +45,7 @@
+ 
+ 
+ @pytest.mark.parametrize("bp_target", ["code", "template"])
++@pytest.mark.skip(reason="django is not packaged by void")
+ def test_django_breakpoint_no_multiproc(start_django, bp_target):
+     bp_file, bp_line, bp_name = {
+         "code": (paths.app_py, lines.app_py["bphome"], "home"),
+@@ -90,6 +91,7 @@
+             assert bp_var_content in home_request.response_text()
+ 
+ 
++@pytest.mark.skip(reason="django is not packaged by void")
+ def test_django_template_exception_no_multiproc(start_django):
+     with debug.Session() as session:
+         with start_django(session):
+@@ -136,6 +138,7 @@
+ 
+ 
+ @pytest.mark.parametrize("exc_type", ["handled", "unhandled"])
++@pytest.mark.skip(reason="django is not packaged by void")
+ def test_django_exception_no_multiproc(start_django, exc_type):
+     exc_line = lines.app_py["exc_" + exc_type]
+ 
+@@ -186,6 +189,7 @@
+             session.request_continue()
+ 
+ 
++@pytest.mark.skip(reason="django is not packaged by void")
+ def test_django_breakpoint_multiproc(start_django):
+     bp_line = lines.app_py["bphome"]
+     bp_var_content = "Django-Django-Test"

--- a/srcpkgs/python3-debugpy/template
+++ b/srcpkgs/python3-debugpy/template
@@ -1,0 +1,41 @@
+# Template file for 'python3-debugpy'
+pkgname=python3-debugpy
+version=1.8.9
+revision=1
+archs="i686* x86_64* aarch64*"
+build_style=python3-pep517
+make_check_args="--timeout=0 -vv --log-cli-level=DEBUG"
+hostmakedepends="python3-setuptools python3-devel python3-wheel"
+depends="python3"
+checkdepends="python3-pytest python3-pytest-xdist python3-pytest-timeout python3-importlib_metadata python3-psutil python3-untangle python3-Flask python3-gevent python3-numpy python3-requests python3-typing_extensions"
+short_desc="Implementation of the Debug Adapter Protocol for Python"
+maintainer="Zachary Hanham <z@zmhanham.com>"
+license="MIT"
+homepage="https://github.com/microsoft/debugpy/"
+distfiles="https://github.com/microsoft/debugpy/archive/refs/tags/v${version}.tar.gz"
+checksum=5bfe7303e21d6cf7bfc9f81931303924ce27873e23d08699568bde52c35a405c
+
+# Suffix for attach lib compiled in pre_build
+case "$XBPS_TARGET_MACHINE" in
+	i686*) _attach_lib_suffix='x86';;
+	x86_64*) _attach_lib_suffix='amd64';;
+	aarch64*) _attach_lib_suffix='arm64';;
+	*) broken='unsupported platform for pydevd_attach_to_process';;
+esac
+
+pre_build() {
+	# Compile pydevd_attach_to_process's attach_linux_*.so lib
+	# Based on contents of linux_and_mac/compile_linux.sh
+	cd src/debugpy/_vendored/pydevd/pydevd_attach_to_process
+	${CXX} ${CXXFLAGS} linux_and_mac/attach.cpp -Ilinux_and_mac -std=c++11 -fPIC -nostartfiles -shared -o "attach_linux_${_attach_lib_suffix}.so"
+}
+
+pre_check() {
+	# Do not wait for spawns/exits
+	export DEBUGPY_PROCESS_SPAWN_TIMEOUT=0
+	export DEBUGPY_PROCESS_EXIT_TIMEOUT=0
+}
+
+post_install() {
+	vlicense LICENSE
+}

--- a/srcpkgs/python3-untangle/template
+++ b/srcpkgs/python3-untangle/template
@@ -1,0 +1,22 @@
+# Template file for 'python3-untangle'
+pkgname=python3-untangle
+version=1.2.1
+revision=1
+build_style=python3-module
+hostmakedepends="python3-setuptools python3-defusedxml"
+depends="python3-defusedxml"
+short_desc="Converts XML to Python objects"
+maintainer="Zachary Hanham <z@zmhanham.com>"
+license="MIT"
+homepage="https://github.com/stchris/untangle"
+changelog="https://raw.githubusercontent.com/stchris/untangle/refs/heads/main/CHANGELOG.md"
+distfiles="https://github.com/stchris/untangle/archive/refs/tags/${version}.tar.gz"
+checksum=696643dd2879c1af55c592e07bf0de48d330157d2def66993abaa0169661dadc
+
+do_check() {
+	python -m unittest discover -s tests
+}
+
+post_install() {
+	vlicense LICENSE
+}


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->

#### Notes
- python3-untangle is needed only as a check dependency of python3-debugpy. Could skip those tests and not add python3-untangle, but it is not a very complicated package and seems pretty stable anyways so might as well add it I think.