### PR TITLE
Update run permission diring db creation

### DIFF
--- a/srcpkgs/postgresql16/files/postgresql16/run
+++ b/srcpkgs/postgresql16/files/postgresql16/run
@@ -14,6 +14,7 @@ if [ ! -d "$PGDATA" ]; then
 
 	mkdir -p "$PGDATA" || exit 1
 	chown -R postgres:postgres "$PGDATA"
+	chown -R postgres:postgres /tmp
 	chmod 0700 "$PGDATA"
 	su - postgres -c "/@PREFIX@/bin/initdb $INITOPTS -D '$PGDATA'" 2>&1 || {
 		rm -fr "$PGDATA"


### PR DESCRIPTION
Fix permissions in `/tmp` folder to prevent initialization timeout for PostgreSQL

This change resolves an issue where PostgreSQL initialization fails with the following error:
"down: postgresql16: 0s, normally up, want up; run: log: (pid 1234) 23s"

# Testing the changes
####    Was this tested? YES
-  This is a minor fix, and it has been verified to address the issue.
-  Security note: Permissions in `/tmp` can be sensitive; please review this commit to ensure it complies with your security policies.