### PR TITLE
lzfse: do not vmove its so into devel

### DIFF
--- a/srcpkgs/lzfse/template
+++ b/srcpkgs/lzfse/template
@@ -1,7 +1,7 @@
 # Template file for 'lzfse'
 pkgname=lzfse
 version=1.0
-revision=1
+revision=2
 build_style=cmake
 short_desc="LZFSE compression library and command line tool"
 maintainer="dkwo <npiazza@disroot.org>"
@@ -19,6 +19,5 @@ lzfse-devel_package() {
 	depends="${sourcepkg}>=${version}_${revision}"
 	pkg_install() {
 		vmove usr/include/lzfse.h
-		vmove usr/lib/liblzfse.so
 	}
 }


### PR DESCRIPTION
- I tested the changes in this PR: yes
- I built this PR locally for my native architecture, (aarch64)

cc @classabbyamp otherwise, lzfse just pulls in devel