### PR TITLE
gnome-mahjongg: update to 48.1

### DIFF
--- a/srcpkgs/gnome-mahjongg/template
+++ b/srcpkgs/gnome-mahjongg/template
@@ -1,6 +1,6 @@
 # Template file for 'gnome-mahjongg'
 pkgname=gnome-mahjongg
-version=48.0
+version=48.1
 revision=1
 build_style=meson
 hostmakedepends="gettext glib-devel itstool pkg-config vala
@@ -9,7 +9,7 @@ makedepends="librsvg-devel libadwaita-devel"
 short_desc="GNOME Mahjongg solitaire game"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later"
-homepage="https://wiki.gnome.org/Apps/Mahjongg"
+homepage="https://gitlab.gnome.org/GNOME/gnome-mahjongg"
 changelog="https://gitlab.gnome.org/GNOME/gnome-mahjongg/-/raw/master/NEWS"
 distfiles="${GNOME_SITE}/${pkgname}/${version%.*}/${pkgname}-${version}.tar.xz"
-checksum=aeb16f4c940bdb6a670c7d9acdd50dd0ec20b321bd7075a985891fbbebcd4fed
+checksum=dd48e0f81aca34beada46c5d221b32591b8ed81e9d361c3a258df9f6b2222c84


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **yes**

#### Local build testing
- I built this PR locally for my native architecture, x86_64
- I crossbuilded this PR locally for these architectures:
  - armv7l
  - armv6l-musl
  - aarch64-musl