### PR TITLE
New package: swaylock-effects-1.7.0.0

### DIFF
--- a/srcpkgs/swaylock-effects/template
+++ b/srcpkgs/swaylock-effects/template
@@ -1,0 +1,20 @@
+# Template file for 'swaylock-effects'
+pkgname=swaylock-effects
+version=1.7.0.0
+revision=1
+build_style=meson
+conf_files="/etc/pam.d/swaylock"
+hostmakedepends="pkg-config wayland-devel scdoc git"
+makedepends="wayland-protocols cairo-devel gdk-pixbuf-devel pam-devel libxkbcommon-devel wayland-devel libgomp-devel"
+short_desc="Swaylock, with fancy effects"
+maintainer="revsuine <pid1@revsuine.xyz>"
+license="MIT"
+# re: choice of fork, see this thread https://github.com/mortie/swaylock-effects/issues/92
+homepage="https://github.com/jirutka/swaylock-effects"
+distfiles="${homepage}/archive/refs/tags/v${version}.tar.gz>swaylock-effects_v${version}.tar.gz"
+checksum=e94d79e189602694bedfbafb553ce3c6c976426e16f76d93bf7e226dc2876eb6
+conflicts="swaylock"
+
+post_install() {
+	vlicense LICENSE
+}


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - armv6l-glibc

Swaylock-effects is a fork of swaylock which adds built-in screenshots and image manipulation effects like blurring. It's inspired by i3lock-color, although the feature sets aren't perfectly overlapping.