### PR TITLE
helix: update to 25.01

### DIFF
--- a/srcpkgs/helix/template
+++ b/srcpkgs/helix/template
@@ -1,7 +1,7 @@
 # Template file for 'helix'
 pkgname=helix
-version=24.07
-revision=2
+version=25.01
+revision=1
 build_style=cargo
 make_install_args="--path helix-term"
 short_desc="Post-modern modal text editor"
@@ -10,7 +10,7 @@ license="MPL-2.0"
 homepage="https://helix-editor.com/"
 changelog="https://raw.githubusercontent.com/helix-editor/helix/master/CHANGELOG.md"
 distfiles="https://github.com/helix-editor/helix/releases/download/${version}/helix-${version}-source.tar.xz"
-checksum=44d9eb113a54a80a2891ac6374c74bcd2bce63d317f1e1c69c286a6fc919922c
+checksum=922fba301e1a3d9b933a445ab2d306cffcd689d678ecd06f00870cfc874cffb8
 
 case "$XBPS_TARGET_MACHINE" in
 	ppc64*) ;;


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
