### PR TITLE
gnome-bluetooth: update to 47.1

### DIFF
--- a/srcpkgs/gnome-bluetooth/template
+++ b/srcpkgs/gnome-bluetooth/template
@@ -1,6 +1,6 @@
 # Template file for 'gnome-bluetooth'
 pkgname=gnome-bluetooth
-version=46.0
+version=47.1
 revision=1
 build_helper="gir"
 build_style=meson
@@ -15,7 +15,7 @@ license="GPL-2.0-or-later, LGPL-2.1-or-later"
 homepage="https://wiki.gnome.org/Projects/GnomeBluetooth"
 changelog="https://gitlab.gnome.org/GNOME/gnome-bluetooth/-/raw/master/NEWS"
 distfiles="${GNOME_SITE}/gnome-bluetooth/${version%.*}/gnome-bluetooth-${version}.tar.xz"
-checksum=13fe1e75f317acdbdf5e80c9029d2e0632d60a9ccf72a43ae36eb7545021fbef
+checksum=03e3e7403a15108ffc1496210a1da5c2961b2834a5c07eccc7a3f493195daba3
 
 build_options="gir"
 build_options_default="gir"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
