### PR TITLE
opus: update to 1.5.2, adopt.

### DIFF
--- a/srcpkgs/opus/template
+++ b/srcpkgs/opus/template
@@ -1,15 +1,15 @@
 # Template file for 'opus'
 pkgname=opus
-version=1.4
+version=1.5.2
 revision=1
 build_style=gnu-configure
-configure_args="--enable-float-approx"
+configure_args="--enable-dred --enable-osce --enable-custom-modes"
 short_desc="Totally open, royalty-free, highly versatile audio codec"
-maintainer="Orphaned <orphan@voidlinux.org>"
+maintainer="Rutpiv <roger_freitas@live.com>"
 license="BSD-3-Clause"
 homepage="https://www.opus-codec.org/"
 distfiles="https://downloads.xiph.org/releases/opus/opus-${version}.tar.gz"
-checksum=c9b32b4253be5ae63d1ff16eea06b94b5f0f2951b7a02aceef58e3a3ce49c51f
+checksum=65c1d2f78b9f2fb20082c38cbe47c951ad5839345876e46941612ee87f9a7ce1
 
 post_install() {
 	vlicense COPYING


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture (x86_64)
- I built this PR locally for these architectures using specific masterdirs:
  - x86_64-musl
  - i686
- I built this PR locally for these architectures (crossbuilds):
  - aarch64
  - aarch64-musl
  - armv7l
  - armv7l-musl
  - armv6l
  - armv6l-musl

---

#### Advanced Features Update for the Opus Codec

This update incorporates advanced features that enhance real-time audio quality, redundancy, and overall codec flexibility. For more details, see the [Opus 1.5 Demo](https://opus-codec.org/demo/opus-1.5/).

- **Deep Packet Loss Concealment (Deep-PLC):**  
  Utilizes neural networks to reconstruct audio during packet loss. Enabled via `--enable-deep-plc`

- **Deep Redundancy (DRED):**  
  Improves robustness with additional error correction. Enabled via `--enable-dred`

- **Opus Speech Coding Enhancement (OSCE):**  
  Boosts speech quality and clarity at low bitrates. Enabled via `--enable-osce`

- **Custom Modes:**  
  Allows non-standard sampling rates (e.g., 44.1 kHz) and custom frame sizes. Enabled via `--enable-custom-modes`

#### Omitted Flags

- `--enable-float-approx`  
  This flag is disabled to prioritize audio precision over speed, aligning with the default behavior of Opus and ensuring suitability for most hardware (including embedded systems with modern FPUs).