### PR TITLE
common/travis/check-install.sh: don't exit after install failure

### DIFF
--- a/common/travis/check-install.sh
+++ b/common/travis/check-install.sh
@@ -30,19 +30,25 @@ ROOTDIR="-r /check-install"
 # if this fails, there were no packages built for this arch and thus no repodatas
 xbps-install $ROOTDIR $ADDREPO $CONFDIR -S || exit 0
 
+failed=()
 while read -r pkg; do
 	for subpkg in $(xsubpkg $pkg); do
 		/bin/echo -e "\x1b[32mTrying to install dependents of $subpkg:\x1b[0m"
 		for dep in $(xbps-query $ADDREPO -RX "$subpkg"); do
+			ret=0
 			xbps-install \
 				$ROOTDIR $ADDREPO $CONFDIR \
 				-ny \
-				"$subpkg" "$(xbps-uhelper getpkgname "$dep")"
-			ret="$?"
-			if [ "$ret" -eq 8 ] || [ "$ret" -eq 11 ]; then
+				"$subpkg" "$(xbps-uhelper getpkgname "$dep")" \
+				|| ret="$?"
+			if [ "$ret" -ne 0 ]; then
 				/bin/echo -e "\x1b[31mFailed to install '$subpkg' and '$dep'\x1b[0m"
-				exit 1
+				failed+=("Failed to install '$subpkg' and '$dep'")
 			fi
 		done
 	done
 done < /tmp/templates
+for msg in "${failed[@]}"; do
+	/bin/echo -e "\x1b[31m$msg\x1b[0m"
+done
+exit ${#failed[@]}


### PR DESCRIPTION
This allows for showing all install errors for a package at once, rather than having to check one at a time.

This also fixes displaying the error message (which currently doesn't happen due to `set -e`)

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

(I tested this with the glib update PR: https://github.com/void-linux/void-packages/actions/runs/14007226644/job/39222652926)

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
