### PR TITLE
milkytracker: update to 1.05.01, adopt.

### DIFF
--- a/srcpkgs/milkytracker/template
+++ b/srcpkgs/milkytracker/template
@@ -1,17 +1,17 @@
 # Template file for 'milkytracker'
 pkgname=milkytracker
-version=1.04.00
+version=1.05.01
 revision=1
 build_style=cmake
 hostmakedepends="pkg-config"
 makedepends="SDL2-devel zlib-devel jack-devel alsa-lib-devel rtmidi-devel"
 depends="libjack rtmidi"
 short_desc="Fast Tracker II inspired music tracker"
-maintainer="tm512 <elykdav@gmail.com>"
+maintainer="Rutpiv <roger_freitas@live.com>"
 license="GPL-3.0-only"
 homepage="http://milkytracker.titandemo.org/"
 distfiles="https://github.com/milkytracker/MilkyTracker/archive/v${version}.tar.gz"
-checksum=29b9c9572ad8bf8f4add2de19c3f8fb0382738763a92e76f3d01dea82c40ff72
+checksum=c487fccf6c97c483f5a624c3a408377393fa45a27cca27323425ad71ee689e16
 
 post_install() {
 	vinstall resources/milkytracker.desktop 644 usr/share/applications


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture (x86_64)
- I built this PR locally for these architectures using specific masterdirs:
  - x86_64-musl
  - i686
- I built this PR locally for these architectures (crossbuilds):
  - aarch64
  - aarch64-musl
  - armv7l
  - armv7l-musl
  - armv6l
  - armv6l-musl