### PR TITLE
liblo: update to 0.32, adopt.

### DIFF
--- a/srcpkgs/liblo/template
+++ b/srcpkgs/liblo/template
@@ -1,15 +1,15 @@
 # Template file for 'liblo'
 pkgname=liblo
-version=0.31
+version=0.32
 revision=1
 build_style=gnu-configure
-configure_args="--enable-ipv6"
 short_desc="Lightweight OSC implementation"
-maintainer="Orphaned <orphan@voidlinux.org>"
+maintainer="Rutpiv <roger_freitas@live.com>"
 license="LGPL-2.1-or-later"
 homepage="http://liblo.sourceforge.net/"
 distfiles="${SOURCEFORGE_SITE}/${pkgname}/${pkgname}-${version}.tar.gz"
-checksum=2b4f446e1220dcd624ecd8405248b08b7601e9a0d87a0b94730c2907dbccc750
+checksum=5df05f2a0395fc5ac90f6b538b8c82bb21941406fd1a70a765c7336a47d70208
+make_check=no # Tests freeze or fail intermittently.
 nopie=yes
 
 pre_configure() {


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture (x86_64)
- I built this PR locally for these architectures using specific masterdirs:
  - x86_64-musl
  - i686
- I built this PR locally for these architectures (crossbuilds):
  - aarch64
  - aarch64-musl
  - armv7l
  - armv7l-musl
  - armv6l
  - armv6l-musl
 
---
I disabled the tests because they fail intermittently—sometimes freezing and other times unpredictably failing different tests.

Additionally, I removed the IPv6 tag from the package. With this change, the package now behaves correctly for dependent packages utilizing the OSC feature. I tested this with `Carla` (with IPv6 enabled) and observed that the `carla-control` feature did not work. After removing the IPv6 tag, the feature now works as expected.

I would like to adopt this package, as it is currently orphaned.