### PR TITLE
gzdoom: remove unused musl patch and fix build

### DIFF
--- a/srcpkgs/gzdoom/patches/gzdoom-musl-fix-build.patch
+++ b/srcpkgs/gzdoom/patches/gzdoom-musl-fix-build.patch
@@ -1,79 +1,3 @@
-diff --git a/libraries/lzma/C/Threads.c b/libraries/lzma/C/Threads.c
-index cf52bd3..86a5cee 100644
---- a/libraries/lzma/C/Threads.c
-+++ b/libraries/lzma/C/Threads.c
-@@ -67,12 +67,12 @@ WRes Thread_Create(CThread *p, THREAD_FUNC_TYPE func, LPVOID param)
- 
-   DWORD threadId;
-   *p = CreateThread(NULL, 0, func, param, 0, &threadId);
--  
-+
-   #else
--  
-+
-   unsigned threadId;
-   *p = (HANDLE)(_beginthreadex(NULL, 0, func, param, 0, &threadId));
--  
-+
-   #endif
- 
-   /* maybe we must use errno here, but probably GetLastError() is also OK. */
-@@ -86,9 +86,9 @@ WRes Thread_Create_With_Affinity(CThread *p, THREAD_FUNC_TYPE func, LPVOID param
- 
-   UNUSED_VAR(affinity)
-   return Thread_Create(p, func, param);
--  
-+
-   #else
--  
-+
-   /* Windows Me/98/95: threadId parameter may not be NULL in _beginthreadex/CreateThread functions */
-   HANDLE h;
-   WRes wres;
-@@ -245,7 +245,7 @@ WRes Thread_Create_With_CpuSet(CThread *p, THREAD_FUNC_TYPE func, LPVOID param,
-     if (cpuSet)
-     {
-       #ifdef Z7_AFFINITY_SUPPORTED
--      
-+
-       /*
-       printf("\n affinity :");
-       unsigned i;
-@@ -265,13 +265,13 @@ WRes Thread_Create_With_CpuSet(CThread *p, THREAD_FUNC_TYPE func, LPVOID param,
-       */
- 
-       // ret2 =
--      pthread_attr_setaffinity_np(&attr, sizeof(*cpuSet), cpuSet);
-+      pthread_setaffinity_np(&attr, sizeof(*cpuSet), cpuSet);
-       // if (ret2) ret = ret2;
-       #endif
-     }
--    
-+
-     ret = pthread_create(&p->_tid, &attr, func, param);
--    
-+
-     if (!ret)
-     {
-       p->_created = 1;
-@@ -324,7 +324,7 @@ WRes Thread_Close(CThread *p)
-   int ret;
-   if (!p->_created)
-     return 0;
--    
-+
-   ret = pthread_detach(p->_tid);
-   p->_tid = 0;
-   p->_created = 0;
-@@ -384,7 +384,7 @@ WRes Event_Reset(CEvent *p)
-   p->_state = False;
-   return pthread_mutex_unlock(&p->_mutex);
- }
-- 
-+
- WRes Event_Wait(CEvent *p)
- {
-   RINOK(pthread_mutex_lock(&p->_mutex))
 diff --git a/libraries/lzma/C/Threads.h b/libraries/lzma/C/Threads.h
 index 4028464..86b0687 100644
 --- a/libraries/lzma/C/Threads.h
@@ -81,30 +5,10 @@ index 4028464..86b0687 100644
 @@ -4,6 +4,10 @@
  #ifndef ZIP7_INC_THREADS_H
  #define ZIP7_INC_THREADS_H
- 
+
 +#ifndef _GNU_SOURCE
 +#define _GNU_SOURCE /* Required for musl to expose cpu_set_t */
 +#endif
 +
  #ifdef _WIN32
  #include "7zWindows.h"
- 
-@@ -108,15 +112,15 @@ typedef UInt64 CCpuSet;
-    But only root function main() contains instructions that
-    set 16-byte alignment for stack pointer. And another functions
-    just keep alignment, if it was set in some parent function.
--   
-+
-    The problem:
-     if we create new thread in MinGW (GCC) 32-bit x86 via _beginthreadex() or CreateThread(),
-        the root function of thread doesn't set 16-byte alignment.
-        And stack frames in all child functions also will be unaligned in that case.
--   
-+
-    Here we set (force_align_arg_pointer) attribute for root function of new thread.
-    Do we need (force_align_arg_pointer) also for another systems?  */
--  
-+
-   #define THREAD_FUNC_ATTRIB_ALIGN_ARG __attribute__((force_align_arg_pointer))
-   // #define THREAD_FUNC_ATTRIB_ALIGN_ARG // for debug : bad alignment in SSE functions
- #else

--- a/srcpkgs/gzdoom/template
+++ b/srcpkgs/gzdoom/template
@@ -1,7 +1,7 @@
 # Template file for 'gzdoom'
 pkgname=gzdoom
 version=4.12.2
-revision=1
+revision=2
 archs="x86_64* aarch64*"
 build_style=cmake
 configure_args="-DINSTALL_PK3_PATH=share/gzdoom -DDYN_GTK=OFF -DDYN_OPENAL=OFF"
@@ -22,7 +22,8 @@ nocross=yes
 CXXFLAGS=-std=gnu++11
 
 if [ "$XBPS_TARGET_LIBC" = musl ]; then
-	CFLAGS="-D_7ZIP_AFFINITY_DISABLE"
+	CFLAGS+=" -DZ7_AFFINITY_DISABLE"
+	CXXFLAGS+=" -DZ7_AFFINITY_DISABLE"
 	makedepends+=" musl-fts-devel libexecinfo-devel"
 fi
 


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **NO** (waiting for x86_64 to build and sync)

#### Local build testing
- I built this PR locally for my native architecture, **tbd**
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - **x86_64-musl**