### PR TITLE
routinator: update to 0.14.2

### DIFF
--- a/srcpkgs/routinator/template
+++ b/srcpkgs/routinator/template
@@ -1,6 +1,6 @@
 # Template file for 'routinator'
 pkgname=routinator
-version=0.14.1
+version=0.14.2
 revision=1
 build_style=cargo
 depends="rsync"
@@ -11,7 +11,7 @@ homepage="https://routinator.docs.nlnetlabs.nl/"
 changelog="https://raw.githubusercontent.com/NLnetLabs/routinator/main/Changelog.md"
 distfiles="https://github.com/NLnetLabs/routinator/archive/v${version}.tar.gz"
 conf_files="/etc/routinator/routinator.conf"
-checksum=4b3aaf647ec61f7085e48af1cbc350cc0bdfce2082dae29cda16950cf4f4ae9d
+checksum=fe89be1da8a8b3467c627010c0a5dae241beceffc427c17ef16501adddebb6ad
 system_accounts="_routinator"
 _routinator_homedir="/var/lib/routinator"
 make_dirs="/var/lib/routinator 0755 _routinator _routinator"


### PR DESCRIPTION
From the release announcement: "This release fixes an issue in the bundled UI that caused it to retrieve data from our own test instance rather than the actual Routinator instance. Users of the bundled UI should upgrade."

#### Testing the changes
- I tested the changes in this PR: **briefly**

- I built this PR locally for my native architecture, (x86_64-musl)
- I built this PR locally for these architectures:
  - aarch64-musl
  - armv7l
  - armv6l-musl