### PR TITLE
cmake: update to 3.31.3

### DIFF
--- a/srcpkgs/cmake/template
+++ b/srcpkgs/cmake/template
@@ -1,6 +1,6 @@
 # Template file for 'cmake'
 pkgname=cmake
-version=3.30.1
+version=3.31.3
 revision=1
 build_style=cmake
 configure_args="-DCMAKE_DOC_DIR=/share/doc/cmake
@@ -17,7 +17,7 @@ maintainer="Đoàn Trần Công Danh <congdanhqx@gmail.com>"
 license="BSD-3-Clause, ICU"
 homepage="https://www.cmake.org"
 distfiles="https://www.cmake.org/files/v${version%.*}/${pkgname}-${version}.tar.gz"
-checksum=df9b3c53e3ce84c3c1b7c253e5ceff7d8d1f084ff0673d048f260e04ccb346e1
+checksum=fac45bc6d410b49b3113ab866074888d6c9e9dc81a141874446eb239ac38cb87
 
 if [ "$XBPS_TARGET_LIBC" = musl ]; then
 	configure_args+=" -DCMake_NO_SELF_BACKTRACE=1"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**
- a warning with FetchContent that shows with the previous cmake 3.30 version no longer shows. I've tested with CPM and a lot of dependencies and includes and it seems to work fine.

#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC) x86-84, libc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - none

