### PR TITLE
thermald: allow conf file

### DIFF
--- a/srcpkgs/thermald/files/thermald/run
+++ b/srcpkgs/thermald/files/thermald/run
@@ -1,4 +1,5 @@
 #!/bin/sh
 exec 2>&1
 sv check dbus >/dev/null || exit 1
-exec thermald --no-daemon --dbus-enable 2>&1
+[ -r conf ] && . ./conf
+exec thermald ${OPTS:=--no-daemon --dbus-enable}

--- a/srcpkgs/thermald/template
+++ b/srcpkgs/thermald/template
@@ -1,7 +1,7 @@
 # Template file for 'thermald'
 pkgname=thermald
 version=2.5.8
-revision=1
+revision=2
 archs="i686* x86_64*"
 build_style=gnu-configure
 hostmakedepends="automake pkg-config glib-devel gtk-doc autoconf-archive"


### PR DESCRIPTION
Check for and source a conf file in thermald's run file to allow custom options.

Get rid of an excess 2>&1 redirection since the script starts with exec 2>&1 already.

#### Testing the changes
- I tested the changes in this PR: **YES**
