### PR TITLE
wine: update to 10.3

### DIFF
--- a/srcpkgs/wine/template
+++ b/srcpkgs/wine/template
@@ -1,7 +1,7 @@
 # Template file for 'wine'
 pkgname=wine
-version=10.2
-revision=2
+version=10.3
+revision=1
 _pkgver=${version/r/-r}
 create_wrksrc=yes
 build_wrksrc=wine-${_pkgver}
@@ -13,8 +13,8 @@ license="LGPL-2.1-or-later"
 homepage="http://www.winehq.org/"
 distfiles="https://dl.winehq.org/wine/source/${version%.*}.x/wine-${_pkgver}.tar.xz
  https://github.com/wine-staging/wine-staging/archive/v${_pkgver}.tar.gz"
-checksum="9d90dfb6cf10b810a7b4789f0067712b4730d3ea2a88b91f1be273b2ad04243f
- 44d051a8622dd6245d63b88d988eebcdb712d309ee57eccdccbe59d6c4788194"
+checksum="de3d88ff0056b82ffdfca842f1119592e4914f48c4ea023768e0419c36467c3e
+ 775fc4e8cef23700e4ec8e14923d6cf737136ef5be3071fcda7dd55168d4b9e9"
 
 # NOTE: wine depends on specific versions of wine-mono and wine-gecko,
 # check for updates to these packages when updating wine


### PR DESCRIPTION
Tested old WoW64, launch with 32bit wine, new WoW64 on musl.

Small release mainly consisting of bugfixes, added clipboard support for the wayland driver.

@Hoshpak 