### PR TITLE
ffmpeg: add optional support for sftp

### DIFF
--- a/srcpkgs/ffmpeg/template
+++ b/srcpkgs/ffmpeg/template
@@ -2,7 +2,7 @@
 # audacity also needs to be bumped when a new ffmpeg version bumps libavformat's soname!
 pkgname=ffmpeg
 version=4.4.4
-revision=10
+revision=11
 build_style=meta
 short_desc="Decoding, encoding and streaming software (transitional dummy package)"
 maintainer="Orphaned <orphan@voidlinux.org>"
@@ -28,17 +28,19 @@ makedepends="zlib-devel bzip2-devel freetype-devel alsa-lib-devel libXfixes-deve
  $(vopt_if webp libwebp-devel) $(vopt_if sofa libmysofa-devel)
  $(vopt_if drm libdrm-devel) libsvt-av1-devel
  $(vopt_if srt srt-devel) $(vopt_if rist librist-devel)
+ $(vopt_if sftp libssh-devel)
  $(vopt_if vulkan 'vulkan-loader-devel')
  $(vopt_if nvenc nv-codec-headers) $(vopt_if nvdec nv-codec-headers)"
 # ffmpeg6 provides ffmpeg, ffprobe, ffplay, etc
 depends="ffmpeg6"
 
 build_options="x265 v4l2 vaapi vdpau vpx fdk_aac aom nvenc sndio pulseaudio
- dav1d zimg webp sofa vulkan drm srt rist nvdec"
-build_options_default="x265 v4l2 vpx aom sndio pulseaudio dav1d webp vulkan drm srt rist"
+ dav1d zimg webp sofa vulkan drm srt rist sftp nvdec"
+build_options_default="x265 v4l2 vpx aom sndio pulseaudio dav1d webp vulkan drm srt rist sftp"
 
 desc_option_srt="Enable support for SRT (Secure, Reliable, Transport)"
 desc_option_rist="Enable support for RIST (Reliable Internet Stream Transport)"
+desc_option_sftp="Enable support for SFTP (Secure File Transport Protocol)"
 desc_option_sofa="Enable support for AES SOFA"
 desc_option_webp="Enable support for WebP"
 
@@ -124,6 +126,7 @@ do_configure() {
 		$(vopt_enable drm libdrm) \
 		$(vopt_enable srt libsrt) \
 		$(vopt_enable rist librist) \
+		$(vopt_enable sftp libssh) \
 		$(vopt_if nvenc '--enable-nvenc') \
 		$(vopt_if nvdec '--enable-nvdec')
 }

--- a/srcpkgs/ffmpeg6/template
+++ b/srcpkgs/ffmpeg6/template
@@ -2,7 +2,7 @@
 # audacity also needs to be bumped when a new ffmpeg version bumps libavformat's soname!
 pkgname=ffmpeg6
 version=6.1.2
-revision=3
+revision=4
 hostmakedepends="pkg-config perl"
 makedepends="zlib-devel bzip2-devel freetype-devel alsa-lib-devel libXfixes-devel
  libXext-devel libXvMC-devel libxcb-devel lame-devel libtheora-devel
@@ -14,7 +14,8 @@ makedepends="zlib-devel bzip2-devel freetype-devel alsa-lib-devel libXfixes-deve
  libwebp-devel libdrm-devel srt-devel librist-devel vulkan-loader-devel
  zimg-devel libmysofa-devel libsvt-av1-devel $(vopt_if vaapi libva-devel)
  $(vopt_if vdpau libvdpau-devel) $(vopt_if fdk_aac fdk-aac-devel)
- $(vopt_if onevpl oneVPL-devel) $(vopt_if nvcodec nv-codec-headers)"
+ $(vopt_if onevpl oneVPL-devel) $(vopt_if nvcodec nv-codec-headers)
+ $(vopt_if sftp libssh-devel)"
 depends="ffplay6>=${version}_${revision}"
 short_desc="Decoding, encoding and streaming software"
 maintainer="Orphaned <orphan@voidlinux.org>"
@@ -24,8 +25,10 @@ changelog="https://raw.githubusercontent.com/FFmpeg/FFmpeg/master/Changelog"
 distfiles="https://www.ffmpeg.org/releases/ffmpeg-${version}.tar.xz"
 checksum=3b624649725ecdc565c903ca6643d41f33bd49239922e45c9b1442c63dca4e38
 
-build_options="vaapi vdpau fdk_aac nvcodec onevpl"
+build_options="vaapi vdpau fdk_aac nvcodec onevpl sftp"
+build_options_default="sftp"
 desc_option_sofa="Enable support for AES SOFA"
+desc_option_sftp="Enable support for SFTP (Secure File Transport Protocol)"
 
 case "$XBPS_TARGET_MACHINE" in
 	i686*)
@@ -102,6 +105,7 @@ do_configure() {
 		$(vopt_if fdk_aac '--enable-nonfree --enable-libfdk-aac') \
 		$(vopt_enable vaapi) $(vopt_enable vdpau) \
 		$(vopt_enable zimg libzimg) \
+		$(vopt_enable sftp libssh) \
 		$(vopt_enable sofa libmysofa) \
 		$(vopt_enable onevpl libvpl) \
 		$(vopt_enable nvcodec nvenc) \


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

Adds a build option for ffmpeg's `--enable-libssh`, so eg. mpv can be used to play sftp:// URLs. Useful if you keep large media files on a separate machine on a LAN