### PR TITLE
cmusfm: update to 0.5.0

### DIFF
--- a/srcpkgs/cmusfm/template
+++ b/srcpkgs/cmusfm/template
@@ -1,7 +1,7 @@
 # Template file for 'cmusfm'
 pkgname=cmusfm
-version=0.4.1
-revision=2
+version=0.5.0
+revision=1
 build_style=gnu-configure
 configure_args="--enable-libnotify"
 hostmakedepends="automake pkg-config"
@@ -11,7 +11,7 @@ maintainer="Arvin Ignaci <arvin.ignaci@gmail.com>"
 license="GPL-3.0-or-later"
 homepage="https://github.com/Arkq/cmusfm"
 distfiles="${homepage}/archive/v${version}.tar.gz"
-checksum=ff5338d4b473a3e295f3ae4273fb097c0f79c42e3d803eefdf372b51dba606f2
+checksum=17aae8fc805e79b367053ad170854edceee5f4c51a9880200d193db9862d8363
 
 pre_configure() {
 	autoreconf --install


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: YES

#### Local build testing
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-glibc
  - x86_64-musl (cross)
  - aarch64 (cross)
  - aarch64-musl (cross)
