### PR TITLE
New package: selenium-4.29.0

### DIFF
--- a/srcpkgs/selenium/template
+++ b/srcpkgs/selenium/template
@@ -1,0 +1,16 @@
+# Template file for 'selenium'
+pkgname=selenium
+version=4.29.0
+revision=1
+build_wrksrc="rust"
+build_style=cargo
+hostmakedepends="python pkg-config"
+makedepends="libzstd-devel"
+short_desc="Browser automation framework and ecosystem"
+maintainer="Anachron <gith@cron.world>"
+license="Apache-2.0"
+homepage="https://selenium.dev"
+distfiles="https://github.com/SeleniumHQ/selenium/archive/refs/tags/selenium-${version}.tar.gz"
+checksum=47454fd528efd86c0d0d1035e8abe61aa1bd57f87771a0fc90d7954d05dae68e
+# fails because google-chrome is hardcoded for linux
+make_check=no


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - none

#### Testing

I did test this with [the official python test script](https://raw.githubusercontent.com/SeleniumHQ/seleniumhq.github.io/refs/heads/trunk/examples/python/tests/getting_started/first_script.py).

#### Packaging language bindings

I am not sure whether we want to package language bindings, such as python, as a system package. It works using `pip` and similiar just as well. 
