### PR TITLE
Rebuild static programs against fixed musl

### DIFF
--- a/srcpkgs/cryptsetup/template
+++ b/srcpkgs/cryptsetup/template
@@ -1,7 +1,7 @@
 # Template file for 'cryptsetup'
 pkgname=cryptsetup
 version=2.7.5
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--with-crypto_backend=openssl --disable-asciidoc
  --enable-libargon2 $(vopt_enable pwquality)"

--- a/srcpkgs/qemu-user/template
+++ b/srcpkgs/qemu-user/template
@@ -1,7 +1,7 @@
 # Template file for 'qemu-user'
 # This package should be updated together with qemu
 pkgname=qemu-user
-version=9.2.0
+version=9.2.1
 revision=1
 build_style=meta
 configure_args="--prefix=/usr --sysconfdir=/etc --libexecdir=/usr/libexec
@@ -15,7 +15,7 @@ maintainer="classabbyamp <void@placeviolette.net>"
 license="GPL-2.0-only, LGPL-2.1-only"
 homepage="https://www.qemu.org"
 distfiles="https://wiki.qemu.org/download/qemu-${version}.tar.bz2"
-checksum=7954be7a779bafb97e20e31da19473437d6e9d461e4adda9bb7acfef55d813f5
+checksum=aeed8eb4353782766e00931ec08e5b9fd20a5d689ca341644347b39dc440e9df
 subpackages="qemu-user-static"
 
 if [ "$CROSS_BUILD" ]; then

--- a/srcpkgs/qemu/template
+++ b/srcpkgs/qemu/template
@@ -1,7 +1,7 @@
 # Template file for 'qemu'
 # This package should be updated together with qemu-user
 pkgname=qemu
-version=9.2.0
+version=9.2.1
 revision=1
 build_style=meta
 configure_args="--prefix=/usr --sysconfdir=/etc --libexecdir=/usr/libexec
@@ -26,7 +26,7 @@ maintainer="classabbyamp <void@placeviolette.net>"
 license="GPL-2.0-only, LGPL-2.1-only"
 homepage="https://www.qemu.org"
 distfiles="https://wiki.qemu.org/download/qemu-${version}.tar.bz2"
-checksum=7954be7a779bafb97e20e31da19473437d6e9d461e4adda9bb7acfef55d813f5
+checksum=aeed8eb4353782766e00931ec08e5b9fd20a5d689ca341644347b39dc440e9df
 ignore_elf_dirs="/usr/share/qemu"
 
 build_options="gtk3 iscsi jack numa opengl pulseaudio sdl2 smartcard spice virgl"

--- a/srcpkgs/toybox/template
+++ b/srcpkgs/toybox/template
@@ -1,7 +1,7 @@
 # Template file for 'toybox'
 pkgname=toybox
 version=0.8.10
-revision=2
+revision=3
 create_wrksrc=yes
 short_desc="BSD-licensed alternative to busybox"
 maintainer="Orphaned <orphan@voidlinux.org>"

--- a/srcpkgs/xbps-static/template
+++ b/srcpkgs/xbps-static/template
@@ -2,7 +2,7 @@
 # NOTE: keep this package synchronized with "srcpkgs/xbps"
 pkgname=xbps-static
 version=0.59.2
-revision=1
+revision=2
 # only musl
 archs="*-musl"
 build_style=configure


### PR DESCRIPTION
To be merged after the cross-* rebuild is done.

Missing:
- [ ] rust-bootstrap (upstream binaries)
- [ ] codelite (?)
- [ ] wasi-libc (needs patch, same as musl)