### PR TITLE
python3-socks: update to 2.6.1.

### DIFF
--- a/srcpkgs/python3-socks/template
+++ b/srcpkgs/python3-socks/template
@@ -1,16 +1,19 @@
 # Template file for 'python3-socks'
 pkgname=python3-socks
-version=2.4.3
-revision=3
-build_style=python3-module
-hostmakedepends="python3-setuptools"
+version=2.6.1
+revision=1
+build_style=python3-pep517
+hostmakedepends="python3-setuptools python3-wheel"
 depends="python3"
-checkdepends="python3-async-timeout python3-curio python3-trio python3-attrs
- python3-async_generator python3-sniffio python3-sortedcontainers
- python3-anyio python3-outcome python3-idna"
+checkdepends="python3-anyio python3-async_generator python3-attrs python3-curio
+ python3-Flask python3-idna python3-outcome python3-pytest-asyncio
+ python3-pytest-cov python3-pytest-flake8 python3-pytest-trio python3-sniffio
+ python3-sortedcontainers python3-tiny-proxy python3-trio python3-trustme
+ python3-yarl"
 short_desc="Core proxy client functionality for Python"
 maintainer="Arjan Mossel <arjanmossel@gmail.com>"
 license="Apache-2.0"
 homepage="https://github.com/romis2012/python-socks"
-distfiles="${PYPI_SITE}/p/python-socks/python-socks-${version}.tar.gz"
-checksum=135430ae36d582dc834c983696c5f66177aa5b587407f540985d616ef2e0c701
+distfiles="${PYPI_SITE}/p/python-socks/python_socks-${version}.tar.gz"
+checksum=9743929aab6ffe0bab640ecfbbee7130af92408ad86e4aa2984789f742f3ec9e
+make_check_pre="env SKIP_IPV6_TESTS=True"

--- a/srcpkgs/python3-tiny-proxy/template
+++ b/srcpkgs/python3-tiny-proxy/template
@@ -1,0 +1,14 @@
+# Template file for 'python3-tiny-proxy'
+pkgname=python3-tiny-proxy
+version=0.2.1
+revision=1
+build_style=python3-pep517
+hostmakedepends="python3-setuptools python3-wheel"
+depends="python3-anyio"
+short_desc="SOCKS5/SOCKS4/HTTP proxy server"
+maintainer="Arjan Mossel <arjanmossel@gmail.com>"
+license="Apache-2.0"
+homepage="https://github.com/romis2012/tiny-proxy"
+distfiles="https://github.com/romis2012/tiny-proxy/archive/v${version}.tar.gz"
+checksum=d816f9c26cf8d6e7cf735f75ed9604d211a78fb4aa9fef35bb103d52b33cfb4f
+make_check=no # Depends on httpx-socks


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

`python3-tiny-proxy` is now needed for the tests to run. I considered `make_check=no`, but well, it's tiny, and this way we can also enable tests for `python3-aiohttp_socks`.

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
