### PR TITLE
efibootmgr: add bootnum to bootorder

### DIFF
--- a/srcpkgs/efibootmgr/files/README.voidlinux
+++ b/srcpkgs/efibootmgr/files/README.voidlinux
@@ -14,6 +14,3 @@ but you always have to reconfigure the kernel:
 
 This is also required after the first installation of this package.
 -----------------------------------------------------------------------
-The bootorder itself is not changed, so your previous boot loader will
-stay enabled until you can edit the order in your firmware interface or
-using "efibootmgr -o <hexnum>"

--- a/srcpkgs/efibootmgr/files/kernel.d/efibootmgr.post-install
+++ b/srcpkgs/efibootmgr/files/kernel.d/efibootmgr.post-install
@@ -22,24 +22,13 @@ if [ "x${PART}" != x ]; then
 	args="$args -p $PART"
 fi
 
-# get major version, e.g. "4.8" for "linux4.8"
-major_version=$(echo $PKGNAME | cut -c 6-)
+# look for previous entry for this kernel version
+existing_entry=$(efibootmgr | grep "Void Linux with kernel ${VERSION}")
 
-# look for previous entry for this major kernel version
-existing_entry=$(efibootmgr | grep "Void Linux with kernel ${major_version}")
-
-# get the boot order
-# this is required because when in the next step the existing entry is removed,
-# it is also removed from the order so it needs to be restored later
-bootorder=$(efibootmgr |grep "BootOrder: " |cut -c 12-)
-
-# if existing, remove it
+# if existing, abort
 if [ "$existing_entry" != "" ]; then
-  /etc/kernel.d/post-remove/50-efibootmgr $PKGNAME
+	exit 0
 fi
 
 # create the new entry
-efibootmgr -qc $args -L "Void Linux with kernel ${major_version}" -l /vmlinuz-${VERSION} -u "${OPTIONS}"
-
-# restore the boot order
-efibootmgr -qo $bootorder
+efibootmgr -qc $args -L "Void Linux with kernel ${VERSION}" -l /vmlinuz-${VERSION} -u "${OPTIONS}"

--- a/srcpkgs/efibootmgr/files/kernel.d/efibootmgr.post-remove
+++ b/srcpkgs/efibootmgr/files/kernel.d/efibootmgr.post-remove
@@ -11,11 +11,8 @@ if [ "x${MODIFY_EFI_ENTRIES}" != x1 ]; then
 	exit 0
 fi
 
-# get major version, e.g. "4.8" for "linux4.8"
-major_version=$(echo $PKGNAME | cut -c 6-)
-
 # get hex number of the matching entry
-hexnum=$(efibootmgr | grep "Void Linux with kernel ${major_version}" | cut -c "5-8")
+hexnum=$(efibootmgr | grep "Void Linux with kernel ${VERSION}" | cut -c "5-8")
 
 # delete it
 [ "$hexnum" ] && efibootmgr -Bq -b $hexnum

--- a/srcpkgs/efibootmgr/template
+++ b/srcpkgs/efibootmgr/template
@@ -1,7 +1,7 @@
 # Template file for 'efibootmgr'
 pkgname=efibootmgr
 version=18
-revision=1
+revision=2
 hostmakedepends="pkg-config"
 makedepends="libefivar-devel popt-devel"
 short_desc="Tool to modify UEFI Firmware Boot Manager Variables"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)

This aims to make the efibootmgr kernel hook more intuitive. It also fixes several issues with the current implementation.

We now create a boot entry for each kernel version instead of just the major kernel version. This allows us to boot into the previous kernel in the event of a bad kernel update.

We now also let the hook manage the boot order. This means you no longer need to manually specify the boot order with `efibootmgr -o`. Simply update and reboot, it just works. This fixes error messages from efibootmgr when the boot order has an entry that doesn't exist or the boot order itself is null.

**Note**:

If you change the kernel parameters in `/etc/default/efibootmgr-kernel-hook`, you need to manually delete the existing boot entry first with `efibootmgr -B -b <hexnum>` before running the hook again.