### PR TITLE
New package: intel-lpmd-0.0.8

### DIFF
--- a/srcpkgs/intel-lpmd/files/intel_lpmd/run
+++ b/srcpkgs/intel-lpmd/files/intel_lpmd/run
@@ -1,0 +1,3 @@
+#!/bin/sh
+exec 2>&1
+exec intel_lpmd --no-daemon --dbus-enable

--- a/srcpkgs/intel-lpmd/template
+++ b/srcpkgs/intel-lpmd/template
@@ -1,0 +1,25 @@
+# Template file for 'intel-lpmd'
+pkgname=intel-lpmd
+version=0.0.8
+revision=1
+archs="x86_64"
+build_style=gnu-configure
+hostmakedepends="automake autoconf-archive dbus-glib-devel elogind-devel
+	glib-devel gtk-doc libxml2-devel libnl3-devel pkg-config upower-devel"
+short_desc="Linux daemon used to optimize active idle power on Intel hybrid CPUs"
+maintainer="Anthony Eadicicco <void@aead.xyz>"
+license="GPL-2.0-only"
+homepage="https://github.com/intel/intel-lpmd"
+distfiles="https://github.com/intel/intel-lpmd/archive/refs/tags/v${version}.tar.gz"
+checksum=f4049a814fe9e67702850e9d84d43d5e37c6a3c3d6aded1234c4810f0c38833c
+
+pre_configure() {
+	./autogen.sh
+
+	# The default mode '0' only works on systemd; see intel_lpmd_config.xml(5)
+	sed -i 's,<Mode>0</Mode>,<Mode>1</Mode>,' data/intel_lpmd_config*.xml
+}
+
+post_install() {
+	vsv intel_lpmd
+}


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**, this is a system-wide package and must be compiled.

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)

Does not build on x86_64-musl, so I masked it to only x86_64. The tool is inherently Intel-specific, so it doesn't make sense to enable it on other archs. 

---

Laptops based on newer Intel CPU families like Meteor Lake contain hybrid P/E core setups that Linux is still catching up on support for. One of the primary open issues is battery life, as even with [the 6.12+ kernel improvements for these platforms](https://git.kernel.org/pub/scm/linux/kernel/git/rafael/linux-pm.git/commit/?h=linux-next&id=929ebc93ccaa8d183a2ba9f1cf769d1bfb847cca), the system doesn't always do a good job of keeping tasks off the P cores when the system is idling or only slightly loaded.

This is a daemon from Intel that seeks to do more. It listens for hardware hints from the CPU such as the new [Intel HFI interface](https://docs.kernel.org/arch/x86/intel-hfi.html) (aka Intel Thread Director), and tries to opportunistically park the P cores when they are not needed. (It also supports parking based on observed CPU usage.)

The included documentation is sparse, and the tool still seems to be a little rough around the edges. However, it's (in theory) important for getting a good experience on these newer Intel-based laptops, so I think it warrants inclusion in the repos.

I tested locally and it seems to work according to the man page. The daemon was able to automatically detect my Meteor Lake based laptop, and load the associated config (`intel_lpmd_config_F6_M170.xml`) for it without any additional intervention. 

The daemon currently exposes 3 different mechanisms for parking the P cores, with the default one being dependent on systemd. I opted to patch the config we ship so it works as expected out of the box.