### PR TITLE
gutenprint: update to 5.3.5.

### DIFF
--- a/srcpkgs/gutenprint/template
+++ b/srcpkgs/gutenprint/template
@@ -1,19 +1,19 @@
 # Template file for 'gutenprint'
 pkgname=gutenprint
-version=5.3.4
+version=5.3.5
 revision=1
 build_style=gnu-configure
 configure_args="--disable-rpath --enable-samples --disable-static
  --disable-static-genppd --enable-cups-ppds --enable-simplified-cups-ppds=only
  --enable-translated-cups-ppds --enable-globalized-cups-ppds"
-hostmakedepends="ghostscript perl"
+hostmakedepends="ghostscript perl pkg-config"
 makedepends="cups-devel"
 short_desc="Top quality printer drivers for POSIX systems"
 maintainer="Anachron <Anachron14@gmx.de>"
 license="GPL-2.0-or-later"
 homepage="http://gimp-print.sourceforge.net/"
 distfiles="${SOURCEFORGE_SITE}/gimp-print/$pkgname-$version.tar.xz"
-checksum=db44a701d2b8e6a8931c83cec06c91226be266d23e5c189d20a39dd175f2023b
+checksum=f5a9f47de28530b1ae2069cfbc647a9a641baeeabe809bb0ef2b3ec5b9668d70
 nocross="https://sourceforge.net/p/gimp-print/mailman/message/34782748/"
 
 post_install() {


### PR DESCRIPTION
This updates gutenprint to 5.3.5. This should fix #40289 and #43534 due to the inclusion of this change in the 5.3.5 release:
[https://sourceforge.net/p/gimp-print/source/merge-requests/10/](https://sourceforge.net/p/gimp-print/source/merge-requests/10/)

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-musl)
- ~~I built this PR locally for these architectures (if supported. mark crossbuilds):~~ **(Cross-compiling not supported by package)**
