### PR TITLE
fontconfig: fix 70-no-bitmaps for deprecation

### DIFF
--- a/srcpkgs/fontconfig/template
+++ b/srcpkgs/fontconfig/template
@@ -1,7 +1,7 @@
 # Template file for 'fontconfig'
 pkgname=fontconfig
 version=2.16.0
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--enable-static --enable-docs --with-cache-dir=/var/cache/${pkgname}"
 hostmakedepends="gperf pkg-config python3"
@@ -20,6 +20,9 @@ post_install() {
 		vsed -i 's,\(Cflags: -I${includedir}\).*,\1,g' ${DESTDIR}/usr/lib/pkgconfig/fontconfig.pc
 	fi
 	vlicense COPYING
+	# deprecated upstream, but is broken unless 70-no-bitmaps-except-emoji exists in conf.d
+	rm "$DESTDIR"/usr/share/fontconfig/conf.avail/70-no-bitmaps.conf
+	ln -s 70-no-bitmaps-except-emoji.conf "$DESTDIR"/usr/share/fontconfig/conf.avail/70-no-bitmaps.conf
 }
 
 fontconfig-devel_package() {


### PR DESCRIPTION
`70-no-bitmaps` now includes `70-no-bitmaps-except-emoji`, but this only works if `70-no-bitmaps-except-emoji` is already in `conf.d` (not just `conf.avail`). This fixes regressions some users have been reporting with bitmap fonts showing up again since the latest update.

#### Testing the changes
- I tested the changes in this PR: **YES**
