### PR TITLE
moby: update to 28.0.1, fix and re-enable cross builds & docker-cli: update to 28.0.1

### DIFF
--- a/srcpkgs/docker-cli/template
+++ b/srcpkgs/docker-cli/template
@@ -1,7 +1,7 @@
 # Template file for 'docker-cli'
 # should be kept in sync with moby
 pkgname=docker-cli
-version=28.0.0
+version=28.0.1
 revision=1
 build_style=go
 go_package="github.com/docker/cli/cmd/docker"
@@ -16,8 +16,10 @@ maintainer="Andrea Brancaleoni <abc@pompel.me>"
 license="Apache-2.0"
 homepage="https://www.docker.com"
 distfiles="https://github.com/docker/cli/archive/v${version}.tar.gz"
-checksum=aad1d43cde6d28538a2f76d52ce9fb3e92677b4e1cca2e5bcc1b612af3d63bff
+checksum=d7495aa47f52e5ba5b16d6ffbc07678cbf496b9f00206c5918f936206ad986f5
 system_groups="docker"
+# tests seem designed to run in docker
+make_check=no
 
 pre_build() {
 	go_ldflags+=" -X \"${_cli_ver_path}.BuildTime=$(date +%Y-%m-%dT%H:%M:%SZ)\""

--- a/srcpkgs/moby/template
+++ b/srcpkgs/moby/template
@@ -1,8 +1,10 @@
 # Template file for 'moby'
 # should be kept in sync with docker-cli
 pkgname=moby
-version=28.0.0
-revision=3
+version=28.0.1
+revision=1
+build_style=go
+go_import_path="github.com/docker/docker"
 hostmakedepends="go pkg-config"
 makedepends="libbtrfs-devel device-mapper-devel libseccomp-devel"
 depends="containerd iptables xz"
@@ -12,32 +14,21 @@ license="Apache-2.0"
 homepage="https://www.docker.com"
 changelog="https://github.com/moby/moby/releases"
 distfiles="https://github.com/moby/moby/archive/v${version}.tar.gz"
-checksum="89e26ecb0c13ef7037305811b0eb6dd4c70741c34ec3428d4396d68b03deb641
- 5c5e3aa7599e85036438a65016796aa11df4afb44d13b5927dcfb0ec5947a86b"
+checksum="ff04cc8eb58aff5494e51186689043c8d25b8aff1553b04b08980f2d70b4b000"
 system_groups="docker"
-make_check=no
-nocross=y
-
-case $XBPS_TARGET_MACHINE in
-        i686*) broken="libnetwork/drivers/bridge/port_mapping_linux.go:679:45: undefined\: syscall.SYS_SETSOCKOPT";;
-esac
-
-case $XBPS_TARGET_MACHINE in
-	i686*) broken="libnetwork/drivers/bridge/port_mapping_linux.go:679:45: undefined: syscall.SYS_SETSOCKOPT";;
-esac
+make_check=no # no other tests are available
 
 do_build() {
-        export AUTO_GOPATH=1
-        export DOCKER_GITCOMMIT="tag v${version}"
-        export DOCKER_BUILDTAGS="seccomp"
-        export DISABLE_WARN_OUTSIDE_CONTAINER=1
+	export AUTO_GOPATH=1
+	export DOCKER_GITCOMMIT="tag v${version}"
+	export DOCKER_BUILDTAGS="seccomp"
+	export DISABLE_WARN_OUTSIDE_CONTAINER=1
 
-        GOPATH="$PWD" VERSION="$version" hack/make.sh dynbinary
+	GOPATH="$PWD" VERSION="$version" hack/make.sh dynbinary
 }
 
 do_install() {
-        vbin bundles/dynbinary-daemon/dockerd
-        vbin bundles/dynbinary-daemon/docker-proxy
-        vsv docker
+	vbin bundles/dynbinary-daemon/dockerd
+	vbin bundles/dynbinary-daemon/docker-proxy
+	vsv docker
 }
-


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl (cross-build)
  - i686 (cross-build)
  - x86_64

This PR fixes #54524 