### PR TITLE
davmail: update to 6.3.0.

### DIFF
--- a/srcpkgs/davmail/template
+++ b/srcpkgs/davmail/template
@@ -1,8 +1,8 @@
 # Template file for 'davmail'
 pkgname=davmail
-version=6.2.2
+version=6.3.0
 revision=1
-_commit=3546
+_commit=3627
 hostmakedepends="openjdk8 apache-ant"
 depends="virtual?java-runtime"
 short_desc="POP/IMAP/SMTP/Caldav/Carddav/LDAP exchange gateway"
@@ -11,7 +11,7 @@ license="GPL-2.0-only"
 homepage="https://davmail.sourceforge.net"
 changelog="https://raw.githubusercontent.com/mguessan/davmail/master/RELEASE-NOTES.md"
 distfiles="${SOURCEFORGE_SITE}/davmail/davmail-src-${version}-${_commit}.tgz"
-checksum=5da4ad73d378fb70ab73a0f262ba359311c244eb618a904e6887c3805f438e3d
+checksum=9d2d3ed68ac1e292a6039bd42b34fa7242e94b3986d049ac87baaea24ac8981f
 
 do_build() {
 	. /etc/profile.d/jdk.sh


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**


#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - None

#### Notice

I'd love to switch to Github releases, but sadly the author does not reliably [tag his releases here](https://github.com/mguessan/davmail/tags).
