### PR TITLE
ncspot: update to 1.2.2, spotify-player: fix workaround

### DIFF
--- a/srcpkgs/ncspot/template
+++ b/srcpkgs/ncspot/template
@@ -1,6 +1,6 @@
 # Template file for 'ncspot'
 pkgname=ncspot
-version=1.2.1
+version=1.2.2
 revision=1
 build_style=cargo
 build_helper="qemu"
@@ -14,14 +14,11 @@ license="BSD-2-Clause"
 homepage="https://github.com/hrkfdn/ncspot"
 changelog="https://raw.githubusercontent.com/hrkfdn/ncspot/main/CHANGELOG.md"
 distfiles="https://github.com/hrkfdn/ncspot/archive/refs/tags/v${version}.tar.gz"
-checksum=6bd08609a56aa5854a1964c9a872fe58b69a768d7d94c874d40d7a8848241213
+checksum=11555a61be381afa6196b0603d12ea34ee0c6e1660d7c586d13927f3e5ba802c
 
-# FIXME: Workaround will be removed when https://github.com/aws/aws-lc-rs/issues/632 is resolved
-case "$XBPS_TARGET_MACHINE" in
-	armv[67]l)
-		export AWS_LC_SYS_CFLAGS="-Wno-stringop-overflow"
-		;;
-esac
+pre_build() {
+	cargo update --package aws-lc-rs
+}
 
 post_build() {
 	cargo auditable build --release --target ${RUST_TARGET} --package xtask

--- a/srcpkgs/spotify-player/template
+++ b/srcpkgs/spotify-player/template
@@ -1,7 +1,7 @@
 # Template file for 'spotify-player'
 pkgname=spotify-player
 version=0.20.4
-revision=1
+revision=2
 build_style=cargo
 make_install_args="--path spotify_player"
 hostmakedepends="pkg-config cmake clang rust-bindgen"
@@ -13,12 +13,9 @@ homepage="https://github.com/aome510/spotify-player"
 distfiles="https://github.com/aome510/spotify-player/archive/refs/tags/v${version}.tar.gz"
 checksum=1d13f47ef4df3415835736f32629d57e331707d781507007ea04217a7dc735d8
 
-# FIXME: Workaround will be removed when https://github.com/aws/aws-lc-rs/issues/632 is resolved
-case "$XBPS_TARGET_MACHINE" in
-	armv[67]l)
-	export AWS_LC_SYS_CFLAGS="-Wno-stringop-overflow"
-	;;
-esac
+pre_build() {
+	cargo update --package aws-lc-rs
+}
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, x86_64
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl
  - i686
  - armv7l{,-musl} (crossbuild)
  - armv6l{,-musl} (crossbuild)

