### PR TITLE
common/shlibs: fix typo

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -102,7 +102,7 @@ libglib-2.0.so.0 glib-2.80.0_1
 libgmodule-2.0.so.0 glib-2.80.0_1
 libgio-2.0.so.0 glib-2.80.0_1
 libgobject-2.0.so.0 glib-2.80.0_1
-libgrepository-2.0.so.0 glib-2.80.0_1
+libgirepository-2.0.so.0 glib-2.80.0_1
 libwt.so.4.10.4 wt-4.10.4_1
 libwtdbo.so.4.10.4 wt-4.10.4_1
 libwtdbosqlite3.so.4.10.4 wt-4.10.4_1


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

it's `libgirepository-2.0.so.0`, not `libgrepository-2.0.so.0`