### PR TITLE
chromium: update to 133.0.6943.98.

### DIFF
--- a/srcpkgs/chromium/template
+++ b/srcpkgs/chromium/template
@@ -1,7 +1,7 @@
 # Template file for 'chromium'
 pkgname=chromium
 # See https://chromiumdash.appspot.com/releases?platform=Linux for the latest version
-version=133.0.6943.53
+version=133.0.6943.98
 revision=1
 archs="i686* x86_64* aarch64* armv7l*"
 _llvmver=19
@@ -31,7 +31,7 @@ license="BSD-3-Clause"
 homepage="https://www.chromium.org/"
 distfiles="https://commondatastorage.googleapis.com/chromium-browser-official/chromium-${version}.tar.xz"
 #distfiles="https://chromium-tarballs.distfiles.gentoo.org/chromium-${version}.tar.xz"
-checksum=433c8891a3d717994b0e9544334491888e835a4b813354eefacae05489c23d01
+checksum=3d442e6fb581aa55e93fc2727ceea24cae23969f294d9becf6f6712dec702be9
 
 lib32disabled=yes
 


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**
 
- I built this PR locally for my native architecture, (x86_64-glibc)

Latest stable release; 4 high impact CVEs addressed. Also submitted PR for google-chrome

https://chromereleases.googleblog.com/2025/02/stable-channel-update-for-desktop_12.html
