### PR TITLE
SDL2_image: update to 2.8.5.

### DIFF
--- a/srcpkgs/SDL2_image/template
+++ b/srcpkgs/SDL2_image/template
@@ -1,7 +1,7 @@
 # Template file for 'SDL2_image'
 pkgname=SDL2_image
-version=2.8.2
-revision=2
+version=2.8.5
+revision=1
 build_style=cmake
 configure_args="-DSDL2IMAGE_WEBP=ON"
 hostmakedepends="pkg-config"
@@ -13,7 +13,7 @@ license="Zlib"
 homepage="https://github.com/libsdl-org/SDL_image"
 changelog="https://raw.githubusercontent.com/libsdl-org/SDL_image/SDL2/CHANGES.txt"
 distfiles="http://www.libsdl.org/projects/SDL_image/release/SDL2_image-${version}.tar.gz"
-checksum=8f486bbfbcf8464dd58c9e5d93394ab0255ce68b51c5a966a918244820a76ddc
+checksum=8bc4c57f41e2c0db7f9b749b253ef6cecdc6f0b689ecbe36ee97b50115fff645
 
 post_install() {
 	vlicense LICENSE.txt LICENSE


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture (x86_64)
- I built this PR locally for these architectures using specific masterdirs:
  - x86_64-musl
  - i686
- I built this PR locally for these architectures (crossbuilds):
  - aarch64
  - aarch64-musl
  - armv7l
  - armv7l-musl
  - armv6l
  - armv6l-musl