### PR TITLE
curl: enable versioned symbols

### DIFF
--- a/srcpkgs/curl/template
+++ b/srcpkgs/curl/template
@@ -1,9 +1,9 @@
 # Template file for 'curl'
 pkgname=curl
 version=8.12.1
-revision=1
+revision=2
 build_style=gnu-configure
-configure_args="ac_cv_sizeof_off_t=8 --enable-threaded-resolver --enable-ipv6
+configure_args="ac_cv_sizeof_off_t=8 --enable-threaded-resolver --enable-versioned-symbols --enable-ipv6
  --with-random=/dev/urandom
  $(vopt_with rtmp librtmp) $(vopt_with gssapi) $(vopt_enable ldap) $(vopt_with gnutls)
  $(vopt_enable ldap ldaps) $(vopt_with ssh libssh2) $(vopt_with ssl) $(vopt_with zstd)


### PR DESCRIPTION
This PR add a flag to enable "versioned symbols" in CURL shared library.

This would fix an issue when using third party binaries like `mongodb` (and probably some others) which uses these symbols (https://discourse.nixos.org/t/patchelf-and-libcurl-no-version-information-available/24453)

For example, this is enabled by default in many distros:

Arch: https://gitlab.archlinux.org/archlinux/packaging/packages/curl/-/blob/main/PKGBUILD?ref_type=heads#L86
Debian: https://salsa.debian.org/debian/curl/-/blob/debian/unstable/debian/rules?ref_type=heads#L13
Ubuntu: https://git.launchpad.net/ubuntu/+source/curl/tree/debian/rules#n13

#### Questions
- The version hasn't changed so the checksum is the same. However, when I tried to run `xgensum -i curl` it printed many lines saying `vopt_*: command not found`. Is this normal or am I doing something wrong? Also, what are all of the commands prefixed with `v`? Where is the documentation for writing templates?

#### Testing the changes
- I tested the changes in this PR: YES.

#### Local build testing
- I built this PR locally for my native architecture, x86_64.