### PR TITLE
gnome-nibbles: update to 4.2.1

### DIFF
--- a/srcpkgs/gnome-nibbles/template
+++ b/srcpkgs/gnome-nibbles/template
@@ -1,6 +1,6 @@
 # Template file for 'gnome-nibbles'
 pkgname=gnome-nibbles
-version=4.2.0
+version=4.2.1
 revision=1
 build_style=meson
 build_helper=qemu
@@ -10,7 +10,7 @@ makedepends="gsound-devel libgnome-games-support2-devel libadwaita-devel"
 short_desc="GNOME snake eats diamonds game"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-3.0-or-later"
-homepage="https://wiki.gnome.org/Apps/Nibbles"
+homepage="https://gitlab.gnome.org/GNOME/gnome-nibbles"
 changelog="https://gitlab.gnome.org/GNOME/gnome-nibbles/-/raw/master/NEWS"
 distfiles="${GNOME_SITE}/${pkgname}/${version%.*}/${pkgname}-${version}.tar.xz"
-checksum=526c2cfc0b2280daf2f54a62e5816656fac3dd60629d07c1ca06d82a6d5244a1
+checksum=abecbd7d0080ef4f542e5fd6f0cf48d6510e9a5a067e96b7190596f7811b5125


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **yes**

#### Local build testing
- I built this PR locally for my native architecture, x86_64
- I crossbuilded this PR locally for these architectures:
  - armv7l
  - armv6l-musl
  - aarch64-musl