### PR TITLE
gtest: update to 1.16.0.

### DIFF
--- a/srcpkgs/gtest/template
+++ b/srcpkgs/gtest/template
@@ -1,6 +1,6 @@
 # Template file for 'gtest'
 pkgname=gtest
-version=1.12.1
+version=1.16.0
 revision=1
 build_style=cmake
 make_cmd=make # using make to avoid a cycle: ninja -> gtest -> ninja
@@ -10,8 +10,8 @@ short_desc="Google's framework for writing C++ tests"
 maintainer="Enno Boland <gottox@voidlinux.org>"
 license="BSD-3-Clause"
 homepage="https://github.com/google/googletest"
-distfiles="https://github.com/google/googletest/archive/release-${version}.tar.gz"
-checksum=81964fe578e9bd7c94dfdb09c8e4d6e6759e19967e397dbea48d1c10e45d0df2
+distfiles="https://github.com/google/googletest/archive/v${version}.tar.gz"
+checksum=78c676fc63881529bf97bf9d45948d905a66833fbfa5318ea2cd7478cb98f399
 
 export CMAKE_GENERATOR="Unix Makefiles"
 


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture (x86_64)
- I built this PR locally for these architectures using specific masterdirs:
  - x86_64-musl
  - i686
- I built this PR locally for these architectures (crossbuilds):
  - aarch64
  - aarch64-musl
  - armv7l
  - armv7l-musl
  - armv6l
  - armv6l-musl
  
---

Tested the update of the package using [Cockatrice PR#54508](https://github.com/void-linux/void-packages/pull/54508) compilation. Everything builds and works as expected.