### PR TITLE
elfutils: update to 0.192.

### DIFF
--- a/srcpkgs/elfutils/template
+++ b/srcpkgs/elfutils/template
@@ -1,13 +1,13 @@
 # Template file for 'elfutils'
 pkgname=elfutils
-version=0.190
+version=0.192
 revision=1
 build_style=gnu-configure
-configure_args="--program-prefix=eu-"
+configure_args="--program-prefix=eu- --enable-debuginfod --enable-libdebuginfod"
 hostmakedepends="pkg-config m4"
 _devel_depends="bzip2-devel liblzma-devel zlib-devel libzstd-devel"
 makedepends="${_devel_depends} libcurl-devel libarchive-devel sqlite-devel
- libmicrohttpd-devel"
+ libmicrohttpd-devel json-c-devel"
 checkdepends="zstd bzip2 curl rpm cpio iproute2 procps-ng"
 short_desc="Utilities to handle ELF object files"
 maintainer="Érico Nogueira <ericonr@disroot.org>"
@@ -15,7 +15,7 @@ license="GPL-3.0-or-later"
 homepage="https://sourceware.org/elfutils/"
 changelog="https://sourceware.org/git/?p=elfutils.git;a=blob_plain;f=NEWS;hb=HEAD"
 distfiles="https://sourceware.org/pub/elfutils/${version}/elfutils-${version}.tar.bz2"
-checksum=8e00a3a9b5f04bc1dc273ae86281d2d26ed412020b391ffcc23198f10231d692
+checksum=616099beae24aba11f9b63d86ca6cc8d566d968b802391334c91df54eab416b4
 # subpackages require explicit ordering
 subpackages="debuginfod libdebuginfod libelf elfutils-devel"
 CFLAGS="-Wno-error=deprecated-declarations" # curl 7.55+


### PR DESCRIPTION
Fix bulid with gcc14 and musl

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
