### PR TITLE
libde265: update to version 1.0.15

### DIFF
--- a/srcpkgs/libde265/template
+++ b/srcpkgs/libde265/template
@@ -1,6 +1,6 @@
 # Template file for 'libde265'
 pkgname=libde265
-version=1.0.12
+version=1.0.15
 revision=1
 build_style=gnu-configure
 hostmakedepends="pkg-config"
@@ -10,7 +10,7 @@ license="LGPL-3.0-or-later"
 homepage="https://www.libde265.org"
 changelog="https://github.com/strukturag/libde265/releases"
 distfiles="https://github.com/strukturag/libde265/releases/download/v${version}/libde265-${version}.tar.gz"
-checksum=62185ea2182e68cf68bba20cc6eb4c287407b509cf0a827d7ddb75614db77b5c
+checksum=00251986c29d34d3af7117ed05874950c875dd9292d016be29d3b3762666511d
 
 post_install() {
 	# Why is this installed anyway?


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
