### PR TITLE
opera: update to 116.0.5366.71

### DIFF
--- a/srcpkgs/opera/template
+++ b/srcpkgs/opera/template
@@ -1,16 +1,16 @@
 # Template file for 'opera'
 pkgname=opera
-version=115.0.5322.77
+version=116.0.5366.71
 revision=1
 archs="x86_64"
 create_wrksrc=yes
-depends="ffmpeg desktop-file-utils hicolor-icon-theme"
+depends="ffmpeg6 desktop-file-utils hicolor-icon-theme"
 short_desc="Fast, secure, easy to use browser"
 maintainer="mobinmob <mobinmob@disroot.org>"
 license="custom:Proprietary"
 homepage="https://www.opera.com/computer"
 distfiles="https://get.geo.opera.com/pub/opera/desktop/${version}/linux/opera-stable_${version}_amd64.rpm"
-checksum=31c73e95bcb0f52221a3724ff136ff50994d51fb5212591d302a7e957e1a9ecd
+checksum=d6b15ab8cdd5288104d16fb408826175a1c9ed99ce8631ae59c238294212be7c
 repository="nonfree"
 nostrip=yes
 


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
<br/>

@mobinmob could you please review the changes??
And, thanks for your time!!

<br/>

I have migrated to ffmpeg6 and it seems to work fine for me, the package itself installs the ffmpeg6 so I don't think we require ffmpeg4 anymore