### PR TITLE
font-sarasa-gothic: use correct path

### DIFF
--- a/srcpkgs/font-sarasa-gothic/template
+++ b/srcpkgs/font-sarasa-gothic/template
@@ -1,7 +1,7 @@
 # Template file for 'font-sarasa-gothic'
 pkgname=font-sarasa-gothic
 version=1.0.27
-revision=1
+revision=2
 depends="font-util"
 short_desc="CJK programming font based on Iosevka and Source Han Sans"
 maintainer="B. Wilson <x@wilsonb.com>"
@@ -9,11 +9,9 @@ license="OFL-1.1"
 homepage="https://github.com/be5invis/Sarasa-Gothic"
 distfiles="https://github.com/be5invis/Sarasa-Gothic/releases/download/v${version}/Sarasa-TTC-${version}.7z"
 checksum=9eecd0122fa546d9a5f8d4b9b7fc6f9ddc41ca107b6f2990ae68456da80d61a6
-font_dirs="/usr/share/fonts/TTF"
+font_dirs="/usr/share/fonts/TTC/sarasa-gothic"
 
 do_install() {
-	local file
-	for file in *.ttc; do
-		vinstall $file 0644 usr/share/fonts/TTF
-	done
+	vmkdir usr/share/fonts/TTC/sarasa-gothic
+	vcopy "*.ttc" usr/share/fonts/TTC/sarasa-gothic
 }


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc

The path (TTC vs. TTF) mismatch finally bothers me enough to make a fix.
