### PR TITLE
kwalletmanager: update to 24.12.0.

### DIFF
--- a/srcpkgs/kwalletmanager/template
+++ b/srcpkgs/kwalletmanager/template
@@ -1,6 +1,6 @@
 # Template file for 'kwalletmanager'
 pkgname=kwalletmanager
-version=24.08.0
+version=24.12.0
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
@@ -14,4 +14,4 @@ license="GPL-2.0-only"
 homepage="https://kde.org/applications/system/org.kde.kwalletmanager5"
 changelog="https://kde.org/announcements/changelogs/gear/${version}/#kwalletmanager"
 distfiles="${KDE_SITE}/release-service/${version}/src/kwalletmanager-${version}.tar.xz"
-checksum=08f900f9ef770b2bc9208781e5dcdb7e0c43f0c7a47a1515b1888f24756542f7
+checksum=5c2beeaadb9efbcbb9ebff8945a57d5806cccad8e78a8514f578253871449596


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**
- I built this PR locally for my native architecture, amd64-glibc

Changes name of dbus service from `kwalletmanager5` to `kwalletmanager`, which is expected by KDE Plasma 6