### PR TITLE
SDL2_image: update to 2.8.8.

### DIFF
--- a/srcpkgs/SDL2_image/template
+++ b/srcpkgs/SDL2_image/template
@@ -1,7 +1,7 @@
 # Template file for 'SDL2_image'
 pkgname=SDL2_image
-version=2.8.5
-revision=2
+version=2.8.8
+revision=1
 build_style=cmake
 configure_args="-DSDL2IMAGE_WEBP=ON"
 hostmakedepends="pkg-config"
@@ -13,7 +13,7 @@ license="Zlib"
 homepage="https://github.com/libsdl-org/SDL_image"
 changelog="https://raw.githubusercontent.com/libsdl-org/SDL_image/SDL2/CHANGES.txt"
 distfiles="http://www.libsdl.org/projects/SDL_image/release/SDL2_image-${version}.tar.gz"
-checksum=8bc4c57f41e2c0db7f9b749b253ef6cecdc6f0b689ecbe36ee97b50115fff645
+checksum=2213b56fdaff2220d0e38c8e420cbe1a83c87374190cba8c70af2156097ce30a
 
 post_install() {
 	vlicense LICENSE.txt LICENSE
@@ -24,6 +24,7 @@ SDL2_image-devel_package() {
 	short_desc+=" - development files"
 	pkg_install() {
 		vmove usr/include
+		vmove usr/lib/cmake
 		vmove usr/lib/pkgconfig
 		vmove "usr/lib/*.so"
 	}


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture (x86_64)
- I built this PR locally for these architectures using specific masterdirs:
  - x86_64-musl
  - i686
- I built this PR locally for these architectures (crossbuilds):
  - aarch64
  - aarch64-musl
  - armv7l
  - armv7l-musl
  - armv6l
  - armv6l-musl

---

I noticed the following warning in the logs: 
```bash
=> SDL2_image-2.8.8_1: running post-install hook: 10-pkglint-devel-paths ...
=> WARNING: usr/lib/cmake should be in -devel package
``` 
To address this, I added the line `vmove usr/lib/cmake` to the template.