### PR TITLE
add manpage to the lsd package

### DIFF
--- a/srcpkgs/lsd/template
+++ b/srcpkgs/lsd/template
@@ -3,7 +3,7 @@ pkgname=lsd
 version=1.1.5
 revision=1
 build_style=cargo
-hostmakedepends="pkg-config"
+hostmakedepends="pkg-config pandoc"
 makedepends="libgit2-devel"
 checkdepends="git"
 short_desc="Next gen ls command with lots of pretty colors and awesome icons"
@@ -24,8 +24,13 @@ fi
 
 export SHELL_COMPLETIONS_DIR="${wrksrc}"
 
+pre_configure() {
+	pandoc -s -f markdown-smart -t man doc/lsd.md -o lsd.1
+}
+
 post_install() {
 	vcompletion lsd.bash bash
 	vcompletion lsd.fish fish
 	vcompletion _lsd zsh
+	vman lsd.1
 }

--- a/srcpkgs/lsd/template
+++ b/srcpkgs/lsd/template
@@ -1,7 +1,7 @@
 # Template file for 'lsd'
 pkgname=lsd
 version=1.1.5
-revision=1
+revision=2
 build_style=cargo
 hostmakedepends="pkg-config pandoc"
 makedepends="libgit2-devel"


### PR DESCRIPTION
I noticed that the `lsd` tool was missing a manpage, so I edited the template file to use pandoc to generate a manpage from the doc/lsd.md that was already present in the sources.