### PR TITLE
Plasma: update to 6.3.2, libdisplay-info: update to 0.2

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -4501,7 +4501,7 @@ libdatachannel.so.0.20 libdatachannel-0.20.2_1
 libgeotiff.so.5 libgeotiff-1.7.1_1
 libdraco.so.8 draco-1.5.6_1
 libpdalcpp.so.17 libpdal-2.7.0_1
-libdisplay-info.so.1 libdisplay-info-0.1.1_1
+libdisplay-info.so.2 libdisplay-info-0.2.0_1
 libsqsh.so.1 libsqsh-1.3.0_1
 libunicode.so.0.4 libunicode-0.4.0_1
 libunicode_ucd.so.0.4 libunicode-0.4.0_1

--- a/common/shlibs
+++ b/common/shlibs
@@ -952,8 +952,8 @@ liblilv-0.so.0 liblilv-0.14.4_1
 libsuil-0.so.0 suil-0.6.4_1
 libmcpp.so.0 libmcpp-2.7.2_1
 libjitterentropy.so.3 jitterentropy-3.0.0_1
-libkdecorations2.so.6 kf6-kdecoration-6.0.0_1
-libkdecorations2private.so.11 kf6-kdecoration-6.0.0_1
+libkdecorations3.so.6 kf6-kdecoration-6.3.2_1
+libkdecorations3private.so.2 kf6-kdecoration-6.3.2_1
 libGlacier2.so.37 libIce-3.7.5_2
 libGlacier2CryptPermissionsVerifier.so.37 libIce-3.7.5_2
 libIce.so.37 libIce-3.7.5_2

--- a/srcpkgs/breeze-qt5/template
+++ b/srcpkgs/breeze-qt5/template
@@ -1,6 +1,6 @@
 # Template file for 'breeze-qt5'
 pkgname=breeze-qt5
-version=6.2.5
+version=6.3.2
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF -DBUILD_QT6=OFF -DKF5_HOST_TOOLING=/usr/lib/cmake"
@@ -13,7 +13,7 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later"
 homepage="https://invent.kde.org/plasma/breeze"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname%-qt5}-${version}.tar.xz"
-checksum=1d3bd4481bb7cd274a13ac5d5852be51ff2975e620872dfc22fbd531bad04e25
+checksum=065cf397152ae1a3f24e8fc3aa0e15fa40535fc4576d433a8bf3a23a03ea5f9a
 replaces="breeze<6.0.0_1"
 
 post_install() {

--- a/srcpkgs/breeze-qt6/template
+++ b/srcpkgs/breeze-qt6/template
@@ -1,6 +1,6 @@
 # Template file for 'breeze-qt6'
 pkgname=breeze-qt6
-version=6.2.5
+version=6.3.2
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF -DBUILD_QT5=OFF
@@ -19,5 +19,5 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later"
 homepage="https://invent.kde.org/plasma/breeze"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname%-qt6}-${version}.tar.xz"
-checksum=1d3bd4481bb7cd274a13ac5d5852be51ff2975e620872dfc22fbd531bad04e25
+checksum=065cf397152ae1a3f24e8fc3aa0e15fa40535fc4576d433a8bf3a23a03ea5f9a
 replaces="breeze<6.0.0_1 breeze-snow-cursor-theme>=0"

--- a/srcpkgs/discover/template
+++ b/srcpkgs/discover/template
@@ -1,6 +1,6 @@
 # Template file for 'discover'
 pkgname=discover
-version=6.2.5
+version=6.3.2
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake"
@@ -17,4 +17,4 @@ maintainer="1is7ac3 <isaac.qa13@gmail.com>"
 license="GPL-2.0-or-later"
 homepage="https://apps.kde.org/discover"
 distfiles="${KDE_SITE}/plasma/${version}/discover-${version}.tar.xz"
-checksum=8ccbb881392a4bad540ab0bb465637a0e206ef6b53e7bf02e71bc8fb6453a4a4
+checksum=f46b33fd917f07368b9b2ace326762888de18fa2fb4516363c2a53cd4c7eab9d

--- a/srcpkgs/drkonqi/template
+++ b/srcpkgs/drkonqi/template
@@ -1,6 +1,6 @@
 # Template file for 'drkonqi'
 pkgname=drkonqi
-version=6.2.5
+version=6.3.2
 revision=1
 build_style=cmake
 configure_args="-DCMAKE_DISABLE_FIND_PACKAGE_Systemd=ON -DBUILD_TESTING=OFF
@@ -18,4 +18,4 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/plasma/drkonqi"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=f95ec56c702eb1cba48411fd1709d8723849e370ff8ea69981482d6f3a5d5c73
+checksum=d397ac8549fd2e294cf932d4b8e105dfdbadf8b3df34ec1b0f91649f30fa930b

--- a/srcpkgs/flatpak-kcm/template
+++ b/srcpkgs/flatpak-kcm/template
@@ -1,6 +1,6 @@
 # Template file for 'flatpak-kcm'
 pkgname=flatpak-kcm
-version=6.2.5
+version=6.3.2
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
@@ -14,4 +14,4 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later, LGPL-2.1-or-later"
 homepage="https://invent.kde.org/plasma/flatpak-kcm"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=26c87213ad9a394a2b3dc6616051d67c5caa3238baaa88a9afb995dd89673b2e
+checksum=17aa6903245ad498e552b233a137cf3241ff1de01b2cf2185653755546ab28bf

--- a/srcpkgs/kactivitymanagerd/template
+++ b/srcpkgs/kactivitymanagerd/template
@@ -1,6 +1,6 @@
 # Template file for 'kactivitymanagerd'
 pkgname=kactivitymanagerd
-version=6.2.5
+version=6.3.2
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins"
@@ -12,4 +12,4 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later"
 homepage="https://invent.kde.org/plasma/kactivitymanagerd"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=f36e1bbc5c100f4c39d1af007a03c474ea3dd1584592029fe24fbbdb1cf9dad6
+checksum=cf2199f99f563cb0742e22fa593cbe7e5b0a8373ca65e33a234471b115707d6b

--- a/srcpkgs/kcm-wacomtablet/template
+++ b/srcpkgs/kcm-wacomtablet/template
@@ -1,6 +1,6 @@
 # Template file for 'kcm-wacomtablet'
 pkgname=kcm-wacomtablet
-version=6.2.5
+version=6.3.2
 revision=1
 build_style=cmake
 configure_args="-DKF6_HOST_TOOLING=/usr/lib/cmake
@@ -17,7 +17,7 @@ maintainer="Piraty <mail@piraty.dev>"
 license="GPL-2.0-or-later"
 homepage="https://invent.kde.org/plasma/wacomtablet"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname#kcm-}-${version}.tar.xz"
