### PR TITLE
caddy: update to 2.9.1

### DIFF
--- a/srcpkgs/caddy/template
+++ b/srcpkgs/caddy/template
@@ -1,7 +1,7 @@
 # Template file for 'caddy'
 pkgname=caddy
-version=2.8.4
-revision=2
+version=2.9.1
+revision=1
 build_style=go
 go_import_path=github.com/caddyserver/caddy/v2
 go_package="${go_import_path}/cmd/caddy"
@@ -13,7 +13,7 @@ license="Apache-2.0"
 homepage="https://caddyserver.com"
 changelog="https://github.com/caddyserver/caddy/releases"
 distfiles="https://github.com/caddyserver/caddy/archive/v${version}.tar.gz"
-checksum=5c2e95ad9e688a18dd9d9099c8c132331e01e0bebd401183e8d9123372cf4fcc
+checksum=beb52478dfb34ad29407003520d94ee0baccbf210d1af72cebf430d6d7dd7b63
 
 system_accounts="caddy"
 caddy_homedir="/var/lib/caddy"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl
  - aarch64
  - aarch64-musl


