### PR TITLE
layer-shell-qt: rebuild again

### DIFF
--- a/srcpkgs/layer-shell-qt/template
+++ b/srcpkgs/layer-shell-qt/template
@@ -1,7 +1,7 @@
 # Template file for 'layer-shell-qt'
 pkgname=layer-shell-qt
 version=6.2.0
-revision=2
+revision=3
 build_style=cmake
 configure_args="-DKDE_INSTALL_QMLDIR=lib/qt6/qml
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

Fixes:
```
plasmashell: symbol lookup error: /usr/lib/libLayerShellQtInterface.so.6: undefined symbol: _ZN15QtWaylandClient14QWaylandWindow9wlSurfaceEv, version Qt_6_PRIVATE_API
```

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, amd64-glibc
