### PR TITLE
update openblas 0.3.29 / scipy 1.15.1

### DIFF
--- a/srcpkgs/openblas/template
+++ b/srcpkgs/openblas/template
@@ -1,6 +1,6 @@
 # Template file for 'openblas'
 pkgname=openblas
-version=0.3.28
+version=0.3.29
 revision=1
 build_style=gnu-makefile
 make_build_args="HOSTCC=gcc USE_OPENMP=1"
@@ -13,7 +13,7 @@ license="BSD-3-Clause"
 homepage="https://www.openblas.net/"
 changelog="https://raw.githubusercontent.com/xianyi/OpenBLAS/develop/Changelog.txt"
 distfiles="https://github.com/xianyi/OpenBLAS/archive/v${version}.tar.gz"
-checksum=f1003466ad074e9b0c8d421a204121100b0751c96fc6fcf3d1456bd12f8a00a1
+checksum=38240eee1b29e2bde47ebb5d61160207dc68668a54cac62c076bb5032013b1eb
 
 case "$XBPS_TARGET_MACHINE" in
 	ppc64*) ;;
@@ -40,7 +40,7 @@ post_install() {
 }
 
 openblas-devel_package() {
-	depends="${sourcepkg}>=${version}_${revision}"
+	depends="${sourcepkg}>=${version}_${revision} libgomp-devel"
 	short_desc+=" - development files"
 	pkg_install() {
 		vmove usr/include/openblas

--- a/srcpkgs/python3-scipy/template
+++ b/srcpkgs/python3-scipy/template
@@ -1,6 +1,6 @@
 # Template file for 'python3-scipy'
 pkgname=python3-scipy
-version=1.15.0
+version=1.15.1
 revision=1
 build_style=python3-pep517
 build_helper="meson numpy"
@@ -21,7 +21,7 @@ license="BSD-3-Clause"
 homepage="https://scipy.org/"
 changelog="https://github.com/scipy/scipy/releases"
 distfiles="${PYPI_SITE}/s/scipy/scipy-${version}.tar.gz"
-checksum=300742e2cc94e36a2880ebe464a1c8b4352a7b0f3e36ec3d2ac006cdbe0219ac
+checksum=033a75ddad1463970c96a88063a1df87ccfddd526437136b6ee81ff0312ebdf6
 # must be tested from site dir of installed version (see dev.py:739)
 make_check_pre='eval env -C "${testdir}/${py3_sitelib}"'
 


### PR DESCRIPTION
- **openblas: update to 0.3.29.**
- **python3-scipy: update to 1.15.1.**
- **sagemath: bump to test - DO NOT MERGE**

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly** (locally sagemath on x86_64)

@ahesford scipy ftbfs without libgomp-devel, I think it should go in openblas-devel depends

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
