### PR TITLE
libfido2: use upstream group "plugdev" for udev

### DIFF
--- a/srcpkgs/libfido2/INSTALL.msg
+++ b/srcpkgs/libfido2/INSTALL.msg
@@ -1,0 +1,3 @@
+Group access to FIDO2 devices has been changed to group "plugdev".
+If you are not using elogind as your session manager, make sure to
+add yourself to that group.

--- a/srcpkgs/libfido2/template
+++ b/srcpkgs/libfido2/template
@@ -1,7 +1,7 @@
 # Template file for 'libfido2'
 pkgname=libfido2
 version=1.15.0
-revision=1
+revision=2
 build_style=cmake
 configure_args="-DUDEV_RULES_DIR=/usr/lib/udev/rules.d"
 hostmakedepends="pkg-config"
@@ -23,8 +23,6 @@ post_extract() {
 
 post_install() {
 	vlicense LICENSE
-	vsed -e 's/GROUP="plugdev"/GROUP="users"/' \
-		-i ${DESTDIR}/usr/lib/udev/rules.d/70-u2f.rules
 }
 
 libfido2-devel_package() {


### PR DESCRIPTION
Proposal to change group permissions from "users" to "plugdev" for accessing FIDO2 devices.

This has been previously discussed in #39688, I could not find a follow-up PR so I created this.