### PR TITLE
go: update to 1.23.6.

### DIFF
--- a/srcpkgs/go/template
+++ b/srcpkgs/go/template
@@ -1,6 +1,6 @@
 # Template file for 'go'
 pkgname=go
-version=1.23.4
+version=1.23.6
 revision=1
 create_wrksrc=yes
 build_wrksrc=go
@@ -12,7 +12,7 @@ license="BSD-3-Clause"
 homepage="https://go.dev/"
 changelog="https://go.dev/doc/devel/release.html"
 distfiles="https://go.dev/dl/go${version}.src.tar.gz"
-checksum=ad345ac421e90814293a9699cca19dd5238251c3f687980bbcae28495b263531
+checksum=039c5b04e65279daceee8a6f71e70bd05cf5b801782b6f77c6e19e2ed0511222
 nostrip=yes
 noverifyrdeps=yes
 # on CI it tries to use `git submodule`, which is not part of chroot-git


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64
  - aarch64-musl
  - armv7l
  - armv6l-musl
  - i686

#### Changelog

go1.23.5 (released 2025-01-16) includes security fixes to the crypto/x509 and net/http packages, as well as bug fixes to the compiler, the runtime, and the net package. See the [Go 1.23.5 milestone](https://github.com/golang/go/issues?q=milestone%3AGo1.23.5+label%3ACherryPickApproved) on our issue tracker for details.

go1.23.6 (released 2025-02-04) includes security fixes to the crypto/elliptic package, as well as bug fixes to the compiler and the go command. See the [Go 1.23.6 milestone](https://github.com/golang/go/issues?q=milestone%3AGo1.23.6+label%3ACherryPickApproved) on our issue tracker for details.