### PR TITLE
sile: update to 0.15.9

### DIFF
--- a/srcpkgs/sile/template
+++ b/srcpkgs/sile/template
@@ -1,10 +1,10 @@
 # Template file for 'sile'
 pkgname=sile
-version=0.15.8
+version=0.15.9
 revision=1
 build_style=gnu-configure
 build_helper=rust
-configure_args="--with-system-lua-sources --with-system-luarocks"
+configure_args="--with-system-lua-sources --with-system-luarocks --disable-emdedded-resources"
 hostmakedepends="jq poppler cargo rust pkg-config automake luarocks-lua51"
 makedepends="harfbuzz-devel lua51-devel lua51-lpeg lua51-luaexpat
  lua51-zlib lua51-luafilesystem lua51-luasocket lua51-luasec lua51-cassowary
@@ -20,7 +20,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
 homepage="https://www.sile-typesetter.org/"
 distfiles="https://github.com/sile-typesetter/sile/releases/download/v${version}/sile-${version}.tar.zst"
-checksum=64c17abafd5b1ef30419a81b000998870c1b081b6372d55bc31df9c3b83f0f6a
+checksum=fbda59503b333d82661601db647d1a2ad67aa8b7098e1ef78c6d8216844ac567
 
 if [ "$CROSS_BUILD" ]; then
 	hostmakedepends+=" ${makedepends}"


### PR DESCRIPTION
Untested bump in the blind ;-)

This includes one change from the recently approved major overhaul (see #51222). The *default* upstream options use a bundling system to wrap dozens and dozens of project Lua files and embed them into the final Rust binary. This was made the default upstream to simplify installation from source for end users that may have trouble working out their system's Lua paths and may or may not compile with the right options. That being said as the upstream developer I personally recommend *not* using this option and installing all the files directly using the package manager if possible. Since this is a system package it will have all the Lua path stuff sorted out for the end user already, and this makes it easier to use SILE. One common thing to do in a SILE based project is modify some internals by copying the distributed functions and tweaking them for some specific use case. Having the system install them as actual Lua files instead of bundled in a binary makes it just a little easier to actually do that. Hence I suggest this option for distro packages.

Otherwise this is a pretty simple version bump.

#### Testing the changes
- [ ] I tested the changes in this PR: **NO**

#### Local build testing
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
