### PR TITLE
python3-keyring: update to 25.6.0.

### DIFF
--- a/srcpkgs/python3-keyring/template
+++ b/srcpkgs/python3-keyring/template
@@ -1,7 +1,7 @@
 # Template file for 'python3-keyring'
 pkgname=python3-keyring
-version=25.4.1
-revision=2
+version=25.6.0
+revision=1
 build_style=python3-pep517
 hostmakedepends="python3-wheel python3-setuptools_scm"
 depends="python3-SecretStorage python3-jeepney
@@ -13,7 +13,7 @@ license="MIT"
 homepage="https://pypi.org/project/keyring/"
 changelog="https://raw.githubusercontent.com/jaraco/keyring/main/NEWS.rst"
 distfiles="${PYPI_SITE}/k/keyring/keyring-${version}.tar.gz"
-checksum=b07ebc55f3e8ed86ac81dd31ef14e81ace9dd9c3d4b5d77a6e9a2016d0d71a1b
+checksum=0b39998aa941431eb3d9b0d4b2460bc773b9df6fed7621c2dfb291a7e0187a66
 
 pre_check() {
 	vsed -e '/addopts/d' -i pytest.ini


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture: **x86_64**