### PR TITLE
update kernel-libc-headers, backport syscall numbers and statx for musl

### DIFF
--- a/srcpkgs/kernel-libc-headers/template
+++ b/srcpkgs/kernel-libc-headers/template
@@ -1,14 +1,14 @@
 # Template file for 'kernel-libc-headers'
 pkgname=kernel-libc-headers
-version=6.1
+version=6.14
 revision=1
 bootstrap=yes
 short_desc="Linux API headers for userland development"
 maintainer="Érico Nogueira <ericonr@disroot.org>"
 license="GPL-2.0-only"
 homepage="http://www.kernel.org"
-distfiles="$KERNEL_SITE/kernel/v${version%%.*}.x/linux-${version}.tar.xz"
-checksum=2ca1f17051a430f6fed1196e4952717507171acfd97d96577212502703b25deb
+distfiles="${KERNEL_SITE}/kernel/v${version%%.*}.x/linux-${version}.tar.xz"
+checksum=a294b683e7b161bb0517bb32ec7ed1d2ea7603dfbabad135170ed12d00c47670
 
 if [ "$CHROOT_READY" ]; then
 	hostmakedepends="perl"
@@ -25,12 +25,11 @@ esac
 
 do_build() {
 	make mrproper
-	make ARCH=${_arch} headers
-	# remove extra files and drm headers
- 	find usr/include -name '.*' -delete
-	rm usr/include/Makefile
-	rm -rf usr/include/drm
+	make ARCH="${_arch}" headers
 }
+
 do_install() {
- 	vcopy usr/include usr
+	# the make header_install depends on rsync so just do the same thing manuall.
+	vcopy usr/include usr
+	find "${DESTDIR}/usr/include" -type f ! -name '*.h' -delete
 }

