### PR TITLE
iproute2: update to 6.13.0.

### DIFF
--- a/srcpkgs/iproute2/template
+++ b/srcpkgs/iproute2/template
@@ -1,6 +1,6 @@
 # Template file for 'iproute2'
 pkgname=iproute2
-version=6.10.0
+version=6.13.0
 revision=1
 build_style=configure
 make_install_args="SBINDIR=/usr/bin"
@@ -12,7 +12,7 @@ maintainer="Enno Boland <gottox@voidlinux.org>"
 license="GPL-2.0-only"
 homepage="https://wiki.linuxfoundation.org/networking/iproute2"
 distfiles="${KERNEL_SITE}/utils/net/iproute2/iproute2-${version}.tar.xz"
-checksum=91a62f82737b44905a00fa803369c447d549e914e9a2a4018fdd75b1d54e8dce
+checksum=a43aa43338d882b44d01e549f3f105a92ae9feea32a82fae45a88e7a49302819
 # Requires unshare, which is not provided by chroot-util-linux.
 make_check=no
 


### PR DESCRIPTION
Fix build with gcc14 and musl

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
