### PR TITLE
xonotic: allow cross-compilation

### DIFF
--- a/srcpkgs/xonotic/template
+++ b/srcpkgs/xonotic/template
@@ -1,7 +1,7 @@
 # Template file for 'xonotic'
 pkgname=xonotic
 version=0.8.6
-revision=2
+revision=3
 hostmakedepends="unzip automake libtool"
 makedepends="gmp-devel MesaLib-devel SDL2-devel libcurl-devel alsa-lib-devel
  libmodplug-devel libvorbis-devel libXpm-devel libjpeg-turbo-devel
@@ -13,7 +13,6 @@ license="GPL-2.0-or-later, BSD-3-Clause"
 homepage="http://xonotic.org"
 distfiles="https://dl.xonotic.org/xonotic-${version}-source.zip"
 checksum=8b92ac781cff4ae89c121a23eacd7dec05a2aabedaccc23a19d1a0958b4012a8
-nocross=yes
 
 do_build() {
 	local target
@@ -25,6 +24,8 @@ do_build() {
 	esac
 	echo $make_build_args
 	cd source/darkplaces
+	sed -i makefile \
+		-e "s;DP_MACHINE:=.*;DP_MACHINE:=${XBPS_TARGET_MACHINE/-musl};"
 	# Inject our $CFLAGS and $LDFLAGS
 	sed -i makefile.inc \
 		-e "s;^\(CPUOPTIMIZATIONS\)?=\(.*\);\1=${CFLAGS} \2;" \
@@ -35,7 +36,7 @@ do_build() {
 
 	cd ${wrksrc}/source/d0_blind_id
 	autoreconf -fi
-	./configure --prefix=/usr --disable-rijndael
+	./configure --prefix=/usr --disable-rijndael --host=$(uname -m)
 	make ${makejobs}
 }
 


### PR DESCRIPTION
sources/darkplaces/makefile checks arch with `uname -m`, which gives host arch, not target one, and then applies some AMD64-exclusive flags if it's compiled on AMD64, which causes breaks.


<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **NO** (only building)

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, amd64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-glibc