-checksum=e5b36f8e3e56d55c29857d6da7c1e3cec538f703df8a1025766388a07acf387b
+checksum=29baeece4400f3b1136a9d5e7126175cf5600a5b87c37c59a16b6c4611bd3476
 
 do_check() {
 	cd build

--- a/srcpkgs/kde-cli-tools/template
+++ b/srcpkgs/kde-cli-tools/template
@@ -1,6 +1,6 @@
 # Template file for 'kde-cli-tools'
 pkgname=kde-cli-tools
-version=6.2.5
+version=6.3.2
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
@@ -15,7 +15,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later, GPL-2.0-or-later"
 homepage="https://invent.kde.org/plasma/kde-cli-tools"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=1dda57f7495060a086658796519d68d54f5e7da4e12fa6d8d4bf4614ac728002
+checksum=34e89efeca2615ea8819575a1c3595c5bb2b34e0881943cc8b616675a3d7c005
 
 post_install() {
 	ln -sf ../libexec/kf6/kdesu ${DESTDIR}/usr/bin

--- a/srcpkgs/kde-gtk-config/template
+++ b/srcpkgs/kde-gtk-config/template
@@ -1,6 +1,6 @@
 # Template file for 'kde-gtk-config'
 pkgname=kde-gtk-config
-version=6.2.5
+version=6.3.2
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF
@@ -15,7 +15,7 @@ maintainer="Luciogi <githubvoidlinux.supremacy429@passinbox.com>"
 license="GPL-2.0-or-later, LGPL-2.1-or-later"
 homepage="https://invent.kde.org/plasma/kde-gtk-config"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=283f9803a15f13734de6298558f875406a5c7c0ea46e9ffba5647f480bfc6a58
+checksum=04a15b14ddd897f141ce5a4c016f339ca6fa0f3167ebd69419536004df1a0fd7
 
 kde-gtk-config5_package() {
 	short_desc+=" - (Dummy transitional package)"

--- a/srcpkgs/kdeplasma-addons/template
+++ b/srcpkgs/kdeplasma-addons/template
@@ -1,6 +1,6 @@
 # Template file for 'kdeplasma-addons'
 pkgname=kdeplasma-addons
-version=6.2.5
+version=6.3.2
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
@@ -18,7 +18,7 @@ maintainer="Luciogi <githubvoidlinux.supremacy429@passinbox.com>"
 license="GPL-2.0-or-later, LGPL-2.1-or-later"
 homepage="https://invent.kde.org/plasma/kdeplasma-addons"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=57d138d5101adbb8092c424c58ceb73e1d05d0cce3ec4a354432744dbd17e426
+checksum=aa9b447bbf17d9f74b289e8984087adfc886eec5457651402e1ae61fff273a32
 
 if [ "$XBPS_WORDSIZE$XBPS_WORDSIZE" = "64$XBPS_TARGET_WORDSIZE" ]; then
 	makedepends+=" qt6-webengine-devel"

--- a/srcpkgs/kf6-kdecoration/template
+++ b/srcpkgs/kf6-kdecoration/template
@@ -1,6 +1,6 @@
 # Template file for 'kf6-kdecoration'
 pkgname=kf6-kdecoration
-version=6.2.5
+version=6.3.2
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF"
@@ -11,7 +11,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/plasma/kdecoration"
 distfiles="${KDE_SITE}/plasma/${version}/kdecoration-${version}.tar.xz"
-checksum=726c58cd4b34fc49546578727a447c76242938add577292cd334bd60bf9d8f26
+checksum=a6f0dd8b341cae979a2816c5a0d87b286148e41026717a2d512980596f1fad2b
 
 kf6-kdecoration-devel_package() {
 	conflicts="kdecoration-devel>=0"

--- a/srcpkgs/kf6-kwayland/template
+++ b/srcpkgs/kf6-kwayland/template
@@ -1,6 +1,6 @@
 # Template file for 'kf6-kwayland'
 pkgname=kf6-kwayland
-version=6.2.5
+version=6.3.2
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF"
@@ -13,7 +13,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/plasma/kwayland"
 distfiles="${KDE_SITE}/plasma/${version}/kwayland-${version}.tar.xz"
-checksum=2a17a8ce5643fd51c3cf787542032c1050da3a1fb00dcc9a32dea288bd38d7d2
+checksum=6e6c877b7e6f001a7717c3b02b53905bc920a5b76dcb24fa81b1a33bc35b86e3
 
 kf6-kwayland-devel_package() {
 	short_desc+=" - development"

--- a/srcpkgs/kgamma/template
+++ b/srcpkgs/kgamma/template
@@ -1,6 +1,6 @@
 # Template file for 'kgamma'
 pkgname=kgamma
-version=6.2.5
+version=6.3.2
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
@@ -14,7 +14,7 @@ maintainer="Luciogi <githubvoidlinux.supremacy429@passinbox.com>"
 license="GPL-2.0-or-later"
 homepage="https://invent.kde.org/plasma/kgamma"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=3df75cdcb020acfd216e9a722404d381c8a4d97262be85f6704b189e665610ce
+checksum=f5c9446a44b28c7472f787bd32104078d51f7959ef56c86c4d2c195f3552c901
 
 kgamma5_package() {
 	build_style=meta

--- a/srcpkgs/kglobalacceld/template
+++ b/srcpkgs/kglobalacceld/template
@@ -1,6 +1,6 @@
 # Template file for 'kglobalacceld'
 pkgname=kglobalacceld
-version=6.2.5
+version=6.3.2
 revision=1
 build_style=cmake
 configure_args="-DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins"
@@ -13,7 +13,7 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-3.0-or-later"
 homepage="https://invent.kde.org/plasma/kglobalacceld"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=94b5cc3780ca6b074093c487ec9e6c3460f635ae5145780f87c0fe8484d8c6c9
+checksum=a3263e42fb74ef087d263a25c7e3a55a960872262dbb4acfcf23514a3686b419
 
 do_check() {
 	cd build

--- a/srcpkgs/kinfocenter/template
+++ b/srcpkgs/kinfocenter/template
@@ -1,6 +1,6 @@
 # Template file for 'kinfocenter'
 pkgname=kinfocenter
-version=6.2.5
+version=6.3.2
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
@@ -15,4 +15,4 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later, LGPL-2.1-or-later, GFDL-1.2-only"
 homepage="https://invent.kde.org/plasma/kinfocenter"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=9ed87edb3a24256189f8dc79c821b8f45589aab7032d8dde78d5d94cf0639ff9
+checksum=c9269e50c451fd7b880b81013bdbdcddec14ba24e6f0b5d95fd035bd26eac5eb

--- a/srcpkgs/kmenuedit/template
+++ b/srcpkgs/kmenuedit/template
@@ -1,6 +1,6 @@
 # Template file for 'kmenuedit'
 pkgname=kmenuedit
-version=6.2.5
+version=6.3.2
 revision=1
 build_style=cmake
 configure_args="-DKF6_HOST_TOOLING=/usr/lib/cmake"
@@ -14,4 +14,4 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later"
 homepage="https://invent.kde.org/plasma/kmenuedit"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=0908645f4fc24a00b023d0537cac6dee7b7abad75c7980b4a01c6c098ded684a
+checksum=423ff6f4c887841b2486d201c0475591ee46f81fae77bc42acad7f0623a0a486

--- a/srcpkgs/kodi/template
+++ b/srcpkgs/kodi/template
@@ -1,7 +1,7 @@
 # Template file for 'kodi'
 pkgname=kodi
 version=21.1
-revision=1
+revision=2
 _codename="Omega"
 _crossguid_ver="ca1bf4b810e2d188d04cb6286f957008ee1b7681"
 _dvdcss_ver="1.4.3-Next-Nexus-Alpha2-2"

--- a/srcpkgs/kpipewire/template
+++ b/srcpkgs/kpipewire/template
@@ -1,6 +1,6 @@
 # Template file for 'kpipewire'
 pkgname=kpipewire
-version=6.2.5
+version=6.3.2
 revision=1
 build_style=cmake
 configure_args="-DKDE_INSTALL_QMLDIR=lib/qt6/qml"
@@ -16,7 +16,7 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-3.0-or-later"
 homepage="https://invent.kde.org/plasma/kpipewire"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=db42d581f0ca427bd80ee6a67d1fa9cef01114266c9aee7faa2cecbd973e6319
+checksum=b5face07052e0ec1db21e31bae3243d6376316f78be06c77d9d5be5b6b001dc4
 
 do_check() {
 	cd build

--- a/srcpkgs/krdp/template
+++ b/srcpkgs/krdp/template
@@ -1,6 +1,6 @@
 # Template file for 'krdp'
 pkgname=krdp
-version=6.2.5
+version=6.3.2
 revision=1
 build_style=cmake
 configure_args="-DKF6_HOST_TOOLING=/usr/lib/cmake
@@ -17,4 +17,4 @@ maintainer="Luciogi <githubvoidlinux.supremacy429@passinbox.com>"
 license="LGPL-2.0-or-later"
 homepage="https://invent.kde.org/plasma/krdp"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=1a8d37e3db91e80cae9e22bf1c5986985c4279de2456ba7bc481c725c34a73fc
+checksum=f18384fe7507f48e96dac6e79a25b67af4532dc469c3d7af3afe6e19a7042bb3

--- a/srcpkgs/kscreen/template
+++ b/srcpkgs/kscreen/template
@@ -1,6 +1,6 @@
 # Template file for 'kscreen'
 pkgname=kscreen
-version=6.2.5
+version=6.3.2
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
@@ -16,4 +16,4 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later, LGPL-2.1-or-later"
 homepage="https://invent.kde.org/plasma/kscreen"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=6237c47fe70384d10e6f20d7f058c6aacca51a493da928077fcec91b0ef69642
+checksum=b75a3ddc25b287df6f61f5afdfa0c561460f868ba797e2de42332f49bc63831e

--- a/srcpkgs/kscreenlocker/template
+++ b/srcpkgs/kscreenlocker/template
@@ -1,6 +1,6 @@
 # Template file for 'kscreenlocker'
 pkgname=kscreenlocker
-version=6.2.5
+version=6.3.2
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
@@ -16,7 +16,7 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later"
 homepage="https://invent.kde.org/plasma/kscreenlocker"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=3a3ed2d040394dc2a80cf25cdd2a6c4022146aca54e72c44af16e8982e8b8e4e
+checksum=1c614c287eeb0d7eb9d29dbae856761d82c57c380fd716d042dba63794aa82de
 
 kscreenlocker-devel_package() {
 	short_desc+=" - development files"

--- a/srcpkgs/ksshaskpass/template
+++ b/srcpkgs/ksshaskpass/template
@@ -1,6 +1,6 @@
 # Template file for 'ksshaskpass'
 pkgname=ksshaskpass
-version=6.2.5
+version=6.3.2
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake"
@@ -12,5 +12,5 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later"
 homepage="https://invent.kde.org/plasma/ksshaskpass"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=85e71c8037d5d2199f861ae707189f42a7caed2f03743ea83b7570c34a11eb72
+checksum=3ede4f622c242779a2e80a0953f2396665847b87f691fe1e60548d311a084659
 alternatives="ssh-askpass:/usr/libexec/ssh-askpass:/usr/bin/ksshaskpass"

--- a/srcpkgs/ksystemstats/template
+++ b/srcpkgs/ksystemstats/template
@@ -1,6 +1,6 @@
 # Template file for 'ksystemstats'
 pkgname=ksystemstats
-version=6.2.5
+version=6.3.2
 revision=1
 build_style=cmake
 configure_args="-DKDE_INSTALL_QMLDIR=lib/qt6/qml
@@ -13,7 +13,7 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-3.0-only,LGPL-3.0-only"
 homepage="https://invent.kde.org/plasma/ksystemstats"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=efff56f55e6fe5ed4231a47a44c8d08d3d46fd10d74d186344ef4f2fcd9595a1
+checksum=caa42877019f33cf597ea1350e7c3d1b163a10db7f10021293a7c79b35dd6003
 
 do_check() {
 	cd build

--- a/srcpkgs/kwallet-pam/template
+++ b/srcpkgs/kwallet-pam/template
@@ -1,6 +1,6 @@
 # Template file for 'kwallet-pam'
 pkgname=kwallet-pam
-version=6.2.5
+version=6.3.2
 revision=1
 build_style=cmake
 hostmakedepends="extra-cmake-modules qt6-base qt6-tools pkg-config"
@@ -11,5 +11,5 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/plasma/kwallet-pam"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=0168d4f2397ae289ae027a7d202b0ffd5f8d7a19b233ebfa6417b843841bfd44
+checksum=974d6327b411d1770ff36282914798d78fcc9a063021db1b6774efa1867fcb7a
 conflicts="kwallet<=5.115.0_1"

--- a/srcpkgs/kwayland-integration/template
+++ b/srcpkgs/kwayland-integration/template
@@ -1,6 +1,6 @@
 # Template file for 'kwayland-integration'
 pkgname=kwayland-integration
-version=6.2.5
+version=6.3.2
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins"
@@ -14,4 +14,4 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/plasma/kwayland-integration"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=06b6fb7ddcf19c727716f476b7224e230f4986c7e3d36066e918859fdc3b4413
+checksum=aecac7266dc7913ab104c6b078e5a5b8ba5991181f0e3b114b09e3d7ffad3a14

--- a/srcpkgs/kwin/template
+++ b/srcpkgs/kwin/template
@@ -1,6 +1,6 @@
 # Template file for 'kwin'
 pkgname=kwin
-version=6.2.5
+version=6.3.2.1
 revision=1
 build_style=cmake
 build_helper=qemu
@@ -27,8 +27,8 @@ short_desc="KDE Window manager"
 maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later"
 homepage="https://invent.kde.org/plasma/kwin"
-distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=5cc450a6e41105c8c49929b72550b331237f96aafb294690f4707bdc5f776848
+distfiles="${KDE_SITE}/plasma/${version%.*}/${pkgname}-${version}.tar.xz"
+checksum=e6123eda2b1fd9f65b36061fdacf96234068d1e24fa7a3352288f4d51b2fc4c2
 replaces="kwayland-server>=0"
 
 kwin-devel_package() {

--- a/srcpkgs/kwrited/template
+++ b/srcpkgs/kwrited/template
@@ -1,6 +1,6 @@
 # Template file for 'kwrited'
 pkgname=kwrited
-version=6.2.5
+version=6.3.2
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins"
@@ -11,4 +11,4 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later"
 homepage="https://invent.kde.org/plasma/kwrited"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=04794f10917a0a94167962015cfbb057c9802061fff91b027de01a3e6937d792
+checksum=041c45a5cf69bd3437be795e982bdf9f55b4f76e1d27858a116ab319940febb1

--- a/srcpkgs/layer-shell-qt/template
+++ b/srcpkgs/layer-shell-qt/template
@@ -1,6 +1,6 @@
 # Template file for 'layer-shell-qt'
 pkgname=layer-shell-qt
-version=6.2.5
+version=6.3.2
 revision=1
 build_style=cmake
 configure_args="-DKDE_INSTALL_QMLDIR=lib/qt6/qml
@@ -14,7 +14,7 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-3.0-or-later"
 homepage="https://invent.kde.org/plasma/layer-shell-qt"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=bc09870218df387c377bad2fed4b2a8f39121ddbdc5c6bb28a40be0c1b000c77
+checksum=a0ec72ba8cd6a6bd37cbc185135e03d64835cc112364c0a05a4eda360ec21500
 
 layer-shell-qt-devel_package() {
 	depends="${sourcepkg}>=${version}_${revision}"

--- a/srcpkgs/libdisplay-info/template
+++ b/srcpkgs/libdisplay-info/template
@@ -1,6 +1,6 @@
 # Template file for 'libdisplay-info'
 pkgname=libdisplay-info
-version=0.1.1
+version=0.2.0
 revision=1
 build_style=meson
 hostmakedepends="hwids"
@@ -9,7 +9,7 @@ maintainer="John <me@johnnynator.dev>"
 license="MIT"
 homepage="https://gitlab.freedesktop.org/emersion/libdisplay-info/"
 distfiles="https://gitlab.freedesktop.org/emersion/libdisplay-info/-/archive/${version}/libdisplay-info-${version}.tar.gz"
-checksum=a5aeef57817916286526292ec816a5338c4d3c0094ce91e584fc82b57070a44f
+checksum=f7331fcaf5527251b84c8fb84238d06cd2f458422ce950c80e86c72927aa8c2b
 # tests require currently unpacakged edid-decode
 make_check=no
 

--- a/srcpkgs/libkf6screen/template
+++ b/srcpkgs/libkf6screen/template
@@ -1,6 +1,6 @@
 # Template file for 'libkf6screen'
 pkgname=libkf6screen
-version=6.2.5
+version=6.3.2
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF
@@ -14,7 +14,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/plasma/libkscreen"
 distfiles="${KDE_SITE}/plasma/${version}/libkscreen-${version}.tar.xz"
-checksum=5edaf6fa2eed6ddcef4bc479f4bb15d3481acb60adf0150e9f9a1382607bbcb8
+checksum=f893d171fbd6c4fda43941a242885ed6e9abe77ef52afeccaf6f0fc70ea594e2
 
 libkf6screen-devel_package() {
 	short_desc+=" - development"

--- a/srcpkgs/libksysguard/template
+++ b/srcpkgs/libksysguard/template
@@ -1,6 +1,6 @@
 # Template file for 'libksysguard'
 pkgname=libksysguard
-version=6.2.5
+version=6.3.2
 revision=1
 build_style=cmake
 configure_args="-DKF6_HOST_TOOLING=/usr/lib/cmake
@@ -17,7 +17,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/plasma/libksysguard"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=9694f3d6b5078b4d82eb8e6ed34eb20e2d109ed7c2234c59a640bc32f31c76ab
+checksum=13323f687843f3e4f37f260a9f90ee3a477dde9cb1f03e6a5e5f455ea88ad595
 
 build_options="webengine"
 

--- a/srcpkgs/libplasma/template
+++ b/srcpkgs/libplasma/template
@@ -1,6 +1,6 @@
 # Template file for 'libplasma'
 pkgname=libplasma
-version=6.2.5
+version=6.3.2
 revision=1
 build_style=cmake
 configure_args="-DKF6_HOST_TOOLING=/usr/lib/cmake
@@ -20,7 +20,7 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-3.0-or-later"
 homepage="https://invent.kde.org/plasma/libplasma"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=af770f5fef978512c70491889516fb769d340f00a02270987d2d1d17753658ec
+checksum=ff95009767ec9d73ec482fc1e5a0c9024b8227a2478f9e371a572cd6b0e5a4ae
 
 do_check() {
 	cd build

--- a/srcpkgs/libxfce4windowing/template
+++ b/srcpkgs/libxfce4windowing/template
@@ -1,7 +1,7 @@
 # Template file for 'libxfce4windowing'
 pkgname=libxfce4windowing
 version=4.20.2
-revision=1
+revision=2
 build_style=meson
 build_helper=gir
 hostmakedepends="wayland-devel pkg-config xfce4-dev-tools glib-devel gettext"

--- a/srcpkgs/milou/template
+++ b/srcpkgs/milou/template
@@ -1,6 +1,6 @@
 # Template file for 'milou'
 pkgname=milou
-version=6.2.5
+version=6.3.2
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF -DKDE_INSTALL_QMLDIR=lib/qt6/qml"
@@ -14,4 +14,4 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later, LGPL-2.1-or-later"
 homepage="https://invent.kde.org/plasma/milou"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=833bcaeafe292e85eff353e09b0631f603ae2121e8d1d6fe061b1f632017accf
+checksum=cc348d1d45199ac314e3907507bdebfe2a5ff02f09f53164720fd1c25a241998

--- a/srcpkgs/mutter/template
+++ b/srcpkgs/mutter/template
@@ -1,7 +1,7 @@
 # Template file for 'mutter'
 pkgname=mutter
 version=47.5
-revision=1
+revision=2
 build_helper="gir"
 build_style=meson
 configure_args="-Degl_device=true -Dudev=true -Dnative_backend=true

--- a/srcpkgs/niri/template
+++ b/srcpkgs/niri/template
@@ -1,6 +1,6 @@
 # Template file for 'niri'
 pkgname=niri
-version=25.01
+version=25.02
 revision=1
 build_style=cargo
 configure_args="--no-default-features --features dbus,xdp-gnome-screencast"
@@ -13,7 +13,7 @@ license="GPL-3.0-or-later"
 homepage="https://github.com/YaLTeR/niri"
 changelog="https://github.com/YaLTeR/niri/releases"
 distfiles="https://github.com/YaLTeR/niri/archive/refs/tags/v${version}.tar.gz"
-checksum=86b89bcfc3fc6a8ed81f9e3f0ac7a29bd30267515efb2c19e1e0bc2ccd67b649
+checksum=602b1f38c6ab01b19e95ac2ef86d7c91dfa9b212437d62fb40def9664c1419d6
 
 pre_check() {
 	export XDG_RUNTIME_DIR=$(mktemp -d "$wrksrc/runtime.XXXXXX")

--- a/srcpkgs/oxygen-qt5/template
+++ b/srcpkgs/oxygen-qt5/template
@@ -1,6 +1,6 @@
 # Template file for 'oxygen-qt5'
 pkgname=oxygen-qt5
-version=6.2.5
+version=6.3.2
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF -DBUILD_QT6=OFF"
@@ -14,7 +14,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later, GPL-2.0-or-later"
 homepage="https://invent.kde.org/plasma/oxygen"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname%-qt5}-${version}.tar.xz"
-checksum=6d772dd509c2bfd03d7f801e45eff151f344172900bae05bb16d8ba2f8d3b7dc
+checksum=4921d8f6e6992f3416ee31765916ab882ee1c2d20220fbc52e9c5a0ec4c219ca
 
 post_install() {
 	rm -rf ${DESTDIR}/usr/share

--- a/srcpkgs/oxygen-qt6/template
+++ b/srcpkgs/oxygen-qt6/template
@@ -1,6 +1,6 @@
 # Template file for 'oxygen-qt6'
 pkgname=oxygen-qt6
-version=6.2.5
+version=6.3.2
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF -DBUILD_QT5=OFF
@@ -15,4 +15,4 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later, GPL-2.0-or-later"
 homepage="https://invent.kde.org/plasma/oxygen"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname%-qt6}-${version}.tar.xz"
-checksum=6d772dd509c2bfd03d7f801e45eff151f344172900bae05bb16d8ba2f8d3b7dc
+checksum=4921d8f6e6992f3416ee31765916ab882ee1c2d20220fbc52e9c5a0ec4c219ca

--- a/srcpkgs/oxygen-sounds/template
+++ b/srcpkgs/oxygen-sounds/template
@@ -1,6 +1,6 @@
 # Template file for 'oxygen-sounds'
 pkgname=oxygen-sounds
-version=6.2.5
+version=6.3.2
 revision=1
 build_style=cmake
 hostmakedepends="extra-cmake-modules"
@@ -9,4 +9,4 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-3.0-or-later"
 homepage="https://invent.kde.org/plasma/oxygen-sounds"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=ee083c672b76005dfde340902cf0302ca081b359caa566679334da967e8f75b4
+checksum=1517b495498a406f28aacb0dbb4ce3f75a923600ee192427266cba0b532f60a0

--- a/srcpkgs/plasma-activities-stats/template
+++ b/srcpkgs/plasma-activities-stats/template
@@ -1,6 +1,6 @@
 # Template file for 'plasma-activities-stats'
 pkgname=plasma-activities-stats
-version=6.2.5
+version=6.3.2
 revision=1
 build_style=cmake
 hostmakedepends="extra-cmake-modules qt6-base qt6-tools"
@@ -11,7 +11,7 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-3.0-or-later"
 homepage="https://invent.kde.org/plasma/plasma-activities-stats"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=cddba25924651e0f5de74a6faabc8990301857bb31f4ee4ac1f69d7a0c48532c
+checksum=019f431b150ecfdecfeb2c394e84551a53f901d56be4cc4b9fc5698c09147095
 
 plasma-activities-stats-devel_package() {
 	depends="${sourcepkg}>=${version}_${revision}"

--- a/srcpkgs/plasma-activities/template
+++ b/srcpkgs/plasma-activities/template
@@ -1,6 +1,6 @@
 # Template file for 'plasma-activities'
 pkgname=plasma-activities
-version=6.2.5
+version=6.3.2
 revision=1
 build_style=cmake
 configure_args="-DKDE_INSTALL_QMLDIR=lib/qt6/qml
@@ -15,7 +15,7 @@ maintainer="John <me@johnnynator.dev>"
 license="(LGPL-2.1-only OR LGPL-3.0-only) AND GPL-2.0-or-later"
 homepage="https://invent.kde.org/plasma/plasma-activities"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=77ea739c7ce5170d92d78d6f3765e19a32f0e24b741f525555d59dc7de15e6c7
+checksum=9a20300f30ad9d785c1e20b12b20fe0259e83947b550d10ea63ab1f91f1dd675
 
 plasma-activities-devel_package() {
 	depends="${sourcepkg}>=${version}_${revision}"

--- a/srcpkgs/plasma-browser-integration/patches/615c9f71840dedb58bb1c391c988cd6accbf2642.patch
+++ b/srcpkgs/plasma-browser-integration/patches/615c9f71840dedb58bb1c391c988cd6accbf2642.patch
@@ -1,0 +1,17 @@
+--- a/flatpak-integrator/plugin.cpp
++++ b/flatpak-integrator/plugin.cpp
+@@ -143,7 +143,14 @@ private:
+     {
+         constexpr auto maxBufferSize = 1024;
+         thread_local std::array<char, maxBufferSize> buffer;
++#ifdef STRERROR_R_CHAR_P
+         return strerror_r(error, buffer.data(), buffer.size());
++#else
++        // Won't be changed by strerror_r but not const so compiler doesn't throw an error
++        static char unknown[] = "unknown error";
++
++        return strerror_r(error, buffer.data(), buffer.size()) ? unknown : buffer.data();
++#endif
+     }
+ 
+     int openNoSymlinks(const std::filesystem::path &path, int flags, mode_t mode = 0)

--- a/srcpkgs/plasma-browser-integration/template
+++ b/srcpkgs/plasma-browser-integration/template
@@ -1,6 +1,6 @@
 # Template file for 'plasma-browser-integration'
 pkgname=plasma-browser-integration
-version=6.2.5
+version=6.3.2
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF
@@ -15,4 +15,4 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-3.0-or-later"
 homepage="https://invent.kde.org/plasma/plasma-browser-integration"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=25da9051669f20a1bf9bd8987d95621b2e664131a3c38701a3c5e2f86d9b5dce
+checksum=151474e9cce936282d8412483f99e526c5f199a30488515c61a22612777578ef

--- a/srcpkgs/plasma-desktop/template
+++ b/srcpkgs/plasma-desktop/template
@@ -1,6 +1,6 @@
 # Template file for 'plasma-desktop'
 pkgname=plasma-desktop
-version=6.2.5
+version=6.3.2
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF
@@ -23,7 +23,7 @@ makedepends="kf6-kauth-devel kf6-kcrash-devel kf6-kdoctools-devel
  libaccounts-qt6-devel signon-plugin-oauth2 SDL2-devel plasma-workspace-devel
  ibus-devel libXcursor-devel libXi-devel libxkbfile-devel libxkbcommon-devel
  xf86-input-evdev-devel xf86-input-libinput-devel qt6-base-private-devel
- qt6-wayland-devel"
+ qt6-wayland-devel libwacom-devel"
 depends="kmenuedit polkit-kde-agent powerdevil systemsettings
  accountsservice ksystemstats xdg-user-dirs noto-fonts-emoji"
 short_desc="KDE Plasma Desktop"
@@ -31,6 +31,6 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later, LGPL-2.0-or-later, LGPL-2.1-or-later, GFDL-1.2-or-later"
 homepage="https://invent.kde.org/plasma/plasma-desktop"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=b73d29202031b7049485d84e615d7bd0a3ca890dcb2c22d8116eb8fe6fe9d068
+checksum=5ddead065623e651705b8898ac6124c2ccdc0cfeb47a2c1368a97d2fd2bf6a48
 replaces="user-manager>=0"
 python_version=3

--- a/srcpkgs/plasma-disks/template
+++ b/srcpkgs/plasma-disks/template
@@ -1,6 +1,6 @@
 # Template file for 'plasma-disks'
 pkgname=plasma-disks
-version=6.2.5
+version=6.3.2
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake -Wno-dev
@@ -16,4 +16,4 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later"
 homepage="https://invent.kde.org/plasma/plasma-disks"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=9b514ab7fb0bde0cb1871334ce9ea8115d898dd2890e96ee068ea5a429be7f75
+checksum=36da6e100f988186d574010e582bea09864ace4be6241d27f1d525b2b349e287

--- a/srcpkgs/plasma-firewall/template
+++ b/srcpkgs/plasma-firewall/template
@@ -1,6 +1,6 @@
 # Template file for 'plasma-firewall'
 pkgname=plasma-firewall
-version=6.2.5
+version=6.3.2
 revision=1
 build_style=cmake
 configure_args="-DKF6_HOST_TOOLING=/usr/lib/cmake
@@ -14,4 +14,4 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-only, GPL-3.0-only"
 homepage="https://invent.kde.org/network/plasma-firewall"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=f0e9b7da481a383ac4511210baa998b8c263601f18211b0655f5c9d98157da69
+checksum=ecda6aea5a88793e0b5ff78acd16da2fb9cc4fb1adba432699968b02e15ca4d4

--- a/srcpkgs/plasma-integration/template
+++ b/srcpkgs/plasma-integration/template
@@ -1,6 +1,6 @@
 # Template file for 'plasma-integration'
 pkgname=plasma-integration
-version=6.2.5
+version=6.3.2
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF -DBUILD_QT5=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
@@ -16,4 +16,4 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.0-or-later"
 homepage="https://invent.kde.org/plasma/plasma-integration"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=5795e52285deea10877fd56474473d061071cb425ba87cef3366832d50764729
+checksum=88684d6d4a7fea6500f73b100a08a76571551fe48ac973d040d5e2c211e52860

--- a/srcpkgs/plasma-nm/template
+++ b/srcpkgs/plasma-nm/template
@@ -1,6 +1,6 @@
 # Template file for 'plasma-nm'
 pkgname=plasma-nm
-version=6.2.5
+version=6.3.2
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
@@ -19,7 +19,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/plasma/plasma-nm"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=146d76936ce98558839a9a7cf30fa951b7ee6cd3daa7c32d71ccdf157a4f6c68
+checksum=bae90ad8deccf40489221bae648e3d83e67030e0387dbce55ed9fb3af4ecbeb6
 
 build_options="openconnect"
 

--- a/srcpkgs/plasma-pa/template
+++ b/srcpkgs/plasma-pa/template
@@ -1,6 +1,6 @@
 # Template file for 'plasma-pa'
 pkgname=plasma-pa
-version=6.2.5
+version=6.3.2
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake -Wno-dev
@@ -18,4 +18,4 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/plasma/plasma-pa"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=5179337a7eac4145a953b46146d4899945d9c43373ad60f76692ffc42cf19d47
+checksum=5bae53450d1b5d188781749eab558273514c7eb8e5d387e088489e5db8a405b6

--- a/srcpkgs/plasma-sdk/template
+++ b/srcpkgs/plasma-sdk/template
@@ -1,6 +1,6 @@
 # Template file for 'plasma-sdk'
 pkgname=plasma-sdk
-version=6.2.5
+version=6.3.2
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
@@ -15,4 +15,4 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later, LGPL-2.1-or-later"
 homepage="https://invent.kde.org/plasma/plasma-sdk"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=76bd62e5ef3d9e717f7c45ff58638732b807e7a513942c62472c02b0b2ae3511
+checksum=a1a8dd470dd5f3f4734b9acf1a56d1678e39fe7b515eda0149cb91307ba0a145

--- a/srcpkgs/plasma-systemmonitor/template
+++ b/srcpkgs/plasma-systemmonitor/template
@@ -1,6 +1,6 @@
 # Template file for 'plasma-systemmonitor'
 pkgname=plasma-systemmonitor
-version=6.2.5
+version=6.3.2
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
@@ -17,7 +17,7 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-only, GPL-3.0-only, LGPL-2.1-only, LGPL-3.0-only"
 homepage="https://invent.kde.org/plasma/plasma-systemmonitor"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=9575d4562e68209627aee2f358070b09122cc3e09fee50c90451df52bf00b2ca
+checksum=078a138ea6fea0b3e4d496dea4b0f53c30954d8591f9498fd7f83058e23c1d22
 
 ksysguard_package() {
 	build_style=meta

--- a/srcpkgs/plasma-thunderbolt/template
+++ b/srcpkgs/plasma-thunderbolt/template
@@ -1,6 +1,6 @@
 # Template file for 'plasma-thunderbolt'
 pkgname=plasma-thunderbolt
-version=6.2.5
+version=6.3.2
 revision=1
 build_style=cmake
 configure_args="-DKF6_HOST_TOOLING=/usr/lib/cmake
@@ -14,7 +14,7 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-3.0-or-later"
 homepage="https://invent.kde.org/plasma/plasma-thunderbolt"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=e6c38c7fe844eba6b2d38a06cf3e9f2c51e989893965e1683917c46d94eb24da
+checksum=63911a4577d2c33561490d368cde644f9def9ff9a9ccb36583290f1cff158977
 
 do_check() {
 	: # Requires running dbus and bolt services

--- a/srcpkgs/plasma-vault/template
+++ b/srcpkgs/plasma-vault/template
@@ -1,6 +1,6 @@
 # Template file for 'plasma-vault'
 pkgname=plasma-vault
-version=6.2.5
+version=6.3.2
 revision=1
 build_style=cmake
 configure_args="-DKF6_HOST_TOOLING=/usr/lib/cmake
@@ -15,4 +15,4 @@ maintainer="Giuseppe Fierro <gspe@ae-design.ws>"
 license="GPL-2.0-or-later, LGPL-2.0-or-later, LGPL-2.1-or-later"
 homepage="https://github.com/KDE/plasma-vault"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=6b7e73fc39c6bb5e2c06573ef88a8948eea570608a8e1e49d912389aefa50b4e
+checksum=fd9dbd3deb769bfcfb30fdeae800c706cf485fb544473743bc98b0e887770c53

--- a/srcpkgs/plasma-wayland-protocols/template
+++ b/srcpkgs/plasma-wayland-protocols/template
@@ -1,6 +1,6 @@
 # Template file for 'plasma-wayland-protocols'
 pkgname=plasma-wayland-protocols
-version=1.15.0
+version=1.16.0
 revision=1
 build_style=cmake
 hostmakedepends="extra-cmake-modules wayland-devel"
@@ -10,7 +10,7 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-3.0-or-later"
 homepage="https://invent.kde.org/libraries/plasma-wayland-protocols"
 distfiles="${KDE_SITE}/${pkgname}/${pkgname}-${version}.tar.xz"
-checksum=e5aedfe7c0b2443aa67882b4792d08814570e00dd82f719a35c922a0993f621e
+checksum=da3fbbe3fa5603f9dc9aabe948a6fc8c3b451edd1958138628e96c83649c1f16
 
 post_install() {
 	vsed -e '/NOT CMAKE_SIZEOF_VOID_P STREQUAL/,+5d' \

--- a/srcpkgs/plasma-workspace-wallpapers/template
+++ b/srcpkgs/plasma-workspace-wallpapers/template
@@ -1,6 +1,6 @@
 # Template file for 'plasma-workspace-wallpapers'
 pkgname=plasma-workspace-wallpapers
-version=6.2.5
+version=6.3.2
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF"
@@ -10,4 +10,4 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later"
 homepage="https://invent.kde.org/plasma/plasma-workspace-wallpapers"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=d8b07a2cc3d34d13434f3a20e9a496ed7502805262e3bb189eb846d574f1bc80
+checksum=3c24f99f757ac7000753dbcdc3108fdace429bd0e0d1f169870849bf75c18585

--- a/srcpkgs/plasma-workspace/template
+++ b/srcpkgs/plasma-workspace/template
@@ -1,6 +1,6 @@
 # Template file for 'plasma-workspace'
 pkgname=plasma-workspace
-version=6.2.5
+version=6.3.2
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF -DKDE_INSTALL_QMLDIR=lib/qt6/qml
@@ -30,7 +30,7 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later, GFDL-1.2-or-later, LGPL-2.1-or-later"
 homepage="https://invent.kde.org/plasma/plasma-workspace"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=b82511e46f62e1b8f60b969c828c8d8d32fc7928401a70cc28c29f85f46c412f
+checksum=f3f00ab0382fee6bbd24bb804691e5f0d53410fa1c6efb294850b909b9c1e499
 
 if [ "$XBPS_TARGET_LIBC" = "glibc" ]; then
 	makedepends+=" libxcrypt-devel"

--- a/srcpkgs/plasma5support/template
+++ b/srcpkgs/plasma5support/template
@@ -1,6 +1,6 @@
 # Template file for 'plasma5support'
 pkgname=plasma5support
-version=6.2.5
+version=6.3.2
 revision=1
 build_style=cmake
 configure_args="-DKDE_INSTALL_QMLDIR=lib/qt6/qml
@@ -9,13 +9,13 @@ hostmakedepends="extra-cmake-modules qt6-base qt6-tools gettext
  qt6-declarative-host-tools"
 makedepends="qt6-declarative-devel kf6-kconfig-devel kf6-ki18n-devel
  kf6-kcoreaddons-devel kf6-knotifications-devel kf6-kguiaddons-devel
- kf6-solid-devel libksysguard-devel kf6-kio-devel"
+ kf6-solid-devel libksysguard-devel kf6-kio-devel kf6-kidletime-devel"
 short_desc="Support components for porting from KF5/Qt5 to KF6/Qt6"
 maintainer="John <me@johnnynator.dev>"
 license="GPL-3.0-or-later"
 homepage="https://invent.kde.org/plasma/plasma5support"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=cac5244aa2961ad020ed2c43427389e0823482ecb179948b5fd6b221606e8b04
+checksum=2c8fae2e87373656d4535441ef091edff80d5dd5b9a905e53da77871531326da
 
 do_check() {
 	cd build

--- a/srcpkgs/polkit-kde-agent/template
+++ b/srcpkgs/polkit-kde-agent/template
@@ -1,6 +1,6 @@
 # Template file for 'polkit-kde-agent'
 pkgname=polkit-kde-agent
-version=6.2.5
+version=6.3.2
 revision=1
 build_style=cmake
 hostmakedepends="extra-cmake-modules qt6-base qt6-tools gettext"
@@ -11,4 +11,4 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later"
 homepage="https://commits.kde.org/polkit-kde-agent"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-1-${version}.tar.xz"
-checksum=b1ffb3e444c6c53db822a8fb4c7505c38f2613a812ae17be2434e02f50c293fb
+checksum=b9fa047ed16066f87acb8e07cd28a66a04b9a9bbe696b1995b19112cb39f9e8c

--- a/srcpkgs/powerdevil/template
+++ b/srcpkgs/powerdevil/template
@@ -1,6 +1,6 @@
 # Template file for 'powerdevil'
 pkgname=powerdevil
-version=6.2.5
+version=6.3.2
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
@@ -18,4 +18,4 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later"
 homepage="https://invent.kde.org/plasma/powerdevil"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=70250396d5efae4be7d3201be878e0e35fd8d9bfb390660d5e0394828b1f464b
+checksum=db858e8539b7e2bc9f96e8a3518683377284b95275b0e686177fb2b0c244527b

--- a/srcpkgs/print-manager/template
+++ b/srcpkgs/print-manager/template
@@ -1,7 +1,7 @@
 # Template file for 'print-manager'
 pkgname=print-manager
 reverts="23.08.5_1 22.12.1_1 22.04.1_1 21.12.3_1 21.12.2_1 21.08.0_1 20.12.2_1"
-version=6.2.5
+version=6.3.2
 revision=1
 build_style=cmake
 configure_args="-DKF6_HOST_TOOLING=/usr/lib/cmake
@@ -17,4 +17,4 @@ maintainer="Giuseppe Fierro <gspe+void@offlink.xyz>"
 license="GPL-2.0-or-later"
 homepage="https://invent.kde.org/plasma/print-manager"
 distfiles="${KDE_SITE}/plasma/${version}/print-manager-${version}.tar.xz"
-checksum=056016ebb75fe02a3f2e71bfa679806c0c0dc20bdc676e34345c2ed04b5feacc
+checksum=2cc1bd77f881e5fcb30ffcb1b7b7abee02e4a94e6ea5269098c6c60db3e00280

--- a/srcpkgs/sddm-kcm/template
+++ b/srcpkgs/sddm-kcm/template
@@ -1,6 +1,6 @@
 # Template file for 'sddm-kcm'
 pkgname=sddm-kcm
-version=6.2.5
+version=6.3.2
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
@@ -15,4 +15,4 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later"
 homepage="https://invent.kde.org/plasma/sddm-kcm"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=fa401116bcfc690fd2557c16cf39461fa9d6e1de0d917a4f49ff92e37d5fdf56
+checksum=ece34d6ff4485a51f9ffa95e9dc3c87811e60b06e527b184fb9ec5908e9e4450

--- a/srcpkgs/spectacle/template
+++ b/srcpkgs/spectacle/template
@@ -1,6 +1,7 @@
 # Template file for 'spectacle'
 pkgname=spectacle
-version=24.12.1
+reverts="24.12.1_1 24.12.0_1 24.08.1_2 24.08.1_1 24.08.0_1 24.05.0_4 24.05.0_3 24.05.0_2 24.05.0_2 24.05.0_2 24.05.0_1 24.02.2_1 23.08.5_1 23.08.4_1 23.08.3_1 23.08.2_1 23.08.0_1 23.04.2_1 23.04.0_1 22.12.1_1 22.08.2_1 22.08.1_1 22.04.3_1 22.04.1_1 21.12.3_1 21.12.2_1 21.12.1_1 21.12.0_1 21.08.3_1 21.08.2_1 21.08.1_1 21.08.0_1 21.04.3_1 21.04.2_1 21.04.1_1 21.04.0_1 20.12.3_1 20.12.2_1 20.12.1_1 20.12.0_1 20.08.3_1 20.08.2_1 20.08.1_1 20.08.0_1 20.04.3_1 20.04.2_1 20.04.2_1 20.04.1_1 20.04.0_1"
+version=6.3.2.1
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake"
@@ -15,6 +16,6 @@ makedepends="kf6-kdeclarative-devel kf6-kxmlgui-devel qt6-base-private-devel
 short_desc="KDE screenshot capture utility"
 maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.0-or-later, GPL-2.0-or-later"
-homepage="https://kde.org/applications/en/utilities/org.kde.spectacle"
-distfiles="${KDE_SITE}/release-service/${version}/src/${pkgname}-${version}.tar.xz"
-checksum=df710e03ebf15133a9760aa0aa83eb1bd85353f7c4a14a834c5f401b094cb999
+homepage="https://apps.kde.org/spectacle/"
+distfiles="${KDE_SITE}/plasma/${version%.*}/${pkgname}-${version}.tar.xz"
+checksum=481c25b1834b60a6a0bffe3706aa3e25009a7d35995cb377847f3a96e875774b

--- a/srcpkgs/systemsettings/template
+++ b/srcpkgs/systemsettings/template
@@ -1,6 +1,6 @@
 # Template file for 'systemsettings'
 pkgname=systemsettings
-version=6.2.5
+version=6.3.2
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
@@ -15,4 +15,4 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later, GFDL-1.2-only"
 homepage="https://invent.kde.org/plasma/systemsettings"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=b5022f294325dbd3da16abefb52a12c018c73a3c78eda032df89173c69abd375
+checksum=24f88dee16d5d0b3b51ac8b2cbc2e461257fe3a9cae2b70831e422f740476bad

--- a/srcpkgs/weston/template
+++ b/srcpkgs/weston/template
@@ -1,7 +1,7 @@
 # Template file for 'weston'
 pkgname=weston
 version=14.0.1
-revision=2
+revision=3
 build_style=meson
 # requires XDG_RUNTIME_DIR for most tests
 configure_args="-Dtests=false $(vopt_bool vaapi backend-drm-screencast-vaapi) "

--- a/srcpkgs/wlroots0.17/template
+++ b/srcpkgs/wlroots0.17/template
@@ -1,7 +1,7 @@
 # Template file for 'wlroots0.17'
 pkgname=wlroots0.17
 version=0.17.4
-revision=1
+revision=2
 build_style=meson
 # Follow upstream packaging recommendations:
 # https://gitlab.freedesktop.org/wlroots/wlroots/-/wikis/Packaging-recommendations

--- a/srcpkgs/wlroots0.18/template
+++ b/srcpkgs/wlroots0.18/template
@@ -1,7 +1,7 @@
 # Template file for 'wlroots0.18'
 pkgname=wlroots0.18
 version=0.18.2
-revision=1
+revision=2
 build_style=meson
 # Follow upstream packaging recommendations:
 # https://gitlab.freedesktop.org/wlroots/wlroots/-/wikis/Packaging-recommendations

--- a/srcpkgs/xdg-desktop-portal-kde/template
+++ b/srcpkgs/xdg-desktop-portal-kde/template
@@ -1,6 +1,6 @@
 # Template file for 'xdg-desktop-portal-kde'
 pkgname=xdg-desktop-portal-kde
-version=6.2.5
+version=6.3.2
 revision=1
 build_style=cmake
 configure_args="-DWaylandScanner_EXECUTABLE=/usr/bin/wayland-scanner"
@@ -17,7 +17,7 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-3.0-or-later"
 homepage="https://invent.kde.org/plasma/xdg-desktop-portal-kde"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=1e86bf6f7dc433400ade93347671ec9cad88e382536dd30930030e4514623af1
+checksum=cdf79d8e02d9be995e91b8d4d317e03441027535e8fc9ee746eb850fc0760341
 
 do_check() {
 	cd build


### PR DESCRIPTION
- **bluedevil: update to 6.3.0**
- **breeze-gtk: update to 6.3.0**
- **breeze-qt5: update to 6.3.0**
- **breeze-qt6: update to 6.3.0**
- **discover: update to 6.3.0**
- **drkonqi: update to 6.3.0**
- **flatpak-kcm: update to 6.3.0**
- **kactivitymanagerd: update to 6.3.0**
- **kcm-wacomtablet: update to 6.3.0**
- **kde-cli-tools: update to 6.3.0**
- **kde-gtk-config: update to 6.3.0**
- **kdeplasma-addons: update to 6.3.0**
- **kf6-kdecoration: update to 6.3.0**
- **kf6-kwayland: update to 6.3.0**
- **kgamma: update to 6.3.0**
- **kglobalacceld: update to 6.3.0**
- **kinfocenter: update to 6.3.0**
- **kmenuedit: update to 6.3.0**
- **kpipewire: update to 6.3.0**
- **krdp: update to 6.3.0**
- **kscreen: update to 6.3.0**
- **kscreenlocker: update to 6.3.0**
- **ksshaskpass: update to 6.3.0**
- **ksystemstats: update to 6.3.0**
- **kwallet-pam: update to 6.3.0**
- **kwayland-integration: update to 6.3.0**
- **kwin: update to 6.3.0**
- **kwrited: update to 6.3.0**
- **layer-shell-qt: update to 6.3.0**
- **libkf6screen: update to 6.3.0**
- **libksysguard: update to 6.3.0**
- **libplasma: update to 6.3.0**
- **milou: update to 6.3.0**
- **oxygen-qt5: update to 6.3.0**
- **oxygen-qt6: update to 6.3.0**
- **oxygen-sounds: update to 6.3.0**
- **plasma-activities-stats: update to 6.3.0**
- **plasma-activities: update to 6.3.0**
- **plasma-browser-integration: update to 6.3.0**
- **plasma-desktop: update to 6.3.0**
- **plasma-disks: update to 6.3.0**
- **plasma-firewall: update to 6.3.0**
- **plasma-integration: update to 6.3.0**
- **plasma-nm: update to 6.3.0**
- **plasma-pa: update to 6.3.0**
- **plasma-sdk: update to 6.3.0**
- **plasma-systemmonitor: update to 6.3.0**
- **plasma-thunderbolt: update to 6.3.0**
- **plasma-vault: update to 6.3.0**
- **plasma-workspace-wallpapers: update to 6.3.0**
- **plasma-workspace: update to 6.3.0**
- **plasma5support: update to 6.3.0**
- **polkit-kde-agent: update to 6.3.0**
- **powerdevil: update to 6.3.0**
- **print-manager: update to 6.3.0**
- **sddm-kcm: update to 6.3.0**
- **systemsettings: update to 6.3.0**
- **xdg-desktop-portal-kde: update to 6.3.0**
- **plasma-wayland-protocols: update to 1.16.0.**
- **libdisplay-info: update to 0.2.0.**
- **kodi: rebuild against libdisplay-info-0.2.0**
- **mutter: rebuild against libdisplay-info-0.2.0**
- **niri: update to 25.02**
- **wlroots0.17: rebuild against libdisplay-info-0.2.0**
- **wlroots0.18: rebuild against libdisplay-info-0.2.0**
- **weston: rebuild against libdisplay-info-0.2.0**
- **spectacle: update to 6.3.2.1.**
