### PR TITLE
mkinitcpio: fix mounting root with mountpoint=legacy

### DIFF
--- a/srcpkgs/mkinitcpio/files/zfs_hook
+++ b/srcpkgs/mkinitcpio/files/zfs_hook
@@ -106,7 +106,7 @@ zfs_mount_handler () {
 
     local node="$1"
     local rootmnt=$(zfs get -H -o value mountpoint "${ZFS_DATASET}")
-    local tab_file="/etc/fstab"
+    local tab_file="${node}/etc/fstab"
     local zfs_datasets="$(zfs list -H -o name -t filesystem -r ${ZFS_DATASET})"
 
     # Mount the root, and any child datasets
@@ -123,6 +123,10 @@ zfs_mount_handler () {
                     zfs_decrypt_fs "${dataset}"
                     mount -t zfs -o "${opt}" "${dataset}" "${node}${mnt}"
                 fi
+            else
+                # no tab_file yet for rootfs
+                zfs_decrypt_fs "${dataset}"
+                mount -t zfs "${dataset}" "${node}${mnt}"
             fi
         else
             zfs_decrypt_fs "${dataset}"

--- a/srcpkgs/mkinitcpio/files/zfs_hook
+++ b/srcpkgs/mkinitcpio/files/zfs_hook
@@ -106,7 +106,7 @@ zfs_mount_handler () {
 
     local node="$1"
     local rootmnt=$(zfs get -H -o value mountpoint "${ZFS_DATASET}")
-    local tab_file="${node}/etc/fstab"
+    local tab_file="/etc/fstab"
     local zfs_datasets="$(zfs list -H -o name -t filesystem -r ${ZFS_DATASET})"
 
     # Mount the root, and any child datasets

--- a/srcpkgs/mkinitcpio/files/zfs_install
+++ b/srcpkgs/mkinitcpio/files/zfs_install
@@ -38,6 +38,7 @@ build() {
     # allow mount(8) to "autodetect" ZFS
     echo 'zfs' >>"${BUILDROOT}/etc/filesystems"
 
+    [[ -f /etc/fstab ]] && add_file "/etc/fstab"
     [[ -f /etc/hostid ]] && add_file "/etc/hostid"
     [[ -f /etc/zfs/zpool.cache ]] && cp "/etc/zfs/zpool.cache" "${BUILDROOT}/etc/zfs/zpool.cache.org"
     [[ -f /etc/modprobe.d/zfs.conf ]] && add_file "/etc/modprobe.d/zfs.conf"

--- a/srcpkgs/mkinitcpio/files/zfs_install
+++ b/srcpkgs/mkinitcpio/files/zfs_install
@@ -38,7 +38,6 @@ build() {
     # allow mount(8) to "autodetect" ZFS
     echo 'zfs' >>"${BUILDROOT}/etc/filesystems"
 
-    [[ -f /etc/fstab ]] && add_file "/etc/fstab"
     [[ -f /etc/hostid ]] && add_file "/etc/hostid"
     [[ -f /etc/zfs/zpool.cache ]] && cp "/etc/zfs/zpool.cache" "${BUILDROOT}/etc/zfs/zpool.cache.org"
     [[ -f /etc/modprobe.d/zfs.conf ]] && add_file "/etc/modprobe.d/zfs.conf"

--- a/srcpkgs/mkinitcpio/template
+++ b/srcpkgs/mkinitcpio/template
@@ -1,7 +1,7 @@
 # Template file for 'mkinitcpio'
 pkgname=mkinitcpio
 version=39.2
-revision=3
+revision=4
 build_style=gnu-makefile
 hostmakedepends="asciidoc"
 depends="busybox-static bsdtar bash zstd"


### PR DESCRIPTION
`${node}` was `/new_root` (logged out with `msg`) - there's nothing in that directory at this point. `findmnt` finds nothing (in absence of a `fstab`) so boot stops.

Copying fstab to the ramfs and removing `${node}` from path fixes this.

#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc


