### PR TITLE
fish-shell: Update to 4.0b1

### DIFF
--- a/srcpkgs/fish-shell/template
+++ b/srcpkgs/fish-shell/template
@@ -1,10 +1,12 @@
 # Template file for 'fish-shell'
 pkgname=fish-shell
-version=3.7.1
+version=4.0b1
 revision=1
 build_style=cmake
-hostmakedepends="gettext"
-makedepends="ncurses-devel pcre2-devel"
+build_helper="rust"
+hostmakedepends="rust cargo gettext pcre2-devel"
+configure_args="-DCMAKE_BUILD_TYPE=Release"
+makedepends="rust-std pcre2-devel"
 checkdepends="python3-pexpect procps-ng"
 short_desc="User friendly shell intended mostly for interactive use"
 maintainer="Orphaned <orphan@voidlinux.org>"
@@ -12,7 +14,7 @@ license="GPL-2.0-only"
 homepage="https://fishshell.com/"
 changelog="https://github.com/fish-shell/fish-shell/raw/master/CHANGELOG.rst"
 distfiles="https://github.com/fish-shell/fish-shell/releases/download/${version}/fish-${version}.tar.xz"
-checksum=614c9f5643cd0799df391395fa6bbc3649427bb839722ce3b114d3bbc1a3b250
+checksum=534334e10f85722214e9daff82a57cc3501235523f16f8f131c2344e4ec98da7
 register_shell="/bin/fish /usr/bin/fish"
 # tests don't work as root
 make_check=ci-skip


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

Adding this as a draft because I wanted to use fish 4.0b1 to get around a fish fzf focus bug, and noticed that fish-shell is currently orphaned. This works, I've built and run on both a x86_64 glibc and musl machine. 
Of course I'm not asking to merge a beta version of fish-shell, I'm just new to void packages, so this might just have incorrect build dependency setup and I'd love any feedback on things before fish v4 releases.

To explain the changes- Fish v4 has moved to Rust, but still uses CMake for build at the moment. There's also a note on the distributors section that notes
> fish no longer depends on the ncurses library, but still uses a terminfo database. When packaging fish, please add a dependency on the package containing your terminfo database instead of curses.

so I've removed the ncurses dependency- I couldn't find any packages in void-packages that noted a terminfo dependency though, so I haven't included that. I may have just been searching for the wrong thing though, please let me know if there's something I should be doing!

Current release notes are here: https://fishshell.com/docs/4.0b1/relnotes.html#fish-4-0b1-released-december-17-2024

I'm more than happy to take over maintenance for fish-shell, but at the moment I'm pretty inexperienced with packaging!

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-musl, x86_64-glibc)
<!--
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
