### PR TITLE
python3-pandas: update to 2.2.3.

### DIFF
--- a/common/scripts/parse-py-metadata.py
+++ b/common/scripts/parse-py-metadata.py
@@ -32,6 +32,9 @@ if TYPE_CHECKING:
     from packaging.requirements import Requirement
     from packaging.utils import canonicalize_name
 
+# packages to always ignore
+global_ignore = ["tzdata"]
+
 
 def msg_err(msg: str, *, nocolor: bool = False, strict: bool = False):
     if nocolor:
@@ -149,6 +152,8 @@ def parse_depends(args):
             pkgname = vpkgs[k]
             if pkgname in rdeps:
                 print(f"   PYTHON: {k} <-> {pkgname}", flush=True)
+            elif pkgname in global_ignore:
+                print(f"   PYTHON: {k} <-> {pkgname} (ignored)", flush=True)
             else:
                 msg_err(f"   PYTHON: {k} <-> {pkgname} NOT IN depends PLEASE FIX!",
                         nocolor=args.nocolor, strict=args.strict)

--- a/srcpkgs/python3-pandas/template
+++ b/srcpkgs/python3-pandas/template
@@ -1,14 +1,15 @@
 # Template file for 'python3-pandas'
 pkgname=python3-pandas
-version=2.2.2
-revision=3
+version=2.2.3
+revision=1
 build_style=python3-pep517
 build_helper="meson numpy"
 # Pandas imposes strict and unnecessary restrictions on build dependencies
 make_build_args="--skip-dependency-check"
 hostmakedepends="python3-meson-python python3-wheel python3-Cython
  python3-numpy python3-versioneer pkg-config"
-makedepends="python3-devel python3-numpy python3-dateutil python3-pytz"
+makedepends="python3-devel python3-numpy python3-dateutil python3-pytz
+ python3-tzdata"
 depends="python3-numpy python3-dateutil python3-pytz"
 short_desc="Python3 data analysis library"
 maintainer="Orphaned <orphan@voidlinux.org>"
@@ -16,7 +17,7 @@ license="BSD-3-Clause"
 homepage="https://pandas.pydata.org/"
 changelog="https://pandas.pydata.org/pandas-docs/stable/whatsnew/index.html"
 distfiles="https://github.com/pandas-dev/pandas/archive/v${version}.tar.gz"
-checksum=79bc6fb5505afd27875c93fec27cece74318470c4e274ec7ef48b16f046dc006
+checksum=19a2160b7fa82440ff3f1eb511331dcad354b3a8802072180472191664803356
 # Builds seem to sometimes have missing symbol problems;
 # the intermittent nature suggests this might be a race
 disable_parallel_build=yes


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc

