### PR TITLE
libcdio: update to 2.2.0, fix build with gcc14

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -421,11 +421,11 @@ libtag_c.so.0 taglib-1.6.1_1
 libfribidi.so.0 fribidi-0.19.2_1
 liba52.so.0 liba52-0.7.4_1
 libcddb.so.2 libcddb-1.3.2_1
-libiso9660.so.11 libcdio-2.0.0_1
+libiso9660.so.12 libcdio-2.2.0_1
 libudf.so.0 libcdio-0.83_1
 libcdio_cdda.so.2 libcdio-paranoia-10.2_1
 libcdio_paranoia.so.2 libcdio-paranoia-10.2_1
-libiso9660++.so.0 libcdio-0.83_1
+libiso9660++.so.1 libcdio-2.2.0_1
 libcdio++.so.1 libcdio-2.0.0_1
 libcdio.so.19 libcdio-2.1.0_1
 libmpcdec.so.5 libmpcdec-1.2.6_1

--- a/srcpkgs/kodi/template
+++ b/srcpkgs/kodi/template
@@ -1,7 +1,7 @@
 # Template file for 'kodi'
 pkgname=kodi
 version=21.1
-revision=2
+revision=3
 _codename="Omega"
 _crossguid_ver="ca1bf4b810e2d188d04cb6286f957008ee1b7681"
 _dvdcss_ver="1.4.3-Next-Nexus-Alpha2-2"

