### PR TITLE
gstreamer: update to 1.24.10 (security)

### DIFF
--- a/srcpkgs/gst-libav/template
+++ b/srcpkgs/gst-libav/template
@@ -1,6 +1,6 @@
 # Template file for 'gst-libav'
 pkgname=gst-libav
-version=1.24.9
+version=1.24.10
 revision=1
 build_style=meson
 hostmakedepends="pkg-config yasm"
@@ -12,7 +12,7 @@ license="LGPL-2.0-or-later"
 homepage="https://gstreamer.freedesktop.org"
 changelog="https://gstreamer.freedesktop.org/releases/${version%.*}/#${version}"
 distfiles="https://gstreamer.freedesktop.org/src/gst-libav/gst-libav-${version}.tar.xz"
-checksum=32682e9ae508ee01f4fb134b3a520081e2ac007220997577624b1d16171d456c
+checksum=4cf2e2d8204e54ba8af9519a8b9b7ffa6e951a7087afa0dfe83c125d49bbb5fb
 
 case "$XBPS_TARGET_MACHINE" in
 	*-musl) # Required by musl for M_SQRT1_2

--- a/srcpkgs/gst-plugins-bad1/template
+++ b/srcpkgs/gst-plugins-bad1/template
@@ -1,6 +1,6 @@
 # Template file for 'gst-plugins-bad1'
 pkgname=gst-plugins-bad1
-version=1.24.9
+version=1.24.10
 revision=1
 build_helper="gir"
 build_style=meson
@@ -35,7 +35,7 @@ license="GPL-2.0-or-later, LGPL-2.1-or-later"
 homepage="https://gstreamer.freedesktop.org"
 changelog="https://gstreamer.freedesktop.org/releases/${version%.*}/#${version}"
 distfiles="https://gstreamer.freedesktop.org/src/gst-plugins-bad/gst-plugins-bad-${version}.tar.xz"
-checksum=36fcf7a9af0a753b43bb03b9835246f74d72f7124369e66a1e2dc7b04f5a5cab
+checksum=1707e3103950c9baed364a8af2ba0495d6b113fcd36e1062dda5f582b8f8904d
 
 build_options="gir gme onevpl wayland"
 build_options_default="gir wayland"

--- a/srcpkgs/gst-plugins-base1/template
+++ b/srcpkgs/gst-plugins-base1/template
@@ -1,6 +1,6 @@
 # Template file for 'gst-plugins-base1'
 pkgname=gst-plugins-base1
-version=1.24.9
+version=1.24.10
 revision=1
 build_style=meson
 build_helper="gir"
@@ -22,7 +22,7 @@ license="GPL-2.0-or-later, LGPL-2.0-or-later"
 homepage="https://gstreamer.freedesktop.org"
 changelog="https://gstreamer.freedesktop.org/releases/${version%.*}/#${version}"
 distfiles="https://gstreamer.freedesktop.org/src/gst-plugins-base/gst-plugins-base-${version}.tar.xz"
-checksum=5bb3b946907d3ce04dd842b610c8111c2b0611351b25a1fa22af5efa897857cb
+checksum=ebd57b1be924c6e24f327dd55bab9d8fbaaebe5e1dc8fca784182ab2b12d23eb
 
 build_options="cdparanoia gir sndio wayland"
 build_options_default="cdparanoia gir wayland"

--- a/srcpkgs/gst-plugins-good1/template
+++ b/srcpkgs/gst-plugins-good1/template
@@ -1,6 +1,6 @@
 # Template file for 'gst-plugins-good1'
 pkgname=gst-plugins-good1
-version=1.24.9
+version=1.24.10
 revision=1
 build_style=meson
 configure_args="-Ddv=disabled -Ddv1394=disabled -Dshout2=disabled -Dqt5=enabled
@@ -23,7 +23,7 @@ license="LGPL-2.1-or-later"
 homepage="https://gstreamer.freedesktop.org"
 changelog="https://gstreamer.freedesktop.org/releases/${version%.*}/#${version}"
 distfiles="https://gstreamer.freedesktop.org/src/gst-plugins-good/gst-plugins-good-${version}.tar.xz"
-checksum=897de50bff337e3ca2f86f1eaa28e0828d83024156162a50c4ea0af86e29799f
+checksum=fce748fa66d7a8ee1fb261489e59d01e3fa787623d6d5c35068416fe7cd0acb3
 
 build_options="gtk3 wayland"
 build_options_default="gtk3 wayland"

--- a/srcpkgs/gst-plugins-ugly1/template
+++ b/srcpkgs/gst-plugins-ugly1/template
@@ -1,6 +1,6 @@
 # Template file for 'gst-plugins-ugly1'
 pkgname=gst-plugins-ugly1
-version=1.24.9
+version=1.24.10
 revision=1
 build_style=meson
 configure_args=" -Dsidplay=disabled -Dgpl=enabled -Dx264=enabled
@@ -17,4 +17,4 @@ license="LGPL-2.1-or-later, GPL-2.0-or-later"
 homepage="https://gstreamer.freedesktop.org"
 changelog="https://gstreamer.freedesktop.org/releases/${version%.*}/#${version}"
 distfiles="https://gstreamer.freedesktop.org/src/gst-plugins-ugly/gst-plugins-ugly-${version}.tar.xz"
-checksum=4b6b30110f38cd05eb67422297142b75a55fe00003105f48b13603e6761cc3b6
+checksum=9df6fd85a7256241efbb25f84b337575e3b345266f5dab3849371e4694779f18

--- a/srcpkgs/gst-rtsp-server/template
+++ b/srcpkgs/gst-rtsp-server/template
@@ -1,6 +1,6 @@
 # Template file for 'gst-rtsp-server'
 pkgname=gst-rtsp-server
