### PR TITLE
gnome-mahjongg: update to 47.2

### DIFF
--- a/srcpkgs/gnome-mahjongg/template
+++ b/srcpkgs/gnome-mahjongg/template
@@ -1,6 +1,6 @@
 # Template file for 'gnome-mahjongg'
 pkgname=gnome-mahjongg
-version=47.1
+version=47.2
 revision=1
 build_style=meson
 hostmakedepends="gettext glib-devel itstool pkg-config vala
@@ -12,4 +12,4 @@ license="GPL-2.0-or-later"
 homepage="https://wiki.gnome.org/Apps/Mahjongg"
 changelog="https://gitlab.gnome.org/GNOME/gnome-mahjongg/-/raw/master/NEWS"
 distfiles="${GNOME_SITE}/${pkgname}/${version%.*}/${pkgname}-${version}.tar.xz"
-checksum=aae90adf1c35741437c443abc77e1ced68c20f1452dbbbd783dcb400ca2e02b0
+checksum=35df926419f37826380a3346207563cd87c7e99a13debe0e93a1409d85cc6157


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **yes**

#### Local build testing
- I built this PR locally for my native architecture, x86_64
- I crossbuilded this PR locally for these architectures:
  - armv7l
  - armv6l-musl
  - aarch64-musl