--- a/srcpkgs/musl/patches/55fb9a177316aa46c639d93dd0323d9a9a8c160c.patch
+++ b/srcpkgs/musl/patches/55fb9a177316aa46c639d93dd0323d9a9a8c160c.patch
@@ -1,0 +1,45 @@
+From 55fb9a177316aa46c639d93dd0323d9a9a8c160c Mon Sep 17 00:00:00 2001
+From: Rich Felker <dalias@aerifal.cx>
+Date: Wed, 9 Sep 2020 21:55:11 -0400
+Subject: [PATCH] use new SYS_faccessat2 syscall to implement faccessat with
+ flags
+
+commit 0a05eace163cee9b08571d2ff9d90f5e82d9c228 implemented AT_EACCESS
+for faccessat with a horrible hack, creating a child process to change
+switch uid/gid and perform the access probe without making potentially
+irreversible changes to the caller's credentials. this was due to the
+syscall lacking a flags argument.
+
+linux 5.8 introduced a new syscall, SYS_faccessat2, fixing this
+deficiency. use it if any flags are passed, and fallback to the old
+strategy on ENOSYS. continue using the old syscall when there are no
+flags.
+---
+ src/unistd/faccessat.c | 11 ++++++++---
+ 1 file changed, 8 insertions(+), 3 deletions(-)
+
+diff --git a/src/unistd/faccessat.c b/src/unistd/faccessat.c
+index 76bbd4c72..557503eb6 100644
+--- a/src/unistd/faccessat.c
++++ b/src/unistd/faccessat.c
+@@ -25,12 +25,17 @@ static int checker(void *p)
+ 
+ int faccessat(int fd, const char *filename, int amode, int flag)
+ {
+-	if (!flag || (flag==AT_EACCESS && getuid()==geteuid() && getgid()==getegid()))
+-		return syscall(SYS_faccessat, fd, filename, amode, flag);
++	if (flag) {
++		int ret = __syscall(SYS_faccessat2, fd, filename, amode, flag);
++		if (ret != -ENOSYS) return __syscall_ret(ret);
++	}
+ 
+-	if (flag != AT_EACCESS)
++	if (flag & ~AT_EACCESS)
+ 		return __syscall_ret(-EINVAL);
+ 
++	if (!flag || (getuid()==geteuid() && getgid()==getegid()))
++		return syscall(SYS_faccessat, fd, filename, amode);
++
+ 	char stack[1024];
+ 	sigset_t set;
+ 	pid_t pid;

--- a/srcpkgs/musl/patches/new-syscalls.patch
+++ b/srcpkgs/musl/patches/new-syscalls.patch
@@ -1,0 +1,370 @@
+--- a/arch/aarch64/bits/syscall.h.in
++++ b/arch/aarch64/bits/syscall.h.in
+@@ -287,4 +287,21 @@
+ #define __NR_fsconfig		431
+ #define __NR_fsmount		432
+ #define __NR_fspick		433
++#define __NR_pidfd_open		4434
++#define __NR_clone3		4435
++#define __NR_close_range	4436
++#define __NR_openat2		4437
++#define __NR_pidfd_getfd	4438
++#define __NR_faccessat2		4439
++#define __NR_process_madvise	4440
++#define __NR_epoll_pwait2	4441
++#define __NR_mount_setattr	4442
++#define __NR_landlock_create_ruleset	4444
++#define __NR_landlock_add_rule	4445
++#define __NR_landlock_restrict_self	4446
++#define __NR_process_mrelease	4448
++#define __NR_futex_waitv	4449
++#define __NR_set_mempolicy_home_node	4450
++#define __NR_cachestat		4451
++#define __NR_fchmodat2		4452
+ 
+--- a/arch/arm/bits/syscall.h.in
++++ b/arch/arm/bits/syscall.h.in
+@@ -387,6 +387,23 @@
+ #define __NR_fsconfig		431
+ #define __NR_fsmount		432
+ #define __NR_fspick		433
++#define __NR_pidfd_open		434
++#define __NR_clone3		435
++#define __NR_close_range	436
++#define __NR_openat2		437
++#define __NR_pidfd_getfd	438
++#define __NR_faccessat2		439
++#define __NR_process_madvise	440
++#define __NR_epoll_pwait2	441
++#define __NR_mount_setattr	442
++#define __NR_landlock_create_ruleset	444
++#define __NR_landlock_add_rule	445
++#define __NR_landlock_restrict_self	446
++#define __NR_process_mrelease	448
++#define __NR_futex_waitv	449
++#define __NR_set_mempolicy_home_node	450
++#define __NR_cachestat		451
++#define __NR_fchmodat2		452
+ 
+ #define __ARM_NR_breakpoint	0x0f0001
+ #define __ARM_NR_cacheflush	0x0f0002
+--- a/arch/i386/bits/syscall.h.in
++++ b/arch/i386/bits/syscall.h.in
+@@ -424,4 +424,22 @@
+ #define __NR_fsconfig		431
+ #define __NR_fsmount		432
+ #define __NR_fspick		433
++#define __NR_pidfd_open		434
++#define __NR_clone3		435
++#define __NR_close_range	436
++#define __NR_openat2		437
++#define __NR_pidfd_getfd	438
++#define __NR_faccessat2		439
++#define __NR_process_madvise	440
++#define __NR_epoll_pwait2	441
++#define __NR_mount_setattr	442
++#define __NR_landlock_create_ruleset	444
++#define __NR_landlock_add_rule	445
++#define __NR_landlock_restrict_self	446
++#define __NR_memfd_secret	447
++#define __NR_process_mrelease	448
++#define __NR_futex_waitv	449
++#define __NR_set_mempolicy_home_node	450
++#define __NR_cachestat		451
++#define __NR_fchmodat2		452
+ 
+--- a/arch/m68k/bits/syscall.h.in
++++ b/arch/m68k/bits/syscall.h.in
+@@ -404,3 +404,21 @@
+ #define __NR_fsconfig		431
+ #define __NR_fsmount		432
+ #define __NR_fspick		433
++#define __NR_pidfd_open		434
++#define __NR_clone3		435
++#define __NR_close_range	436
++#define __NR_openat2		437
++#define __NR_pidfd_getfd	438
++#define __NR_faccessat2		439
++#define __NR_process_madvise	440
++#define __NR_epoll_pwait2	441
++#define __NR_mount_setattr	442
++#define __NR_landlock_create_ruleset	444
++#define __NR_landlock_add_rule	445
++#define __NR_landlock_restrict_self	446
++#define __NR_process_mrelease	448
++#define __NR_futex_waitv	449
++#define __NR_set_mempolicy_home_node	450
++#define __NR_cachestat		451
++#define __NR_fchmodat2		452
++
+--- a/arch/microblaze/bits/syscall.h.in
++++ b/arch/microblaze/bits/syscall.h.in
+@@ -425,4 +425,21 @@
+ #define __NR_fsconfig		431
+ #define __NR_fsmount		432
+ #define __NR_fspick		433
++#define __NR_pidfd_open		434
++#define __NR_clone3		435
++#define __NR_close_range	436
++#define __NR_openat2		437
++#define __NR_pidfd_getfd	438
++#define __NR_faccessat2		439
++#define __NR_process_madvise	440
++#define __NR_epoll_pwait2	441
++#define __NR_mount_setattr	442
++#define __NR_landlock_create_ruleset	444
++#define __NR_landlock_add_rule	445
++#define __NR_landlock_restrict_self	446
++#define __NR_process_mrelease	448
++#define __NR_futex_waitv	449
++#define __NR_set_mempolicy_home_node	450
++#define __NR_cachestat		451
++#define __NR_fchmodat2		452
+ 
+--- a/arch/mips/bits/syscall.h.in
++++ b/arch/mips/bits/syscall.h.in
+@@ -406,4 +406,21 @@
+ #define __NR_fsconfig		4431
+ #define __NR_fsmount		4432
+ #define __NR_fspick		4433
++#define __NR_pidfd_open		4434
++#define __NR_clone3		4435
++#define __NR_close_range	4436
++#define __NR_openat2		4437
++#define __NR_pidfd_getfd	4438
++#define __NR_faccessat2		4439
++#define __NR_process_madvise	4440
++#define __NR_epoll_pwait2	4441
++#define __NR_mount_setattr	4442
++#define __NR_landlock_create_ruleset	4444
++#define __NR_landlock_add_rule	4445
++#define __NR_landlock_restrict_self	4446
++#define __NR_process_mrelease	4448
++#define __NR_futex_waitv	4449
++#define __NR_set_mempolicy_home_node	4450
++#define __NR_cachestat		4451
++#define __NR_fchmodat2		4452
+ 
+--- a/arch/mips64/bits/syscall.h.in
++++ b/arch/mips64/bits/syscall.h.in
+@@ -336,4 +336,21 @@
+ #define __NR_fsconfig		5431
+ #define __NR_fsmount		5432
+ #define __NR_fspick		5433
++#define __NR_pidfd_open		5434
++#define __NR_clone3		5435
++#define __NR_close_range	5436
++#define __NR_openat2		5437
++#define __NR_pidfd_getfd	5438
++#define __NR_faccessat2		5439
++#define __NR_process_madvise	5440
++#define __NR_epoll_pwait2	5441
++#define __NR_mount_setattr	5442
++#define __NR_landlock_create_ruleset	5444
++#define __NR_landlock_add_rule	5445
++#define __NR_landlock_restrict_self	5446
++#define __NR_process_mrelease	5448
++#define __NR_futex_waitv	5449
++#define __NR_set_mempolicy_home_node	5450
++#define __NR_cachestat		5451
++#define __NR_fchmodat2		5452
+ 
+--- a/arch/mipsn32/bits/syscall.h.in
++++ b/arch/mipsn32/bits/syscall.h.in
+@@ -360,4 +360,21 @@
+ #define __NR_fsconfig		6431
+ #define __NR_fsmount		6432
+ #define __NR_fspick		6433
++#define __NR_pidfd_open		6434
++#define __NR_clone3		6435
++#define __NR_close_range	6436
++#define __NR_openat2		6437
++#define __NR_pidfd_getfd	6438
++#define __NR_faccessat2		6439
++#define __NR_process_madvise	6440
++#define __NR_epoll_pwait2	6441
++#define __NR_mount_setattr	6442
++#define __NR_landlock_create_ruleset	6444
++#define __NR_landlock_add_rule	6445
++#define __NR_landlock_restrict_self	6446
++#define __NR_process_mrelease	6448
++#define __NR_futex_waitv	6449
++#define __NR_set_mempolicy_home_node	6450
++#define __NR_cachestat		6451
++#define __NR_fchmodat2		6452
+ 
+--- a/arch/or1k/bits/syscall.h.in
++++ b/arch/or1k/bits/syscall.h.in
+@@ -309,4 +309,21 @@
+ #define __NR_fsconfig		431
+ #define __NR_fsmount		432
+ #define __NR_fspick		433
++#define __NR_pidfd_open		434
++#define __NR_clone3		435
++#define __NR_close_range	436
++#define __NR_openat2		437
++#define __NR_pidfd_getfd	438
++#define __NR_faccessat2		439
++#define __NR_process_madvise	440
++#define __NR_epoll_pwait2	441
++#define __NR_mount_setattr	442
++#define __NR_landlock_create_ruleset	444
++#define __NR_landlock_add_rule	445
++#define __NR_landlock_restrict_self	446
++#define __NR_process_mrelease	448
++#define __NR_futex_waitv	449
++#define __NR_set_mempolicy_home_node	450
++#define __NR_cachestat		451
++#define __NR_fchmodat2		452
+ 
+--- a/arch/powerpc/bits/syscall.h.in
++++ b/arch/powerpc/bits/syscall.h.in
+@@ -413,4 +413,21 @@
+ #define __NR_fsconfig		431
+ #define __NR_fsmount		432
+ #define __NR_fspick		433
++#define __NR_pidfd_open		434
++#define __NR_clone3		435
++#define __NR_close_range	436
++#define __NR_openat2		437
++#define __NR_pidfd_getfd	438
++#define __NR_faccessat2		439
++#define __NR_process_madvise	440
++#define __NR_epoll_pwait2	441
++#define __NR_mount_setattr	442
++#define __NR_landlock_create_ruleset	444
++#define __NR_landlock_add_rule	445
++#define __NR_landlock_restrict_self	446
++#define __NR_process_mrelease	448
++#define __NR_futex_waitv	449
++#define __NR_set_mempolicy_home_node	450
++#define __NR_cachestat		451
++#define __NR_fchmodat2		452
+ 
+--- a/arch/riscv64/bits/syscall.h.in
++++ b/arch/riscv64/bits/syscall.h.in
+@@ -287,6 +287,23 @@
+ #define __NR_fsconfig		431
+ #define __NR_fsmount		432
+ #define __NR_fspick		433
++#define __NR_pidfd_open		434
++#define __NR_clone3		435
++#define __NR_close_range	436
++#define __NR_openat2		437
++#define __NR_pidfd_getfd	438
++#define __NR_faccessat2		439
++#define __NR_process_madvise	440
++#define __NR_epoll_pwait2	441
++#define __NR_mount_setattr	442
++#define __NR_landlock_create_ruleset	444
++#define __NR_landlock_add_rule	445
++#define __NR_landlock_restrict_self	446
++#define __NR_process_mrelease	448
++#define __NR_futex_waitv	449
++#define __NR_set_mempolicy_home_node	450
++#define __NR_cachestat		451
++#define __NR_fchmodat2		452
+ 
+ #define __NR_sysriscv __NR_arch_specific_syscall
+ #define __NR_riscv_flush_icache (__NR_sysriscv + 15)
+--- a/arch/s390x/bits/syscall.h.in
++++ b/arch/s390x/bits/syscall.h.in
+@@ -350,4 +350,22 @@
+ #define __NR_fsconfig		431
+ #define __NR_fsmount		432
+ #define __NR_fspick		433
++#define __NR_pidfd_open		434
++#define __NR_clone3		435
++#define __NR_close_range	436
++#define __NR_openat2		437
++#define __NR_pidfd_getfd	438
++#define __NR_faccessat2		439
++#define __NR_process_madvise	440
++#define __NR_epoll_pwait2	441
++#define __NR_mount_setattr	442
++#define __NR_landlock_create_ruleset	444
++#define __NR_landlock_add_rule	445
++#define __NR_landlock_restrict_self	446
++#define __NR_memfd_secret	447
++#define __NR_process_mrelease	448
++#define __NR_futex_waitv	449
++#define __NR_set_mempolicy_home_node	450
++#define __NR_cachestat		451
++#define __NR_fchmodat2		452
+ 
+--- a/arch/sh/bits/syscall.h.in
++++ b/arch/sh/bits/syscall.h.in
+@@ -397,4 +397,21 @@
+ #define __NR_fsconfig		431
+ #define __NR_fsmount		432
+ #define __NR_fspick		433
++#define __NR_pidfd_open		434
++#define __NR_clone3		435
++#define __NR_close_range	436
++#define __NR_openat2		437
++#define __NR_pidfd_getfd	438
++#define __NR_faccessat2		439
++#define __NR_process_madvise	440
++#define __NR_epoll_pwait2	441
++#define __NR_mount_setattr	442
++#define __NR_landlock_create_ruleset	444
++#define __NR_landlock_add_rule	445
++#define __NR_landlock_restrict_self	446
++#define __NR_process_mrelease	448
++#define __NR_futex_waitv	449
++#define __NR_set_mempolicy_home_node	450
++#define __NR_cachestat		451
++#define __NR_fchmodat2		452
+ 
+--- a/arch/x32/bits/syscall.h.in
++++ b/arch/x32/bits/syscall.h.in
+@@ -296,6 +296,24 @@
+ #define __NR_fsconfig		(0x40000000 + 431)
+ #define __NR_fsmount		(0x40000000 + 432)
+ #define __NR_fspick		(0x40000000 + 433)
++#define __NR_pidfd_open		(0x40000000 + 434)
++#define __NR_clone3		(0x40000000 + 435)
++#define __NR_close_range	(0x40000000 + 436)
++#define __NR_openat2		(0x40000000 + 437)
++#define __NR_pidfd_getfd	(0x40000000 + 438)
++#define __NR_faccessat2		(0x40000000 + 439)
++#define __NR_process_madvise	(0x40000000 + 440)
++#define __NR_epoll_pwait2	(0x40000000 + 441)
++#define __NR_mount_setattr	(0x40000000 + 442)
++#define __NR_landlock_create_ruleset	(0x40000000 + 444)
++#define __NR_landlock_add_rule	(0x40000000 + 445)
++#define __NR_landlock_restrict_self	(0x40000000 + 446)
++#define __NR_memfd_secret	(0x40000000 + 447)
++#define __NR_process_mrelease	(0x40000000 + 448)
++#define __NR_futex_waitv	(0x40000000 + 449)
++#define __NR_set_mempolicy_home_node	(0x40000000 + 450)
++#define __NR_cachestat		(0x40000000 + 451)
++#define __NR_fchmodat2		(0x40000000 + 452)
+ 
+ #define __NR_rt_sigaction (0x40000000 + 512)
+ #define __NR_rt_sigreturn (0x40000000 + 513)
+--- a/arch/x86_64/bits/syscall.h.in
++++ b/arch/x86_64/bits/syscall.h.in
+@@ -343,4 +343,22 @@
+ #define __NR_fsconfig		431
+ #define __NR_fsmount		432
+ #define __NR_fspick		433
++#define __NR_pidfd_open		434
++#define __NR_clone3		435
++#define __NR_close_range	436
++#define __NR_openat2		437
++#define __NR_pidfd_getfd	438
++#define __NR_faccessat2		439
++#define __NR_process_madvise	440
++#define __NR_epoll_pwait2	441
++#define __NR_mount_setattr	442
++#define __NR_landlock_create_ruleset	444
++#define __NR_landlock_add_rule	445
++#define __NR_landlock_restrict_self	446
++#define __NR_memfd_secret	447
++#define __NR_process_mrelease	448
++#define __NR_futex_waitv	449
++#define __NR_set_mempolicy_home_node	450
++#define __NR_cachestat		451
++#define __NR_fchmodat2		452
+ 

--- a/srcpkgs/musl/patches/statx.patch
+++ b/srcpkgs/musl/patches/statx.patch
@@ -1,0 +1,201 @@
+From b817541f1cfd38e4b81257b3215e276ea9d0fc61 Mon Sep 17 00:00:00 2001
+From: Duncan Bellamy <dunk@denkimushi.com>
+Date: Wed, 31 Aug 2022 20:07:34 +0100
+Subject: [PATCH] add statx interface using syscall, fallback to fstatat
+
+---
+ include/sys/stat.h | 55 ++++++++++++++++++++++++++++++++++++++++++++++
+ src/linux/statx.c  | 42 +++++++++++++++++++++++++++++++++++
+ 2 files changed, 97 insertions(+)
+ create mode 100644 src/linux/statx.c
+
+diff --git a/include/sys/stat.h b/include/sys/stat.h
+index e6d0049c..6690192d 100644
+--- a/include/sys/stat.h
++++ b/include/sys/stat.h
+@@ -18,6 +18,13 @@ extern "C" {
+ #define __NEED_blkcnt_t
+ #define __NEED_struct_timespec
+ 
++#ifdef _GNU_SOURCE
++#define __NEED_int64_t
++#define __NEED_uint64_t
++#define __NEED_uint32_t
++#define __NEED_uint16_t
++#endif
++
+ #include <bits/alltypes.h>
+ 
+ #include <bits/stat.h>
+@@ -98,6 +105,54 @@ int lchmod(const char *, mode_t);
+ #define S_IEXEC S_IXUSR
+ #endif
+ 
++#if defined(_GNU_SOURCE)
++#define STATX_TYPE 1U
++#define STATX_MODE 2U
++#define STATX_NLINK 4U
++#define STATX_UID 8U
++#define STATX_GID 0x10U
++#define STATX_ATIME 0x20U
++#define STATX_MTIME 0x40U
++#define STATX_CTIME 0x80U
++#define STATX_INO 0x100U
++#define STATX_SIZE 0x200U
++#define STATX_BLOCKS 0x400U
++#define STATX_BASIC_STATS 0x7ffU
++#define STATX_BTIME 0x800U
++#define STATX_ALL 0xfffU
++
++struct statx_timestamp {
++	int64_t tv_sec;
++	uint32_t tv_nsec, __pad;
++};
++
++struct statx {
++	uint32_t stx_mask;
++	uint32_t stx_blksize;
++	uint64_t stx_attributes;
++	uint32_t stx_nlink;
++	uint32_t stx_uid;
++	uint32_t stx_gid;
++	uint16_t stx_mode;
++	uint16_t __pad0[1];
++	uint64_t stx_ino;
++	uint64_t stx_size;
++	uint64_t stx_blocks;
++	uint64_t stx_attributes_mask;
++	struct statx_timestamp stx_atime;
++	struct statx_timestamp stx_btime;
++	struct statx_timestamp stx_ctime;
++	struct statx_timestamp stx_mtime;
++	uint32_t stx_rdev_major;
++	uint32_t stx_rdev_minor;
++	uint32_t stx_dev_major;
++	uint32_t stx_dev_minor;
++	uint64_t __pad1[14];
++};
++
++int statx(int, const char *__restrict, int, unsigned, struct statx *__restrict);
++#endif
++
+ #if defined(_LARGEFILE64_SOURCE) || defined(_GNU_SOURCE)
+ #define stat64 stat
+ #define fstat64 fstat
+diff --git a/src/linux/statx.c b/src/linux/statx.c
+new file mode 100644
+index 00000000..4616bff4
+--- /dev/null
++++ b/src/linux/statx.c
+@@ -0,0 +1,42 @@
++#define _GNU_SOURCE
++#include <sys/stat.h>
++#include <string.h>
++#include <syscall.h>
++#include <sys/sysmacros.h>
++#include <errno.h>
++
++int statx(int dirfd, const char *restrict path, int flags, unsigned mask, struct statx *restrict stx)
++{
++	int ret = __syscall(SYS_statx, dirfd, path, flags, mask, stx);
++
++#ifndef SYS_fstatat
++	return __syscall_ret(ret);
++#endif
++
++	if (ret != -ENOSYS) return __syscall_ret(ret);
++
++	struct stat st;
++	ret = fstatat(dirfd, path, &st, flags);
++	if (ret) return ret;
++
++	stx->stx_dev_major = major(st.st_dev);
++	stx->stx_dev_minor = minor(st.st_dev);
++	stx->stx_ino = st.st_ino;
++	stx->stx_mode = st.st_mode;
++	stx->stx_nlink = st.st_nlink;
++	stx->stx_uid = st.st_uid;
++	stx->stx_gid = st.st_gid;
++	stx->stx_size = st.st_size;
++	stx->stx_blksize = st.st_blksize;
++	stx->stx_blocks = st.st_blocks;
++	stx->stx_atime.tv_sec = st.st_atim.tv_sec;
++	stx->stx_atime.tv_nsec = st.st_atim.tv_nsec;
++	stx->stx_mtime.tv_sec = st.st_mtim.tv_sec;
++	stx->stx_mtime.tv_nsec = st.st_mtim.tv_nsec;
++	stx->stx_ctime.tv_sec = st.st_ctim.tv_sec;
++	stx->stx_ctime.tv_nsec = st.st_ctim.tv_nsec;
++	stx->stx_btime = (struct statx_timestamp){.tv_sec=0, .tv_nsec=0};
++	stx->stx_mask = STATX_BASIC_STATS;
++
++	return 0;
++}
+
+From 251cbb6366403a056b39638264932c82d18ec610 Mon Sep 17 00:00:00 2001
+From: Gabriel Ravier <gabravier@gmail.com>
+Date: Fri, 13 Sep 2024 22:00:15 +0200
+Subject: [PATCH] statx: fix ENOSYS emulation not setting stx_rdev_*
+
+The current implementation of the statx function fails to set the
+values of stx->stx_rdev_major and stx->stx_rdev_minor if the statx
+syscall fails with ENOSYS and thus the statx function has to fall back
+on fstatat-based emulation.
+---
+ src/linux/statx.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/src/linux/statx.c b/src/linux/statx.c
+index 4616bff4a..5f6dde923 100644
+--- a/src/linux/statx.c
++++ b/src/linux/statx.c
+@@ -21,6 +21,8 @@ int statx(int dirfd, const char *restrict path, int flags, unsigned mask, struct
+ 
+ 	stx->stx_dev_major = major(st.st_dev);
+ 	stx->stx_dev_minor = minor(st.st_dev);
++	stx->stx_rdev_major = major(st.st_rdev);
++	stx->stx_rdev_minor = minor(st.st_rdev);
+ 	stx->stx_ino = st.st_ino;
+ 	stx->stx_mode = st.st_mode;
+ 	stx->stx_nlink = st.st_nlink;
+
+From 4ca8c267768e371930ef7ec9593a5f8b44a7f810 Mon Sep 17 00:00:00 2001
+From: Rich Felker <dalias@aerifal.cx>
+Date: Fri, 13 Sep 2024 17:08:11 -0400
+Subject: [PATCH] statx: fix uninitialized attributes/mask in fallback path
+
+commit b817541f1cfd38e4b81257b3215e276ea9d0fc61 introduced statx with
+a fallback using fstatat, but failed to fill in stx_rdev_major/minor
+and stx_attributes[_mask]. the rdev omission has been addressed
+separately. rather than explicitly zeroing the attributes and their
+mask, pre-fill the entire structure with zeros. this will also cover
+the padding adjacent to stx_mode, in case it's ever used in the
+future.
+
+explicit zeroing of stx_btime is removed since, with this change, it
+will already be pre-zeroed. as an aside, zeroing it was not strictly
+necessary, since STATX_BASIC_STATS does not include STATX_BTIME and
+thus does not indicate any validity for it.
+---
+ src/linux/statx.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/linux/statx.c b/src/linux/statx.c
+index 5f6dde92..4fb96e4b 100644
+--- a/src/linux/statx.c
++++ b/src/linux/statx.c
+@@ -19,6 +19,7 @@ int statx(int dirfd, const char *restrict path, int flags, unsigned mask, struct
+ 	ret = fstatat(dirfd, path, &st, flags);
+ 	if (ret) return ret;
+ 
++	*stx = (struct statx){0};
+ 	stx->stx_dev_major = major(st.st_dev);
+ 	stx->stx_dev_minor = minor(st.st_dev);
+ 	stx->stx_rdev_major = major(st.st_rdev);
+@@ -37,7 +38,6 @@ int statx(int dirfd, const char *restrict path, int flags, unsigned mask, struct
+ 	stx->stx_mtime.tv_nsec = st.st_mtim.tv_nsec;
+ 	stx->stx_ctime.tv_sec = st.st_ctim.tv_sec;
+ 	stx->stx_ctime.tv_nsec = st.st_ctim.tv_nsec;
+-	stx->stx_btime = (struct statx_timestamp){.tv_sec=0, .tv_nsec=0};
+ 	stx->stx_mask = STATX_BASIC_STATS;
+ 
+ 	return 0;

--- a/srcpkgs/musl/template
+++ b/srcpkgs/musl/template
@@ -2,7 +2,7 @@
 pkgname=musl
 reverts="1.2.0_1"
 version=1.1.24
-revision=23
+revision=24
 archs="*-musl"
 bootstrap=yes
 build_style=gnu-configure


### PR DESCRIPTION
`statx` backport is easy and just applies, for the syscall numbers in `syscalls.h` I just copied over the new values instead of applying all the upstream patches in order since that would be +1k lines instead of just 300.

There is no reason to keep `kernel-libc-headers` on on old version and its generally suggested to use the latest available one, even if you target old kernels.

The musl changes are for two packages that I would like to update, first `ostree` hard depends on `statx(3)` and `firejail` depends on the landlock syscall numbers. Instead of just adding landlock numbers I decided its generally more useful to just ship all the syscall numbers.