### PR TITLE
golangci-lint: update to 2.0.1

### DIFF
--- a/srcpkgs/golangci-lint/patches/0002-nilnil-use-32bit-compatible-test-values.patch
+++ b/srcpkgs/golangci-lint/patches/0002-nilnil-use-32bit-compatible-test-values.patch
@@ -1,0 +1,59 @@
+From 0addaedb77cd1badc5aa036f4b9cab5fe3fa0d19 Mon Sep 17 00:00:00 2001
+From: sn0w <me@sn0w.cx>
+Date: Sat, 22 Feb 2025 21:48:41 +0100
+Subject: [PATCH 2/2] nilnil: use 32bit-compatible test values
+
+---
+ pkg/golinters/nilnil/testdata/nilnil.go                 | 4 ++--
+ pkg/golinters/nilnil/testdata/nilnil_detect_opposite.go | 2 +-
+ 2 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/pkg/golinters/nilnil/testdata/nilnil.go b/pkg/golinters/nilnil/testdata/nilnil.go
+index 2446df77..2f7dcbdb 100644
+--- a/pkg/golinters/nilnil/testdata/nilnil.go
++++ b/pkg/golinters/nilnil/testdata/nilnil.go
+@@ -275,11 +275,11 @@ func unsafePtrValid() (unsafe.Pointer, error) {
+ 
+ func uintPtrValid() (uintptr, error) {
+ 	if false {
+ 		return 0, io.EOF
+ 	}
+-	return 0xc82000c290, nil
++	return 0xabcd, nil
+ }
+ 
+ func channelTypeValid() (ChannelType, error) {
+ 	if false {
+ 		return nil, io.EOF
+@@ -347,11 +347,11 @@ func unsafePtrOpposite() (unsafe.Pointer, error) {
+ 
+ func uintPtrOpposite() (uintptr, error) {
+ 	if false {
+ 		return 0, io.EOF
+ 	}
+-	return 0xc82000c290, wrap(io.EOF)
++	return 0xabcd, wrap(io.EOF)
+ }
+ 
+ func channelTypeOpposite() (ChannelType, error) {
+ 	if false {
+ 		return nil, io.EOF
+diff --git a/pkg/golinters/nilnil/testdata/nilnil_detect_opposite.go b/pkg/golinters/nilnil/testdata/nilnil_detect_opposite.go
+index 799d86de..6ef18cae 100644
+--- a/pkg/golinters/nilnil/testdata/nilnil_detect_opposite.go
++++ b/pkg/golinters/nilnil/testdata/nilnil_detect_opposite.go
+@@ -35,11 +35,11 @@ func unsafePtrOpposite() (unsafe.Pointer, error) {
+ 
+ func uintPtrOpposite() (uintptr, error) {
+ 	if false {
+ 		return 0, io.EOF
+ 	}
+-	return 0xc82000c290, wrap(io.EOF) // want "return both a non-nil error and a valid value: use separate returns instead"
++	return 0xabcd, wrap(io.EOF) // want "return both a non-nil error and a valid value: use separate returns instead"
+ }
+ 
+ func channelTypeOpposite() (ChannelType, error) {
+ 	if false {
+ 		return nil, io.EOF
+-- 
+2.48.1

--- a/srcpkgs/golangci-lint/template
+++ b/srcpkgs/golangci-lint/template
@@ -1,9 +1,9 @@
 # Template file for 'golangci-lint'
 pkgname=golangci-lint
-version=1.61.0
+version=2.0.1
 revision=1
 build_style=go
-go_import_path="github.com/golangci/golangci-lint"
+go_import_path="github.com/golangci/golangci-lint/v2"
 go_package="./cmd/golangci-lint"
 go_ldflags="-X main.version=${version} -X main.date=${SOURCE_DATE_EPOCH} -X main.commit=v${version}"
 short_desc="Linters Runner for Go"
@@ -12,7 +12,7 @@ license="GPL-3.0-only"
 homepage="https://github.com/golangci/golangci-lint"
 changelog="https://raw.githubusercontent.com/golangci/golangci-lint/master/CHANGELOG.md"
 distfiles="https://github.com/golangci/golangci-lint/archive/v${version}.tar.gz"
-checksum=f4efcc09dde3eb81ba7e2fc4230d3e99375a4b176dd28c31cab07371cf5c07db
+checksum=036cb1cb358a416d73525172dd235c5284b69c4c4ceb91e66fd1d661b4d6e24b
 
 # fix: collect2: fatal error: cannot find 'ld'
 export LDFLAGS="-fuse-ld=bfd"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64

#### Note

Additionally applied patch by @realsn0w from PR #54427. The upstream package has broken tests for 32-bit architectures. The patch ensures compatibility with the 32-bit i686 architecture.