### PR TITLE
python updates (jsonschema, openapi-core, and many deps)

### DIFF
--- a/srcpkgs/python3-attrs/template
+++ b/srcpkgs/python3-attrs/template
@@ -1,7 +1,7 @@
 # Template file for 'python3-attrs'
 pkgname=python3-attrs
-version=24.2.0
-revision=2
+version=25.1.0
+revision=1
 build_style=python3-pep517
 hostmakedepends="python3-setuptools hatch-vcs hatch-fancy-pypi-readme"
 depends="python3"
@@ -12,7 +12,7 @@ license="MIT"
 homepage="https://attrs.readthedocs.io/"
 changelog="https://raw.githubusercontent.com/python-attrs/attrs/main/CHANGELOG.md"
 distfiles="${PYPI_SITE}/a/attrs/attrs-${version}.tar.gz"
-checksum=5cfb1b9148b5b086569baec03f20d7b6bf3bcacc9a42bebf87ffaaca362f6346
+checksum=1c97078a80c814273a76b2a298a932eb681c87415c11dee0a6921de7f1b02c3e
 
 post_install() {
 	vlicense LICENSE

--- a/srcpkgs/python3-coverage/template
+++ b/srcpkgs/python3-coverage/template
@@ -1,7 +1,7 @@
 # Template file for 'python3-coverage'
 pkgname=python3-coverage
-version=7.6.1
-revision=2
+version=7.6.12
+revision=1
 build_style=python3-pep517
 hostmakedepends="python3-setuptools"
 makedepends="python3-devel"
@@ -12,7 +12,7 @@ license="Apache-2.0"
 homepage="https://github.com/nedbat/coveragepy"
 changelog="https://raw.githubusercontent.com/nedbat/coveragepy/master/CHANGES.rst"
 distfiles="${PYPI_SITE}/c/coverage/coverage-${version}.tar.gz"
-checksum=953510dfb7b12ab69d20135a0662397f077c59b1e6379a768e97c59d852ee51d
+checksum=48cfc4641d95d34766ad41d9573cc0f22a48aa88d22657a1fe01dca0dbae4de2
 
 pre_check() {
 	# required setup, see tox.ini

--- a/srcpkgs/python3-fastjsonschema/template
+++ b/srcpkgs/python3-fastjsonschema/template
@@ -1,7 +1,7 @@
 # Template file for 'python3-fastjsonschema'
 pkgname=python3-fastjsonschema
-version=2.20.0
-revision=2
+version=2.21.1
+revision=1
 build_style=python3-pep517
 hostmakedepends="python3-setuptools python3-wheel"
 depends="python3"
@@ -12,7 +12,7 @@ license="BSD-3-Clause"
 homepage="https://github.com/horejsek/python-fastjsonschema"
 changelog="https://raw.githubusercontent.com/horejsek/python-fastjsonschema/master/CHANGELOG.txt"
 distfiles="https://github.com/horejsek/python-fastjsonschema/archive/refs/tags/v${version}.tar.gz"
-checksum=2d2e4951614ee57a08f7bdb689687d4f31e59e3ad466c085495105a72ad95b38
+checksum=20891fd6659d94ce18dcf075afd6cd6b817bf39013a25a4d11a2162d2fa0daa0
 
 post_install() {
 	vlicense LICENSE

--- a/srcpkgs/python3-isodate/template
+++ b/srcpkgs/python3-isodate/template
@@ -1,22 +1,18 @@
 # Template file for 'python3-isodate'
 pkgname=python3-isodate
-version=0.6.1
-revision=4
-build_style=python3-module
-hostmakedepends="python3-setuptools"
-depends="python3-six"
-checkdepends="${depends}"
+version=0.7.2
+revision=1
+build_style=python3-pep517
+hostmakedepends="python3-setuptools_scm"
+depends="python3"
+checkdepends="python3-pytest"
 short_desc="ISO 8601 date/time/duration parser and formatter (Python3)"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="BSD-3-Clause"
 homepage="https://github.com/gweis/isodate"
 distfiles="${PYPI_SITE}/i/isodate/isodate-${version}.tar.gz"
-checksum=48c5881de7e8b0a0d648cb024c8062dc84e7b840ed81e864c7614fd3c127bde9
+checksum=4cd1aa0f43ca76f4a6c6c0292a85f40b35ec2e43e315b59f06e6d32171a953e6
 
 post_install() {
-	# licence is in a separate file at HEAD of master, but not released
-	sed -n '/Copyright/,/CONTRACT/p' src/isodate/__init__.py >LICENSE
 	vlicense LICENSE
-	# remove tests from installed package
-	rm -r ${DESTDIR}/${py3_sitelib}/${pkgname#*-}/tests
 }

--- a/srcpkgs/python3-jsonschema-path/template
+++ b/srcpkgs/python3-jsonschema-path/template
@@ -1,10 +1,10 @@
 # Template file for 'python3-jsonschema-path'
 pkgname=python3-jsonschema-path
-version=0.3.3
-revision=2
+version=0.3.4
+revision=1
 build_style=python3-pep517
 hostmakedepends="python3-poetry-core"
-depends="python3-pathable python3-referencing python3-yaml"
+depends="python3-pathable python3-referencing python3-yaml python3-requests"
 checkdepends="$depends python3-pytest-cov python3-responses"
 short_desc="JSONSchema Spec with object-oriented paths"
 maintainer="Gonzalo Tornaría <tornaria@cmat.edu.uy>"
@@ -12,7 +12,7 @@ license="Apache-2.0"
 homepage="https://github.com/p1c2u/jsonschema-path"
 changelog="https://github.com/p1c2u/jsonschema-path/releases"
 distfiles="https://github.com/p1c2u/jsonschema-path/archive/refs/tags/${version}.tar.gz"
-checksum=b2757571934d8ecc0ebad61a6310ad3e04a17b45c0a51be44529d50abdd355e0
+checksum=71b7e165c7ee86c346593e2ac21b5beafc9bbaac337ef053df028e8827469950
 
 python3-jsonschema-spec_package() {
 	depends="${sourcepkg}>=${version}_${revision}"

--- a/srcpkgs/python3-jsonschema-specifications/template
+++ b/srcpkgs/python3-jsonschema-specifications/template
@@ -1,7 +1,7 @@
 # Template file for 'python3-jsonschema-specifications'
 pkgname=python3-jsonschema-specifications
-version=2023.12.1
-revision=2
+version=2024.10.1
+revision=1
 build_style=python3-pep517
 hostmakedepends="hatchling hatch-vcs"
 depends="python3-referencing"
@@ -11,7 +11,7 @@ maintainer="Gonzalo Tornaría <tornaria@cmat.edu.uy>"
 license="MIT"
 homepage="https://github.com/python-jsonschema/jsonschema-specifications"
 distfiles="${PYPI_SITE}/j/jsonschema-specifications/jsonschema_specifications-${version}.tar.gz"
-checksum=48a76787b3e70f5ed53f1160d2b81f586e4ca6d1548c5de7085d1682674764cc
+checksum=0f38b83639958ce1152d02a7f062902c41c8fd20d558b0c34344292d417ae272
 
 post_install() {
 	vlicense COPYING

--- a/srcpkgs/python3-lazy-object-proxy/template
+++ b/srcpkgs/python3-lazy-object-proxy/template
@@ -1,8 +1,8 @@
 # Template file for 'python3-lazy-object-proxy'
 pkgname=python3-lazy-object-proxy
-version=1.9.0
-revision=3
-build_style=python3-module
+version=1.10.0
+revision=1
+build_style=python3-pep517
 hostmakedepends="python3-setuptools_scm"
 makedepends="python3-devel"
 depends="python3"
@@ -13,7 +13,7 @@ license="BSD-2-Clause"
 homepage="https://github.com/ionelmc/python-lazy-object-proxy"
 changelog="https://raw.githubusercontent.com/ionelmc/python-lazy-object-proxy/master/CHANGELOG.rst"
 distfiles="${PYPI_SITE}/l/lazy-object-proxy/lazy-object-proxy-${version}.tar.gz"
-checksum=659fb5809fa4629b8a1ac5106f669cfc7bef26fbb389dda53b3e010d1ac4ebae
+checksum=78247b6d45f43a52ef35c25b5581459e85117225408a4128a3daf8bf9648ac69
 
 post_install() {
 	vlicense LICENSE

--- a/srcpkgs/python3-openapi-core/template
+++ b/srcpkgs/python3-openapi-core/template
@@ -1,7 +1,7 @@
 # Template file for 'python3-openapi-core'
 pkgname=python3-openapi-core
-version=0.19.3
-revision=2
+version=0.19.4
+revision=1
 build_style=python3-pep517
 # disable tests requiring unpackaged dependencies
 make_check_args="
@@ -12,7 +12,8 @@ make_check_args="
  --ignore=tests/integration/contrib/starlette
  "
 hostmakedepends="python3-poetry-core"
-depends="python3-asgiref python3-isodate python3-more-itertools
+depends="python3-isodate python3-jsonschema python3-jsonschema-path
+ python3-more-itertools python3-openapi-schema-validator
  python3-openapi-spec-validator python3-parse python3-Werkzeug"
 checkdepends="$depends python3-pytest-cov python3-pytest-aiohttp
  python3-Flask python3-requests python3-responses python3-WebOb"
@@ -22,7 +23,7 @@ license="BSD-3-Clause"
 homepage="https://github.com/python-openapi/openapi-core"
 changelog="https://github.com/python-openapi/openapi-core/releases"
 distfiles="${PYPI_SITE}/o/openapi-core/openapi_core-${version}.tar.gz"
-checksum=5db6479ecccf76c52422961dc42b411b7625a802087d847251fdd66f0392b095
+checksum=1150d9daa5e7b4cacfd7d7e097333dc89382d7d72703934128dcf8a1a4d0df49
 
 post_install() {
 	vlicense LICENSE

--- a/srcpkgs/python3-openapi-schema-validator/template
+++ b/srcpkgs/python3-openapi-schema-validator/template
@@ -1,10 +1,11 @@
 # Template file for 'python3-openapi-schema-validator'
 pkgname=python3-openapi-schema-validator
-version=0.6.2
-revision=2
+version=0.6.3
+revision=1
 build_style=python3-pep517
 hostmakedepends="python3-poetry-core"
-depends="python3-jsonschema python3-rfc3339-validator"
+depends="python3-jsonschema python3-jsonschema-specifications
+ python3-rfc3339-validator"
 checkdepends="$depends python3-pytest-cov"
 short_desc="OpenAPI schema validation for Python"
 maintainer="Gonzalo Tornaría <tornaria@cmat.edu.uy>"
@@ -12,7 +13,7 @@ license="BSD-3-Clause"
 homepage="https://github.com/python-openapi/openapi-schema-validator"
 changelog="https://github.com/python-openapi/openapi-schema-validator/releases"
 distfiles="${PYPI_SITE}/o/openapi-schema-validator/openapi_schema_validator-${version}.tar.gz"
-checksum=11a95c9c9017912964e3e5f2545a5b11c3814880681fcacfb73b1759bb4f2804
+checksum=f37bace4fc2a5d96692f4f8b31dc0f8d7400fd04f3a937798eaf880d425de6ee
 
 post_install() {
 	vlicense LICENSE

--- a/srcpkgs/python3-pathable/template
+++ b/srcpkgs/python3-pathable/template
@@ -1,7 +1,7 @@
 # Template file for 'python3-pathable'
 pkgname=python3-pathable
-version=0.4.3
-revision=3
+version=0.4.4
+revision=1
 build_style=python3-pep517
 hostmakedepends="python3-poetry-core"
 depends="python3"
@@ -12,4 +12,4 @@ license="Apache-2.0"
 homepage="https://github.com/p1c2u/pathable"
 changelog="https://github.com/p1c2u/pathable/releases"
 distfiles="https://github.com/p1c2u/pathable/archive/refs/tags/${version}.tar.gz"
-checksum=eea76120e5fdc54f4e9b7bc5e24748d163cef61c3e60ed32675828ade141cf4b
+checksum=1ef8fc64baab9440e14fdb1dd7ef7bef9e6d9dcba9d0552ba3f83c6cc1f2a0ab

--- a/srcpkgs/python3-py-cpuinfo/template
+++ b/srcpkgs/python3-py-cpuinfo/template
@@ -1,16 +1,18 @@
 # Template file for 'python3-py-cpuinfo'
 pkgname=python3-py-cpuinfo
-version=8.0.0
-revision=6
-build_style=python3-module
-hostmakedepends="python3-setuptools"
+version=9.0.0
+revision=1
+build_style=python3-pep517
+hostmakedepends="python3-setuptools python3-wheel"
 depends="python3"
+checkdepends="python3-pytest"
 short_desc="Python module for getting CPU info"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
 homepage="https://github.com/workhorsy/py-cpuinfo"
 distfiles="${PYPI_SITE}/p/py-cpuinfo/py-cpuinfo-${version}.tar.gz"
-checksum=5f269be0e08e33fd959de96b34cd4aeeeacac014dd8305f70eb28d06de2345c5
+checksum=3cdbbf3fac90dc6f118bfd64384f309edeadd902d7c8fb17f02ffa1fc3f49690
+conflicts=cpuinfo
 
 post_install() {
 	vlicense LICENSE

--- a/srcpkgs/python3-pytest-asyncio/template
+++ b/srcpkgs/python3-pytest-asyncio/template
@@ -1,6 +1,6 @@
 # Template file for 'python3-pytest-asyncio'
 pkgname=python3-pytest-asyncio
-version=0.25.0
+version=0.25.3
 revision=1
 build_style=python3-pep517
 hostmakedepends="python3-setuptools_scm python3-wheel"
@@ -12,7 +12,7 @@ license="Apache-2.0"
 homepage="https://github.com/pytest-dev/pytest-asyncio"
 changelog="https://raw.githubusercontent.com/pytest-dev/pytest-asyncio/master/docs/source/reference/changelog.rst"
 distfiles="${PYPI_SITE}/p/pytest-asyncio/pytest_asyncio-${version}.tar.gz"
-checksum=8c0610303c9e0442a5db8604505fc0f545456ba1528824842b37b4a626cbf609
+checksum=fc1da2cf9f125ada7e710b4ddad05518d4cee187ae9412e9ac9271003497f07a
 
 if [ "$XBPS_BUILD_ENVIRONMENT" = void-packages-ci ]; then
 	# these tests fail on CI (bind to a tcp address)

--- a/srcpkgs/python3-pytest-benchmark/template
+++ b/srcpkgs/python3-pytest-benchmark/template
@@ -1,7 +1,7 @@
 # Template file for 'python3-pytest-benchmark'
 pkgname=python3-pytest-benchmark
-version=4.0.0
-revision=3
+version=5.1.0
+revision=1
 build_style=python3-pep517
 hostmakedepends="python3-setuptools python3-wheel"
 depends="python3-pytest python3-py-cpuinfo"
@@ -11,7 +11,7 @@ license="BSD-2-Clause"
 homepage="https://github.com/ionelmc/pytest-benchmark"
 changelog="https://github.com/ionelmc/pytest-benchmark/raw/master/CHANGELOG.rst"
 distfiles="${PYPI_SITE}/p/pytest-benchmark/pytest-benchmark-${version}.tar.gz"
-checksum=fb0785b83efe599a6a956361c0691ae1dbb5318018561af10f3e915caa0048d1
+checksum=9ea661cdc292e8231f7cd4c10b0319e56a2118e2c09d9f50e1b3d150d2aca105
 # requires itself to be properly installed
 make_check=no
 

--- a/srcpkgs/python3-pytest-httpserver/template
+++ b/srcpkgs/python3-pytest-httpserver/template
@@ -1,7 +1,7 @@
 # Template file for 'python3-pytest-httpserver'
 pkgname=python3-pytest-httpserver
-version=1.1.0
-revision=2
+version=1.1.2
+revision=1
 build_style=python3-pep517
 hostmakedepends="python3-poetry-core"
 depends="python3-pytest python3-Werkzeug"
@@ -12,7 +12,7 @@ license="MIT"
 homepage="https://www.github.com/csernazs/pytest-httpserver"
 changelog="https://raw.githubusercontent.com/csernazs/pytest-httpserver/master/CHANGES.rst"
 distfiles="https://github.com/csernazs/pytest-httpserver/archive/refs/tags/${version}.tar.gz"
-checksum=4378ff64c5c305d7174d3f7aed9c00330c8bf6caa60ea0340885a9879aeee94d
+checksum=b706af59bcf019d9d1e623b7934c316038529cb18137163289ab5387ba627d43
 
 if [ "$XBPS_BUILD_ENVIRONMENT" = "void-packages-ci" ]; then
 	# this test fails on CI (bind to ipv6 "::1" address)

--- a/srcpkgs/python3-referencing/template
+++ b/srcpkgs/python3-referencing/template
@@ -1,7 +1,7 @@
 # Template file for 'python3-referencing'
 pkgname=python3-referencing
-version=0.35.1
-revision=3
+version=0.36.2
+revision=1
 build_style=python3-pep517
 hostmakedepends="hatchling hatch-vcs"
 depends="python3-attrs python3-rpds-py"
@@ -12,7 +12,7 @@ license="MIT"
 homepage="https://github.com/python-jsonschema/referencing"
 changelog="https://raw.githubusercontent.com/python-jsonschema/referencing/main/docs/changes.rst"
 distfiles="${PYPI_SITE}/r/referencing/referencing-${version}.tar.gz"
-checksum=25b42124a6c8b632a425174f24087783efb348a6f1e0008e63cd4466fedf703c
+checksum=df2e89862cd09deabbdba16944cc3f10feb6b3e6f18e902f7cc25609a34775aa
 
 if [ "$XBPS_CHECK_PKGS" = full ]; then
 	# cyclic dependency

--- a/srcpkgs/python3-responses/template
+++ b/srcpkgs/python3-responses/template
@@ -1,7 +1,7 @@
 # Template file for 'python3-responses'
 pkgname=python3-responses
-version=0.25.3
-revision=2
+version=0.25.6
+revision=1
 build_style=python3-pep517
 hostmakedepends="python3-setuptools python3-wheel"
 depends="python3-requests python3-urllib3 python3-yaml"
@@ -13,8 +13,4 @@ license="Apache-2.0"
 homepage="https://github.com/getsentry/responses"
 changelog="https://raw.githubusercontent.com/getsentry/responses/master/CHANGES"
 distfiles="${PYPI_SITE}/r/responses/responses-${version}.tar.gz"
-checksum=617b9247abd9ae28313d57a75880422d55ec63c29d33d629697590a034358dba
-
-post_install() {
-	rm -r ${DESTDIR}/${py3_sitelib}/responses/tests
-}
+checksum=eae7ce61a9603004e76c05691e7c389e59652d91e94b419623c12bbfb8e331d8

--- a/srcpkgs/python3-rpds-py/template
+++ b/srcpkgs/python3-rpds-py/template
@@ -1,7 +1,7 @@
 # Template file for 'python3-rpds-py'
 pkgname=python3-rpds-py
-version=0.20.0
-revision=2
+version=0.23.1
+revision=1
 build_style=python3-pep517
 build_helper=rust
 hostmakedepends="cargo maturin"
@@ -14,7 +14,7 @@ license="MIT"
 homepage="https://github.com/crate-py/rpds"
 changelog="https://github.com/crate-py/rpds/releases"
 distfiles="${PYPI_SITE}/r/rpds-py/rpds_py-${version}.tar.gz"
-checksum=d72a210824facfdaf8768cf2d7ca25a042c30320b3020de2fa04640920d4e121
+checksum=7f3240dcfa14d198dba24b8b9cb3b108c06b68d45b7babd9eefc1038fdf7e707
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
- **python3-py-cpuinfo: update to 9.0.0.**
- **python3-pytest-benchmark: update to 5.1.0.**
- **python3-fastjsonschema: update to 2.21.1.**
- **python3-attrs: update to 25.1.0.**
- **python3-rpds-py: update to 0.23.1.**
- **python3-referencing: update to 0.36.2.**
- **python3-jsonschema-specifications: update to 2024.10.1.**
- **python3-isodate: update to 0.7.2.**
- **python3-pytest-asyncio: update to 0.25.3.**
- **python3-coverage: update to 7.6.12.**
- **python3-pytest-httpserver: update to 1.1.2.**
- **python3-responses: update to 0.25.6.**
- **python3-pathable: update to 0.4.4.**
- **python3-jsonschema-path: update to 0.3.4.**
- **python3-lazy-object-proxy: update to 1.10.0.**
- **python3-openapi-schema-validator: update to 0.6.3.**
- **python3-openapi-core: update to 0.19.4.**

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
