### PR TITLE
eww: add wayland build option, patch cargo lockfile

### DIFF
--- a/srcpkgs/eww/patches/lockfile.patch
+++ b/srcpkgs/eww/patches/lockfile.patch
@@ -1,0 +1,37 @@
+diff --git a/Cargo.lock b/Cargo.lock
+index 5d94bd4..acd2c8d 100644
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -1676,7 +1676,7 @@ dependencies = [
+  "libm",
+  "log",
+  "regex",
+- "time 0.3.34",
++ "time 0.3.36",
+  "urlencoding",
+ ]
+ 
+@@ -2893,9 +2893,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "time"
+-version = "0.3.34"
++version = "0.3.36"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "c8248b6521bb14bc45b4067159b9b6ad792e2d6d754d6c41fb50e29fefe38749"
++checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
+ dependencies = [
+  "deranged",
+  "itoa",
+@@ -2914,9 +2914,9 @@ checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+ 
+ [[package]]
+ name = "time-macros"
+-version = "0.2.17"
++version = "0.2.18"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "7ba3a3ef41e6672a2f0f001392bb5dcd3ff0a9992d618ca761a11c3121547774"
++checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
+ dependencies = [
+  "num-conv",
+  "time-core",

--- a/srcpkgs/eww/template
+++ b/srcpkgs/eww/template
@@ -1,9 +1,10 @@
 # Template file for 'eww'
 pkgname=eww
 version=0.6.0
-revision=1
+revision=2
 build_style=cargo
-build_helper="qemu"
+build_helper=qemu
+configure_args="--no-default-features --features $(vopt_if wayland wayland x11)"
 make_install_args="--path=crates/eww"
 hostmakedepends="pkg-config"
 makedepends="gtk+3-devel gtk-layer-shell-devel pango-devel gdk-pixbuf-devel
@@ -15,6 +16,8 @@ homepage="https://elkowar.github.io/eww"
 changelog="https://raw.githubusercontent.com/elkowar/eww/master/CHANGELOG.md"
 distfiles="https://github.com/elkowar/eww/archive/refs/tags/v${version}.tar.gz"
 checksum=cef361946946c566b79f8ddc6208d1a3f16b4ff9961439a3f86935e1cfa174a1
+
+build_options="wayland"
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
- I tested the changes in this PR: **YES**
- I built this PR locally for my native architecture, x86_64

This PR adds a wayland build option for `eww`.

Since `rust 1.80.0`, `eww 0.6.0` is know [not to compile](https://github.com/elkowar/eww/issues/1156) due to an incompatibility with crate `time 0.3.34` (this is currently [fixed](https://github.com/elkowar/eww/pull/1144) upstream, but not released). Note that this affects the current revision of `eww`, independent of the wayland specific stuff (the template fails to build due to the new rust version). This PR also adds [a small patch from nixpkgs](https://github.com/NixOS/nixpkgs/blob/40cffc01bc89548395103929e3ddb98b57d00e67/pkgs/by-name/ew/eww/lockfile.patch) to circumvent this problem.