### PR TITLE
dive: update to 0.13.1

### DIFF
--- a/srcpkgs/dive/template
+++ b/srcpkgs/dive/template
@@ -1,7 +1,7 @@
 # Template file for 'dive'
 pkgname=dive
-version=0.12.0
-revision=2
+version=0.13.1
+revision=1
 build_style=go
 go_import_path="github.com/wagoodman/dive"
 short_desc="Container image exploration tool"
@@ -9,7 +9,7 @@ maintainer="Cameron Nemo <cam@nohom.org>"
 license="MIT"
 homepage="https://github.com/wagoodman/dive"
 distfiles="${homepage}/archive/v${version}.tar.gz"
-checksum=2b69b8d28220c66e2575a782a370a0c05077936ae3ce69180525412fcca09230
+checksum=2a9666e9c3fddd5e2e5bad81dccda520b8102e7cea34e2888f264b4eb0506852
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
- I tested the changes in this PR: **YES**

- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures:
  - aarch64-musl

