### PR TITLE
hooks/pre-pkg/03-rewrite-python-shebang.sh: rewrite plain python shebang

### DIFF
--- a/common/hooks/pre-pkg/03-rewrite-python-shebang.sh
+++ b/common/hooks/pre-pkg/03-rewrite-python-shebang.sh
@@ -24,7 +24,7 @@ hook() {
 		while IFS= read -r -d '' file; do
 			[ ! -s "$file" ] && continue
 
-			pyinterp=$(sed -n -E -e 2q -e 's@^#!.*([[:space:]]|/)(python([0-9](\.[0-9]+)?)?)([[:space:]]+.*|$)@\2@p' "$file")
+			pyinterp=$(sed -n -E -e 2q -e 's@^#!(.*([[:space:]]|/))?(python([0-9](\.[0-9]+)?)?)([[:space:]]+.*|$)@\3@p' "$file")
 			[ -z "$pyinterp" ] && continue
 
 			pyver=${pyinterp#python}


### PR DESCRIPTION
Shebangs containing #!python are ignored currently, which causes a problem since newer versions of python3-setuptools generate this, so replace them with the proper shebang when encountered.

https://github.com/pypa/setuptools/issues/4863

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
