### PR TITLE
mesa-asahi: Enable Honeykrisp vulkan driver

### DIFF
--- a/srcpkgs/mesa-asahi/template
+++ b/srcpkgs/mesa-asahi/template
@@ -1,7 +1,7 @@
 # Template file for 'mesa-asahi'
 pkgname=mesa-asahi
 version=25.0.0+20241211
-revision=1
+revision=2
 _llvmver=19
 _mesaver=${version%+*}
 archs="aarch64*"
@@ -13,7 +13,7 @@ configure_args="-Dglvnd=enabled -Dshared-glapi=enabled -Dgbm=enabled -Degl=enabl
  -Dlmsensors=enabled -Dplatforms=x11$(vopt_if wayland ,wayland)
  -Dllvm=enabled -Db_lto=false -Dcpp_std=gnu++17
  -Dgallium-vdpau=enabled -Dgallium-va=enabled
- -Dvulkan-drivers=swrast,virtio -Dvulkan-layers=device-select,overlay
+ -Dvulkan-drivers=swrast,virtio,asahi -Dvulkan-layers=device-select,overlay
  -Dgallium-drivers=swrast,asahi,virgl,zink
  -Dgallium-opencl=icd -Dgallium-rusticl=true -Drust_std=2021"
 hostmakedepends="gettext flex pkg-config python3-Mako glslang llvm${_llvmver}


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, aarch64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
