### PR TITLE
puddletag: update to 2.4.0

### DIFF
--- a/srcpkgs/puddletag/template
+++ b/srcpkgs/puddletag/template
@@ -1,14 +1,21 @@
 # Template file for 'puddletag'
 pkgname=puddletag
-version=2.2.0
-revision=2
+version=2.4.0
+revision=1
 build_style=python3-pep517
 hostmakedepends="python3-setuptools python3-wheel"
 depends="python3 python3-configobj python3-mutagen python3-parsing
- python3-PyQt5 python3-PyQt5-svg"
+ python3-PyQt5 python3-PyQt5-svg python3-audioread python3-certifi
+ python3-charset-normalizer python3-idna python3-Levenshtein python3-lxml
+ python3-pyacoustid python3-sip-PyQt5 python3-rapidfuzz python3-requests
+ python3-urllib3 python3-six python3-Unidecode"
 short_desc="Powerful, simple, spreadsheet-like audio tag editor"
-maintainer="Daniel Progrestian <progrestian@tuta.io>"
+maintainer="JkktBkkt <apkabikov+void@gmail.com>"
 license="GPL-3.0-or-later"
 homepage="https://github.com/puddletag/puddletag"
 distfiles="https://github.com/puddletag/puddletag/archive/${version}.tar.gz"
-checksum=fc26a9fcd842e3cd4b97ac83b9fdbd270d73f2a90285e47135e2719dcacc986a
+checksum=892864eabdb9bea627087e6b342a861ec6b8400d7f8e706a85565d71a1fb1be3
+
+post_patch() {
+	vsed -i '/^pyqt.-qt/d' requirements.txt
+}

--- a/srcpkgs/puddletag/update
+++ b/srcpkgs/puddletag/update
@@ -1,0 +1,2 @@
+site="https://github.com/puddletag/puddletag/tags"
+pattern="releases/tag/\K[0-9.]+"


### PR DESCRIPTION
In-repo release is broken due to imghdr removed from python3.13, upstream patched the issue
Takeover as maintainer, as @progrestian 's last activity was 1.5 years ago and puddletag is their only contribution to void repos
Added update script

Dependency checking hook wants PyQt5-Qt5 but that's just Qt5 libs which we already include in python3-PyQt5, so ignored that warning. Applied others.

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64
- I built this PR locally for these architectures as cross:
 - aarch64-musl
 - aarch64
 - armv6l-musl
 - armv6l
 - armv7l-musl
 - armv7l
 - i686
 - x86_64-musl