### PR TITLE
gmic-krita: update to 3.5.0.1.

### DIFF
--- a/srcpkgs/gmic-krita/patches/conflict.patch
+++ b/srcpkgs/gmic-krita/patches/conflict.patch
@@ -1,0 +1,46 @@
+install these files to a different path to avoid conflicts with gmic itself
+
+--- a/src/gmic_stdlib.gmic
++++ b/src/gmic_stdlib.gmic
+@@ -5287,7 +5287,7 @@
+   path_test2=${-path_gimp}plug-ins/
+   path_test3=${-path_gimp}plug-ins/gmic_gimp_qt/
+   if !${-is_windows}
+-    path_test4=/usr/share/gmic/
++    path_test4=/usr/share/gmic-krita/
+     path_test5=$g_path_unix
+   else
+     path_test4=$g_path_unix
+--- a/gmic-qt/src/Host/KritaPlugin/gmicqttoolplugin.cpp
++++ b/gmic-qt/src/Host/KritaPlugin/gmicqttoolplugin.cpp
+@@ -66,7 +66,7 @@
+   // Workaround for deploying basic CLUTs
+   // See https://krita-artists.org/t/unknown-filename-gmic-qt/37813
+   {
+-    const auto srcPath = QDir(QCoreApplication::applicationDirPath().append(QStringLiteral("/../share/gmic/"))).absolutePath();
++    const auto srcPath = QDir(QCoreApplication::applicationDirPath().append(QStringLiteral("/../share/gmic-krita/"))).absolutePath();
+     const auto dstPath = GmicQt::gmicConfigPath(true);
+     const std::list<QString> files = {"/gmic_cluts.gmz", "/gmic_denoise_cnn.gmz"};
+ 
+--- a/gmic-qt/CMakeLists.txt
++++ b/gmic-qt/CMakeLists.txt
+@@ -698,8 +698,8 @@
+ 
+ include(GNUInstallDirs)
+ 
+-install(FILES ${CMAKE_SOURCE_DIR}/../resources/gmic_cluts.gmz DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/gmic)
+-install(FILES ${CMAKE_SOURCE_DIR}/../resources/gmic_denoise_cnn.gmz DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/gmic)
++install(FILES ${CMAKE_SOURCE_DIR}/../resources/gmic_cluts.gmz DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/gmic-krita)
++install(FILES ${CMAKE_SOURCE_DIR}/../resources/gmic_denoise_cnn.gmz DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/gmic-krita)
+ 
+ set(gmic_qt_QRC
+     gmic_qt.qrc
+@@ -896,7 +896,7 @@
+ else()
+ 
+   message(FATAL_ERROR "GMIC_QT_HOST is not defined as gimp, gimp3, kritaplugin, none, paintdotnet or 8bf")
+-  
++
+ endif()
+ 
+ feature_summary(WHAT ALL FATAL_ON_MISSING_REQUIRED_PACKAGES)

--- a/srcpkgs/gmic-krita/template
+++ b/srcpkgs/gmic-krita/template
@@ -1,6 +1,6 @@
 # Template file for 'gmic-krita'
 pkgname=gmic-krita
-version=3.2.4.1
+version=3.5.0.1
 revision=1
 build_wrksrc="gmic-qt"
 build_style=cmake
@@ -13,4 +13,4 @@ maintainer="John <me@johnnynator.dev>"
 license="CECILL-2.1"
 homepage="http://gmic.eu/"
 distfiles="https://files.kde.org/krita/build/dependencies/gmic-${version}-patched.tar.gz"
-checksum=e5ef81ded4de2d7d2e17a60f90e8046e2bc06bc7a2439ab3a0123611d210eed8
+checksum=1ae8ca0d368615af6ebdf1cbff005cb20868e1032b9d2c016ce7af91c9582392

--- a/srcpkgs/gmic-krita/update
+++ b/srcpkgs/gmic-krita/update
@@ -1,0 +1,1 @@
+pattern='<a href="gmic-\K[0-9.]+(?=-patched.tar.gz)'


### PR DESCRIPTION
cc @johnnynator

the files in `/usr/share/gmic` were moved to `/usr/share/gmic-krita` to avoid conflicts with regular gmic, which will install some of the same files there in new versions

#### Testing the changes
- I tested the changes in this PR: **YES**
