### PR TITLE
vtable-dumper: fix license

### DIFF
--- a/srcpkgs/vtable-dumper/template
+++ b/srcpkgs/vtable-dumper/template
@@ -1,12 +1,12 @@
 # Template file for 'vtable-dumper'
 pkgname=vtable-dumper
 version=1.2
-revision=1
+revision=2
 build_style=gnu-makefile
 makedepends="elfutils-devel"
 short_desc="Tool to list content of virtual tables in a shared library"
 maintainer="meator <meator.dev@gmail.com>"
-license="GPL-3.0-or-later"
+license="LGPL-2.1-or-later"
 homepage="https://github.com/lvc/vtable-dumper"
 distfiles="https://github.com/lvc/vtable-dumper/archive/refs/tags/${version}.tar.gz"
 checksum=6993781b6a00936fc5f76dc0db4c410acb46b6d6e9836ddbe2e3c525c6dd1fd2


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->
Right when I noticed that #53942 was merged, I looked through the PR just to be sure and I have noticed that I forgot to edit the default `GPL-3.0-or-later` license of `vtable-dumper`. This PR fixes my mistake.

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
