### PR TITLE
vale: update to 3.10.0.

### DIFF
--- a/srcpkgs/vale/template
+++ b/srcpkgs/vale/template
@@ -1,18 +1,19 @@
 # Template file for 'vale'
 pkgname=vale
-version=3.9.3
+version=3.10.0
 revision=1
 build_style=go
 go_import_path="github.com/errata-ai/vale/v3"
 go_package="${go_import_path}/cmd/vale"
 go_ldflags=" -X main.version=${version}"
+make_check_args="-skip TestSymlinkFixture"
 short_desc="Natural language linter"
 maintainer="icp <pangolin@vivaldi.net>"
 license="MIT"
 homepage="https://vale.sh"
 changelog="https://github.com/errata-ai/vale/releases"
 distfiles="https://github.com/errata-ai/vale/archive/refs/tags/v${version}.tar.gz"
-checksum=5ecf6ea4183e0c976bf5f391e296da833f173956fd6f9f28597f8e63af66e178
+checksum=2bce5943e0c885dd1bb520922afcce0e985c39d600ae8cf88579aca219c5f1d0
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture: **x86_64**