### PR TITLE
gst-plugins-bad1: enable build with nvcodec

### DIFF
--- a/srcpkgs/gst-plugins-bad1/template
+++ b/srcpkgs/gst-plugins-bad1/template
@@ -1,12 +1,12 @@
 # Template file for 'gst-plugins-bad1'
 pkgname=gst-plugins-bad1
 version=1.24.10
-revision=1
+revision=2
 build_helper="gir"
 build_style=meson
 configure_args="-Dpackage-origin=https://voidlinux.org -Ddoc=disabled
- -Dopencv=disabled -Dmsdk=disabled -Dopensles=disabled -Dtinyalsa=disabled
- -Dwasapi=disabled -Dnvcodec=disabled -Ddc1394=disabled
+ -Dopencv=disabled -Dmsdk=disabled -Dopensles=disabled
+ -Dtinyalsa=disabled -Dwasapi=disabled -Ddc1394=disabled
  -Diqa=disabled -Dlibde265=disabled -Dmpeg2enc=disabled
  -Dmplex=disabled -Dmusepack=disabled -Dopenexr=disabled
  -Dopenh264=disabled -Dopenmpt=disabled -Dopenni2=disabled -Dsctp=disabled
@@ -26,7 +26,7 @@ makedepends="alsa-lib-devel celt-devel openssl-devel exempi-devel
  libgudev-devel libusb-devel libaom-devel libbs2b-devel chromaprint-devel
  fdk-aac-devel flite-devel fluidsynth-devel liblrdf-devel ladspa-sdk
  lilv-devel lv2 libopenjpeg2-devel sbc-devel spandsp-devel vulkan-loader-devel
- webrtc-audio-processing-devel libzbar-devel ffmpeg6-devel
+ webrtc-audio-processing-devel libzbar-devel ffmpeg6-devel nv-codec-headers
  srt-devel libva-devel $(vopt_if onevpl oneVPL-devel) $(vopt_if gme libgme-devel)"
 depends="gst-plugins-base1>=${version}"
 short_desc="GStreamer plugins from the bad set (v1.x)"


### PR DESCRIPTION
This change adds the nv-codec-headers package as a build dependency to gst-plugins-bad1 enabling the build of the nvcodec plugins.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)

