### PR TITLE
New package: xiphos-4.3.1

### DIFF
--- a/srcpkgs/xiphos/patches/build-without-uuidgen.patch
+++ b/srcpkgs/xiphos/patches/build-without-uuidgen.patch
@@ -1,0 +1,12 @@
+Its actually not needed during build. void's build chroot does not come with it.
+And installing it by installing `util-linux` breaks the build chroot.
+--- a/cmake/XiphosBuildTools.cmake
++++ b/cmake/XiphosBuildTools.cmake
+@@ -85,7 +85,6 @@
+ 
+ # ePub help: yelp-build needs uuidgen, epub needs zip
+ if (EPUB)
+-  xiphos_find_program (UUIDGEN uuidgen)
+   xiphos_find_program (ZIP zip)
+ endif (EPUB)
+ 

--- a/srcpkgs/xiphos/patches/https-by-default.patch
+++ b/srcpkgs/xiphos/patches/https-by-default.patch
@@ -1,0 +1,28 @@
+commit a6bf0fe8d243bb7637410985dac6dfee42f56ff7
+Author: T.J. Townsend <blakkheim@archlinux.org>
+Date:   Sun Oct 9 22:51:53 2022 -0400
+
+    Fetch modules over HTTPS instead of FTP by default.
+
+diff --git a/src/backend/module_manager.cc b/src/backend/module_manager.cc
+index 1b53a601..b0b3b0e0 100644
+--- a/src/backend/module_manager.cc
++++ b/src/backend/module_manager.cc
+@@ -554,13 +554,13 @@ void backend_init_module_mgr_config(void)
+ 
+ 	SWConfig config(confPath.c_str());
+ 
+-	InstallSource is("FTP");
++	InstallSource is("HTTPS");
+ 	is.caption = "CrossWire";
+-	is.source = "ftp.crosswire.org";
+-	is.directory = "/pub/sword/raw";
++	is.source = "www.crosswire.org";
++	is.directory = "/ftpmirror/pub/sword/raw";
+ 
+ 	config["General"]["PassiveFTP"] = "true";
+-	config["Sources"]["FTPSource"] = is.getConfEnt();
++	config["Sources"]["HTTPSSource"] = is.getConfEnt();
+ 	config.save();
+ 
+ 	InstallSource is_local("DIR");

--- a/srcpkgs/xiphos/template
+++ b/srcpkgs/xiphos/template
@@ -1,0 +1,16 @@
+# Template file for 'xiphos'
+pkgname=xiphos
+version=4.3.2
+revision=1
+build_style=cmake
+hostmakedepends="appstream-glib dbus-glib-devel desktop-file-utils gettext
+ glib-devel libxml2-python3 pkg-config python3-lxml yelp-tools zip"
+makedepends="biblesync-devel dbus-glib-devel gtk+3-devel icu-devel intltool
+ itstool libffi libsoup3-devel libwebkit2gtk41-devel libxml2 libxslt
+ minizip-devel sword-devel zlib"
+short_desc="GTK3 Bible tool for reading, study, and research"
+maintainer="Samuel Allan <samuelengineer@fastmail.com>"
+license="GPL-2.0-only"
+homepage="https://xiphos.org/"
+distfiles="https://github.com/crosswire/xiphos/archive/refs/tags/${version}.tar.gz"
+checksum=9d90678657aa1cf34a5101aa56bcdbdfdb586609d8a43004b872ca80988f5f35


### PR DESCRIPTION
Based on the template provided by @jonpikum at
https://github.com/void-linux/void-packages/issues/50026#issuecomment-2766343046 . Includes the patch from https://gitlab.archlinux.org/archlinux/packaging/packages/xiphos/-/blob/main/https-by-default.patch .

Fixes: #50026

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**


#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**


<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
