### PR TITLE
onefetch: update to 2.23.1, adopt

### DIFF
--- a/srcpkgs/onefetch/template
+++ b/srcpkgs/onefetch/template
@@ -1,6 +1,6 @@
 # Template file for 'onefetch'
 pkgname=onefetch
-version=2.22.0
+version=2.23.1
 revision=1
 build_style=cargo
 build_helper=qemu
@@ -9,12 +9,12 @@ hostmakedepends="pkg-config"
 makedepends="zlib-devel libzstd-devel"
 checkdepends="git"
 short_desc="Git repository summary on your terminal"
-maintainer="Orphaned <orphan@voidlinux.org>"
+maintainer="Saksham <voidisnull@duck.com>"
 license="MIT"
 homepage="https://onefetch.dev"
 changelog="https://github.com/o2sh/onefetch/raw/main/CHANGELOG.md"
 distfiles="https://github.com/o2sh/onefetch/archive/refs/tags/${version}.tar.gz"
-checksum=1741516c628bb70b432285aa78439c4acfeb5df19e48b8d85dba5f71336e190b
+checksum=72e87f6a62682ad88aa07b02815ee1e2863fe45e04df3bba49026bf3edd10537
 
 if [ "$XBPS_TARGET_ENDIAN" = "be" ]; then
 	broken="exr crate unimplemented for BE"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures:
  - x86_64-musl
