### PR TITLE
Revert "wpa_supplicant: use capabilities in service"

### DIFF
--- a/srcpkgs/wpa_supplicant/INSTALL.msg
+++ b/srcpkgs/wpa_supplicant/INSTALL.msg
@@ -1,4 +1,0 @@
-The runit service now uses Linux capabilities to run as non-root.
-If you edited `wpa_supplicant.conf` files, you must set
-	`control_interface_group=_wpas`
-there, so that the unprivileged daemon can function properly.

--- a/srcpkgs/wpa_supplicant/files/wpa_supplicant.conf
+++ b/srcpkgs/wpa_supplicant/files/wpa_supplicant.conf
@@ -1,7 +1,7 @@
 # Default configuration file for wpa_supplicant.conf(5).
 
 ctrl_interface=/run/wpa_supplicant
-ctrl_interface_group=_wpas
+ctrl_interface_group=wheel
 eapol_version=1
 ap_scan=1
 fast_reauth=1

--- a/srcpkgs/wpa_supplicant/files/wpa_supplicant/run
+++ b/srcpkgs/wpa_supplicant/files/wpa_supplicant/run
@@ -7,14 +7,10 @@ else
 	OPTS="${AUTO}"
 fi
 
-# automigrate
-chown -R _wpas:_wpas /etc/wpa_supplicant
-! [ -d /run/wpa_supplicant ] && install -m 700 -g _wpas -o _wpas -d /run/wpa_supplicant
-chown -R _wpas:_wpas /run/wpa_supplicant
+# revert automigrate
+chown -R root:root /etc/wpa_supplicant
+! [ -d /run/wpa_supplicant ] && install -m 700 -g root -o root -d /run/wpa_supplicant
+chown -R root:root /run/wpa_supplicant
 
 exec 2>&1
-exec setpriv --reuid _wpas --regid _wpas --clear-groups \
-  --ambient-caps -all,+net_admin,+net_raw \
-  --inh-caps -all,+net_admin,+net_raw \
-  --bounding-set -all,+net_admin,+net_raw \
-  --no-new-privs -- wpa_supplicant ${OPTS}
+exec wpa_supplicant ${OPTS}

--- a/srcpkgs/wpa_supplicant/template
+++ b/srcpkgs/wpa_supplicant/template
@@ -1,7 +1,7 @@
 # Template file for 'wpa_supplicant'
 pkgname=wpa_supplicant
 version=2.11
-revision=2
+revision=3
 build_wrksrc="${pkgname}"
 build_style=gnu-makefile
 make_build_args="V=1 BINDIR=/usr/bin"
@@ -20,7 +20,6 @@ make_check=no # has no test suite
 build_options="dbus readline"
 build_options_default="dbus readline"
 conf_files="/etc/${pkgname}/${pkgname}.conf"
-system_accounts="_wpas"
 
 pre_build() {
 	cp -f ${FILESDIR}/config .config


### PR DESCRIPTION
This reverts commit b43eee69fdadff822b9c0988d4867395426139bc.

Many users have reported an inability to control wpa_supplicant with this change, including not being able to use wpa_cli as root or not and not having working internet on fresh installs.

#### Testing the changes
- I tested the changes in this PR: **YES**

cc @dkwo @leahneukirchen
