### PR TITLE
deadbeef: update to 1.10.0, reenable last.fm scrobbling

### DIFF
--- a/srcpkgs/deadbeef/template
+++ b/srcpkgs/deadbeef/template
@@ -1,9 +1,9 @@
 # Template file for 'deadbeef'
 pkgname=deadbeef
-version=1.9.6
+version=1.10.0
 revision=1
 build_style=gnu-configure
-configure_args="--disable-oss --disable-lfm --disable-gtk2 --disable-libretro"
+configure_args="--disable-oss --disable-gtk2 --disable-libretro"
 hostmakedepends="automake libtool gettext gettext-devel intltool pkg-config
  yasm clang glib-devel"
 makedepends="
@@ -25,7 +25,7 @@ distfiles="https://github.com/DeaDBeeF-Player/deadbeef/archive/${version}.tar.gz
  https://github.com/DeaDBeeF-Player/ddb_dsp_libretro/archive/${_libretro_commit}.tar.gz>libretro-${_libretro_commit}.tar.gz
  https://github.com/DeaDBeeF-Player/ddb_output_pw/archive/${_output_pw_commit}.tar.gz>output_pw-${_output_pw_commit}.tar.gz
  https://github.com/DeaDBeeF-Player/mp4p/archive/${_mp4p_commit}.tar.gz>mp4p-${_mp4p_commit}.tar.gz"
-checksum="53ed535335e637437adf77eb4bcadb781eddbf5539f74373d5a863389df5e2d0
+checksum="bb3f4446cf462a018b3ee4407ef7018c654b5366f59e5c82e60e6578eee4537d
  444d4d89edbd51b9d2305c83a49e18949e0f21a42eec2a95ce03efd752a81049
  59115ddcd0378aa2f5914138c5c256198d66339bfbb3d65389b9bf4fa327f9ee
  3b5bdbcb2808d12b9f5af630a91e77be1036aeb487d5fa0a323ce8080918439b"


### PR DESCRIPTION
Last.fm scrobbling seems to have been disabled a few versions ago due to a "shlib dependency on a library not shipped in Void", but that must've gotten fixed at some point, as none of the shared library dependencies of `/usr/lib/deadbeef/lastfm.so` seem to be unpackaged, or not listed under common/shlibs; so I took the oportunity and reenabled it.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
