### PR TITLE
gnome-keyring: update to 46.2.

### DIFF
--- a/srcpkgs/gnome-keyring/template
+++ b/srcpkgs/gnome-keyring/template
@@ -1,6 +1,6 @@
 # Template file for 'gnome-keyring'
 pkgname=gnome-keyring
-version=46.1
+version=46.2
 revision=1
 build_style=gnu-configure
 configure_args="--with-pam-dir=/usr/lib/security --disable-schemas-compile
@@ -13,9 +13,9 @@ short_desc="GNOME password and secret manager"
 maintainer="Érico Nogueira <ericonr@disroot.org>"
 license="GPL-2.0-or-later, LGPL-2.1-or-later"
 homepage="https://wiki.gnome.org/Projects/GnomeKeyring/"
-changelog="https://gitlab.gnome.org/GNOME/gnome-keyring/-/raw/master/NEWS"
+changelog="https://gitlab.gnome.org/GNOME/gnome-keyring/-/raw/main/NEWS"
 distfiles="${GNOME_SITE}/$pkgname/${version%.*}/$pkgname-$version.tar.xz"
-checksum=b1d3ae9132ff2f8b3f25a190790892968e3d0acf952a487e40f644a8550ce3f6
+checksum=bf26c966b8a8b7f3285ecc8bb3e467b9c20f9535b94dc451c9c559ddcff61925
 lib32disabled=yes
 make_check_pre="dbus-run-session xvfb-run"
 make_check=ci-skip # times out


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
