### PR TITLE
gnome-keyring: update to 48.0

### DIFF
--- a/srcpkgs/gnome-keyring/template
+++ b/srcpkgs/gnome-keyring/template
@@ -1,11 +1,10 @@
 # Template file for 'gnome-keyring'
 pkgname=gnome-keyring
-version=46.2
+version=48.0
 revision=1
-build_style=gnu-configure
-configure_args="--with-pam-dir=/usr/lib/security --disable-schemas-compile
- --enable-ssh-agent"
-hostmakedepends="pkg-config glib-devel openssh docbook-xsl libxslt"
+build_style=meson
+configure_args="-Dsystemd=disabled -Dssh-agent=true"
+hostmakedepends="pkg-config glib-devel openssh docbook-xsl libxslt gettext"
 makedepends="gcr-devel pam-devel"
 depends="dconf"
 checkdepends="dbus xvfb-run"
@@ -15,7 +14,7 @@ license="GPL-2.0-or-later, LGPL-2.1-or-later"
 homepage="https://wiki.gnome.org/Projects/GnomeKeyring/"
 changelog="https://gitlab.gnome.org/GNOME/gnome-keyring/-/raw/main/NEWS"
 distfiles="${GNOME_SITE}/$pkgname/${version%.*}/$pkgname-$version.tar.xz"
-checksum=bf26c966b8a8b7f3285ecc8bb3e467b9c20f9535b94dc451c9c559ddcff61925
+checksum=f20518c920e9ea3f9c9b8b44be8c50d8d7feecd0dd5624960f77bd2ca4fbeb9d
 lib32disabled=yes
 make_check_pre="dbus-run-session xvfb-run"
 make_check=ci-skip # times out


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)