### PR TITLE
SDL3: update to 3.2.2

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -4537,3 +4537,4 @@ libopencore-amrnb.so.0 opencore-amr-0.1.6_1
 libopencore-amrwb.so.0 opencore-amr-0.1.6_1
 libilbc.so.3 libilbc-3.0.4_1
 libmaliit-plugins.so.2 maliit-keyboard-2.3.1_1
+libSDL3.so.0 SDL3-3.2.2_1

--- a/srcpkgs/SDL3/template
+++ b/srcpkgs/SDL3/template
@@ -1,9 +1,9 @@
 # Template file for 'SDL3'
 pkgname=SDL3
-version=3.2.0
+version=3.2.2
 revision=1
 build_style=cmake
-configure_args="-DSDL_ALSA=ON -DSDL_ESD=OFF -DSDL_RPATH=OFF
+configure_args="-DSDL_ALSA=ON -DSDL_RPATH=OFF
  -DSDL_CLOCK_GETTIME=ON -DSDL_PULSEAUDIO_SHARED=OFF
  -DSDL_ALSA_SHARED=OFF -DSDL_DBUS=ON"
 hostmakedepends="pkg-config nasm"
@@ -15,7 +15,7 @@ license="Zlib"
 homepage="https://www.libsdl.org/"
 changelog="https://raw.githubusercontent.com/libsdl-org/SDL/refs/heads/main/WhatsNew.txt"
 distfiles="https://www.libsdl.org/release/SDL3-${version}.tar.gz"
-checksum=bf308f92c5688b1479faf5cfe24af72f3cd4ce08d0c0670d6ce55bc2ec1e9a5e
+checksum=d3dcf1b2f64746be0f248ef27b35aec4f038dafadfb83491f98a7fecdaf6efec
 
 # Package build options
 build_options="gles opengl pulseaudio pipewire sndio vulkan wayland x11"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)


Removed the SDL_ESD=off tag, because it wasn't used in the compilation.