### PR TITLE
New package: fooyin-0.8.1

### DIFF
--- a/srcpkgs/fooyin/patches/fix-cmake-sndfile.patch
+++ b/srcpkgs/fooyin/patches/fix-cmake-sndfile.patch
@@ -1,0 +1,57 @@
+--- a/cmake/modules/FindSndFile.cmake
++++ b/cmake/modules/FindSndFile.cmake
+@@ -5,22 +5,21 @@
+ # SndFile::SndFile - the sndfile library
+ 
+ find_package(PkgConfig QUIET)
+-if(PkgConfig_FOUND)
+-    pkg_check_modules(SndFile sndfile QUIET)
+-else()
+-    find_path(
+-        SndFile_INCLUDEDIR
+-        NAMES sndfile.h
+-        PATH_SUFFIXES sndfile
+-        DOC "SndFile include directory"
+-    )
++pkg_check_modules(SndFile sndfile QUIET)
++find_path(
++    SndFile_INCLUDEDIR
++    NAMES sndfile.h
++    PATH_SUFFIXES sndfile
++    HINTS ${PC_SndFile_INCLUDE_DIRS}
++    DOC "SndFile include directory"
++)
+ 
+-    find_library(
+-        SndFile_LINK_LIBRARIES
+-        NAMES sndfile sndfile-1
+-        DOC "SndFile library"
+-    )
+-endif()
++find_library(
++    SndFile_LINK_LIBRARIES
++    NAMES sndfile sndfile-1
++    HINTS ${PC_SndFile_LIBRARY_DIRS}
++    DOC "SndFile library"
++)
+ 
+ include(FindPackageHandleStandardArgs)
+ find_package_handle_standard_args(
+@@ -30,17 +29,6 @@
+     SndFile_INCLUDEDIR
+ )
+ 
+-file(STRINGS "${SndFile_INCLUDEDIR}/sndfile.h"
+-     SndFile_SUPPORTS_SET_COMPRESSION_LEVEL
+-     REGEX ".*SFC_SET_COMPRESSION_LEVEL.*"
+-)
+-if(SndFile_SUPPORTS_SET_COMPRESSION_LEVEL)
+-    set(SndFile_SUPPORTS_SET_COMPRESSION_LEVEL ON)
+-else()
+-    set(SndFile_SUPPORTS_SET_COMPRESSION_LEVEL OFF)
+-endif()
+-mark_as_advanced(SndFile_SUPPORTS_SET_COMPRESSION_LEVEL)
+-
+ if(SndFile_FOUND)
+     if(NOT TARGET SndFile::sndfile)
+         add_library(SndFile::sndfile INTERFACE IMPORTED)

--- a/srcpkgs/fooyin/template
+++ b/srcpkgs/fooyin/template
@@ -1,0 +1,35 @@
+# Template file for 'fooyin'
+pkgname=fooyin
+version=0.8.1
+revision=1
+_libvgm_rev="34c368cde98f33c42455fbbfbec07073ba79bf5c"
+build_style=cmake
+configure_args="
+ -DBUILD_PCH=ON
+ -DBUILD_WERROR=OFF"
+hostmakedepends="pkg-config qt6-base-devel qt6-tools"
+makedepends="qt6-base-devel qt6-svg-devel alsa-lib-devel
+ ffmpeg6-devel icu-devel libarchive-devel libebur128-devel
+ libgme-devel libopenmpt-devel libsndfile-devel pipewire-devel SDL2-devel
+ taglib-devel KDSingleApplication"
+depends="qt6-svg"
+checkdepends="gtest-devel"
+short_desc="Customisable music player"
+maintainer="Ivan Mirić <imiric-gh@proton.me>"
+license="GPL-3.0-only"
+homepage="https://www.fooyin.org/"
+changelog="https://raw.githubusercontent.com/fooyin/fooyin/refs/heads/master/CHANGELOG.md"
+distfiles="https://github.com/fooyin/fooyin/archive/v${version}.tar.gz
+ https://github.com/ValleyBell/libvgm/archive/${_libvgm_rev}.tar.gz"
+checksum="e702389488e19c4c48b1b62bf1b2adf263b818138e3b232a39259057cbcec9c2
+ 29eaaaa86ed79ca54d6fa68fa9bf056c67ffdc2ad2c2b6c17e1f94ea415c96d2"
+
+skip_extraction="${_libvgm_rev}.tar.gz"
+
+if [ "$XBPS_CHECK_PKGS" ]; then
+	configure_args+=" -DBUILD_TESTING=ON"
+fi
+
+post_extract() {
+	vsrcextract -C 3rdparty/libvgm "${_libvgm_rev}.tar.gz"
+}


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

#### Local build testing
- I built this PR locally for my native architecture, **x86_64**
- I tried building for other architectures such as armv6l, but couldn't get past this error:
  ```
  CMake Error at cmake/modules/FindSndFile.cmake:33 (file):
    file STRINGS file "/usr/include/sndfile.h" cannot be read.
  ```
  You can also see the [failure in CI](https://github.com/void-linux/void-packages/actions/runs/13873851395/job/38823716818?pr=54695).
  `libsndfile-devel` is specified in `makedepends`, so I'm not sure why that happens.

#### Note
This is based on the [AUR package](https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=fooyin), and the [build instructions](https://github.com/fooyin/fooyin/blob/master/BUILD.md). I wasn't sure how to specify the optional dependencies (equivalent of `optdepends` in Arch's PKGBUILD), so I just didn't include any of them in `depends`. Let me know if this should be changed.

Perhaps unrelated, but the app doesn't play any audio for me with the PipeWire output ([possibly related issue](https://github.com/fooyin/fooyin/issues/212), though it should be fixed in 0.8.1), and raises an error with the ALSA output. Playing works fine with the SDL2 output. These are likely app issues, though, and not related to the build.

I have a Git version of the template as well. Should I create another PR for it?