### PR TITLE
python3-urwid: update to 2.6.16, adopt

### DIFF
--- a/srcpkgs/python3-urwid/template
+++ b/srcpkgs/python3-urwid/template
@@ -1,22 +1,22 @@
 # Template file for 'python3-urwid'
 pkgname=python3-urwid
-version=2.2.3
-revision=2
+version=2.6.16
+revision=1
 build_style=python3-pep517
 # "vterm" tests do pipe writes that hang
 make_check_args="--ignore=tests/test_vterm.py"
 make_check_target="tests"
 hostmakedepends="python3-setuptools_scm python3-wheel"
 makedepends="python3-devel"
-depends="python3"
-checkdepends="python3-pytest"
+depends="python3-typing_extensions python3-wcwidth"
+checkdepends="python3-pytest python3-wcwidth"
 short_desc="Console user interface library for Python"
-maintainer="Orphaned <orphan@voidlinux.org>"
+maintainer="Emil Miler <em@0x45.cz>"
 license="LGPL-2.1-or-later"
 homepage="http://urwid.org/"
 changelog="https://raw.githubusercontent.com/urwid/urwid/master/docs/changelog.rst"
 distfiles="${PYPI_SITE}/u/urwid/urwid-${version}.tar.gz"
-checksum=e4516d55dcee6bd012b3e72a10c75f2866c63a740f0ec4e1ada05c1e1cc02e34
+checksum=93ad239939e44c385e64aa00027878b9e5c486d59e855ec8ab5b1e1adcdb32a2
 
 pre_check() {
 	vsed -i -e '/addopts/d' pyproject.toml


### PR DESCRIPTION
This update is required to fix `stig` and possibly other packages.

- I tested the changes in this PR: **YES**
- I built this PR locally for my native architecture, (x86_64-glibc)