### PR TITLE
asahi-firmware: restrict arch

### DIFF
--- a/srcpkgs/asahi-firmware/template
+++ b/srcpkgs/asahi-firmware/template
@@ -1,7 +1,8 @@
 # Template file for 'asahi-firmware'
 pkgname=asahi-firmware
 version=0.7.9
-revision=1
+revision=2
+archs="aarch64*"
 build_style=python3-module
 hostmakedepends="python3-setuptools"
 depends="python3 lzfse"


### PR DESCRIPTION
It does not make sense to build this for all archs.
