### PR TITLE
New package: tuxedo-yt6801-1.0.29tux0

### DIFF
--- a/srcpkgs/tuxedo-yt6801/template
+++ b/srcpkgs/tuxedo-yt6801/template
@@ -1,0 +1,22 @@
+# Template file for 'tuxedo-yt6801'
+pkgname=tuxedo-yt6801
+version=1.0.29tux0
+revision=1
+depends="dkms"
+short_desc="Kernel module for Motorcomm YT6801 ethernet controller (DKMS)"
+maintainer="Seth <sutura-git@qkco.os>"
+license="GPL-2.0-or-later"
+homepage="https://gitlab.com/tuxedocomputers/development/packages/tuxedo-yt6801"
+distfiles="https://gitlab.com/tuxedocomputers/development/packages/tuxedo-yt6801/-/archive/v${version}/tuxedo-yt6801-v${version}.tar.gz"
+checksum=ecbf5b80bf14784cadef81d05c8dd31329448d205822c627d7661ee0fa529c82
+
+dkms_modules="tuxedo-yt6801 ${version}"
+
+do_install() {
+	sed "s/#MODULE_VERSION#/${version}/" debian/tuxedo-yt6801.dkms > dkms.conf
+	vmkdir usr/src/${pkgname}-${version}
+	vcopy "src/*.c" usr/src/${pkgname}-${version}
+	vcopy "src/*.h" usr/src/${pkgname}-${version}
+	vcopy dkms.conf usr/src/${pkgname}-${version}
+	vcopy "src/Kbuild" usr/src/${pkgname}-${version}
+}


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

- I built this PR locally for my native architecture, x86_64-glibc
