### PR TITLE
python3-pulsectl-asyncio: update to 1.2.2.

### DIFF
--- a/srcpkgs/python3-pulsectl-asyncio/template
+++ b/srcpkgs/python3-pulsectl-asyncio/template
@@ -1,7 +1,7 @@
 # Template file for 'python3-pulsectl-asyncio'
 pkgname=python3-pulsectl-asyncio
-version=1.2.1
-revision=2
+version=1.2.2
+revision=1
 build_style=python3-pep517
 hostmakedepends="python3-setuptools python3-wheel"
 depends="python3-pulsectl libpulseaudio"
@@ -10,7 +10,7 @@ maintainer="Kai Stian Olstad <void@olstad.com>"
 license="MIT"
 homepage="https://github.com/mhthies/pulsectl-asyncio"
 distfiles="${PYPI_SITE}/p/pulsectl-asyncio/pulsectl_asyncio-${version}.tar.gz"
-checksum=e2993931fe1367908b5f8f603204744de7b9667853660eb7fc4db88b4b1bbffe
+checksum=ee4c427a10f44d2e38065e480668a47316b5d93612ebe3d05d9318f0fe0d417f
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-LIBC)