### PR TITLE
spotify: update to 1.2.56

### DIFF
--- a/srcpkgs/spotify/template
+++ b/srcpkgs/spotify/template
@@ -1,8 +1,8 @@
 # Template file for 'spotify'
 pkgname=spotify
-version=1.2.52
+version=1.2.56
 revision=1
-_subver=442.g01893f92
+_subver=502.ga68d2d4f
 archs="x86_64"
 create_wrksrc=yes
 hostmakedepends="libcurl"
@@ -12,7 +12,7 @@ maintainer="Stefan Mühlinghaus <jazzman@alphabreed.com>"
 license="custom:Proprietary"
 homepage="https://www.spotify.com"
 distfiles="http://repository.spotify.com/pool/non-free/s/spotify-client/spotify-client_${version}.${_subver}_amd64.deb"
-checksum=c26366c253b856cdad552057d565b5f3c5568c443ef379d5044bc12dfdcf2fe7
+checksum=b1088324c2c0e2aa0fdbdef99a565bb2698a6a9bb277218efc9f6ed79840bedc
 repository=nonfree
 restricted=yes
 nostrip=yes


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
