### PR TITLE
New package: Bonzomatic-2023.06.15

### DIFF
--- a/srcpkgs/Bonzomatic/patches/fix-wayland.patch
+++ b/srcpkgs/Bonzomatic/patches/fix-wayland.patch
@@ -1,0 +1,34 @@
+Fixes GLEW initialization and screen size retrieval in fullscreen mode for Wayland
+
+diff --git a/src/platform_glfw/Renderer.cpp b/src/platform_glfw/Renderer.cpp
+index 15f8be2..7d8df55 100644
+--- a/src/platform_glfw/Renderer.cpp
++++ b/src/platform_glfw/Renderer.cpp
+@@ -286,7 +286,7 @@ bool Open( Renderer::Settings * settings )
+ 
+   glewExperimental = GL_TRUE;
+   GLenum err = glewInit();
+-  if ( GLEW_OK != err )
++  if (GLEW_OK != err && !(err == GLEW_ERROR_NO_GLX_DISPLAY && getenv("WAYLAND_DISPLAY")))
+   {
+     printf( "[GLFW] glewInit failed: %s\n", glewGetErrorString( err ) );
+     glfwTerminate();
+@@ -306,9 +306,17 @@ bool Open( Renderer::Settings * settings )
+ 
+   // Now, since OpenGL is behaving a lot in fullscreen modes, lets collect the real obtained size!
+   printf( "[GLFW] Requested framebuffer size: %d x %d\n", nWidth, nHeight );
++
++  const GLFWvidmode* mode = glfwGetVideoMode(monitor);
+   int fbWidth = 1;
+   int fbHeight = 1;
+-  glfwGetFramebufferSize( mWindow, &fbWidth, &fbHeight );
++
++  if (mode != NULL) {
++    // Use the screen resolution of the primary monitor as framebuffer size
++    fbWidth = mode->width;
++    fbHeight = mode->height;
++  }
++
+   nWidth = settings->nWidth = fbWidth;
+   nHeight = settings->nHeight = fbHeight;
+   printf( "[GLFW] Obtained framebuffer size: %d x %d\n", fbWidth, fbHeight );

--- a/srcpkgs/Bonzomatic/template
+++ b/srcpkgs/Bonzomatic/template
@@ -1,0 +1,20 @@
+# Template file for 'Bonzomatic'
+pkgname=Bonzomatic
+version=2023.06.15
+revision=1
+build_style=cmake
+configure_args="-DBONZOMATIC_USE_SYSTEM_GLEW=ON -DBONZOMATIC_USE_SYSTEM_GLFW=ON"
+hostmakedepends="pkg-config"
+makedepends="alsa-lib-devel glew-devel glfw-devel libX11-devel libXrandr-devel
+	libXinerama-devel libXcursor-devel libXi-devel fontconfig-devel"
+short_desc="Live shader coding tool"
+maintainer="Rutpiv <roger_freitas@live.com>"
+license="Unlicense"
+homepage="https://github.com/Gargaj/Bonzomatic"
+distfiles="https://github.com/Gargaj/Bonzomatic/archive/${version//./-}.tar.gz"
+checksum=f41903d47fc744a726c7ecdaee78e2d9dda790beb22e310a63f6a0a1c0cfd4a7
+make_check=no  # No tests configured.
+
+post_install() {
+	vlicense LICENSE
+}


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

#### Local build testing
- I built this PR locally for my native architecture (x86_64)
- I built this PR locally for these architectures using specific masterdirs:
  - x86_64-musl
  - i686
- I built this PR locally for these architectures (crossbuilds):
  - aarch64
  - aarch64-musl
  - armv7l
  - armv7l-musl
  - armv6l
  - armv6l-musl
  
---

This patch, placed alongside the template, fixes the issues that arise when enabling `-DBONZOMATIC_USE_SYSTEM_GLEW=ON` and `-DBONZOMATIC_USE_SYSTEM_GLFW=ON` to use the system libraries instead of the ones provided in the externals folder.

It addresses the GLEW initialization and screen size retrieval problems specifically for Wayland environments. The framebuffer size retrieval logic was incorrect, and this patch ensures that the primary monitor's resolution is used in fullscreen mode, resolving the apparent issues with the system libraries.

While this patch resolves the issues observed on Wayland, it has only been tested in this environment. The behavior on X11 is uncertain, but I believe it should work correctly based on the changes made.