### PR TITLE
electron33: update to 33.2.0.

### DIFF
--- a/srcpkgs/electron33/patches/spellchecker-infinate-loop.patch
+++ b/srcpkgs/electron33/patches/spellchecker-infinate-loop.patch
@@ -1,0 +1,31 @@
+From 9f6ee267adabcbd3348dd1a4daf57843aef14050 Mon Sep 17 00:00:00 2001
+From: "trop[bot]" <37223003+trop[bot]@users.noreply.github.com>
+Date: Fri, 13 Dec 2024 16:47:55 +0000
+Subject: [PATCH] fix: custom spell-checker stuck in infinite loop
+
+`ReadUnicodeCharacter` updates index to the last character read, and not after it. We need to manually increment it to move to the next character.
+
+It also doesn't validate that the index is valid, so we need to check that index is within bounds.
+
+Refs: #44336
+
+Co-authored-by: Jesper Ek <deadbeef84@gmail.com>
+---
+ shell/renderer/api/electron_api_spell_check_client.cc | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/shell/renderer/api/electron_api_spell_check_client.cc b/shell/renderer/api/electron_api_spell_check_client.cc
+index b97f1771ff723..95e05ecccb524 100644
+--- a/src/electron/shell/renderer/api/electron_api_spell_check_client.cc
++++ b/src/electron/shell/renderer/api/electron_api_spell_check_client.cc
+@@ -32,7 +32,9 @@ namespace {
+ 
+ bool HasWordCharacters(const std::u16string& text, size_t index) {
+   base_icu::UChar32 code;
+-  while (base::ReadUnicodeCharacter(text.c_str(), text.size(), &index, &code)) {
++  while (index < text.size() &&
++         base::ReadUnicodeCharacter(text.c_str(), text.size(), &index, &code)) {
++    ++index;
+     UErrorCode error = U_ZERO_ERROR;
+     if (uscript_getScript(code, &error) != USCRIPT_COMMON)
+       return true;

--- a/srcpkgs/electron33/template
+++ b/srcpkgs/electron33/template
@@ -1,9 +1,9 @@
 # Template file for 'electron33'
 pkgname=electron33
-version=33.0.2
+version=33.2.0
 revision=1
 _nodever=20.18.0
-_chromiumver=130.0.6723.59
+_chromiumver=130.0.6723.118
 archs="x86_64* aarch64*"
 create_wrksrc=yes
 build_wrksrc="src"
@@ -27,8 +27,8 @@ homepage="https://electronjs.org"
 distfiles="https://github.com/electron/electron/archive/v$version.tar.gz>electron-${version}.tar.gz
  https://commondatastorage.googleapis.com/chromium-browser-official/chromium-$_chromiumver.tar.xz
  https://github.com/nodejs/node/archive/v$_nodever.tar.gz>node-$_nodever.tar.gz"
-checksum="c6d3be16998ee1f92020078e39dd5c7ea98a1222d2f68919b533ef7f507521fa
- 90401be8adcd6f580db5c71ea865c97db0e719ba41f406f5869fc7f44bd20e4f
+checksum="6a0589bbdbf1d5ccc8508b536c1beeb5f49cedb1806dc0de9b04f568946be056
+ a0a9a740ebb864e89febf4d5480ffbf31b45ac5a506ae70184fa842e27b2d177
  651bb82f6af18084070893559643759165ce050b5839f830d4cc098130d3ad89"
 
 


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

[ci skip]

cc: @Johnnynator 

#### Testing the changes
- I tested the changes in this PR: **YES**

Tested on x86_64 and x86_64-musl and appears to work.

Fixes crashing in vscode 1.96.x.
See: https://github.com/void-linux/void-packages/pull/51909

#### Local build testing
- I built this PR locally for my native architecture, x86_64
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl (native)

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->