### PR TITLE
libdeflate: link utilities (libdeflate-gzip) to installed shared library

### DIFF
--- a/srcpkgs/libdeflate/template
+++ b/srcpkgs/libdeflate/template
@@ -1,8 +1,9 @@
 # Template file for 'libdeflate'
 pkgname=libdeflate
 version=1.19
-revision=1
+revision=2
 build_style=cmake
+configure_args="-DLIBDEFLATE_USE_SHARED_LIB=ON"
 checkdepends="zlib-devel"
 short_desc="Optimized library for DEFLATE/zlib/gzip (de)compression"
 maintainer="mobinmob <mobinmob@disroot.org>"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

Void packages dynamically linked executables, but the libdeflate utilities are built with libdeflate itself statically linked by default, despite libdeflate.so.0 being provided in the same package