### PR TITLE
nitrokey-udev-rules: update to 1.1.0

### DIFF
--- a/srcpkgs/nitrokey-udev-rules/template
+++ b/srcpkgs/nitrokey-udev-rules/template
@@ -1,13 +1,13 @@
 # Template file for 'nitrokey-udev-rules'
 pkgname=nitrokey-udev-rules
-version=1.0.0
+version=1.1.0
 revision=1
 short_desc="Udev rules for Nitrokey devices"
 maintainer="Mateusz Sylwestrzak <slymattz@gmail.com>"
 license="CC0-1.0"
 homepage="https://github.com/Nitrokey/nitrokey-udev-rules"
 distfiles="https://github.com/Nitrokey/nitrokey-udev-rules/archive/refs/tags/v${version}.tar.gz"
-checksum=604658f9d10c02b4ec4c299a103777efaa4b55ebf95f6deb2736461f7959ae9d
+checksum=c2e0166f4c624317ca407d84255a318e3d219b04854631c12028c9ce5b53ddd9
 
 post_patch() {
 	# allow non-elogind users to access Nitrokey devices


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture: x86_64-glibc
