### PR TITLE
gnome-robots: update to 41.2

### DIFF
--- a/srcpkgs/gnome-robots/template
+++ b/srcpkgs/gnome-robots/template
@@ -1,14 +1,22 @@
 # Template file for 'gnome-robots'
 pkgname=gnome-robots
-version=40.0
+version=41.2
 revision=1
 build_style=meson
-hostmakedepends="gettext glib-devel itstool pkg-config vala"
-makedepends="gsound-devel gtk4-devel libcanberra-devel librsvg-devel
- libglib-devel libgnome-games-support-devel"
+build_helper=rust
+hostmakedepends="gettext glib-devel itstool pkg-config cargo
+ gtk4-update-icon-cache desktop-file-utils"
+makedepends="libadwaita-devel librsvg-devel rust-std"
 short_desc="GNOME classic robots game"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="https://wiki.gnome.org/Apps/Robots"
 distfiles="${GNOME_SITE}/${pkgname}/${version%.*}/${pkgname}-${version}.tar.xz"
-checksum=6fbf2f885750f1a5110a724f8f35addd9bc61184ee31cf0c0cb89953e4f4cb11
+checksum=9121c2f836812043feef2ba661cd5d0fd48e3d6319c43941b9fdd158b9b0eb91
+
+post_patch() {
+	if [ "$CROSS_BUILD" ]; then
+		vsed -i src/meson.build \
+			-e "s%rust_target /%'${RUST_TARGET}' / &%"
+	fi
+}

--- a/srcpkgs/librsvg/template
+++ b/srcpkgs/librsvg/template
@@ -1,7 +1,7 @@
 # Template file for 'librsvg'
 pkgname=librsvg
-version=2.59.1
-revision=4
+version=2.59.2
+revision=1
 build_style=meson
 build_helper="gir rust"
 hostmakedepends="cargo cargo-c pkg-config glib-devel gdk-pixbuf-devel
@@ -14,7 +14,7 @@ license="LGPL-2.1-or-later"
 homepage="https://gitlab.gnome.org/GNOME/librsvg"
 changelog="https://gitlab.gnome.org/GNOME/librsvg/-/raw/main/NEWS"
 distfiles="${GNOME_SITE}/librsvg/${version%.*}/librsvg-${version}.tar.xz"
-checksum=6116267c7ddabfd4daaf1c341326da0a773139a7223e885ae40ee09bd6986ef6
+checksum=ecd293fb0cc338c170171bbc7bcfbea6725d041c95f31385dc935409933e4597
 
 # reference files are for specific pango and harfbuzz versions
 # the test suite isn't designed to be run by distros


### PR DESCRIPTION
requires a new version of librsvg

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)