### PR TITLE
moby: Remove unneeded systemd cgroup mount

### DIFF
--- a/srcpkgs/moby/files/docker/run
+++ b/srcpkgs/moby/files/docker/run
@@ -2,8 +2,4 @@
 exec 2>&1
 [ -r conf ] && . ./conf
 modprobe -q loop || exit 1
-mountpoint -q /sys/fs/cgroup/systemd || {
-    mkdir -p /sys/fs/cgroup/systemd;
-    mount -t cgroup -o none,name=systemd cgroup /sys/fs/cgroup/systemd;
-}
 exec chpst -o 1048576 -p 1048576 dockerd $OPTS 2>&1

--- a/srcpkgs/moby/template
+++ b/srcpkgs/moby/template
@@ -2,7 +2,7 @@
 # should be kept in sync with docker-cli
 pkgname=moby
 version=28.0.1
-revision=1
+revision=2
 build_style=go
 go_import_path="github.com/docker/docker"
 hostmakedepends="go pkg-config"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->
This change removes the code that created the `/sys/fs/cgroup/systemd` mountpoint.
The change was added in an [earlier PR](https://github.com/void-linux/void-packages/pull/5959
) that referenced a page in the wiki.  The wiki is gone but I believe the error was the one described in [this comment](https://github.com/void-linux/void-packages/issues/5402#issue-387336249).
I do not believe the mountpoint is required anymore.

Also, when running kubernetes on a host with docker running the following errors show up in the kubelet logs.  They disappear when the  `/sys/fs/cgroup/systemd` mountpoint is removed.
```
2025-01-15T07:59:14.160779-06:00 localhost kubelet: E0115 07:59:14.160635    2856 cadvisor_stats_provider.go:522] "Partial failure issuing cadvisor.ContainerInfoV2" err="partial failures: [\"/systemd\": RecentStats: unable to find data in memory cache]"

2025-01-15T07:59:14.857118-06:00 localhost kubelet: W0115 07:59:14.857085    2856 container.go:588] Failed to update stats for container "/systemd": error while statting cgroup v2: [openat2 /sys/fs/cgroup/systemd/pids.current: invalid cross-device link openat2 /sys/fs/cgroup/systemd/memory.stat: invalid cross-device link openat2 /sys/fs/cgroup/systemd/io.stat: invalid cross-device link openat2 /sys/fs/cgroup/systemd/cpu.stat: invalid cross-device link openat2 /sys/fs/cgroup/systemd/cpu.pressure: invalid cross-device link openat2 /sys/fs/cgroup/systemd/memory.pressure: invalid cross-device link openat2 /sys/fs/cgroup/systemd/io.pressure: invalid cross-device link openat2 /sys/fs/cgroup/systemd/hugetlb.2MB.rsvd.current: invalid cross-device link openat2 /sys/fs/cgroup/systemd/rdma.current: invalid cross-device link openat2 /sys/fs/cgroup/systemd/misc.current: invalid cross-device link], continuing to push stats

```

#### Testing the changes
- I tested the changes in this PR: **YES**
- I tested with all three CGROUP_MODE values in `/etc/rc.conf`

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64
