### PR TITLE
MangoHud: add mangoapp sub-package

### DIFF
--- a/srcpkgs/MangoHud-mangoapp
+++ b/srcpkgs/MangoHud-mangoapp
@@ -1,0 +1,1 @@
+MangoHud

--- a/srcpkgs/MangoHud/template
+++ b/srcpkgs/MangoHud/template
@@ -4,10 +4,10 @@ version=0.7.2
 revision=2
 build_style=meson
 configure_args="-Dwith_xnvctrl=disabled
- -Dwith_nvml=disabled -Duse_system_spdlog=enabled"
+ -Dwith_nvml=disabled -Duse_system_spdlog=enabled -Dmangoapp=true"
 hostmakedepends="Vulkan-Headers python3-Mako glslang pkg-config"
 makedepends="libglvnd-devel dbus-devel vulkan-loader spdlog json-c++
- wayland-devel libxkbcommon-devel"
+ wayland-devel libxkbcommon-devel glfw-devel glew-devel"
 short_desc="Vulkan and OpenGL overlay for monitoring FPS, temperatures and more"
 maintainer="John <me@johnnynator.dev>"
 license="MIT"
@@ -23,4 +23,13 @@ fi
 
 post_install() {
 	vlicense LICENSE
+}
+
+MangoHud-mangoapp_package() {
+	short_desc="Transparent background application with a built in mangohud"
+	depends="${sourcepkg}>=${version}_${revision}"
+	pkg_install() {
+		vmove usr/bin/mangoapp
+		vmove usr/share/man/man1/mangoapp.1
+	}
 }


### PR DESCRIPTION
`mangoapp` is required if you wish to use MangoHud within a `gamescope` session. From the MangoHud README...

> To enable mangohud with gamescope you need to install mangoapp.
> `gamescope --mangoapp %command%`
>
> Using normal mangohud with gamescope is not supported.

I added this as a sub-package because `mangoapp` remains optional outside of `gamescope`, and it pulls in at least one extra dependency when installed.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures:
  - aarch64 (crossbuild)
  - x86_64-musl (crossbuild)
