### PR TITLE
libnotify: update to 0.8.4.

### DIFF
--- a/srcpkgs/libnotify/patches/stylesheet_url.patch
+++ b/srcpkgs/libnotify/patches/stylesheet_url.patch
@@ -1,0 +1,35 @@
+From a392f3ef205bd8d8f2fa0e298a869d8abc481728 Mon Sep 17 00:00:00 2001
+From: Jan Tojnar <jtojnar@gmail.com>
+Date: Sun, 2 Mar 2025 22:29:13 +0100
+Subject: [PATCH] Revert "meson: update stylesheet url"
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+The change is incorrect.
+
+`http://docbook.sourceforge.net/release/xsl/current/manpages/docbook.xsl` is the variant of the stylesheet that does not use namespaces and will produce a broken manual page. https://gitlab.gnome.org/GNOME/libnotify/-/commit/162d1958694822658dfa27e3dd1c702dee4c285c expects DocBook stylesheet with namespace support.
+
+It does not really matter if the URI ceases resolving to a file – we disable network access for `xsltproc` so it only serves as an identifier for the stylesheet to be discovered locally using a XML catalog.
+
+This reverts commit 2f99025b7ad54f29dc5236aa7dfcfa97d1c8efde.
+---
+ meson.build | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/meson.build b/meson.build
+index a5be706..c99c23e 100644
+--- a/meson.build
++++ b/meson.build
+@@ -57,7 +57,7 @@ configure_file(input: 'config.h.meson',
+ 
+ if get_option('man')
+   xsltproc = find_program('xsltproc', required: true)
+-  stylesheet = 'http://docbook.sourceforge.net/release/xsl/current/manpages/docbook.xsl'
++  stylesheet = 'http://docbook.sourceforge.net/release/xsl-ns/current/manpages/docbook.xsl'
+   xsltproc_command = [
+     xsltproc,
+     '--nonet',
+-- 
+GitLab
+

--- a/srcpkgs/libnotify/template
+++ b/srcpkgs/libnotify/template
@@ -1,6 +1,6 @@
 # Template file for 'libnotify'
 pkgname=libnotify
-version=0.8.3
+version=0.8.4
 revision=1
 build_style=meson
 build_helper=gir
@@ -14,7 +14,7 @@ license="LGPL-2.1-or-later"
 homepage="https://gitlab.gnome.org/GNOME/libnotify"
 changelog="https://gitlab.gnome.org/GNOME/libnotify/-/raw/master/NEWS"
 distfiles="https://gitlab.gnome.org/GNOME/libnotify/-/archive/${version}/libnotify-${version}.tar.gz"
-checksum=5bcfeff21b6669c009c862e25c42556723f7a46c2c3454fce0fd532ebed715a0
+checksum=230416324c7db3b84eec82bd545ebdf0e205c34444574554e163457088de27db
 # https://gitlab.gnome.org/GNOME/libnotify/-/issues/30
 make_check=no
 


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **NO**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl [ok]
  - armv7l [ok]
  - armv6l-musl [ok]


!!
meson.build:75:4: ERROR: Problem encountered: DocBook stylesheet for generating man pages not
found, you need to install docbook-xsl-ns or similar package.
!!

- add patch `meson: update stylesheet url`