### PR TITLE
mkinitcpio: improve zfs hook

### DIFF
--- a/srcpkgs/mkinitcpio/files/zfs_hook
+++ b/srcpkgs/mkinitcpio/files/zfs_hook
@@ -105,30 +105,32 @@ zfs_mount_handler () {
     fi
 
     local node="$1"
-    local rootmnt=$(zfs get -H -o value mountpoint "${ZFS_DATASET}")
-    local tab_file="${node}/etc/fstab"
-    local zfs_datasets="$(zfs list -H -o name -t filesystem -r ${ZFS_DATASET})"
+    local rootopt="${rwopt_exp}${rootflags:+,${rootflags}}"
+    local mountpoint
 
-    # Mount the root, and any child datasets
-    for dataset in ${zfs_datasets}; do
-        mountpoint=$(zfs get -H -o value mountpoint "${dataset}")
-        canmount=$(zfs get -H -o value canmount "${dataset}")
-        # skip dataset
-        [ ${dataset} != "${ZFS_DATASET}" -a \( ${canmount} = "off" -o ${canmount} = "noauto" -o ${mountpoint} = "none" \) ] && continue
-        if [ ${mountpoint} = "legacy" ]; then
-            if [ -f "${tab_file}" ]; then
-                if findmnt -snero source -F "${tab_file}" -S "${dataset}" > /dev/null 2>&1; then
-                    opt=$(findmnt -snero options -F "${tab_file}" -S "${dataset}")
-                    mnt=$(findmnt -snero target -F "${tab_file}" -S "${dataset}")
-                    zfs_decrypt_fs "${dataset}"
-                    mount -t zfs -o "${opt}" "${dataset}" "${node}${mnt}"
-                fi
-            fi
-        else
-            zfs_decrypt_fs "${dataset}"
-            mount -t zfs -o "zfsutil,${rwopt_exp}" "${dataset}" "${node}/${mountpoint##${rootmnt}}"
-        fi
-    done
+    mountpoint="$(zfs list -H -o mountpoint "${ZFS_DATASET}")" || mountpoint=
+    [ "${mountpoint}" = "legacy" ] || rootopt="zfsutil,${rootopt}"
+
+    # Decrypt (if needed) and mount the root
+    zfs_decrypt_fs "${ZFS_DATASET}"
+    mount -t zfs -o "${rootopt}" "${ZFS_DATASET}" "${node}"
+
+    # Walk the tree looking for auto-mount /usr, just in case
+    local fs canmount
+    zfs list -H -o name,mountpoint,canmount -r -t filesystem "${pool}" \
+        | while read -r fs mountpoint canmount; do
+            # Ignore all filesystems not marked for automatic mount
+            [ "${canmount}" = "on" ] || continue
+            # Ignore all mountpoints but /usr
+            [ "${mountpoint}" = "/usr" ] || continue
+            # Ignore the root filesystem that has just been mounted
+            [ "${fs}" = "${ZFS_DATASET}" ] && continue
+
+            # Decrypt (if needed) and mount first automounted /usr filesystem
+            zfs_decrypt_fs "${fs}"
+            mount -o "zfsutil,${rwopt_exp}" "${fs}" "${node}/usr"
+            break
+        done
 }
 
 set_flags() {

--- a/srcpkgs/mkinitcpio/template
+++ b/srcpkgs/mkinitcpio/template
@@ -1,7 +1,7 @@
 # Template file for 'mkinitcpio'
 pkgname=mkinitcpio
 version=39.2
-revision=3
+revision=4
 build_style=gnu-makefile
 hostmakedepends="asciidoc"
 depends="busybox-static bsdtar bash zstd"


### PR DESCRIPTION
In response to my comments in https://github.com/void-linux/void-packages/pull/54391, I propose the following cleanup of the mkinitcpio ZFS hook. I have not yet tested these changes!

I'd be open to changing the walk for `/usr` to descend from `${ZFS_DATASET}` to preserve the current behavior. This would still drop the mounting of **all other** children, which I still maintain is a job for the final init. I'm not even thrilled about mounting `/usr` here, but I guess we need it to fill the gaps in the `usr` hook for ZFS users with mount management enabled.

cc: @classabbyamp 

#### Testing the changes
- I tested the changes in this PR: **yes**