### PR TITLE
python3-Sphinx: update to 8.2.1.

### DIFF
--- a/srcpkgs/python3-Babel/template
+++ b/srcpkgs/python3-Babel/template
@@ -1,18 +1,18 @@
 # Template file for 'python3-Babel'
 pkgname=python3-Babel
-version=2.16.0
-revision=2
+version=2.17.0
+revision=1
 build_style=python3-pep517
 hostmakedepends="python3-setuptools"
 depends="python3"
-checkdepends="$depends python3-pytest python3-freezegun python3-pytz"
-short_desc="Tools for internationalizing Python applications (Python3)"
+checkdepends="$depends python3-pytest-xdist python3-freezegun python3-pytz"
+short_desc="Tools for internationalizing Python applications"
 maintainer="Gonzalo Tornaría <tornaria@cmat.edu.uy>"
 license="BSD-3-Clause"
 homepage="https://babel.pocoo.org"
 changelog="https://raw.githubusercontent.com/python-babel/babel/master/CHANGES.rst"
 distfiles="${PYPI_SITE}/B/Babel/babel-${version}.tar.gz"
-checksum=d1f3554ca26605fe173f3de0c65f750f5a42f924499bf134de6423582298e316
+checksum=0c54cffb19f690cdcc52a3b50bcbf71e07a808d1c80d549f2459b9d2cf0afb9d
 
 post_install() {
 	vlicense LICENSE

--- a/srcpkgs/python3-Sphinx/template
+++ b/srcpkgs/python3-Sphinx/template
@@ -1,6 +1,6 @@
 # Template file for 'python3-Sphinx'
 pkgname=python3-Sphinx
-version=8.1.3
+version=8.3.0
 revision=1
 build_style=python3-pep517
 hostmakedepends="python3-flit_core python3-pyproject-hooks"
@@ -9,9 +9,9 @@ depends="python3-Jinja2 python3-docutils python3-Pygments
  python3-requests python3-packaging python3-sphinxcontrib-applehelp
  python3-sphinxcontrib-devhelp python3-sphinxcontrib-htmlhelp
  python3-sphinxcontrib-jsmath python3-sphinxcontrib-qthelp
- python3-sphinxcontrib-serializinghtml"
+ python3-sphinxcontrib-serializinghtml python3-roman-numerals-py"
 checkdepends="$depends python3-html5lib python3-mypy ImageMagick gettext
- python3-pytest python3-setuptools python3-filelock python3-defusedxml
+ python3-pytest-xdist python3-setuptools python3-filelock python3-defusedxml
  graphviz"
 short_desc="Python 3 documentation generator"
 maintainer="Đoàn Trần Công Danh <congdanhqx@gmail.com>"
@@ -20,8 +20,13 @@ homepage="http://sphinx-doc.org"
 changelog="https://github.com/sphinx-doc/sphinx/raw/master/CHANGES"
 # distfiles="${PYPI_SITE}/S/Sphinx/Sphinx-${version}.tar.gz"
 distfiles="${PYPI_SITE}/s/sphinx/sphinx-${version}.tar.gz"
-checksum=43c1911eecb0d3e161ad78611bc905d1ad0e523e4ddc202a58a821773dc4c927
+checksum=3bad4314a7fa72ce92344eaaa14c42ddf3177ee6a79c227e4ff8ae07d416f584
 replaces="python-Sphinx>=0"
+
+post_patch() {
+	# rename so it works with any python
+	mv -i tests/roots/test-ext-apidoc-duplicates/fish_licence/{halibut*.so,halibut.so}
+}
 
 post_install() {
 	vlicense LICENSE.rst

--- a/srcpkgs/python3-alabaster/template
+++ b/srcpkgs/python3-alabaster/template
@@ -1,17 +1,18 @@
 # Template file for 'python3-alabaster'
 pkgname=python3-alabaster
-version=0.7.12
-revision=8
-build_style=python3-module
-hostmakedepends="python3-setuptools"
+version=1.0.0
+revision=1
+build_style=python3-pep517
+hostmakedepends="python3-flit_core"
 depends="python3"
 short_desc="Configurable sidebar-enabled Sphinx theme (Python3)"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="BSD-3-Clause"
 homepage="https://alabaster.readthedocs.io/"
+changelog="https://raw.githubusercontent.com/sphinx-doc/alabaster/refs/heads/master/docs/changelog.rst"
 distfiles="${PYPI_SITE}/a/alabaster/alabaster-${version}.tar.gz"
-checksum=a661d72d58e6ea8a57f7a86e37d86716863ee5e92788398526d58b26a4e4dc02
+checksum=c00dca57bca26fa62a6d7d0a9fcce65f3e026e9bfe33e9c538fd3fbb2144fd9e
 
 post_install() {
-	vlicense LICENSE
+	vlicense LICENSE.rst
 }

--- a/srcpkgs/python3-docutils/patches/fix-test.patch
+++ b/srcpkgs/python3-docutils/patches/fix-test.patch
@@ -1,0 +1,24 @@
+--- a/test/test_parsers/test_rst/test_directives/test_code.py
++++ b/test/test_parsers/test_rst/test_directives/test_code.py
+@@ -167,7 +167,8 @@
+              7 \n\
+         <inline classes="keyword">
+             def
+-         \n\
++        <inline classes="whitespace">
++             \n\
+         <inline classes="name function">
+             my_function
+         <inline classes="punctuation">
+--- a/test/test_parsers/test_rst/test_directives/test_code_long.py
++++ b/test/test_parsers/test_rst/test_directives/test_code_long.py
+@@ -62,7 +62,8 @@
+              7 \n\
+         <inline classes="keyword">
+             def
+-         \n\
++        <inline classes="whitespace">
++             \n\
+         <inline classes="name function">
+             my_function
+         <inline classes="punctuation">

--- a/srcpkgs/python3-docutils/template
+++ b/srcpkgs/python3-docutils/template
@@ -1,9 +1,9 @@
 # Template file for 'python3-docutils'
 pkgname=python3-docutils
-version=0.20.1
-revision=3
-build_style=python3-module
-hostmakedepends="python3-setuptools"
+version=0.21.2
+revision=1
+build_style=python3-pep517
+hostmakedepends="python3-flit_core"
 # docutils/writers/odf_odt/pygmentsformatter.py
 depends="python3-Pygments"
 checkdepends="${depends} python3-pytest"
@@ -12,21 +12,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="Public Domain, BSD-2-Clause, GPL-3.0-or-later, Python-2.0"
 homepage="https://docutils.sourceforge.io"
 distfiles="${PYPI_SITE}/d/docutils/docutils-${version}.tar.gz"
-checksum=f08a4e276c3a1583a86dce3e34aba3fe04d02bba2dd51ed16106244e8a923e3b
-
-alternatives="
- docutils:rst2html:/usr/bin/rst2html.py
- docutils:rst2html4:/usr/bin/rst2html4.py
- docutils:rst2html5:/usr/bin/rst2html5.py
- docutils:rst2latex:/usr/bin/rst2latex.py
- docutils:rst2man:/usr/bin/rst2man.py
- docutils:rst2odt:/usr/bin/rst2odt.py
- docutils:rst2odt_prepstyles:/usr/bin/rst2odt_prepstyles.py
- docutils:rst2pseudoxml:/usr/bin/rst2pseudoxml.py
- docutils:rst2s5:/usr/bin/rst2s5.py
- docutils:rst2xetex:/usr/bin/rst2xetex.py
- docutils:rst2xml:/usr/bin/rst2xml.py
- docutils:rstpep2html:/usr/bin/rstpep2html.py"
+checksum=3a6b18732edf182daa3cd12775bbb338cf5691468f91eeeb109deff6ebfa986f
 
 post_install() {
 	vlicense COPYING.txt COPYING

--- a/srcpkgs/python3-roman-numerals-py/template
+++ b/srcpkgs/python3-roman-numerals-py/template
@@ -1,0 +1,19 @@
+# Template file for 'python3-roman-numerals-py'
+pkgname=python3-roman-numerals-py
+version=3.1.0
+revision=1
+build_style=python3-pep517
+hostmakedepends="python3-flit_core"
+depends="python3"
+checkdepends="python3-pytest"
+short_desc="Manipulate well-formed Roman numerals"
+maintainer="Orphaned <orphan@voidlinux.org>"
+license="0BSD OR CC0-1.0"
+homepage="https://pypi.org/project/roman-numerals-py/"
+changelog="https://github.com/AA-Turner/roman-numerals/blob/master/CHANGES.rst"
+distfiles="${PYPI_SITE}/r/roman-numerals-py/roman_numerals_py-${version}.tar.gz"
+checksum=be4bf804f083a4ce001b5eb7e3c0862479d10f94c936f6c4e5f250aa5ff5bd2d
+
+post_install() {
+	vlicense LICENCE.rst
+}

--- a/srcpkgs/python3-sphinxcontrib-applehelp/template
+++ b/srcpkgs/python3-sphinxcontrib-applehelp/template
@@ -1,7 +1,7 @@
 # Template file for 'python3-sphinxcontrib-applehelp'
 pkgname=python3-sphinxcontrib-applehelp
-version=1.0.4
-revision=3
+version=2.0.0
+revision=1
 build_style=python3-pep517
 hostmakedepends="python3-flit_core python3-pyproject-hooks python3-setuptools
  python3-wheel"
@@ -10,10 +10,10 @@ short_desc="Sphinx extension which outputs Apple help book"
 maintainer="Đoàn Trần Công Danh <congdanhqx@gmail.com>"
 license="BSD-2-Clause"
 homepage="http://sphinx-doc.org"
-distfiles="${PYPI_SITE}/s/sphinxcontrib-applehelp/sphinxcontrib-applehelp-${version}.tar.gz"
-checksum=828f867945bbe39817c210a1abfd1bc4895c8b73fcaade56d45357a348a07d7e
+distfiles="${PYPI_SITE}/s/sphinxcontrib-applehelp/sphinxcontrib_applehelp-${version}.tar.gz"
+checksum=2f29ef331735ce958efa4734873f084941970894c6090408b079c61b2e1c06d1
 make_check=no # cyclic with Sphinx
 
 post_install() {
-	vlicense LICENSE
+	vlicense LICENCE.rst
 }

--- a/srcpkgs/python3-sphinxcontrib-devhelp/template
+++ b/srcpkgs/python3-sphinxcontrib-devhelp/template
@@ -1,18 +1,18 @@
 # Template file for 'python3-sphinxcontrib-devhelp'
 pkgname=python3-sphinxcontrib-devhelp
-version=1.0.2
-revision=6
-build_style=python3-module
-hostmakedepends="python3-setuptools"
+version=2.0.0
+revision=1
+build_style=python3-pep517
+hostmakedepends="python3-flit_core"
 depends="python3"
-checkdepends="python3-Sphinx"
 short_desc="Sphinx extension which outputs Devhelp document"
 maintainer="Đoàn Trần Công Danh <congdanhqx@gmail.com>"
 license="BSD-2-Clause"
 homepage="http://sphinx-doc.org"
-distfiles="${PYPI_SITE}/s/sphinxcontrib-devhelp/sphinxcontrib-devhelp-${version}.tar.gz"
-checksum=ff7f1afa7b9642e7060379360a67e9c41e8f3121f2ce9164266f61b9f4b338e4
+distfiles="${PYPI_SITE}/s/sphinxcontrib-devhelp/sphinxcontrib_devhelp-${version}.tar.gz"
+checksum=411f5d96d445d1d73bb5d52133377b4248ec79db5c793ce7dbe59e074b4dd1ad
+make_check=no # cyclic with Sphinx
 
 post_install() {
-	vlicense LICENSE
+	vlicense LICENCE.rst
 }

--- a/srcpkgs/python3-sphinxcontrib-htmlhelp/template
+++ b/srcpkgs/python3-sphinxcontrib-htmlhelp/template
@@ -1,7 +1,7 @@
 # Template file for 'python3-sphinxcontrib-htmlhelp'
 pkgname=python3-sphinxcontrib-htmlhelp
-version=2.0.1
-revision=3
+version=2.1.0
+revision=1
 build_style=python3-pep517
 hostmakedepends="python3-flit_core python3-pyproject-hooks python3-setuptools
  python3-wheel"
@@ -10,10 +10,10 @@ short_desc="Sphinx extension which outputs HTML document"
 maintainer="Đoàn Trần Công Danh <congdanhqx@gmail.com>"
 license="BSD-2-Clause"
 homepage="http://sphinx-doc.org"
-distfiles="${PYPI_SITE}/s/sphinxcontrib-htmlhelp/sphinxcontrib-htmlhelp-${version}.tar.gz"
-checksum=0cbdd302815330058422b98a113195c9249825d681e18f11e8b1f78a2f11efff
+distfiles="${PYPI_SITE}/s/sphinxcontrib-htmlhelp/sphinxcontrib_htmlhelp-${version}.tar.gz"
+checksum=c9e2916ace8aad64cc13a0d233ee22317f2b9025b9cf3295249fa985cc7082e9
 make_check=no # cyclic with Sphinx
 
 post_install() {
-	vlicense LICENSE
+	vlicense LICENCE.rst
 }

--- a/srcpkgs/python3-sphinxcontrib-qthelp/template
+++ b/srcpkgs/python3-sphinxcontrib-qthelp/template
@@ -1,18 +1,18 @@
 # Template file for 'python3-sphinxcontrib-qthelp'
 pkgname=python3-sphinxcontrib-qthelp
-version=1.0.3
-revision=6
-build_style=python3-module
-hostmakedepends="python3-setuptools"
+version=2.0.0
+revision=1
+build_style=python3-pep517
+hostmakedepends="python3-flit_core"
 depends="python3"
-checkdepends="python3-Sphinx"
 short_desc="Sphinx extension which outputs QtHelp document"
 maintainer="Đoàn Trần Công Danh <congdanhqx@gmail.com>"
 license="BSD-2-Clause"
 homepage="http://sphinx-doc.org"
-distfiles="${PYPI_SITE}/s/sphinxcontrib-qthelp/sphinxcontrib-qthelp-${version}.tar.gz"
-checksum=4c33767ee058b70dba89a6fc5c1892c0d57a54be67ddd3e7875a18d14cba5a72
+distfiles="${PYPI_SITE}/s/sphinxcontrib-qthelp/sphinxcontrib_qthelp-${version}.tar.gz"
+checksum=4fe7d0ac8fc171045be623aba3e2a8f613f8682731f9153bb2e40ece16b9bbab
+make_check=no # cyclic with Sphinx
 
 post_install() {
-	vlicense LICENSE
+	vlicense LICENCE.rst
 }

--- a/srcpkgs/python3-sphinxcontrib-serializinghtml/template
+++ b/srcpkgs/python3-sphinxcontrib-serializinghtml/template
@@ -1,18 +1,18 @@
 # Template file for 'python3-sphinxcontrib-serializinghtml'
 pkgname=python3-sphinxcontrib-serializinghtml
-version=1.1.9
-revision=2
+version=2.0.0
+revision=1
 build_style=python3-pep517
-hostmakedepends="python3-setuptools_scm python3-wheel python3-flit_core"
+hostmakedepends="python3-flit_core"
 depends="python3"
 short_desc="Sphinx extension which outputs serialized HTML document"
 maintainer="Đoàn Trần Công Danh <congdanhqx@gmail.com>"
 license="BSD-2-Clause"
 homepage="http://sphinx-doc.org"
 distfiles="${PYPI_SITE}/s/sphinxcontrib_serializinghtml/sphinxcontrib_serializinghtml-${version}.tar.gz"
-checksum=0c64ff898339e1fac29abd2bf5f11078f3ec413cfe9c046d3120d7ca65530b54
+checksum=e9d912827f872c029017a53f0ef2180b327c3f7fd23c87229f7a8e8b70031d4d
 make_check=no # cyclic Sphinx
 
 post_install() {
-	vlicense LICENSE
+	vlicense LICENCE.rst
 }


### PR DESCRIPTION
On top of #54495:
- **python3-flit_core: update to 3.11.0.**
- **New package: python3-roman-numerals-py-3.1.0**
- **python3-Sphinx: update to 8.2.1.**

@sgn this updates sphinx on top of the other PR. We could squash both
together if you prefer.

@ahesford sphinx 8.2.1 needs an updated `flit_core`. I'm not sure if
this is a problem, or whether `flit_core-bootstrap` has to be updated in
sync.


#### Testing the changes
- I tested the changes in this PR: **briefly**
