### PR TITLE
common/build-style/go.sh: disable verbose test output

### DIFF
--- a/common/build-style/go.sh
+++ b/common/build-style/go.sh
@@ -63,7 +63,7 @@ do_build() {
 do_check() {
 	: ${make_check_target:=./...}
 
-	${make_check_pre} go test -p "$XBPS_MAKEJOBS" -v -tags "${go_build_tags}" -ldflags "${go_ldflags}" ${make_check_args} ${make_check_target}
+	${make_check_pre} go test -p "$XBPS_MAKEJOBS" -tags "${go_build_tags}" -ldflags "${go_ldflags}" ${make_check_args} ${make_check_target}
 }
 
 do_install() {


### PR DESCRIPTION
The output with `-v` is often too verbose, making it difficult to scour the logs, especially in the GitHub actions UI.