### PR TITLE
blender: fixes broken assets

### DIFF
--- a/srcpkgs/blender/template
+++ b/srcpkgs/blender/template
@@ -14,7 +14,7 @@ configure_args="-DWITH_INSTALL_PORTABLE=OFF -DWITH_PYTHON_INSTALL=OFF
  -DWITH_BUILDINFO=OFF -DPYTHON_VERSION=${py3_ver} -DPYTHON_LIBPATH=/usr/lib
  -DPYTHON_LIBRARY=python${py3_ver}${py3_abiver} -DPYTHON_INCLUDE_DIRS=/${py3_inc}
  -DWITH_SYSTEM_LZO=ON -DWITH_SYSTEM_EIGEN3=ON -DWITH_SYSTEM_FREETYPE=ON"
-hostmakedepends="pkg-config"
+hostmakedepends="pkg-config git git-lfs"
 makedepends="libgomp-devel libpng-devel tiff-devel python3-devel glu-devel
  glew-devel freetype-devel jack-devel libopenal-devel libsndfile-devel
  libsamplerate-devel ffmpeg6-devel fftw-devel boost-devel pcre-devel llvm
@@ -54,3 +54,12 @@ x86_64*)
 	configure_args+=" -DWITH_OPENIMAGEDENOISE=ON"
 	;;
 esac
+
+# The Blender repository has a submodule that stores important assets, which uses the `blender/blender-assets` repository at `projects.blender.org`. Unfortunately, this repository is mostly composed of Git LFS files, and due a bug in gitea, the git hosting software that the website uses, the repository's tag archives (both .zip and .tar.gz) only contain LFS pointer files, which cannot be used at all.
+# The safest workaround to this bug is to clone the repository and resolving the LFS pointers manually.
+post_extract() {
+    git clone -b "v${version}" "https://projects.blender.org/blender/blender-assets.git" release/datafiles/assets/
+    git -C release/datafiles/assets/ lfs install
+    git -C release/datafiles/assets/ lfs pull
+}
+


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
<!--
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->

#### What? Huh? Why?

Fixes #53648.

it's 4:30AM, i'm probably gonna type something close to what i typed in the comments.

The Blender repository recently shuffled a few features around internally, and put the new brushes (and possibly more tools) in a submodule pointing to the `blender-assets` repository. Unfortunately, this repository also has heavy usage of the Git LFS system, and because of https://github.com/go-gitea/gitea/issues/4773, we can no longer just download the archive of the repository and extract it into the proper place in this particular scenario. The solution I implemented was just git cloning the `blender-assets` repository into the right place, settings up LFS and then pulling the LFS files. Luckily enough, `blender-assets` tags mirror Blender's own version releases, so we can just use Blender's version to find the right `blender-assets` tag.