### PR TITLE
kompare, kolourpaint, kfind: update to 24.12.2.

### DIFF
--- a/srcpkgs/kfind/template
+++ b/srcpkgs/kfind/template
@@ -1,6 +1,6 @@
 # Template file for 'kfind'
 pkgname=kfind
-version=24.08.0
+version=24.12.2
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
@@ -15,4 +15,4 @@ license="GPL-2.0-or-later"
 homepage="https://www.kde.org/applications/utilities/kfind/"
 changelog="https://kde.org/announcements/changelogs/gear/${version}/#kfind"
 distfiles="${KDE_SITE}/release-service/${version}/src/kfind-${version}.tar.xz"
-checksum=58ddebb376545a761a665a5739a9b986d2f304dd23cf473ced5e7a87e46d59dd
+checksum=f5cf704e35a372ff41a845593b346cf43de7ca8f437d5bb192ec96335208840f

--- a/srcpkgs/kolourpaint/template
+++ b/srcpkgs/kolourpaint/template
@@ -1,6 +1,6 @@
 # Template file for 'kolourpaint'
 pkgname=kolourpaint
-version=24.08.0
+version=24.12.2
 revision=1
 build_style=cmake
 configure_args="-DQT_MAJOR_VERSION=6 -DBUILD_TESTING=OFF
@@ -14,7 +14,7 @@ license="BSD-2-Clause, GPL-2.0-or-later, LGPL-2.1-only, GFDL-1.2-only"
 homepage="http://www.kolourpaint.org/"
 changelog="https://kde.org/announcements/changelogs/gear/${version}/#kolourpaint"
 distfiles="${KDE_SITE}/release-service/${version}/src/kolourpaint-${version}.tar.xz"
-checksum=0dbcd92f6f55bf448d5557bf6f15fca5779259c7c05f2d4846129c6c20246d8f
+checksum=32e5d4e260df37fa6d7fb296fb56f27820ffb61fabbc193e85b69662aee42bbb
 
 post_install() {
 	vlicense COPYING

--- a/srcpkgs/kompare/template
+++ b/srcpkgs/kompare/template
@@ -1,6 +1,6 @@
 # Template file for 'kompare'
 pkgname=kompare
-version=24.08.0
+version=24.12.2
 revision=1
 build_style=cmake
 configure_args="-DKF6_HOST_TOOLING=/usr/lib/cmake
@@ -14,4 +14,4 @@ license="GPL-2.0-only, GFDL-1.2-only"
 homepage="https://www.kde.org/applications/development/kompare/"
 changelog="https://kde.org/announcements/changelogs/gear/${version}/#kompare"
 distfiles="${KDE_SITE}/release-service/${version}/src/kompare-${version}.tar.xz"
-checksum=31dec3ef38f3ca5a95bc22518356e72301bfd94098c269fa6aff796aeb8f080d
+checksum=f106b1ac6d2871c32977ace560d70ef99ee1ea802b047b0f630f00f577b20551


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**
<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
