### PR TITLE
iperf: update to 2.2.1.

### DIFF
--- a/srcpkgs/iperf/patches/fix-udphdr-musl.patch
+++ b/srcpkgs/iperf/patches/fix-udphdr-musl.patch
@@ -1,0 +1,13 @@
+--- a/include/headers.h	2024-11-06 18:47:34.000000000 -0300
++++ b/include/headers.h	2024-04-07 00:47:17.000000000 -0300
+@@ -134,8 +134,8 @@
+ // Bummer, AF_PACKET requires kernel headers as <netpacket/packet.h> isn't sufficient
+ #include <linux/filter.h>
+ #include <linux/if_packet.h>
+-#include <netinet/ip.h>
+-#include <netinet/udp.h>
++#include <linux/ip.h>
++#include <linux/udp.h>
+ // In older linux kernels, the kernel headers and glibc headers are in conflict,
+ // specificially <linux/in6.h> and <netinit/in.h>
+ // preventing the following include:

--- a/srcpkgs/iperf/template
+++ b/srcpkgs/iperf/template
@@ -1,6 +1,6 @@
 # Template file for 'iperf'
 pkgname=iperf
-version=2.2.0
+version=2.2.1
 revision=1
 build_style=gnu-configure
 configure_args="--enable-ipv6 --enable-multicast --enable-threads"
@@ -10,7 +10,7 @@ license="NCSA"
 homepage="https://iperf.fr/"
 changelog="https://sourceforge.net/p/iperf2/code/ci/master/tree/doc/RELEASE_NOTES?format=raw"
 distfiles="${SOURCEFORGE_SITE}/${pkgname}2/${pkgname}-${version}.tar.gz"
-checksum=16810a9575e4c6dd65e4a18ab5df3cdac6730b3c832cf080a8990f132f68364a
+checksum=754ab0a7e28033dbea81308ef424bc7df4d6e2fe31b60cc536b61b51fefbd8fb
 
 post_patch() {
 	case $XBPS_TARGET_MACHINE in


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
