### PR TITLE
openh264: update to 2.6.0

### DIFF
--- a/srcpkgs/openh264/template
+++ b/srcpkgs/openh264/template
@@ -1,6 +1,6 @@
 # Template file for 'openh264'
 pkgname=openh264
-version=2.4.1
+version=2.6.0
 revision=1
 build_style=meson
 hostmakedepends="nasm pkg-config"
@@ -10,7 +10,7 @@ maintainer="John <me@johnnynator.dev>"
 license="BSD-2-Clause"
 homepage="https://github.com/cisco/openh264"
 distfiles="https://github.com/cisco/openh264/archive/v$version.tar.gz"
-checksum=8ffbe944e74043d0d3fb53d4a2a14c94de71f58dbea6a06d0dc92369542958ea
+checksum=558544ad358283a7ab2930d69a9ceddf913f4a51ee9bf1bfb9e377322af81a69
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

> A vulnerability in the decoding functions of OpenH264 codec library could allow a remote, unauthenticated attacker to trigger a heap overflow.

**[https://github.com/cisco/openh264/security/advisories/GHSA-m99q-5j7x-7m9x](https://github.com/cisco/openh264/security/advisories/GHSA-m99q-5j7x-7m9x)**

#### Testing the changes
- I tested the changes in this PR: **NO**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64 (cross)
  - armv7l-musl (cross)
  - i686
  - x86_64-musl