### PR TITLE
[RFC] non-recursive check to break build-check cycles

### DIFF
--- a/common/xbps-src/shutils/build_dependencies.sh
+++ b/common/xbps-src/shutils/build_dependencies.sh
@@ -384,6 +384,8 @@ install_pkg_deps() {
         (
         curpkgdepname=$($XBPS_UHELPER_CMD getpkgname "$i" 2>/dev/null)
         setup_pkg $curpkgdepname
+        # do not check when building dependencies, except for "full" (-K)
+        [ "$XBPS_CHECK_PKGS" == full ] || unset XBPS_CHECK_PKGS
         exec env XBPS_DEPENDENCY=1 XBPS_BINPKG_EXISTS=1 XBPS_DEPENDS_CHAIN="$XBPS_DEPENDS_CHAIN, $sourcepkg(host)" \
             $XBPS_LIBEXECDIR/build.sh $sourcepkg $pkg $target $cross_prepare || exit $?
         ) || exit $?

--- a/srcpkgs/python3-jsonschema-specifications/template
+++ b/srcpkgs/python3-jsonschema-specifications/template
@@ -1,7 +1,7 @@
 # Template file for 'python3-jsonschema-specifications'
 pkgname=python3-jsonschema-specifications
 version=2024.10.1
-revision=1
+revision=2
 build_style=python3-pep517
 hostmakedepends="hatchling hatch-vcs"
 depends="python3-referencing"

--- a/srcpkgs/python3-jsonschema/template
+++ b/srcpkgs/python3-jsonschema/template
@@ -1,10 +1,11 @@
 # Template file for 'python3-jsonschema'
 pkgname=python3-jsonschema
 version=4.23.0
-revision=2
+revision=3
 build_style=python3-pep517
 hostmakedepends="hatchling hatch-vcs hatch-fancy-pypi-readme"
-depends="python3-attrs python3-jsonschema-specifications"
+depends="python3-attrs python3-jsonschema-specifications python3-referencing
+ python3-rpds-py"
 checkdepends="${depends} python3-pytest python3-idna python3-jsonpointer
  python3-pip python3-rfc3339-validator python3-rfc3987"
 short_desc="Implementation of JSON Schema for Python3"

--- a/srcpkgs/python3-referencing/template
+++ b/srcpkgs/python3-referencing/template
@@ -5,7 +5,7 @@ revision=1
 build_style=python3-pep517
 hostmakedepends="hatchling hatch-vcs"
 depends="python3-attrs python3-rpds-py"
-checkdepends="$depends python3-pytest-subtests"
+checkdepends="$depends python3-pytest-subtests python3-jsonschema"
 short_desc="Cross-specification JSON Referencing"
 maintainer="Gonzalo Tornaría <tornaria@cmat.edu.uy>"
 license="MIT"
@@ -13,14 +13,6 @@ homepage="https://github.com/python-jsonschema/referencing"
 changelog="https://raw.githubusercontent.com/python-jsonschema/referencing/main/docs/changes.rst"
 distfiles="${PYPI_SITE}/r/referencing/referencing-${version}.tar.gz"
 checksum=df2e89862cd09deabbdba16944cc3f10feb6b3e6f18e902f7cc25609a34775aa
-
-if [ "$XBPS_CHECK_PKGS" = full ]; then
-	# cyclic dependency
-	checkdepends+=" python3-jsonschema"
-else
-	# needs python3-jsonschema
-	make_check_args+=" --ignore=suite/test_sanity.py"
-fi
 
 post_install() {
 	vlicense COPYING


### PR DESCRIPTION
- **shutils/build_dependencies.sh: non-recursive check**
- **python3-referencing: check circular dep**
- **python3-jsonschema-specifications: bump to test check cycle**
- **python3-jsonschema: bump to test check cycle**

There's too many build-check cycles and handling them is complicated
when updating simultaneously a few interdependent packages.

This PR makes it so enabling check on a package will not affect dependencies
that are built in the process.

For CI and for xbulk, this means that some packages could be built more than
once (at most twice) but every package will be checked exactly one time. But
only if there is a build-check cycle, since otherwise sort-dependencies will
find a good build order that avoids it.
