### PR TITLE
[RFC] xbps-src: add a command `show-diff`

### DIFF
--- a/xbps-src
+++ b/xbps-src
@@ -968,6 +968,18 @@ case "$XBPS_TARGET" in
                 fi # The trailing space gets stripped before printing anyway
         done
         ;;
+    show-diff)
+        read_pkg ignore-problems
+        mkdir -p "${XBPS_STATEDIR}/show-diff"
+        cd "${XBPS_STATEDIR}/show-diff"
+        if [ ! -d clean-wrksrc ]; then
+            ( . "${XBPS_COMMONDIR}/hooks/do-extract/00-distfiles.sh"
+              wrksrc="$PWD/clean-wrksrc" hook )
+            ln -Ts clean-wrksrc a
+            ln -Trs "$wrksrc" b
+        fi
+        diff -ru a b | grep -v '^Only in b[/:]'
+        ;;
     dbulk-dump)
         read_pkg
         check_pkg_arch "$XBPS_CROSS_BUILD"


### PR DESCRIPTION
Usage: ./xbps-src show-diff PKG

Shows differences between the original sources and $wrksrc, in the form
of a patch that can be used for the template.

Note this ignores new files.


#### Testing the changes
- I tested the changes in this PR: **briefly**


#### Alternatives

One alternative suggested in irc is to use unpatch from

https://leahneukirchen.org/dotfiles/bin/unpatch

Save the original files as .orig, then run

- `unpatch -g -p3 masterdir-*/builddir/pkg-ver`

With vim, one can use `:set patchmode=.orig`


Two more suggestions from irc related to this:

 - `alias xpatch="nvim -c 'set patchmode=.orig'"`

 - `autocmd BufNewFile,BufRead masterdir-*/builddir/* setlocal patchmode=.orig`
