### PR TITLE
libjpeg-turbo: update to 3.1.0

### DIFF
--- a/srcpkgs/libjpeg-turbo/template
+++ b/srcpkgs/libjpeg-turbo/template
@@ -1,6 +1,6 @@
 # Template file for 'libjpeg-turbo'
 pkgname=libjpeg-turbo
-version=3.0.1
+version=3.1.0
 revision=1
 build_style=cmake
 configure_args="-DWITH_JPEG8=1"
@@ -10,8 +10,8 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="IJG, BSD-3-Clause, Zlib"
 homepage="https://libjpeg-turbo.org/"
 changelog="https://raw.githubusercontent.com/libjpeg-turbo/libjpeg-turbo/main/ChangeLog.md"
-distfiles="${SOURCEFORGE_SITE}/libjpeg-turbo/libjpeg-turbo-${version}.tar.gz"
-checksum=22429507714ae147b3acacd299e82099fce5d9f456882fc28e252e4579ba2a75
+distfiles="https://github.com/libjpeg-turbo/libjpeg-turbo/archive/refs/tags/3.1.0.tar.gz"
+checksum=35fec2e1ddfb05ecf6d93e50bc57c1e54bc81c16d611ddf6eff73fff266d8285
 
 provides="jpeg-8_1"
 replaces="jpeg>=0"
@@ -19,8 +19,8 @@ replaces="jpeg>=0"
 post_install() {
 	vlicense LICENSE.md
 
-	vinstall jpegint.h 644 usr/include
-	vinstall transupp.h 644 usr/include
+	vinstall src/jpegint.h 644 usr/include
+	vinstall src/transupp.h 644 usr/include
 
 	rm -r ${DESTDIR}/usr/share/doc \
 		  ${DESTDIR}/usr/bin/tjbench


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

For testing I ran jpegtran from libjpeg-turbo-tool:
```
$ jpegtran -optimize -progressive < in.jpg  > out.jpg
```
It produced a valid JPEG.

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
