### PR TITLE
SuiteSparse: update to 7.10.1

### DIFF
--- a/srcpkgs/SuiteSparse/template
+++ b/srcpkgs/SuiteSparse/template
@@ -1,6 +1,6 @@
 # Template file for 'SuiteSparse'
 pkgname=SuiteSparse
-version=7.8.3
+version=7.10.1
 revision=1
 build_style=cmake
 hostmakedepends="cmake gcc-fortran"
@@ -12,7 +12,7 @@ license="custom:multiple"
 homepage="https://people.engr.tamu.edu/davis/suitesparse.html"
 changelog="https://raw.githubusercontent.com/DrTimothyAldenDavis/SuiteSparse/master/ChangeLog"
 distfiles="https://github.com/DrTimothyAldenDavis/SuiteSparse/archive/refs/tags/v${version}.tar.gz"
-checksum=ce39b28d4038a09c14f21e02c664401be73c0cb96a9198418d6a98a7db73a259
+checksum=9e2974e22dba26a3cffe269731339ae8e01365cfe921b06be6359902bd05862c
 
 build_options="openblas"
 


### PR DESCRIPTION
- **SuiteSparse: update to 7.10.1.**
- ~~**octave: update to 9.4.0.**~~

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

~~There's an alternative update to octave-9.4.0 as part of #51891 (to enable hdf5 support for octave on cross).~~

Note that it's not necessary to recompile octave for the SuiteSparse update; I include it here mostly so the SuiteSparse update is also tested through octave.

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
