### PR TITLE
doxygen: add documentation

### DIFF
--- a/srcpkgs/doxygen-doc
+++ b/srcpkgs/doxygen-doc
@@ -1,0 +1,1 @@
+doxygen

--- a/srcpkgs/doxygen/files/use-native-doxygen.patch
+++ b/srcpkgs/doxygen/files/use-native-doxygen.patch
@@ -1,0 +1,39 @@
+This patch is applied only when cross building. It makes sure that the native
+version of doxygen is used for documentation generation and not the freshly built
+one (which cannot be executed on host).
+--- a/doc/CMakeLists.txt
++++ b/doc/CMakeLists.txt
+@@ -50,13 +50,9 @@
+ find_program(PDFLATEX NAMES pdflatex )
+ find_program(MAKEINDEX NAMES makeindex )
+ 
+-if (doxygen_BINARY_DIR)
+-    set(DOXYGEN_EXECUTABLE ${doxygen_BINARY_DIR}/bin/doxygen)
+-else()
+     # when building only the doxygen_doc, from the doc/ directory, the
+     # doxygen project variables are unknown so look for doxygen in PATH
+     find_package(Doxygen)
+-endif()
+ 
+ set(DOC_INSTALL_DIR "share/doc/packages/doxygen" CACHE STRING "Relative path where to install the documentation")
+ set(DOC_FILES
+--- a/examples/CMakeLists.txt
++++ b/examples/CMakeLists.txt
+@@ -65,6 +65,8 @@
+ configure_file(${PROJECT_SOURCE_DIR}/doc/doxygen_manual.css ${PROJECT_BINARY_DIR}/examples/doxygen_manual.css COPYONLY)
+ configure_file(${PROJECT_SOURCE_DIR}/doc/doxygen_manual_chm.css ${PROJECT_BINARY_DIR}/examples/doxygen_manual_chm.css COPYONLY)
+ 
++find_package(Doxygen)
++
+ foreach (f_inp  ${BASIC_EXAMPLES})
+         list(LENGTH ${f_inp} f_len)
+         list(GET    ${f_inp} 0 f)
+@@ -82,7 +84,7 @@
+     add_custom_command(
+         COMMAND ${CMAKE_COMMAND} -E make_directory ${PROJECT_BINARY_DIR}/html/examples/${f}
+         COMMAND ${CMAKE_COMMAND} -E make_directory ${PROJECT_BINARY_DIR}/latex/examples/${f}
+-        COMMAND ${CMAKE_COMMAND} -E env PROJECT_BINARY_DIR=${PROJECT_BINARY_DIR} EXTRA_SETTINGS=docuexample.cfg ${EXECUTABLE_OUTPUT_PATH}/doxygen ${f}.cfg
++        COMMAND ${CMAKE_COMMAND} -E env PROJECT_BINARY_DIR=${PROJECT_BINARY_DIR} EXTRA_SETTINGS=docuexample.cfg ${DOXYGEN_EXECUTABLE} ${f}.cfg
+         COMMAND ${Python_EXECUTABLE}  ${TOP}/examples/strip_example.py  < ${PROJECT_BINARY_DIR}/latex/examples/${f}/latex/refman.tex > ${PROJECT_BINARY_DIR}/latex/examples/${f}/latex/refman_doc.tex
+         DEPENDS doxygen ${f}.${f_ext} ${f}.cfg ${TOP}/examples/strip_example.py ${f_dep} baseexample.cfg docuexample.cfg
+         OUTPUT ${PROJECT_BINARY_DIR}/html/examples/${f}/html/index.html ${PROJECT_BINARY_DIR}/latex/examples/${f}/latex/refman_doc.tex

--- a/srcpkgs/doxygen/template
+++ b/srcpkgs/doxygen/template
@@ -1,9 +1,10 @@
 # Template file for 'doxygen'
 pkgname=doxygen
 version=1.14.0
-revision=1
+revision=2
 build_style=cmake
-hostmakedepends="perl python3 flex"
+configure_args="-Dbuild_doc=ON -DDOC_INSTALL_DIR=share/doc/doxygen/"
+hostmakedepends="perl python3 flex texlive texlive-latexextra texlive-dvi"
 checkdepends="libxml2 texlive-BibTeX"
 short_desc="Source code documentation generator tool"
 maintainer="Érico Nogueira <ericonr@disroot.org>"
@@ -12,6 +13,10 @@ homepage="http://www.doxygen.org/"
 changelog="https://www.doxygen.nl/manual/changelog.html"
 distfiles="http://doxygen.nl/files/doxygen-${version}.src.tar.gz"
 checksum=d4536d11ab13037327d8d026b75f5a86b7ccb2093e2f546235faf61fd86e6b5d
+
+if [ "$CROSS_BUILD" ]; then
+	hostmakedepends+=" doxygen"
+fi
 
 build_options="wizard"
 desc_option_wizard="build Qt5 GUI configuration tool, doxywizard"
@@ -25,9 +30,20 @@ if [ "$build_option_wizard" ]; then
 	makedepends+=" qt5-devel"
 fi
 
-post_install() {
-	vman doc/doxygen.1
-	if [ "$build_option_wizard" ]; then
-		vman doc/doxywizard.1
+# Use the host doxygen when building documentation on cross.
+do_patch() {
+	if [ "$CROSS_BUILD" ]; then
+		patch -Np1 < ${FILESDIR}/use-native-doxygen.patch
 	fi
+}
+
+post_build() {
+	ninja -C build docs
+}
+
+doxygen-doc_package() {
+	short_desc+=" - documentation"
+	pkg_install() {
+		vmove usr/share/doc
+	}
 }


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->
EDIT: The entirety of the original description is no longer relevant. This PR is now a continuation of #44079.

~This PR is currently based on (and requires) #53680. If requested, I can merge this PR into #53680 or base it off of HEAD. This PR will be a draft until the PR is merged or until one of the alternative solutions are taken.~

~This PR is an adaptation of my former PR #44079. I let that PR stale out because I wasn't particularly happy with the solution and because I have received no (positive or negative) feedback.~

~The current solution is much cleaner (located mainly in `0001-fix-cross-doc-generation.patch`). The old solution was fully functional though, it just made use of the self-dependency hack[^1] (which I believe should be avoided if other solutions are possible).~

~I have also removed support for the generation of PDF documentation. I find this to be less useful (and less used) than the HTML one. Users can download the upstream hosted PDF book if they so wish.~

~The original purpose of `0002-do-not-generate-pdf-docs.patch` was to remove the chunky LaTeX host make dependency, but I have since figured out that `latex` is required in two places:~

1. ~For generating PDF book (removed by this PR)~
2. ~For generating formulas in https://www.doxygen.nl/manual/formulas.html~

~2\. could be eliminated by using Doxygen's MathJax alternative renderrer, removing the need for `texlive`, `texlive-latexextra` and `texlive-dvi` in `hostmakedepends`. I can implement this change if requested.~

~If having PDF documentation alongside HTML one is desirable, `0002-do-not-generate-pdf-docs.patch` can be cleanly dropped.~

~If having PDF documentation is not desirable, an alternative solution could be to let CMake generate it, but remove it in `post_install()`.~

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->

[^1]: I have documented this in my tutorial: https://xbps-src-tutorials.github.io/tips-and-tricks.html#using-the-native-package