### PR TITLE
waydroid: update to 1.5.2. (libgbinder 1.1.42.)

### DIFF
--- a/srcpkgs/libgbinder/template
+++ b/srcpkgs/libgbinder/template
@@ -1,6 +1,6 @@
 # Template file for 'libgbinder'
 pkgname=libgbinder
-version=1.1.39
+version=1.1.42
 revision=1
 build_style=gnu-makefile
 make_use_env=1
@@ -16,7 +16,7 @@ license="BSD-3-Clause"
 homepage="https://github.com/mer-hybris/libgbinder"
 changelog="https://raw.githubusercontent.com/mer-hybris/libgbinder/master/debian/changelog"
 distfiles="https://github.com/mer-hybris/libgbinder/archive/refs/tags/${version}.tar.gz"
-checksum=fb10b125c4071413273b81de761cf3ef4ce169e814b740e6fc6ddb1ae2dad066
+checksum=32dcf31c5dc823af11558d180ed5fabb160fdfafe60f01d3212fd200a0842aed
 
 post_install() {
 	vlicense LICENSE

--- a/srcpkgs/waydroid/template
+++ b/srcpkgs/waydroid/template
@@ -1,7 +1,7 @@
 # Template file for 'waydroid'
 pkgname=waydroid
-version=1.4.2
-revision=2
+version=1.5.2
+revision=1
 # https://developer.android.com/ndk/guides/abis#sa
 archs="aarch64* armv7* i686* x86_64*"
 build_style=gnu-makefile
@@ -14,7 +14,7 @@ license="GPL-3.0-or-later"
 homepage="https://waydro.id"
 changelog="https://raw.githubusercontent.com/waydroid/waydroid/main/debian/changelog"
 distfiles="https://github.com/waydroid/waydroid/archive/refs/tags/${version}.tar.gz"
-checksum=835af2ecfb61ba9c85eff6d2371886325c19b5ee0fbd9bab41169d3da36170cd
+checksum=89d4dcae4bd320464d6fea45769cdae762c12c5ff9179b06dfc5135ab5342260
 
 python_version=3
 pycompile_dirs="usr/lib/waydroid"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture (x86_64)
- I built this PR locally for these architectures using specific masterdirs:
  - x86_64-musl
  - i686
- I built this PR locally for these architectures (crossbuilds):
  - aarch64
  - aarch64-musl
  - armv7l
  - armv7l-musl

---

This PR updates the Waydroid package in Void Linux. I tested it with a fresh installation, and everything seems to be working correctly. Additionally, I updated the libgbinder package, which is used by Waydroid.