### PR TITLE
conky: fix maintainer mode

### DIFF
--- a/srcpkgs/conky/template
+++ b/srcpkgs/conky/template
@@ -4,7 +4,7 @@ version=1.22.0
 revision=1
 build_style=cmake
 conf_files="/etc/conky/conky.conf /etc/conky/conky_no_x11.conf"
-configure_args="-DMAINTAINER_MODE=ON -DRELEASE=ON
+configure_args="-DMAINTAINER_MODE=OFF -DRELEASE=ON
  -DDOC_PATH=share/doc/${pkgname} -DBUILD_CURL=ON
  -DBUILD_RSS=ON -DBUILD_WLAN=ON -DBUILD_X11=ON -DBUILD_XDBE=ON
  -DBUILD_IMLIB2=ON -DBUILD_LUA_CAIRO=ON -DBUILD_LUA_IMLIB2=ON
@@ -22,18 +22,27 @@ distfiles="https://github.com/brndnmtthws/conky/archive/v${version}.tar.gz
 checksum="8633b78e6c0c9e7128efc9fe54b48df75a3860928e3fb101bcf71f6fb3844959
  4e2f31b09deb60f289f74d9e7f75e2e987ee0c5d400fc4cbf4ef2b60fe457295"
 
+# MAINTAINER_MODE turns on BUILD_TESTS and is only for the conky project
+if [ -n "$CROSS_BUILD" ] ; then
+	configure_args+=" -DBUILD_TESTS=OFF"
+else
+	configure_args+=" -DBUILD_TESTS=ON"
+fi
+
 post_extract() {
 	mv conky-*/* .
-	if [ -n "$CROSS_BUILD" ] ; then
-		# some tests are in 'build()' now, 'make_check' does nothing
-		echo "" > cmake/CatchAddTests.cmake
-	fi
 }
 
 post_configure() { # conky-cli
-	configure_args="-DMAINTAINER_MODE=ON -DRELEASE=ON -DDOC_PATH=share/doc/${pkgname}
+	configure_args="-DMAINTAINER_MODE=OFF -DRELEASE=ON -DDOC_PATH=share/doc/${pkgname}
 	-DBUILD_X11=OFF -DBUILD_WAYLAND=OFF -DBUILD_CURL=ON -DBUILD_XDBE=OFF
 	-DBUILD_RSS=ON -DBUILD_IMLIB2=OFF -DBUILD_WLAN=ON"
+	# this probably doesn't really need to be tested again
+	if [ -n "$CROSS_BUILD" ] ; then
+		configure_args+=" -DBUILD_TESTS=OFF"
+	else
+		configure_args+=" -DBUILD_TESTS=ON"
+	fi
 	(
 		cmake_builddir="cli-build"
 		do_configure


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, **x86_64**
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - **aarch64-musl**

#### Comments

per last update - https://github.com/void-linux/void-packages/pull/52924

https://github.com/brndnmtthws/conky/issues/2131

Void and nix both have `MAINTAINER_MODE` on when it should not be. It is for conky's own CI and turns on `BUILD_TESTS` when enabled.

The new conky code does bomb with `BUILD_TESTS` on and `MAINTAINER_MODE` off. But Void disables checks for cross builds anyway, so it's good enough to disable tests and maint-mode.

This doesn't really need rebuilt, just a better fix than previous fix.