### PR TITLE
gnome-backgrounds: update to 48.0

### DIFF
--- a/srcpkgs/gnome-backgrounds/template
+++ b/srcpkgs/gnome-backgrounds/template
@@ -1,6 +1,6 @@
 # Template file for 'gnome-backgrounds'
 pkgname=gnome-backgrounds
-version=47.0
+version=48.2.1
 revision=1
 build_style=meson
 hostmakedepends="gettext"
@@ -10,5 +10,5 @@ maintainer="Enno Boland <gottox@voidlinux.org>"
 license="GPL-2.0-or-later, CC-BY-2.0, CC-BY-SA-2.0, CC-BY-SA-3.0"
 homepage="https://gitlab.gnome.org/GNOME/gnome-backgrounds"
 changelog="https://gitlab.gnome.org/GNOME/gnome-backgrounds/-/raw/main/NEWS"
-distfiles="${GNOME_SITE}/gnome-backgrounds/${version%.*}/gnome-backgrounds-${version}.tar.xz"
-checksum=874a4a39c4261736f6a854722833400b612441c4681aa5982d90b15abc9c91fd
+distfiles="${GNOME_SITE}/gnome-backgrounds/${version%%.*}/gnome-backgrounds-${version}.tar.xz"
+checksum=6a1c5b7b2e0d8f5ce977926d55f9c2d65dd180822cdea5e59150dcfb5abd1ed9


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)