### PR TITLE
Signal-Desktop: fix missing program icons

### DIFF
--- a/srcpkgs/Signal-Desktop/template
+++ b/srcpkgs/Signal-Desktop/template
@@ -1,14 +1,14 @@
 # Template file for 'Signal-Desktop'
 pkgname=Signal-Desktop
 version=7.36.1
-revision=1
+revision=2
 # Signal officially only supports x86_64
 # x86_64-musl could potentially work based on the Alpine port:
 # https://git.alpinelinux.org/aports/tree/testing/signal-desktop
 # ARM: https://github.com/signalapp/Signal-Desktop/issues/3410
 archs="x86_64"
 hostmakedepends="git git-lfs nodejs-lts python3 python3-distutils-extra tar"
-depends="cairo gtk+3 libvips pango"
+depends="cairo gtk+3 libvips pango desktop-file-utils hicolor-icon-theme"
 short_desc="Signal Private Messenger for Linux"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="AGPL-3.0-only"
@@ -63,6 +63,10 @@ do_install() {
 	ln -s /usr/lib/signal-desktop/signal-desktop ${DESTDIR}/usr/bin/
 
 	vinstall signal-desktop.desktop 644 usr/share/applications
+
+	for size in 16 24 32 48 64 128 256 512 1024; do
+		vinstall build/icons/png/${size}x${size}.png 644 usr/share/icons/hicolor/${size}x${size}/apps signal-desktop.png
+	done
 
 	vlicense LICENSE
 }


### PR DESCRIPTION
#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)

Should close #53612 