### PR TITLE
New package: decibels-48.0

### DIFF
--- a/srcpkgs/decibels/template
+++ b/srcpkgs/decibels/template
@@ -1,0 +1,28 @@
+# Template file for 'decibels'
+pkgname=decibels
+version=48.0
+revision=1
+build_style=meson
+hostmakedepends="blueprint-compiler desktop-file-utils gettext gjs glib-devel
+ gtk4-update-icon-cache nodejs pkg-config"
+makedepends="gjs-devel libadwaita-devel"
+depends="gjs gst-plugins-good1 libadwaita"
+checkdepends="appstream-glib"
+short_desc="Play audio files"
+maintainer="chrysos349 <chrysostom349@gmail.com>"
+license="GPL-3.0-or-later"
+homepage="https://apps.gnome.org/Decibels/"
+changelog="https://gitlab.gnome.org/GNOME/decibels/-/raw/main/NEWS"
+distfiles="${GNOME_SITE}/decibels/${version%.*}/decibels-${version}.tar.xz"
+checksum=229b11a9263147bcb8c3e21ff0d4af659fb26262f8aece547adcf8c65e031f74
+
+pre_configure() {
+	npm i typescript
+	export PATH="$PATH:$(pwd)/node_modules/.bin"
+}
+
+pre_build() {
+	if [ "$CROSS_BUILD" ]; then
+		export GI_TYPELIB_PATH="${XBPS_CROSS_BASE}/usr/lib/girepository-1.0"
+	fi
+}


### PR DESCRIPTION
it's a new official gnome app since version 48 (see #54783), a simple audio player.

#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**


#### Local build testing
- I built this PR locally for my native architecture, (x86_64)