-version=1.24.9
+version=1.24.10
 revision=1
 build_style=meson
 build_helper=gir
@@ -14,7 +14,7 @@ license="LGPL-2.1-or-later"
 homepage="https://gstreamer.freedesktop.org"
 changelog="https://gstreamer.freedesktop.org/releases/${version%.*}/#${version}"
 distfiles="https://gstreamer.freedesktop.org/src/gst-rtsp-server/gst-rtsp-server-${version}.tar.xz"
-checksum=299c9aafac3c91bbebe4cd481ed4e4ade8cb2b0677097bc4a8dcf6d4364c9804
+checksum=db21dfdd7bf2e718564d557378ada5358b411efe2a3e89e9f0f87a74537e2adc
 
 gst-rtsp-server-devel_package() {
 	depends="${sourcepkg}>=${version}_${revision} gst-plugins-base1-devel"

--- a/srcpkgs/gst1-editing-services/template
+++ b/srcpkgs/gst1-editing-services/template
@@ -1,7 +1,7 @@
 # Template file for 'gst1-editing-services'
 pkgname=gst1-editing-services
-version=1.24.9
-revision=2
+version=1.24.10
+revision=1
 build_style=meson
 build_helper="gir"
 configure_args="-Ddoc=disabled $(vopt_feature gir introspection)"
@@ -14,7 +14,7 @@ license="LGPL-2.0-or-later"
 homepage="https://gstreamer.freedesktop.org"
 changelog="https://gstreamer.freedesktop.org/releases/${version%.*}/#${version}"
 distfiles="https://gstreamer.freedesktop.org/src/gst-editing-services/gst-editing-services-${version}.tar.xz"
-checksum=07506e53bec6c54ec1dfaa5033bad8df42d2f217451822b4c8bf783ef8a27012
+checksum=6f00b11b4e5e34c2a32d64df521dca77519d626fcc5e3863c0218bd12367e174
 
 build_options="gir"
 

--- a/srcpkgs/gst1-python3/template
+++ b/srcpkgs/gst1-python3/template
@@ -1,7 +1,7 @@
 # Template file for 'gst1-python3'
 pkgname=gst1-python3
-version=1.24.9
-revision=2
+version=1.24.10
+revision=1
 build_style=meson
 hostmakedepends="pkg-config python3"
 makedepends="libglib-devel python3-devel python3-gobject-devel gst-plugins-base1-devel"
@@ -12,5 +12,5 @@ license="LGPL-2.1-or-later"
 homepage="https://gstreamer.freedesktop.org"
 changelog="https://gstreamer.freedesktop.org/releases/${version%.*}/#${version}"
 distfiles="https://gstreamer.freedesktop.org/src/gst-python/gst-python-${version}.tar.xz"
-checksum=80e61d587c34cbac79e46c927b71cf32c4bf9bb0868ce5aa4b7444bdad83f42e
+checksum=135bcf8b6f1468bc31e5660409fe8ed38109f01dec44743514aa2fa6b3863309
 make_check=no # Upstream didn't adjust checks to match their API changes

--- a/srcpkgs/gstreamer-vaapi/template
+++ b/srcpkgs/gstreamer-vaapi/template
@@ -1,6 +1,6 @@
 # Template file for 'gstreamer-vaapi'
 pkgname=gstreamer-vaapi
-version=1.24.9
+version=1.24.10
 revision=1
 build_style=meson
 hostmakedepends="pkg-config"
@@ -11,7 +11,7 @@ license="LGPL-2.1-or-later"
 homepage="https://gstreamer.freedesktop.org"
 changelog="https://gstreamer.freedesktop.org/releases/${version%.*}/#${version}"
 distfiles="https://gstreamer.freedesktop.org/src/gstreamer-vaapi/gstreamer-vaapi-${version}.tar.xz"
-checksum=c2373e9b4d6655535d355207f60084b0fb3b28566fe9bb4ca1da714439da4ae1
+checksum=21593dbde5c6bcdcfe99195defbe3c3f4da01cb85f8ec10aae943887d39d8a4c
 
 pre_check() {
 	# Seems to need certain hardware to pass

--- a/srcpkgs/gstreamer1/template
+++ b/srcpkgs/gstreamer1/template
@@ -1,6 +1,6 @@
 # Template file for 'gstreamer1'
 pkgname=gstreamer1
-version=1.24.9
+version=1.24.10
 revision=1
 build_style=meson
 build_helper="gir"
@@ -17,7 +17,7 @@ license="LGPL-2.0-or-later"
 homepage="https://gstreamer.freedesktop.org"
 changelog="https://gstreamer.freedesktop.org/releases/${version%.*}/#${version}"
 distfiles="https://gstreamer.freedesktop.org/src/gstreamer/gstreamer-${version}.tar.xz"
-checksum=ebf47b6beef508a00c8557d4c1f1713e5c7ef9ba70dac45deed80e182bcf260f
+checksum=9fc45b1a332e8f812f09e95c281cd75969f6d1682d062a815db0e7bc047518fd
 
 pre_check() {
 	# gst_gstdatetime is known to fail according to LFS


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, **x86_64**

#### Comments

Security fixes https://gstreamer.freedesktop.org/security/

some of them are remote code execution (RCE)
- https://gstreamer.freedesktop.org/security/sa-2024-0014.html
- https://gstreamer.freedesktop.org/security/sa-2016-0001.html
- https://gstreamer.freedesktop.org/security/sa-2016-0002.html
- https://gstreamer.freedesktop.org/security/sa-2021-0002.html
- https://gstreamer.freedesktop.org/security/sa-2021-0003.html
- https://gstreamer.freedesktop.org/security/sa-2022-0001.html

using on top of my intel libvpl stuff https://github.com/void-linux/void-packages/pull/51496