### PR TITLE
soju: create /run/soju on startup

### DIFF
--- a/srcpkgs/soju/files/soju/run
+++ b/srcpkgs/soju/files/soju/run
@@ -1,4 +1,6 @@
 #!/bin/sh
 exec 2>&1
 [ -r conf ] && . ./conf
+mkdir -p /run/soju
+chown _soju:_soju /run/soju
 exec chpst -u _soju soju ${OPTS}

--- a/srcpkgs/soju/template
+++ b/srcpkgs/soju/template
@@ -1,7 +1,7 @@
 # Template file for 'soju'
 pkgname=soju
 version=0.9.0
-revision=2
+revision=3
 build_style=go
 go_import_path="codeberg.org/emersion/soju"
 go_package="./cmd/... ./contrib/..."


### PR DESCRIPTION
The default configuration file now contains

	listen unix+admin://

which defaults to /run/soju/admin, the directory thus needs to exist.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**|**briefly**|**NO**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
