### PR TITLE
asahi-base: force load module in tinyramfs

### DIFF
--- a/srcpkgs/asahi-base/files/tinyramfs-hook-asahi.init
+++ b/srcpkgs/asahi-base/files/tinyramfs-hook-asahi.init
@@ -1,5 +1,6 @@
 modprobe apple-mailbox
 modprobe nvme-apple
+modprobe -f xhci-plat-hcd
 
 for i in $(seq 0 50); do
 	[ -e /sys/bus/platform/drivers/nvme-apple/*.nvme/nvme/nvme*/nvme*n1/ ] && break

--- a/srcpkgs/asahi-base/template
+++ b/srcpkgs/asahi-base/template
@@ -1,6 +1,6 @@
 # Template file for 'asahi-base'
 pkgname=asahi-base
-version=20250205
+version=20250403
 revision=1
 archs="aarch64*"
 build_style=meta


### PR DESCRIPTION
- I tested the changes in this PR: yes

This lets tinyramfs use keyboard on mac mini to e.g. decrypt luks.
The reference dracut implementation in asahi-scripts does the same btw.