### PR TITLE
mesa-asahi: fix subpkg order

### DIFF
--- a/srcpkgs/mesa-asahi/template
+++ b/srcpkgs/mesa-asahi/template
@@ -38,6 +38,10 @@ replaces="mesa>=0 mesa-libgallium>=0 libglapi>=0"
 provides="mesa-${_mesaver}_${revision} mesa-libgallium-${_mesaver}_${revision} libglapi-${_mesaver}_${revision}"
 shlib_provides="libglapi.so libgallium-${_mesaver}-devel.so"
 
+# alphabetical order is not good
+subpackages="libgbm-asahi libgbm-asahi-devel libOSMesa-asahi MesaLib-asahi-devel mesa-asahi-opencl
+ mesa-asahi-vaapi mesa-asahi-vdpau mesa-asahi-vulkan-overlay-layer  mesa-asahi-dri"
+
 build_options="wayland"
 build_options_default="wayland"
 


### PR DESCRIPTION
- I tested the changes in this PR: yes
- I built this PR locally for my native architecture, aarch64

cc @classabbyamp the subpackages variable is needed to enforce an ordering, as building subpkgs alphabetically fails due to them moving around similar files/folders.