### PR TITLE
sile: update to 0.15.12

### DIFF
--- a/srcpkgs/sile/template
+++ b/srcpkgs/sile/template
@@ -1,6 +1,6 @@
 # Template file for 'sile'
 pkgname=sile
-version=0.15.9
+version=0.15.10
 revision=1
 build_style=gnu-configure
 build_helper=rust
@@ -20,7 +20,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
 homepage="https://www.sile-typesetter.org/"
 distfiles="https://github.com/sile-typesetter/sile/releases/download/v${version}/sile-${version}.tar.zst"
-checksum=fbda59503b333d82661601db647d1a2ad67aa8b7098e1ef78c6d8216844ac567
+checksum=b0f001b4a7c8a5a98635610b9c29e455a8077ae1eaff52a84f7eb8fda2c70eed
 
 if [ "$CROSS_BUILD" ]; then
 	hostmakedepends+=" ${makedepends}"

--- a/srcpkgs/sile/template
+++ b/srcpkgs/sile/template
@@ -1,6 +1,6 @@
 # Template file for 'sile'
 pkgname=sile
-version=0.15.10
+version=0.15.11
 revision=1
 build_style=gnu-configure
 build_helper=rust
@@ -20,7 +20,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
 homepage="https://www.sile-typesetter.org/"
 distfiles="https://github.com/sile-typesetter/sile/releases/download/v${version}/sile-${version}.tar.zst"
-checksum=b0f001b4a7c8a5a98635610b9c29e455a8077ae1eaff52a84f7eb8fda2c70eed
+checksum=27e4b68d3f3fd5b5f7e44dc5c8b2ef3e7486638853d8fed4aaee7d2fde5c2342
 
 if [ "$CROSS_BUILD" ]; then
 	hostmakedepends+=" ${makedepends}"

--- a/srcpkgs/sile/template
+++ b/srcpkgs/sile/template
@@ -1,6 +1,6 @@
 # Template file for 'sile'
 pkgname=sile
-version=0.15.11
+version=0.15.12
 revision=1
 build_style=gnu-configure
 build_helper=rust
@@ -20,7 +20,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
 homepage="https://www.sile-typesetter.org/"
 distfiles="https://github.com/sile-typesetter/sile/releases/download/v${version}/sile-${version}.tar.zst"
-checksum=27e4b68d3f3fd5b5f7e44dc5c8b2ef3e7486638853d8fed4aaee7d2fde5c2342
+checksum=a3234111d56bb22f0cba2608954ec88df260eb4772f054ed29770912003ec8a0
 
 if [ "$CROSS_BUILD" ]; then
 	hostmakedepends+=" ${makedepends}"


### PR DESCRIPTION
[Upstream release](https://github.com/sile-typesetter/sile/releases/tag/v0.15.10) has lots of changes, but none of them particularly relevant to building. No changes to the build recpipe should be necessary for this release.

Notably if Void wanted to use offline build abilities, the upstream release does now have a vendored crates artifact that can be used to avoid `cargo` pulling them at build time.

#### Testing the changes
- I tested the changes in this PR: **NO**
