### PR TITLE
vala{,doc}: update to 0.56.18

### DIFF
--- a/srcpkgs/vala/template
+++ b/srcpkgs/vala/template
@@ -1,7 +1,7 @@
 # Template file for 'vala'
 pkgname=vala
 # Should be kept in sync with 'valadoc' (shared distfiles)
-version=0.56.17
+version=0.56.18
 revision=1
 build_style=gnu-configure
 configure_args="--disable-valadoc GI_GIRDIR=/usr/share/gir-1.0"
@@ -14,7 +14,7 @@ license="LGPL-2.1-or-later"
 homepage="https://wiki.gnome.org/Projects/Vala"
 changelog="https://gitlab.gnome.org/GNOME/vala/raw/master/NEWS"
 distfiles="${GNOME_SITE}/vala/${version%.*}/vala-${version}.tar.xz"
-checksum=26100c4e4ef0049c619275f140d97cf565883d00c7543c82bcce5a426934ed6a
+checksum=f2affe7d40ab63db8e7b9ecc3f6bdc9c2fc7e3134c84ff2d795f482fe926a382
 shlib_provides="libvalaccodegen.so"
 make_check=extended # take a lot of time
 

--- a/srcpkgs/valadoc/template
+++ b/srcpkgs/valadoc/template
@@ -1,7 +1,7 @@
 # Template file for 'valadoc'
 pkgname=valadoc
 # Should be kept in sync with 'vala' (shared distfiles)
-version=0.56.17
+version=0.56.18
 revision=1
 build_style=gnu-configure
 configure_args="--with-cgraph=yes GI_GIRDIR=/usr/share/gir-1.0"
@@ -15,7 +15,7 @@ license="LGPL-2.1-or-later"
 homepage="https://wiki.gnome.org/Projects/Vala"
 changelog="https://gitlab.gnome.org/GNOME/vala/raw/master/NEWS"
 distfiles="${GNOME_SITE}/vala/${version%.*}/vala-${version}.tar.xz"
-checksum=26100c4e4ef0049c619275f140d97cf565883d00c7543c82bcce5a426934ed6a
+checksum=f2affe7d40ab63db8e7b9ecc3f6bdc9c2fc7e3134c84ff2d795f482fe926a382
 
 pre_configure() {
 	autoreconf -if


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)