### PR TITLE
routinator: update to 0.14.1

### DIFF
--- a/srcpkgs/routinator/template
+++ b/srcpkgs/routinator/template
@@ -1,6 +1,6 @@
 # Template file for 'routinator'
 pkgname=routinator
-version=0.14.0
+version=0.14.1
 revision=1
 build_style=cargo
 depends="rsync"
@@ -11,7 +11,7 @@ homepage="https://routinator.docs.nlnetlabs.nl/"
 changelog="https://raw.githubusercontent.com/NLnetLabs/routinator/main/Changelog.md"
 distfiles="https://github.com/NLnetLabs/routinator/archive/v${version}.tar.gz"
 conf_files="/etc/routinator/routinator.conf"
-checksum=861e90f395344be19880485185df47e8fd258cc583b82be702af660b466955cb
+checksum=4b3aaf647ec61f7085e48af1cbc350cc0bdfce2082dae29cda16950cf4f4ae9d
 system_accounts="_routinator"
 _routinator_homedir="/var/lib/routinator"
 make_dirs="/var/lib/routinator 0755 _routinator _routinator"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-musl, x86_64-glibc)
- I built this PR locally for these architectures:
  - aarch64-musl
  - armv7l
  - armv6l-musl