### PR TITLE
New package: rofi-wayland-1.7.5+wayland3

### DIFF
--- a/srcpkgs/rofi-wayland/template
+++ b/srcpkgs/rofi-wayland/template
@@ -1,0 +1,25 @@
+# Template file for 'rofi-wayland'
+# adapted from rofi template file
+pkgname=rofi-wayland
+version=1.7.5+wayland3
+revision=1
+archs="x86_64"
+build_style=meson
+hostmakedepends="autoconf automake flex glib-devel pkg-config which"
+makedepends="libXinerama-devel librsvg-devel
+ libxkbcommon-devel pango-devel startup-notification-devel
+ xcb-util-wm-devel xcb-util-xrm-devel xcb-util-cursor-devel
+ wayland-protocols wayland-devel"
+depends="wayland"
+short_desc="Window switcher, run dialog and dmenu replacement"
+maintainer="revsuine <pid1@revsuine.xyz>"
+license="MIT"
+homepage="https://github.com/lbonn/rofi"
+changelog="${homepage}/releases"
+distfiles="${homepage}/releases/download/${version}/rofi-${version}.tar.xz"
+checksum=fc427e89fd8a4c45fa96294594b3c1093a6a5596c1e1098e18ce9f3aa09eb187
+conflicts="rofi"
+
+post_install() {
+	vlicense COPYING
+}


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc

Fork of Rofi with Wayland support.

Architecture note: I'm not sure if the project only supports x86_86-glibc or if this is just a build error on my part, but I tried building for armv6l and x86_64-musl and both times got

```
Program flex found: YES (/usr/bin/flex)
Program bison found: YES (/usr/bin/bison)
Program wayland-scanner found: NO

meson.build:290:22: ERROR: Program 'wayland-scanner' not found or not executable
```

Before exiting and failing to build. My understanding is that `wayland-scanner` should be provided by `wayland-devel`, and I get

```
Program flex found: YES (/usr/bin/flex)
Program bison found: YES (/usr/bin/bison)
Program wayland-scanner found: YES (/usr/bin/wayland-scanner)
Dependency gio-2.0 found: YES 2.82.1 (cached)
Program /usr/bin/glib-compile-resources found: YES (/usr/bin/glib-compile-resources)
Program go-md2man found: NO
Configuring rofi.doxy using configuration
Program doxygen found: NO
Program cppcheck found: NO
Program ohcount found: NO
Build targets in project: 43
```

when building for x86_64.

So I have set `archs="x86_64"`, but someone can suggest a way to get it to build on other archs that would be good. Or perhaps my error is not reproducible and it's something with my system, in which case the `archs` line can be removed too.