### PR TITLE
soju: fix wrong command name in README.voidlinux

### DIFF
--- a/srcpkgs/soju/files/README.voidlinux
+++ b/srcpkgs/soju/files/README.voidlinux
@@ -3,6 +3,6 @@ The system service /etc/sv/soju runs soju as system user _soju.
 By default, the database will be stored in /var/db/soju/ and logs will be in
 /var/log/soju/. Both directories are owned by user _soju.
 
-To initialize the database, make sure you run sojuctl as the _soju user:
+To initialize the database, make sure you run sojudb as the _soju user:
 
-$ sudo -u _soju sojuctl -config /etc/soju/config create-user <username> -admin
+$ sudo -u _soju sojudb -config /etc/soju/config create-user <username> -admin

--- a/srcpkgs/soju/template
+++ b/srcpkgs/soju/template
@@ -1,7 +1,7 @@
 # Template file for 'soju'
 pkgname=soju
 version=0.8.2
-revision=1
+revision=2
 build_style=go
 go_import_path="codeberg.org/emersion/soju"
 go_package="./cmd/... ./contrib/..."


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
