### PR TITLE
urlwatch: update to 2.29

### DIFF
--- a/srcpkgs/python3-minidb/template
+++ b/srcpkgs/python3-minidb/template
@@ -1,18 +1,18 @@
 # Template file for 'python3-minidb'
 pkgname=python3-minidb
-version=2.0.6
-revision=4
+version=2.0.8
+revision=1
 build_style=python3-module
 hostmakedepends="python3-setuptools"
 depends="python3"
+checkdepends="python3-pytest"
 short_desc="Simple SQLite3 store for Python objects"
-maintainer="Orphaned <orphan@voidlinux.org>"
+maintainer="RunningDroid <runningdroid@zoho.com>"
 license="ISC"
 homepage="https://thp.io/2010/minidb/"
 distfiles="https://github.com/thp/minidb/archive/${version}.tar.gz"
-checksum=7e4ef07d858d6e6118dfd000031e7698fb29b44bd8fe38e713d241fcaec6ee1e
+checksum=f177870a9f44ff834aa7986ebb9451445a5afa8e756ab400c16ea1d746441aaf
 
 post_install() {
-	sed -n '/# Copyright/,/OF THIS SOFTWARE./p' minidb.py > COPYING
-	vlicense COPYING
+	vlicense LICENSE
 }

--- a/srcpkgs/urlwatch/template
+++ b/srcpkgs/urlwatch/template
@@ -1,25 +1,25 @@
 # Template file for 'urlwatch'
 pkgname=urlwatch
-version=2.28
-revision=3
+version=2.29
+revision=1
 build_style=python3-module
 # skip the tests that require python modules that aren't packaged
 # (pdftotext & pytesseract)
 make_check_args="-k not((pdf)or(ocr))"
 hostmakedepends="python3-setuptools"
-depends="python3-appdirs python3-keyring python3-minidb python3-requests
+depends="python3-platformdirs python3-keyring python3-minidb python3-requests
  python3-yaml python3-lxml python3-cssselect"
 # Check the Docs for optional packages:
 # https://urlwatch.readthedocs.io/en/latest/dependencies.html#optional-packages
 checkdepends="python3-pytest python3-pycodestyle python3-docutils
- python3-jq ${depends}"
+ python3-jq python3-Pygments ${depends}"
 short_desc="Tool for monitoring webpages for updates"
 maintainer="RunningDroid <runningdroid@zoho.com>"
 license="BSD-3-Clause"
 homepage="https://thp.io/2008/urlwatch/"
 changelog="https://raw.githubusercontent.com/thp/urlwatch/master/CHANGELOG.md"
 distfiles="${PYPI_SITE}/u/urlwatch/urlwatch-${version}.tar.gz"
-checksum=911df3abbd8923e46ec167a9657a812436caf93f7f9917cb7c95ebd73d28cce5
+checksum=f317ca8b123b15af510ec9e08bf885d8a8b574f502253e5ded200d757366da98
 
 post_install() {
 	vlicense COPYING


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

This PR updates `python3-minidb` as well to fix the test added because of this bug: thp/urlwatch#779

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
