### PR TITLE
incus: update to 6.9.0.

### DIFF
--- a/srcpkgs/incus/template
+++ b/srcpkgs/incus/template
@@ -1,7 +1,7 @@
 # Template file for 'incus'
 pkgname=incus
-version=6.6.0
-revision=3
+version=6.9.0
+revision=1
 build_style=go
 build_helper=qemu
 go_import_path=github.com/lxc/incus/v6
@@ -18,7 +18,7 @@ maintainer="dkwo <npiazza@disroot.org>"
 license="Apache-2.0"
 homepage="https://linuxcontainers.org/incus"
 distfiles="https://github.com/lxc/incus/archive/refs/tags/v${version}.tar.gz"
-checksum=0274f6258591a3189737812228722d5c7b0cc57deb5edd0f65750d3323210394
+checksum=7c50d4eb2ae5a33eab27821c95e01fc9a5d977c9b6b594a51571e6fefd4119d2
 system_groups="_incus-admin _incus"
 make_dirs="
  /var/lib/incus 0755 root root


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**,  with XBPS_CHECK_PKGS=yes and on a running system with lxc containers and qemu VMs.

#### Local build testing
- I built this PR locally for my native architecture: amd64 glibc
- I cross-compiled this PR locally for aarch64

This PR affects incus and symlinked srcpkgs incus-client and incus-tools.