#### Note
[2.2.3](https://pandas.pydata.org/pandas-docs/stable/whatsnew/v2.2.3.html#pandas-2-2-3-is-now-compatible-with-python-3-13) has Python 3.13 support.

Building succeeded with warning about missing [tzdata](https://github.com/python/tzdata). I guess it's different from python3-pytzdata and not packaged? Not sure if it is needed as previous versions all require it.🤔 Tested against my scripts and pandas just works like 2.2.2.

<details><summary>Build log</summary>
<p>


```
Successfully built pandas-2.2.3-cp313-cp313-linux_x86_64.whl
=> python3-pandas-2.2.3_1: skipping check (make_check=no) ...
=> python3-pandas-2.2.3_1: running pre-install hook: 00-libdir ...
=> python3-pandas-2.2.3_1: running pre-install hook: 02-script-wrapper ...
=> python3-pandas-2.2.3_1: running pre-install hook: 98-fixup-gir-path ...
=> python3-pandas-2.2.3_1: running do_install ...
=> python3-pandas-2.2.3_1: running post_install ...
=> python3-pandas-2.2.3_1: running post-install hook: 00-compress-info-files ...
=> python3-pandas-2.2.3_1: running post-install hook: 00-fixup-gir-path ...
=> python3-pandas-2.2.3_1: running post-install hook: 00-libdir ...
=> python3-pandas-2.2.3_1: running post-install hook: 00-uncompress-manpages ...
=> python3-pandas-2.2.3_1: running post-install hook: 01-remove-misc ...
=> python3-pandas-2.2.3_1: running post-install hook: 02-remove-libtool-archives ...
=> python3-pandas-2.2.3_1: running post-install hook: 02-remove-perl-files ...
=> python3-pandas-2.2.3_1: running post-install hook: 02-remove-python-bytecode-files ...
=> python3-pandas-2.2.3_1: running post-install hook: 03-remove-empty-dirs ...
=> python3-pandas-2.2.3_1: running post-install hook: 04-create-xbps-metadata-scripts ...
   Added trigger 'pycompile' for the 'INSTALL' script.
   Added trigger 'pycompile' for the 'REMOVE' script.
=> python3-pandas-2.2.3_1: running post-install hook: 05-generate-gitrevs ...
=> python3-pandas-2.2.3_1: running post-install hook: 06-strip-and-debug-pkgs ...
   Stripped library: /usr/lib/python3.13/site-packages/pandas/_libs/reshape.cpython-313-x86_64-linux-gnu.so
   Stripped library: /usr/lib/python3.13/site-packages/pandas/_libs/sparse.cpython-313-x86_64-linux-gnu.so
   Stripped library: /usr/lib/python3.13/site-packages/pandas/_libs/sas.cpython-313-x86_64-linux-gnu.so
   Stripped library: /usr/lib/python3.13/site-packages/pandas/_libs/interval.cpython-313-x86_64-linux-gnu.so
   Stripped library: /usr/lib/python3.13/site-packages/pandas/_libs/algos.cpython-313-x86_64-linux-gnu.so
   Stripped library: /usr/lib/python3.13/site-packages/pandas/_libs/index.cpython-313-x86_64-linux-gnu.so
   Stripped library: /usr/lib/python3.13/site-packages/pandas/_libs/hashing.cpython-313-x86_64-linux-gnu.so
   Stripped library: /usr/lib/python3.13/site-packages/pandas/_libs/pandas_datetime.cpython-313-x86_64-linux-gnu.so
   Stripped library: /usr/lib/python3.13/site-packages/pandas/_libs/byteswap.cpython-313-x86_64-linux-gnu.so
   Stripped library: /usr/lib/python3.13/site-packages/pandas/_libs/tslibs/timezones.cpython-313-x86_64-linux-gnu.so
   Stripped library: /usr/lib/python3.13/site-packages/pandas/_libs/tslibs/np_datetime.cpython-313-x86_64-linux-gnu.so
   Stripped library: /usr/lib/python3.13/site-packages/pandas/_libs/tslibs/timedeltas.cpython-313-x86_64-linux-gnu.so
   Stripped library: /usr/lib/python3.13/site-packages/pandas/_libs/tslibs/parsing.cpython-313-x86_64-linux-gnu.so
   Stripped library: /usr/lib/python3.13/site-packages/pandas/_libs/tslibs/base.cpython-313-x86_64-linux-gnu.so
   Stripped library: /usr/lib/python3.13/site-packages/pandas/_libs/tslibs/fields.cpython-313-x86_64-linux-gnu.so
   Stripped library: /usr/lib/python3.13/site-packages/pandas/_libs/tslibs/strptime.cpython-313-x86_64-linux-gnu.so
   Stripped library: /usr/lib/python3.13/site-packages/pandas/_libs/tslibs/period.cpython-313-x86_64-linux-gnu.so
   Stripped library: /usr/lib/python3.13/site-packages/pandas/_libs/tslibs/tzconversion.cpython-313-x86_64-linux-gnu.so
   Stripped library: /usr/lib/python3.13/site-packages/pandas/_libs/tslibs/dtypes.cpython-313-x86_64-linux-gnu.so
   Stripped library: /usr/lib/python3.13/site-packages/pandas/_libs/tslibs/vectorized.cpython-313-x86_64-linux-gnu.so
   Stripped library: /usr/lib/python3.13/site-packages/pandas/_libs/tslibs/conversion.cpython-313-x86_64-linux-gnu.so
   Stripped library: /usr/lib/python3.13/site-packages/pandas/_libs/tslibs/ccalendar.cpython-313-x86_64-linux-gnu.so
   Stripped library: /usr/lib/python3.13/site-packages/pandas/_libs/tslibs/offsets.cpython-313-x86_64-linux-gnu.so
   Stripped library: /usr/lib/python3.13/site-packages/pandas/_libs/tslibs/nattype.cpython-313-x86_64-linux-gnu.so
   Stripped library: /usr/lib/python3.13/site-packages/pandas/_libs/tslibs/timestamps.cpython-313-x86_64-linux-gnu.so
   Stripped library: /usr/lib/python3.13/site-packages/pandas/_libs/join.cpython-313-x86_64-linux-gnu.so
   Stripped library: /usr/lib/python3.13/site-packages/pandas/_libs/lib.cpython-313-x86_64-linux-gnu.so
   Stripped library: /usr/lib/python3.13/site-packages/pandas/_libs/ops.cpython-313-x86_64-linux-gnu.so
   Stripped library: /usr/lib/python3.13/site-packages/pandas/_libs/arrays.cpython-313-x86_64-linux-gnu.so
   Stripped library: /usr/lib/python3.13/site-packages/pandas/_libs/writers.cpython-313-x86_64-linux-gnu.so
   Stripped library: /usr/lib/python3.13/site-packages/pandas/_libs/parsers.cpython-313-x86_64-linux-gnu.so
   Stripped library: /usr/lib/python3.13/site-packages/pandas/_libs/testing.cpython-313-x86_64-linux-gnu.so
   Stripped library: /usr/lib/python3.13/site-packages/pandas/_libs/ops_dispatch.cpython-313-x86_64-linux-gnu.so
   Stripped library: /usr/lib/python3.13/site-packages/pandas/_libs/json.cpython-313-x86_64-linux-gnu.so
   Stripped library: /usr/lib/python3.13/site-packages/pandas/_libs/indexing.cpython-313-x86_64-linux-gnu.so
   Stripped library: /usr/lib/python3.13/site-packages/pandas/_libs/properties.cpython-313-x86_64-linux-gnu.so
   Stripped library: /usr/lib/python3.13/site-packages/pandas/_libs/window/indexers.cpython-313-x86_64-linux-gnu.so
   Stripped library: /usr/lib/python3.13/site-packages/pandas/_libs/window/aggregations.cpython-313-x86_64-linux-gnu.so
   Stripped library: /usr/lib/python3.13/site-packages/pandas/_libs/missing.cpython-313-x86_64-linux-gnu.so
   Stripped library: /usr/lib/python3.13/site-packages/pandas/_libs/hashtable.cpython-313-x86_64-linux-gnu.so
   Stripped library: /usr/lib/python3.13/site-packages/pandas/_libs/groupby.cpython-313-x86_64-linux-gnu.so
   Stripped library: /usr/lib/python3.13/site-packages/pandas/_libs/tslib.cpython-313-x86_64-linux-gnu.so
   Stripped library: /usr/lib/python3.13/site-packages/pandas/_libs/pandas_parser.cpython-313-x86_64-linux-gnu.so
   Stripped library: /usr/lib/python3.13/site-packages/pandas/_libs/internals.cpython-313-x86_64-linux-gnu.so
=> python3-pandas-2.2.3_1: running post-install hook: 10-pkglint-devel-paths ...
=> python3-pandas-2.2.3_1: running post-install hook: 11-pkglint-elf-in-usrshare ...
=> python3-pandas-2.2.3_1: running post-install hook: 12-rename-python3-c-bindings ...
=> WARNING: python3-pandas-2.2.3_1: renamed 'reshape.cpython-313-x86_64-linux-gnu.so' to 'reshape.so'.
=> WARNING: python3-pandas-2.2.3_1: renamed 'sparse.cpython-313-x86_64-linux-gnu.so' to 'sparse.so'.                           
=> WARNING: python3-pandas-2.2.3_1: renamed 'sas.cpython-313-x86_64-linux-gnu.so' to 'sas.so'.                                 
=> WARNING: python3-pandas-2.2.3_1: renamed 'interval.cpython-313-x86_64-linux-gnu.so' to 'interval.so'.                       
=> WARNING: python3-pandas-2.2.3_1: renamed 'algos.cpython-313-x86_64-linux-gnu.so' to 'algos.so'.                             
=> WARNING: python3-pandas-2.2.3_1: renamed 'index.cpython-313-x86_64-linux-gnu.so' to 'index.so'.                             
=> WARNING: python3-pandas-2.2.3_1: renamed 'hashing.cpython-313-x86_64-linux-gnu.so' to 'hashing.so'.                         
=> WARNING: python3-pandas-2.2.3_1: renamed 'pandas_datetime.cpython-313-x86_64-linux-gnu.so' to 'pandas_datetime.so'.         
=> WARNING: python3-pandas-2.2.3_1: renamed 'byteswap.cpython-313-x86_64-linux-gnu.so' to 'byteswap.so'.                       
=> WARNING: python3-pandas-2.2.3_1: renamed 'timezones.cpython-313-x86_64-linux-gnu.so' to 'timezones.so'.                     
=> WARNING: python3-pandas-2.2.3_1: renamed 'np_datetime.cpython-313-x86_64-linux-gnu.so' to 'np_datetime.so'.                 
=> WARNING: python3-pandas-2.2.3_1: renamed 'timedeltas.cpython-313-x86_64-linux-gnu.so' to 'timedeltas.so'.                   
=> WARNING: python3-pandas-2.2.3_1: renamed 'parsing.cpython-313-x86_64-linux-gnu.so' to 'parsing.so'.                         
=> WARNING: python3-pandas-2.2.3_1: renamed 'base.cpython-313-x86_64-linux-gnu.so' to 'base.so'.                               
=> WARNING: python3-pandas-2.2.3_1: renamed 'fields.cpython-313-x86_64-linux-gnu.so' to 'fields.so'.                           
=> WARNING: python3-pandas-2.2.3_1: renamed 'strptime.cpython-313-x86_64-linux-gnu.so' to 'strptime.so'.                       
=> WARNING: python3-pandas-2.2.3_1: renamed 'period.cpython-313-x86_64-linux-gnu.so' to 'period.so'.                           
=> WARNING: python3-pandas-2.2.3_1: renamed 'tzconversion.cpython-313-x86_64-linux-gnu.so' to 'tzconversion.so'.               
=> WARNING: python3-pandas-2.2.3_1: renamed 'dtypes.cpython-313-x86_64-linux-gnu.so' to 'dtypes.so'.                           
=> WARNING: python3-pandas-2.2.3_1: renamed 'vectorized.cpython-313-x86_64-linux-gnu.so' to 'vectorized.so'.                   
=> WARNING: python3-pandas-2.2.3_1: renamed 'conversion.cpython-313-x86_64-linux-gnu.so' to 'conversion.so'.                   
=> WARNING: python3-pandas-2.2.3_1: renamed 'ccalendar.cpython-313-x86_64-linux-gnu.so' to 'ccalendar.so'.                     
=> WARNING: python3-pandas-2.2.3_1: renamed 'offsets.cpython-313-x86_64-linux-gnu.so' to 'offsets.so'.                         
=> WARNING: python3-pandas-2.2.3_1: renamed 'nattype.cpython-313-x86_64-linux-gnu.so' to 'nattype.so'.                         
=> WARNING: python3-pandas-2.2.3_1: renamed 'timestamps.cpython-313-x86_64-linux-gnu.so' to 'timestamps.so'.                   
=> WARNING: python3-pandas-2.2.3_1: renamed 'join.cpython-313-x86_64-linux-gnu.so' to 'join.so'.                               
=> WARNING: python3-pandas-2.2.3_1: renamed 'lib.cpython-313-x86_64-linux-gnu.so' to 'lib.so'.                                 
=> WARNING: python3-pandas-2.2.3_1: renamed 'ops.cpython-313-x86_64-linux-gnu.so' to 'ops.so'.                                 
=> WARNING: python3-pandas-2.2.3_1: renamed 'arrays.cpython-313-x86_64-linux-gnu.so' to 'arrays.so'.                           
=> WARNING: python3-pandas-2.2.3_1: renamed 'writers.cpython-313-x86_64-linux-gnu.so' to 'writers.so'.                         
=> WARNING: python3-pandas-2.2.3_1: renamed 'parsers.cpython-313-x86_64-linux-gnu.so' to 'parsers.so'.                         
=> WARNING: python3-pandas-2.2.3_1: renamed 'testing.cpython-313-x86_64-linux-gnu.so' to 'testing.so'.                         
=> WARNING: python3-pandas-2.2.3_1: renamed 'ops_dispatch.cpython-313-x86_64-linux-gnu.so' to 'ops_dispatch.so'.               
=> WARNING: python3-pandas-2.2.3_1: renamed 'json.cpython-313-x86_64-linux-gnu.so' to 'json.so'.                               
=> WARNING: python3-pandas-2.2.3_1: renamed 'indexing.cpython-313-x86_64-linux-gnu.so' to 'indexing.so'.                       
=> WARNING: python3-pandas-2.2.3_1: renamed 'properties.cpython-313-x86_64-linux-gnu.so' to 'properties.so'.                   
=> WARNING: python3-pandas-2.2.3_1: renamed 'indexers.cpython-313-x86_64-linux-gnu.so' to 'indexers.so'.                       
=> WARNING: python3-pandas-2.2.3_1: renamed 'aggregations.cpython-313-x86_64-linux-gnu.so' to 'aggregations.so'.               
=> WARNING: python3-pandas-2.2.3_1: renamed 'missing.cpython-313-x86_64-linux-gnu.so' to 'missing.so'.                         
=> WARNING: python3-pandas-2.2.3_1: renamed 'hashtable.cpython-313-x86_64-linux-gnu.so' to 'hashtable.so'.                     
=> WARNING: python3-pandas-2.2.3_1: renamed 'groupby.cpython-313-x86_64-linux-gnu.so' to 'groupby.so'.                         
=> WARNING: python3-pandas-2.2.3_1: renamed 'tslib.cpython-313-x86_64-linux-gnu.so' to 'tslib.so'.                             
=> WARNING: python3-pandas-2.2.3_1: renamed 'pandas_parser.cpython-313-x86_64-linux-gnu.so' to 'pandas_parser.so'.             
=> WARNING: python3-pandas-2.2.3_1: renamed 'internals.cpython-313-x86_64-linux-gnu.so' to 'internals.so'.                     
=> python3-pandas-2.2.3_1: running post-install hook: 13-pkg-config-clean-xbps-cross-base-ref ...                              
=> python3-pandas-2.2.3_1: running post-install hook: 14-fix-permissions ...
=> python3-pandas-2.2.3_1: running post-install hook: 15-qt-private-api ...
=> python3-pandas-2.2.3_1: running post-install hook: 80-prepare-32bit ...
=> python3-pandas-2.2.3_1: running post-install hook: 98-shlib-provides ...
=> python3-pandas-2.2.3_1: running post-install hook: 99-pkglint-warn-cross-cruft ...
=> python3-pandas-2.2.3_1: running pre-pkg hook: 03-rewrite-python-shebang ...
=> python3-pandas-2.2.3_1: running pre-pkg hook: 04-generate-provides ...
   py3:pandas-2.2.3_1
=> python3-pandas-2.2.3_1: running pre-pkg hook: 04-generate-runtime-deps ...
   SONAME: libc.so.6 <-> glibc>=2.39_1
   SONAME: libstdc++.so.6 <-> libstdc++>=4.4.0_1
   SONAME: libm.so.6 <-> glibc>=2.39_1
   SONAME: libgcc_s.so.1 <-> libgcc>=4.4.0_1
=> python3-pandas-2.2.3_1: running pre-pkg hook: 05-generate-32bit-runtime-deps ...
=> python3-pandas-2.2.3_1: running pre-pkg hook: 06-verify-python-deps ...
   PYTHON: py3:numpy <-> python3-numpy
   PYTHON: py3:python-dateutil <-> python3-dateutil
   PYTHON: py3:pytz <-> python3-pytz
   PYTHON: py3:tzdata <-> UNKNOWN PKG PLEASE FIX!
=> python3-pandas-2.2.3_1: missing dependencies detected!
=> python3-pandas-2.2.3_1: running pre-pkg hook: 90-set-timestamps ...
=> python3-pandas-2.2.3_1: setting mtimes to Thu Dec 19 02:37:37 AM UTC 2024
=> python3-pandas-2.2.3_1: running pre-pkg hook: 99-pkglint-subpkgs ...
=> python3-pandas-2.2.3_1: running pre-pkg hook: 99-pkglint ...
=> python3-pandas-2.2.3_1: running pre-pkg hook: 999-collected-rdeps ...
   python3-numpy>=0 python3-dateutil>=0 python3-pytz>=0 glibc>=2.39_1 libstdc++>=4.4.0_1 libgcc>=4.4.0_1 
=> python3-pandas-2.2.3_1: running do-pkg hook: 00-gen-pkg ...
=> Creating python3-pandas-2.2.3_1.x86_64.xbps for repository /host/binpkgs/main ...
=> python3-pandas-2.2.3_1: running post-pkg hook: 00-register-pkg ...
=> Registering new packages to /host/binpkgs/main
index: added `python3-pandas-2.2.3_1' (x86_64).
index: 60 packages registered.
=> python3-pandas-2.2.3_1: removing autodeps, please wait...
=> python3-pandas-2.2.3_1: cleaning build directory...
=> python3-pandas: removing files from destdir...
```


</p>
</details> 