### PR TITLE
rio: update to 0.2.5

### DIFF
--- a/srcpkgs/rio/template
+++ b/srcpkgs/rio/template
@@ -1,6 +1,6 @@
 # Template file for 'rio'
 pkgname=rio
-version=0.2.4
+version=0.2.5
 revision=1
 build_style=cargo
 build_wrksrc="frontends/rioterm"
@@ -13,7 +13,7 @@ license="MIT"
 homepage="https://raphamorim.io/rio/"
 changelog="https://raw.githubusercontent.com/raphamorim/rio/main/CHANGELOG.md"
 distfiles="https://github.com/raphamorim/rio/archive/refs/tags/v${version}.tar.gz"
-checksum=2b7cd1a87164fc2a79c17362a0bb9e96034230a727031bd5f8a75b322aec514d
+checksum=03fb35ae46d3dcb48f3ea193854c8ad959018c364e5b632e0130970d0f18cddd
 
 post_install() {
 	vinstall ${wrksrc}/misc/logo.svg 644 usr/share/icons/hicolor/scalable/apps rio.svg


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
