### PR TITLE
rockpro64-uboot: update to 2025.04.

### DIFF
--- a/srcpkgs/rockpro64-uboot/files/README.voidlinux
+++ b/srcpkgs/rockpro64-uboot/files/README.voidlinux
@@ -1,0 +1,18 @@
+There are different options for where to install U-Boot on the RockPro64.
+Below are commands that can be used to write U-Boot to various locations.
+
+# Write U-Boot to SD Card or eMMC
+
+# SD Card
+export target_dev=/dev/mmcblk1
+# eMMC
+export target_dev=/dev/mmcblk2
+dd if=/usr/lib/rockpro64-uboot/u-boot-rockchip.bin of=${target_dev} seek=64
+
+
+# Write U-Boot to SPI
+flash_erase /dev/mtd0 0 0   # wipe SPI flash prior to writing U-Boot
+dd if=/usr/lib/rockpro64-uboot/u-boot-rockchip-spi.bin of=/dev/mtd0
+
+For more information see the U-Boot documentation:
+https://github.com/u-boot/u-boot/blob/v2025.01/doc/board/rockchip/rockchip.rst

--- a/srcpkgs/rockpro64-uboot/template
+++ b/srcpkgs/rockpro64-uboot/template
@@ -1,17 +1,17 @@
 # Template file for 'rockpro64-uboot'
 pkgname=rockpro64-uboot
-version=2024.07
+version=2025.04
 revision=1
 archs="aarch64*"
 hostmakedepends="bison flex bc dtc which python3 swig python3-devel python3-setuptools python3-pyelftools openssl-devel libuuid-devel gnutls-devel ncurses-libtinfo-devel"
 makedepends="atf-rk3399-bl31"
-depends="u-boot-tools"
+depends="u-boot-tools mtd-utils"
 short_desc="Das U-Boot for the RockPro64 SBC"
 maintainer="Tim Sandquist <tim.sandquist@gmail.com>"
 license="GPL-2.0-or-later, BSD-3-Clause"
 homepage="https://www.denx.de/wiki/U-Boot/"
 distfiles="https://ftp.denx.de/pub/u-boot/u-boot-${version}.tar.bz2"
-checksum=f591da9ab90ef3d6b3d173766d0ddff90c4ed7330680897486117df390d83c8f
+checksum=439d3bef296effd54130be6a731c5b118be7fddd7fcc663ccbc5fb18294d8718
 
 do_configure() {
 	unset CFLAGS CXXFLAGS CPPFLAGS LDFLAGS
@@ -31,6 +31,9 @@ do_build() {
 do_install() {
 	vinstall idbloader.img 0644 usr/lib/rockpro64-uboot
 	vinstall u-boot.itb 0644 usr/lib/rockpro64-uboot
+	vinstall u-boot-rockchip-spi.bin 0644 usr/lib/rockpro64-uboot
+	vinstall u-boot-rockchip.bin 0644 usr/lib/rockpro64-uboot
+	vdoc "${FILESDIR}/README.voidlinux"
 	vlicense Licenses/Exceptions
 	vlicense Licenses/README
 	vlicense Licenses/bsd-2-clause.txt


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

I tested the U-Boot install methods that I documented in the README.voidlinux file.
- Writing U-Boot to eMMC using the `/usr/lib/rockpro64-uboot/u-boot-rockchip.bin` image and booting from eMMC.
- Writing U-Boot to SPI using the `/usr/lib/rockpro64-uboot/u-boot-rockchip-spi.bin` image and booting from USB.

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
