### PR TITLE
python3-readability-lxml: add new python3-lxml_html_clean dependency, required since lxml 5.2

### DIFF
--- a/srcpkgs/python3-lxml_html_clean/template
+++ b/srcpkgs/python3-lxml_html_clean/template
@@ -1,0 +1,26 @@
+# Template file for 'python3-lxml_html_clean'
+pkgname=python3-lxml_html_clean
+version=0.4.1
+revision=1
+build_style=python3-pep517
+hostmakedepends="python3-setuptools"
+depends="python3-lxml"
+checkdepends="${depends}"
+short_desc="HTML cleaning support for lxml"
+maintainer="Maeve Sproule <code@sprock.dev>"
+license="BSD-3-Clause"
+homepage="https://github.com/fedora-python/lxml_html_clean"
+changelog="https://raw.githubusercontent.com/fedora-python/lxml_html_clean/main/CHANGES.rst"
+distfiles="${PYPI_SITE}/l/lxml_html_clean/lxml_html_clean-${version}.tar.gz"
+checksum=40c838bbcf1fc72ba4ce811fbb3135913017b27820d7c16e8bc412ae1d8bc00b
+
+do_check() {
+	# Don't invoke tox because it uses pip to install the dependencies
+	# (including the unpackaged memory-profiler), causing in errors in CI.
+	python3 -m unittest -v tests/test_*.py
+	python3 -m doctest tests/test_*.txt
+}
+
+post_install() {
+	vlicense LICENSE.txt
+}

--- a/srcpkgs/python3-readability-lxml/template
+++ b/srcpkgs/python3-readability-lxml/template
@@ -1,10 +1,10 @@
 # Template file for 'python3-readability-lxml'
 pkgname=python3-readability-lxml
 version=0.8.1
-revision=9
+revision=10
 build_style=python3-module
 hostmakedepends="python3-setuptools"
-depends="python3-lxml python3-chardet python3-cssselect"
+depends="python3-lxml python3-lxml_html_clean python3-chardet python3-cssselect"
 short_desc="Fast html to text parser"
 maintainer="Benjamín Albiñana <benalb@gmail.com>"
 license="Apache-2.0"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### New package dependency
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**
- **This package adds a new / split-off dependency that is required by an existing package (see below).**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - armv7l-musl
  - armv6l-musl (crossbuild)

lxml 5.2 moved lxml.html.clean to a separate project, leaving only a compatibility shim in its place. Since the update to Void's python3-lxml package on Dec. 13, importing readability causes the following error to be emitted:

```
ImportError: lxml.html.clean module is now a separate project lxml_html_clean.
Install lxml[html_clean] or lxml_html_clean directly.
```
    
Adding a new python3-lxml_html_clean dependency resolves this error and causes readability to behave as it did before.