### PR TITLE
poppler: update to 25.02.0

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -350,9 +350,9 @@ libMagickCore-7.Q16HDRI.so.10 libmagick-7.1.0.10_1
 libMagickWand-7.Q16HDRI.so.10 libmagick-7.1.0.10_1
 libMagick++-7.Q16HDRI.so.5 libmagick-7.0.11.1_1
 libltdl.so.7 libltdl-2.2.6_1
-libpoppler.so.140 libpoppler-24.08.0_1
+libpoppler.so.146 libpoppler-25.02.0_1
 libpoppler-glib.so.8 poppler-glib-0.18.2_1
-libpoppler-cpp.so.1 poppler-cpp-24.08.0_1
+libpoppler-cpp.so.2 poppler-cpp-25.02.0_1
 libpoppler-qt5.so.1 poppler-qt5-0.31.0_1
 libpoppler-qt6.so.3 poppler-qt6-23.12.0_1
 libtcl8.6.so tcl-8.6.0_1

--- a/srcpkgs/calligra/template
+++ b/srcpkgs/calligra/template
@@ -1,7 +1,7 @@
 # Template file for 'calligra'
 pkgname=calligra
 version=3.2.1
-revision=24
+revision=25
 build_style=cmake
 configure_args="-Wno-dev -DCALLIGRA_SHOULD_BUILD_UNMAINTAINED=ON
  -DMEINPROC5_EXECUTABLE=/usr/bin/meinproc5 -DBUILD_TESTING=OFF"

--- a/srcpkgs/efl/template
+++ b/srcpkgs/efl/template
@@ -1,7 +1,7 @@
 # Template file for 'efl'
 pkgname=efl
 version=1.26.2
-revision=8
+revision=9
 build_style=meson
 configure_args="
  -Dbuild-examples=false

--- a/srcpkgs/extractpdfmark/template
+++ b/srcpkgs/extractpdfmark/template
@@ -1,7 +1,7 @@
 # Template file for 'extractpdfmark'
 pkgname=extractpdfmark
 version=1.1.1
-revision=2
+revision=3
 build_wrksrc=build
 build_style=gnu-configure
 configure_script="../configure"

--- a/srcpkgs/fim/template
+++ b/srcpkgs/fim/template
@@ -1,7 +1,7 @@
 # Template file for 'fim'
 pkgname=fim
 version=0.7.1
-revision=2
+revision=3
 build_style=gnu-configure
 configure_args="--enable-poppler"
 make_check_args="-j1"

