### PR TITLE
New targetcli

### DIFF
--- a/srcpkgs/targetcli-fb/template
+++ b/srcpkgs/targetcli-fb/template
@@ -1,17 +1,17 @@
 # Template file for 'targetcli-fb'
 pkgname=targetcli-fb
-version=2.1.54
-revision=5
-build_style=python3-module
-hostmakedepends="python3-setuptools"
+version=3.0.1
+revision=1
+build_style=python3-pep517
+hostmakedepends="hatchling hatch-vcs"
 depends="configshell-fb python3-six rtslib-fb python3-parsing python3-gobject"
 checkdepends="$depends"
 short_desc="CLI for configuring the LIO generic SCSI target"
 maintainer="Toyam Cox <Vaelatern@voidlinux.org>"
 license="Apache-2.0"
 homepage="https://github.com/open-iscsi/targetcli-fb"
-distfiles="https://github.com/open-iscsi/targetcli-fb/archive/v${version}.tar.gz"
-checksum=7ae4120a54f24b13263b4b85c43952a03546f8b9fc9bd15fe87678f68245a33f
+distfiles="${PYPI_SITE}/t/targetcli/targetcli-${version}.tar.gz"
+checksum=f50223ec1d429024a790e6792f8df22f88dcd1e1d07acbb7c78399097f48cb9d
 make_dirs="
 	/etc/target 0755 root root
 	/etc/target/backup 0755 root root"


### PR DESCRIPTION
Ok so the targetcli is incorrect because it's a dev release.

The configshell though is right and I'm testing it on one of my iscsi target machines (currently in dev, suddenly to become load bearing...).

Configshell fixes a Python 3.11 incompatibility.

rtslib-fb also needs a bump but it can't be built right now because it's not published to pypi. It also seems to operate just fine for now.