### PR TITLE
asahi-base: update to 20250202, depend on asahi-scripts and dracut.

### DIFF
--- a/srcpkgs/asahi-base/template
+++ b/srcpkgs/asahi-base/template
@@ -1,10 +1,10 @@
 # Template file for 'asahi-base'
 pkgname=asahi-base
-version=20250116
+version=20250202
 revision=1
 archs="aarch64*"
 build_style=meta
-depends="linux-asahi m1n1 asahi-uboot speakersafetyd"
+depends="linux-asahi m1n1 asahi-uboot speakersafetyd dracut asahi-scripts"
 short_desc="Void Linux Apple Silicon support package"
 maintainer="Will Springer <skirmisher@protonmail.com>, dkwo <npiazza@disroot.org>"
 license="Public Domain"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **NO**

Other "base" packages depend on dracut, and asahi-scripts is needed for the dracut hooks

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
@dkwo 