### PR TITLE
New package: fooyin-0.8.1.

### DIFF
--- a/srcpkgs/fooyin/template
+++ b/srcpkgs/fooyin/template
@@ -1,0 +1,27 @@
+# Template file for 'fooyin'
+pkgname=fooyin
+version=0.8.1
+revision=1
+build_style=cmake
+configure_args="-DBUILD_LIBVGM=off $(vopt_if alsa -DBUILD_ALSA=on)"
+hostmakedepends="pkg-config"
+# libsndfile is supposed to be an optional plugin, but CMake blows up the whole
+# build if the headers aren't found
+makedepends="KDSingleApplication libsndfile-devel taglib-devel ffmpeg6-devel icu-devel
+	qt6-base-devel qt6-tools-devel qt6-svg-devel
+	$(vopt_if alsa alsa-lib-devel)
+	$(vopt_if pipewire pipewire-devel)
+	"
+short_desc="Customisable music player"
+maintainer="klardotsh <josh@klar.sh>"
+license="GPL-3.0-or-later"
+homepage="https://www.fooyin.org"
+distfiles="https://github.com/fooyin/${pkgname}/archive/refs/tags/v${version}.tar.gz"
+checksum=e702389488e19c4c48b1b62bf1b2adf263b818138e3b232a39259057cbcec9c2
+
+build_options="alsa pipewire"
+build_options_default="alsa pipewire"
+
+
+export CMAKE_GENERATOR="Ninja"
+export LDFLAGS="-Wl,-z -lpthread"


### PR DESCRIPTION
Unsure exactly what my longer-term maintenance appetite will be for this (depends on whether I end up daily-driving this as a potential `cmus` replacement), but since I got it packaged up for my own testing purposes, I figured I should at least share the template.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
