### PR TITLE
nicotine+: adopt.

### DIFF
--- a/srcpkgs/nicotine+/template
+++ b/srcpkgs/nicotine+/template
@@ -1,13 +1,13 @@
 # Template file for 'nicotine+'
 pkgname=nicotine+
 version=3.3.10
-revision=2
+revision=1
 build_style=python3-pep517
 hostmakedepends="python3-setuptools gettext"
 depends="gtk4 python3-gobject"
 checkdepends="$depends python3-pytest python3-pytest-xvfb dejavu-fonts-ttf"
 short_desc="Graphical client for the Soulseek peer-to-peer network"
-maintainer="doggone <doggone@airmail.cc>"
+maintainer="yosh <yosh-git@riseup.net>"
 license="GPL-3.0-or-later"
 homepage="https://nicotine-plus.org"
 changelog="https://raw.githubusercontent.com/nicotine-plus/nicotine-plus/master/NEWS.md"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- locally for my native architecture, `x86_64-glibc`
- locally using masterdir:
  - `i686-glibc`
  - `x86_64-musl`
- crossbuilds:
  - `armv7l-musl`

doing a `git log --author=doggone` (as well as for `Rolf` and `Charlier`, the name used [for the initial commit](https://github.com/void-linux/void-packages/commit/8e860eb705cbb5b8f3e3ca982457b889f15bb3d3)) has latest commits from 2015. nicotine's just been updated by various other authors across the years, so I think having an actual active person to contact for the package would be good