### PR TITLE
vscode: update to 1.99.3

### DIFF
--- a/srcpkgs/vscode/template
+++ b/srcpkgs/vscode/template
@@ -1,8 +1,8 @@
 # Template file for 'vscode'
 pkgname=vscode
-version=1.97.2
+version=1.99.3
 revision=1
-_electronver=33.0.2
+_electronver=33.2.0
 _npmver=10.8.3
 hostmakedepends="pkg-config python3 python3-setuptools nodejs tar git ripgrep"
 makedepends="libxkbfile-devel libsecret-devel libxml2-devel mit-krb5-devel nodejs-devel ncurses-devel electron33-devel"
@@ -12,7 +12,7 @@ maintainer="Alex Lohr <alexthkloss@web.de>"
 license="MIT"
 homepage="https://code.visualstudio.com/"
 distfiles="https://github.com/microsoft/vscode/archive/refs/tags/${version}.tar.gz"
-checksum=6bbb7144e11fefe06418c1f3671a877794a7513c2add85121f560dc686c31351
+checksum=81659cfc11d5c3a9a2ab46cd7e9a4d4ce4d4389a9e36cb8d1070503fc4e4ad3e
 nocross=yes # x64 build does not cut it, it contains native code
 
 if [ "$XBPS_TARGET_WORDSIZE" = "32" ]; then
@@ -42,9 +42,9 @@ do_build() {
 	npm install -g npm@${_npmver}
 
 	# The default memory limit may be too low for current versions of node
-	# to successfully build vscode.  This sets it to 4GB, but
+	# to successfully build vscode.  This sets it to 8GB, but
 	# change this number if it still doesn't work for your system.
-	_mem_limit="--max_old_space_size=4095"
+	_mem_limit="--max_old_space_size=16384"
 
 	export NODE_OPTIONS="${_mem_limit}"
 
@@ -58,7 +58,7 @@ do_build() {
 	vsed -e "s/validateChecksum: true/validateChecksum: false/g" -i build/lib/electron.*s
 
 	export CFLAGS="$CFLAGS -I/usr/include/node"
-	npm run gulp vscode-linux-x64-min
+	node_modules/.bin/gulp --max_old_space_size=16384 --optimize-for-size --series vscode-linux-x64-min
 }
 
 do_install() {


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

I get the error message

```
Error [ERR_WORKER_OUT_OF_MEMORY]: Worker terminated due to reaching memory limit: JS heap out of memory
```

probably due to my personal system being limited to 8GB of RAM.

__Update__: I had to change a few bits, but I finally fixed the build. It now requires 16GB at least (using swap works fine, but slows things down considerably).

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
