### PR TITLE
corectrl: update to 1.4.3

### DIFF
--- a/srcpkgs/corectrl/template
+++ b/srcpkgs/corectrl/template
@@ -1,6 +1,6 @@
 # Template file for 'corectrl'
 pkgname=corectrl
-version=1.4.1
+version=1.4.3
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF" # requires https://github.com/rollbear/trompeloeil which isn't packaged
@@ -16,4 +16,4 @@ license="GPL-3.0-or-later"
 homepage="https://gitlab.com/corectrl/corectrl"
 changelog="https://gitlab.com/corectrl/corectrl/-/raw/master/CHANGELOG.md"
 distfiles="https://gitlab.com/corectrl/corectrl/-/archive/v${version}/corectrl-v${version}.tar.gz"
-checksum="dec3471142884e1940daa85bec7dbd4df1bc5a33cf1c523048031d4916fa9acd"
+checksum="33e5ab55eff77868a0fdf34d3a0d2b434ff7defd03e2997a2d36eae82230c7f4"


### PR DESCRIPTION
Just a version bump. Although I was able to build for x86_64, aarch64, and aarch64-musl but x86_64-musl would not build with this error.
```

CMake Error: AUTOMOC for target corectrl_lib: Test run of "moc" executable "/usr/x86_64-linux-musl/usr/lib/qt5/bin/moc" failed.
/usr/x86_64-linux-musl/usr/lib/qt5/bin/moc -h

no such file or directory
CMake Generate step failed.  Build files cannot be regenerated correctly.
=> ERROR: corectrl-1.4.3_1: do_configure: 'CFLAGS="-DNDEBUG ${CFLAGS/ -pipe / }" CXXFLAGS="-DNDEBUG ${CXXFLAGS/ -pipe / }" cmake ${cmake_args} ${configure_args} ${LIBS:+-DCMAKE_C_STANDARD_LIBRARIES="$LIBS"} ${LIBS:+-DCMAKE_CXX_STANDARD_LIBRARIES="$LIBS"} ${wrksrc}/${build_wrksrc}' exited with 1
=> ERROR:   in do_configure() at common/build-style/cmake.sh:77
```

I was able to run the application fine on x86_64.

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64
  - aarch64-musl
