### PR TITLE
gnome-bulider: update to 48.0.

### DIFF
--- a/srcpkgs/gnome-builder/template
+++ b/srcpkgs/gnome-builder/template
@@ -1,6 +1,6 @@
 # Template file for 'gnome-builder'
 pkgname=gnome-builder
-version=47.2
+version=48.0
 revision=1
 _llvmver=19
 build_style=meson
@@ -15,7 +15,7 @@ makedepends="llvm${_llvmver}-devel cairo-devel clang${_llvmver} libspelling-deve
  libadwaita-devel pcre2-devel gobject-introspection
  python3-gobject-devel sysprof-devel libportal-gtk4-devel
  libsoup3-devel cmark-devel pango-devel libportal-devel
- libpanel-devel d-spy-devel editorconfig-devel libdex-devel"
+ libpanel-devel editorconfig-devel libdex-devel"
 depends="desktop-file-utils flatpak-builder python3-lxml python3-gobject"
 checkdepends="xvfb-run cmark-devel dbus"
 short_desc="IDE for GNOME"
@@ -23,7 +23,7 @@ maintainer="Enno Boland <gottox@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="https://wiki.gnome.org/Apps/Builder"
 #changelog="https://gitlab.gnome.org/GNOME/gnome-builder/-/raw/main/NEWS"
-changelog="https://gitlab.gnome.org/GNOME/gnome-builder/-/raw/gnome-builder-47/NEWS"
+changelog="https://gitlab.gnome.org/GNOME/gnome-builder/-/raw/gnome-builder-48/NEWS"
 distfiles="${GNOME_SITE}/gnome-builder/${version%.*}/gnome-builder-${version}.tar.xz"
-checksum=4687b93c47cd1e33665a2dc503790b6213ee827872fc004d978d14bcbfa9b495
+checksum=7afe9a7a3b3c6621768bc46a61d698dd788b3653fb46a708238bdccf4de67ba4
 make_check_pre="xvfb-run"

--- a/srcpkgs/gtksourceview5/template
+++ b/srcpkgs/gtksourceview5/template
@@ -1,6 +1,6 @@
 # Template file for 'gtksourceview5'
 pkgname=gtksourceview5
-version=5.12.1
+version=5.16.0
 revision=1
 build_style=meson
 build_helper="gir"
@@ -15,10 +15,10 @@ short_desc="Text widget that extends GTK4 GtkTextView widget"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="LGPL-2.1-or-later"
 homepage="https://wiki.gnome.org/Projects/GtkSourceView"
-changelog="https://gitlab.gnome.org/GNOME/gtksourceview/-/raw/master/NEWS"
-#changelog="https://gitlab.gnome.org/GNOME/gtksourceview/-/raw/gtksourceview-5-8/NEWS"
+#changelog="https://gitlab.gnome.org/GNOME/gtksourceview/-/raw/master/NEWS"
+changelog="https://gitlab.gnome.org/GNOME/gtksourceview/-/raw/gtksourceview-5-16/NEWS"
 distfiles="${GNOME_SITE}/gtksourceview/${version%.*}/gtksourceview-${version}.tar.xz"
-checksum=84c82aad985c5aadae7cea7804904a76341ec82b268d46594c1a478f39b42c1f
+checksum=ab35d420102f3e8b055dd3b8642d3a48209f888189e6254d0ffb4b6a7e8c3566
 make_check_pre="xvfb-run"
 
 # Package build options


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
