### PR TITLE
runit-void: load apparmor profiles from symlinks in /etc/apparmor.d

### DIFF
--- a/srcpkgs/runit-void/files/09-apparmor.sh
+++ b/srcpkgs/runit-void/files/09-apparmor.sh
@@ -18,7 +18,7 @@ if [ -n "$APPARMOR" ]; then
 	[ "$APPARMOR" = "complain" ] && AACOMPLAIN="-C"
 
 	if [ -d /etc/apparmor.d -a -x /usr/bin/apparmor_parser ]; then
-		apparmor_parser -a $AACOMPLAIN $(find /etc/apparmor.d -maxdepth 1 -type f ! -name '*.new-*_*')
+		find -L /etc/apparmor.d -maxdepth 1 -type f ! -name '*.new-*_*' -exec apparmor_parser -a $AACOMPLAIN -- {} +
 	else
 		printf '! AppArmor installation problem - ensure you have installed apparmor package\n'
 	fi

--- a/srcpkgs/runit-void/template
+++ b/srcpkgs/runit-void/template
@@ -1,7 +1,7 @@
 # Template file for 'runit-void'
 pkgname=runit-void
 version=20250212
-revision=1
+revision=2
 build_style=gnu-makefile
 short_desc="Void Linux runit scripts"
 maintainer="Enno Boland <gottox@voidlinux.org>"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

Fixes: the existing script doesn't load apparmor profiles from symlinks, so eg. if you symlink to one of the /usr/share/apparmor/extra-profiles/, that will be silently skipped

This also doesn't rely on shell whitespace splitting (ot that there should be whitespace anywhere in these filenames anyway)