### PR TITLE
pipewire: update to 1.4.2

### DIFF
--- a/srcpkgs/mpv/patches/0.39.0-pipewire-1.4-fix.patch
+++ b/srcpkgs/mpv/patches/0.39.0-pipewire-1.4-fix.patch
@@ -1,0 +1,33 @@
+https://github.com/mpv-player/mpv/commit/c9970b5ba66e25aeab36cdbdb91b973f2d3f8d90.patch
+From c9970b5ba66e25aeab36cdbdb91b973f2d3f8d90 Mon Sep 17 00:00:00 2001
+From: llyyr <llyyr.public@gmail.com>
+Date: Wed, 19 Feb 2025 19:08:36 +0530
+Subject: [PATCH] ao_pipewire: don't load client-rt.conf properties
+
+Deprecated in https://gitlab.freedesktop.org/pipewire/pipewire/-/commit/24bcacc6195ffbf8e40c9ea1374eb6666252eadc
+
+Fixes: #15914
+---
+ audio/out/ao_pipewire.c | 9 +++++----
+ 1 file changed, 5 insertions(+), 4 deletions(-)
+
+diff --git a/audio/out/ao_pipewire.c b/audio/out/ao_pipewire.c
+index 5e6bb1fa4fdf7..88c48ddca60e7 100644
+--- a/audio/out/ao_pipewire.c
++++ b/audio/out/ao_pipewire.c
+@@ -510,10 +510,11 @@ static int pipewire_init_boilerplate(struct ao *ao)
+     if (pw_thread_loop_start(p->loop) < 0)
+         goto error;
+ 
+-    context = pw_context_new(
+-            pw_thread_loop_get_loop(p->loop),
+-            pw_properties_new(PW_KEY_CONFIG_NAME, "client-rt.conf", NULL),
+-            0);
++    struct pw_properties *props = NULL;
++#if !PW_CHECK_VERSION(1, 3, 81)
++    props = pw_properties_new(PW_KEY_CONFIG_NAME, "client-rt.conf", NULL);
++#endif
++    context = pw_context_new(pw_thread_loop_get_loop(p->loop), props, 0);
+     if (!context)
+         goto error;
+ 

--- a/srcpkgs/mpv/template
+++ b/srcpkgs/mpv/template
@@ -1,7 +1,7 @@
 # Template file for 'mpv'
 pkgname=mpv
 version=0.39.0
-revision=2
+revision=3
 build_style=meson
 configure_args="-Dcdda=enabled -Ddvbin=enabled -Ddvdnav=enabled
  -Dlibmpv=true -Dcplugins=enabled

--- a/srcpkgs/pipewire/template
+++ b/srcpkgs/pipewire/template
@@ -1,6 +1,6 @@
 # Template file for 'pipewire'
 pkgname=pipewire
-version=1.2.7
+version=1.4.2
 revision=1
 build_style=meson
 configure_args="
@@ -30,10 +30,11 @@ makedepends="$(vopt_if sdl2 SDL2-devel) gst-plugins-base1-devel jack-devel
  vulkan-loader-devel pulseaudio-devel avahi-libs-devel webrtc-audio-processing-devel
  readline-devel openssl-devel lilv-devel libcanberra-devel dbus-devel
  libmysofa-devel opus-devel $(vopt_if ffado libffado-devel) liblc3-devel
- $(vopt_if selinux libselinux-devel) libcamera-devel libcap-devel"
+ $(vopt_if selinux libselinux-devel) libcamera-devel libcap-devel libebur128-devel"
 depends="libspa-alsa>=${version}_${revision} libspa-audioconvert>=${version}_${revision}
  libspa-audiomixer>=${version}_${revision} libspa-control>=${version}_${revision}
- libspa-v4l2>=${version}_${revision} pulseaudio-utils virtual?pipewire-session-manager"
+ libspa-v4l2>=${version}_${revision} libspa-videoconvert>=${version}_${revision}
+ pulseaudio-utils libebur128 virtual?pipewire-session-manager"
 checkdepends="pulseaudio-utils"
 short_desc="Server and user space API to deal with multimedia pipelines"
 maintainer="cinerea0 <cinerea0@protonmail.com>"
@@ -41,7 +42,7 @@ license="MIT"
 homepage="https://pipewire.org/"
 changelog="https://gitlab.freedesktop.org/pipewire/pipewire/-/raw/master/NEWS"
 distfiles="https://gitlab.freedesktop.org/pipewire/pipewire/-/archive/${version}/pipewire-${version}.tar.gz"
-checksum=e75568ed18bcbe75e9779af57cb9cc256fd7ebfaadc12bb347a0717055d1d3a9
+checksum=4712aada64b9b49ad41fbb8b440914481432a560f2619ffbdd49461f8d22994f
 make_dirs="/var/lib/pipewire 0755 _pipewire _pipewire"
 system_accounts="_pipewire"
 


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly** (at least for the official 1.4 release, though I have been using the 1.3.x release candidates without any issues for about a month)

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures (crossbuilds):
  - aarch64-glibc

PipeWire 1.4 adds support for EBU R128 loudness normalization (via libebur128), so I've added that as a dependency. Should it be put behind a build option? I would have to make sure that it actually has a meson flag and isn't a hard dependency.