### PR TITLE
gnome-online-accounts: update to 3.52.2

### DIFF
--- a/srcpkgs/gnome-online-accounts/template
+++ b/srcpkgs/gnome-online-accounts/template
@@ -1,14 +1,14 @@
 # Template file for 'gnome-online-accounts'
 pkgname=gnome-online-accounts
-version=3.50.2
-revision=2
+version=3.52.2
+revision=1
 build_style=meson
 build_helper="gir"
 configure_args="$(vopt_bool gir introspection) $(vopt_bool gir vapi)
  -Dman=true"
 hostmakedepends="pkg-config gettext glib-devel docbook-xsl libxslt vala
- gtk4-update-icon-cache"
-makedepends="gtk4-devel json-glib-devel libsecret-devel
+ gtk4-update-icon-cache gi-docgen"
+makedepends="gtk4-devel json-glib-devel libsecret-devel keyutils-devel
  rest-devel gcr4-devel mit-krb5-devel libsoup3-devel libadwaita-devel"
 depends="hicolor-icon-theme"
 short_desc="GNOME service to access online accounts"
@@ -18,7 +18,7 @@ homepage="https://wiki.gnome.org/Projects/GnomeOnlineAccounts"
 changelog="https://gitlab.gnome.org/GNOME/gnome-online-accounts/-/raw/gnome-46/NEWS"
 #changelog="https://gitlab.gnome.org/GNOME/gnome-online-accounts/-/raw/master/NEWS"
 distfiles="${GNOME_SITE}/gnome-online-accounts/${version%.*}/gnome-online-accounts-${version}.tar.xz"
-checksum=df16ad975d139c6bfc4ebb2ec8bb8327297a791ef2bf0b977c78076af5faa98e
+checksum=fb413f48deefbb9fc3002a91579dee947ceeed41f49c2f51317af7489b676f67
 
 build_options="gir"
 build_options_default="gir"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
