### PR TITLE
gnome-font-viewer: update to 48.0

### DIFF
--- a/srcpkgs/gnome-font-viewer/template
+++ b/srcpkgs/gnome-font-viewer/template
@@ -1,6 +1,6 @@
 # Template file for 'gnome-font-viewer'
 pkgname=gnome-font-viewer
-version=47.0
+version=48.0
 revision=1
 build_style=meson
 hostmakedepends="pkg-config glib-devel gettext"
@@ -12,6 +12,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="https://gitlab.gnome.org/GNOME/gnome-font-viewer"
 changelog="https://gitlab.gnome.org/GNOME/gnome-font-viewer/-/raw/main/NEWS"
-#changelog="https://gitlab.gnome.org/GNOME/gnome-font-viewer/-/raw/gnome-47/NEWS"
+# FIXME: dead link
+#changelog="https://gitlab.gnome.org/GNOME/gnome-font-viewer/-/raw/gnome-48/NEWS"
 distfiles="${GNOME_SITE}/gnome-font-viewer/${version%.*}/gnome-font-viewer-${version}.tar.xz"
-checksum=b8e5a042e0b241b0c7cae43f74da0d5f88e6423017a91feb86e7617edb4080ed
+checksum=732624231b624ff5c7ac03a8ce71be12393daa53551d11550b20d7b0a3a872a7


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)