### PR TITLE
ppsspp: update to 1.18.1., revert to ffmpeg4

### DIFF
--- a/srcpkgs/ppsspp/patches/fix-ffmpeg6.patch
+++ b/srcpkgs/ppsspp/patches/fix-ffmpeg6.patch
@@ -1,0 +1,33 @@
+--- a/Core/HW/MediaEngine.cpp	2024-11-04 17:16:10.000000000 +0100
++++ -	2024-12-26 20:30:02.355062203 +0100
+@@ -52,6 +52,11 @@
+ #include "libavutil/imgutils.h"
+ #include "libswscale/swscale.h"
+ 
++#if LIBAVFORMAT_VERSION_INT >= AV_VERSION_INT(59, 23, 100)
++	// private libavformat api (see demux.h in ffmpeg src tree)
++	void avpriv_stream_set_need_parsing(AVStream *st, enum AVStreamParseType type);
++#endif
++
+ }
+ #endif // USE_FFMPEG
+ 
+@@ -426,12 +426,17 @@ bool MediaEngine::addVideoStream(int streamNum, int streamId) {
+ 				streamId = PSMF_VIDEO_STREAM_ID | streamNum;
+ 
+ 			stream->id = 0x00000100 | streamId;
++#if LIBAVFORMAT_VERSION_INT >= AV_VERSION_INT(59, 23, 100)
++			avpriv_stream_set_need_parsing(stream, AVSTREAM_PARSE_FULL);
++#else
++			stream->need_parsing = AVSTREAM_PARSE_FULL;
++#endif
++
+ #if LIBAVFORMAT_VERSION_INT >= AV_VERSION_INT(57, 33, 100)
+ 			stream->codecpar->codec_type = AVMEDIA_TYPE_VIDEO;
+ 			stream->codecpar->codec_id = AV_CODEC_ID_H264;
+ #else
+ 			stream->request_probe = 0;
+-			stream->need_parsing = AVSTREAM_PARSE_FULL;
+ #endif
+ 			// We could set the width here, but we don't need to.
+ 			if (streamNum >= m_expectedVideoStreams) {

--- a/srcpkgs/ppsspp/template
+++ b/srcpkgs/ppsspp/template
@@ -1,21 +1,24 @@
 # Template file for 'ppsspp'
+# !! any change to ffmpeg should be tested with apropiate games,
+# major ffmpeg updates have a high likelyhood of breaking video playback
 pkgname=ppsspp
-version=1.17.1
-revision=2
+version=1.18.1
+revision=1
 _glslang_commit=b34f619e1c85810dcb3c578107d2e48ba4ee2b37
 _SPIRV_Cross_commit=4212eef67ed0ca048cb726a6767185504e7695e5
 _armips_commit=a8d71f0f279eb0d30ecf6af51473b66ae0cf8e8d
 _discord_rpc_commit=963aa9f3e5ce81a4682c6ca3d136cddda614db33
-_miniupnp_commit=3a87be33e797ba947b2b2a5f8d087f6c3ff4d93e
+_miniupnp_commit=27d13ca9beeb5541f5fbf11959dced03dac39972
 _cpu_features_commit=fd4ffc1632db7b4e763bd28ffa6fc9d761cf3587
-_rcheevos_commit=e7989c300280ba06d7621ae5b4e00ac7fe28d97a
+_rcheevos_commit=32917bdddf4982e62047862c6633e7671aaaf2cb
 _libchdr_commit=26d27ca4903aaccd3ef41337b29bf5ecafb1f0ca
+_OpenXR_SDK_commit=be392bf6949adeeabad5082aa79d12aacbda781f
 build_style=cmake
 configure_args="-DHEADLESS=1 -DUSE_SYSTEM_FFMPEG=1 -DUNITTEST=ON
  -DUSING_QT_UI=$(vopt_if qt ON OFF) -DUSE_SYSTEM_ZSTD=ON
  -DARMIPS_USE_STD_FILESYSTEM=ON"
 hostmakedepends="pkg-config python3 $(vopt_if qt qt5-host-tools)"
-makedepends="zlib-devel glew-devel ffmpeg6-devel libzip-devel
+makedepends="zlib-devel glew-devel ffmpeg-devel libzip-devel
  snappy-devel rapidjson libpng-devel libzstd-devel
  $(vopt_if sdl2 'SDL2_ttf-devel SDL2-devel') wayland-devel
  $(vopt_if qt 'qt5-devel qt5-multimedia-devel')"
@@ -33,16 +36,18 @@ distfiles="
  https://github.com/hrydgard/miniupnp/archive/${_miniupnp_commit}.tar.gz
  https://github.com/google/cpu_features/archive/${_cpu_features_commit}.tar.gz
  https://github.com/RetroAchievements/rcheevos/archive/${_rcheevos_commit}.tar.gz
- https://github.com/rtissera/libchdr/archive/${_libchdr_commit}.tar.gz"
-checksum="dd65e7a317cd461386a1641ddf475686d8bdb2f408bdae910386d8b3ca6a8195
+ https://github.com/rtissera/libchdr/archive/${_libchdr_commit}.tar.gz
+ https://github.com/KhronosGroup/OpenXR-SDK/archive/${_OpenXR_SDK_commit}.tar.gz"
+checksum="cc9425202552cbce8bc7ee5b883670703761011ab5c987c426887f7c2ef2703f
  9be7a69f5e5e2b9db55feb6d36d4b78bfe7a0cfb02e5915ff9bad87d719b38f8
  a7adf77b5680795302aee160309c6cb81b0da341d92bd7face01f9a156b65aeb
  a520df5b673fc1649661f8506ddf35f62fb55e05d9f5a6c44b4d807b6aab3fbd
  8f4115999391f95f443615fc5b13cb2398926ac4c418d3d34ff5735f71c6faea
- 1b1d2897f66835ea5eeec5851fe8757aca5afd86984107dcdc0e4b1ce2f2f8be
+ a07a32b2db1f6c5f2823847d47ba6e326b08fbcfe78690801fda9c3aeddf25a3
  60b2e0e7adfbf40f0c69fb77ad197440a8435532285a83b19f99b4f886cca67a
- fc184cc6fc17ca6645faef3b275fd6e18af76a04e0ee009a3a34bd2f58ffe485
- 006f323b6330c98883db887cbb7d2d13379498f34d5a2ee98850a1ff21a93d8a"
+ 22a43d8c283d96d08bb1c5d121660d3db051946025ff92eff8ee6b8c7eb18f0f
+ 006f323b6330c98883db887cbb7d2d13379498f34d5a2ee98850a1ff21a93d8a
+ f91007ec5cd5380184678cb282353a6b97b6ba2278ef4911e217472186a31762"
 
 skip_extraction="
  ${_armips_commit}.tar.gz
@@ -53,6 +58,7 @@ skip_extraction="
  ${_cpu_features_commit}.tar.gz
  ${_rcheevos_commit}.tar.gz
  ${_libchdr_commit}.tar.gz
+ ${_OpenXR_SDK_commit}.tar.gz
  "
 
 # ppsspp always tries to compile x86 unittest
@@ -76,6 +82,7 @@ post_extract() {
 	vsrcextract -C ext/cpu_features ${_cpu_features_commit}.tar.gz
 	vsrcextract -C ext/rcheevos ${_rcheevos_commit}.tar.gz
 	vsrcextract -C ext/libchdr ${_libchdr_commit}.tar.gz
+	vsrcextract -C ext/OpenXR-SDK ${_OpenXR_SDK_commit}.tar.gz
 }
 
 post_patch() {
@@ -92,17 +99,15 @@ post_configure() {
 
 do_install() {
 	vinstall icons/icon.svg 644 usr/share/pixmaps ppsspp.svg
-	vinstall Qt/PPSSPP.desktop 644 usr/share/applications
 	vbin build/PPSSPPHeadless ppsspp-headless
 	vmkdir usr/share/ppsspp
 	vcopy build/assets usr/share/ppsspp/
 
 	if [ $build_option_sdl2 ]; then
-		vbin build/PPSSPPSDL ppsspp-sdl
-		sed -e 's,^Exec=.*,Exec=/usr/bin/ppsspp-sdl,' -i $DESTDIR/usr/share/applications/PPSSPP.desktop
+		vbin build/PPSSPPSDL
+		vinstall SDL/PPSSPPSDL.desktop 644 usr/share/applications
 	elif [ $build_option_qt ] ;then
-		vbin build/PPSSPPQt ppsspp-qt
-		sed -e 's,^Exec=.*,Exec=/usr/bin/ppsspp-qt,' -i $DESTDIR/usr/share/applications/PPSSPP.desktop
+		vbin build/PPSSPPQt
+		vinstall Qt/PPSSPPQt.desktop 644 usr/share/applications
 	fi
-	sed -e 's,^Icon=.*,Icon=/usr/share/pixmaps/ppsspp.svg,' -i $DESTDIR/usr/share/applications/PPSSPP.desktop
 }


### PR DESCRIPTION
the discussion about ffmpeg6 can be had once we actually drop ffmpeg4

ffmpeg6 breaks video playback twofold:
a) messed up video (can be fixed by using private API to set AVSTREAM_PARSE_FULL)
b) ppsspp hangs at the end of a video

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
