### PR TITLE
wine: Fix wine staging build

### DIFF
--- a/srcpkgs/wine/template
+++ b/srcpkgs/wine/template
@@ -94,6 +94,7 @@ fi
 
 post_patch() {
 	if [ "${build_option_staging}" ]; then
+		export PATH="/usr/libexec/chroot-git:${PATH}"
 		"../wine-staging-${_pkgver}/staging/patchinstall.py" --all
 	fi
 }


### PR DESCRIPTION
[ci-skip]

Upstream wine have added a dependency on git where it's now needed when running the patchinstall.py program that applies the wine staging patches to the wine source tree. This change adds git as a build dependency if the "staging" option is specified to xbps-src.

#### Testing the changes
- I tested the changes in this PR: **YES**

Tested with the following command

./xbps-src -o staging pkg wine

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - i686