--- a/srcpkgs/libcdio/patches/gcc14.patch
+++ b/srcpkgs/libcdio/patches/gcc14.patch
@@ -1,0 +1,76 @@
+Source: https://gitweb.gentoo.org/repo/gentoo.git/tree/dev-libs/libcdio/files/libcdio-2.1.0-no-lfs-shims.patch
+
+From https://bugs.gentoo.org/918988
+From: Alfred Wingate <parona@protonmail.com>
+Date: Mon, 20 May 2024 22:02:08 +0300
+Subject: [PATCH] Do not use LFS shims, rely on _FILE_OFFSET_BITS=64
+
+See https://savannah.gnu.org/bugs/?65751 and https://bugs.gentoo.org/918988
+
+Setting _FILE_OFFSET_BITS=64 is enough to get the LFS interface,
+using LFS shims is unnecessary on 64-bit systems and they may
+not be available on 32-bit systems on glibc.
+
+Signed-off-by: Alfred Wingate <parona@protonmail.com>
+--- a/configure.ac
++++ b/configure.ac
+@@ -547,10 +547,10 @@ AC_DEFINE_UNQUOTED(LIBCDIO_SOURCE_PATH, "$LIBCDIO_SOURCE_PATH",
+ 	[Full path to libcdio top_sourcedir.])
+ AC_SUBST(LIBCDIO_SOURCE_PATH)
+ 
+-AC_CHECK_FUNCS( [chdir drand48 fseeko fseeko64 ftruncate geteuid getgid \
+-		 getuid getpwuid gettimeofday lseek64 lstat memcpy memset mkstemp rand \
+-		 seteuid setegid snprintf setenv strndup unsetenv tzset sleep \
+-		 _stati64 usleep vsnprintf readlink realpath gmtime_r localtime_r] )
++AC_CHECK_FUNCS( [chdir drand48 fseeko ftruncate geteuid getgid getuid \
++		 getpwuid gettimeofday lstat memcpy memset mkstemp rand seteuid \
++		 setegid snprintf setenv strndup unsetenv tzset sleep _stati64 \
++		 usleep vsnprintf readlink realpath gmtime_r localtime_r] )
+ 
+ # check for timegm() support
+ AC_CHECK_FUNC(timegm, AC_DEFINE(HAVE_TIMEGM,1,
+--- a/lib/driver/_cdio_generic.c
++++ b/lib/driver/_cdio_generic.c
+@@ -55,16 +55,6 @@
+ #define PATH_MAX 4096
+ #endif
+ 
+-/* If available and LFS is enabled, try to use lseek64 */
+-#if defined(HAVE_LSEEK64) && defined(_FILE_OFFSET_BITS) && (_FILE_OFFSET_BITS == 64)
+-#if defined(_MSC_VER)
+-#include <io.h>
+-#endif
+-#define CDIO_LSEEK lseek64
+-#else
+-#define CDIO_LSEEK lseek
+-#endif
+-
+ /*!
+   Eject media -- there's nothing to do here. We always return -2.
+   Should we also free resources?
+@@ -170,7 +160,7 @@ off_t
+ cdio_generic_lseek (void *user_data, off_t offset, int whence)
+ {
+   generic_img_private_t *p_env = user_data;
+-  return CDIO_LSEEK(p_env->fd, offset, whence);
++  return lseek(p_env->fd, offset, whence);
+ }
+ 
+ /*!
+--- a/lib/driver/_cdio_stdio.c
++++ b/lib/driver/_cdio_stdio.c
+@@ -47,11 +47,7 @@
+ #include "_cdio_stdio.h"
+ #include "cdio_assert.h"
+ 
+-/* On 32 bit platforms, fseek can only access streams of 2 GB or less.
+-   Prefer fseeko/fseeko64, that take a 64 bit offset when LFS is enabled */
+-#if defined(HAVE_FSEEKO64) && defined(_FILE_OFFSET_BITS) && (_FILE_OFFSET_BITS == 64)
+-#define CDIO_FSEEK fseeko64
+-#elif defined(HAVE_FSEEKO)
++#if defined(HAVE_FSEEKO)
+ #define CDIO_FSEEK fseeko
+ #else
+ #define CDIO_FSEEK fseek
+-- 
+2.45.1

--- a/srcpkgs/libcdio/template
+++ b/srcpkgs/libcdio/template
@@ -1,16 +1,16 @@
 # Template file for 'libcdio'
 pkgname=libcdio
-version=2.1.0
+version=2.2.0
 revision=1
 build_style=gnu-configure
 hostmakedepends="automake libtool pkg-config"
 makedepends="ncurses-devel libcddb-devel"
 short_desc="CD-ROM access library"
 maintainer="Orphaned <orphan@voidlinux.org>"
-license="GPL-3"
+license="GPL-3.0-or-later"
 homepage="http://www.gnu.org/software/libcdio/"
-distfiles="${GNU_SITE}/$pkgname/$pkgname-$version.tar.bz2"
-checksum=8550e9589dbd594bfac93b81ecf129b1dc9d0d51e90f9696f1b2f9b2af32712b
+distfiles="https://github.com/libcdio/libcdio/releases/download/${version}/libcdio-${version}.tar.gz"
+checksum=1b6c58137f71721ddb78773432d26252ee6500d92d227d4c4892631c30ea7abb
 
 pre_configure() {
 	autoreconf -fi

--- a/srcpkgs/mpd/template
+++ b/srcpkgs/mpd/template
@@ -1,7 +1,7 @@
 # Template file for 'mpd'
 pkgname=mpd
 version=0.23.15
-revision=3
+revision=4
 build_style=meson
 configure_args="-Dopus=enabled -Dmikmod=enabled -Dneighbor=true
  -Dsoundcloud=enabled -Dpipe=true -Dtwolame=enabled -Dbzip2=enabled

--- a/srcpkgs/python3-pycdio/template
+++ b/srcpkgs/python3-pycdio/template
@@ -1,7 +1,7 @@
 # Template file for 'python3-pycdio'
 pkgname=python3-pycdio
-version=2.1.0
-revision=7
+version=2.1.1
+revision=1
 build_style=python3-module
 hostmakedepends="python3-setuptools pkg-config swig"
 makedepends="libcdio-devel python3-devel"
@@ -10,5 +10,5 @@ short_desc="Python OO interface to libcdio (CD Input and Control library)"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-3.0-or-later"
 homepage="https://www.gnu.org/software/libcdio"
-distfiles="${GNU_SITE}/libcdio/pycdio-${version}.tar.gz"
-checksum=d6d2e59d16339788835eed62ff75cfa38e7caa6f7e290dcc0d07f8ec30de6705
+distfiles="https://github.com/rocky/pycdio/archive/refs/tags/${version}.tar.gz"
+checksum=a1754d3f01b1a8cefa15070ecce467822b4de0436d06a5ace1e3351f223e13f2

--- a/srcpkgs/vcdimager/template
+++ b/srcpkgs/vcdimager/template
@@ -1,7 +1,7 @@
 # Template file for 'vcdimager'
 pkgname=vcdimager
 version=2.0.1
-revision=2
+revision=3
 build_style=gnu-configure
 hostmakedepends="pkg-config"
 makedepends="libcdio-devel libxml2-devel popt-devel libcdio-paranoia-devel"
@@ -11,6 +11,7 @@ license="GPL-2.0-or-later"
 homepage="http://www.gnu.org/software/vcdimager/"
 distfiles="${GNU_SITE}/vcdimager/${pkgname}-${version}.tar.gz"
 checksum=67515fefb9829d054beae40f3e840309be60cda7d68753cafdd526727758f67a
+make_check=no # Tests check against hardcoded checksums
 
 nocross="https://travis-ci.org/void-linux/void-packages/jobs/403903864#L989
  https://travis-ci.org/void-linux/void-packages/jobs/403903865#L989"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
