### PR TITLE
Linphone 5.3.100

### DIFF
--- a/srcpkgs/bcmatroska2/template
+++ b/srcpkgs/bcmatroska2/template
@@ -1,6 +1,6 @@
 # Template file for 'bcmatroska2'
 pkgname=bcmatroska2
-version=5.3.79
+version=5.3.100
 revision=1
 build_style=cmake
 configure_args="-DBUILD_SHARED_LIBS=TRUE"
@@ -10,7 +10,7 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-only"
 homepage="https://gitlab.linphone.org/BC/public/bcmatroska2"
 distfiles="https://gitlab.linphone.org/BC/public/bcmatroska2/-/archive/${version}/bcmatroska2-${version}.tar.gz"
-checksum=3f2cfaa97f6f5d4a22536008c40f0d23f8bc421c166cd59f0253b63c38113a21
+checksum=00339ce5a81ccde6026a5bc5557f6235dd8998c39236090febc5bbb23514314e
 
 bcmatroska2-devel_package() {
 	depends="bcmatroska2-${version}_${revision}"

--- a/srcpkgs/bctoolbox/patches/disable-psa-crypto.patch
+++ b/srcpkgs/bctoolbox/patches/disable-psa-crypto.patch
@@ -1,0 +1,22 @@
+From: Bastian Germann <bage@debian.org>
+Date: Fri, 13 Dec 2024 18:54:55 +0100
+Subject: Disable PSA crypto
+
+---
+ src/crypto/mbedtls.cc | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/crypto/mbedtls.cc b/src/crypto/mbedtls.cc
+index 4bc16d4..5b08c84 100644
+--- a/src/crypto/mbedtls.cc
++++ b/src/crypto/mbedtls.cc
+@@ -33,7 +33,7 @@
+ #include <mbedtls/hkdf.h>                // HKDF implemented in version 2.11.0 of mbedtls
+ #endif
+ 
+-#if MBEDTLS_VERSION_NUMBER >= 0x03060000 // v3.6.0
++#if 0
+                                          // starting from version 3.6, use PSA crypto
+ #include "bctoolbox/logging.h"
+ #include <mutex>
+

--- a/srcpkgs/bctoolbox/template
+++ b/srcpkgs/bctoolbox/template
@@ -1,7 +1,7 @@
 # Template file for 'bctoolbox'
 pkgname=bctoolbox
-version=5.3.79
-revision=2
+version=5.3.100
+revision=1
 build_style=cmake
 configure_args="-DENABLE_TESTS=ON -DENABLE_TESTS_COMPONENT=FALSE
  -DENABLE_STRICT=FALSE -DCMAKE_MODULE_PATH=/usr/lib/cmake
@@ -12,7 +12,7 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-only"
 homepage="https://gitlab.linphone.org/BC/public/bctoolbox"
 distfiles="https://gitlab.linphone.org/BC/public/bctoolbox/-/archive/${version}/bctoolbox-${version}.tar.gz"
-checksum=8293326971b5e7c3b0ef77e4f62653ecaf169af0c82d34acb1e26ff62c4e3801
+checksum=e2ade0baf465423475ae7a14463f74d6d61a7daab4700c8c140f2bb90d257ca8
 
 bctoolbox-devel_package() {
 	depends="bctoolbox-${version}_${revision}"

--- a/srcpkgs/belcard/template
+++ b/srcpkgs/belcard/template
@@ -1,6 +1,6 @@
 # Template file for 'belcard'
 pkgname=belcard
-version=5.3.79
+version=5.3.100
 revision=1
 build_style=cmake
 configure_args="-DBUILD_SHARED_LIBS=TRUE -DENABLE_UNIT_TESTS=FALSE"
@@ -10,7 +10,7 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-3.0-or-later"
 homepage="https://linphone.org"
 distfiles="https://gitlab.linphone.org/BC/public/belcard/-/archive/${version}/belcard-${version}.tar.gz"
-checksum=ffa3f1d513de344566257547018b263eb80d3419e66178f5e542901798023b14
+checksum=98c8f029eabe4fb5ff35288cddca35a26c83ba9edd870b4d15b8b562e2e2967f
 
 belcard-devel_package() {
 	short_desc+=" - development files"

--- a/srcpkgs/belle-sip/template
+++ b/srcpkgs/belle-sip/template
@@ -1,7 +1,7 @@
 # Template file for 'belle-sip'
 pkgname=belle-sip
-version=5.3.79
-revision=2
+version=5.3.100
+revision=1
 build_style=cmake
 configure_args="-DENABLE_STRICT=OFF -DENABLE_UNIT_TESTS=NO -DCMAKE_SKIP_INSTALL_RPATH=ON
  -DCMAKE_MODULE_PATH=/usr/lib/cmake -DBUILD_SHARED_LIBS=TRUE"
@@ -11,7 +11,7 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later"
 homepage="https://www.linphone.org"
 distfiles="https://gitlab.linphone.org/BC/public/belle-sip/-/archive/${version}/belle-sip-${version}.tar.gz"
-checksum=df4a9ee5bb725cafc3fe286548e9475d4b22cdc3aafe0953bc60b45dd002ae61
+checksum=ffe6139f573d14fd8e402e558cd73437612e112195dbc3266fef31ed3d095d87
 
 belle-sip-devel_package() {
 	depends="${sourcepkg}>=${version}_${revision}"

--- a/srcpkgs/belr/template
+++ b/srcpkgs/belr/template
@@ -1,6 +1,6 @@
 # Template file for 'belr'
 pkgname=belr
-version=5.3.79
+version=5.3.100
 revision=1
 build_style=cmake
 configure_args="-DBUILD_SHARED_LIBS=TRUE -DENABLE_UNIT_TESTS=FALSE"
@@ -10,7 +10,7 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-3.0-or-later"
 homepage="https://www.linphone.org"
 distfiles="https://gitlab.linphone.org/BC/public/belr/-/archive/${version}/belr-${version}.tar.gz"
-checksum=16e4d3a309bfec5882a1880797624877bfb0954958c4cb67d62ad460ce14cd1a
+checksum=3f0494e6e7e204f8eb8abc73d2c9305f283a0fe5aea658abe97cbcd3ab6a656e
 
 belr-devel_package() {
 	short_desc+=" - development files"

--- a/srcpkgs/bzrtp/template
+++ b/srcpkgs/bzrtp/template
@@ -1,7 +1,7 @@
 # Template file for 'bzrtp'
 pkgname=bzrtp
-version=5.3.79
-revision=2
+version=5.3.100
+revision=1
 build_style=cmake
 configure_args="-DENABLE_TESTS=FALSE -DBUILD_SHARED_LIBS=TRUE"
 makedepends="bctoolbox-devel mbedtls-devel libxml2-devel bctoolbox-devel sqlite-devel"
@@ -10,7 +10,7 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later"
 homepage="https://www.linphone.org"
 distfiles="https://gitlab.linphone.org/BC/public/bzrtp/-/archive/${version}/bzrtp-${version}.tar.gz"
-checksum=c1f1fec987257953d5c31ef3648a906932ee6a25f8c92d869dd94b41522b235b
+checksum=f7191cd3b50711e5fa6f303f2a80f7ca1b82c94fe14e1f7bd4e356142d9211f6
 
 bzrtp-devel_package() {
 	depends="${makedepends} ${sourcepkg}>=${version}_${revision}"

--- a/srcpkgs/linphone-desktop/template
+++ b/srcpkgs/linphone-desktop/template
@@ -1,7 +1,7 @@
 # Template file for 'linphone-desktop'
 pkgname=linphone-desktop
 version=5.2.6
-revision=3
+revision=4
 build_wrksrc="linphone-app" # The root cmake is glue code for their vendored libs
 build_style=cmake
 cmake_builddir="build-cmake"

--- a/srcpkgs/linphone/template
+++ b/srcpkgs/linphone/template
@@ -1,6 +1,6 @@
 # Template file for 'linphone'
 pkgname=linphone
-version=5.3.79
+version=5.3.100
 revision=1
 build_style="cmake"
 configure_args="-DBUILD_SHARED_LIBS=TRUE
@@ -20,7 +20,7 @@ maintainer="John <me@johnnynator.dev>"
 license="AGPL-3.0-or-later"
 homepage="https://www.linphone.org"
 distfiles="https://gitlab.linphone.org/BC/public/liblinphone/-/archive/${version}/liblinphone-${version}.tar.gz"
-checksum=d0351d454f5bee69d1c88e956a25c539782595a815070b59d965c3a6945e0de3
+checksum=1b467d87aa8ec5e45e11419d4522d860ca7ac7dc8fc4cf0300b450187e9a5a59
 
 pre_build() {
 	echo "#define MS2_GIT_VERSION=unknown" > coreapi/gitversion.h

--- a/srcpkgs/mediastreamer/template
+++ b/srcpkgs/mediastreamer/template
@@ -1,7 +1,7 @@
 # Template file for 'mediastreamer'
 pkgname=mediastreamer
-version=5.3.79
-revision=2
+version=5.3.100
+revision=1
 build_style=cmake
 configure_args="-DENABLE_STRICT=0 -DENABLE_UNIT_TESTS=0 -DBUILD_SHARED_LIBS=TRUE
  -DENABLE_QT_GL=TRUE"
@@ -15,7 +15,7 @@ maintainer="John <me@johnnynator.dev>"
 license="AGPL-3.0-or-later"
 homepage="https://www.linphone.org/technical-corner/mediastreamer2"
 distfiles="https://gitlab.linphone.org/BC/public/mediastreamer2/-/archive/${version}/mediastreamer2-${version}.tar.gz"
-checksum=05fbdb71f4ad309458a20a93172451f0c6c26260107f6f5d60da2481f2711cc4
+checksum=0c2327b1c9c43ef94bda0d3509744f84b4e2c33e462221cd4ced550f1a539e95
 
 post_install() {
 	vlicense LICENSE.txt

--- a/srcpkgs/ortp/template
+++ b/srcpkgs/ortp/template
@@ -1,6 +1,6 @@
 # Template file for 'ortp'
 pkgname=ortp
-version=5.3.79
+version=5.3.100
 revision=1
 build_style=cmake
 configure_args="-DBUILD_SHARED_LIBS=TRUE -DENABLE_UNIT_TESTS=OFF"
@@ -10,7 +10,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://www.linphone.org/technical-corner/ortp"
 distfiles="https://gitlab.linphone.org/BC/public/ortp/-/archive/${version}/ortp-${version}.tar.gz"
-checksum=0444cd7a9e2d77e6fa3c0421b607e6afd73e37122f674e945de039b1637d06a8
+checksum=c2b7aa0e6aef62cfab90ae934f607c9bc6d12661cc59e79e2272778666357740
 
 ortp-devel_package() {
 	depends="bctoolbox-devel ortp-${version}_${revision}"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

mediastreamer still not compatible with ffmpeg6 :(

#### Testing the changes
- I tested the changes in this PR: **YES**|**briefly**|**NO**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
