### PR TITLE
wireplumber: update to 0.5.7.

### DIFF
--- a/srcpkgs/wireplumber/template
+++ b/srcpkgs/wireplumber/template
@@ -1,6 +1,6 @@
 # Template file for 'wireplumber'
 pkgname=wireplumber
-version=0.5.6
+version=0.5.7
 revision=1
 build_style=meson
 build_helper=gir
@@ -14,7 +14,7 @@ license="MIT"
 homepage="https://pipewire.pages.freedesktop.org/wireplumber"
 changelog="https://gitlab.freedesktop.org/pipewire/wireplumber/-/raw/master/NEWS.rst"
 distfiles="https://gitlab.freedesktop.org/pipewire/wireplumber/-/archive/$version/wireplumber-$version.tar.gz"
-checksum=ce7b7217d880bed1438e408ea412716a259cb46b09f597bfd652a577dc60185c
+checksum=8cd43a582f68368ee5a915e97bf9dadc44d2dfe8c7bb4f96bb7b40ea2ed7848f
 provides="pipewire-session-manager-0_1"
 
 post_install() {


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture (x86_64)
- I built this PR locally for these architectures using specific masterdirs:
  - x86_64-musl
  - i686
- I built this PR locally for these architectures (crossbuilds):
  - aarch64
  - aarch64-musl
  - armv7l
  - armv7l-musl
  - armv6l
  - armv6l-musl
  
---

I have tested the update with the PipeWire version 1.2.6 from the repository and with version 1.2.7 from this PR (https://github.com/void-linux/void-packages/pull/53277). Everything seems to be working correctly in both cases.
