### PR TITLE
ergo: update to 2.15.0.

### DIFF
--- a/srcpkgs/ergo/template
+++ b/srcpkgs/ergo/template
@@ -1,7 +1,7 @@
 # Template file for 'ergo'
 pkgname=ergo
-version=2.14.0
-revision=2
+version=2.15.0
+revision=1
 build_style=go
 go_import_path="github.com/ergochat/ergo"
 go_ldflags="-X main.version=$version"
@@ -11,7 +11,7 @@ license="MIT"
 homepage="https://ergo.chat/"
 changelog="https://raw.githubusercontent.com/ergochat/ergo/master/CHANGELOG.md"
 distfiles="https://github.com/ergochat/ergo/archive/v${version}.tar.gz"
-checksum=60085302182e54b9afe1a3f0c4e3a9da16fecdaa6bc4c1f0aceccded856969dd
+checksum=e2f88fe008a4e32798422b7a65fe81834d68d4695a014b37eded01278b170ce7
 system_accounts="_ergo"
 _ergo_homedir="/var/lib/ergo"
 make_dirs="/var/lib/ergo 0755 _ergo _ergo"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, x86_64

