### PR TITLE
New package: adwaita-fonts-48.2.

### DIFF
--- a/srcpkgs/adwaita-fonts/template
+++ b/srcpkgs/adwaita-fonts/template
@@ -1,0 +1,13 @@
+# Template file for 'adwaita-fonts'
+pkgname=adwaita-fonts
+version=48.2
+revision=1
+build_style=meson
+depends="font-util"
+short_desc="Typefaces for GNOME"
+maintainer="oreo639 <oreo6391@gmail.com>"
+license="OFL-1.1"
+homepage="https://gitlab.gnome.org/GNOME/adwaita-fonts"
+distfiles="${GNOME_SITE}/adwaita-fonts/${version%.*}/adwaita-fonts-${version}.tar.xz"
+checksum=156f7e92f2f82e527fc73c309dbb237c0a4a5c3a95bc5ee94a5efb6947c553e0
+font_dirs="/usr/share/fonts/Adwaita/"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

Replaces cantarell and adobe-source-code-pro in GNOME 48.

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
