### PR TITLE
cargo-deny: update to 0.16.3.

### DIFF
--- a/srcpkgs/cargo-deny/template
+++ b/srcpkgs/cargo-deny/template
@@ -1,6 +1,6 @@
 # Template file for 'cargo-deny'
 pkgname=cargo-deny
-version=0.16.1
+version=0.16.3
 revision=1
 _adv_commit="6ef1d1fd84c57e46253ff16bf7379c115e1062eb"
 _test_adv_commit="1f44d565d81692a44b8c7af8a80f587e19757f8c"
@@ -15,7 +15,7 @@ license="MIT, Apache-2.0"
 homepage="https://github.com/EmbarkStudios/cargo-deny"
 changelog="https://raw.githubusercontent.com/EmbarkStudios/cargo-deny/main/CHANGELOG.md"
 distfiles="https://github.com/EmbarkStudios/cargo-deny/archive/refs/tags/${version}.tar.gz"
-checksum=8e09aef97b0c299eefd23f019ad615559887f4ae3d54bd6affdd33a503a04fcf
+checksum=99f8906b6468ae309c5c7312f9ce1d7567300dcc43cd58228955dcc5522fcaff
 
 if [ "$XBPS_TARGET_ENDIAN" = "be" ]; then
 	broken="bitvec crate unimplemented for big endian"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture: **x86_64**