### PR TITLE
libcap: fix bootstrap

### DIFF
--- a/srcpkgs/libcap/template
+++ b/srcpkgs/libcap/template
@@ -15,6 +15,8 @@ changelog="https://sites.google.com/site/fullycapable/release-notes-for-libcap"
 distfiles="${KERNEL_SITE}/libs/security/linux-privs/libcap2/libcap-${version}.tar.xz"
 checksum=b7006c9af5168315f35fc734bf1a8d2aa70766bd8b8c4340962e05b19c35b900
 
+subpackages="libcap-devel libcap-progs"
+
 if [ "$CROSS_BUILD" ]; then
 	make_build_args+=" CROSS_COMPILE=${XBPS_CROSS_TRIPLET}-"
 fi
@@ -23,6 +25,7 @@ if [ "$CHROOT_READY" ]; then
 	hostmakedepends="gperf"
 	makedepends="pam-devel"
 	make_build_args+=" PAM_CAP=yes"
+	subpackages+=" libcap-pam"
 else
 	make_build_args+=" PAM_CAP=no"
 fi


### PR DESCRIPTION
- I tested the changes in this PR: yes
- I built this PR locally for my native architecture, (aarch64)

Currently, the bootsrap is broken for me on aarch64. This should fix it.

cc @sgn 