### PR TITLE
kubernetes: Add runit to kubeadm initssytems list

### DIFF
--- a/srcpkgs/kubeadm
+++ b/srcpkgs/kubeadm
@@ -1,0 +1,1 @@
+kubernetes

--- a/srcpkgs/kubernetes/files/environ/kubelet
+++ b/srcpkgs/kubernetes/files/environ/kubelet
@@ -15,3 +15,13 @@ KUBELET_API_SERVER="--api-servers=http://127.0.0.1:8080"
 
 # Add your own!
 KUBELET_ARGS=""
+
+# Simulate kubelet drop-in file for systemd
+# https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/kubelet-integration/#the-kubelet-drop-in-file-for-systemd
+KUBELET_KUBECONFIG_ARGS="--bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf --kubeconfig=/etc/kubernetes/kubelet.conf"
+KUBELET_CONFIG_ARGS="--config=/var/lib/kubelet/config.yaml"
+[ -r /var/lib/kubelet/kubeadm-flags.env ] && . /var/lib/kubelet/kubeadm-flags.env
+[ -r /etc/default/kubelet ] && . /etc/default/kubelet
+
+# Uncomment the next line to make use of the kubelet drop-in variables or set your own $OPTS variable
+#OPTS="$KUBELET_KUBECONFIG_ARGS $KUBELET_CONFIG_ARGS $KUBELET_KUBEADM_ARGS $KUBELET_EXTRA_ARGS"

--- a/srcpkgs/kubernetes/files/kubelet/run
+++ b/srcpkgs/kubernetes/files/kubelet/run
@@ -2,4 +2,4 @@
 exec 2>&1
 [ -r /etc/kubernetes/config ] && . /etc/kubernetes/config
 [ -r /etc/kubernetes/kubelet ] && . /etc/kubernetes/kubelet
-exec kubelet $OPTS 2>/dev/null
+exec kubelet $OPTS

--- a/srcpkgs/kubernetes/patches/cgroupfs_default_cgroupDriver.patch
+++ b/srcpkgs/kubernetes/patches/cgroupfs_default_cgroupDriver.patch
@@ -1,0 +1,14 @@
+diff --git a/cmd/kubeadm/app/componentconfigs/kubelet.go b/cmd/kubeadm/app/componentconfigs/kubelet.go
+index 436bf1bc87c..6c7c915acd7 100644
+--- a/cmd/kubeadm/app/componentconfigs/kubelet.go
++++ b/cmd/kubeadm/app/componentconfigs/kubelet.go
+@@ -193,7 +193,7 @@ func (kc *kubeletConfig) Default(cfg *kubeadmapi.ClusterConfiguration, _ *kubead
+ 	kc.config.RotateCertificates = kubeletRotateCertificates
+ 
+ 	if len(kc.config.CgroupDriver) == 0 {
+-		klog.V(1).Infof("the value of KubeletConfiguration.cgroupDriver is empty; setting it to %q", constants.CgroupDriverSystemd)
+-		kc.config.CgroupDriver = constants.CgroupDriverSystemd
++		klog.V(1).Infof("the value of KubeletConfiguration.cgroupDriver is empty; setting it to %q", "cgroupfs")
++		kc.config.CgroupDriver = "cgroupfs"
+ 	}
+ }

--- a/srcpkgs/kubernetes/patches/runit.patch
+++ b/srcpkgs/kubernetes/patches/runit.patch
@@ -1,0 +1,85 @@
+--- a/cmd/kubeadm/app/util/initsystem/initsystem_unix.go
++++ b/cmd/kubeadm/app/util/initsystem/initsystem_unix.go
+@@ -21,6 +21,7 @@ package initsystem
+ import (
+ 	"fmt"
+ 	"os/exec"
++	"os"
+ 	"strings"
+ )
+ 
+@@ -146,6 +147,63 @@ func (sysd SystemdInitSystem) ServiceIsActive(service string) bool {
+ 	return false
+ }
+ 
++// RunitInitSystem defines runit
++type RunitInitSystem struct{}
++
++// EnableCommand return a string describing how to enable a service
++func (runit RunitInitSystem) EnableCommand(service string) string {
++	return fmt.Sprintf("ln -s /etc/sv/%[1]s /var/service/%[1]s", service)
++}
++
++// ServiceExists ensures the service is defined for this init system.
++func (runit RunitInitSystem) ServiceExists(service string) bool {
++	servicePath := string(fmt.Sprintf("/etc/sv/%s/run", service))
++	info, err := os.Stat(servicePath)
++	if os.IsNotExist(err) {
++		return false
++	}
++	return !info.IsDir()
++}
++
++// ServiceIsActive ensures the service is running, or attempting to run. (crash looping in the case of kubelet)
++func (runit RunitInitSystem) ServiceIsActive(service string) bool {
++	args := []string{"status", fmt.Sprintf("/var/service/%s", service)}
++	outBytes, _ := exec.Command("sv", args...).CombinedOutput()
++	outStr := string(outBytes)
++	return strings.HasPrefix(outStr, "run:")
++}
++
++// ServiceIsEnabled ensures the service is enabled to start on each boot.
++func (runit RunitInitSystem) ServiceIsEnabled(service string) bool {
++	servicePath := string(fmt.Sprintf("/var/service/%s/run", service))
++	info, err := os.Stat(servicePath)
++	if os.IsNotExist(err) {
++		return false
++	}
++	return !info.IsDir()
++}
++
++// ServiceRestart tries to reload the environment and restart the specific service
++func (runit RunitInitSystem) ServiceRestart(service string) error {
++	servicePath := string(fmt.Sprintf("/var/service/%s", service))
++	args := []string{"restart", servicePath}
++	return exec.Command("sv", args...).Run()
++}
++
++// ServiceStart tries to start a specific service
++func (runit RunitInitSystem) ServiceStart(service string) error {
++	servicePath := string(fmt.Sprintf("/var/service/%s", service))
++	args := []string{"start", servicePath}
++	return exec.Command("sv", args...).Run()
++}
++
++// ServiceStop tries to stop a specific service
++func (runit RunitInitSystem) ServiceStop(service string) error {
++	servicePath := string(fmt.Sprintf("/var/service/%s", service))
++	args := []string{"stop", servicePath}
++	return exec.Command("sv", args...).Run()
++}
++
+ // GetInitSystem returns an InitSystem for the current system, or nil
+ // if we cannot detect a supported init system.
+ // This indicates we will skip init system checks, not an error.
+@@ -159,6 +217,10 @@ func GetInitSystem() (InitSystem, error) {
+ 	if err == nil {
+ 		return &OpenRCInitSystem{}, nil
+ 	}
++	_, err = exec.LookPath("runit")
++	if err == nil {
++		return &RunitInitSystem{}, nil
++	}
+ 
+ 	return nil, fmt.Errorf("no supported init system detected, skipping checking for services")
+ }

