### PR TITLE
python3-Sphinx: update deps

### DIFF
--- a/srcpkgs/python3-Babel/template
+++ b/srcpkgs/python3-Babel/template
@@ -1,18 +1,18 @@
 # Template file for 'python3-Babel'
 pkgname=python3-Babel
-version=2.16.0
-revision=2
+version=2.17.0
+revision=1
 build_style=python3-pep517
 hostmakedepends="python3-setuptools"
 depends="python3"
-checkdepends="$depends python3-pytest python3-freezegun python3-pytz"
-short_desc="Tools for internationalizing Python applications (Python3)"
+checkdepends="$depends python3-pytest-xdist python3-freezegun python3-pytz"
+short_desc="Tools for internationalizing Python applications"
 maintainer="Gonzalo Tornaría <tornaria@cmat.edu.uy>"
 license="BSD-3-Clause"
 homepage="https://babel.pocoo.org"
 changelog="https://raw.githubusercontent.com/python-babel/babel/master/CHANGES.rst"
 distfiles="${PYPI_SITE}/B/Babel/babel-${version}.tar.gz"
-checksum=d1f3554ca26605fe173f3de0c65f750f5a42f924499bf134de6423582298e316
+checksum=0c54cffb19f690cdcc52a3b50bcbf71e07a808d1c80d549f2459b9d2cf0afb9d
 
 post_install() {
 	vlicense LICENSE

--- a/srcpkgs/python3-Sphinx/patches/Adapt_tests_for_Pygments_2.19.patch
+++ b/srcpkgs/python3-Sphinx/patches/Adapt_tests_for_Pygments_2.19.patch
@@ -1,0 +1,226 @@
+Backported from https://github.com/sphinx-doc/sphinx/commit/5ff3740063c1ac57f17ecd697bcd06cc1de4e75c
+
+From 5ff3740063c1ac57f17ecd697bcd06cc1de4e75c Mon Sep 17 00:00:00 2001
+From: Adam Turner <9087854+aa-turner@users.noreply.github.com>
+Date: Mon, 6 Jan 2025 06:56:10 +0000
+Subject: [PATCH] Adapt tests for Pygments 2.19
+
+---
+ tests/test_builders/test_build_html_code.py  |  8 +++++++-
+ tests/test_builders/test_build_latex.py      |  9 +++++++--
+ tests/test_directives/test_directive_code.py | 15 +++++++++++++--
+ tests/test_extensions/test_ext_viewcode.py   |  8 +++++++-
+ tests/test_highlighting.py                   |  2 +-
+ tests/test_intl/test_intl.py                 | 15 +++++++++++++--
+ 6 files changed, 48 insertions(+), 9 deletions(-)
+
+diff --git a/tests/test_builders/test_build_html_code.py b/tests/test_builders/test_build_html_code.py
+index 349e1d1641a..02684b22e04 100644
+--- a/tests/test_builders/test_build_html_code.py
++++ b/tests/test_builders/test_build_html_code.py
+@@ -1,3 +1,4 @@
++import pygments
+ import pytest
+ 
+ 
+@@ -34,11 +35,16 @@ def test_html_codeblock_linenos_style_inline(app):
+ 
+ @pytest.mark.sphinx('html', testroot='reST-code-role')
+ def test_html_code_role(app):
++    if tuple(map(int, pygments.__version__.split('.')[:2])) >= (2, 19):
++        sp = '<span class="w"> </span>'
++    else:
++        sp = ' '
++
+     app.build()
+     content = (app.outdir / 'index.html').read_text(encoding='utf8')
+ 
+     common_content = (
+-        '<span class="k">def</span> <span class="nf">foo</span>'
++        f'<span class="k">def</span>{sp}<span class="nf">foo</span>'
+         '<span class="p">(</span>'
+         '<span class="mi">1</span> '
+         '<span class="o">+</span> '
+diff --git a/tests/test_builders/test_build_latex.py b/tests/test_builders/test_build_latex.py
+index 3e63aca7078..4626b7fbe47 100644
+--- a/tests/test_builders/test_build_latex.py
++++ b/tests/test_builders/test_build_latex.py
+@@ -11,6 +11,7 @@
+ from shutil import copyfile
+ from subprocess import CalledProcessError
+ 
++import pygments
+ import pytest
+ 
+ from sphinx.builders.latex import default_latex_documents
+@@ -2115,12 +2116,16 @@ def test_latex_container(app):
+ 
+ @pytest.mark.sphinx('latex', testroot='reST-code-role')
+ def test_latex_code_role(app):
++    if tuple(map(int, pygments.__version__.split('.')[:2])) >= (2, 19):
++        sp = r'\PYG{+w}{ }'
++    else:
++        sp = ' '
++
+     app.build()
+     content = (app.outdir / 'projectnamenotset.tex').read_text(encoding='utf8')
+ 
+     common_content = (
+-        r'\PYG{k}{def} '
+-        r'\PYG{n+nf}{foo}'
++        r'\PYG{k}{def}' + sp + r'\PYG{n+nf}{foo}'
+         r'\PYG{p}{(}'
+         r'\PYG{l+m+mi}{1} '
+         r'\PYG{o}{+} '
+diff --git a/tests/test_directives/test_directive_code.py b/tests/test_directives/test_directive_code.py
+index 4e6c03a6663..d54b320ce16 100644
+--- a/tests/test_directives/test_directive_code.py
++++ b/tests/test_directives/test_directive_code.py
+@@ -2,6 +2,7 @@
+ 
+ from __future__ import annotations
+ 
++import pygments
+ import pytest
+ from docutils import nodes
+ 
+@@ -394,6 +395,11 @@ def test_literal_include_block_start_with_comment_or_brank(app):
+ 
+ @pytest.mark.sphinx('html', testroot='directive-code')
+ def test_literal_include_linenos(app):
++    if tuple(map(int, pygments.__version__.split('.')[:2])) >= (2, 19):
++        sp = '<span class="w"> </span>'
++    else:
++        sp = ' '
++
+     app.build(filenames=[app.srcdir / 'linenos.rst'])
+     html = (app.outdir / 'linenos.html').read_text(encoding='utf8')
+ 
+@@ -411,7 +417,7 @@ def test_literal_include_linenos(app):
+ 
+     # :lines: 5-9
+     assert (
+-        '<span class="linenos">5</span><span class="k">class</span> '
++        f'<span class="linenos">5</span><span class="k">class</span>{sp}'
+         '<span class="nc">Foo</span><span class="p">:</span>'
+     ) in html
+ 
+@@ -556,12 +562,17 @@ def test_code_block_highlighted(app):
+ 
+ @pytest.mark.sphinx('html', testroot='directive-code')
+ def test_linenothreshold(app):
++    if tuple(map(int, pygments.__version__.split('.')[:2])) >= (2, 19):
++        sp = '<span class="w"> </span>'
++    else:
++        sp = ' '
++
+     app.build(filenames=[app.srcdir / 'linenothreshold.rst'])
+     html = (app.outdir / 'linenothreshold.html').read_text(encoding='utf8')
+ 
+     # code-block using linenothreshold
+     assert (
+-        '<span class="linenos">1</span><span class="k">class</span> '
++        f'<span class="linenos">1</span><span class="k">class</span>{sp}'
+         '<span class="nc">Foo</span><span class="p">:</span>'
+     ) in html
+ 
+diff --git a/tests/test_extensions/test_ext_viewcode.py b/tests/test_extensions/test_ext_viewcode.py
+index 5721dfb638f..92455ee5ad5 100644
+--- a/tests/test_extensions/test_ext_viewcode.py
++++ b/tests/test_extensions/test_ext_viewcode.py
+@@ -6,6 +6,7 @@
+ import shutil
+ from typing import TYPE_CHECKING
+ 
++import pygments
+ import pytest
+ 
+ if TYPE_CHECKING:
+@@ -13,6 +14,11 @@
+ 
+ 
+ def check_viewcode_output(app: SphinxTestApp) -> str:
++    if tuple(map(int, pygments.__version__.split('.')[:2])) >= (2, 19):
++        sp = '<span> </span>'
++    else:
++        sp = ' '
++
+     warnings = re.sub(r'\\+', '/', app.warning.getvalue())
+     assert re.findall(
+         r"index.rst:\d+: WARNING: Object named 'func1' not found in include "
+@@ -41,7 +47,7 @@ def check_viewcode_output(app: SphinxTestApp) -> str:
+         '<a class="viewcode-back" href="../../index.html#spam.Class1">[docs]</a>\n'
+     ) in result
+     assert '<span>@decorator</span>\n' in result
+-    assert '<span>class</span> <span>Class1</span><span>:</span>\n' in result
++    assert f'<span>class</span>{sp}<span>Class1</span><span>:</span>\n' in result
+     assert '<span>    </span><span>&quot;&quot;&quot;</span>\n' in result
+     assert '<span>    this is Class1</span>\n' in result
+     assert '<span>    &quot;&quot;&quot;</span>\n' in result
+diff --git a/tests/test_highlighting.py b/tests/test_highlighting.py
+index 91f887633d2..141de97020d 100644
+--- a/tests/test_highlighting.py
++++ b/tests/test_highlighting.py
+@@ -12,7 +12,7 @@
+ 
+ from sphinx.highlighting import PygmentsBridge
+ 
+-if tuple(map(int, pygments.__version__.split('.')))[:2] < (2, 18):
++if tuple(map(int, pygments.__version__.split('.')[:2])) < (2, 18):
+     from pygments.formatter import Formatter
+ 
+     Formatter.__class_getitem__ = classmethod(lambda cls, name: cls)  # type: ignore[attr-defined]
+diff --git a/tests/test_intl/test_intl.py b/tests/test_intl/test_intl.py
+index ab104b55600..1280a3d04c0 100644
+--- a/tests/test_intl/test_intl.py
++++ b/tests/test_intl/test_intl.py
+@@ -11,6 +11,7 @@
+ import time
+ from typing import TYPE_CHECKING
+ 
++import pygments
+ import pytest
+ from babel.messages import mofile, pofile
+ from babel.messages.catalog import Catalog
+@@ -1487,6 +1488,11 @@ def test_xml_strange_markup(app):
+ @pytest.mark.sphinx('html', testroot='intl')
+ @pytest.mark.test_params(shared_result='test_intl_basic')
+ def test_additional_targets_should_not_be_translated(app):
++    if tuple(map(int, pygments.__version__.split('.')[:2])) >= (2, 19):
++        sp = '<span class="w"> </span>'
++    else:
++        sp = ' '
++
+     app.build()
+     # [literalblock.txt]
+     result = (app.outdir / 'literalblock.html').read_text(encoding='utf8')
+@@ -1525,7 +1531,7 @@ def test_additional_targets_should_not_be_translated(app):
+     # doctest block should not be translated but be highlighted
+     expected_expr = (
+         """<span class="gp">&gt;&gt;&gt; </span>"""
+-        """<span class="kn">import</span> <span class="nn">sys</span>  """
++        f"""<span class="kn">import</span>{sp}<span class="nn">sys</span>  """
+         """<span class="c1"># sys importing</span>"""
+     )
+     assert_count(expected_expr, result, 1)
+@@ -1570,6 +1576,11 @@ def test_additional_targets_should_not_be_translated(app):
+     },
+ )
+ def test_additional_targets_should_be_translated(app):
++    if tuple(map(int, pygments.__version__.split('.')[:2])) >= (2, 19):
++        sp = '<span class="w"> </span>'
++    else:
++        sp = ' '
++
+     app.build()
+     # [literalblock.txt]
+     result = (app.outdir / 'literalblock.html').read_text(encoding='utf8')
+@@ -1619,7 +1630,7 @@ def test_additional_targets_should_be_translated(app):
+     # doctest block should not be translated but be highlighted
+     expected_expr = (
+         """<span class="gp">&gt;&gt;&gt; </span>"""
+-        """<span class="kn">import</span> <span class="nn">sys</span>  """
++        f"""<span class="kn">import</span>{sp}<span class="nn">sys</span>  """
+         """<span class="c1"># SYS IMPORTING</span>"""
+     )
+     assert_count(expected_expr, result, 1)

--- a/srcpkgs/python3-Sphinx/template
+++ b/srcpkgs/python3-Sphinx/template
@@ -11,7 +11,7 @@ depends="python3-Jinja2 python3-docutils python3-Pygments
  python3-sphinxcontrib-jsmath python3-sphinxcontrib-qthelp
  python3-sphinxcontrib-serializinghtml"
 checkdepends="$depends python3-html5lib python3-mypy ImageMagick gettext
- python3-pytest python3-setuptools python3-filelock python3-defusedxml
+ python3-pytest-xdist python3-setuptools python3-filelock python3-defusedxml
  graphviz"
 short_desc="Python 3 documentation generator"
 maintainer="Đoàn Trần Công Danh <congdanhqx@gmail.com>"

--- a/srcpkgs/python3-alabaster/template
+++ b/srcpkgs/python3-alabaster/template
@@ -1,17 +1,18 @@
 # Template file for 'python3-alabaster'
 pkgname=python3-alabaster
-version=0.7.12
-revision=8
-build_style=python3-module
-hostmakedepends="python3-setuptools"
+version=1.0.0
+revision=1
+build_style=python3-pep517
+hostmakedepends="python3-flit_core"
 depends="python3"
 short_desc="Configurable sidebar-enabled Sphinx theme (Python3)"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="BSD-3-Clause"
 homepage="https://alabaster.readthedocs.io/"
+changelog="https://raw.githubusercontent.com/sphinx-doc/alabaster/refs/heads/master/docs/changelog.rst"
 distfiles="${PYPI_SITE}/a/alabaster/alabaster-${version}.tar.gz"
-checksum=a661d72d58e6ea8a57f7a86e37d86716863ee5e92788398526d58b26a4e4dc02
+checksum=c00dca57bca26fa62a6d7d0a9fcce65f3e026e9bfe33e9c538fd3fbb2144fd9e
 
 post_install() {
-	vlicense LICENSE
+	vlicense LICENSE.rst
 }

--- a/srcpkgs/python3-docutils/patches/fix-test.patch
+++ b/srcpkgs/python3-docutils/patches/fix-test.patch
@@ -1,0 +1,24 @@
+--- a/test/test_parsers/test_rst/test_directives/test_code.py
++++ b/test/test_parsers/test_rst/test_directives/test_code.py
+@@ -167,7 +167,8 @@
+              7 \n\
+         <inline classes="keyword">
+             def
+-         \n\
++        <inline classes="whitespace">
++             \n\
+         <inline classes="name function">
+             my_function
+         <inline classes="punctuation">
+--- a/test/test_parsers/test_rst/test_directives/test_code_long.py
++++ b/test/test_parsers/test_rst/test_directives/test_code_long.py
+@@ -62,7 +62,8 @@
+              7 \n\
+         <inline classes="keyword">
+             def
+-         \n\
++        <inline classes="whitespace">
++             \n\
+         <inline classes="name function">
+             my_function
+         <inline classes="punctuation">

--- a/srcpkgs/python3-docutils/template
+++ b/srcpkgs/python3-docutils/template
@@ -1,9 +1,9 @@
 # Template file for 'python3-docutils'
 pkgname=python3-docutils
-version=0.20.1
-revision=3
-build_style=python3-module
-hostmakedepends="python3-setuptools"
+version=0.21.2
+revision=1
+build_style=python3-pep517
+hostmakedepends="python3-flit_core"
 # docutils/writers/odf_odt/pygmentsformatter.py
 depends="python3-Pygments"
 checkdepends="${depends} python3-pytest"
@@ -12,21 +12,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="Public Domain, BSD-2-Clause, GPL-3.0-or-later, Python-2.0"
 homepage="https://docutils.sourceforge.io"
 distfiles="${PYPI_SITE}/d/docutils/docutils-${version}.tar.gz"
-checksum=f08a4e276c3a1583a86dce3e34aba3fe04d02bba2dd51ed16106244e8a923e3b
-
-alternatives="
- docutils:rst2html:/usr/bin/rst2html.py
- docutils:rst2html4:/usr/bin/rst2html4.py
- docutils:rst2html5:/usr/bin/rst2html5.py
- docutils:rst2latex:/usr/bin/rst2latex.py
- docutils:rst2man:/usr/bin/rst2man.py
- docutils:rst2odt:/usr/bin/rst2odt.py
- docutils:rst2odt_prepstyles:/usr/bin/rst2odt_prepstyles.py
- docutils:rst2pseudoxml:/usr/bin/rst2pseudoxml.py
- docutils:rst2s5:/usr/bin/rst2s5.py
- docutils:rst2xetex:/usr/bin/rst2xetex.py
- docutils:rst2xml:/usr/bin/rst2xml.py
- docutils:rstpep2html:/usr/bin/rstpep2html.py"
+checksum=3a6b18732edf182daa3cd12775bbb338cf5691468f91eeeb109deff6ebfa986f
 
 post_install() {
 	vlicense COPYING.txt COPYING

--- a/srcpkgs/python3-sphinxcontrib-applehelp/template
+++ b/srcpkgs/python3-sphinxcontrib-applehelp/template
@@ -1,7 +1,7 @@
 # Template file for 'python3-sphinxcontrib-applehelp'
 pkgname=python3-sphinxcontrib-applehelp
-version=1.0.4
-revision=3
+version=2.0.0
+revision=1
 build_style=python3-pep517
 hostmakedepends="python3-flit_core python3-pyproject-hooks python3-setuptools
  python3-wheel"
@@ -10,10 +10,10 @@ short_desc="Sphinx extension which outputs Apple help book"
 maintainer="Đoàn Trần Công Danh <congdanhqx@gmail.com>"
 license="BSD-2-Clause"
 homepage="http://sphinx-doc.org"
-distfiles="${PYPI_SITE}/s/sphinxcontrib-applehelp/sphinxcontrib-applehelp-${version}.tar.gz"
-checksum=828f867945bbe39817c210a1abfd1bc4895c8b73fcaade56d45357a348a07d7e
+distfiles="${PYPI_SITE}/s/sphinxcontrib-applehelp/sphinxcontrib_applehelp-${version}.tar.gz"
+checksum=2f29ef331735ce958efa4734873f084941970894c6090408b079c61b2e1c06d1
 make_check=no # cyclic with Sphinx
 
 post_install() {
-	vlicense LICENSE
+	vlicense LICENCE.rst
 }

--- a/srcpkgs/python3-sphinxcontrib-devhelp/template
+++ b/srcpkgs/python3-sphinxcontrib-devhelp/template
@@ -1,18 +1,18 @@
 # Template file for 'python3-sphinxcontrib-devhelp'
 pkgname=python3-sphinxcontrib-devhelp
-version=1.0.2
-revision=6
-build_style=python3-module
-hostmakedepends="python3-setuptools"
+version=2.0.0
+revision=1
+build_style=python3-pep517
+hostmakedepends="python3-flit_core"
 depends="python3"
-checkdepends="python3-Sphinx"
 short_desc="Sphinx extension which outputs Devhelp document"
 maintainer="Đoàn Trần Công Danh <congdanhqx@gmail.com>"
 license="BSD-2-Clause"
 homepage="http://sphinx-doc.org"
-distfiles="${PYPI_SITE}/s/sphinxcontrib-devhelp/sphinxcontrib-devhelp-${version}.tar.gz"
-checksum=ff7f1afa7b9642e7060379360a67e9c41e8f3121f2ce9164266f61b9f4b338e4
+distfiles="${PYPI_SITE}/s/sphinxcontrib-devhelp/sphinxcontrib_devhelp-${version}.tar.gz"
+checksum=411f5d96d445d1d73bb5d52133377b4248ec79db5c793ce7dbe59e074b4dd1ad
+make_check=no # cyclic with Sphinx
 
 post_install() {
-	vlicense LICENSE
+	vlicense LICENCE.rst
 }

--- a/srcpkgs/python3-sphinxcontrib-htmlhelp/template
+++ b/srcpkgs/python3-sphinxcontrib-htmlhelp/template
@@ -1,7 +1,7 @@
 # Template file for 'python3-sphinxcontrib-htmlhelp'
 pkgname=python3-sphinxcontrib-htmlhelp
-version=2.0.1
-revision=3
+version=2.1.0
+revision=1
 build_style=python3-pep517
 hostmakedepends="python3-flit_core python3-pyproject-hooks python3-setuptools
  python3-wheel"
@@ -10,10 +10,10 @@ short_desc="Sphinx extension which outputs HTML document"
 maintainer="Đoàn Trần Công Danh <congdanhqx@gmail.com>"
 license="BSD-2-Clause"
 homepage="http://sphinx-doc.org"
-distfiles="${PYPI_SITE}/s/sphinxcontrib-htmlhelp/sphinxcontrib-htmlhelp-${version}.tar.gz"
-checksum=0cbdd302815330058422b98a113195c9249825d681e18f11e8b1f78a2f11efff
+distfiles="${PYPI_SITE}/s/sphinxcontrib-htmlhelp/sphinxcontrib_htmlhelp-${version}.tar.gz"
+checksum=c9e2916ace8aad64cc13a0d233ee22317f2b9025b9cf3295249fa985cc7082e9
 make_check=no # cyclic with Sphinx
 
 post_install() {
-	vlicense LICENSE
+	vlicense LICENCE.rst
 }

--- a/srcpkgs/python3-sphinxcontrib-qthelp/template
+++ b/srcpkgs/python3-sphinxcontrib-qthelp/template
@@ -1,18 +1,18 @@
 # Template file for 'python3-sphinxcontrib-qthelp'
 pkgname=python3-sphinxcontrib-qthelp
-version=1.0.3
-revision=6
-build_style=python3-module
-hostmakedepends="python3-setuptools"
+version=2.0.0
+revision=1
+build_style=python3-pep517
+hostmakedepends="python3-flit_core"
 depends="python3"
-checkdepends="python3-Sphinx"
 short_desc="Sphinx extension which outputs QtHelp document"
 maintainer="Đoàn Trần Công Danh <congdanhqx@gmail.com>"
 license="BSD-2-Clause"
 homepage="http://sphinx-doc.org"
-distfiles="${PYPI_SITE}/s/sphinxcontrib-qthelp/sphinxcontrib-qthelp-${version}.tar.gz"
-checksum=4c33767ee058b70dba89a6fc5c1892c0d57a54be67ddd3e7875a18d14cba5a72
+distfiles="${PYPI_SITE}/s/sphinxcontrib-qthelp/sphinxcontrib_qthelp-${version}.tar.gz"
+checksum=4fe7d0ac8fc171045be623aba3e2a8f613f8682731f9153bb2e40ece16b9bbab
+make_check=no # cyclic with Sphinx
 
 post_install() {
-	vlicense LICENSE
+	vlicense LICENCE.rst
 }

--- a/srcpkgs/python3-sphinxcontrib-serializinghtml/template
+++ b/srcpkgs/python3-sphinxcontrib-serializinghtml/template
@@ -1,18 +1,18 @@
 # Template file for 'python3-sphinxcontrib-serializinghtml'
 pkgname=python3-sphinxcontrib-serializinghtml
-version=1.1.9
-revision=2
+version=2.0.0
+revision=1
 build_style=python3-pep517
-hostmakedepends="python3-setuptools_scm python3-wheel python3-flit_core"
+hostmakedepends="python3-flit_core"
 depends="python3"
 short_desc="Sphinx extension which outputs serialized HTML document"
 maintainer="Đoàn Trần Công Danh <congdanhqx@gmail.com>"
 license="BSD-2-Clause"
 homepage="http://sphinx-doc.org"
 distfiles="${PYPI_SITE}/s/sphinxcontrib_serializinghtml/sphinxcontrib_serializinghtml-${version}.tar.gz"
-checksum=0c64ff898339e1fac29abd2bf5f11078f3ec413cfe9c046d3120d7ca65530b54
+checksum=e9d912827f872c029017a53f0ef2180b327c3f7fd23c87229f7a8e8b70031d4d
 make_check=no # cyclic Sphinx
 
 post_install() {
-	vlicense LICENSE
+	vlicense LICENCE.rst
 }


### PR DESCRIPTION
- **python3-docutils: update to 0.21.2.**
- **python3-Babel: update to 2.17.0.**
- **python3-alabaster: update to 1.0.0.**
- **python3-sphinxcontrib-applehelp: update to 2.0.0.**
- **python3-sphinxcontrib-devhelp: update to 2.0.0.**
- **python3-sphinxcontrib-htmlhelp: update to 2.1.0.**
- **python3-sphinxcontrib-qthelp: update to 2.0.0.**
- **python3-sphinxcontrib-serializinghtml: update to 2.0.0.**
- **python3-Sphinx: fix check**

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**


@sgn this is necessary to fix python requires for sphinx:
```
$ pip check | grep sphinx
sphinx 8.1.3 has requirement alabaster>=0.7.14, but you have alabaster 0.7.12.
sphinx 8.1.3 has requirement sphinxcontrib-applehelp>=1.0.7, but you have sphinxcontrib-applehelp 1.0.4.
sphinx 8.1.3 has requirement sphinxcontrib-devhelp>=1.0.6, but you have sphinxcontrib-devhelp 1.0.2.
sphinx 8.1.3 has requirement sphinxcontrib-htmlhelp>=2.0.6, but you have sphinxcontrib-htmlhelp 2.0.1.
sphinx 8.1.3 has requirement sphinxcontrib-qthelp>=1.0.6, but you have sphinxcontrib-qthelp 1.0.3.
```

Otherwise, one gets errors when building a wheel that requires it, e.g.:
```
$ git clone -q https://github.com/sagemath/sagemath-giac/
$ cd sagemath-giac
$ python -m build -nw
* Getting build dependencies for wheel...

ERROR Missing dependencies:
	sagemath-standard
	sphinx<9,>=5.2 -> sphinxcontrib-serializinghtml>=1.1.9 -> Sphinx>=5 -> alabaster>=0.7.14
	sagemath-standard
	sphinx<9,>=5.2 -> sphinxcontrib-serializinghtml>=1.1.9 -> Sphinx>=5 -> sphinxcontrib-devhelp>=1.0.6
	sagemath-standard
	sphinx<9,>=5.2 -> sphinxcontrib-serializinghtml>=1.1.9 -> Sphinx>=5 -> sphinxcontrib-qthelp>=1.0.6
	sagemath-standard
	ipywidgets>=7.5.1 -> jupyterlab_widgets~=3.0.11
	sagemath-standard
	sphinx<9,>=5.2 -> sphinxcontrib-devhelp>=1.0.6
	sagemath-standard
	sphinx<9,>=5.2 -> sphinxcontrib-qthelp>=1.0.6
	sagemath-standard
	sphinx<9,>=5.2 -> alabaster>=0.7.14
	sagemath-standard
	sphinx<9,>=5.2 -> sphinxcontrib-serializinghtml>=1.1.9 -> Sphinx>=5 -> sphinxcontrib-htmlhelp>=2.0.6
	sagemath-standard
	sphinx<9,>=5.2 -> sphinxcontrib-serializinghtml>=1.1.9 -> Sphinx>=5 -> sphinxcontrib-applehelp>=1.0.7
	sagemath-standard
	sphinx<9,>=5.2 -> sphinxcontrib-htmlhelp>=2.0.6
	sagemath-standard
	sphinx<9,>=5.2 -> sphinxcontrib-applehelp>=1.0.7
```

This package has a dependency on `sagemath-standard` which implies the `sphinx` dependency.  It builds fine with this PR (+ #54482 for the missing `jupyterlab_widgets`)
