### PR TITLE
asahi-uboot: fix cross

### DIFF
--- a/srcpkgs/asahi-uboot/template
+++ b/srcpkgs/asahi-uboot/template
@@ -6,6 +6,7 @@ archs="aarch64*"
 hostmakedepends="bison flex which python3 swig python3-devel
  python3-setuptools python3-pyelftools bc dtc"
 makedepends="openssl-devel libuuid-devel gnutls-devel ncurses-libtinfo-devel"
+hostmakedepends+=" ${makedepends}"
 depends="m1n1"
 checkdepends="python3-pytest dtc-devel python3-filelock"
 short_desc="Das U-Boot for Apple Silicon Macs"


### PR DESCRIPTION
it was missing some hostmakedepends.
it's now possibly redundant, but i tested cross build from x86_64 to aarch64.

cc @classabbyamp 