### PR TITLE
linux: update to 6.12.

### DIFF
--- a/srcpkgs/linux/template
+++ b/srcpkgs/linux/template
@@ -1,7 +1,7 @@
 # Template file for 'linux'
 pkgname=linux
-version=6.6
-revision=2
+version=6.12
+revision=1
 build_style=meta
 depends="linux${version} linux-base"
 short_desc="Linux kernel meta package"


### PR DESCRIPTION
with the merge of zfs 2.2.7, we should now be safe to update this to 6.12