--- a/srcpkgs/inkscape/patches/0001-poppler-fofitruetype.patch
+++ b/srcpkgs/inkscape/patches/0001-poppler-fofitruetype.patch
@@ -1,0 +1,59 @@
+From 0399372ec240d23e0e70548237a541f2b5bf0f34 Mon Sep 17 00:00:00 2001
+From: KrIr17 <elendil.krir17@gmail.com>
+Date: Tue, 5 Nov 2024 00:40:15 +0100
+Subject: [PATCH] Fix building with Poppler 24.11
+
+Poppler 24.11 no longer sets the default value for faceIndex to 0 in
+`FoFiTrueType::make()` and `FoFiTrueType::load()` [1], so we do it
+on our end instead.
+
+Fixes https://gitlab.com/inkscape/inkscape/-/issues/5370
+
+[1] https://gitlab.freedesktop.org/poppler/poppler/-/commit/94467509a013dd5cf46c942baa598f2b296571f4
+---
+ .../internal/pdfinput/poppler-cairo-font-engine.cpp  | 12 ++++++------
+ 1 file changed, 6 insertions(+), 6 deletions(-)
+
+diff --git a/src/extension/internal/pdfinput/poppler-cairo-font-engine.cpp b/src/extension/internal/pdfinput/poppler-cairo-font-engine.cpp
+index 34a8eed682d..728b1d1aac4 100644
+--- a/src/extension/internal/pdfinput/poppler-cairo-font-engine.cpp
++++ b/src/extension/internal/pdfinput/poppler-cairo-font-engine.cpp
+@@ -419,9 +419,9 @@ CairoFreeTypeFont *CairoFreeTypeFont::create(GfxFont *gfxFont, XRef *xref, FT_Li
+                 FoFiTrueType *ff;
+ #endif
+                 if (!font_data.empty()) {
+-                    ff = FoFiTrueType::make((fontchar)font_data.data(), font_data.size());
++                    ff = FoFiTrueType::make((fontchar)font_data.data(), font_data.size(), 0);
+                 } else {
+-                    ff = FoFiTrueType::load(fileName.c_str());
++                    ff = FoFiTrueType::load(fileName.c_str(), 0);
+                 }
+                 if (!ff) {
+                     goto err2;
+@@ -444,9 +444,9 @@ CairoFreeTypeFont *CairoFreeTypeFont::create(GfxFont *gfxFont, XRef *xref, FT_Li
+             FoFiTrueType *ff;
+ #endif
+             if (!font_data.empty()) {
+-                ff = FoFiTrueType::make((fontchar)font_data.data(), font_data.size());
++                ff = FoFiTrueType::make((fontchar)font_data.data(), font_data.size(), 0);
+             } else {
+-                ff = FoFiTrueType::load(fileName.c_str());
++                ff = FoFiTrueType::load(fileName.c_str(), 0);
+             }
+             if (!ff) {
+                 error(errSyntaxError, -1, "failed to load truetype font\n");
+@@ -512,9 +512,9 @@ CairoFreeTypeFont *CairoFreeTypeFont::create(GfxFont *gfxFont, XRef *xref, FT_Li
+                     FoFiTrueType *ff;
+ #endif
+                     if (!font_data.empty()) {
+-                        ff = FoFiTrueType::make((fontchar)font_data.data(), font_data.size());
++                        ff = FoFiTrueType::make((fontchar)font_data.data(), font_data.size(), 0);
+                     } else {
+-                        ff = FoFiTrueType::load(fileName.c_str());
++                        ff = FoFiTrueType::load(fileName.c_str(), 0);
+                     }
+                     if (ff) {
+                         if (ff->isOpenTypeCFF()) {
+-- 
+GitLab
+

--- a/srcpkgs/inkscape/patches/0002-poppler-gfxcolorspace.patch
+++ b/srcpkgs/inkscape/patches/0002-poppler-gfxcolorspace.patch
@@ -1,0 +1,430 @@
+From 22304ae8034d067670a9f95022083a75fac92b4c Mon Sep 17 00:00:00 2001
+From: PBS <pbs3141@gmail.com>
+Date: Tue, 22 Oct 2024 14:48:31 +0100
+Subject: [PATCH] Future-proof against poppler 24.10 changes
+
+---
+ .../internal/pdfinput/pdf-parser.cpp          | 120 ++++++++----------
+ src/extension/internal/pdfinput/pdf-parser.h  |   4 +-
+ .../pdfinput/poppler-transition-api.h         |   6 +
+ 3 files changed, 61 insertions(+), 69 deletions(-)
+
+diff --git a/src/extension/internal/pdfinput/pdf-parser.cpp b/src/extension/internal/pdfinput/pdf-parser.cpp
+index 97b2909218a..28000a87b0c 100644
+--- a/src/extension/internal/pdfinput/pdf-parser.cpp
++++ b/src/extension/internal/pdfinput/pdf-parser.cpp
+@@ -817,11 +817,11 @@ void PdfParser::opSetExtGState(Object args[], int /*numArgs*/)
+             _POPPLER_FREE(obj3);
+             if (_POPPLER_CALL_ARGS_DEREF(obj3, obj2.dictLookup, "G").isStream()) {
+                 if (_POPPLER_CALL_ARGS_DEREF(obj4, obj3.streamGetDict()->lookup, "Group").isDict()) {
+-                    GfxColorSpace *blendingColorSpace = nullptr;
++                    std::unique_ptr<GfxColorSpace> blendingColorSpace;
+                     GBool isolated = gFalse;
+                     GBool knockout = gFalse;
+                     if (!_POPPLER_CALL_ARGS_DEREF(obj5, obj4.dictLookup, "CS").isNull()) {
+-                        blendingColorSpace = GfxColorSpace::parse(nullptr, &obj5, nullptr, state);
++                        blendingColorSpace = std::unique_ptr<GfxColorSpace>(GfxColorSpace::parse(nullptr, &obj5, nullptr, state));
+                     }
+                     _POPPLER_FREE(obj5);
+                     if (_POPPLER_CALL_ARGS_DEREF(obj5, obj4.dictLookup, "I").isBool()) {
+@@ -842,7 +842,7 @@ void PdfParser::opSetExtGState(Object args[], int /*numArgs*/)
+                             }
+                         }
+                     }
+-                    doSoftMask(&obj3, alpha, blendingColorSpace, isolated, knockout, funcs[0], &backdropColor);
++                    doSoftMask(&obj3, alpha, blendingColorSpace.get(), isolated, knockout, funcs[0], &backdropColor);
+                     if (funcs[0]) {
+                         delete funcs[0];
+                     }
+@@ -927,9 +927,6 @@ void PdfParser::doSoftMask(Object *str, GBool alpha,
+ 	  alpha, transferFunc, backdropColor);
+   --formDepth;
+ 
+-  if (blendingColorSpace) {
+-    delete blendingColorSpace;
+-  }
+   _POPPLER_FREE(obj1);
+ }
+ 
+@@ -946,42 +943,43 @@ void PdfParser::opSetRenderingIntent(Object /*args*/[], int /*numArgs*/)
+  *
+  * Maintains a cache for named color spaces to avoid expensive re-parsing.
+  */
+-GfxColorSpace *PdfParser::lookupColorSpaceCopy(Object &arg)
++std::unique_ptr<GfxColorSpace> PdfParser::lookupColorSpaceCopy(Object &arg)
+ {
+     assert(!arg.isNull());
+-    GfxColorSpace *colorSpace = nullptr;
+ 
+     if (char const *name = arg.isName() ? arg.getName() : nullptr) {
+         auto const cache_name = std::to_string(formDepth) + "-" + name;
+-        if ((colorSpace = colorSpacesCache[cache_name].get())) {
+-            return colorSpace->copy();
++        if (auto cached = colorSpacesCache[cache_name].get()) {
++            return std::unique_ptr<GfxColorSpace>(cached->copy());
+         }
+ 
+-        Object obj = res->lookupColorSpace(name);
+-        if (obj.isNull()) {
+-            colorSpace = GfxColorSpace::parse(res, &arg, nullptr, state);
++        std::unique_ptr<GfxColorSpace> colorSpace;
++        if (auto obj = res->lookupColorSpace(name); !obj.isNull()) {
++            colorSpace = std::unique_ptr<GfxColorSpace>(GfxColorSpace::parse(res, &obj, nullptr, state));
+         } else {
+-            colorSpace = GfxColorSpace::parse(res, &obj, nullptr, state);
++            colorSpace = std::unique_ptr<GfxColorSpace>(GfxColorSpace::parse(res, &arg, nullptr, state));
+         }
+ 
+         if (colorSpace && colorSpace->getMode() != csPattern) {
+-            colorSpacesCache[cache_name].reset(colorSpace->copy());
++            colorSpacesCache[cache_name] = std::unique_ptr<GfxColorSpace>(colorSpace->copy());
+         }
++
++        return colorSpace;
+     } else {
+         // We were passed in an object directly.
+-        colorSpace = GfxColorSpace::parse(res, &arg, nullptr, state);
++        return std::unique_ptr<GfxColorSpace>(GfxColorSpace::parse(res, &arg, nullptr, state));
+     }
+-    return colorSpace;
+ }
+ 
+ /**
+  * Look up pattern/gradients from the GfxResource dictionary
+  */
+-GfxPattern *PdfParser::lookupPattern(Object *obj, GfxState *state)
++std::unique_ptr<GfxPattern> PdfParser::lookupPattern(Object *obj, GfxState *state)
+ {
+-    if (!obj->isName())
+-        return nullptr;
+-    return res->lookupPattern(obj->getName(), nullptr, state);
++    if (!obj->isName()) {
++        return {};
++    }
++    return std::unique_ptr<GfxPattern>(res->lookupPattern(obj->getName(), nullptr, state));
+ }
+ 
+ // TODO not good that numArgs is ignored but args[] is used:
+@@ -990,7 +988,7 @@ void PdfParser::opSetFillGray(Object args[], int /*numArgs*/)
+   GfxColor color;
+   builder->beforeStateChange(state);
+   state->setFillPattern(nullptr);
+-  state->setFillColorSpace(new GfxDeviceGrayColorSpace());
++  state->setFillColorSpace(_POPPLER_CONSUME_UNIQPTR_ARG(std::make_unique<GfxDeviceGrayColorSpace>()));
+   color.c[0] = dblToCol(args[0].getNum());
+   state->setFillColor(&color);
+   builder->updateStyle(state);
+@@ -1002,7 +1000,7 @@ void PdfParser::opSetStrokeGray(Object args[], int /*numArgs*/)
+   GfxColor color;
+   builder->beforeStateChange(state);
+   state->setStrokePattern(nullptr);
+-  state->setStrokeColorSpace(new GfxDeviceGrayColorSpace());
++  state->setStrokeColorSpace(_POPPLER_CONSUME_UNIQPTR_ARG(std::make_unique<GfxDeviceGrayColorSpace>()));
+   color.c[0] = dblToCol(args[0].getNum());
+   state->setStrokeColor(&color);
+   builder->updateStyle(state);
+@@ -1015,7 +1013,7 @@ void PdfParser::opSetFillCMYKColor(Object args[], int /*numArgs*/)
+   int i;
+   builder->beforeStateChange(state);
+   state->setFillPattern(nullptr);
+-  state->setFillColorSpace(new GfxDeviceCMYKColorSpace());
++  state->setFillColorSpace(_POPPLER_CONSUME_UNIQPTR_ARG(std::make_unique<GfxDeviceCMYKColorSpace>()));
+   for (i = 0; i < 4; ++i) {
+     color.c[i] = dblToCol(args[i].getNum());
+   }
+@@ -1029,7 +1027,7 @@ void PdfParser::opSetStrokeCMYKColor(Object args[], int /*numArgs*/)
+   GfxColor color;
+   builder->beforeStateChange(state);
+   state->setStrokePattern(nullptr);
+-  state->setStrokeColorSpace(new GfxDeviceCMYKColorSpace());
++  state->setStrokeColorSpace(_POPPLER_CONSUME_UNIQPTR_ARG(std::make_unique<GfxDeviceCMYKColorSpace>()));
+   for (int i = 0; i < 4; ++i) {
+     color.c[i] = dblToCol(args[i].getNum());
+   }
+@@ -1043,7 +1041,7 @@ void PdfParser::opSetFillRGBColor(Object args[], int /*numArgs*/)
+   GfxColor color;
+   builder->beforeStateChange(state);
+   state->setFillPattern(nullptr);
+-  state->setFillColorSpace(new GfxDeviceRGBColorSpace());
++  state->setFillColorSpace(_POPPLER_CONSUME_UNIQPTR_ARG(std::make_unique<GfxDeviceRGBColorSpace>()));
+   for (int i = 0; i < 3; ++i) {
+     color.c[i] = dblToCol(args[i].getNum());
+   }
+@@ -1056,7 +1054,7 @@ void PdfParser::opSetStrokeRGBColor(Object args[], int /*numArgs*/) {
+   GfxColor color;
+   builder->beforeStateChange(state);
+   state->setStrokePattern(nullptr);
+-  state->setStrokeColorSpace(new GfxDeviceRGBColorSpace());
++  state->setStrokeColorSpace(_POPPLER_CONSUME_UNIQPTR_ARG(std::make_unique<GfxDeviceRGBColorSpace>()));
+   for (int i = 0; i < 3; ++i) {
+     color.c[i] = dblToCol(args[i].getNum());
+   }
+@@ -1068,14 +1066,14 @@ void PdfParser::opSetStrokeRGBColor(Object args[], int /*numArgs*/) {
+ void PdfParser::opSetFillColorSpace(Object args[], int numArgs)
+ {
+   assert(numArgs >= 1);
+-  GfxColorSpace *colorSpace = lookupColorSpaceCopy(args[0]);
++  auto colorSpace = lookupColorSpaceCopy(args[0]);
+   builder->beforeStateChange(state);
+   state->setFillPattern(nullptr);
+ 
+   if (colorSpace) {
+     GfxColor color;
+-    state->setFillColorSpace(colorSpace);
+     colorSpace->getDefaultColor(&color);
++    state->setFillColorSpace(_POPPLER_CONSUME_UNIQPTR_ARG(colorSpace));
+     state->setFillColor(&color);
+     builder->updateStyle(state);
+   } else {
+@@ -1089,14 +1087,14 @@ void PdfParser::opSetStrokeColorSpace(Object args[], int numArgs)
+   assert(numArgs >= 1);
+   builder->beforeStateChange(state);
+ 
+-  GfxColorSpace *colorSpace = lookupColorSpaceCopy(args[0]);
++  auto colorSpace = lookupColorSpaceCopy(args[0]);
+ 
+   state->setStrokePattern(nullptr);
+ 
+   if (colorSpace) {
+     GfxColor color;
+-    state->setStrokeColorSpace(colorSpace);
+     colorSpace->getDefaultColor(&color);
++    state->setStrokeColorSpace(_POPPLER_CONSUME_UNIQPTR_ARG(colorSpace));
+     state->setStrokeColor(&color);
+     builder->updateStyle(state);
+   } else {
+@@ -1159,7 +1157,7 @@ void PdfParser::opSetFillColorN(Object args[], int numArgs) {
+       builder->updateStyle(state);
+     }
+     if (auto pattern = lookupPattern(&(args[numArgs - 1]), state)) {
+-        state->setFillPattern(pattern);
++        state->setFillPattern(_POPPLER_CONSUME_UNIQPTR_ARG(pattern));
+         builder->updateStyle(state);
+     }
+ 
+@@ -1202,7 +1200,7 @@ void PdfParser::opSetStrokeColorN(Object args[], int numArgs) {
+       builder->updateStyle(state);
+     }
+     if (auto pattern = lookupPattern(&(args[numArgs - 1]), state)) {
+-        state->setStrokePattern(pattern);
++        state->setStrokePattern(_POPPLER_CONSUME_UNIQPTR_ARG(pattern));
+         builder->updateStyle(state);
+     }
+ 
+@@ -1579,11 +1577,11 @@ void PdfParser::doShadingPatternFillFallback(GfxShadingPattern *sPat,
+ // TODO not good that numArgs is ignored but args[] is used:
+ void PdfParser::opShFill(Object args[], int /*numArgs*/)
+ {
+-  GfxShading *shading = nullptr;
+   GfxPath *savedPath = nullptr;
+   bool savedState = false;
+ 
+-  if (!(shading = res->lookupShading(args[0].getName(), nullptr, state))) {
++  auto shading = std::unique_ptr<GfxShading>(res->lookupShading(args[0].getName(), nullptr, state));
++  if (!shading) {
+     return;
+   }
+ 
+@@ -1615,19 +1613,19 @@ void PdfParser::opShFill(Object args[], int /*numArgs*/)
+   // do shading type-specific operations
+   switch (shading->getType()) {
+   case 1: // Function-based shading
+-    doFunctionShFill(static_cast<GfxFunctionShading *>(shading));
++    doFunctionShFill(static_cast<GfxFunctionShading *>(shading.get()));
+     break;
+   case 2: // Axial shading
+   case 3: // Radial shading
+-      builder->addClippedFill(shading, stateToAffine(state));
++      builder->addClippedFill(shading.get(), stateToAffine(state));
+       break;
+   case 4: // Free-form Gouraud-shaded triangle mesh
+   case 5: // Lattice-form Gouraud-shaded triangle mesh
+-    doGouraudTriangleShFill(static_cast<GfxGouraudTriangleShading *>(shading));
++    doGouraudTriangleShFill(static_cast<GfxGouraudTriangleShading *>(shading.get()));
+     break;
+   case 6: // Coons patch mesh
+   case 7: // Tensor-product patch mesh
+-    doPatchMeshShFill(static_cast<GfxPatchMeshShading *>(shading));
++    doPatchMeshShFill(static_cast<GfxPatchMeshShading *>(shading.get()));
+     break;
+   }
+ 
+@@ -1636,8 +1634,6 @@ void PdfParser::opShFill(Object args[], int /*numArgs*/)
+     restoreState();
+     state->setPath(savedPath);
+   }
+-
+-  delete shading;
+ }
+ 
+ void PdfParser::doFunctionShFill(GfxFunctionShading *shading) {
+@@ -2528,7 +2524,7 @@ void PdfParser::doImage(Object * /*ref*/, Stream *str, GBool inlineImg)
+         
+     } else {
+         // get color space and color map
+-        GfxColorSpace *colorSpace;
++        std::unique_ptr<GfxColorSpace> colorSpace;
+         _POPPLER_CALL_ARGS(obj1, dict->lookup, "ColorSpace");
+         if (obj1.isNull()) {
+             _POPPLER_FREE(obj1);
+@@ -2537,13 +2533,11 @@ void PdfParser::doImage(Object * /*ref*/, Stream *str, GBool inlineImg)
+         if (!obj1.isNull()) {
+             colorSpace = lookupColorSpaceCopy(obj1);
+         } else if (csMode == streamCSDeviceGray) {
+-            colorSpace = new GfxDeviceGrayColorSpace();
++            colorSpace = std::make_unique<GfxDeviceGrayColorSpace>();
+         } else if (csMode == streamCSDeviceRGB) {
+-            colorSpace = new GfxDeviceRGBColorSpace();
++            colorSpace = std::make_unique<GfxDeviceRGBColorSpace>();
+         } else if (csMode == streamCSDeviceCMYK) {
+-            colorSpace = new GfxDeviceCMYKColorSpace();
+-        } else {
+-            colorSpace = nullptr;
++            colorSpace = std::make_unique<GfxDeviceCMYKColorSpace>();
+         }
+         _POPPLER_FREE(obj1);
+         if (!colorSpace) {
+@@ -2554,10 +2548,9 @@ void PdfParser::doImage(Object * /*ref*/, Stream *str, GBool inlineImg)
+             _POPPLER_FREE(obj1);
+             _POPPLER_CALL_ARGS(obj1, dict->lookup, "D");
+         }
+-        GfxImageColorMap *colorMap = new GfxImageColorMap(bits, &obj1, colorSpace);
++        auto colorMap = std::make_unique<GfxImageColorMap>(bits, &obj1, _POPPLER_CONSUME_UNIQPTR_ARG(colorSpace));
+         _POPPLER_FREE(obj1);
+         if (!colorMap->isOk()) {
+-            delete colorMap;
+             goto err1;
+         }
+         
+@@ -2568,7 +2561,7 @@ void PdfParser::doImage(Object * /*ref*/, Stream *str, GBool inlineImg)
+         int maskWidth = 0;
+         int maskHeight = 0;
+         maskInvert = gFalse;
+-        GfxImageColorMap *maskColorMap = nullptr;
++        std::unique_ptr<GfxImageColorMap> maskColorMap;
+         _POPPLER_CALL_ARGS(maskObj, dict->lookup, "Mask");
+         _POPPLER_CALL_ARGS(smaskObj, dict->lookup, "SMask");
+         Dict* maskDict;
+@@ -2624,7 +2617,7 @@ void PdfParser::doImage(Object * /*ref*/, Stream *str, GBool inlineImg)
+ 	            _POPPLER_FREE(obj1);
+                     _POPPLER_CALL_ARGS(obj1, maskDict->lookup, "CS");
+             }
+-            GfxColorSpace *maskColorSpace = lookupColorSpaceCopy(obj1);
++            auto maskColorSpace = lookupColorSpaceCopy(obj1);
+             _POPPLER_FREE(obj1);
+             if (!maskColorSpace || maskColorSpace->getMode() != csDeviceGray) {
+                 goto err1;
+@@ -2634,10 +2627,9 @@ void PdfParser::doImage(Object * /*ref*/, Stream *str, GBool inlineImg)
+                 _POPPLER_FREE(obj1);
+                 _POPPLER_CALL_ARGS(obj1, maskDict->lookup, "D");
+             }
+-            maskColorMap = new GfxImageColorMap(maskBits, &obj1, maskColorSpace);
++            maskColorMap = std::make_unique<GfxImageColorMap>(maskBits, &obj1, _POPPLER_CONSUME_UNIQPTR_ARG(maskColorSpace));
+             _POPPLER_FREE(obj1);
+             if (!maskColorMap->isOk()) {
+-                delete maskColorMap;
+                 goto err1;
+             }
+             //~ handle the Matte entry
+@@ -2718,17 +2710,15 @@ void PdfParser::doImage(Object * /*ref*/, Stream *str, GBool inlineImg)
+         
+         // draw it
+         if (haveSoftMask) {
+-	    builder->addSoftMaskedImage(state, str, width, height, colorMap, interpolate,
+-				maskStr, maskWidth, maskHeight, maskColorMap, maskInterpolate);
+-            delete maskColorMap;
++	    builder->addSoftMaskedImage(state, str, width, height, colorMap.get(), interpolate,
++				maskStr, maskWidth, maskHeight, maskColorMap.get(), maskInterpolate);
+         } else if (haveExplicitMask) {
+- 	    builder->addMaskedImage(state, str, width, height, colorMap, interpolate,
++ 	    builder->addMaskedImage(state, str, width, height, colorMap.get(), interpolate,
+ 				maskStr, maskWidth, maskHeight, maskInvert, maskInterpolate);
+         } else {
+-	    builder->addImage(state, str, width, height, colorMap, interpolate,
+-		        haveColorKeyMask ? maskColors : static_cast<int *>(nullptr));
++	    builder->addImage(state, str, width, height, colorMap.get(), interpolate,
++		        haveColorKeyMask ? maskColors : nullptr);
+         }
+-        delete colorMap;
+         
+         _POPPLER_FREE(maskObj);
+         _POPPLER_FREE(smaskObj);
+@@ -2746,7 +2736,6 @@ void PdfParser::doForm(Object *str, double *offset)
+ {
+     Dict *dict;
+     GBool transpGroup, isolated, knockout;
+-    GfxColorSpace *blendingColorSpace;
+     Object matrixObj, bboxObj;
+     double m[6], bbox[4];
+     Object resObj;
+@@ -2812,12 +2801,12 @@ void PdfParser::doForm(Object *str, double *offset)
+ 
+     // check for a transparency group
+     transpGroup = isolated = knockout = gFalse;
+-    blendingColorSpace = nullptr;
++    std::unique_ptr<GfxColorSpace> blendingColorSpace;
+     if (_POPPLER_CALL_ARGS_DEREF(obj1, dict->lookup, "Group").isDict()) {
+         if (_POPPLER_CALL_ARGS_DEREF(obj2, obj1.dictLookup, "S").isName("Transparency")) {
+         transpGroup = gTrue;
+         if (!_POPPLER_CALL_ARGS_DEREF(obj3, obj1.dictLookup, "CS").isNull()) {
+-                blendingColorSpace = GfxColorSpace::parse(nullptr, &obj3, nullptr, state);
++            blendingColorSpace = std::unique_ptr<GfxColorSpace>(GfxColorSpace::parse(nullptr, &obj3, nullptr, state));
+         }
+         _POPPLER_FREE(obj3);
+         if (_POPPLER_CALL_ARGS_DEREF(obj3, obj1.dictLookup, "I").isBool()) {
+@@ -2835,12 +2824,9 @@ void PdfParser::doForm(Object *str, double *offset)
+ 
+     // draw it
+     ++formDepth;
+-    doForm1(str, resDict, m, bbox, transpGroup, gFalse, blendingColorSpace, isolated, knockout);
++    doForm1(str, resDict, m, bbox, transpGroup, gFalse, blendingColorSpace.get(), isolated, knockout);
+     --formDepth;
+ 
+-    if (blendingColorSpace) {
+-        delete blendingColorSpace;
+-    }
+     _POPPLER_FREE(resObj);
+ }
+ 
+diff --git a/src/extension/internal/pdfinput/pdf-parser.h b/src/extension/internal/pdfinput/pdf-parser.h
+index c7c10caefed..8325ea24364 100644
+--- a/src/extension/internal/pdfinput/pdf-parser.h
++++ b/src/extension/internal/pdfinput/pdf-parser.h
+@@ -137,7 +137,7 @@ public:
+     void loadPatternColorProfiles(Dict *resources);
+     void loadColorProfile();
+     void loadColorSpaceProfile(GfxColorSpace *space, Object *obj);
+-    GfxPattern *lookupPattern(Object *obj, GfxState *state);
++    std::unique_ptr<GfxPattern> lookupPattern(Object *obj, GfxState *state);
+ 
+     std::shared_ptr<CairoFontEngine> getFontEngine();
+ 
+@@ -176,7 +176,7 @@ private:
+     //! Caches color spaces by name
+     std::map<std::string, std::unique_ptr<GfxColorSpace>> colorSpacesCache;
+ 
+-    GfxColorSpace *lookupColorSpaceCopy(Object &);
++    std::unique_ptr<GfxColorSpace> lookupColorSpaceCopy(Object &);
+ 
+     void setDefaultApproximationPrecision(); // init color deltas
+     void pushOperator(const char *name);
+diff --git a/src/extension/internal/pdfinput/poppler-transition-api.h b/src/extension/internal/pdfinput/poppler-transition-api.h
+index 481aefadf46..8f03aa17779 100644
+--- a/src/extension/internal/pdfinput/poppler-transition-api.h
++++ b/src/extension/internal/pdfinput/poppler-transition-api.h
+@@ -15,6 +15,12 @@
+ #include <glib/poppler-features.h>
+ #include <poppler/UTF.h>
+ 
++#if POPPLER_CHECK_VERSION(24, 10, 0)
++#define _POPPLER_CONSUME_UNIQPTR_ARG(value) std::move(value)
++#else
++#define _POPPLER_CONSUME_UNIQPTR_ARG(value) value.release()
++#endif
++
+ #if POPPLER_CHECK_VERSION(24, 5, 0)
+ #define _POPPLER_HAS_UNICODE_BOM(value) (hasUnicodeByteOrderMark(value->toStr()))
+ #define _POPPLER_HAS_UNICODE_BOMLE(value) (hasUnicodeByteOrderMarkLE(value->toStr()))
+-- 
+GitLab
+

--- a/srcpkgs/inkscape/patches/0003-poppler-includes.patch
+++ b/srcpkgs/inkscape/patches/0003-poppler-includes.patch
@@ -1,0 +1,39 @@
+From 874dcfbd303bc7a1bddb6f34aebbb4dba8eda771 Mon Sep 17 00:00:00 2001
+From: Rafael Siejakowski <rs@rs-math.net>
+Date: Sun, 10 Nov 2024 13:20:48 +0100
+Subject: [PATCH] Fix Poppler private includes
+
+In the PDF parser, include the Poppler private headers using
+the angular brackets and the poppler/ directory prefix, as is
+done in other places in the code which need Poppler's private
+headers.
+
+This fixes build against Poppler installed at a custom path.
+---
+ src/extension/internal/pdfinput/pdf-parser.h | 7 +++----
+ 1 file changed, 3 insertions(+), 4 deletions(-)
+
+diff --git a/src/extension/internal/pdfinput/pdf-parser.h b/src/extension/internal/pdfinput/pdf-parser.h
+index 8325ea24364..7d9189dfc0a 100644
+--- a/src/extension/internal/pdfinput/pdf-parser.h
++++ b/src/extension/internal/pdfinput/pdf-parser.h
+@@ -24,13 +24,12 @@
+ #pragma interface
+ #endif
+ 
+-#include "glib/poppler-features.h"
+-#include "Object.h"
+-
++#include <2geom/affine.h>
++#include <glib/poppler-features.h>
+ #include <map>
+ #include <memory>
++#include <poppler/Object.h>
+ #include <string>
+-#include <2geom/affine.h>
+ 
+ #define Operator Operator_Gfx
+ #include <poppler/Gfx.h>
+-- 
+GitLab
+

--- a/srcpkgs/inkscape/patches/0004-poppler-getimageparams.patch
+++ b/srcpkgs/inkscape/patches/0004-poppler-getimageparams.patch
@@ -1,0 +1,53 @@
+From c9046810d899a408bfbd489aad91872b1203ee6d Mon Sep 17 00:00:00 2001
+From: KrIr17 <elendil.krir17@gmail.com>
+Date: Thu, 5 Dec 2024 15:03:47 +0100
+Subject: [PATCH] Fix building with poppler 24.12.0
+
+Fixes https://gitlab.com/inkscape/inkscape/-/issues/5415
+---
+ src/extension/internal/pdfinput/pdf-parser.cpp           | 4 +++-
+ src/extension/internal/pdfinput/poppler-transition-api.h | 6 ++++++
+ 2 files changed, 9 insertions(+), 1 deletion(-)
+
+diff --git a/src/extension/internal/pdfinput/pdf-parser.cpp b/src/extension/internal/pdfinput/pdf-parser.cpp
+index 28000a87b0c..9ea30b90a48 100644
+--- a/src/extension/internal/pdfinput/pdf-parser.cpp
++++ b/src/extension/internal/pdfinput/pdf-parser.cpp
+@@ -2403,6 +2403,7 @@ void PdfParser::doImage(Object * /*ref*/, Stream *str, GBool inlineImg)
+     int bits;
+     GBool interpolate;
+     StreamColorSpaceMode csMode;
++    GBool hasAlpha;
+     GBool mask;
+     GBool invert;
+     Object maskObj, smaskObj;
+@@ -2414,7 +2415,8 @@ void PdfParser::doImage(Object * /*ref*/, Stream *str, GBool inlineImg)
+     // get info from the stream
+     bits = 0;
+     csMode = streamCSNone;
+-    str->getImageParams(&bits, &csMode);
++    hasAlpha = false;
++    str->_POPPLER_GET_IMAGE_PARAMS(&bits, &csMode, &hasAlpha);
+     
+     // get stream dict
+     dict = str->getDict();
+diff --git a/src/extension/internal/pdfinput/poppler-transition-api.h b/src/extension/internal/pdfinput/poppler-transition-api.h
+index 8f03aa17779..b7a54828e74 100644
+--- a/src/extension/internal/pdfinput/poppler-transition-api.h
++++ b/src/extension/internal/pdfinput/poppler-transition-api.h
+@@ -39,6 +39,12 @@
+ #define _POPPLER_FUNCTION_TYPE_STITCHING 3
+ #endif
+ 
++#if POPPLER_CHECK_VERSION(24,12,0)
++#define _POPPLER_GET_IMAGE_PARAMS(bits, csMode, hasAlpha) getImageParams(bits, csMode, hasAlpha)
++#else
++#define _POPPLER_GET_IMAGE_PARAMS(bits, csMode, hasAlpha) getImageParams(bits, csMode)
++#endif
++
+ #if POPPLER_CHECK_VERSION(22, 4, 0)
+ #define _POPPLER_FONTPTR_TO_GFX8(font_ptr) ((Gfx8BitFont *)font_ptr.get())
+ #else
+-- 
+GitLab
+

--- a/srcpkgs/inkscape/patches/6811.patch
+++ b/srcpkgs/inkscape/patches/6811.patch
@@ -1,0 +1,195 @@
+From 6c330d56fdf54cb002b8a84b33f73d2a8dd40879 Mon Sep 17 00:00:00 2001
+From: Tavmjong Bah <tavmjong@free.fr>
+Date: Fri, 8 Nov 2024 15:03:12 +0100
+Subject: [PATCH] Fixes two problems related to emojis in PDF import.
+
+1. UTF-8 conversion.
+
+   If a "ToUnicode" table is included in an OpenType font in a PDF
+   file, one can find the Unicode code point that corresponds to a
+   given glyph (or group of glyphs). This is often the only way one
+   can reconstruct text from a PDF (which might contain only glyphs
+   and glyph positions). For Emoji, the code points are outside the
+   "Basic Plane" (code points that can be encode by four or fewer
+   hexadecimal digits) and in are located the "Supplementary
+   Multilingual Plane", a.k.a. "Plane 1".  Code points in "Plane 1" are
+   represented by a hexadecimal number of the form "1xxxx", where 'x'
+   is any hex digit.
+
+   Inkscape's PDF import code takes a Unicode code point and converts
+   it to its UTF-8 representation. This code assumes that the code
+   point can be represented by a gunichar2 which is typedef'ed from a
+   guint16. The glib function g_utf16_to_utf8 is then used for the
+   conversion. This in incorrect: a single guint16 can only represent
+   a 4 hex-digit code point and then not all possible values (some
+   values are used to indicate that a second 16-bit value is being used
+   to to enable encoding a code point outside the basic plane).
+
+   We already use std::wstring_convert<> and std::codecvt<> earlier in
+   the same function to build up a string to store the original text
+   in the 'aria-label' attribute. I changed the code to reuse that
+   result. Note that these are deprecated and will be removed in C++26
+   so we'll eventually need to find a different solution.
+
+2. Empty paths.
+
+   Emoji fonts usually have color. There are four competing methods of
+   embedding color font data in an OpenType font. Two of these use
+   bitmaps. If a font has only bitmap glyph data then there is no
+   vector data to build a path. If there is no path, Inkscape's
+   current code returns 'nullptr' instead of a pointer to a Path
+   node. This triggers an assert. Simply removing the assert leads to
+   other problems down the line. The simplest solution is to return a
+   Path node with an empty "d" attribute. This also allows one to
+   store the original text in the "aria-label" attribute of the Path
+   node.
+
+   In the future, we should be able to render bitmaps from fonts in
+   the same way the same way that we render SVG OpenType fonts (which
+   caches the glyphs as bitmaps).
+
+Unfixed problems:
+
+   If the "Noto-Color-Emoji" font is present, it will be used for
+   rendering emoji even if "Noto-Emoji" or "Symbola" is specified. It
+   will also be used as a fallback font for rendering emoji.
+   "Noto-Color-Emoji" has to "glyf" table and thus lacks vectorized
+   paths. This leads to empty paths. It would be good to block the use
+   of "Noto-Color-Emoji" in this case. It's not clear how easy it
+   would be to do this.
+
+   What is even stranger is that the terminal will not show an Emoji
+   if "Noto-Color-Emoji" is not installed even though the glyph that
+   is shown is not from "Noto-Color-Emoji"! (It's from "Symbola".)
+
+   There appears to be incorrect logic in SvgBuider::_flushTextPath().
+   If the style changes inside the function, the node existing node is
+   replaced, effectively orphaning the previous node. Whether this
+   actually happens in PDF input is unknown.
+---
+ .../internal/pdfinput/svg-builder.cpp         | 54 +++++++++----------
+ 1 file changed, 26 insertions(+), 28 deletions(-)
+
+diff --git a/src/extension/internal/pdfinput/svg-builder.cpp b/src/extension/internal/pdfinput/svg-builder.cpp
+index 73f57f04952..bb2ce5145e8 100644
+--- a/src/extension/internal/pdfinput/svg-builder.cpp
++++ b/src/extension/internal/pdfinput/svg-builder.cpp
+@@ -1250,7 +1250,7 @@ void SvgBuilder::updateFont(GfxState *state, std::shared_ptr<CairoFont> cairo_fo
+     TRACE(("updateFont()\n"));
+     updateTextMatrix(state, flip);    // Ensure that we have a text matrix built
+ 
+-    auto font = state->getFont();
++    auto font = state->getFont();  // GfxFont
+     auto font_id = font->getID()->num;
+ 
+     auto new_font_size = state->getFontSize();
+@@ -1711,6 +1711,10 @@ void SvgBuilder::_setTextStyle(Inkscape::XML::Node *node, GfxState *state, SPCSS
+ /**
+  * Renders the text as a path object using cairo and returns the node object.
+  *
++ * If the path is empty (e.g. due to trying to render a color bitmap font),
++ * return path node with empty "d" attribute. The aria attribute will still
++ * contain the original text.
++ *
+  * cairo_font   - The font that cairo can use to convert text to path.
+  * font_size    - The size of the text when drawing the path.
+  * transform    - The matrix which will place the text on the page, this is critical
+@@ -1722,8 +1726,13 @@ Inkscape::XML::Node *SvgBuilder::_renderText(std::shared_ptr<CairoFont> cairo_fo
+                                              const Geom::Affine &transform,
+                                              cairo_glyph_t *cairo_glyphs, unsigned int count)
+ {
+-    if (!cairo_glyphs || !cairo_font || _aria_label.empty())
+-        return nullptr;
++    Inkscape::XML::Node *path = _addToContainer("svg:path");
++    path->setAttribute("d", "");
++
++    if (!cairo_glyphs || !cairo_font || _aria_label.empty()) {
++        std::cerr << "SvgBuilder::_renderText: Invalid argument!" << std::endl;
++        return path;
++    }
+ 
+     // The surface isn't actually used, no rendering in cairo takes place.
+     cairo_surface_t *surface = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, _width, _height);
+@@ -1738,16 +1747,17 @@ Inkscape::XML::Node *SvgBuilder::_renderText(std::shared_ptr<CairoFont> cairo_fo
+ 
+     // Failing to render text.
+     if (!pathv) {
+-        g_warning("Failed to render PDF text!");
+-        return nullptr;
++        std::cerr << "SvgBuilder::_renderText: Failed to render PDF text! " << _aria_label << std::endl;
++        return path;
+     }
+ 
+     auto textpath = sp_svg_write_path(*pathv);
+-    if (textpath.empty())
+-        return nullptr;
+-
+-    Inkscape::XML::Node *path = _addToContainer("svg:path");
+     path->setAttribute("d", textpath);
++
++    if (textpath.empty()) {
++        std::cerr << "SvgBuilder::_renderText: Empty path! " << _aria_label << std::endl;
++    }
++
+     return path;
+ }
+ 
+@@ -1785,7 +1795,7 @@ void SvgBuilder::endString(GfxState *state)
+  * dx, dy:  Advance of glyph.
+  * originX, originY
+  * code: 8-bit char code, 16 bit CID, or Unicode of glyph.
+- * u: Unicode mapping of character.
++ * u: Unicode mapping of character. "Unicode" is an unsigned int.
+  */
+ void SvgBuilder::addChar(GfxState *state, double x, double y, double dx, double dy, double originX, double originY,
+                          CharCode code, int /*nBytes*/, Unicode const *u, int uLen)
+@@ -1801,9 +1811,13 @@ void SvgBuilder::addChar(GfxState *state, double x, double y, double dx, double
+     }
+     _aria_space = false;
+ 
++    std::string utf8_code;
+     static std::wstring_convert<std::codecvt_utf8<char32_t>, char32_t> conv1;
++    // Note std::wstring_convert and std::codecvt_utf are deprecated and will be removed in C++26.
+     if (u) {
+-        _aria_label += conv1.to_bytes(*u);
++        // 'u' maybe null if there is not a "ToUnicode" table in the PDF!
++        utf8_code = conv1.to_bytes(*u);
++        _aria_label += utf8_code;
+     }
+ 
+     // Skip control characters, found in LaTeX generated PDFs
+@@ -1835,6 +1849,7 @@ void SvgBuilder::addChar(GfxState *state, double x, double y, double dx, double
+     }
+ 
+     SvgGlyph new_glyph;
++    new_glyph.code = utf8_code;
+     new_glyph.is_space = is_space;
+     new_glyph.delta = delta;
+     new_glyph.position = Geom::Point( x - originX, y - originY );
+@@ -1849,23 +1864,6 @@ void SvgBuilder::addChar(GfxState *state, double x, double y, double dx, double
+     }
+     _text_position += delta;
+ 
+-    // Convert the character to UTF-8 since that's our SVG document's encoding
+-    {
+-        gunichar2 uu[8] = {0};
+-
+-        for (int i = 0; i < uLen; i++) {
+-            uu[i] = u[i];
+-        }
+-
+-        gchar *tmp = g_utf16_to_utf8(uu, uLen, nullptr, nullptr, nullptr);
+-        if ( tmp && *tmp ) {
+-            new_glyph.code = tmp;
+-        } else {
+-            new_glyph.code.clear();
+-        }
+-        g_free(tmp);
+-    }
+-
+     // Copy current style if it has changed since the previous glyph
+     if (_invalidated_style || _glyphs.empty()) {
+         _invalidated_style = false;
+-- 
+GitLab
+

--- a/srcpkgs/inkscape/patches/poppler_25.02.0.patch
+++ b/srcpkgs/inkscape/patches/poppler_25.02.0.patch
@@ -1,0 +1,179 @@
+From 5c4c6d116dae5250d75d34a45f0d9220824d2e20 Mon Sep 17 00:00:00 2001
+From: KrIr17 <elendil.krir17@gmail.com>
+Date: Sun, 9 Feb 2025 22:52:53 +0530
+Subject: [PATCH] Fix building with poppler 25.02.0
+
+1. `getCodeToGIDMap`, `getCIDToGID`, `getCIDToGIDMap` are now `std::vector`
+
+2. `pdfDocEncodingToUTF16` returns an `std::string`
+---
+ .../pdfinput/poppler-cairo-font-engine.cpp    | 50 +++++++++++++++----
+ .../pdfinput/poppler-transition-api.h         | 20 +++++---
+ 3 files changed, 63 insertions(+), 16 deletions(-)
+
+diff --git a/src/extension/internal/pdfinput/poppler-cairo-font-engine.cpp b/src/extension/internal/pdfinput/poppler-cairo-font-engine.cpp
+index 728b1d1aac4..bd1d4e49367 100644
+--- a/src/extension/internal/pdfinput/poppler-cairo-font-engine.cpp
++++ b/src/extension/internal/pdfinput/poppler-cairo-font-engine.cpp
+@@ -405,14 +405,22 @@ CairoFreeTypeFont *CairoFreeTypeFont::create(GfxFont *gfxFont, XRef *xref, FT_Li
+             break;
+         case fontCIDType2:
+         case fontCIDType2OT:
++#if POPPLER_CHECK_VERSION(25,2,0)
++            if (!gfxcid->getCIDToGID().empty()) {
++                const auto src = gfxcid->getCIDToGID();
++                codeToGID = std::move(src);
++            }
++#else
+             if (gfxcid->getCIDToGID()) {
+                 n = gfxcid->getCIDToGIDLen();
+                 if (n) {
+-                    const int *src = gfxcid->getCIDToGID();
++                    const auto src = gfxcid->getCIDToGID();
+                     codeToGID.reserve(n);
+                     codeToGID.insert(codeToGID.begin(), src, src + n);
+                 }
+-            } else {
++            }
++#endif
++            else {
+ #if POPPLER_CHECK_VERSION(22, 1, 0)
+                 std::unique_ptr<FoFiTrueType> ff;
+ #else
+@@ -427,13 +435,18 @@ CairoFreeTypeFont *CairoFreeTypeFont::create(GfxFont *gfxFont, XRef *xref, FT_Li
+                     goto err2;
+                 }
+ #if POPPLER_CHECK_VERSION(22, 1, 0)
+-                int *src = gfxcid->getCodeToGIDMap(ff.get(), &n);
++                auto src = gfxcid->_POPPLER_GET_CODE_TO_GID_MAP(ff.get(), &n);
+ #else
+-                int *src = gfxcid->getCodeToGIDMap(ff, &n);
++                auto src = gfxcid->_POPPLER_GET_CODE_TO_GID_MAP(ff, &n);
+ #endif
++
++#if POPPLER_CHECK_VERSION(25,2,0)
++                codeToGID = std::move(src);
++#else
+                 codeToGID.reserve(n);
+                 codeToGID.insert(codeToGID.begin(), src, src + n);
+                 gfree(src);
++#endif
+             }
+             /* Fall through */
+         case fontTrueType:
+@@ -455,13 +468,17 @@ CairoFreeTypeFont *CairoFreeTypeFont::create(GfxFont *gfxFont, XRef *xref, FT_Li
+             /* This might be set already for the CIDType2 case */
+             if (fontType == fontTrueType || fontType == fontTrueTypeOT) {
+ #if POPPLER_CHECK_VERSION(22, 1, 0)
+-                int *src = gfx8bit->getCodeToGIDMap(ff.get());
++                auto src = gfx8bit->getCodeToGIDMap(ff.get());
+ #else
+-                int *src = gfx8bit->getCodeToGIDMap(ff);
++                auto src = gfx8bit->getCodeToGIDMap(ff);
+ #endif
++#if POPPLER_CHECK_VERSION(25,2,0)
++                codeToGID = std::move(src);
++#else
+                 codeToGID.reserve(256);
+                 codeToGID.insert(codeToGID.begin(), src, src + 256);
+                 gfree(src);
++#endif
+             }
+             font_face = getFreeTypeFontFace(fontEngine, lib, fileName, std::move(font_data));
+             if (!font_face) {
+@@ -479,10 +496,14 @@ CairoFreeTypeFont *CairoFreeTypeFont::create(GfxFont *gfxFont, XRef *xref, FT_Li
+                     ff1c = FoFiType1C::load(fileName.c_str());
+                 }
+                 if (ff1c) {
+-                    int *src = ff1c->getCIDToGIDMap(&n);
++                    auto src = ff1c->_POPPLER_GET_CID_TO_GID_MAP(&n);
++#if POPPLER_CHECK_VERSION(25,2,0)
++                    codeToGID = std::move(src);
++#else
+                     codeToGID.reserve(n);
+                     codeToGID.insert(codeToGID.begin(), src, src + n);
+                     gfree(src);
++#endif
+                     delete ff1c;
+                 }
+             }
+@@ -495,14 +516,21 @@ CairoFreeTypeFont *CairoFreeTypeFont::create(GfxFont *gfxFont, XRef *xref, FT_Li
+             break;
+ 
+         case fontCIDType0COT:
++#if POPPLER_CHECK_VERSION(25,2,0)
++            if (!gfxcid->getCIDToGID().empty()) {
++                const auto src = gfxcid->getCIDToGID();
++                codeToGID = std::move(src);
++            }
++#else
+             if (gfxcid->getCIDToGID()) {
+                 n = gfxcid->getCIDToGIDLen();
+                 if (n) {
+-                    const int *src = gfxcid->getCIDToGID();
++                    const auto src = gfxcid->getCIDToGID();
+                     codeToGID.reserve(n);
+                     codeToGID.insert(codeToGID.begin(), src, src + n);
+                 }
+             }
++#endif
+ 
+             if (codeToGID.empty()) {
+                 if (!useCIDs) {
+@@ -518,10 +546,14 @@ CairoFreeTypeFont *CairoFreeTypeFont::create(GfxFont *gfxFont, XRef *xref, FT_Li
+                     }
+                     if (ff) {
+                         if (ff->isOpenTypeCFF()) {
+-                            int *src = ff->getCIDToGIDMap(&n);
++                            auto src = ff1c->_POPPLER_GET_CID_TO_GID_MAP(&n);
++#if POPPLER_CHECK_VERSION(25,2,0)
++                            codeToGID = std::move(src);
++#else
+                             codeToGID.reserve(n);
+                             codeToGID.insert(codeToGID.begin(), src, src + n);
+                             gfree(src);
++#endif
+                         }
+                     }
+                 }
+diff --git a/src/extension/internal/pdfinput/poppler-transition-api.h b/src/extension/internal/pdfinput/poppler-transition-api.h
+index b7a54828e74..a67132ba6bd 100644
+--- a/src/extension/internal/pdfinput/poppler-transition-api.h
++++ b/src/extension/internal/pdfinput/poppler-transition-api.h
+@@ -15,6 +15,20 @@
+ #include <glib/poppler-features.h>
+ #include <poppler/UTF.h>
+ 
++#if POPPLER_CHECK_VERSION(25,2,0)
++#define _POPPLER_GET_CODE_TO_GID_MAP(ff, len) getCodeToGIDMap(ff)
++#define _POPPLER_GET_CID_TO_GID_MAP(len) getCIDToGIDMap()
++#else
++#define _POPPLER_GET_CODE_TO_GID_MAP(ff, len) getCodeToGIDMap(ff, len)
++#define _POPPLER_GET_CID_TO_GID_MAP(len) getCIDToGIDMap(len)
++#endif
++
++#if POPPLER_CHECK_VERSION(24,12,0)
++#define _POPPLER_GET_IMAGE_PARAMS(bits, csMode, hasAlpha) getImageParams(bits, csMode, hasAlpha)
++#else
++#define _POPPLER_GET_IMAGE_PARAMS(bits, csMode, hasAlpha) getImageParams(bits, csMode)
++#endif
++
+ #if POPPLER_CHECK_VERSION(24, 10, 0)
+ #define _POPPLER_CONSUME_UNIQPTR_ARG(value) std::move(value)
+ #else
+@@ -39,12 +53,6 @@
+ #define _POPPLER_FUNCTION_TYPE_STITCHING 3
+ #endif
+ 
+-#if POPPLER_CHECK_VERSION(24,12,0)
+-#define _POPPLER_GET_IMAGE_PARAMS(bits, csMode, hasAlpha) getImageParams(bits, csMode, hasAlpha)
+-#else
+-#define _POPPLER_GET_IMAGE_PARAMS(bits, csMode, hasAlpha) getImageParams(bits, csMode)
+-#endif
+-
+ #if POPPLER_CHECK_VERSION(22, 4, 0)
+ #define _POPPLER_FONTPTR_TO_GFX8(font_ptr) ((Gfx8BitFont *)font_ptr.get())
+ #else
+-- 
+GitLab
+

--- a/srcpkgs/inkscape/template
+++ b/srcpkgs/inkscape/template
@@ -1,7 +1,7 @@
 # Template file for 'inkscape'
 pkgname=inkscape
 version=1.4
-revision=2
+revision=3
 build_style=cmake
 make_check_target="check"
 hostmakedepends="automake gettext glib-devel intltool libgraphicsmagick-devel

--- a/srcpkgs/ipe/template
+++ b/srcpkgs/ipe/template
@@ -1,7 +1,7 @@
 # Template file for 'ipe'
 pkgname=ipe
 version=7.2.26
-revision=13
+revision=14
 _tools_commit=v7.2.24.1
 create_wrksrc=yes
 hostmakedepends="pkg-config doxygen qt5-qmake qt5-tools qt5-host-tools"

--- a/srcpkgs/kitinerary/patches/KMime_new_const_API-fix_compilation.patch
+++ b/srcpkgs/kitinerary/patches/KMime_new_const_API-fix_compilation.patch
@@ -1,0 +1,22 @@
+--- a/src/lib/processors/mimedocumentprocessor.cpp	2024-08-16 07:00:56.000000000 +0200
++++ b/src/lib/processors/mimedocumentprocessor.cpp	2025-02-24 14:03:09.980662872 +0100
+@@ -142,13 +142,14 @@
+     }
+ 
+     // special handling of multipart/related to add images to the corresponding HTML document
+-    if (ct && ct->isMultipart() && ct->isSubtype("related") && ct->parameter("type"_L1) == "text/html"_L1 && children.size() >= 2) {
+-        const auto child = children.front();
+-        if (child->contentType(false) && child->contentType(false)->isHTMLText()) {
++    if (ct && ct->isMultipart() && ct->isSubtype("related") && ct->parameter("type") == "text/html"_L1 && children.size() >= 2) {
++        const KMime::Content *child = children.front();
++        if (child->contentType() && child->contentType()->isHTMLText()) {
+             auto htmlNode = expandContentNode(node, child, engine);
+             for (auto it = std::next(children.begin()); it != children.end(); ++it) {
+-                auto imgNode = expandContentNode(htmlNode, (*it), engine);
+-                const auto cid = (*it)->contentID(false);
++                const KMime::Content *imgChild = *it;
++                auto imgNode = expandContentNode(htmlNode, imgChild, engine);
++                const auto cid = imgChild->contentID();
+                 if (cid) {
+                     imgNode.setLocation(cid->identifier());
+                 }

--- a/srcpkgs/kitinerary/patches/poppler_25.02.0.patch
+++ b/srcpkgs/kitinerary/patches/poppler_25.02.0.patch
@@ -1,0 +1,49 @@
+--- a/src/lib/pdf/pdfdocument.cpp	2024-08-16 07:00:56.000000000 +0200
++++ b/src/lib/pdf/pdfdocument.cpp	2025-02-23 22:41:15.141361948 +0100
+@@ -39,10 +39,15 @@
+     m_doc->m_popplerDoc->displayPageSlice(&device, m_pageNum + 1, 72, 72, 0, false, true, false, -1, -1, -1, -1);
+     m_doc->m_popplerDoc->processLinks(&device, m_pageNum + 1);
+     device.finalize();
+-    const auto pageRect = m_doc->m_popplerDoc->getPage(m_pageNum + 1)->getCropBox();
+-    std::unique_ptr<GooString> s(device.getText(pageRect->x1, pageRect->y1, pageRect->x2, pageRect->y2));
+ 
++	const auto pageRect = m_doc->m_popplerDoc->getPage(m_pageNum + 1)->getCropBox();
++#if KPOPPLER_VERSION < QT_VERSION_CHECK(25, 1, 0)
++	std::unique_ptr<GooString> s(device.getText(pageRect->x1, pageRect->y1, pageRect->x2, pageRect->y2));
+     m_text = QString::fromUtf8(s->c_str());
++#else
++	const auto s = device.getText(pageRect->x1, pageRect->y1, pageRect->x2, pageRect->y2);
++	m_text = QString::fromUtf8(s.c_str());
++#endif
+     m_images = std::move(device.m_images);
+     for (auto it = m_images.begin(); it != m_images.end(); ++it) {
+         (*it).d->m_page = this;
+@@ -107,8 +112,13 @@
+ 
+     TextOutputDev device(nullptr, false, 0, false, false);
+     d->m_doc->m_popplerDoc->displayPageSlice(&device, d->m_pageNum + 1, 72, 72, 0, false, true, false, -1, -1, -1, -1);
++#if KPOPPLER_VERSION <QT_VERSION_CHECK(25, 1, 0)
+     std::unique_ptr<GooString> s(device.getText(l, t, r, b));
+     return QString::fromUtf8(s->c_str());
++#else
++    const auto s = device.getText(l, t, r, b);
++    return QString::fromUtf8(s.c_str());
++#endif
+ }
+ 
+ int PdfPage::imageCount() const
+@@ -314,9 +324,14 @@
+ #endif
+         return QString::fromUtf16(reinterpret_cast<const char16_t*>(s->toStr().c_str()), s->toStr().size() / 2);
+     } else {
++#if KPOPPLER_VERSION >= QT_VERSION_CHECK(25, 2, 0)
++        const auto utf16Data = pdfDocEncodingToUTF16(s->toStr());
++        return QString::fromUtf16(reinterpret_cast<const char16_t *>(utf16Data.c_str()), utf16Data.size() / 2);
++#else
+         int len = 0;
+         std::unique_ptr<const char[]> utf16Data(pdfDocEncodingToUTF16(s->toStr(), &len));
+         return QString::fromUtf16(reinterpret_cast<const char16_t*>(utf16Data.get()), len / 2);
++#endif
+     }
+ 
+     return QString::fromUtf8(s->c_str());

--- a/srcpkgs/kitinerary/template
+++ b/srcpkgs/kitinerary/template
@@ -1,7 +1,7 @@
 # Template file for 'kitinerary'
 pkgname=kitinerary
 version=24.08.0
-revision=1
+revision=2
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins

--- a/srcpkgs/libcupsfilters/template
+++ b/srcpkgs/libcupsfilters/template
@@ -1,7 +1,7 @@
 # Template file for 'libcupsfilters'
 pkgname=libcupsfilters
 version=2.1.1
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--disable-mutool
  --with-test-font-path=/usr/share/fonts/TTF/DejaVuSans.ttf"

--- a/srcpkgs/libreoffice/template
+++ b/srcpkgs/libreoffice/template
@@ -1,7 +1,7 @@
 # Template file for 'libreoffice'
 pkgname=libreoffice
 version=25.2.0.3
-revision=1
+revision=2
 build_style=meta
 build_helper="gir"
 make_build_target="build"

--- a/srcpkgs/pdf2djvu/template
+++ b/srcpkgs/pdf2djvu/template
@@ -1,7 +1,7 @@
 # Template file for 'pdf2djvu'
 pkgname=pdf2djvu
 version=0.9.19
-revision=7
+revision=8
 build_style=gnu-configure
 hostmakedepends="pkg-config djvulibre gettext"
 makedepends="djvulibre-devel poppler-devel libgraphicsmagick-devel exiv2-devel libuuid-devel"

--- a/srcpkgs/pdfgrep/template
+++ b/srcpkgs/pdfgrep/template
@@ -1,7 +1,7 @@
 # Template file for 'pdfgrep'
 pkgname=pdfgrep
 version=2.2.0
-revision=2
+revision=3
 build_style=gnu-configure
 hostmakedepends="pkg-config"
 makedepends="libgcrypt-devel poppler-cpp-devel pcre2-devel"

--- a/srcpkgs/poppler-qt5/template
+++ b/srcpkgs/poppler-qt5/template
@@ -4,7 +4,7 @@
 # IT IS SPLIT TO AVOID A CYCLIC DEPENDENCY: qt5 -> cups -> poppler -> qt5.
 #
 pkgname=poppler-qt5
-version=24.08.0
+version=25.02.0
 revision=1
 build_style=cmake
 configure_args="-DENABLE_UNSTABLE_API_ABI_HEADERS=ON -DENABLE_GLIB=OFF
@@ -21,7 +21,7 @@ license="GPL-2.0-or-later, GPL-3.0-or-later"
 homepage="https://poppler.freedesktop.org"
 changelog="https://gitlab.freedesktop.org/poppler/poppler/-/raw/master/NEWS"
 distfiles="https://poppler.freedesktop.org/poppler-${version}.tar.xz"
-checksum=97453fbddf0c9a9eafa0ea45ac710d3d49bcf23a62e864585385d3c0b4403174
+checksum=21234cb2a9647d73c752ce4031e65a79d11a511a835f2798284c2497b8701dee
 # fails to find a bunch of files
 make_check=no
 

--- a/srcpkgs/poppler/template
+++ b/srcpkgs/poppler/template
@@ -2,9 +2,9 @@
 #
 # THIS PKG MUST BE SYNCHRONIZED WITH "srcpkgs/poppler-qt5".
 pkgname=poppler
-version=24.08.0
+version=25.02.0
 revision=1
-_testVersion=ff3133cdb6cb496ee1d2c3231bfa35006a5e8410
+_testVersion=91ee031c882634c36f2f0f2f14eb6646dd542fb9
 create_wrksrc=yes
 build_style=cmake
 build_helper="gir"
@@ -24,8 +24,8 @@ homepage="https://poppler.freedesktop.org"
 changelog="https://gitlab.freedesktop.org/poppler/poppler/-/raw/master/NEWS"
 distfiles="https://poppler.freedesktop.org/poppler-${version}.tar.xz
  https://gitlab.freedesktop.org/poppler/test/-/archive/${_testVersion}/test-${_testVersion}.tar.gz"
-checksum="97453fbddf0c9a9eafa0ea45ac710d3d49bcf23a62e864585385d3c0b4403174
- 98a06e7dd7619fe20bfd99505a31993dbe40517678d81278e6395a30a40f03bf"
+checksum="21234cb2a9647d73c752ce4031e65a79d11a511a835f2798284c2497b8701dee
+ 4155211ed0e5b05ffd0b57e7e4679215ba02c7f58fcd16e6b82844b2f6a6f590"
 
 build_options="gir boost"
 build_options_default="gir boost"

--- a/srcpkgs/scribus/patches/fix_build_with_poppler_25.02.0.patch
+++ b/srcpkgs/scribus/patches/fix_build_with_poppler_25.02.0.patch
@@ -1,0 +1,172 @@
+diff --git a/scribus/plugins/import/pdf/importpdf.cpp b/scribus/plugins/import/pdf/importpdf.cpp
+index 92539d1..ac8e2eb 100644
+--- a/scribus/plugins/import/pdf/importpdf.cpp
++++ b/scribus/plugins/import/pdf/importpdf.cpp
+@@ -462,11 +462,11 @@ bool PdfPlug::convert(const QString& fn)
+ 
+ 			if (dev->isOk())
+ 			{
+-				OCGs* ocg = pdfDoc->getOptContentConfig();
++				POPPLER_CONST_25_02 OCGs* ocg = pdfDoc->getOptContentConfig();
+ 				if (ocg && ocg->hasOCGs())
+ 				{
+ 					QStringList ocgNames;
+-					Array *order = ocg->getOrderArray();
++					POPPLER_CONST_25_02 Array *order = ocg->getOrderArray();
+ 					if (order)
+ 					{
+ 						for (int i = 0; i < order->getLength (); ++i)
+diff --git a/scribus/plugins/import/pdf/importpdfconfig.h b/scribus/plugins/import/pdf/importpdfconfig.h
+index b922816..b3d35f0 100644
+--- a/scribus/plugins/import/pdf/importpdfconfig.h
++++ b/scribus/plugins/import/pdf/importpdfconfig.h
+@@ -15,6 +15,12 @@ for which a new license (GPL+exception) is in place.
+ 	+ ((micro) *     1))
+ #define POPPLER_ENCODED_VERSION POPPLER_VERSION_ENCODE(POPPLER_VERSION_MAJOR, POPPLER_VERSION_MINOR, POPPLER_VERSION_MICRO)
+ 
++#if POPPLER_ENCODED_VERSION >= POPPLER_VERSION_ENCODE(25, 2, 0)
++#define POPPLER_CONST_25_02 const
++#else
++#define POPPLER_CONST_25_02
++#endif
++
+ #if POPPLER_ENCODED_VERSION >= POPPLER_VERSION_ENCODE(0, 82, 0)
+ #define POPPLER_CONST_082 const
+ #else
+diff --git a/scribus/plugins/import/pdf/slaoutput.cpp b/scribus/plugins/import/pdf/slaoutput.cpp
+index 0244c9f..72e11b4 100644
+--- a/scribus/plugins/import/pdf/slaoutput.cpp
++++ b/scribus/plugins/import/pdf/slaoutput.cpp
+@@ -2932,7 +2932,7 @@ void SlaOutputDev::beginMarkedContent(const char *name, Object *dictRef)
+ 	{
+ 		if (dictRef->isNull())
+ 			return;
+-		OCGs *contentConfig = m_catalog->getOptContentConfig();
++		POPPLER_CONST_25_02 OCGs *contentConfig = m_catalog->getOptContentConfig();
+ 		OptionalContentGroup *oc;
+ 		if (dictRef->isRef())
+ 		{
+@@ -3081,10 +3081,11 @@ void SlaOutputDev::updateFont(GfxState *state)
+ 	SplashFontFile *fontFile;
+ 	SplashFontSrc *fontsrc = nullptr;
+ 	Object refObj, strObj;
+-#if POPPLER_ENCODED_VERSION < POPPLER_VERSION_ENCODE(22, 4, 0)
+-	int tmpBufLen = 0;
+-#endif
++#if POPPLER_ENCODED_VERSION >= POPPLER_VERSION_ENCODE(25, 2, 0)
++	std::vector<int> codeToGID;
++#else
+ 	int *codeToGID = nullptr;
++#endif
+ 	const double *textMat = nullptr;
+ 	double m11, m12, m21, m22, fontSize;
+ 	SplashCoord mat[4] = { 1.0, 0.0, 0.0, 1.0 };
+@@ -3244,10 +3245,20 @@ void SlaOutputDev::updateFont(GfxState *state)
+ 			}
+ 			else
+ 			{
++#if POPPLER_ENCODED_VERSION >= POPPLER_VERSION_ENCODE(25, 2, 0)
++				codeToGID.clear();
++#else
+ 				codeToGID = nullptr;
++#endif
+ 				n = 0;
+ 			}
+-#if POPPLER_ENCODED_VERSION >= POPPLER_VERSION_ENCODE(24, 11, 0)
++#if POPPLER_ENCODED_VERSION >= POPPLER_VERSION_ENCODE(25, 2, 0)
++			if (!(fontFile = m_fontEngine->loadTrueTypeFont(std::move(id), fontsrc, std::move(codeToGID), fontLoc->fontNum)))
++			{
++				error(errSyntaxError, -1, "Couldn't create a font for '{0:s}'", gfxFont->getName() ? gfxFont->getName()->c_str() : "(unnamed)");
++				goto err2;
++			}
++#elif POPPLER_ENCODED_VERSION >= POPPLER_VERSION_ENCODE(24, 11, 0)
+ 			if (!(fontFile = m_fontEngine->loadTrueTypeFont(std::move(id), fontsrc, codeToGID, n, fontLoc->fontNum)))
+ 			{
+ 				error(errSyntaxError, -1, "Couldn't create a font for '{0:s}'", gfxFont->getName() ? gfxFont->getName()->c_str() : "(unnamed)");
+@@ -3278,6 +3289,18 @@ void SlaOutputDev::updateFont(GfxState *state)
+ #endif
+ 			break;
+ 		case fontCIDType0COT:
++#if POPPLER_ENCODED_VERSION >= POPPLER_VERSION_ENCODE(25, 2, 0)
++			if (((GfxCIDFont*) gfxFont)->getCIDToGIDLen() > 0)
++			{
++				codeToGID = ((GfxCIDFont*) gfxFont)->getCIDToGID();
++				n = codeToGID.size();
++			}
++			else
++			{
++				codeToGID.clear();
++				n = 0;
++			}
++#else
+ 			if (((GfxCIDFont *) gfxFont)->getCIDToGID())
+ 			{
+ 				n = ((GfxCIDFont *) gfxFont)->getCIDToGIDLen();
+@@ -3289,7 +3312,15 @@ void SlaOutputDev::updateFont(GfxState *state)
+ 				codeToGID = nullptr;
+ 				n = 0;
+ 			}
+-#if POPPLER_ENCODED_VERSION >= POPPLER_VERSION_ENCODE(24, 11, 0)
++#endif
++#if POPPLER_ENCODED_VERSION >= POPPLER_VERSION_ENCODE(25, 2, 0)
++			if (!(fontFile = m_fontEngine->loadOpenTypeCFFFont(std::move(id), fontsrc, std::move(codeToGID), fontLoc->fontNum)))
++			{
++				error(errSyntaxError, -1, "Couldn't create a font for '{0:s}'",
++					gfxFont->getName() ? gfxFont->getName()->c_str() : "(unnamed)");
++				goto err2;
++			}
++#elif POPPLER_ENCODED_VERSION >= POPPLER_VERSION_ENCODE(24, 11, 0)
+ 			if (!(fontFile = m_fontEngine->loadOpenTypeCFFFont(std::move(id), fontsrc, codeToGID, n, fontLoc->fontNum)))
+ 			{
+ 				error(errSyntaxError, -1, "Couldn't create a font for '{0:s}'",
+@@ -3307,6 +3338,15 @@ void SlaOutputDev::updateFont(GfxState *state)
+ 			break;
+ 		case fontCIDType2:
+ 		case fontCIDType2OT:
++#if POPPLER_ENCODED_VERSION >= POPPLER_VERSION_ENCODE(25, 2, 0)
++			codeToGID.clear();
++			n = 0;
++			if (((GfxCIDFont*) gfxFont)->getCIDToGIDLen() > 0)
++			{
++				codeToGID = ((GfxCIDFont*) gfxFont)->getCIDToGID();
++				n = codeToGID.size();
++			}
++#else
+ 			codeToGID = nullptr;
+ 			n = 0;
+ 			if (((GfxCIDFont *) gfxFont)->getCIDToGID())
+@@ -3318,6 +3358,7 @@ void SlaOutputDev::updateFont(GfxState *state)
+ 					memcpy(codeToGID, ((GfxCIDFont *)gfxFont)->getCIDToGID(), n * sizeof(*codeToGID));
+ 				}
+ 			}
++#endif
+ 			else
+ 			{
+ #if POPPLER_ENCODED_VERSION >= POPPLER_VERSION_ENCODE(24, 11, 0)
+@@ -3338,15 +3379,20 @@ void SlaOutputDev::updateFont(GfxState *state)
+ #endif
+ 				if (! ff)
+ 					goto err2;
+-#if POPPLER_ENCODED_VERSION >= POPPLER_VERSION_ENCODE(22, 2, 0)
+-				codeToGID = ((GfxCIDFont*) gfxFont)->getCodeToGIDMap(ff.get(), &n);
+-				ff.reset();
++#if POPPLER_ENCODED_VERSION >= POPPLER_VERSION_ENCODE(25, 2, 0)
++				codeToGID = ((GfxCIDFont*) gfxFont)->getCodeToGIDMap(ff.get());
+ #else
+-				codeToGID = ((GfxCIDFont *)gfxFont)->getCodeToGIDMap(ff, &n);
+-				delete ff;
++				codeToGID = ((GfxCIDFont*) gfxFont)->getCodeToGIDMap(ff.get(), &n);
+ #endif
++				ff.reset();
+ 			}
+-#if POPPLER_ENCODED_VERSION >= POPPLER_VERSION_ENCODE(24, 11, 0)
++#if POPPLER_ENCODED_VERSION >= POPPLER_VERSION_ENCODE(25, 2, 0)
++			if (!(fontFile = m_fontEngine->loadTrueTypeFont(std::move(id), fontsrc, std::move(codeToGID), fontLoc->fontNum)))
++			{
++				error(errSyntaxError, -1, "Couldn't create a font for '{0:s}'", gfxFont->getName() ? gfxFont->getName()->c_str() : "(unnamed)");
++				goto err2;
++			}
++#elif POPPLER_ENCODED_VERSION >= POPPLER_VERSION_ENCODE(24, 11, 0)
+ 			if (!(fontFile = m_fontEngine->loadTrueTypeFont(std::move(id), fontsrc, codeToGID, n, fontLoc->fontNum)))
+ 			{
+ 				error(errSyntaxError, -1, "Couldn't create a font for '{0:s}'", gfxFont->getName() ? gfxFont->getName()->c_str() : "(unnamed)");

--- a/srcpkgs/scribus/template
+++ b/srcpkgs/scribus/template
@@ -1,7 +1,7 @@
 # Template file for 'scribus'
 pkgname=scribus
-version=1.6.2
-revision=2
+version=1.6.3
+revision=1
 build_style=cmake
 configure_args="-DCMAKE_SKIP_RPATH=TRUE -DQT_PREFIX=${XBPS_CROSS_BASE}/usr
  -DWANT_GRAPHICSMAGICK=1 -DWANT_CPP20=ON"
@@ -17,7 +17,7 @@ maintainer="Enno Boland <gottox@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="https://scribus.net"
 distfiles="$SOURCEFORGE_SITE/scribus/scribus/${version}/scribus-${version}.tar.xz"
-checksum=7eff9b1f47e372e56bb369f1dbe18fe49101789b5e6bcfdb7890e0346b641383
+checksum=0ae58ced410101e82655e3b4c20a070cf1767145ada233dcef7c20b8ba6bd487
 python_version=3
 
 do_patch() {


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing

- [x] poppler: x86_64-{glibc,musl}, i686
- [x] poppler-qt5: x86_64-{glibc,musl}, i686

- [x] calligra: x86_64-{glibc,musl} @Johnnynator
saving to PDF in calligra works
- [x] fim: x86_64-{glibc,musl} @leahneukirchen 
fim works and displays PDFs correctly
- [x] inkscape: x86_64-{glibc,musl} @atk 
inkscape works without an issue
- [x] ipe: x86_64-{glibc,musl}
ipe works (exporting PDFs and importing them)
- [x] pdf2djvu: x86_64-{glibc,musl}
pdf2djvu works
- [x] scribus: x86_64-{glibc,musl} @Gottox 
scribus works (both importing and exporting PDFs)
- [x] efl: x86_64-{glibc,musl}
- [x] extractpdfmark: x86_64-{glibc,musl}
extractpdfmark works
- [x] libcupsfilters: x86_64-{glibc,musl} @ahesford 
pdftops converts PDFs to PostScript
- [x] pdfgrep: x86_64-{glibc,musl} @leahneukirchen 
pdfgrep works
- [x] libreoffice: x86_64-glibc, aarch64-musl (crossbuild) @sgn 
drag and dropping PDFs works but opening them with libreoffice draw from a file explorer/terminal doesn't. The dialog window reads: _General Error. General input/output error._

- [x] kitinerary: x86_64-{glibc,musl} @Johnnynator
```
/usr/libexec/kf6/kitinerary-extractor --capabilities
Engine version      : 6.2.0
Qt version          : 6.8.2
HTML support        : libxml2
PDF support         : poppler (25.02.0)
iCal support        : kcal (6.10.0)
Barcode decoder     : ZXing (2.2.1)
Phone number decoder: libphonenumber
Extractors          : 253
```
[ci skip]