### PR TITLE
streamlink: update to 7.1.3

### DIFF
--- a/srcpkgs/streamlink/template
+++ b/srcpkgs/streamlink/template
@@ -1,6 +1,6 @@
 # Template file for 'streamlink'
 pkgname=streamlink
-version=7.1.1
+version=7.1.3
 revision=1
 build_style=python3-pep517
 hostmakedepends="python3-wheel python3-versioningit"
@@ -14,7 +14,7 @@ license="BSD-2-Clause"
 homepage="https://streamlink.github.io/"
 changelog="https://raw.githubusercontent.com/streamlink/streamlink/master/CHANGELOG.md"
 distfiles="https://github.com/streamlink/streamlink/releases/download/$version/streamlink-$version.tar.gz"
-checksum=c1881ed0bba53612d979d9a918b7dec056fc93cd202a5b07a080e5568dbdab4c
+checksum=f64b1a499b6d42af3965a39f30aef2e9e36f3d2d32a3311b8688af342bd5ba7a
 make_check_pre="env PYTHONPATH=src"
 
 post_install() {


### PR DESCRIPTION
Primarily just a version bump. No major changes on streamlinks end, besides requiring freezegun 1.5.0 and we (Void) are already on 1.5.1.

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86-64)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - aarch64
  - x86-64-musl
