### PR TITLE
lightsoff: update to 48.0

### DIFF
--- a/srcpkgs/lightsoff/template
+++ b/srcpkgs/lightsoff/template
@@ -1,14 +1,14 @@
 # Template file for 'lightsoff'
 pkgname=lightsoff
-version=46.0
+version=48.0
 revision=1
 build_style=meson
 hostmakedepends="gettext glib-devel itstool pkg-config vala"
-makedepends="clutter-gtk-devel librsvg-devel"
+makedepends="libadwaita-devel"
 short_desc="GNOME puzzlle game where you turn off lights"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="https://wiki.gnome.org/Apps/Lightsoff"
 changelog="https://gitlab.gnome.org/GNOME/lightsoff/-/raw/master/NEWS"
 distfiles="${GNOME_SITE}/${pkgname}/${version%%.*}/${pkgname}-${version}.tar.xz"
-checksum=672b1532e0645fae02f2837a96d539edcfd4c3ba4f72e591dc73fe479ebb8b92
+checksum=de6929b74bdc9c2ebc3f3f52c7cb3142c09fd5f3d2664e390a6387ddae0c7684


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)