### PR TITLE
x265: enable higher bit depths

### DIFF
--- a/srcpkgs/kf6-kimageformats/template
+++ b/srcpkgs/kf6-kimageformats/template
@@ -18,7 +18,7 @@ checksum=0c45787f97d00fc0257f7de3250d84e950de2a332c45e7528138f7cf843154cc
 
 do_check() {
 	cd build
-	exclude="kimageformats-read-xcf|kimageformats-read-psd|kimageformats-read-hej2|kimageformats-write-heif"
+	exclude="kimageformats-read-xcf|kimageformats-read-psd|kimageformats-read-hej2"
 	case "$XBPS_TARGET_MACHINE" in
 		i686*) exclude+="|kimageformats-write-exr";;
 		*) ;;

--- a/srcpkgs/x265/template
+++ b/srcpkgs/x265/template
@@ -1,10 +1,11 @@
 # Template file for 'x265'
 pkgname=x265
 version=3.6
-revision=1
+revision=2
 build_wrksrc=source
 build_style=cmake
-configure_args="-DENABLE_PIC=1"
+configure_args="-DENABLE_PIC=1 -DEXTRA_LINK_FLAGS='-L.'
+ -DEXTRA_LIB='x265_main10.a;x265_main12.a' -DLINKED_10BIT=TRUE -DLINKED_12BIT=TRUE"
 hostmakedepends="git"
 short_desc="Open Source H.265/HEVC video encoder"
 maintainer="Orphaned <orphan@voidlinux.org>"
@@ -50,6 +51,50 @@ pre_configure() {
 	if [ "$CROSS_BUILD" ]; then
 		vsed -i CMakeLists.txt -e "s; -mcpu=native;;"
 	fi
+}
+
+post_configure() {
+	# We need to build the library multiple times in order to support multiple bit depths
+	# The libraries are linked together using -DDEXTRA_LIB=...
+
+	configure_args="${configure_args/-DEXTRA_LIB=.*/}"
+	configure_args="${configure_args/-DLINKED_10BIT=.*/}"
+	configure_args="${configure_args/-DLINKED_12BIT=.*/}"
+
+	# source/common/x86/intrapred16.asm:20642: error: invalid combination of opcode and operands
+	case "$XBPS_TARGET_MACHINE" in
+		i686*) configure_args="${configure_args/-DENABLE_ASSEMBLY=.*/} -DENABLE_ASSEMBLY=OFF" ;;
+		*) ;;
+	esac
+
+	(
+		cmake_builddir="build-10" \
+		configure_args="${configure_args} -DHIGH_BIT_DEPTH=TRUE -DENABLE_CLI=FALSE -DEXPORT_C_API=FALSE -DENABLE_SHARED=FALSE" \
+		do_configure
+	)
+
+	(
+		cmake_builddir="build-12" \
+		configure_args="${configure_args} -DHIGH_BIT_DEPTH=TRUE -DMAIN12=TRUE -DENABLE_CLI=FALSE -DEXPORT_C_API=FALSE -DENABLE_SHARED=FALSE" \
+		do_configure
+	)
+}
+
+pre_build() {
+	(
+		cd build-10
+		export NINJA_STATUS="[1/3][%f/%t] "
+		ninja ${makejobs} ${make_build_args} ${make_build_target}
+	)
+
+	(
+		cd build-12
+		export NINJA_STATUS="[2/3][%f/%t] "
+		ninja ${makejobs} ${make_build_args} ${make_build_target}
+	)
+
+	ln -sf ../build-10/libx265.a build/libx265_main10.a
+	ln -sf ../build-12/libx265.a build/libx265_main12.a
 }
 
 x265-devel_package() {


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

This adds support for higher bit depths and fixes the kimageformats-write-heif test for kf6-kimageformats.

Unfortunately this requires x265 to be built 3 times, thankfully the compiles are pretty short.
https://gitlab.alpinelinux.org/alpine/aports/-/blob/master/community/x265/APKBUILD
https://salsa.debian.org/multimedia-team/x265/-/blob/master/debian/rules

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
