### PR TITLE
evince: update to 48.0

### DIFF
--- a/srcpkgs/evince/template
+++ b/srcpkgs/evince/template
@@ -1,7 +1,7 @@
 # Template file for 'evince'
 pkgname=evince
-version=46.3.1
-revision=2
+version=48.0
+revision=1
 build_helper="gir"
 build_style=meson
 configure_args="$(vopt_bool gir introspection) $(vopt_bool gtk_doc gtk_doc)
@@ -19,7 +19,7 @@ license="GPL-2.0-or-later"
 homepage="https://wiki.gnome.org/Apps/Evince"
 changelog="https://gitlab.gnome.org/GNOME/evince/-/raw/gnome-${version%%.*}/NEWS"
 distfiles="${GNOME_SITE}/evince/${version%%.*}/evince-${version}.tar.xz"
-checksum=945c20a6f23839b0d5332729171458e90680da8264e99c6f9f41c219c7eeee7c
+checksum=cd2f658355fa9075fdf9e5b44aa0af3a7e0928c55614eb1042b36176cf451126
 
 build_options="gir gtk_doc"
 build_options_default="gir gtk_doc"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)