### PR TITLE
google-chrome: update to 133.0.6943.98.

### DIFF
--- a/srcpkgs/google-chrome/template
+++ b/srcpkgs/google-chrome/template
@@ -1,6 +1,6 @@
 # Template file for 'google-chrome'
 pkgname=google-chrome
-version=133.0.6943.53
+version=133.0.6943.98
 revision=1
 _channel=stable
 archs="x86_64"
@@ -11,7 +11,7 @@ maintainer="Michael Aldridge <maldridge@voidlinux.org>"
 license="custom:chrome"
 homepage="https://www.google.com/chrome/"
 distfiles="https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-${_channel}_${version}-1_amd64.deb"
-checksum=ef75f672885ba08f866c50e4e62923c674f53ca8c6e14a32ce103d4fd41ef559
+checksum=507a6df53a31ac4d95037739fb33a9318a4a58f45620878212b219c045a47ea8
 
 skiprdeps="/opt/google/chrome/libqt5_shim.so /opt/google/chrome/libqt6_shim.so"
 repository=nonfree


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)

(yet another) Stable channel update addressing 4 CVEs.
https://chromereleases.googleblog.com/2025/02/stable-channel-update-for-desktop_12.html