### PR TITLE
dnscrypt-proxy: update to 2.1.8.

### DIFF
--- a/srcpkgs/dnscrypt-proxy/template
+++ b/srcpkgs/dnscrypt-proxy/template
@@ -1,7 +1,7 @@
 # Template file for 'dnscrypt-proxy'
 pkgname=dnscrypt-proxy
-version=2.1.5
-revision=2
+version=2.1.8
+revision=1
 build_style=go
 go_import_path=github.com/dnscrypt/dnscrypt-proxy
 go_package="${go_import_path}/dnscrypt-proxy"
@@ -12,7 +12,7 @@ license="ISC"
 homepage="https://github.com/DNSCrypt/dnscrypt-proxy"
 changelog="https://raw.githubusercontent.com/DNSCrypt/dnscrypt-proxy/master/ChangeLog"
 distfiles="https://github.com/DNSCrypt/dnscrypt-proxy/archive/refs/tags/${version}.tar.gz"
-checksum=044c4db9a3c7bdcf886ff8f83c4b137d2fd37a65477a92bfe86bf69587ea7355
+checksum=db2d593d084d034235faaf09743318b4039fb5be2d3a6e17cb0157091d23f4db
 conf_files="/etc/dnscrypt-proxy/dnscrypt-proxy.toml"
 system_accounts="dnscrypt_proxy"
 


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture (x86_64-glibc)

