### PR TITLE
eza: update to 0.20.16

### DIFF
--- a/srcpkgs/eza/template
+++ b/srcpkgs/eza/template
@@ -1,10 +1,10 @@
 # Template file for 'eza'
 pkgname=eza
-version=0.20.15
+version=0.20.16
 revision=1
 build_style=cargo
 hostmakedepends="pkg-config"
-makedepends="libgit2-1.8-devel"
+makedepends="libgit2-1.9-devel"
 short_desc="Modern replacement for ls"
 maintainer="tranzystorekk <tranzystorek.io@protonmail.com>"
 license="EUPL-1.2"
@@ -12,8 +12,8 @@ homepage="https://eza.rocks"
 changelog="https://raw.githubusercontent.com/eza-community/eza/main/CHANGELOG.md"
 distfiles="https://github.com/eza-community/eza/archive/refs/tags/v${version}.tar.gz
  https://github.com/eza-community/eza/releases/download/v${version}/man-${version}.tar.gz"
-checksum="cbb50e61b35b06ccf487ee6cc88d3b624931093546194dd5a2bbd509ed1786d6
- 6f52b6ba44dd99c2f4d08708bd5b2c1c8d65c18d37354f4a06599025776dd1f2"
+checksum="be5eb8d314f817bbfdcad4d21e66d2a8c4006ba4619735297b5233887ebdbe99
+ b5c505663ecb5dc219ff895d6c7eecfa13f1b973daf0772e300118cee50938cc"
 
 skip_extraction="man-${version}.tar.gz"
 


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
