### PR TITLE
gst-plugins-base1: break cycle by making libvisual dependency optional

### DIFF
--- a/srcpkgs/gst-plugins-base1/template
+++ b/srcpkgs/gst-plugins-base1/template
@@ -1,18 +1,18 @@
 # Template file for 'gst-plugins-base1'
 pkgname=gst-plugins-base1
 version=1.24.10
-revision=1
+revision=2
 build_style=meson
 build_helper="gir"
 configure_args="-Dtremor=disabled -Dexamples=disabled -Ddoc=disabled
  $(vopt_feature cdparanoia cdparanoia) $(vopt_feature gir introspection)
- $(vopt_feature sndio sndio)"
+ $(vopt_feature sndio sndio) $(vopt_feature libvisual libvisual)"
 hostmakedepends="gettext pkg-config glib-devel orc $(vopt_if wayland wayland-devel)"
 makedepends="gstreamer1-devel glib-devel libxml2-devel pango-devel
  cairo-devel liboil-devel alsa-lib-devel libXv-devel libXext-devel
- libvisual-devel libgudev-devel libtheora-devel libvorbis-devel
- libSM-devel orc-devel $(vopt_if cdparanoia libcdparanoia-devel)
- opus-devel MesaLib-devel $(vopt_if sndio sndio-devel) graphene-devel
+ libgudev-devel libtheora-devel libvorbis-devel libSM-devel orc-devel
+ graphene-devel opus-devel MesaLib-devel $(vopt_if cdparanoia libcdparanoia-devel)
+ $(vopt_if libvisual libvisual-devel) $(vopt_if sndio sndio-devel)
  $(vopt_if wayland 'wayland-devel wayland-protocols')"
 depends="orc>=0.4.18 gstreamer1>=${version}"
 checkdepends="mesa-dri"
@@ -24,8 +24,9 @@ changelog="https://gstreamer.freedesktop.org/releases/${version%.*}/#${version}"
 distfiles="https://gstreamer.freedesktop.org/src/gst-plugins-base/gst-plugins-base-${version}.tar.xz"
 checksum=ebd57b1be924c6e24f327dd55bab9d8fbaaebe5e1dc8fca784182ab2b12d23eb
 
-build_options="cdparanoia gir sndio wayland"
+build_options="cdparanoia gir libvisual sndio wayland"
 build_options_default="cdparanoia gir wayland"
+desc_option_libvisual="Enable audio visualization plugin"
 desc_option_sndio="Enable sndio support (unsupported, known to be problematic)"
 
 # Remove sndio if not upstreamed


### PR DESCRIPTION
Closes: #54215

#### Testing the changes
- I tested the changes in this PR: **NO**

I have no idea if the absence of this plugin breaks any packages as we ship them, or how many people's workflows will be disrupted, but cutting `libvisual` out of the loop seems to be the easiest way to break a dependency cycle.

cc: @Piraty 