### PR TITLE
wine: update to 10.2

### DIFF
--- a/srcpkgs/wine/INSTALL
+++ b/srcpkgs/wine/INSTALL
@@ -1,0 +1,16 @@
+# *-*-shell-*-*
+# The second to be added is to create all symbolic links.
+
+wine32=usr/bin/wine32
+wine64=usr/bin/wine64
+
+case ${ACTION} in
+post)
+	if test -x $wine32 -a -x $wine64; then
+		ln -sf /usr/lib/wine/x86_64-unix usr/lib32/wine/     2>/dev/null
+		ln -sf /usr/lib/wine/x86_64-windows usr/lib32/wine/  2>/dev/null
+		ln -sf /usr/lib32/wine/i386-unix usr/lib/wine/       2>/dev/null
+		ln -sf /usr/lib32/wine/i386-windows usr/lib/wine/    2>/dev/null
+	fi
+	;;
+esac

--- a/srcpkgs/wine/REMOVE
+++ b/srcpkgs/wine/REMOVE
@@ -1,0 +1,16 @@
+# *-*-shell-*-*
+# The first to be removed is to remove all symbolic links.
+
+wine32=usr/bin/wine32
+wine64=usr/bin/wine64
+
+case ${ACTION} in
+pre)
+	if test -x $wine32 -a -x $wine64; then
+		unlink usr/lib32/wine/x86_64-unix    2>/dev/null
+		unlink usr/lib32/wine/x86_64-windows 2>/dev/null
+		unlink usr/lib/wine/i386-unix        2>/dev/null
+		unlink usr/lib/wine/i386-windows     2>/dev/null
+	fi
+	;;
+esac

--- a/srcpkgs/wine/files/wine
+++ b/srcpkgs/wine/files/wine
@@ -2,12 +2,12 @@
 # Based on the Debian wrapper script written by Jens Reyer and Michael Gilbert
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
-wine32=/usr/libexec/wine/wine
-wine64=/usr/libexec/wine/wine64
+wine32=/usr/bin/wine32
+wine64=/usr/bin/wine64
 
 wine32_hint () {
     if [ "$(xbps-uhelper arch)" = "x86_64-musl" ]; then
-        echo "wine support under musl is limited to 64bit"
+        echo "wine under musl supports both 64bit & 32bit under the new experimental WoW64 mode"
     else
         echo "it looks like wine-32bit is missing, you should install it."
         if uname -a | grep "x86_64" > /dev/null && xbps-query -l | grep void-repo-multilib > /dev/null; then
@@ -19,9 +19,7 @@ wine32_hint () {
     fi
 }
 
-if test -x $wine32; then
-    wine=$wine32
-elif test -x $wine64; then
+if test -x $wine64; then
     wine=$wine64
     if test -z "$WINELOADER"; then
         export WINELOADER=$wine64
@@ -30,9 +28,13 @@ elif test -x $wine64; then
         x-all*|x*,-all*|x*err-all*)
             ;;
         *)
-            wine32_hint >&2
+            if ! test -x $wine32; then
+	        wine32_hint >&2
+	    fi
             ;;
     esac
+elif test -x $wine32; then
+    wine=$wine32
 else
     echo "error: unable to find wine executable.  this shouldn't happen." >&2
     exit 1
@@ -42,4 +44,8 @@ if test -z "$WINEDEBUG"; then
     export WINEDEBUG=fixme-all
 fi
 
-exec $wine "$@"
+appname=$(basename "$0")
+case "$appname" in
+	wine|wine32|wine64) exec $wine "$@" ;;
+	*) exec $wine "$appname.exe" "$@" ;;
+esac

--- a/srcpkgs/wine/files/wineserver
+++ b/srcpkgs/wine/files/wineserver
@@ -2,8 +2,8 @@
 # Based on the Debian wrapper script written by Jens Reyer and Michael Gilbert
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
-wineserver32=/usr/libexec/wine/wineserver32
-wineserver64=/usr/libexec/wine/wineserver64
+wineserver32=/usr/bin/wineserver32
+wineserver64=/usr/bin/wineserver64
 
 if test -x "$wineserver64"; then
     wineserver=$wineserver64

--- a/srcpkgs/wine/template
+++ b/srcpkgs/wine/template
@@ -1,21 +1,20 @@
 # Template file for 'wine'
 pkgname=wine
-reverts="10.2_1"
-version=10.1
+version=10.2
 revision=2
 _pkgver=${version/r/-r}
 create_wrksrc=yes
 build_wrksrc=wine-${_pkgver}
 build_style=gnu-configure
-configure_args="--bindir=/usr/libexec/wine $(vopt_with xshm)"
+configure_args="$(vopt_with xshm)"
 short_desc="Run Microsoft Windows applications"
 maintainer="Helmut Pozimski <helmut@pozimski.eu>"
 license="LGPL-2.1-or-later"
 homepage="http://www.winehq.org/"
 distfiles="https://dl.winehq.org/wine/source/${version%.*}.x/wine-${_pkgver}.tar.xz
  https://github.com/wine-staging/wine-staging/archive/v${_pkgver}.tar.gz"
