### PR TITLE
libxcrypt: update to 4.4.38

### DIFF
--- a/srcpkgs/libxcrypt/template
+++ b/srcpkgs/libxcrypt/template
@@ -1,7 +1,7 @@
 # Template file for 'libxcrypt'
 pkgname=libxcrypt
-version=4.4.36
-revision=3
+version=4.4.38
+revision=1
 archs="~*-musl"
 build_style=gnu-configure
 configure_args="--enable-hashes=all --disable-failure-tokens --enable-obsolete-api=no"
@@ -9,11 +9,11 @@ make_cmd="make -C build"
 hostmakedepends="perl-bootstrap"
 checkdepends="python3-passlib"
 short_desc="Modern library for one-way hashing of passwords"
-maintainer="oreo639 <oreo639@gmail.com>"
+maintainer="oreo639 <oreo6391@gmail.com>"
 license="LGPL-2.1-or-later, BSD-3-Clause, BSD-2-Clause, 0BSD, Public Domain"
 homepage="https://github.com/besser82/libxcrypt"
 distfiles="https://github.com/besser82/libxcrypt/releases/download/v${version}/libxcrypt-${version}.tar.xz"
-checksum=e5e1f4caee0a01de2aee26e3138807d6d3ca2b8e67287966d1fefd65e1fd8943
+checksum=80304b9c306ea799327f01d9a7549bdb28317789182631f1b54f4511b4206dd6
 
 if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
 	broken="musl already provides libcrypt"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

Also fix typo in maintainer email.

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
