### PR TITLE
Revert "python3-pystache: remove package", update to 0.6.7.

### DIFF
--- a/srcpkgs/python3-pystache/template
+++ b/srcpkgs/python3-pystache/template
@@ -1,0 +1,18 @@
+# Template file for 'python3-pystache'
+pkgname=python3-pystache
+version=0.6.7
+revision=1
+build_style=python3-module
+hostmakedepends="python3-setuptools"
+depends="python3-setuptools"
+short_desc="Python3 implementation of Mustache"
+maintainer="John <me@johnnynator.dev>"
+license="MIT"
+homepage="https://github.com/PennyDreadfulMTG/pystache"
+distfiles="${PYPI_SITE}/p/pystache/pystache-${version}.tar.gz"
+checksum=55d8bb5aac450389369584b1627cecbe9069e13a09471a8fe783c44b64e94d5a
+
+post_install() {
+	vlicense LICENSE
+	ln -s pystache "${DESTDIR}/usr/bin/pystache3"
+}

--- a/srcpkgs/removed-packages/template
+++ b/srcpkgs/removed-packages/template
@@ -1,6 +1,6 @@
 # Template file for 'removed-packages'
 pkgname=removed-packages
-version=0.1.20241213
+version=0.1.20241227
 revision=1
 build_style=meta
 short_desc="Uninstalls packages removed from repository"
@@ -742,7 +742,6 @@ replaces="
  python3-pyside2<=5.15.10_1
  python3-pyside<=5.15.0_2
  python3-pyspotify<=2.1.3_5
- python3-pystache<=0.5.4_8
  python3-sabyenc3<=5.4.4_2
  python3-scikit-video<=1.1.11_6
  python3-shiboken2<=5.15.10_2


### PR DESCRIPTION
This reverts commit c4563fb92874f300a36c16fb85fbb4cceade59f3.

this package was still used by linphone as a buildtime dependency

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
