### PR TITLE
SDL2_mixer: update to 2.8.1.

### DIFF
--- a/srcpkgs/SDL2_mixer/template
+++ b/srcpkgs/SDL2_mixer/template
@@ -1,6 +1,6 @@
 # Template file for 'SDL2_mixer'
 pkgname=SDL2_mixer
-version=2.6.3
+version=2.8.1
 revision=1
 build_style=gnu-configure
 hostmakedepends="pkg-config"
@@ -13,7 +13,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="BSD-3-Clause"
 homepage="https://www.libsdl.org/projects/SDL_mixer/"
 distfiles="https://www.libsdl.org/projects/SDL_mixer/release/${pkgname}-${version}.tar.gz"
-checksum=7a6ba86a478648ce617e3a5e9277181bc67f7ce9876605eea6affd4a0d6eea8f
+checksum=cb760211b056bfe44f4a1e180cc7cb201137e4d1572f2002cc1be728efd22660
 
 post_install() {
 	vlicense LICENSE.txt
@@ -24,6 +24,7 @@ SDL2_mixer-devel_package() {
 	short_desc+=" - development files"
 	pkg_install() {
 		vmove usr/include
+		vmove usr/lib/cmake
 		vmove usr/lib/pkgconfig
 		vmove "usr/lib/*.so"
 		vmove "usr/lib/*.a"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture (x86_64)
- I built this PR locally for these architectures using specific masterdirs:
  - x86_64-musl
  - i686
- I built this PR locally for these architectures (crossbuilds):
  - aarch64
  - aarch64-musl
  - armv7l
  - armv7l-musl
  - armv6l
  - armv6l-musl

---

I noticed the following warning in the logs: 
```bash
=> SDL2_mixer-2.8.1_1: running post-install hook: 10-pkglint-devel-paths ...
=> WARNING: usr/lib/cmake should be in -devel package
``` 
To address this, I added the line `vmove usr/lib/cmake` to the template.