### PR TITLE
mixxx: update to 2.5.0

### DIFF
--- a/srcpkgs/guidelines-support-library/template
+++ b/srcpkgs/guidelines-support-library/template
@@ -1,6 +1,6 @@
 # Template file for 'guidelines-support-library'
 pkgname=guidelines-support-library
-version=4.0.0
+version=4.1.0
 revision=1
 build_style=cmake
 configure_args="-DGSL_TEST:BOOL=OFF"
@@ -9,7 +9,7 @@ maintainer="0x5c <dev@0x5c.io>"
 license="MIT"
 homepage="https://github.com/microsoft/GSL"
 distfiles="https://github.com/microsoft/GSL/archive/refs/tags/v${version}.tar.gz"
-checksum=f0e32cb10654fea91ad56bde89170d78cfbf4363ee0b01d8f097de2ba49f6ce9
+checksum=0a227fc9c8e0bf25115f401b9a46c2a68cd28f299d24ab195284eb3f1d7794bd
 
 post_install() {
 	vlicense LICENSE

--- a/srcpkgs/mixxx/template
+++ b/srcpkgs/mixxx/template
@@ -1,22 +1,27 @@
 # Template file for 'mixxx'
 pkgname=mixxx
-version=2.3.3
-revision=8
+version=2.5.0
+revision=1
 build_style=cmake
-configure_args="-DCMAKE_BUILD_TYPE=Release"
-hostmakedepends="extra-cmake-modules pkg-config protobuf qt5-host-tools qt5-qmake"
+# ENGINEPRIME is for libdjinterop which mixxx's cmake tries to download
+# void's cmake is not built with openssl support to do this
+configure_args="-DCMAKE_BUILD_TYPE=Release -DENGINEPRIME=OFF"
+hostmakedepends="extra-cmake-modules pkg-config protobuf qt6-base
+ qt6-declarative-host-tools qt6-shadertools"
 makedepends="chromaprint-devel faad2-devel ffmpeg6-devel libkeyfinder-devel glu-devel
  lame-devel libid3tag-devel libmad-devel libmodplug-devel libusb-devel
  opusfile-devel libflac-devel libogg-devel libsndfile-devel libvorbis-devel
- wavpack-devel portaudio-devel portmidi-devel protobuf-devel qt5-script-devel
- qt5-svg-devel qt5-xmlpatterns-devel rubberband-devel taglib-devel upower-devel
- vamp-plugin-sdk-devel lv2 lilv-devel qt5-x11extras-devel hidapi-devel libtheora-devel
- speex-devel soundtouch-devel qtkeychain-qt5-devel qt5-plugin-mysql qt5-plugin-odbc
- qt5-plugin-pgsql qt5-plugin-sqlite qt5-plugin-tds libebur128-devel"
-depends="qt5-plugin-sqlite"
+ wavpack-devel portaudio-devel portmidi-devel protobuf-devel qt6-base-devel
+ qt6-base-private-devel qt6-declarative-devel qt6-declarative-private-devel
+ qt6-tools-devel qt6-qt5compat-devel qt6-shadertools-devel qt6-svg-devel
+ rubberband-devel taglib-devel upower-devel vamp-plugin-sdk-devel lv2 lilv-devel
+ hidapi-devel libtheora-devel speex-devel soundtouch-devel qtkeychain-qt6-devel
+ qt6-plugin-mysql qt6-plugin-odbc qt6-plugin-pgsql qt6-plugin-sqlite libebur128-devel
+ benchmark-devel gtest-devel guidelines-support-library"
+depends="qt6-plugin-sqlite"
 short_desc="Open source digital DJing software that allows mixing music"
 maintainer="prez <prez@national.shitposting.agency>"
 license="GPL-2.0-or-later"
 homepage="https://www.mixxx.org"
 distfiles="https://github.com/mixxxdj/mixxx/archive/${version}.tar.gz"
-checksum=8e3a5a545175982336bb07c81a3839897a007c43689b93641242db662f6beb9c
+checksum=95ad113f1988abaa4fabc2e19027d5456a6ba9cb0f6366a386a2239030f41089


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **BRIEF**

#### Local build testing
- I built this PR locally for my native architecture, **x86_64**
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - **aarch64-musl**

#### Comments

`guidelines-support-library` update to 4.1.0 @0x5c (contour and freecad seem to build, no need for bump but can be)

~~`mixxx` started using qt6 but tries to provide `QML`, which runs a binary and fails on aarch64 crossbuild. i don't think the build was using QML anyway.~~ thx johnny

`mixxx` also tries to download `libdjinterop` through cmake, which i was told is not supported in void. it wasn't in the previous version so it should be fine to ditch in 2.5.0

![mixxx](https://github.com/user-attachments/assets/25b93c2c-3f83-48bb-b277-6bf8dff66e52)