### PR TITLE
fix deluge

### DIFF
--- a/srcpkgs/deluge/patches/replace-cgi.patch
+++ b/srcpkgs/deluge/patches/replace-cgi.patch
@@ -1,0 +1,107 @@
+From 5d96cfc72f0bfa36d90afd2725aa2216b8073d66 Mon Sep 17 00:00:00 2001
+From: Mamoru TASAKA <mtasaka@fedoraproject.org>
+Date: Thu, 29 Aug 2024 15:31:25 +0900
+Subject: [PATCH] [UI] Replace deprecated cgi module with email
+
+As PEP 594 says, cgi module is marked as deprecated
+in python 3.11, and will be removed in 3.13
+(actually removed at least in 3.13 rc1).
+
+As suggested on PEP 594, replace cgi.parse_header
+with email.message.EmailMessage introduced in python 3.6.
+
+Updated test modify test_download_with_rename_sanitised
+- With RFC2045 specification, Content-Disposition filenames
+parameter containing slash (directory separator) must be
+quoted, so changing as such.
+
+Ref: https://peps.python.org/pep-0594/#deprecated-modules
+Ref: https://peps.python.org/pep-0594/#cgi
+
+Closes: https://github.com/deluge-torrent/deluge/pull/462
+---
+ deluge/httpdownloader.py            | 14 +++++++++-----
+ deluge/tests/test_httpdownloader.py |  4 ++--
+ deluge/ui/web/json_api.py           |  6 ++++--
+ 3 files changed, 15 insertions(+), 9 deletions(-)
+
+diff --git a/deluge/httpdownloader.py b/deluge/httpdownloader.py
+index 700ade06bf..c19e3aa7ed 100644
+--- a/deluge/httpdownloader.py
++++ b/deluge/httpdownloader.py
+@@ -6,7 +6,7 @@
+ # See LICENSE for more details.
+ #
+ 
+-import cgi
++import email.message
+ import logging
+ import os.path
+ import zlib
+@@ -133,9 +133,10 @@ def request_callback(self, response):
+                 content_disp = headers.getRawHeaders(b'content-disposition')[0].decode(
+                     'utf-8'
+                 )
+-                content_disp_params = cgi.parse_header(content_disp)[1]
+-                if 'filename' in content_disp_params:
+-                    new_file_name = content_disp_params['filename']
++                message = email.message.EmailMessage()
++                message['content-disposition'] = content_disp
++                new_file_name = message.get_filename()
++                if new_file_name:
+                     new_file_name = sanitise_filename(new_file_name)
+                     new_file_name = os.path.join(
+                         os.path.split(self.filename)[0], new_file_name
+@@ -152,7 +153,10 @@ def request_callback(self, response):
+                     self.filename = new_file_name
+ 
+             cont_type_header = headers.getRawHeaders(b'content-type')[0].decode()
+-            cont_type, params = cgi.parse_header(cont_type_header)
++            message = email.message.EmailMessage()
++            message['content-type'] = cont_type_header
++            cont_type = message.get_content_type()
++            params = message['content-type'].params
+             # Only re-ecode text content types.
+             encoding = None
+             if cont_type.startswith('text/'):
+diff --git a/deluge/tests/test_httpdownloader.py b/deluge/tests/test_httpdownloader.py
+index 1c27045603..0a4695b5ce 100644
+--- a/deluge/tests/test_httpdownloader.py
++++ b/deluge/tests/test_httpdownloader.py
+@@ -206,10 +206,10 @@ async def test_download_with_rename_exists(self):
+         self.assert_contains(filename, 'This file should be called renamed')
+ 
+     async def test_download_with_rename_sanitised(self):
+-        url = self.get_url('rename?filename=/etc/passwd')
++        url = self.get_url('rename?filename="/etc/passwd"')
+         filename = await download_file(url, fname('original'))
+         assert filename == fname('passwd')
+-        self.assert_contains(filename, 'This file should be called /etc/passwd')
++        self.assert_contains(filename, 'This file should be called "/etc/passwd"')
+ 
+     async def test_download_with_attachment_no_filename(self):
+         url = self.get_url('attachment')
+diff --git a/deluge/ui/web/json_api.py b/deluge/ui/web/json_api.py
+index 1a0e66f77d..dd921c801e 100644
+--- a/deluge/ui/web/json_api.py
++++ b/deluge/ui/web/json_api.py
+@@ -6,7 +6,7 @@
+ # See LICENSE for more details.
+ #
+ 
+-import cgi
++import email.message
+ import json
+ import logging
+ import os
+@@ -191,7 +191,9 @@ def _on_json_request(self, request):
+         Handler to take the json data as a string and pass it on to the
+         _handle_request method for further processing.
+         """
+-        content_type, _ = cgi.parse_header(request.getHeader(b'content-type').decode())
++        message = email.message.EmailMessage()
++        message['content-type'] = request.getHeader(b'content-type').decode()
++        content_type = message.get_content_type()
+         if content_type != 'application/json':
+             message = 'Invalid JSON request content-type: %s' % content_type
+             raise JSONException(message)

--- a/srcpkgs/deluge/template
+++ b/srcpkgs/deluge/template
@@ -1,7 +1,7 @@
 # Template file for 'deluge'
 pkgname=deluge
 version=2.1.1
-revision=3
+revision=4
 build_style=python3-module
 # TODO package python3-slimit to minify javascript
 hostmakedepends="intltool python3-setuptools python3-wheel"

--- a/srcpkgs/python3-openssl/template
+++ b/srcpkgs/python3-openssl/template
@@ -1,18 +1,18 @@
 # Template file for 'python3-openssl'
 pkgname=python3-openssl
-version=24.2.1
-revision=2
+version=24.3.0
+revision=1
 build_style=python3-module
 hostmakedepends="python3-setuptools"
 depends="python3-cryptography"
-checkdepends="python3-pytest $depends python3-flaky python3-pretend"
+checkdepends="python3-pytest $depends python3-pytest-rerunfailures python3-pretend"
 short_desc="Python3 interface to the OpenSSL library"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="Apache-2.0"
 homepage="https://pyopenssl.org/"
 changelog="https://raw.githubusercontent.com/pyca/pyopenssl/master/CHANGELOG.rst"
 distfiles="${PYPI_SITE}/p/pyopenssl/pyopenssl-${version}.tar.gz"
-checksum=4247f0dbe3748d560dcbb2ff3ea01af0f9a1a001ef5f7c4c647956ed8cbf0e95
+checksum=49f7a019577d834746bc55c5fce6ecbcec0f2b4ec5ce1cf43a9a173b8138bb36
 
 if [ "$XBPS_TARGET_WORDSIZE" = "32" ]; then
 	# https://github.com/pyca/pyopenssl/issues/974

--- a/srcpkgs/python3-pytest-rerunfailures/template
+++ b/srcpkgs/python3-pytest-rerunfailures/template
@@ -1,0 +1,13 @@
+# Template file for 'python3-pytest-rerunfailures'
+pkgname=python3-pytest-rerunfailures
+version=15.0
+revision=1
+build_style=python3-module
+hostmakedepends="python3-setuptools"
+depends="python3-packaging python3-pytest"
+short_desc="Pytest plugin that re-runs tests to eliminate flaky failures"
+maintainer="toadwastoast <toadwastoast@proton.me>"
+license="MPL-2.0"
+homepage="https://pypi.org/project/pytest-rerunfailures/"
+distfiles="${PYPI_SITE}/p/pytest-rerunfailures/pytest-rerunfailures-${version}.tar.gz"
+checksum=2d9ac7baf59f4c13ac730b47f6fa80e755d1ba0581da45ce30b72fb3542b4474

--- a/srcpkgs/python3-zope.interface/template
+++ b/srcpkgs/python3-zope.interface/template
@@ -1,7 +1,7 @@
 # Template file for 'python3-zope.interface'
 pkgname=python3-zope.interface
-version=6.1
-revision=2
+version=7.2
+revision=1
 build_style=python3-module
 hostmakedepends="python3-setuptools"
 makedepends="python3-devel"
@@ -12,7 +12,7 @@ license="ZPL-2.1"
 homepage="https://github.com/zopefoundation/zope.interface"
 changelog="https://raw.githubusercontent.com/zopefoundation/zope.interface/master/CHANGES.rst"
 distfiles="${PYPI_SITE}/z/zope.interface/zope.interface-${version}.tar.gz"
-checksum=2fdc7ccbd6eb6b7df5353012fbed6c3c5d04ceaca0038f75e601060e95345309
+checksum=8b49f1a3d1ee4cdaf5b32d2e738362c7f5e40ac8b46dd7d1a65e82a4872728fe
 # Tests can't find the package they test
 make_check=no
 


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures:
  - aarch64-musl (cross)
  - armv6l (cross)
  
With the update to python 3.13 `deluge` became incompatible with a few things and it crashes on startup, so I had to update `python3-openssl` and `python3-zope.interface` in order for it to work again. 

It's also necessary to patch this [commit](https://github.com/deluge-torrent/deluge/commit/5d96cfc72f0bfa36d90afd2725aa2216b8073d66) into the package, since python 3.13 dropped support for cgi.

We could also just wait to see if upstream releases a new version of deluge compatible with python 3.13, but it could take a while.
