### PR TITLE
google-chrome: update to 133.0.6943.53.

### DIFF
--- a/srcpkgs/google-chrome/template
+++ b/srcpkgs/google-chrome/template
@@ -1,6 +1,6 @@
 # Template file for 'google-chrome'
 pkgname=google-chrome
-version=132.0.6834.159
+version=133.0.6943.53
 revision=1
 _channel=stable
 archs="x86_64"
@@ -11,7 +11,7 @@ maintainer="Michael Aldridge <maldridge@voidlinux.org>"
 license="custom:chrome"
 homepage="https://www.google.com/chrome/"
 distfiles="https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-${_channel}_${version}-1_amd64.deb"
-checksum=e54ef927fd5194e1feb705f05269405b81f47a5e2d9a001c7bc8df05fea0331c
+checksum=ef75f672885ba08f866c50e4e62923c674f53ca8c6e14a32ce103d4fd41ef559
 
 skiprdeps="/opt/google/chrome/libqt5_shim.so /opt/google/chrome/libqt6_shim.so"
 repository=nonfree


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)

Other info: This is the latest stable channel release, addressing 12 security fixes including 2 high severity undisclosed (as yet) issues.

https://chromereleases.googleblog.com/2025/02/stable-channel-update-for-desktop.html


