### PR TITLE
xbps-src: re-run post-install hooks if -f flag is used

### DIFF
--- a/common/xbps-src/libexec/xbps-src-doinstall.sh
+++ b/common/xbps-src/libexec/xbps-src-doinstall.sh
@@ -44,7 +44,7 @@ fi
 XBPS_SUBPKG_INSTALL_DONE="${XBPS_STATEDIR}/${PKGNAME}_${XBPS_CROSS_BUILD}_subpkg_install_done"
 
 # If it's a subpkg execute the pkg_install() function.
-if [ ! -f $XBPS_SUBPKG_INSTALL_DONE ]; then
+if [ ! -f $XBPS_SUBPKG_INSTALL_DONE -o -n "$XBPS_BUILD_FORCEMODE" ]; then
     if [ "$sourcepkg" != "$PKGNAME" ]; then
         # Source all subpkg environment setup snippets.
         for f in ${XBPS_COMMONDIR}/environment/setup-subpkg/*.sh; do


### PR DESCRIPTION
[ci skip]

This fixed the issue where the post-install hooks are not rerun even though `-f` was specified. Resulting in some weird error about lib64 not being allowed, since xbps-src creates the symlink in the destdir and removes it again in the post-install hook.