### PR TITLE
Chirp: update to 20250425, add new dependency python3-lark

### DIFF
--- a/srcpkgs/chirp/template
+++ b/srcpkgs/chirp/template
@@ -1,14 +1,14 @@
 # Template file for 'chirp'
 pkgname=chirp
-version=20241025
-revision=2
+version=20250425
+revision=1
 build_style=python3-pep517
 hostmakedepends="python3-setuptools python3-wheel"
 depends="python3-six wxPython python3-pyserial python3-requests
- python3-suds python3-yattag"
+ python3-suds python3-yattag python3-lark"
 short_desc="Open-source tool for programming amateur radios"
 maintainer="Emil Miler <em@0x45.cz>"
 license="GPL-3.0-or-later"
 homepage="https://chirpmyradio.com/projects/chirp/wiki/Home"
 distfiles="https://archive.chirpmyradio.com/chirp_next/next-${version}/chirp-${version}.tar.gz"
-checksum=3e1812264a06a95833ed32a8c0ac83a7f93b8d94e58484390b8892fcdeae6024
+checksum=89630ffdd011a1503a2cfae185147a3f282350e902c917dd0a89ba37b613fced

--- a/srcpkgs/python3-lark/template
+++ b/srcpkgs/python3-lark/template
@@ -1,0 +1,17 @@
+# Template file for 'python3-lark'
+pkgname=python3-lark
+version=1.2.2
+revision=1
+build_style=python3-pep517
+hostmakedepends="python3-setuptools"
+depends="python3"
+short_desc="Modern general-purpose parsing library"
+maintainer="Emil Miler <em@0x45.cz>"
+license="MIT"
+homepage="https://github.com/lark-parser/lark"
+distfiles="${PYPI_SITE}/l/lark/lark-${version}.tar.gz"
+checksum=ca807d0162cd16cef15a8feecb862d7319e7a09bdb13aef927968e45040fed80
+
+post_install() {
+	vlicense LICENSE
+}


### PR DESCRIPTION
- I tested the changes in this PR: **YES**
- I built this PR locally for my native architecture, (x86_64-glibc)