### PR TITLE
hut: update to 0.6.0.

### DIFF
--- a/srcpkgs/hut/template
+++ b/srcpkgs/hut/template
@@ -1,18 +1,18 @@
 # Template file for 'hut'
 pkgname=hut
-version=0.4.0
-revision=2
+version=0.6.0
+revision=1
 build_style=go
 build_helper=qemu
-go_import_path="git.sr.ht/~emersion/hut"
+go_import_path="git.sr.ht/~xenrox/hut"
 hostmakedepends="scdoc"
 short_desc="CLI tool for sr.ht"
 maintainer="Dakota Walsh <kota@nilsu.org>"
 license="AGPL-3.0-only"
-homepage="https://git.sr.ht/~emersion/hut"
-changelog="https://git.sr.ht/~emersion/hut/log"
-distfiles="https://git.sr.ht/~emersion/hut/archive/v${version}.tar.gz"
-checksum=f25ab4452e4622f404a6fa5713e8505302bfcee4dd3a8dfe76f1fc4c05688c09
+homepage="https://git.sr.ht/~xenrox/hut"
+changelog="https://git.sr.ht/~xenrox/hut/log"
+distfiles="https://git.sr.ht/~xenrox/hut/archive/v${version}.tar.gz"
+checksum=f6abe54b433c30557c49aa41d351ec97ef24b4bee3f9dbc91e7db8f366592f99
 
 post_install() {
 	hut=$(find $GOPATH/bin -name hut)


### PR DESCRIPTION
additional:
	- the main repo has moved from ~emersion to ~xenrox

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
