### PR TITLE
New package: dioxus-cli-0.6.3

### DIFF
--- a/srcpkgs/dioxus-cli/template
+++ b/srcpkgs/dioxus-cli/template
@@ -1,0 +1,20 @@
+# Template file for 'dioxus-cli'
+pkgname=dioxus-cli
+version=0.6.3
+revision=1
+build_style=cargo
+build_wrksrc="packages/cli"
+hostmakedepends="pkg-config"
+makedepends="openssl-devel libgit2-1.8-devel libzstd-devel"
+short_desc="CLI for building Dioxus apps"
+maintainer="jedsek <jedsek@qq.com>"
+license="Apache-2.0 OR MIT"
+homepage="https://dioxuslabs.com/"
+distfiles="https://github.com/DioxusLabs/dioxus/archive/refs/tags/v${version}.tar.gz"
+checksum=85aee32b0f86ac094451e533c5874d178d47e08b764b7a815d36cb91b80f042a
+
+post_install() {
+	vdoc README.md
+	vlicense $wrksrc/LICENSE-APACHE
+	vlicense $wrksrc/LICENSE-MIT
+}


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, x86_64-musl

closes #54453 
