### PR TITLE
snes9x-gtk: update to 1.63

### DIFF
--- a/srcpkgs/snes9x-gtk/template
+++ b/srcpkgs/snes9x-gtk/template
@@ -1,17 +1,18 @@
 # Template file for 'snes9x-gtk'
 pkgname=snes9x-gtk
-version=1.60
-revision=2
+version=1.63
+revision=1
 build_wrksrc="gtk"
-build_style=meson
+build_style=cmake
+configure_args="-DUSE_SLANG=OFF"
 hostmakedepends="gettext-devel glib-devel pkg-config intltool"
-makedepends="minizip-devel gtk+3-devel SDL2-devel xorg-server-devel"
+makedepends="minizip-devel gtk+3-devel SDL2-devel xorg-server-devel gtkmm-devel portaudio-devel"
 short_desc="SNES Emulator"
 maintainer="Hinterwaeldlers <mguethle@xunit.de>"
 license="LGPL-2.1-or-later"
 homepage="http://www.snes9x.com/"
 distfiles="https://github.com/snes9xgit/snes9x/archive/$version.tar.gz"
-checksum=861c8c0ab1d302d9df51e5ac4717a0069b33614a3f22bf3ab17ebf3405e58722
+checksum=84560ce38a734ac8299645883d8e0c0423b7da2430bde5f88276bba1be6d5330
 
 nocross="cannot run test program while cross compiling"
 


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)