### PR TITLE
libmtp: update to 1.1.22, adopt.

### DIFF
--- a/srcpkgs/libmtp/patches/fix-warning.patch
+++ b/srcpkgs/libmtp/patches/fix-warning.patch
@@ -1,0 +1,12 @@
+--- a/src/libmtp.c
++++ b/src/libmtp.c
+@@ -7498,7 +7498,8 @@ static LIBMTP_folder_t *get_subfolders_for_folder(LIBMTP_folder_t *list, uint32_
+      * we basically don't care. Hopefully parent_id is maintained for all
+      * children, because we rely on that instead.
+      */
+-    if (ob->oi.AssociationDesc != 0x00000000U) {
++    if (ob->oi.AssociationDesc != 0x00000000U &&
++        ob->oi.AssociationDesc != 0x00000001U) {
+       LIBMTP_INFO("MTP extended association type 0x%08x encountered\n", ob->oi.AssociationDesc);
+     }
+ 

--- a/srcpkgs/libmtp/template
+++ b/srcpkgs/libmtp/template
@@ -1,6 +1,6 @@
 # Template file for 'libmtp'
 pkgname=libmtp
-version=1.1.21
+version=1.1.22
 revision=1
 build_style=gnu-configure
 configure_args="--disable-static --with-udev=/usr/lib/udev
@@ -8,23 +8,19 @@ configure_args="--disable-static --with-udev=/usr/lib/udev
 hostmakedepends="pkg-config"
 makedepends="libgcrypt-devel libusb-devel"
 short_desc="Library for Microsoft's Media Transfer Protocol (MTP)"
-maintainer="Orphaned <orphan@voidlinux.org>"
+maintainer="Gonzalo Tornaría <tornaria@cmat.edu.uy>"
 license="LGPL-2.1-or-later"
 homepage="https://libmtp.sourceforge.net"
 changelog="https://sourceforge.net/projects/libmtp/files/libmtp/${version}/README"
 distfiles="${SOURCEFORGE_SITE}/${pkgname}/${pkgname}-${version}.tar.gz"
-checksum=c4ffa5ab8c8f48c91b0047f2e253c101c418d5696a5ed65c839922a4280872a7
+checksum=c3fcf411aea9cb9643590cbc9df99fa5fe30adcac695024442973d76fa5f87bc
 
 if [ "$CROSS_BUILD" ]; then
-	# XXX needs host mtp-hotplug
+	# use mtp-hotplug from host, needed to create udev rules and hwdb
+	configure_args+=" --enable-crossbuilddir"
+	# ... so, install mtp-hotplug in host
 	hostmakedepends+=" libmtp"
 fi
-
-pre_configure() {
-	if [ "$CROSS_BUILD" ]; then
-		vsed -e "s,\(util/mtp-hotplug \),mtp-hotplug ,g" -i Makefile.in
-	fi
-}
 
 libmtp-devel_package() {
 	depends="${makedepends} ${sourcepkg}>=${version}_${revision}"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
