### PR TITLE
libarchive: update to 3.7.9

### DIFF
--- a/srcpkgs/libarchive/template
+++ b/srcpkgs/libarchive/template
@@ -1,6 +1,6 @@
 # Template file for 'libarchive'
 pkgname=libarchive
-version=3.7.7
+version=3.7.9
 revision=1
 bootstrap=yes
 build_style=gnu-configure
@@ -18,7 +18,7 @@ license="BSD-2-Clause"
 homepage="https://www.libarchive.org/"
 changelog="https://github.com/libarchive/libarchive/releases"
 distfiles="https://github.com/libarchive/libarchive/releases/download/v${version}/libarchive-${version}.tar.xz"
-checksum=879acd83c3399c7caaee73fe5f7418e06087ab2aaf40af3e99b9e29beb29faee
+checksum=ed8b5732e4cd6e30fae909fb945cad8ff9cb7be5c6cdaa3944ec96e4a200c04c
 
 build_options="acl expat lzo lz4 ssl zstd"
 build_options_default="acl ssl lz4 zstd"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - i686-glibc (crossbuild)