### PR TITLE
terminator: update to 2.1.4. , python3-cairo: python3-packaging-bootstrap in add hostdepends

### DIFF
--- a/srcpkgs/python3-cairo/template
+++ b/srcpkgs/python3-cairo/template
@@ -1,9 +1,9 @@
 # Template file for 'python3-cairo'
 pkgname=python3-cairo
-version=1.26.0
-revision=2
+version=1.27.0
+revision=1
 build_style=meson
-hostmakedepends="pkg-config"
+hostmakedepends="pkg-config python3-packaging-bootstrap"
 makedepends="cairo-devel python3-devel"
 depends="python3"
 checkdepends="python3-pytest"
@@ -13,7 +13,7 @@ license="LGPL-2.1-only, MPL-1.1"
 homepage="https://pycairo.readthedocs.io/"
 changelog="https://raw.githubusercontent.com/pygobject/pycairo/main/NEWS"
 distfiles="https://github.com/pygobject/pycairo/releases/download/v${version}/pycairo-${version}.tar.gz"
-checksum=2dddd0a874fbddb21e14acd9b955881ee1dc6e63b9c549a192d613a907f9cbeb
+checksum=5cb21e7a00a2afcafea7f14390235be33497a2cce53a98a19389492a60628430
 
 if [ "$XBPS_CHECK_PKGS" ]; then
 	configure_args="-Dtests=true"

--- a/srcpkgs/terminator/template
+++ b/srcpkgs/terminator/template
@@ -1,20 +1,15 @@
 # Template file for 'terminator'
 pkgname=terminator
-version=2.1.3
-revision=2
+version=2.1.4
+revision=1
 build_style=python3-module
 hostmakedepends="intltool python3-setuptools"
 depends="desktop-file-utils gsettings-desktop-schemas libkeybinder3 libnotify
- python3-dbus python3-gobject python3-psutil python3-configobj vte3 pango"
+ python3-dbus python3-gobject python3-psutil python3-configobj vte3 pango python3-cairo"
 short_desc="Tiling terminal emulator application"
 maintainer="Enno Boland <gottox@voidlinux.org>"
 license="GPL-2.0-only"
 homepage="https://gnome-terminator.org"
 changelog="https://raw.githubusercontent.com/gnome-terminator/terminator/master/CHANGELOG.md"
 distfiles="https://github.com/gnome-terminator/terminator/releases/download/v$version/terminator-$version.tar.gz"
-checksum=0ae9943f3d6b72230c14bcb355de84dd81274c033e76ca4698e80d7c93cd6ae5
-
-post_patch() {
-	# Package does not *need* pytest-runner to build, and Void doesn't have it
-	vsed -e '/pytest-runner/d' -i setup.py
-}
+checksum=af27b0ece862e61dde71d0827afa4a29a414e44599effe3edeebc52cbdf0c5e8


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-GLIBC)