### PR TITLE
at-spi2-core: update to 2.56.0

### DIFF
--- a/srcpkgs/at-spi2-core/template
+++ b/srcpkgs/at-spi2-core/template
@@ -1,6 +1,6 @@
 # Template file for 'at-spi2-core'
 pkgname=at-spi2-core
-version=2.52.0
+version=2.56.0
 revision=1
 build_style=meson
 build_helper="gir"
@@ -12,10 +12,10 @@ short_desc="Assistive Technology Service Provider Interface"
 maintainer="Enno Boland <gottox@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="https://gitlab.gnome.org/GNOME/at-spi2-core"
-changelog="https://gitlab.gnome.org/GNOME/at-spi2-core/-/raw/gnome-46/NEWS"
+changelog="https://gitlab.gnome.org/GNOME/at-spi2-core/-/raw/gnome-48/NEWS"
 #changelog="https://gitlab.gnome.org/GNOME/at-spi2-core/-/raw/main/NEWS"
 distfiles="${GNOME_SITE}/at-spi2-core/${version%.*}/at-spi2-core-${version}.tar.xz"
-checksum=0ac3fc8320c8d01fa147c272ba7fa03806389c6b03d3c406d0823e30e35ff5ab
+checksum=80d7e8ea0be924e045525367f909d6668dfdd3e87cd40792c6cfd08e6b58e95c
 make_check=no # non-trivial dbus setup
 
 # Package build options


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)