### PR TITLE
lego: update to 4.22.2.

### DIFF
--- a/srcpkgs/lego/template
+++ b/srcpkgs/lego/template
@@ -1,6 +1,6 @@
 # Template file for 'lego'
 pkgname=lego
-version=4.21.0
+version=4.22.2
 revision=1
 build_style=go
 go_import_path="github.com/go-acme/lego/v4"
@@ -11,7 +11,7 @@ license="MIT"
 homepage="https://go-acme.github.io/lego"
 changelog="https://raw.githubusercontent.com/go-acme/lego/master/CHANGELOG.md"
 distfiles="https://github.com/go-acme/lego/archive/v${version}.tar.gz"
-checksum=21204483e62bff3e762583e42044183dbe6efe6b401772bb186be821501d9463
+checksum=d4d5a3032d1ed99a5cdf551b2555288c3fcd961be536e58f477dce35d22c8702
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - none