### PR TITLE
font-cozette: update to 1.26.0

### DIFF
--- a/srcpkgs/font-cozette/template
+++ b/srcpkgs/font-cozette/template
@@ -1,6 +1,6 @@
 # Template file for 'font-cozette'
 pkgname=font-cozette
-version=1.23.2
+version=1.26.0
 revision=1
 create_wrksrc=yes
 hostmakedepends="font-util bdftopcf"
@@ -11,7 +11,7 @@ license="MIT"
 homepage="https://github.com/slavfox/Cozette"
 changelog="https://github.com/slavfox/Cozette/raw/master/CHANGELOG.md"
 distfiles="https://github.com/slavfox/Cozette/releases/download/v.${version}/CozetteFonts-v-${version//./-}.zip"
-checksum=88428fabfb47bed97878e485d6dd22023bed8bd3ca0f4aea5bf11b8d4473b748
+checksum=0f1582d475afc685c82184e49a67d78907fa2137a51b73ea99aaa5fb54c27b54
 font_dirs="/usr/share/fonts/misc /usr/share/fonts/TTF"
 
 do_install() {


### PR DESCRIPTION
Primarily version bump. I had no issues compiling and tested in XFCE terminal.

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl
  - aarch64
  - aarch64-musl
