### PR TITLE
lego: update to 4.21.0.

### DIFF
--- a/srcpkgs/lego/template
+++ b/srcpkgs/lego/template
@@ -1,7 +1,7 @@
 # Template file for 'lego'
 pkgname=lego
-version=4.15.0
-revision=2
+version=4.21.0
+revision=1
 build_style=go
 go_import_path="github.com/go-acme/lego/v4"
 go_package="${go_import_path}/cmd/lego"
@@ -11,7 +11,7 @@ license="MIT"
 homepage="https://go-acme.github.io/lego"
 changelog="https://raw.githubusercontent.com/go-acme/lego/master/CHANGELOG.md"
 distfiles="https://github.com/go-acme/lego/archive/v${version}.tar.gz"
-checksum=3feb0501ca95d8c1fe831375ece6be6cfe57b76b51a9420d211e2472d132330d
+checksum=21204483e62bff3e762583e42044183dbe6efe6b401772bb186be821501d9463
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)