### PR TITLE
gns3-server/gns3-gui: update to 2.2.53

### DIFF
--- a/srcpkgs/gns3-gui/template
+++ b/srcpkgs/gns3-gui/template
@@ -1,7 +1,7 @@
 # Template file for 'gns3-gui'
 pkgname=gns3-gui
-version=2.2.52
-revision=2
+version=2.2.53
+revision=1
 build_style=python3-module
 hostmakedepends="python3-setuptools"
 depends="python3-setuptools python3-psutil python3-jsonschema
@@ -14,7 +14,7 @@ license="GPL-3.0-or-later"
 homepage="https://gns3.com"
 changelog="https://raw.githubusercontent.com/GNS3/gns3-gui/master/CHANGELOG"
 distfiles="https://github.com/GNS3/${pkgname}/archive/v${version}.tar.gz"
-checksum=ff854f1403a99887c132daa210663c2b9b28ab5e8062500a8dc349e897b4c5c1
+checksum=d6d8de369e3aa96ba49e4ba1cbc33c813053af58786817f477cd3fb8ad24066e
 
 
 post_patch() {

--- a/srcpkgs/gns3-server/template
+++ b/srcpkgs/gns3-server/template
@@ -1,7 +1,7 @@
 # Template file for 'gns3-server'
 pkgname=gns3-server
-version=2.2.52
-revision=2
+version=2.2.53
+revision=1
 build_style=python3-module
 hostmakedepends="python3-setuptools"
 depends="python3-setuptools python3-jsonschema python3-aiohttp python3-aiohttp-cors
@@ -14,7 +14,7 @@ license="GPL-3.0-or-later"
 homepage="https://gns3.com"
 changelog="https://raw.githubusercontent.com/GNS3/gns3-server/master/CHANGELOG"
 distfiles="https://github.com/GNS3/gns3-server/archive/v${version}.tar.gz"
-checksum=e4c1bfe7383033937fa1543f003ba659ce199d8757523b84acdd39becf8f9db0
+checksum=d9a8ed44a8dfe3740107f3f7445ab8eaac338ba6c5f06d319fabf2bbedb77ec9
 
 post_patch() {
 	# comment out requirements since versions are usually out of sync with Void packages


### PR DESCRIPTION
This is the latest update to the 2.2 branch of GNS3.  3.0 is the new stable release but it doubles the number of dependencies required by GNS3.  I do not plan on updating this to 3.0.  This package was almost removed from Void a few years ago and perhaps it's time.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
