### PR TITLE
just: update to 1.39.0.

### DIFF
--- a/srcpkgs/just/template
+++ b/srcpkgs/just/template
@@ -1,6 +1,6 @@
 # Template file for 'just'
 pkgname=just
-version=1.37.0
+version=1.39.0
 revision=1
 build_style=cargo
 build_helper=qemu
@@ -12,7 +12,7 @@ license="CC0-1.0"
 homepage="https://github.com/casey/just"
 changelog="https://raw.githubusercontent.com/casey/just/master/CHANGELOG.md"
 distfiles="https://github.com/casey/just/archive/refs/tags/${version}.tar.gz"
-checksum=13af58413af8f5d41d72c955de0ed9863a53f286df5f848e3d68bcb070b54ef2
+checksum=8a900072d7f909bc91030df5896168752bb9108967dbb7149d2cfb11fdeb087a
 make_check=ci-skip  # test fails when run as root
 
 # Fix failing test


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- Local tests passed.

cc @cinerea0
