### PR TITLE
lua54-luarepl: fix cross compiled binary

### DIFF
--- a/srcpkgs/lua54-luarepl/template
+++ b/srcpkgs/lua54-luarepl/template
@@ -1,11 +1,12 @@
 # Template file for 'lua54-luarepl'
 pkgname=lua54-luarepl
 version=0.10
-revision=1
+revision=2
 build_style=meta
 hostmakedepends="lua51 lua52 lua53 lua54 luarocks-lua54"
 depends="lua54"
-short_desc="Reusable REPL component for Lua, written in Lua"
+_desc="Reusable REPL component for Lua, written in Lua"
+short_desc="${_desc} (5.4.x)"
 maintainer="Luciogi <githubvoidlinux.supremacy429@passinbox.com>"
 license="MIT"
 homepage="https://github.com/hoelzro/lua-repl"
@@ -17,37 +18,36 @@ _rocksrel=1
 _package() {
 	luarocks --lua-version="$1" --tree="${PKGDESTDIR}/usr/" \
 		make --deps-mode=none --no-manifest "${_rockname}-${version}-${_rocksrel}.rockspec"
-		echo /destdir/${pkgname}-${version}
-		sed -i -e "s|/destdir/${pkgname}-${version}||" "${PKGDESTDIR}/usr/bin/rep.lua"
+		vsed -i "${PKGDESTDIR}/usr/bin/rep.lua" -e "s|$(realpath "${PKGDESTDIR}")||g"
 		mv "${PKGDESTDIR}/usr/bin/rep.lua" "${PKGDESTDIR}/usr/bin/rep.lua${1/./}"
+		vlicense COPYING
 }
 
 do_install() {
 	_package 5.4
-	sed -i -e "s|lua5\.3|lua5\.4|" "${PKGDESTDIR}/usr/bin/rep.lua54"
-	vlicense COPYING
+	vsed -i "${PKGDESTDIR}/usr/bin/rep.lua54" -e "s|lua5\.3|lua5\.4|"
 }
 
 lua53-luarepl_package() {
 	depends="lua53"
+	short_desc="${_desc} (5.3.x)"
 	pkg_install() {
 		_package 5.3
-		vlicense COPYING
 	}
 }
 
 lua52-luarepl_package() {
 	depends="lua52"
+	short_desc="${_desc} (5.2.x)"
 	pkg_install() {
 		_package 5.2
-		vlicense COPYING
 	}
 }
 
 lua51-luarepl_package() {
 	depends="lua51"
+	short_desc="${_desc} (5.1.x)"
 	pkg_install() {
 		_package 5.1
-		vlicense COPYING
 	}
 }


### PR DESCRIPTION
When cross compiling the path in /usr/bin/repl.lua contains the target
arch in the destdir path, which must be replaced differently than the
others.

Aside from that, added lua version to the package and sub packages
descriptions, as well as switched to vsed to catch this next time. And
move vlicense in _package.

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl (crossbuilt)
