### PR TITLE
gnome-clocks: update to 47.0

### DIFF
--- a/srcpkgs/gnome-clocks/template
+++ b/srcpkgs/gnome-clocks/template
@@ -1,6 +1,6 @@
 # Template file for 'gnome-clocks'
 pkgname=gnome-clocks
-version=46.0
+version=47.0
 revision=1
 build_helper="gir"
 build_style=meson
@@ -17,4 +17,4 @@ license="GPL-2.0-or-later"
 homepage="https://wiki.gnome.org/Apps/Clocks"
 changelog="https://gitlab.gnome.org/GNOME/gnome-clocks/-/raw/master/NEWS"
 distfiles="${GNOME_SITE}/gnome-clocks/${version%.*}/gnome-clocks-${version}.tar.xz"
-checksum=eaa3c578cdcef9754e668b5626709b73f3526710235f4b72076d2ff49a4f99c7
+checksum=428bdf4bd17e26de6cef014cd7a7eebd89143c3f2732b24b7da69812baa52131


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
