### PR TITLE
m1n1: hook: use exit, not return

### DIFF
--- a/srcpkgs/m1n1/files/kernel.d/m1n1.post-install
+++ b/srcpkgs/m1n1/files/kernel.d/m1n1.post-install
@@ -10,8 +10,8 @@ PKGNAME="$1"
 VERSION="$2"
 
 [ -e "${ROOTDIR}/etc/default/m1n1-kernel-hook" ] && . "${ROOTDIR}/etc/default/m1n1-kernel-hook"
-[ -d "${BOOT}" ] || return 0
-[ -d "${M1N1_T}" ] || return 0
+[ -d "${BOOT}" ] || exit 0
+[ -d "${M1N1_T}" ] || exit 0
 
 m1n1config=/run/m1n1.conf
 : >"$m1n1config"
@@ -48,7 +48,7 @@ case "$PAYLOAD" in
 		echo "Payload: m1n1 dtbs uboot config"
 	;;
 	*)
-		echo "Error: unknown PAYLOAD" && return 1
+		echo "Error: unknown PAYLOAD" && exit 1
 	;;
 esac
 

--- a/srcpkgs/m1n1/template
+++ b/srcpkgs/m1n1/template
@@ -1,7 +1,7 @@
 # Template file for 'm1n1'
 pkgname=m1n1
 version=1.4.17
-revision=1
+revision=2
 archs="aarch64*"
 hostmakedepends="ImageMagick void-artwork"
 short_desc="Asahi Linux bootloader"


### PR DESCRIPTION
- I tested the changes in this PR: yes
- I built this PR locally for my native architecture, (aarch64-glibc)

@classabbyamp one more fix