### PR TITLE
prosody: update to 13.0.0.

### DIFF
--- a/srcpkgs/prosody/template
+++ b/srcpkgs/prosody/template
@@ -1,6 +1,6 @@
 # Template file for 'prosody'
 pkgname=prosody
-version=0.12.5
+version=13.0.0
 revision=1
 build_style=configure
 configure_args="
@@ -27,7 +27,7 @@ license="MIT"
 homepage="https://prosody.im/"
 changelog="https://prosody.im/doc/release/${version}"
 distfiles="https://prosody.im/downloads/source/${pkgname}-${version}.tar.gz"
-checksum=778fb7707a0f10399595ba7ab9c66dd2a2288c0ae3a7fe4ab78f97d462bd399f
+checksum=4309c5cfeb1a74d3f97185f6243a0c1068eb39fa7e91abc42cf2194bf067fc54
 
 system_accounts="prosody"
 prosody_homedir="/var/lib/prosody"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl (crossbuilt)

Crossbuilt on x86_64-glibc for aarch64-musl. Tested on a aarch64-musl
and runs as expected
