### PR TITLE
eudev: import upstream patch for audio

### DIFF
--- a/srcpkgs/eudev/patches/78-sound-card.rules.patch
+++ b/srcpkgs/eudev/patches/78-sound-card.rules.patch
@@ -1,0 +1,42 @@
+From 917ae648f61681257000c3a1f0aca3fbd646563a Mon Sep 17 00:00:00 2001
+From: Johannes Nixdorf <mixi@shadowice.org>
+Date: Fri, 22 Dec 2023 10:27:08 +0100
+Subject: [PATCH] 78-sound-card.rules: Import ID_PATH early
+
+Pipewire requires ID_PATH to use the same device names as with systemd's
+udev. Some rules, such as the ones in asahi-audio [1] use those names, and
+fail if they don't match [2].
+
+On systemd's udev this is instead imported in 71-seat.rules, which we don't
+have.
+
+[1]: https://github.com/AsahiLinux/asahi-audio
+[2]: https://github.com/AsahiLinux/asahi-audio/issues/16
+
+Signed-off-by: Johannes Nixdorf <mixi@shadowice.org>
+---
+ rules/78-sound-card.rules | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/rules/78-sound-card.rules b/rules/78-sound-card.rules
+index f2fc27739..c49bd1d4e 100644
+--- a/rules/78-sound-card.rules
++++ b/rules/78-sound-card.rules
+@@ -38,6 +38,8 @@ KERNEL!="card*", GOTO="sound_end"
+ ENV{SOUND_INITIALIZED}="1"
+ 
+ IMPORT{builtin}="hwdb"
++IMPORT{builtin}="path_id"
++
+ SUBSYSTEMS=="usb", IMPORT{builtin}="usb_id"
+ SUBSYSTEMS=="usb", GOTO="skip_pci"
+ 
+@@ -62,8 +64,6 @@ LABEL="skip_pci"
+ ENV{ID_SERIAL}=="?*", ENV{ID_USB_INTERFACE_NUM}=="?*", ENV{ID_ID}="$env{ID_BUS}-$env{ID_SERIAL}-$env{ID_USB_INTERFACE_NUM}"
+ ENV{ID_SERIAL}=="?*", ENV{ID_USB_INTERFACE_NUM}=="", ENV{ID_ID}="$env{ID_BUS}-$env{ID_SERIAL}"
+ 
+-IMPORT{builtin}="path_id"
+-
+ # The values used here for $SOUND_FORM_FACTOR and $SOUND_CLASS should be kept
+ # in sync with those defined for PulseAudio's src/pulse/proplist.h
+ # PA_PROP_DEVICE_FORM_FACTOR, PA_PROP_DEVICE_CLASS properties.

--- a/srcpkgs/eudev/template
+++ b/srcpkgs/eudev/template
@@ -4,7 +4,7 @@ _UDEV_VERSION="251" # compatible udev version provided
 
 pkgname=eudev
 version=3.2.14
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--enable-hwdb --enable-manpages"
 hostmakedepends="pkg-config gperf"


### PR DESCRIPTION
- I tested the changes in this PR: yes, on aarch64 Apple silicon
- I built this PR locally for my native architecture, (x86_64-glibc)