### PR TITLE
tealdeer: add alternative symlink for fish completions

### DIFF
--- a/srcpkgs/tealdeer/template
+++ b/srcpkgs/tealdeer/template
@@ -1,7 +1,7 @@
 # Template file for 'tealdeer'
 pkgname=tealdeer
 version=1.7.1
-revision=1
+revision=2
 # uses rustls/ring
 archs="x86_64* aarch64* i686* armv[67]*"
 build_style=cargo
@@ -12,7 +12,9 @@ homepage="https://github.com/dbrgn/tealdeer"
 changelog="https://raw.githubusercontent.com/dbrgn/tealdeer/main/CHANGELOG.md"
 distfiles="https://github.com/dbrgn/tealdeer/archive/refs/tags/v${version}.tar.gz"
 checksum=2b10e141774d2a50d25a1d3ca3d911dedc0e1313366ce0a364068c7a686300d8
-alternatives="tldr:/usr/bin/tldr:/usr/bin/tealdeer"
+alternatives="
+ tldr:tldr:/usr/bin/tealdeer
+ tldr:tldr.fish:/usr/share/fish/vendor_completions.d/tealdeer.fish"
 
 post_install() {
 	vlicense LICENSE-MIT

--- a/srcpkgs/tldr/template
+++ b/srcpkgs/tldr/template
@@ -1,7 +1,7 @@
 # Template file for 'tldr'
 pkgname=tldr
 version=1.0.0.alpha
-revision=4
+revision=5
 _version=${version/.alpha/-alpha}
 build_style=go
 go_import_path="github.com/isacikgoz/tldr"
@@ -14,7 +14,6 @@ homepage="https://isacikgoz.me/tldr/"
 distfiles="https://github.com/isacikgoz/tldr/archive/v${_version}.tar.gz"
 checksum=d40e1c602d84acc67cdee3b9bed001fb8ec198c7049c1d05eb071ab05af66c19
 alternatives="tldr:tldr:/usr/bin/gtldr"
-conflicts="tealdeer<=1.2.0_1"
 
 post_install() {
 	mv ${DESTDIR}/usr/bin/tldr ${DESTDIR}/usr/bin/gtldr


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

Without this, fish shell doesn't automatically load completions for the `tldr` symlink.

#### Testing the changes
- I tested the changes in this PR: **YES**

cc @filiprojek

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
