### PR TITLE
wee-slack: update to 2.11.0.

### DIFF
--- a/srcpkgs/wee-slack/template
+++ b/srcpkgs/wee-slack/template
@@ -1,6 +1,6 @@
 # Template file for 'wee-slack'
 pkgname=wee-slack
-version=2.10.1
+version=2.11.0
 revision=1
 depends="weechat weechat-python python3-websocket-client"
 short_desc="WeeChat plugin for Slack.com"
@@ -9,7 +9,7 @@ license="MIT"
 homepage="https://github.com/wee-slack/wee-slack"
 changelog="https://raw.githubusercontent.com/wee-slack/wee-slack/master/CHANGELOG.md"
 distfiles="https://github.com/wee-slack/wee-slack/archive/v${version}.tar.gz"
-checksum=6215241a88af93e7911bd913f8d0d070d4225f0cd4abc40aa37388ae69ec4a38
+checksum=1554a0fb304860c159049b16f321d09131a6a962244c008fe230b04b100aec93
 
 do_install() {
 	vinstall wee_slack.py 644 usr/lib/weechat/python/


### PR DESCRIPTION
wee-slack 2.10.1 no longer works.  There was a change to the API.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
