### PR TITLE
base-files: fix /etc/profile call to unset appendpath

### DIFF
--- a/srcpkgs/base-files/files/profile
+++ b/srcpkgs/base-files/files/profile
@@ -18,7 +18,7 @@ appendpath '/usr/bin'
 appendpath '/usr/sbin'
 appendpath '/sbin'
 appendpath '/bin'
-unset appendpath
+unset -f appendpath
 
 export PATH
 


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

Have confirmed this behaviour of unset in bash, mksh and dash myself. And to quote the `unset` section of the manpage for sh:

```
     unset [-fv] name ...
            The specified variables and functions are unset and unexported.
            If -f or -v is specified, the corresponding function or variable
            is unset, respectively.  If a given name corresponds to both a
            variable and a function, and no options are given, only the
            variable is unset.
```