--- a/srcpkgs/kubernetes/template
+++ b/srcpkgs/kubernetes/template
@@ -1,9 +1,10 @@
 # Template file for 'kubernetes'
 pkgname=kubernetes
 version=1.32.1
-revision=1
+revision=2
 archs="aarch64* x86_64* ppc64le*"
 build_style=go
+build_helper=qemu
 go_import_path="github.com/kubernetes/kubernetes"
 hostmakedepends="rsync git go-bindata which curl tar"
 depends="kubectl conntrack-tools"
@@ -13,18 +14,35 @@ license="Apache-2.0"
 homepage="http://kubernetes.io"
 distfiles="https://$go_import_path/archive/v$version.tar.gz"
 checksum=9724c849c524c2e69a0a0da4f1a3b0335d7d544eeaa9fc22cb5b87d7c0c52c9d
-nocross=yes
 system_accounts="kube"
 make_dirs="/var/lib/kubelet 0755 kube kube"
 conf_files="/etc/kubernetes/*"
+make_check=no # Too many tests
+
+# Cross builds fail with -fuse-ld=gold
+LDFLAGS="-fuse-ld=bfd"
 
 do_build() {
-	make
-	hack/generate-docs.sh
+	KUBE_BUILD_PLATFORMS=linux/${GOARCH} make
+
+	# Build the man pages on the host machine
+	# Run in a subshell to keep variables isolated
+	(
+		# Set GO variables based on host
+		case "$XBPS_MACHINE" in
+		        aarch64*) export GOARCH=arm64;;
+		        x86_64*) export GOARCH=amd64;;
+		esac
+		CGO_CFLAGS=${CFLAGS_host} CC=${GCC_host} CC_target=${GCC_host} \
+			GCC=${GCC_host} GCC_target=${GCC_host} \
+			PATH=$PATH:_output/local/go/bin/linux_${GOARCH} \
+			hack/update-generated-docs.sh
+	)
+
 	find "_output/local/bin/linux/" -type f -executable | grep "kubectl$" | egrep -v "gen|test" | while read line
 	do
-		$line completion bash > completion.bash
-		$line completion zsh > completion.zsh
+		vtargetrun $line completion bash > completion.bash
+		vtargetrun $line completion zsh > completion.zsh
 		break
 	done
 }
@@ -53,8 +71,18 @@ kubectl_package() {
 	short_desc="Controls the Kubernetes cluster manager"
 	pkg_install() {
 		vmove usr/bin/kubectl
+		vmove usr/bin/kubectl-convert
 		vmove usr/share/man/man1/kubectl*
 		vcompletion completion.bash bash
 		vcompletion completion.zsh zsh
+	}
+}
+
+kubeadm_package() {
+	short_desc="Tool built for creating Kubernetes clusters"
+	pkg_install() {
+		vmove usr/bin/kubeadm
+		vmove usr/share/man/man1/kubeadm*
+		vmkdir etc/kubernetes/manifests
 	}
 }


### PR DESCRIPTION
- Add runit to kubeadm initssytems list (I've been using this patch for 4 years)
- Create kubeadm subpackage.
- Set cgroupfs as default cgroup driver in kubeadm.
- Add example kubelet variables that simulate systemd drop-in.  https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/kubelet-integration/#the-kubelet-drop-in-file-for-systemd


<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-glibc
  - aarch64-musl
