### PR TITLE
prosody: update to 0.12.5.

### DIFF
--- a/srcpkgs/prosody/template
+++ b/srcpkgs/prosody/template
@@ -1,6 +1,6 @@
 # Template file for 'prosody'
 pkgname=prosody
-version=0.12.4
+version=0.12.5
 revision=1
 build_style=configure
 configure_args="
@@ -27,7 +27,7 @@ license="MIT"
 homepage="https://prosody.im/"
 changelog="https://prosody.im/doc/release/${version}"
 distfiles="https://prosody.im/downloads/source/${pkgname}-${version}.tar.gz"
-checksum=47d712273c2f29558c412f6cdaec073260bbc26b7dda243db580330183d65856
+checksum=778fb7707a0f10399595ba7ab9c66dd2a2288c0ae3a7fe4ab78f97d462bd399f
 
 system_accounts="prosody"
 prosody_homedir="/var/lib/prosody"


### PR DESCRIPTION
- **New package: lua54-say-1.4.1**
- **New package: lua54-assert-1.9.0**
- **New package: lua54-cliargs-3.0.2**
- **New package: lua54-dkjson-2.8**
- **New package: lua54-mediator-1.1.2**
- **New package: lua54-penlight-1.14.0**
- **New package: lua54-system-0.4.5**
- **New package: lua54-term-0.8**
- **New package: busted-2.2.0**
- **prosody: update to 0.12.5.**

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)

Built on x86_64-glibc for aarch64-musl and tested correctly. 
Server comes up and I can chat with folks

Opening it now ~~to have an open PR on January 1st~~ because it uses
some work from PR #51222. So I want to signal that these 2 PRs use
the same technique (luarocks) for packaging some dependencies.

If the busted package was to not be added then this PR would be much
much smaller, just prosody. But this might be a good time to start
testing the prosody package (and whatever other lua packages that may
want to use busted (but not busted dependencies. Not sure that's a good
idea))
