### PR TITLE
kcachegrind: update to 24.12.2.

### DIFF
--- a/srcpkgs/kcachegrind/template
+++ b/srcpkgs/kcachegrind/template
@@ -1,6 +1,6 @@
 # Template file for 'kcachegrind'
 pkgname=kcachegrind
-version=24.08.0
+version=24.12.2
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
@@ -17,5 +17,5 @@ license="GPL-2.0-only, GFDL-1.2-only"
 homepage="https://kde.org/applications/development/kcachegrind/"
 changelog="https://kde.org/announcements/changelogs/gear/${version}/#kcachegrind"
 distfiles="${KDE_SITE}/release-service/${version}/src/kcachegrind-${version}.tar.xz"
-checksum=3378ee7e6722172044176ca1c0f07b850bb1cece9a1564ac48ecb4f3dbfa7170
+checksum=3dc95c6ddcb7c59bfa8963c0f839ea343bce74b9209cb379273eda85cdbd8548
 python_version=3


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture (x86_64)
- I built this PR locally for these architectures using specific masterdirs:
  - x86_64-musl
  - i686
- I built this PR locally for these architectures (crossbuilds):
  - aarch64
  - aarch64-musl
  - armv7l
  - armv7l-musl
  - armv6l
  - armv6l-musl