### PR TITLE
build_helper/rust: automatically use the wrapper script

### DIFF
--- a/common/build-helper/rust.sh
+++ b/common/build-helper/rust.sh
@@ -87,9 +87,11 @@ is_auditable() {
 }
 
 if ! command -v cargo-auditable >/dev/null || is_auditable "$@"; then
-	exec /usr/bin/cargo "$@"
+	CARGO=/usr/bin/cargo exec /usr/bin/cargo "$@"
 fi
-exec /usr/bin/cargo auditable "$@"
+CARGO=/usr/bin/cargo exec /usr/bin/cargo auditable "$@"
 _EOF
 
 chmod 755 ${XBPS_WRAPPERDIR}/cargo
+
+export CARGO="${XBPS_WRAPPERDIR}/cargo"

--- a/common/build-style/cargo.sh
+++ b/common/build-style/cargo.sh
@@ -3,21 +3,21 @@
 #
 
 do_build() {
-	: ${make_cmd:=cargo auditable}
+	: ${make_cmd:=cargo}
 
 	${make_cmd} build --release --locked --target ${RUST_TARGET} \
  		${configure_args} ${make_build_args}
 }
 
 do_check() {
-	: ${make_cmd:=cargo auditable}
+	: ${make_cmd:=cargo}
 
 	${make_check_pre} ${make_cmd} test --release --locked --target ${RUST_TARGET} \
 		${configure_args} ${make_check_args}
 }
 
 do_install() {
-	: ${make_cmd:=cargo auditable}
+	: ${make_cmd:=cargo}
 	: ${make_install_args:=--path .}
 
 	${make_cmd} install --target ${RUST_TARGET} --root="${DESTDIR}/usr" \


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

This makes various non-cargo-buildstyle places like `uv` use `cargo-auditable` automatically, as long as `build_helper=rust`, `hostmakedepends="cargo cargo-auditable"` and `makedepends="rust-std"` is provided.

The wrapper needs to reset the `CARGO` variable, otherwise cargo falls into an endless loop of recursively calling the script.

Unfortunately, I didn't find a way to make it work with https://github.com/corrosion-rs/corrosion (cmake-rust glue that the new `fish-shell` beta uses, it needs the wrapper passed via `configure_args`)

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
