### PR TITLE
gnome-clocks: update to 48.0

### DIFF
--- a/srcpkgs/gnome-clocks/template
+++ b/srcpkgs/gnome-clocks/template
@@ -1,6 +1,6 @@
 # Template file for 'gnome-clocks'
 pkgname=gnome-clocks
-version=47.0
+version=48.0
 revision=1
 build_helper="gir"
 build_style=meson
@@ -15,7 +15,8 @@ short_desc="Clock application for the GNOME Desktop"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="https://wiki.gnome.org/Apps/Clocks"
-#changelog="https://gitlab.gnome.org/GNOME/gnome-clocks/-/raw/master/NEWS"
-changelog="https://gitlab.gnome.org/GNOME/gnome-clocks/-/raw/gnome-47/NEWS"
+changelog="https://gitlab.gnome.org/GNOME/gnome-clocks/-/raw/master/NEWS"
+# FIXME: dead link
+changelog="https://gitlab.gnome.org/GNOME/gnome-clocks/-/raw/gnome-48/NEWS"
 distfiles="${GNOME_SITE}/gnome-clocks/${version%.*}/gnome-clocks-${version}.tar.xz"
-checksum=428bdf4bd17e26de6cef014cd7a7eebd89143c3f2732b24b7da69812baa52131
+checksum=616ee1fb75300b1f26b9766219e954751360ca0fa0f491311bcf83bf38087c62


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)