### PR TITLE
elinks: update to 0.18.0, adopt

### DIFF
--- a/srcpkgs/elinks/template
+++ b/srcpkgs/elinks/template
@@ -1,6 +1,6 @@
 # Template file for 'elinks'
 pkgname=elinks
-version=0.17.1.1
+version=0.18.0
 revision=1
 build_style=gnu-configure
 configure_args="--enable-true-color --enable-fastmem --without-spidermonkey"
@@ -8,12 +8,12 @@ hostmakedepends="automake libtool pkg-config gettext"
 makedepends="gpm-devel zlib-devel bzip2-devel libidn-devel tre-devel
  ncurses-devel openssl-devel"
 short_desc="Full-Featured Text WWW Browser"
-maintainer="Orphaned <orphan@voidlinux.org>"
+maintainer="Saksham <voidisnull@duck.com>"
 license="GPL-2.0-only"
 homepage="https://github.com/rkd77/elinks"
 changelog="https://raw.githubusercontent.com/rkd77/elinks/master/NEWS"
 distfiles="https://github.com/rkd77/elinks/archive/v${version}.tar.gz"
-checksum=d8e7eaff3d47e65c9a01a7a9d865eb21f773713801ae715475c27f77af76a280
+checksum=b4200c17dfe5574daddeceda69a42ef8f2459fc43e92cac73dcf30c3343c95a5
 # ld: no input files
 disable_parallel_build=yes
 


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**


#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures:
  - x86_64-musl
