### PR TITLE
backintime: update to 1.5.4

### DIFF
--- a/srcpkgs/backintime/template
+++ b/srcpkgs/backintime/template
@@ -1,7 +1,7 @@
 # Template file for 'backintime'
 pkgname=backintime
-version=1.5.3
-revision=2
+version=1.5.4
+revision=1
 configure_args="--python3"
 pycompile_dirs="/usr/share/backintime"
 hostmakedepends="gettext python3"
@@ -11,7 +11,7 @@ maintainer="Alpicoid <alpicoid@tuta.io>"
 license="GPL-2.0-or-later"
 homepage="https://github.com/bit-team/backintime"
 distfiles="https://github.com/bit-team/backintime/releases/download/v${version}/backintime-${version}.tar.gz"
-checksum=2adf4f2d3b2c95b43f1bc7184c034bc3fa2387b7b94099018770316d979b1534
+checksum=d4cfae7c3efcb6d20a7b3401f21c261e43f023d9191955a846f4ee141bf605dd
 python_version=3
 
 do_configure() {


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**


#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures:
  - aarch64-musl (cross)
  - armv6l-musl (cross)
