### PR TITLE
New package: firefox-ublock-origin-1.62.0

### DIFF
--- a/srcpkgs/firefox-ublock-origin/template
+++ b/srcpkgs/firefox-ublock-origin/template
@@ -1,0 +1,32 @@
+# Template file for 'firefox-ublock-origin'
+pkgname=firefox-ublock-origin
+version=1.62.0
+revision=1
+build_style=gnu-makefile
+make_build_target="firefox"
+hostmakedepends="python3 zip"
+depends="firefox"
+short_desc="Effecient blocker for Firefox"
+maintainer="Emil Tomczyk <emru@emru.xyz>"
+license="GPL-3.0-or-later"
+homepage="https://ublockorigin.com/"
+_uassets_master="5722991a9ad362eaf4f2bb6ff64f08cccbafa2ef"
+_uassets_ghpages="2dde847869577e87fb9e0e095ac25323eba26560"
+distfiles="https://github.com/gorhill/uBlock/archive/refs/tags/${version}.tar.gz
+https://github.com/uBlockOrigin/uAssets/archive/${_uassets_master}.tar.gz
+https://github.com/uBlockOrigin/uAssets/archive/${_uassets_ghpages}.tar.gz"
+checksum="1f9d69f968ddec2ccfd3b104a3e0cda80403efd1a63356924406cf5296cde67b
+ a04e029394796104f60c346625707e1740069df8aea7e35af6d679b7b6febccb
+ afb5a554eefe4f4f8ecb8217d29518df71c76f1e85a10ffbd788c61e400c736d"
+skip_extraction="${_uassets_master}.tar.gz
+${_uassets_ghpages}.tar.gz"
+
+post_extract() {
+	vsrcextract -C dist/build/uAssets/main ${_uassets_master}.tar.gz
+	vsrcextract -C dist/build/uAssets/prod ${_uassets_ghpages}.tar.gz
+}
+
+do_install() {
+	vinstall dist/build/uBlock0.firefox.xpi 0644 \
+		usr/lib/firefox/browser/extensions uBlock0@raymondhill.net.xpi
+}


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**


#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): Good question


#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc

I've based this template on Alpine's one.
Installs uBlock Origin for Firefox systemwide.
I'm going to use it in some deployments.
Is this package any good? Or shouldn't it be in repo?
Extension is installed same way as in `firefox-i18n` and `firefox-esr-i18n` packages.