### PR TITLE
miniserve: update to 0.29.0

### DIFF
--- a/srcpkgs/miniserve/template
+++ b/srcpkgs/miniserve/template
@@ -1,6 +1,6 @@
 # Template file for 'miniserve'
 pkgname=miniserve
-version=0.28.0
+version=0.29.0
 revision=1
 build_style=cargo
 build_helper=qemu
@@ -10,14 +10,14 @@ make_check_args="--
  --skip qrcode_shown_in_tty_when_enabled"
 hostmakedepends="pkg-config"
 makedepends="libzstd-devel"
-checkdepends="curl"
+checkdepends="curl openssl-devel"
 short_desc="CLI tool to serve files and dirs over HTTP"
 maintainer="Enno Boland <gottox@voidlinux.org>"
 license="MIT"
 homepage="https://github.com/svenstaro/miniserve"
 changelog="https://raw.githubusercontent.com/svenstaro/miniserve/master/CHANGELOG.md"
 distfiles="https://github.com/svenstaro/miniserve/archive/refs/tags/v${version}.tar.gz"
-checksum=c4c5e12796bdae2892eff3832b66c4c04364738b62cf1429259428b03363d1f1
+checksum=48351a8165bd51f3c855695af1c25032b502f873c80f52f98a538174951cbb9f
 make_check=ci-skip  # port binding succeeds locally but fails in CI
 
 case "$XBPS_TARGET_MACHINE" in


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
