### PR TITLE
plasma-workspace: add kpipewire dependency

### DIFF
--- a/srcpkgs/plasma-workspace/template
+++ b/srcpkgs/plasma-workspace/template
@@ -1,7 +1,7 @@
 # Template file for 'plasma-workspace'
 pkgname=plasma-workspace
 version=6.2.4
-revision=1
+revision=2
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF -DKDE_INSTALL_QMLDIR=lib/qt6/qml
  -DWaylandScanner_EXECUTABLE=/usr/bin/wayland-scanner
@@ -25,7 +25,7 @@ makedepends="qt6-declarative-devel libplasma-devel qt6-base-private-devel
  kpipewire-devel kirigami-addons-devel libkexiv2-devel qcoro-qt6-devel"
 depends="kactivitymanagerd kwin iso-codes milou plasma-integration
  qt6-wayland xorg-server-xwayland qt6-tools kf6-kquickcharts kirigami-addons"
-short_desc="KDE Window manager"
+short_desc="KDE Window manager kpipewire"
 maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later, GFDL-1.2-or-later, LGPL-2.1-or-later"
 homepage="https://invent.kde.org/plasma/plasma-workspace"


### PR DESCRIPTION
used by the org.kde.plasma.cameraindicator plasmoid

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**|**briefly**|**NO**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
