### PR TITLE
dbeaver: update to 24.3.5

### DIFF
--- a/srcpkgs/dbeaver/template
+++ b/srcpkgs/dbeaver/template
@@ -1,9 +1,9 @@
 # Template file for 'dbeaver'
 pkgname=dbeaver
-version=24.3.2
+version=24.3.5
 revision=1
-_dbeaver_common_commit=bc3c2e688a2578156efc42550ff750254dea0378
-_dbeaver_jdbc_libsql_commit=dc67e1440c64dd2da15707e14680087103e0a19f
+_dbeaver_common_commit=a9221c6c7af61733dfd4a4c392130c11cbbe70c2
+_dbeaver_jdbc_libsql_commit=15082a110a1577a7a1f246e22969f21269438066
 # the build downloads binaries linked to glibc
 archs="x86_64 aarch64"
 build_wrksrc="dbeaver"
@@ -17,9 +17,9 @@ changelog="https://dbeaver.io/news/"
 distfiles="https://github.com/dbeaver/dbeaver/archive/${version}.tar.gz
  https://github.com/dbeaver/dbeaver-common/archive/${_dbeaver_common_commit}.tar.gz
  https://github.com/dbeaver/dbeaver-jdbc-libsql/archive/${_dbeaver_jdbc_libsql_commit}.tar.gz"
-checksum="7f2f16566396f800a9345218eb4aecd5cf9e6611480454fc2372948c54c878aa
- 8ed55dffcea0c266e466559bba608086b16c3060d57d62b57e43c992db6983c2
- a84bd6e105a0fe8ccafd506710c08cacd038f97ff1b5b83431287564efce2271"
+checksum="7db11c8d4694279ec524936655a7267a6c9ca8e0d76a09cb36438f08a9160bfa
+ 043fc7b54d1d9ce2636dc1405729ad06f3166ec8ede78f67ef821314c01a1813
+ 081a5cb9c10ecc1c802f18e144e649b434d0685833877a7aad4a7b35df3ef1a6"
 nopie=true
 
 post_extract() {


### PR DESCRIPTION
#### Testing the changes

- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
