### PR TITLE
libevdev: update to 1.13.3.

### DIFF
--- a/srcpkgs/libevdev/template
+++ b/srcpkgs/libevdev/template
@@ -1,6 +1,6 @@
 # Template file for 'libevdev'
 pkgname=libevdev
-version=1.13.2
+version=1.13.3
 revision=1
 build_style=gnu-configure
 configure_args="--disable-gcov"
@@ -11,7 +11,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
 homepage="https://www.freedesktop.org/wiki/Software/libevdev/"
 distfiles="${FREEDESKTOP_SITE}/libevdev/libevdev-${version}.tar.xz"
-checksum=3eca86a6ce55b81d5bce910637fc451c8bbe373b1f9698f375c7f1ad0de3ac48
+checksum=abf1aace86208eebdd5d3550ffded4c8d73bb405b796d51c389c9d0604cbcfbf
 
 post_install() {
 	vlicense COPYING


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl
  - i686
  - aarch64 (crossbuild)
  - aarch64-musl (crossbuild)

