### PR TITLE
kde framework: update to 6.11.0

### DIFF
--- a/srcpkgs/breeze-icons/template
+++ b/srcpkgs/breeze-icons/template
@@ -1,6 +1,6 @@
 # Template file for 'breeze-icons'
 pkgname=breeze-icons
-version=6.10.0
+version=6.11.0
 revision=1
 build_style=cmake
 build_helper=qemu
@@ -13,7 +13,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-3.0-or-later"
 homepage="https://community.kde.org/Frameworks"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname}-${version}.tar.xz"
-checksum=fe458eb957be655ea801d41f1dd3c4cfa829e7ba6040b38d69d09f6b69c31e2a
+checksum=f9cd9ec1b6a4111467cba31a7eed50ee5f03846fb1f5c32b3abdbf68877f8a4e
 nostrip=yes
 
 if [ -z "$CROSS_BUILD" ]; then

--- a/srcpkgs/extra-cmake-modules/template
+++ b/srcpkgs/extra-cmake-modules/template
@@ -1,6 +1,6 @@
 # Template file for 'extra-cmake-modules'
 pkgname=extra-cmake-modules
-version=6.10.0
+version=6.11.0
 revision=1
 build_style=cmake
 configure_args="-DBUILD_HTML_DOCS=ON -DBUILD_TESTING=ON"
@@ -14,7 +14,7 @@ maintainer="John <me@johnnynator.dev>"
 license="BSD-3-Clause"
 homepage="https://invent.kde.org/frameworks/extra-cmake-modules"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname}-${version}.tar.xz"
