### PR TITLE
android-file-transfer-linux: update to 4.4

### DIFF
--- a/srcpkgs/android-file-transfer-linux/template
+++ b/srcpkgs/android-file-transfer-linux/template
@@ -1,19 +1,19 @@
 # Template file for 'android-file-transfer-linux'
 pkgname=android-file-transfer-linux
-version=4.3
+version=4.4
 revision=1
 build_style=cmake
+build_helper="qmake6"
 configure_args="-DBUILD_SHARED_LIB=1"
-hostmakedepends="qt5-qmake qt5-host-tools ninja pkg-config"
-makedepends="file-devel fuse-devel qt5-devel readline-devel
- qt5-tools-devel"
-depends="qt5-svg android-file-transfer-linux-cli android-file-transfer-linux-libs"
+hostmakedepends="ninja pkg-config qt6-base qt6-tools"
+makedepends="file-devel fuse-devel readline-devel qt6-base-devel"
+depends="qt6-svg android-file-transfer-linux-cli android-file-transfer-linux-libs"
 short_desc="Android File Transfer for Linux"
 maintainer="Toyam Cox <Vaelatern@voidlinux.org>"
 license="LGPL-2.1-or-later"
 homepage="https://github.com/whoozle/android-file-transfer-linux"
 distfiles="https://github.com/whoozle/android-file-transfer-linux/archive/v${version}.tar.gz"
-checksum=8ff658630fc820a7ca0b70025aa47d235b7fb64f5cb6a72ca76a7acbf3435128
+checksum=d8225cad6eb2e120afd4c82232030d74fd480e666a0fcc4ab93f4cd57620f7c8
 
 android-file-transfer-linux-libs_package() {
 	short_desc+=" - library"


### PR DESCRIPTION
- I tested the changes in this PR: yes
- I built this PR locally for my native architecture, (x86_64-glibc)

The new release fixes issue with recent Android (otherwise broken), and builds with qt6.

Edit: even though the package ships its own `libmpt-ng`, I had to install `libmtp` and add my user to `plugdev` group in order for this tool to work for non-root (the reason being that libmtp ships udev rules, while they don't).

cc @Vaelatern 