### PR TITLE
gnome-color-manager: update to 3.36.2

### DIFF
--- a/srcpkgs/gnome-color-manager/template
+++ b/srcpkgs/gnome-color-manager/template
@@ -1,6 +1,6 @@
 # Template file for 'gnome-color-manager'
 pkgname=gnome-color-manager
-version=3.36.0
+version=3.36.2
 revision=1
 build_style=meson
 hostmakedepends="gettext pkg-config itstool libglib-devel glib-devel"
@@ -8,9 +8,11 @@ makedepends="colord-devel gtk+3-devel
  clutter-gtk-devel libcanberra-devel gnome-desktop-devel
  libexif-devel shared-color-targets"
 depends="desktop-file-utils hicolor-icon-theme colord shared-color-targets"
+checkdepends="dbus xvfb-run"
 short_desc="Color profile manager for the GNOME desktop"
 maintainer="Enno Boland <gottox@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="https://gitlab.gnome.org/GNOME/gnome-color-manager"
 distfiles="${GNOME_SITE}/${pkgname}/${version%.*}/${pkgname}-${version}.tar.xz"
-checksum=9ddb9e6b6472e119801381f90905332ec1d4258981721bba831ca246ceb3ad3b
+checksum=3904d42abb4ea566df0b880e82bf0b9f86386c692f15b318469a4c7be33a887f
+make_check_pre="dbus-run-session xvfb-run"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)