### PR TITLE
ntpd-rs: Set cap_net_bind_service during daemon startup allows it to …

### DIFF
--- a/srcpkgs/ntpd-rs/INSTALL
+++ b/srcpkgs/ntpd-rs/INSTALL
@@ -1,5 +1,0 @@
-case "${ACTION}" in
-post)
-	setcap CAP_SYS_TIME=+ep usr/bin/ntp-daemon
-	;;
-esac

--- a/srcpkgs/ntpd-rs/files/ntpd-rs/run
+++ b/srcpkgs/ntpd-rs/files/ntpd-rs/run
@@ -1,4 +1,10 @@
 #!/bin/sh
 exec 2>&1
+[ -r conf ] && . ./conf
 [ ! -d /run/ntpd-rs ] && mkdir /run/ntpd-rs && chown _ntpd_rs:_ntpd_rs /run/ntpd-rs
-exec chpst -u _ntpd_rs:_ntpd_rs ntp-daemon
+
+exec setpriv --reuid _ntpd_rs --regid _ntpd_rs --clear-groups \
+	--ambient-caps -all,+sys_time,+net_bind_service \
+	--inh-caps -all,+sys_time,+net_bind_service \
+	--bounding-set -all,+sys_time,+net_bind_service \
+	--no-new-privs -- ntp-daemon

--- a/srcpkgs/ntpd-rs/template
+++ b/srcpkgs/ntpd-rs/template
@@ -1,7 +1,7 @@
 # Template file for 'ntpd-rs'
 pkgname=ntpd-rs
 version=1.4.0
-revision=1
+revision=2
 build_style=cargo
 make_check_args="--
  --skip daemon::keyexchange::tests::client_connection_refused
@@ -9,7 +9,6 @@ make_check_args="--
  --skip daemon::keyexchange::tests::key_exchange_weird_packet
 "
 make_install_args="--path ntpd"
-depends="libcap-progs"
 short_desc="Full-featured implementation of the Network Time Protocol"
 maintainer="tranzystorekk <tranzystorek.io@protonmail.com>"
 license="Apache-2.0 OR MIT"


### PR DESCRIPTION
…run in server mode and listen on port 123

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
