### PR TITLE
kio-gdrive: update to 24.12.1.

### DIFF
--- a/srcpkgs/kio-gdrive/template
+++ b/srcpkgs/kio-gdrive/template
@@ -1,6 +1,6 @@
 # Template file for 'kio-gdrive'
 pkgname=kio-gdrive
-version=24.08.0
+version=24.12.3
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
@@ -18,4 +18,4 @@ license="GPL-2.0-or-later"
 homepage="https://community.kde.org/KIO_GDrive"
 changelog="https://kde.org/announcements/changelogs/gear/${version}/#kio-gdrive"
 distfiles="${KDE_SITE}/release-service/${version}/src/kio-gdrive-${version}.tar.xz"
-checksum=1f6148711f3d95acdbc6257be250ae50309ed95c39d7d8fbcda0029b4345afbe
+checksum=748116c746bf4eaa2114ac8fe1dc4c85b285ff0af8e2968206a4d97fbceb5126


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**


#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)

Fixes #54565