### PR TITLE
singular: skip *p* versions which are not stable releases

### DIFF
--- a/srcpkgs/singular/update
+++ b/srcpkgs/singular/update
@@ -1,1 +1,3 @@
-pattern='(singular|Release)?-?\K[-.p\d]+(?=\.tar\.gz")'
+# skip *p* which often behaves as a prerelease for next version
+# see https://github.com/sagemath/sage/pull/38689#issuecomment-2366934173
+ignore='*p*'


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

See my comment https://github.com/sagemath/sage/pull/38689#issuecomment-2366934173

@dkwo

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
