### PR TITLE
swirc: update to 3.5.2.

### DIFF
--- a/srcpkgs/swirc/template
+++ b/srcpkgs/swirc/template
@@ -1,6 +1,6 @@
 # Template file for 'swirc'
 pkgname=swirc
-version=3.5.1
+version=3.5.2
 revision=1
 build_style=configure
 configure_args="$(vopt_with notify libnotify)"
@@ -17,7 +17,7 @@ license="BSD-3-Clause, ISC, MIT"
 homepage="https://www.nifty-networks.net/swirc"
 changelog="https://raw.githubusercontent.com/uhlin/swirc/master/CHANGELOG.md"
 distfiles="https://www.nifty-networks.net/swirc/releases/swirc-${version}.tgz"
-checksum=821637d795455fa3c2c0733180d6e43c3cfc766bd2133922501bd23378f4abc0
+checksum=3dee9d77ef243ae1d4e1e2f704e13771ae3f764a997479d86da12828a62b8a10
 
 build_options="notify"
 build_options_default="notify"


### PR DESCRIPTION
Swirc 3.5.2 out!

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, **x86_64-musl**
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - armv6l-musl **cross**
