### PR TITLE
greybird-themes: update to 3.23.4

### DIFF
--- a/srcpkgs/greybird-themes/template
+++ b/srcpkgs/greybird-themes/template
@@ -1,6 +1,6 @@
 # Template file for 'greybird-themes'
 pkgname=greybird-themes
-version=3.23.3
+version=3.23.4
 revision=1
 build_style=meson
 hostmakedepends="sassc glib-devel gdk-pixbuf-devel librsvg-devel"
@@ -9,4 +9,4 @@ maintainer="Daniel Martinez <danielmartinez@cock.li>"
 license="GPL-2.0-or-later, CC-BY-SA-3.0"
 homepage="https://github.com/shimmerproject/Greybird"
 distfiles="https://github.com/shimmerproject/Greybird/archive/v${version}.tar.gz"
-checksum=2c97d3a7281c80f5752294f196bff22a814aef8da7ca3b7545f50bbb9ed16d64
+checksum=74dcec9b9bcf6c869941b661c50ce0d752b4eb4e193747db536ffd7e97d32453


### PR DESCRIPTION
Fixes greybird theme display bug with xfdesktop v4.19 and v4.20.
Closes https://github.com/void-linux/void-packages/issues/53634.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)