### PR TITLE
gnome-boxes: update to 48.0

### DIFF
--- a/srcpkgs/gnome-boxes/template
+++ b/srcpkgs/gnome-boxes/template
@@ -1,6 +1,6 @@
 # Template file for 'gnome-boxes'
 pkgname=gnome-boxes
-version=47.0
+version=48.0
 revision=1
 build_helper="gir"
 build_style=meson
@@ -18,4 +18,4 @@ license="LGPL-2.0-or-later"
 homepage="https://wiki.gnome.org/Apps/Boxes"
 changelog="https://gitlab.gnome.org/GNOME/gnome-boxes/-/raw/main/NEWS"
 distfiles="${GNOME_SITE}/gnome-boxes/${version%%.*}/gnome-boxes-${version}.tar.xz"
-checksum=65bf6c2de1bf4d51695c9192c5b1e6285cb32c98a18aa948a376ea32038bc78f
+checksum=d05f5f42568fafbf6d88771161b06ed5f739d43121278d418cae95c56e513ead


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)