### PR TITLE
rust-bindgen: update to 0.71.1

### DIFF
--- a/srcpkgs/rust-bindgen/template
+++ b/srcpkgs/rust-bindgen/template
@@ -1,6 +1,6 @@
 # Template file for 'rust-bindgen'
 pkgname=rust-bindgen
-version=0.69.4
+version=0.71.1
 revision=1
 build_style="cargo"
 configure_args="--bins"
@@ -13,7 +13,7 @@ license="BSD-3-Clause"
 homepage="https://rust-lang.github.io/rust-bindgen/"
 changelog="https://raw.githubusercontent.com/rust-lang/rust-bindgen/master/CHANGELOG.md"
 distfiles="https://github.com/rust-lang/rust-bindgen/archive/refs/tags/v${version}.tar.gz"
-checksum=c02ce18b95c4e5021b95b8b461e5dbe6178edffc52a5f555cbca35b910559b5e
+checksum=620d80c32b6aaf42d12d85de86fc56950c86b2a13a5b943c10c29d30c4f3efb0
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **NO**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl