### PR TITLE
google-chrome: update to 132.0.6834.159.

### DIFF
--- a/srcpkgs/google-chrome/template
+++ b/srcpkgs/google-chrome/template
@@ -1,6 +1,6 @@
 # Template file for 'google-chrome'
 pkgname=google-chrome
-version=131.0.6778.204
+version=132.0.6834.159
 revision=1
 _channel=stable
 archs="x86_64"
@@ -11,7 +11,7 @@ maintainer="Michael Aldridge <maldridge@voidlinux.org>"
 license="custom:chrome"
 homepage="https://www.google.com/chrome/"
 distfiles="https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-${_channel}_${version}-1_amd64.deb"
-checksum=bc065416e7d17ef911b1b5e7a960f8cc4de181359b845a8395ab9737b9ba988c
+checksum=e54ef927fd5194e1feb705f05269405b81f47a5e2d9a001c7bc8df05fea0331c
 
 skiprdeps="/opt/google/chrome/libqt5_shim.so /opt/google/chrome/libqt6_shim.so"
 repository=nonfree


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc

Latest Google Chrome release per the Chrome blog on January 28:

https://chromereleases.googleblog.com/2025/01/stable-channel-update-for-desktop_28.html