-checksum="63471e37b1a515795ff3368d26a039261660e1377cb427d1b61b3a7b76091663
- 029009c52a0eb428451d8381992bbcabe50bed4527f3a9c73d00f55c7f3af9cc"
+checksum="9d90dfb6cf10b810a7b4789f0067712b4730d3ea2a88b91f1be273b2ad04243f
+ 44d051a8622dd6245d63b88d988eebcdb712d309ee57eccdccbe59d6c4788194"
 
 # NOTE: wine depends on specific versions of wine-mono and wine-gecko,
 # check for updates to these packages when updating wine
@@ -25,6 +24,7 @@ build_options_default="mingw xshm"
 desc_option_mingw="Use the MinGW cross compiler to build WinPE DLLs"
 desc_option_staging="Apply the wine-staging patchset"
 desc_option_xshm="Enable support for the X Shared Memory Extension"
+desc_option_wow64="Run 32-bit Windows apps on a purely 64-bit Unix installation"
 
 
 if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
@@ -70,12 +70,12 @@ make_check=extended
 if [ "$XBPS_TARGET_WORDSIZE" != 32 ]; then
 	configure_args+=" --enable-win64 --libdir=/usr/lib"
 	_wine_suffix="64"
-	_wineserver_suffix=${_wine_suffix}
 else
-	_wineserver_suffix="32"
+	_wine_suffix="32"
 	CFLAGS=" -D_LARGE_FILE_SOURCE=1 -D_FILE_OFFSET_BITS=64"
 	CPPFLAGS=" -D_LARGE_FILE_SOURCE=1 -D_FILE_OFFSET_BITS=64"
 fi
+_wineserver_suffix=${_wine_suffix}
 
 if [ "$XBPS_LIBC" = "glibc" ]; then
 	hostmakedepends+=" prelink"
@@ -86,16 +86,14 @@ if [ "${build_option_wow64}" ]; then
 	makedepends+=" cross-i686-w64-mingw32"
 fi
 
-_wine_libexec="/usr/libexec/wine"
-nopie_files="${_wine_libexec}/wine${_wine_suffix}"
+nopie_files="/usr/bin/wine${_wine_suffix}"
 
 if [ "${_nopie}" = yes ]; then
-	nopie_files+=" ${_wine_libexec}/wineserver${_wineserver_suffix}"
+	nopie_files+=" /usr/bin/wineserver${_wineserver_suffix}"
 fi
 
 post_patch() {
 	if [ "${build_option_staging}" ]; then
-		export PATH="/usr/libexec/chroot-git:${PATH}"
 		"../wine-staging-${_pkgver}/staging/patchinstall.py" --all
 	fi
 }
@@ -118,23 +116,14 @@ post_install() {
 	install -d ${DESTDIR}/etc/fonts/conf.{avail,d}
 	install -m644 ${FILESDIR}/30-win32-aliases.conf ${DESTDIR}/etc/fonts/conf.avail
 	ln -s ../conf.avail/30-win32-aliases.conf ${DESTDIR}/etc/fonts/conf.d/30-win32-aliases.conf
-	mv ${DESTDIR}${_wine_libexec}/wineserver ${DESTDIR}${_wine_libexec}/wineserver${_wineserver_suffix}
+
+	mv ${DESTDIR}/usr/bin/wine ${DESTDIR}/usr/bin/wine${_wine_suffix}
+	mv ${DESTDIR}/usr/bin/wineserver ${DESTDIR}/usr/bin/wineserver${_wineserver_suffix}
 	vbin ${FILESDIR}/wine
 	vbin ${FILESDIR}/wineserver
-	for file in msiexec regedit regsvr32 wineboot winecfg winepath winemine winefile \
-		winedbg wineconsole notepad msidb widl winebuild winecpp winedump wineg++ \
-		winegcc winemaker wmc wrc function_grep.pl
-	do
-		mv ${DESTDIR}/usr/libexec/wine/${file} ${DESTDIR}/usr/bin/
-	done
-	case $XBPS_TARGET_MACHINE in
-		x86_64*)
-			ln -s ${_wine_libexec}/wine64 ${DESTDIR}/usr/bin/wine64
-		;;
-	esac
 
 	# install man page for wine executable
-	for f in loader/wine*.man; do
+	for f in tools/wine/wine*.man; do
 		vman "$f" "${f//man/1}"
 	done
 }


### PR DESCRIPTION
Also add doc about the new WoW64 build option and update the alert in the script.

Broken wine64 symlink was removed.

Hotfix for updated wine-tools, the script now passes the 0th argument to wine properly(Props to @oreo639).

The removal of the wine/wine64 scheme caused issues with users not being able to install both wine and wine-32bit together. It's being addressed by now installing to `/usr/libexec/wine/wine32` and `/usr/libexec/wine/wine64` respectively.

There is a bug report that the 32bit build is broken, uncertain if it's related to the issue described above, left as a [WIP] & draft until resolved.
logs: https://gist.github.com/oreo639/cf2f5f8cb27475db87fc58051e69ddf4

