### PR TITLE
go: update to 1.23.4.

### DIFF
--- a/srcpkgs/go/template
+++ b/srcpkgs/go/template
@@ -1,6 +1,6 @@
 # Template file for 'go'
 pkgname=go
-version=1.23.3
+version=1.23.4
 revision=1
 create_wrksrc=yes
 build_wrksrc=go
@@ -12,7 +12,7 @@ license="BSD-3-Clause"
 homepage="https://go.dev/"
 changelog="https://go.dev/doc/devel/release.html"
 distfiles="https://go.dev/dl/go${version}.src.tar.gz"
-checksum=8d6a77332487557c6afa2421131b50f83db4ae3c579c3bc72e670ee1f6968599
+checksum=ad345ac421e90814293a9699cca19dd5238251c3f687980bbcae28495b263531
 nostrip=yes
 noverifyrdeps=yes
 # on CI it tries to use `git submodule`, which is not part of chroot-git


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)

- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64
  - aarch64-musl
  - i686
  - i686-musl
  - x86_64
  - x86_64-musl
  - armv7l

#### CHANGELOG

go1.23.4 (released 2024-12-03) includes fixes to the compiler, the runtime, the trace command, and the syscall package. See the [Go 1.23.4 milestone](https://github.com/golang/go/issues?q=milestone%3AGo1.23.4+label%3ACherryPickApproved) on our issue tracker for details.

@the-maldridge @classabbyamp