-checksum=506989a0d400913403e669c1912238db053cd6b38dff74b17e2e6f879c79cca0
+checksum=69fdab5f0fedfb73d1accff5012d510b486e1dd75c711e925a6912a3e71814b0
 python_version=3
 
 do_check() {

--- a/srcpkgs/kf6-kbookmarks/template
+++ b/srcpkgs/kf6-kbookmarks/template
@@ -1,6 +1,6 @@
 # Template file for 'kf6-kbookmarks'
 pkgname=kf6-kbookmarks
-version=6.10.0
+version=6.11.0
 revision=1
 build_style=cmake
 hostmakedepends="extra-cmake-modules qt6-tools qt6-base"
@@ -10,7 +10,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/kbookmarks"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=891eb12d2b9a2c3cdfbfdba250599c544d7186ce8d1ef07f4fc4cce1d57a945b
+checksum=b5c677453c70314b9eecc0011a73103f045eabc94bc5f2f223b5979780c801c7
 
 kf6-kbookmarks-devel_package() {
 	depends="$makedepends ${sourcepkg}>=${version}_${revision}"

--- a/srcpkgs/kf6-kcalendarcore/template
+++ b/srcpkgs/kf6-kcalendarcore/template
@@ -1,6 +1,6 @@
 # Template file for 'kf6-kcalendarcore'
 pkgname=kf6-kcalendarcore
-version=6.10.0
+version=6.11.0
 revision=1
 build_style=cmake
 configure_args="-DKDE_INSTALL_QMLDIR=lib/qt6/qml"
@@ -12,7 +12,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/kcalendarcore"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=988f2fd648341967384d95d3d12bb936a8a7737a931e72c2b5616050bc30336a
+checksum=ea261324d1b80ef4786b86cf86bfa32c332aa0357b05ba299b13f54be69a7380
 
 do_check() {
 	cd build

--- a/srcpkgs/kf6-kcmutils/template
+++ b/srcpkgs/kf6-kcmutils/template
@@ -1,6 +1,6 @@
 # Template file for 'kf6-kcmutils'
 pkgname=kf6-kcmutils
-version=6.10.0
+version=6.11.0
 revision=1
 build_style=cmake
 build_helper=qemu
@@ -16,7 +16,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/kcmutils"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=a4bcb4b04ee4a03a9a9fdbb96c2736021d94b22c22f8d5d5d157b9ce982eb001
+checksum=64d2c5cd8165189c2d741bb543aab72b5bc8db5c540ca4e88c2f8d0f93e77990
 
 kf6-kcmutils-devel_package() {
 	depends="$makedepends ${sourcepkg}>=${version}_${revision}"

--- a/srcpkgs/kf6-kcodecs/template
+++ b/srcpkgs/kf6-kcodecs/template
@@ -1,6 +1,6 @@
 # Template file for 'kf6-kcodecs'
 pkgname=kf6-kcodecs
-version=6.10.0
+version=6.11.0
 revision=1
 build_style=cmake
 hostmakedepends="extra-cmake-modules qt6-tools qt6-base
@@ -11,7 +11,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/kcodecs"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=96183ffbb18502cd67b6fc78ac286e233ef46ee0d713ee1df2cb4c138f2141a0
+checksum=fbddc437ba9969d89635b75f0ef7e41c925c61c64dac1fff008c2e9138139fe4
 
 kf6-kcodecs-devel_package() {
 	depends="$makedepends ${sourcepkg}>=${version}_${revision}"

--- a/srcpkgs/kf6-kcolorscheme/template
+++ b/srcpkgs/kf6-kcolorscheme/template
@@ -1,6 +1,6 @@
 # Template file for 'kf6-kcolorscheme'
 pkgname=kf6-kcolorscheme
-version=6.10.0
+version=6.11.0
 revision=1
 build_style=cmake
 hostmakedepends="extra-cmake-modules qt6-tools qt6-base
@@ -12,7 +12,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/kcolorscheme"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=f070ed593f1d4010af5a56e247532be96a2c7ca9befc922b084c16215af79bdf
+checksum=8b27bddb830f0173f44ae9aac05213579909b85fa696a2871b2ee11cb239bcc8
 
 kf6-kcolorscheme-devel_package() {
 	depends="$makedepends ${sourcepkg}>=${version}_${revision}"

--- a/srcpkgs/kf6-kcompletion/template
+++ b/srcpkgs/kf6-kcompletion/template
@@ -1,6 +1,6 @@
 # Template file for 'kf6-kcompletion'
 pkgname=kf6-kcompletion
-version=6.10.0
+version=6.11.0
 revision=1
 build_style=cmake
 hostmakedepends="extra-cmake-modules qt6-tools qt6-base "
@@ -10,7 +10,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/kcompletion"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=b56e925bbe881c89fce9c80441e1565ad1adfcb16f1cac5bb08a281fb9334bc9
+checksum=c812b60de4530de3003916e45fbab121c5f9f576e2430ab2cdf0e3e4c9041852
 
 kf6-kcompletion-devel_package() {
 	depends="$makedepends ${sourcepkg}>=${version}_${revision}"

--- a/srcpkgs/kf6-kconfig/template
+++ b/srcpkgs/kf6-kconfig/template
@@ -1,6 +1,6 @@
 # Template file for 'kf6-kconfig'
 pkgname=kf6-kconfig
-version=6.10.0
+version=6.11.0
 revision=1
 build_style=cmake
 configure_args="-DKDE_INSTALL_QMLDIR=lib/qt6/qml
@@ -13,7 +13,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/kconfig"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=00ef2c75be68bacf8c30e3bf072358b8f6d2bc78d462e7b14c086808c69d8d7f
+checksum=c71072aaf2771295b591fc62d4fb657cefb38df29f240ef9c7120854b42d0f7f
 
 do_check() {
 	cd build

--- a/srcpkgs/kf6-kconfigwidgets/template
+++ b/srcpkgs/kf6-kconfigwidgets/template
@@ -1,6 +1,6 @@
 # Template file for 'kf6-kconfigwidgets'
 pkgname=kf6-kconfigwidgets
-version=6.10.0
+version=6.11.0
 revision=1
 build_style=cmake
 configure_args="-DKF6_HOST_TOOLING=/usr/lib/cmake"
@@ -13,7 +13,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/kconfigwidgets"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=5cb17bcafaae3eefc144fb1014f14cb9998c9e13b714808d940ab20d9c0fb51c
+checksum=28a1bb125161fe9ab0dbfa899433512e928669be31ce149fa25191a24a50242a
 
 do_check() {
 	cd build

--- a/srcpkgs/kf6-kcontacts/template
+++ b/srcpkgs/kf6-kcontacts/template
@@ -1,6 +1,6 @@
 # Template file for 'kf6-kcontacts'
 pkgname=kf6-kcontacts
-version=6.10.0
+version=6.11.0
 revision=1
 build_style=cmake
 hostmakedepends="extra-cmake-modules qt6-tools qt6-base
@@ -12,7 +12,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/kcontacts"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=b622ad011925584fb82cf0bfea713fddd4101c47ab6c23efb5fb878f1a69b46d
+checksum=2f0cd26b32bdbad14b6e5f3eff99e23aedf2425eacb0d4d6f44724dce6e26562
 
 do_check() {
 	cd build

--- a/srcpkgs/kf6-kcoreaddons/template
+++ b/srcpkgs/kf6-kcoreaddons/template
@@ -1,6 +1,6 @@
 # Template file for 'kf6-kcoreaddons'
 pkgname=kf6-kcoreaddons
-version=6.10.0
+version=6.11.0
 revision=1
 build_style=cmake
 configure_args="-DKDE_INSTALL_QMLDIR=lib/qt6/qml
@@ -14,7 +14,7 @@ license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/kcoreaddons"
 #changelog=""
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=89bf28747915e987cab21c77397b0971caffa1258b6f575543d73d4188184a72
+checksum=ff691c6e0933493ea3e8c4a0ba41fa46ced7b9394e6f35ef9dee349ccfcc3a39
 
 do_check() {
 	cd build

--- a/srcpkgs/kf6-kcrash/template
+++ b/srcpkgs/kf6-kcrash/template
@@ -1,6 +1,6 @@
 # Template file for 'kf6-kcrash'
 pkgname=kf6-kcrash
-version=6.10.0
+version=6.11.0
 revision=1
 build_style=cmake
 hostmakedepends="extra-cmake-modules qt6-tools qt6-base "
@@ -10,7 +10,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/kcrash"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=c0329da6ac28aaac824db235e578999e4a487e5cedbb3cec3a6a39e9ee9b5db4
+checksum=ba13e9f5dd2b40125d5d61d29b612db6383315dc0f510cc1f0e33bb6c9b0ae89
 
 kf6-kcrash-devel_package() {
 	depends="$makedepends ${sourcepkg}>=${version}_${revision}"

--- a/srcpkgs/kf6-kdav/template
+++ b/srcpkgs/kf6-kdav/template
@@ -1,6 +1,6 @@
 # Template file for 'kf6-kdav'
 pkgname=kf6-kdav
-version=6.10.0
+version=6.11.0
 revision=1
 build_style=cmake
 hostmakedepends="extra-cmake-modules qt6-tools qt6-base
@@ -11,7 +11,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/kdav"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=2e8eff3e8c35001688807a97e490a6e7851a7a1a1fdf72df5559863b8612903d
+checksum=9ca5586e672f5643988dcd604b6a030f59b3d5e78f1cf3725f2e4f257852340e
 replaces="kdav>=0"
 
 kf6-kdav-devel_package() {

--- a/srcpkgs/kf6-kdbusaddons/template
+++ b/srcpkgs/kf6-kdbusaddons/template
@@ -1,6 +1,6 @@
 # Template file for 'kf6-kdbusaddons'
 pkgname=kf6-kdbusaddons
-version=6.10.0
+version=6.11.0
 revision=1
 build_style=cmake
 hostmakedepends="extra-cmake-modules qt6-tools qt6-base "
@@ -11,7 +11,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/kdbusaddons"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=e88bfaa6a10f80d9f7b2116281c4485213984caed555ac68557bb53ee88bbb32
+checksum=62e0f3b0487ef1ab729fc85bcb5498c9449e0b74fe8049779434158bb8b12a87
 make_check_pre="dbus-run-session"
 
 kf6-kdbusaddons-devel_package() {

--- a/srcpkgs/kf6-kdeclarative/template
+++ b/srcpkgs/kf6-kdeclarative/template
@@ -1,6 +1,6 @@
 # Template file for 'kf6-kdeclarative'
 pkgname=kf6-kdeclarative
-version=6.10.0
+version=6.11.0
 revision=1
 build_style=cmake
 configure_args="-DKDE_INSTALL_QMLDIR=lib/qt6/qml"
@@ -13,7 +13,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/kdeclarative"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=db9eb2b5e615b484949e41ac5a05c5cea136e231d15a3de203902cedcdfd9e73
+checksum=6ae811367bcbc8190f8a5d2ef39a8e6c72871c41ec26e2a4b0c38324a3e8596b
 
 kf6-kdeclarative-devel_package() {
 	depends="$makedepends ${sourcepkg}>=${version}_${revision}"

--- a/srcpkgs/kf6-kded/template
+++ b/srcpkgs/kf6-kded/template
@@ -1,6 +1,6 @@
 # Template file for 'kf6-kded'
 pkgname=kf6-kded
-version=6.10.0
+version=6.11.0
 revision=1
 build_style=cmake
 configure_args="-DKF6_HOST_TOOLING=/usr/lib/cmake"
@@ -13,7 +13,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/kded"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=5601d9dbfdc9507feaf17f4774bb7d12d38c7e19724ae8b987639a16ff0e6a8e
+checksum=55c9921114299abd9bdc5e601ccc6a750ff2d331fc0836d79670ccbc508e06a4
 
 kf6-kded-devel_package() {
 	depends="$makedepends ${sourcepkg}>=${version}_${revision}"

--- a/srcpkgs/kf6-kdesu/template
+++ b/srcpkgs/kf6-kdesu/template
@@ -1,6 +1,6 @@
 # Template file for 'kf6-kdesu'
 pkgname=kf6-kdesu
-version=6.10.0
+version=6.11.0
 revision=1
 build_style=cmake
 hostmakedepends="extra-cmake-modules qt6-tools qt6-base
@@ -12,7 +12,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/kdesu"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=5ab993abca85cb5798bb437b96a2b3d88079df86128ee30d66ee11f60e51c22e
+checksum=aacb49d313e79f106795c4dab7de9991e6fe4e724c2b4c19deefcd171f6a3ba7
 
 kf6-kdesu-devel_package() {
 	depends="$makedepends ${sourcepkg}>=${version}_${revision}"

--- a/srcpkgs/kf6-kdnssd/template
+++ b/srcpkgs/kf6-kdnssd/template
@@ -1,6 +1,6 @@
 # Template file for 'kf6-kdnssd'
 pkgname=kf6-kdnssd
-version=6.10.0
+version=6.11.0
 revision=1
 build_style=cmake
 hostmakedepends="extra-cmake-modules qt6-tools qt6-base "
@@ -10,7 +10,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/kdnssd"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=fd8f08501fc40b9a29fc370f7f7871083f2489922e1bd50bc5b0fd78017daa27
+checksum=69db354bb2a6faac16ec1eb77e6f71308f8ebd9205967c75db5bac937e799bd9
 
 kf6-kdnssd-devel_package() {
 	depends="$makedepends ${sourcepkg}>=${version}_${revision}"

--- a/srcpkgs/kf6-kdoctools/template
+++ b/srcpkgs/kf6-kdoctools/template
@@ -1,6 +1,6 @@
 # Template file for 'kf6-kdoctools'
 pkgname=kf6-kdoctools
-version=6.10.0
+version=6.11.0
 revision=1
 build_style=cmake
 build_helper=qemu
@@ -13,7 +13,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/kdoctools"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=03fa98e1213235ee4d4839d16e3edb22ee56849b9ab03d140639cf9facb6b038
+checksum=dfcdc6a0258f5cc2e55d248f616cc7c6224e1b06140deb687e401b537959fc08
 
 post_patch() {
 	vsed -i -e '

--- a/srcpkgs/kf6-kfilemetadata/template
+++ b/srcpkgs/kf6-kfilemetadata/template
@@ -1,6 +1,6 @@
 # Template file for 'kf6-kfilemetadata'
 pkgname=kf6-kfilemetadata
-version=6.10.0
+version=6.11.0
 revision=1
 build_style=cmake
 configure_args="-DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins"
@@ -14,7 +14,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/kfilemetadata"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=100b48770a16b8e12dd3ec4075bdd3b8333e7962d2fc7492cd077dcc03e3c355
+checksum=f9190969eaf66f9d27690cc3b85a3d19395ee3657582c9ae6c94c49a113312c7
 
 do_check() {
 	cd build

--- a/srcpkgs/kf6-kglobalaccel/template
+++ b/srcpkgs/kf6-kglobalaccel/template
@@ -1,6 +1,6 @@
 # Template file for 'kf6-kglobalaccel'
 pkgname=kf6-kglobalaccel
-version=6.10.0
+version=6.11.0
 revision=1
 build_style=cmake
 hostmakedepends="extra-cmake-modules qt6-tools qt6-base "
@@ -10,7 +10,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/kglobalaccel"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=05b0ec6a44d43ce7a9cfd6cd70c8d07dca5c5f6216968af8128fe9a5ed9b1928
+checksum=0552e4e5c58a244733af49cfdd0c8fc04a63828b6c2346b36820222d5e3bcef5
 
 kf6-kglobalaccel-devel_package() {
 	depends="${makedepends//private-} ${sourcepkg}>=${version}_${revision}"

--- a/srcpkgs/kf6-kguiaddons/template
+++ b/srcpkgs/kf6-kguiaddons/template
@@ -1,6 +1,6 @@
 # Template file for 'kf6-kguiaddons'
 pkgname=kf6-kguiaddons
-version=6.10.0
+version=6.11.0
 revision=1
 build_style=cmake
 hostmakedepends="extra-cmake-modules qt6-tools qt6-base
@@ -13,7 +13,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/kguiaddons"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=b3be04077313e559c5a8f66491d5d286cefe947aaf7c8937544ce85af4853ffa
+checksum=ef0925f609ae5b62ed689451dfe9937719ce4ec26714952b5496e3e128d5cc5c
 
 kf6-kguiaddons-geo-uri-handler_package() {
 	short_desc+=" - Geo URI handler"

--- a/srcpkgs/kf6-kholidays/template
+++ b/srcpkgs/kf6-kholidays/template
@@ -1,6 +1,6 @@
 # Template file for 'kf6-kholidays'
 pkgname=kf6-kholidays
-version=6.10.0
+version=6.11.0
 revision=1
 build_style=cmake
 configure_args="-DKDE_INSTALL_QMLDIR=lib/qt6/qml
@@ -13,7 +13,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/kholidays"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=788efeca7a5524c5a668623aba830ad6d875aa2711f0cac5f2329add2ab4458d
+checksum=ccdbfab5eafc043574900d66e0022326f6048e7dcdb09bc538dedea99889c6af
 
 kf6-kholidays-devel_package() {
 	depends="$makedepends ${sourcepkg}>=${version}_${revision}"

--- a/srcpkgs/kf6-ki18n/template
+++ b/srcpkgs/kf6-ki18n/template
@@ -1,6 +1,6 @@
 # Template file for 'kf6-ki18n'
 pkgname=kf6-ki18n
-version=6.10.0
+version=6.11.0
 revision=1
 build_style=cmake
 configure_args="-DKDE_INSTALL_QMLDIR=lib/qt6/qml
@@ -14,7 +14,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/ki18n"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=2f59f093f8ce340ab46c556b35c2ead2b96dfeb2ff0024c553ac8c53e9b8a11a
+checksum=658a05ceca184ba31ce58a6e9c51ee76f2829459c56dbcd3bad3aa157eaf11fe
 
 do_check() {
 	cd build

--- a/srcpkgs/kf6-kiconthemes/template
+++ b/srcpkgs/kf6-kiconthemes/template
@@ -1,6 +1,6 @@
 # Template file for 'kf6-kiconthemes'
 pkgname=kf6-kiconthemes
-version=6.10.0
+version=6.11.0
 revision=1
 build_style=cmake
 configure_args="-DKDE_INSTALL_QMLDIR=lib/qt6/qml
@@ -14,7 +14,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/kiconthemes"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=15807e785183c048810af0141b3a560085f2bbf00f3a21fe962eb37a673f9314
+checksum=1671ab3fd9b1e0753a7062bab80f5489f3ac750ecb30b91db99a6689988afb87
 
 kf6-kiconthemes-devel_package() {
 	depends="${makedepends//private-} ${sourcepkg}>=${version}_${revision}"

--- a/srcpkgs/kf6-kidletime/template
+++ b/srcpkgs/kf6-kidletime/template
@@ -1,6 +1,6 @@
 # Template file for 'kf6-kidletime'
 pkgname=kf6-kidletime
-version=6.10.0
+version=6.11.0
 revision=1
 build_style=cmake
 configure_args="-DKDE_INSTALL_QMLDIR=lib/qt6/qml
@@ -14,7 +14,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/kidletime"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=fa25fe866aefd4536022142822ce9856f7a85ffa95070980527de9b31eab0988
+checksum=96efb0b533a37ddb2e1888dff7d4722c19c47d660f74d1b0a422eb95718f4882
 
 kf6-kidletime-devel_package() {
 	depends="${sourcepkg}>=${version}_${revision} qt6-base-devel"

--- a/srcpkgs/kf6-kimageformats/template
+++ b/srcpkgs/kf6-kimageformats/template
@@ -1,6 +1,6 @@
 # Template file for 'kf6-kimageformats'
 pkgname=kf6-kimageformats
-version=6.10.0
+version=6.11.0
 revision=1
 build_style=cmake
 configure_args="-DKIMAGEFORMATS_HEIF=ON -DKDE_INSTALL_QMLDIR=lib/qt6/qml
@@ -14,10 +14,10 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/kimageformats"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=e16f32ee64393199a283942f6fe7b6f77b3746034f90e4244689c28faab1f9d3
+checksum=0c45787f97d00fc0257f7de3250d84e950de2a332c45e7528138f7cf843154cc
 
 do_check() {
 	cd build
 	# disable failing tests
-	ctest -E "kimageformats-read-xcf|kimageformats-read-psd|kimageformats-read-hej2"
+	ctest -E "kimageformats-read-xcf|kimageformats-read-psd|kimageformats-read-hej2|kimageformats-write-heif"
 }

--- a/srcpkgs/kf6-kio/template
+++ b/srcpkgs/kf6-kio/template
@@ -1,6 +1,6 @@
 # Template file for 'kf6-kio'
 pkgname=kf6-kio
-version=6.10.0
+version=6.11.0
 revision=1
 build_style=cmake
 configure_args="-DKDE_INSTALL_QMLDIR=lib/qt6/qml
@@ -20,7 +20,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/kio"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=7eb454438f149e7ed513c3bbd526b67e3e3ecfe32ae7c986168baa59600b699c
+checksum=fe511e43a5386f963c9afef93a21c0df44a2c24fcc417777e4d0569102477ff8
 
 do_check() {
 	cd build

--- a/srcpkgs/kf6-kirigami/template
+++ b/srcpkgs/kf6-kirigami/template
@@ -1,6 +1,6 @@
 # Template file for 'kf6-kirigami'
 pkgname=kf6-kirigami
-version=6.10.0
+version=6.11.0
 revision=1
 build_style=cmake
 configure_args="-DKDE_INSTALL_QMLDIR=lib/qt6/qml
@@ -14,7 +14,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/kirigami"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=2e245ffd79eca1fcfb591f43ff39e7c2f5160e868a36e20ebbe2d66c550da8d4
+checksum=22392c95bb835f11626250f0728ce73590db638814e7181148fcf66a1f442ea6
 
 kf6-kirigami-devel_package() {
 	depends="${makedepends//private-} ${sourcepkg}>=${version}_${revision}"

--- a/srcpkgs/kf6-kitemmodels/template
+++ b/srcpkgs/kf6-kitemmodels/template
@@ -1,6 +1,6 @@
 # Template file for 'kf6-kitemmodels'
 pkgname=kf6-kitemmodels
-version=6.10.0
+version=6.11.0
 revision=1
 build_style=cmake
 configure_args="-DKDE_INSTALL_QMLDIR=lib/qt6/qml
@@ -13,7 +13,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/kitemmodels"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=83859a4aee67bf5e768a93325422264cb9e847013f281c5cb02e631c3b3b0007
+checksum=398dc4e3c5c44461350a20ac234055bafc2b184284ddea91563134ef62f5d6a6
 
 kf6-kitemmodels-devel_package() {
 	depends="$makedepends ${sourcepkg}>=${version}_${revision}"

--- a/srcpkgs/kf6-kitemviews/template
+++ b/srcpkgs/kf6-kitemviews/template
@@ -1,6 +1,6 @@
 # Template file for 'kf6-kitemviews'
 pkgname=kf6-kitemviews
-version=6.10.0
+version=6.11.0
 revision=1
 build_style=cmake
 configure_args="$(vopt_bool designerplugin BUILD_DESIGNERPLUGIN)"
@@ -11,7 +11,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/kitemviews"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=8b15ff5719ea65e9d0c722eea6412e312d05d9da49c872caf9d97d329d56d76d
+checksum=e3625368e3f8cf6127218cc3e847fbf0176a5978c86228b11a320ad96fea2cbc
 
 build_options="designerplugin"
 

--- a/srcpkgs/kf6-kjobwidgets/template
+++ b/srcpkgs/kf6-kjobwidgets/template
@@ -1,6 +1,6 @@
 # Template file for 'kf6-kjobwidgets'
 pkgname=kf6-kjobwidgets
-version=6.10.0
+version=6.11.0
 revision=1
 build_style=cmake
 hostmakedepends="extra-cmake-modules qt6-tools qt6-base "
@@ -11,7 +11,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/kjobwidgets"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=ee3ff5d21c8484959d0af1976a7c1bab01f4368414df2ebb2cb8540b3c28691b
+checksum=2bb342e554f8ecf84d7218a6567628dcc73c1b914d0c5aad1c8bf7753986ddd7
 
 kf6-kjobwidgets-devel_package() {
 	depends="${makedepends//private-} ${sourcepkg}>=${version}_${revision}"

--- a/srcpkgs/kf6-knewstuff/template
+++ b/srcpkgs/kf6-knewstuff/template
@@ -1,6 +1,6 @@
 # Template file for 'kf6-knewstuff'
 pkgname=kf6-knewstuff
-version=6.10.0
+version=6.11.0
 revision=1
 build_style=cmake
 configure_args="-DKDE_INSTALL_QMLDIR=lib/qt6/qml
@@ -15,7 +15,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/knewstuff"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=81cb5ea54fe03d27f80a481dde18a767ca1a95267403bd87483cfdd81981e4e7
+checksum=8b3802b6b64309ab6709af350f248dc62e3e6d50b0db4ecb0c968acfbfb23520
 
 kf6-knewstuff-devel_package() {
 	depends="$makedepends ${sourcepkg}>=${version}_${revision}"

--- a/srcpkgs/kf6-knotifications/template
+++ b/srcpkgs/kf6-knotifications/template
@@ -1,6 +1,6 @@
 # Template file for 'kf6-knotifications'
 pkgname=kf6-knotifications
-version=6.10.0
+version=6.11.0
 revision=1
 build_style=cmake
 configure_args="-DKDE_INSTALL_QMLDIR=lib/qt6/qml
@@ -13,7 +13,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/knotifications"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=36b7881d50400f37b4f3aeaa4c0a6a943e5783d35441e2b0cacdc6dad06af2a1
+checksum=a2e0815ea6e5c294fdd36316ca9792a406f5c123ec01a1c73a7e54cb0be2ea31
 
 kf6-knotifications-devel_package() {
 	depends="$makedepends ${sourcepkg}>=${version}_${revision}"

--- a/srcpkgs/kf6-knotifyconfig/template
+++ b/srcpkgs/kf6-knotifyconfig/template
@@ -1,6 +1,6 @@
 # Template file for 'kf6-knotifyconfig'
 pkgname=kf6-knotifyconfig
-version=6.10.0
+version=6.11.0
 revision=1
 build_style=cmake
 hostmakedepends="extra-cmake-modules qt6-tools qt6-base
@@ -12,7 +12,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/knotifyconfig"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=f0ba447a58edefd8302905ed88030291990e273eded97d11d2b7de986a35d05c
+checksum=612511161758144a9d3d99d4f0a9eb75931c3f8af5966e045a088023ca1d0c6f
 
 kf6-knotifyconfig-devel_package() {
 	depends="$makedepends ${sourcepkg}>=${version}_${revision}"

--- a/srcpkgs/kf6-kpackage/template
+++ b/srcpkgs/kf6-kpackage/template
@@ -1,6 +1,6 @@
 # Template file for 'kf6-kpackage'
 pkgname=kf6-kpackage
-version=6.10.0
+version=6.11.0
 revision=1
 build_style=cmake
 hostmakedepends="extra-cmake-modules qt6-tools qt6-base
@@ -11,7 +11,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/kpackage"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=0f49c1cdb49e01c6dce372abbc9814ccbd74b7f2b130c7310674345e3498cec1
+checksum=bfc704ea1708f37150a9d14edcbb9eed8ebf8d54753930da63432cda954a1ea7
 
 kf6-kpackage-devel_package() {
 	depends="$makedepends ${sourcepkg}>=${version}_${revision}"

--- a/srcpkgs/kf6-kparts/template
+++ b/srcpkgs/kf6-kparts/template
@@ -1,6 +1,6 @@
 # Template file for 'kf6-kparts'
 pkgname=kf6-kparts
-version=6.10.0
+version=6.11.0
 revision=1
 build_style=cmake
 hostmakedepends="extra-cmake-modules qt6-tools qt6-base
@@ -12,7 +12,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/kparts"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=a3c460f635f32e254093da3d46d53fe9a4a7cca5987149047981b477c50a060c
+checksum=3995f3556aba434de7b13dae099b51a0a86aeade60ba1e06592836d40669bb6a
 
 kf6-kparts-devel_package() {
 	depends="$makedepends ${sourcepkg}>=${version}_${revision}"

--- a/srcpkgs/kf6-kpeople/template
+++ b/srcpkgs/kf6-kpeople/template
@@ -1,6 +1,6 @@
 # Template file for 'kf6-kpeople'
 pkgname=kf6-kpeople
-version=6.10.0
+version=6.11.0
 revision=1
 build_style=cmake
 configure_args="-DKDE_INSTALL_QMLDIR=lib/qt6/qml
@@ -14,7 +14,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/kpeople"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=a991c539d7964dfd947889fd3f9b2e1259d8c0d3dc693c14c1bdfcd8d29971f0
+checksum=3f67af43442358e7b4d9a0a81d86133707ffaae0f5e05c48aa1f390ec47ff96b
 
 do_check() {
 	cd build

--- a/srcpkgs/kf6-kplotting/template
+++ b/srcpkgs/kf6-kplotting/template
@@ -1,6 +1,6 @@
 # Template file for 'kf6-kplotting'
 pkgname=kf6-kplotting
-version=6.10.0
+version=6.11.0
 revision=1
 build_style=cmake
 hostmakedepends="extra-cmake-modules qt6-tools qt6-base "
@@ -10,7 +10,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/kplotting"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=6941d93019bfb1e9977cfa592ba110fbf9c3b7f247af40f336e040071f922d3f
+checksum=ceb915cc026cd20ff10e8fdb3e4914ea61f73686a2d9fe6a8839a5ead14a9892
 
 kf6-kplotting-devel_package() {
 	depends="$makedepends ${sourcepkg}>=${version}_${revision}"

--- a/srcpkgs/kf6-kpty/template
+++ b/srcpkgs/kf6-kpty/template
@@ -1,6 +1,6 @@
 # Template file for 'kf6-kpty'
 pkgname=kf6-kpty
-version=6.10.0
+version=6.11.0
 revision=1
 build_style=cmake
 configure_args="-DUTEMPTER_EXECUTABLE=/usr/lib/utempter/utempter"
@@ -12,7 +12,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/kpty"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=1fccd92d67eac0bfeadac3badbb409dcd720ed224284ed056166ab5787f2d647
+checksum=f1d985bf0a14061a764c7c01bcb6cf284a59ad82de13e72cfd1bd268819eebc2
 
 kf6-kpty-devel_package() {
 	depends="$makedepends ${sourcepkg}>=${version}_${revision}"

--- a/srcpkgs/kf6-kquickcharts/template
+++ b/srcpkgs/kf6-kquickcharts/template
@@ -1,6 +1,6 @@
 # Template file for 'kf6-kquickcharts'
 pkgname=kf6-kquickcharts
-version=6.10.0
+version=6.11.0
 revision=1
 build_style=cmake
 configure_args="-DKDE_INSTALL_QMLDIR=lib/qt6/qml
@@ -13,7 +13,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/kquickcharts"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=a2036f7b1ee7abb9c278c7822fc18723d661d856da9dbf9f006ceebed731598f
+checksum=ffc35a7b0dde52acdae508925a555b76006cc9d4b78eb003e9a31cd439f2993f
 
 kf6-kquickcharts-devel_package() {
 	depends="$makedepends ${sourcepkg}>=${version}_${revision}"

--- a/srcpkgs/kf6-krunner/template
+++ b/srcpkgs/kf6-krunner/template
@@ -1,6 +1,6 @@
 # Template file for 'kf6-krunner'
 pkgname=kf6-krunner
-version=6.10.0
+version=6.11.0
 revision=1
 build_style=cmake
 hostmakedepends="extra-cmake-modules qt6-tools qt6-base
@@ -13,7 +13,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/krunner"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=459c97ad510c3565d4547b51c4dbaf19b3834c0afdf77bf6ee4dff346957d62b
+checksum=2179da656375d8839ea7c2c502087b527c6715e1018582ac8f63612ca527aa90
 
 do_check() {
 	cd build

--- a/srcpkgs/kf6-kservice/template
+++ b/srcpkgs/kf6-kservice/template
@@ -1,6 +1,6 @@
 # Template file for 'kf6-kservice'
 pkgname=kf6-kservice
-version=6.10.0
+version=6.11.0
 revision=1
 build_style=cmake
 configure_args="-DKF6_HOST_TOOLING=/usr/lib/cmake"
@@ -13,7 +13,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/kservice"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=04ad53850967e38822f8af1652b118992cd1bfa382e2718278bb6de03a0bdbb3
+checksum=161cd296577ff9802b088b06866ec5ab4c1c1a6fe19f76bb5134cdf8a6ab4005
 
 do_check() {
 	cd build

--- a/srcpkgs/kf6-kstatusnotifieritem/template
+++ b/srcpkgs/kf6-kstatusnotifieritem/template
@@ -1,6 +1,6 @@
 # Template file for 'kf6-kstatusnotifieritem'
 pkgname=kf6-kstatusnotifieritem
-version=6.10.0
+version=6.11.0
 revision=1
 build_style=cmake
 hostmakedepends="extra-cmake-modules qt6-tools qt6-base "
@@ -10,7 +10,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/kstatusnotifieritem"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=4fa19843a737b43674d19b9ad31466c6aa64bbe27709073c3e2c33aa03bfac22
+checksum=26c92c25b1f70296bde9e71fba1f719778c85cb57227f6045f606af99c48a8bd
 
 kf6-kstatusnotifieritem-devel_package() {
 	depends="${makedepends//private-} ${sourcepkg}>=${version}_${revision}"

--- a/srcpkgs/kf6-ksvg/template
+++ b/srcpkgs/kf6-ksvg/template
@@ -1,6 +1,6 @@
 # Template file for 'kf6-ksvg'
 pkgname=kf6-ksvg
-version=6.10.0
+version=6.11.0
 revision=1
 build_style=cmake
 configure_args="-DKDE_INSTALL_QMLDIR=lib/qt6/qml
@@ -15,7 +15,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/ksvg"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=173e151f6ef8360149f835b1fc7494e97a33f9056d294ab213c9ef9e6d84d0c8
+checksum=053092e36b76deeffe19629ae12a372b172f947bee3cc2034c68e7ba4e1da6cf
 
 kf6-ksvg-devel_package() {
 	depends="$makedepends ${sourcepkg}>=${version}_${revision}"

--- a/srcpkgs/kf6-ktexteditor/template
+++ b/srcpkgs/kf6-ktexteditor/template
@@ -1,6 +1,6 @@
 # Template file for 'kf6-ktexteditor'
 pkgname=kf6-ktexteditor
-version=6.10.0
+version=6.11.0
 revision=1
 build_style=cmake
 configure_args="-DKF6_HOST_TOOLING=/usr/lib/cmake
@@ -19,7 +19,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/ktexteditor"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=3f80c4feb8737cef83775e2c79f86060c16af89ee8b48e2d72f94bdc1a180b9f
+checksum=82d33dccad98e2f514de4d17c4e665197fdd8588a55979358f88aeeac6fc4419
 
 kf6-ktexteditor-devel_package() {
 	depends="$makedepends ${sourcepkg}>=${version}_${revision}"

--- a/srcpkgs/kf6-ktexttemplate/template
+++ b/srcpkgs/kf6-ktexttemplate/template
@@ -1,6 +1,6 @@
 # Template file for 'kf6-ktexttemplate'
 pkgname=kf6-ktexttemplate
-version=6.10.0
+version=6.11.0
 revision=1
 build_style=cmake
 configure_args="-DKDE_INSTALL_QMLDIR=lib/qt6/qml
@@ -13,7 +13,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/ktexttemplate"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=3e39190adb90d4f71672e33d117b35fe84a8f35aaa90a678846401044894aa3d
+checksum=b0f30c6e49a132cdf587228e0ba1e1d974cc155d233b57ff617f5d55e7f7b905
 
 kf6-ktexttemplate-devel_package() {
 	depends="$makedepends ${sourcepkg}>=${version}_${revision}"

--- a/srcpkgs/kf6-ktextwidgets/template
+++ b/srcpkgs/kf6-ktextwidgets/template
@@ -1,6 +1,6 @@
 # Template file for 'kf6-ktextwidgets'
 pkgname=kf6-ktextwidgets
-version=6.10.0
+version=6.11.0
 revision=1
 build_style=cmake
 hostmakedepends="extra-cmake-modules qt6-tools qt6-base
@@ -13,7 +13,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/ktextwidgets"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=4db67be70da68e3fd2c2a9d3359dcfb9b11eb82a34f2b88d3e6ed08e358ab073
+checksum=0f043b8a60698ccdb88e3d6957b5f5c97cfe793ea2eea421fc467fffdf200697
 
 kf6-ktextwidgets-devel_package() {
 	depends="$makedepends ${sourcepkg}>=${version}_${revision}"

--- a/srcpkgs/kf6-kunitconversion/template
+++ b/srcpkgs/kf6-kunitconversion/template
@@ -1,6 +1,6 @@
 # Template file for 'kf6-kunitconversion'
 pkgname=kf6-kunitconversion
-version=6.10.0
+version=6.11.0
 revision=1
 build_style=cmake
 hostmakedepends="extra-cmake-modules qt6-tools qt6-base
@@ -11,7 +11,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/kunitconversion"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=23c59904d48049deb8f1de8aa56e7b0c10a9fc82808f36a32f4f446433869dbf
+checksum=8d26a83d1371bd70c48281708680c69e61faca44963deab52d07c9723c27ee49
 
 kf6-kunitconversion-devel_package() {
 	depends="$makedepends ${sourcepkg}>=${version}_${revision}"

--- a/srcpkgs/kf6-kuserfeedback/template
+++ b/srcpkgs/kf6-kuserfeedback/template
@@ -1,6 +1,6 @@
 # Template file for 'kf6-kuserfeedback'
 pkgname=kf6-kuserfeedback
-version=6.10.0
+version=6.11.0
 revision=1
 build_style=cmake
 configure_args="-DKDE_INSTALL_QMLDIR=lib/qt6/qml
@@ -14,7 +14,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/kuserfeedback"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=5dd17da7169a9a90c82757536c667d748d1909985b979bb1e2e51da84a07372f
+checksum=ac516b7b8f9cd0891664f8b580d0a5a5c494cf6b5dbfddd87b6f6256548b7910
 
 do_check() {
 	cd build

--- a/srcpkgs/kf6-kwallet/template
+++ b/srcpkgs/kf6-kwallet/template
@@ -1,6 +1,6 @@
 # Template file for 'kf6-kwallet'
 pkgname=kf6-kwallet
-version=6.10.0
+version=6.11.0
 revision=1
 build_style=cmake
 configure_args="-DKF6_HOST_TOOLING=/usr/lib/cmake"
@@ -15,7 +15,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/kwallet"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=e1993911a15b4318d64abce0acdc1b5fc5a6116dc7595eff86dde03b35e6bd50
+checksum=ce94b032446ed1e1383e673185b5a4372deeab71df8b7a49083a1b6ead822e09
 
 kf6-kwallet-devel_package() {
 	depends="$makedepends ${sourcepkg}>=${version}_${revision}"

--- a/srcpkgs/kf6-kwidgetsaddons/template
+++ b/srcpkgs/kf6-kwidgetsaddons/template
@@ -1,6 +1,6 @@
 # Template file for 'kf6-kwidgetsaddons'
 pkgname=kf6-kwidgetsaddons
-version=6.10.0
+version=6.11.0
 revision=1
 build_style=cmake
 configure_args="$(vopt_bool designerplugin BUILD_DESIGNERPLUGIN)"
@@ -11,7 +11,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/kwidgetsaddons"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=e0fa4943d7874287fd2c2c254f1ef21edf7e573b6b19354df5fdef8cbbefe74e
+checksum=1c64e7354804845db0cd83ae671dfb5d2cb08308551a0b6c7b8a339aa6dcb436
 
 build_options="designerplugin"
 

--- a/srcpkgs/kf6-kwindowsystem/template
+++ b/srcpkgs/kf6-kwindowsystem/template
@@ -1,6 +1,6 @@
 # Template file for 'kf6-kwindowsystem'
 pkgname=kf6-kwindowsystem
-version=6.10.0
+version=6.11.0
 revision=1
 build_style=cmake
 configure_args="-DKDE_INSTALL_QMLDIR=lib/qt6/qml
@@ -14,7 +14,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/kwindowsystem"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=046b7aa2247811323e48b629884b824a6ffec475df2316256e7ff0b9df677944
+checksum=d872e85d0915dd5cf1e2baf89fbef62e9855ff3317ecc5939882bc1724628d5a
 
 post_install() {
 	sed -i -e 's:/usr/[a-z0-9-]*/usr/include;::' \

--- a/srcpkgs/kf6-kxmlgui/template
+++ b/srcpkgs/kf6-kxmlgui/template
@@ -1,6 +1,6 @@
 # Template file for 'kf6-kxmlgui'
 pkgname=kf6-kxmlgui
-version=6.10.0
+version=6.11.0
 revision=1
 build_style=cmake
 hostmakedepends="extra-cmake-modules qt6-tools qt6-base
@@ -12,7 +12,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/kxmlgui"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=561fa755638da16cae204b670f62fab70156b9121b9313612238ca9c9e8e1292
+checksum=69c3a6a6363bdbe3ccbace76e23c6ccec173eb0f9c1954ef7317d998d6edb6fc
 
 do_check() {
 	cd build

--- a/srcpkgs/kf6-modemmanager-qt/template
+++ b/srcpkgs/kf6-modemmanager-qt/template
@@ -1,6 +1,6 @@
 # Template file for 'kf6-modemmanager-qt'
 pkgname=kf6-modemmanager-qt
-version=6.10.0
+version=6.11.0
 revision=1
 build_style=cmake
 hostmakedepends="extra-cmake-modules qt6-tools qt6-base
@@ -12,7 +12,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/modemmanager-qt"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=640a3f96487f3e875e83ef815f14e1077042ae9ee83276b3d7f7fc3875e2ee15
+checksum=a636323902c57a9abf199168e9c33b3432c538e276251e6bb7ce753fffef5fee
 
 do_check() {
 	cd build

--- a/srcpkgs/kf6-networkmanager-qt/template
+++ b/srcpkgs/kf6-networkmanager-qt/template
@@ -1,6 +1,6 @@
 # Template file for 'kf6-networkmanager-qt'
 pkgname=kf6-networkmanager-qt
-version=6.10.0
+version=6.11.0
 revision=1
 build_style=cmake
 configure_args="-DKDE_INSTALL_QMLDIR=lib/qt6/qml"
@@ -12,7 +12,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/networkmanager-qt"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=2f437ab6b534fb7dcde6ed40ebdc2c1680532f742b8e326ea68a47ae58173191
+checksum=e6e172324e4c978591299e2981ad6ae38e5d1e3d78db6ac83751604af202b60c
 
 do_check() {
 	cd build

--- a/srcpkgs/kf6-prison/template
+++ b/srcpkgs/kf6-prison/template
@@ -1,6 +1,6 @@
 # Template file for 'kf6-prison'
 pkgname=kf6-prison
-version=6.10.0
+version=6.11.0
 revision=1
 build_style=cmake
 configure_args="-DKDE_INSTALL_QMLDIR=lib/qt6/qml"
@@ -13,7 +13,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/prison"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=b4a0f395eca50c818f8e0656b04664783453b1a9a709a4a45a8ae2e273602c7b
+checksum=7cc8dff3ef172b24d10ee50c0876d79c87730b6fb23bd678708f7770b9da4f20
 
 kf6-prison-devel_package() {
 	depends="$makedepends ${sourcepkg}>=${version}_${revision}"

--- a/srcpkgs/kf6-purpose/template
+++ b/srcpkgs/kf6-purpose/template
@@ -1,6 +1,6 @@
 # Template file for 'kf6-purpose'
 pkgname=kf6-purpose
-version=6.10.0
+version=6.11.0
 revision=1
 build_style=cmake
 configure_args="-DKDE_INSTALL_QMLDIR=lib/qt6/qml
@@ -15,7 +15,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/purpose"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=19de7943df772c1b5ce2771099a17536e97e7ff6c5a5411c1346c25b24e51a57
+checksum=48e172f05869e1a2cc19e0eb6230ae12cfe23d234b40d6d3bb2f411c7f6984e0
 
 kf6-purpose-devel_package() {
 	depends="$makedepends ${sourcepkg}>=${version}_${revision}"

--- a/srcpkgs/kf6-qqc2-desktop-style/template
+++ b/srcpkgs/kf6-qqc2-desktop-style/template
@@ -1,6 +1,6 @@
 # Template file for 'kf6-qqc2-desktop-style'
 pkgname=kf6-qqc2-desktop-style
-version=6.10.0
+version=6.11.0
 revision=1
 build_style=cmake
 configure_args="-DKDE_INSTALL_QMLDIR=lib/qt6/qml
@@ -13,7 +13,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/qqc2-desktop-style"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=9e19540f8fa7d0e6a1ffb1c353a24e8c7f8e2b37a8594393af7a4d5d9e0e8e51
+checksum=996542716196bfac8a228a36b4618c992e193782779dcf4138d638e38306652c
 
 do_check() {
 	cd build

--- a/srcpkgs/kf6-solid/template
+++ b/srcpkgs/kf6-solid/template
@@ -1,6 +1,6 @@
 # Template file for 'kf6-solid'
 pkgname=kf6-solid
-version=6.10.0
+version=6.11.0
 revision=1
 build_style=cmake
 hostmakedepends="extra-cmake-modules qt6-tools qt6-base flex pkg-config"
@@ -13,7 +13,7 @@ license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/solid"
 #changelog=""
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=24892e81a3047f753519dbd384b47635c5a2543d8ee0bf3c299b0fcfef318e8c
+checksum=cdecc7665b801a508b9ad0929b025ac93fe287be503589c8d8c38a520c2508d7
 
 kf6-solid-devel_package() {
 	depends="qt6-base-devel ${sourcepkg}>=${version}_${revision}"

--- a/srcpkgs/kf6-sonnet/template
+++ b/srcpkgs/kf6-sonnet/template
@@ -1,6 +1,6 @@
 # Template file for 'kf6-sonnet'
 pkgname=kf6-sonnet
-version=6.10.0
+version=6.11.0
 revision=1
 build_style=cmake
 configure_args="$(vopt_bool designerplugin BUILD_DESIGNERPLUGIN)
@@ -14,7 +14,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/sonnet"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=99c0bca563594fd115f31f18ad3264770046290c6695ded0d2aa3c2eddb0d4b7
+checksum=19441de62d9d97f61e48d26e003543e75607b2ba8f6e4feb19f956289af21d60
 
 build_options="designerplugin"
 

--- a/srcpkgs/kf6-syndication/template
+++ b/srcpkgs/kf6-syndication/template
@@ -1,6 +1,6 @@
 # Template file for 'kf6-syndication'
 pkgname=kf6-syndication
-version=6.10.0
+version=6.11.0
 revision=1
 build_style=cmake
 hostmakedepends="extra-cmake-modules qt6-tools qt6-base"
@@ -10,7 +10,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/syndication"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=a743c525e806e5f07b5b7b27cfe34882100b212b4d846e661c61a27ae1396330
+checksum=d889c553a5189339217e8d06b628595aba3c842b74693e7a8179606b13629e1d
 
 kf6-syndication-devel_package() {
 	depends="$makedepends ${sourcepkg}>=${version}_${revision}"

--- a/srcpkgs/kf6-syntax-highlighting/template
+++ b/srcpkgs/kf6-syntax-highlighting/template
@@ -1,6 +1,6 @@
 # Template file for 'kf6-syntax-highlighting'
 pkgname=kf6-syntax-highlighting
-version=6.10.0
+version=6.11.0
 revision=1
 build_style=cmake
 configure_args="
@@ -15,7 +15,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/syntax-highlighting"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=b5b5e343ff27bc5c95be0051d5606dfcb3295f835830e7fc6dac8d2863891699
+checksum=b23dbbe195030a2927caafc5fdf4ca7a372c44ca95013d6115037fe62e1fcb51
 
 if [ "$CROSS_BUILD" ]; then
 	hostmakedepends+=" kf6-syntax-highlighting-devel"

--- a/srcpkgs/kf6-threadweaver/template
+++ b/srcpkgs/kf6-threadweaver/template
@@ -1,6 +1,6 @@
 # Template file for 'kf6-threadweaver'
 pkgname=kf6-threadweaver
-version=6.10.0
+version=6.11.0
 revision=1
 build_style=cmake
 hostmakedepends="extra-cmake-modules qt6-tools qt6-base "
@@ -10,7 +10,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/threadweaver"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=136a636a33ccfa9a375a2e1ee503760a0a910002b972be0eef20352eb106bb84
+checksum=c408d9ef3c13e9906e6ef1a162def5bf7459f099197b1788eb3d96df4505dd8f
 
 kf6-threadweaver-devel_package() {
 	depends="$makedepends ${sourcepkg}>=${version}_${revision}"


### PR DESCRIPTION
- **kf6-attica: update to 6.11.0.**
- **kf6-baloo: update to 6.11.0.**
- **kf6-bluez-qt: update to 6.11.0.**
- **kf6-frameworkintegration: update to 6.11.0.**
- **kf6-karchive: update to 6.11.0.**
- **kf6-kauth: update to 6.11.0.**
- **kf6-kbookmarks: update to 6.11.0.**
- **kf6-kcalendarcore: update to 6.11.0.**
- **kf6-kcmutils: update to 6.11.0.**
- **kf6-kcodecs: update to 6.11.0.**
- **kf6-kcolorscheme: update to 6.11.0.**
- **kf6-kcompletion: update to 6.11.0.**
- **kf6-kconfig: update to 6.11.0.**
- **kf6-kconfigwidgets: update to 6.11.0.**
- **kf6-kcontacts: update to 6.11.0.**
- **kf6-kcoreaddons: update to 6.11.0.**
- **kf6-kcrash: update to 6.11.0.**
- **kf6-kdav: update to 6.11.0.**
- **kf6-kdbusaddons: update to 6.11.0.**
- **kf6-kdeclarative: update to 6.11.0.**
- **kf6-kded: update to 6.11.0.**
- **kf6-kdesu: update to 6.11.0.**
- **kf6-kdnssd: update to 6.11.0.**
- **kf6-kdoctools: update to 6.11.0.**
- **kf6-kfilemetadata: update to 6.11.0.**
- **kf6-kglobalaccel: update to 6.11.0.**
- **kf6-kguiaddons: update to 6.11.0.**
- **kf6-kholidays: update to 6.11.0.**
- **kf6-ki18n: update to 6.11.0.**
- **kf6-kiconthemes: update to 6.11.0.**
- **kf6-kidletime: update to 6.11.0.**
- **kf6-kimageformats: update to 6.11.0.**
- **kf6-kio: update to 6.11.0.**
- **kf6-kirigami: update to 6.11.0.**
- **kf6-kitemmodels: update to 6.11.0.**
- **kf6-kitemviews: update to 6.11.0.**
- **kf6-kjobwidgets: update to 6.11.0.**
- **kf6-knewstuff: update to 6.11.0.**
- **kf6-knotifications: update to 6.11.0.**
- **kf6-knotifyconfig: update to 6.11.0.**
- **kf6-kpackage: update to 6.11.0.**
- **kf6-kparts: update to 6.11.0.**
- **kf6-kpeople: update to 6.11.0.**
- **kf6-kplotting: update to 6.11.0.**
- **kf6-kpty: update to 6.11.0.**
- **kf6-kquickcharts: update to 6.11.0.**
- **kf6-krunner: update to 6.11.0.**
- **kf6-kservice: update to 6.11.0.**
- **kf6-kstatusnotifieritem: update to 6.11.0.**
- **kf6-ksvg: update to 6.11.0.**
- **kf6-ktexteditor: update to 6.11.0.**
- **kf6-ktexttemplate: update to 6.11.0.**
- **kf6-ktextwidgets: update to 6.11.0.**
- **kf6-kunitconversion: update to 6.11.0.**
- **kf6-kuserfeedback: update to 6.11.0.**
- **kf6-kwallet: update to 6.11.0.**
- **kf6-kwidgetsaddons: update to 6.11.0.**
- **kf6-kwindowsystem: update to 6.11.0.**
- **kf6-kxmlgui: update to 6.11.0.**
- **kf6-modemmanager-qt: update to 6.11.0.**
- **kf6-networkmanager-qt: update to 6.11.0.**
- **kf6-prison: update to 6.11.0.**
- **kf6-purpose: update to 6.11.0.**
- **kf6-qqc2-desktop-style: update to 6.11.0.**
- **kf6-solid: update to 6.11.0.**
- **kf6-sonnet: update to 6.11.0.**
- **kf6-syndication: update to 6.11.0.**
- **kf6-syntax-highlighting: update to 6.11.0.**
- **kf6-threadweaver: update to 6.11.0.**
- **breeze-icons: update to 6.11.0.**
- **extra-cmake-modules: update to 6.11.0.**

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**|**briefly**|**NO**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->

[ci skip]
[skip ci]
[piks ic]
[ic piks]
