### PR TITLE
libnitrokey: use the up-to-date udev rules file

### DIFF
--- a/srcpkgs/libnitrokey/template
+++ b/srcpkgs/libnitrokey/template
@@ -1,16 +1,23 @@
 # Template file for 'libnitrokey'
 pkgname=libnitrokey
 version=3.8
-revision=2
+revision=3
 build_style=cmake
 hostmakedepends="pkg-config"
 makedepends="hidapi-devel"
+depends="nitrokey-udev-rules"
 short_desc="Communicate with Nitrokey devices in a clean and easy manner"
 maintainer="Julio Galvan <juliogalvan@protonmail.com>"
 license="LGPL-3.0-or-later"
 homepage="https://github.com/Nitrokey/libnitrokey"
 distfiles="https://github.com/Nitrokey/libnitrokey/releases/download/v${version}/libnitrokey-v${version}.tar.gz"
 checksum=3b7ebcfc47b2c45313bc5f17842f0160cbaf87f41d2621af18c5b56837e393a1
+
+post_install() {
+	# udev rules are now shipped separately
+	# https://github.com/Nitrokey/nitrokey-udev-rules
+	rm "$PKGDESTDIR/usr/lib/udev/rules.d/41-nitrokey.rules"
+}
 
 libnitrokey-devel_package() {
 	short_desc+=" - development files"

--- a/srcpkgs/nitrokey-udev-rules/template
+++ b/srcpkgs/nitrokey-udev-rules/template
@@ -1,0 +1,20 @@
+# Template file for 'nitrokey-udev-rules'
+pkgname=nitrokey-udev-rules
+version=1.0.0
+revision=1
+short_desc="Udev rules for Nitrokey devices"
+maintainer="Mateusz Sylwestrzak <slymattz@gmail.com>"
+license="CC0-1.0"
+homepage="https://github.com/Nitrokey/nitrokey-udev-rules"
+distfiles="https://github.com/Nitrokey/nitrokey-udev-rules/archive/refs/tags/v${version}.tar.gz"
+checksum=604658f9d10c02b4ec4c299a103777efaa4b55ebf95f6deb2736461f7959ae9d
+
+post_patch() {
+	# allow non-elogind users to access Nitrokey devices
+	vsed -i 41-nitrokey.rules \
+		-e '/TAG\s*+=\s*"uaccess"/s/$/, GROUP="plugdev"/'
+}
+
+do_install() {
+	vinstall 41-nitrokey.rules 0644 usr/lib/udev/rules.d
+}


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Motivation for the split
the Nitrokey team has moved [41-nitrokey.rules](https://github.com/Nitrokey/nitrokey-udev-rules?tab=readme-ov-file#nitrokey-udev-rules) to a separate repository where it still remains maintained. The file shipped with libnitrokey is obsolete and no longer maintained.

Using the maintained version of udev rules is more futureproof as it is supposed to be compatible with both legacy (Pro/Storage) and current Nitrokey devices.

https://docs.nitrokey.com/software/nitropy/linux/udev

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture: x86_64-glibc
