### PR TITLE
Correct noverifypydeps documentation, actually use it in 06-verify-python-deps

### DIFF
--- a/Manual.md
+++ b/Manual.md
@@ -1644,7 +1644,7 @@ Can be used to ensure additional dependency sets are checked. Example: `python_e
 
 - `nopyprovides`: if set, don't create `provides` entries for Python modules in the package.
 
-- `nopyverifydeps`: if set, don't verify Python module dependencies.
+- `noverifypydeps`: if set, don't verify Python module dependencies.
 
 Also, a set of useful variables are defined to use in the templates:
 

--- a/common/hooks/pre-pkg/06-verify-python-deps.sh
+++ b/common/hooks/pre-pkg/06-verify-python-deps.sh
@@ -6,7 +6,7 @@
 hook() {
     local py3_bin="${XBPS_MASTERDIR}/usr/bin/python3"
 
-    if [ -z "$nopyprovides" ] && [ -d "${PKGDESTDIR}/${py3_sitelib}" ] && [ -x "${py3_bin}" ]; then
+    if [ -z "$noverifypydeps" ] && [ -d "${PKGDESTDIR}/${py3_sitelib}" ] && [ -x "${py3_bin}" ]; then
             PYTHONPATH="${XBPS_MASTERDIR}/${py3_sitelib}-bootstrap" "${py3_bin}" \
                 "${XBPS_COMMONDIR}"/scripts/parse-py-metadata.py \
                 ${NOCOLORS:+-C} ${XBPS_STRICT:+-s} -S "${PKGDESTDIR}/${py3_sitelib}" -v "${pkgver}" \


### PR DESCRIPTION
- **Manual.md: fix naming of nopyverifydeps**
- **common/hooks/pre-pkg/06-verify-python-deps: check for nopyverifydeps**
