### PR TITLE
dwarffortress: update to 51.11, adopt; Dwarf-Therapist: update to 42.1.13, adopt.

### DIFF
--- a/srcpkgs/Dwarf-Therapist/template
+++ b/srcpkgs/Dwarf-Therapist/template
@@ -1,16 +1,21 @@
 # Template file for 'Dwarf-Therapist'
 pkgname=Dwarf-Therapist
-version=41.2.1
+version=42.1.13
 revision=1
 build_style=cmake
 makedepends="qt5-declarative-devel libcap-devel hicolor-icon-theme"
 depends="dwarffortress"
 short_desc="Management tool designed to run side-by-side with Dwarf Fortress"
-maintainer="Robert Stancil <robert.stancil@mavs.uta.edu>"
+maintainer="Rutpiv <roger_freitas@live.com>"
 license="GPL-3.0-or-later"
 homepage="https://github.com/Dwarf-Therapist/Dwarf-Therapist/"
 distfiles="https://github.com/Dwarf-Therapist/Dwarf-Therapist/archive/v${version}.tar.gz"
-checksum=ec954daff6e03d9d44153ed3df90685de3a7a07431fd47639d83b2f5b3f62e4b
+checksum=513c0443d2641f185d76edb8cdf79214fded1efa407137290b8c096ed410672a
+
+post_build() {
+	vsed -i dist/xdg/applications/dwarftherapist.desktop \
+			 -e 's|^Exec=dwarftherapist$|Exec=ptrace_cap_wrapper dwarftherapist|'
+}
 
 post_install() {
 	vbin dist/ptrace_scope/patch_df_ptracer

--- a/srcpkgs/dwarffortress/files/dwarffortress
+++ b/srcpkgs/dwarffortress/files/dwarffortress
@@ -1,26 +1,29 @@
 #!/bin/sh
 ## dwarf fortress wrapper written and maintained by
 # Robert Stancil <robert.stancil@mavs.uta.edu>
-# 
+#
 # MIT License
 #
 # Copyright (c) 2019 Robert Stancil <robert.stancil@mavs.uta.edu>
 #
-# Permission is hereby granted, free of charge, to any person obtaining a copy 
-# of this software and associated documentation files (the "Software"), to deal 
-# in the Software without restriction, including without limitation the rights 
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell 
-# copies of the Software, and to permit persons to whom the Software is 
+# Modified by: Rutpiv <roger_freitas@live.com> in 2024 to adjust symlink
+# creation and preserve existing save data by backing up old directories.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
 #
-# The above copyright notice and this permission notice (including the next 
+# The above copyright notice and this permission notice (including the next
 # paragraph) shall be included in all copies or substantial portions of the Software.
 #
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, 
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ##
 
@@ -48,6 +51,22 @@ if [ -z ${XDG_DATA_HOME:-$HOME/.local/share} ]; then
  exit
 fi
 
+# Check if an existing 'dwarffortress' directory with the old structure is found.
+# If found, create a backup of the directory before removing it.
+# The backup is stored as a tar.gz archive with a timestamp to prevent overwriting.
+if [ -d "${XDG_DATA_HOME:-$HOME/.local/share}/dwarffortress" ] &&
+	 [ -f "${XDG_DATA_HOME:-$HOME/.local/share}/dwarffortress/df" ]; then
+ echo "Existing old 'dwarffortress' directory found. Creating a backup..."
+
+ timestamp=$(date +%Y%m%d%H%M%S)
+ backup_file="${XDG_DATA_HOME:-$HOME/.local/share}/dwarffortress_backup_${timestamp}.tar.gz"
+ tar -czf "$backup_file" -C "${XDG_DATA_HOME:-$HOME/.local/share}" dwarffortress
+ echo "Backup created at $backup_file"
+
+ rm -rf "${XDG_DATA_HOME:-$HOME/.local/share}/dwarffortress"
+ echo "Old 'dwarffortress' directory removed."
+fi
+
 if [ ! -d ${XDG_DATA_HOME:-$HOME/.local/share}/dwarffortress ]; then
  _FORCE=yes
 fi
@@ -55,7 +74,10 @@ if [ $_FORCE ]
 then
  rm -rf ${XDG_DATA_HOME:-$HOME/.local/share}/dwarffortress
  cp /usr/share/dwarffortress ${XDG_DATA_HOME:-$HOME/.local/share} -r
- ln -s /usr/lib/dwarffortress/libs ${XDG_DATA_HOME:-$HOME/.local/share}/dwarffortress/
+ for lib in /usr/lib/dwarffortress/libs/*; do
+        ln -s "$lib" "${XDG_DATA_HOME:-$HOME/.local/share}/dwarffortress/"
+ done
+ ln -s /usr/bin/dwarfort ${XDG_DATA_HOME:-$HOME/.local/share}/dwarffortress/
 fi
 
-${XDG_DATA_HOME:-$HOME/.local/share}/dwarffortress/df
+${XDG_DATA_HOME:-$HOME/.local/share}/dwarffortress/run_df

--- a/srcpkgs/dwarffortress/template
+++ b/srcpkgs/dwarffortress/template
@@ -1,33 +1,30 @@
 # Template file for 'dwarffortress'
 pkgname=dwarffortress
-version=0.47.05
-revision=2
-_urlver=${version#*.}
+version=51.11
+revision=1
+_urlver=${version//./_}
 archs="x86_64"
 depends="gtk+ SDL SDL_ttf SDL_image virtual?libGL glu"
 short_desc="Control a dwarven outpost in a randomly generated world"
-maintainer="Robert Stancil <robert.stancil@mavs.uta.edu>"
+maintainer="Rutpiv <roger_freitas@live.com>"
 license="custom: Proprietary"
-homepage="http://www.bay12games.com/dwarves/"
-distfiles="http://www.bay12games.com/dwarves/df_${_urlver//./_}_linux.tar.bz2"
-checksum=ac74a6dbb7d7d9621f430405080322ab50c35f6632352ff2ea923f6dc5affca3
+homepage="https://www.bay12games.com/dwarves/"
+distfiles="https://www.bay12games.com/dwarves/df_${_urlver}_linux.tar.bz2"
+checksum=e75730205326e5cc126978e3869cf8a52dc3f01e7f32de7e93500bbb517e2567
 
 nostrip_files="Dwarf_Fortress"
 nopie="distfiles are precompiled as PIE"
 repository=nonfree
 noshlibprovides=yes
 
-post_extract() {
-	rm libs/libstdc++.so.6
-	rm libs/libgcc_s.so.1
-}
-
 do_install() {
 	vbin ${FILESDIR}/dwarffortress
+	vbin dwarfort
+	rm dwarfort
 	vmkdir /usr/share/dwarffortress
 	vmkdir /usr/lib/dwarffortress/libs
-	vcopy "libs/*" /usr/lib/dwarffortress/libs
-	rm -r libs
-	vcopy "*" /usr/share/dwarffortress/
+	vcopy lib* /usr/lib/dwarffortress/libs
+	rm lib*
+	vcopy * /usr/share/dwarffortress/
 	vlicense "readme.txt" dwarffortress.txt
 }


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture (x86_64)

---

**Summary of Changes:**  
The `dwarffortress` package required updates due to changes in its versioning system and file structure starting from version `0.47.05`. Additionally, I updated the `dwarftherapist` package, which depends on `dwarffortress`. Below are the details of the changes:  

1. **Dwarffortress Package Updates:**  
   - **Versioning Adjustments:**  
     - Simplified version handling to align with the new tagging system.  
     - Updated URLs from `http` to `https` for security.  
   - **Installation Adjustments:**  
     - Removed the now-unnecessary `post_extract` function.  
     - Updated `do_install` to ensure compliance with the new file structure and installation standards.  
   - **Wrapper Updates:**  
     - Reworked the wrapper script to match the updated directory tree and startup script.  
     - Added a backup function for the old `dwarffortress` directory. This preserves save data, even though saves from older versions are incompatible with newer releases.  
   - **Compatibility Considerations:**  
     - Verified compatibility between version `50.10` and the latest `50.15`. The wrapper remains stable due to no changes in the libraries across these versions.  
   - Adopted the package, as it was no longer maintained.  

2. **Dwarf-Therapist Package Updates:**   
   - Modified the `.desktop` file to include the `ptrace_cap_wrapper` in the execution command.  
     - This wrapper automates the setup required for `Dwarf-Therapist` to work on modern kernels by enabling the necessary permissions to modify the memory of a running `Dwarf Fortress` instance.  
     - Without this automation, players would need to manually disable the `kernel.yama.ptrace_scope` security feature or execute the application through the terminal (`ptrace_cap_wrapper dwarftherapist`).  
   - This change improves the user experience by eliminating the need for manual setup.
   - Adopted the package, as it was no longer maintained.  

By adopting both packages (`dwarffortress` and `dwarftherapist`), I’ve ensured that they are updated and functioning correctly with the latest standards. These changes streamline the player experience and provide better long-term compatibility. 