### PR TITLE
minijail: update to v2024.05.22

### DIFF
--- a/srcpkgs/minijail/patches/ppc.patch
+++ b/srcpkgs/minijail/patches/ppc.patch
@@ -5,8 +5,8 @@ others are already undef'd for other platforms above that.
 
 --- a/gen_constants-inl.h
 +++ b/gen_constants-inl.h
-@@ -24,3 +24,8 @@
- // build errors on such broken systems.
+@@ -35,6 +35,11 @@
+  */
  #undef BLKTRACESETUP
  #undef FS_IOC_FIEMAP
 +#undef ELF_ARCH
@@ -14,3 +14,6 @@ others are already undef'd for other platforms above that.
 +#undef ELF_DATA
 +#undef ELF_GREG_TYPE
 +#undef FIOQSIZE
+ 
+ /* The old glibc bundled with the Android host toolchain is missing some ioctl
+  * definitions used by minijail policy in crosvm and other projects. Locally

--- a/srcpkgs/minijail/template
+++ b/srcpkgs/minijail/template
@@ -1,19 +1,26 @@
 # Template file for 'minijail'
 pkgname=minijail
-version=16
+version=2024.05.22
 revision=1
 build_style=gnu-makefile
 makedepends="libcap-devel"
+checkdepends="wget tar gzip"
 short_desc="Sandboxing and containment tool used in Chrome OS and Android"
 maintainer="Cameron Nemo <cam@nohom.org>"
 license="BSD-3-Clause"
 homepage="https://android.googlesource.com/platform/external/minijail"
 distfiles="https://github.com/google/minijail/archive/linux-v${version}.tar.gz"
-checksum=1efb6224465cf8a5bb7a69659b35482e69786fce572f29125201e9a0e793bdd6
+checksum=3136365ca3762da3e725f734fbdc544d8c82d6a763f803b2850ed3c993c216f0
 
 if [ "$XBPS_TARGET_ENDIAN" = "be" ]; then
 	broken="bpf.h:110:2: error: #error Unsupported endianness"
 fi
+
+do_check() {
+	chmod +x ./get_googletest.sh
+	./get_googletest.sh
+	make test
+}
 
 do_install() {
 	vbin minijail0


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

Updates minijail to the latest released tag. As for testing, I'm currently using this quite [extensively](https://codeberg.org/gruf/dotfiles/src/branch/main/system/etc/sv) (on x86_64) myself without any issues.

The patch change was a very simple case of they changed the comments around the changed code, which needed updating. Zero logic changes.