### PR TITLE
stig: update to 0.13.0a0

### DIFF
--- a/srcpkgs/stig/template
+++ b/srcpkgs/stig/template
@@ -1,17 +1,17 @@
 # Template file for 'stig'
 pkgname=stig
-version=0.12.10a0
-revision=2
+version=0.13.0a0
+revision=1
 build_style=python3-module
 hostmakedepends="python3-setuptools"
-depends="python3-blinker python3-natsort python3-xdg python3-aiohttp
- python3-aiohttp_socks python3-setproctitle python3-urwid python3-urwidtrees
- python3-async-timeout"
+depends="python3-aiohttp python3-aiohttp_socks python3-async-timeout
+ python3-blinker python3-natsort python3-setproctitle python3-urwid
+ python3-urwidtrees python3-xdg"
 short_desc="TUI and CLI for the BitTorrent client Transmission"
 maintainer="Emil Miler <em@0x45.cz>"
 license="GPL-3.0-or-later"
 homepage="https://github.com/rndusr/stig"
 changelog="https://github.com/rndusr/stig/blob/master/CHANGELOG"
 distfiles="https://github.com/rndusr/stig/archive/v${version}.tar.gz"
-checksum=69105ed6ae6a8bd4450d37516368318b1c069b78fe8734171694e729fee2dc56
+checksum=cac8040edcf15225aa5adab212eefd46d640e09e9e0406098acacde052831d98
 make_check=no # needs python3-asynctest which is not packaged


### PR DESCRIPTION
#55004 has to be merged first, otherwise this version of stig would fail on start.

- I tested the changes in this PR: **YES**
- I built this PR locally for my native architecture, (x86_64-glibc)