### PR TITLE
tzutils: tzdata provides py3:tzdata

### DIFF
--- a/srcpkgs/tzutils/patches/only-check-relevant.patch
+++ b/srcpkgs/tzutils/patches/only-check-relevant.patch
@@ -1,8 +1,11 @@
 --- a/Makefile
 +++ b/Makefile
-@@ -827,7 +827,7 @@ check: check_back check_mild
+@@ -855,9 +855,9 @@ tzselect:	tzselect.ksh version
+ 
+ check: check_back check_mild
  check_mild:	check_character_set check_white_space check_links \
- 		  check_name_lengths check_now \
+-		  check_name_lengths check_now \
++		  check_name_lengths \
  		  check_slashed_abbrs check_sorted \
 -		  check_tables check_web check_ziguard check_zishrink check_tzs
 +		  check_tables check_ziguard check_zishrink check_tzs

--- a/srcpkgs/tzutils/template
+++ b/srcpkgs/tzutils/template
@@ -1,7 +1,7 @@
 # Template file for 'tzutils'
 pkgname=tzutils
 version=2024a
-revision=1
+revision=2
 bootstrap=yes
 short_desc="Time zone and daylight-saving time utilities"
 maintainer="Đoàn Trần Công Danh <congdanhqx@gmail.com>"
@@ -52,6 +52,7 @@ do_install() {
 
 tzdata_package() {
 	short_desc="Time zone and daylight-saving time data"
+	provides="python3-tzdata-${version}_${revision} py3:tzdata-${version}"
 	pkg_install() {
 		vmove usr/share/man/man5
 		vmove "usr/share/zoneinfo*"


### PR DESCRIPTION
according to the [Python documentation][1], the `zoneinfo` module uses the system timezone data if available, and also provides an installable `tzdata` library on PyPi. Some Python packages (like pandas) spuriously always depend on this library. By having `tzdata` provide this py3: package, it would work around Python packages that make this mistake, and avoid needing to package `python3-tzdata` or set `noverifypydeps` (which would be overkill).

@sgn, this is your package, what do you think?

[1]: https://docs.python.org/3/library/zoneinfo.html

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

