### PR TITLE
streamlink: update to 7.1.1

### DIFF
--- a/srcpkgs/streamlink/template
+++ b/srcpkgs/streamlink/template
@@ -1,12 +1,12 @@
 # Template file for 'streamlink'
 pkgname=streamlink
-version=7.0.0
-revision=2
+version=7.1.1
+revision=1
 build_style=python3-pep517
 hostmakedepends="python3-wheel python3-versioningit"
 depends="python3-lxml python3-pycryptodome python3-pycountry
  python3-pysocks python3-requests python3-websocket-client python3-isodate
- python3-urllib3 python3-certifi python3-typing_extensions python3-trio python3-trio-websocket"
+ python3-urllib3 python3-certifi python3-trio python3-trio-websocket"
 checkdepends="$depends python3-pytest python3-requests-mock python3-pytest-trio python3-freezegun"
 short_desc="Utility extracting streams from services, forked from livestreamer"
 maintainer="Tom Strausbaugh <tstrausbaugh@straustech.net>"
@@ -14,7 +14,7 @@ license="BSD-2-Clause"
 homepage="https://streamlink.github.io/"
 changelog="https://raw.githubusercontent.com/streamlink/streamlink/master/CHANGELOG.md"
 distfiles="https://github.com/streamlink/streamlink/releases/download/$version/streamlink-$version.tar.gz"
-checksum=51a4062862e6795d694046ca6e70549d6d13583c640d1505966804b0e03feff2
+checksum=c1881ed0bba53612d979d9a918b7dec056fc93cd202a5b07a080e5568dbdab4c
 make_check_pre="env PYTHONPATH=src"
 
 post_install() {


### PR DESCRIPTION
Version bump. Did not see any major/breaking changes in the release notes. The one thing I did see is they removed the typing extensions dependency. I tested and it works fine.

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl
  - aarch64
  - aarch64-musl
