### PR TITLE
New package: trippy-0.12.1

### DIFF
--- a/srcpkgs/trippy/INSTALL
+++ b/srcpkgs/trippy/INSTALL
@@ -1,0 +1,5 @@
+case "${ACTION}" in
+post)
+	setcap CAP_NET_RAW+ep usr/bin/trip
+	;;
+esac

--- a/srcpkgs/trippy/template
+++ b/srcpkgs/trippy/template
@@ -1,0 +1,13 @@
+# Template file for 'trippy'
+pkgname=trippy
+version=0.12.1
+revision=1
+build_style=cargo
+make_install_args="--path=crates/trippy"
+short_desc="Tool to assist with analysis of networking issues"
+maintainer="icp <pangolin@vivaldi.net>"
+license="Apache-2.0"
+homepage="https://trippy.rs/"
+changelog="https://raw.githubusercontent.com/fujiapple852/trippy/refs/heads/master/RELEASES.md"
+distfiles="https://github.com/fujiapple852/trippy/archive/refs/tags/${version}.tar.gz"
+checksum=ae868123cba03977786f0dd74297f2e15e021d753684bd6e47554003f03a3d5b


### PR DESCRIPTION
#### Description
[Trippy](https://trippy.rs/) combines the functionality of traceroute and ping and is designed to assist with the analysis of networking issues.

#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

#### Local build testing
- I built this PR locally for my native architecture: **x86_64**