### PR TITLE
python3-typogrify: update to 2.1.0, switch to a maintained fork

### DIFF
--- a/srcpkgs/python3-typogrify/template
+++ b/srcpkgs/python3-typogrify/template
@@ -1,16 +1,16 @@
 # Template file for 'python3-typogrify'
 pkgname=python3-typogrify
-version=2.0.7
-revision=5
-build_style=python3-module
-hostmakedepends="python3-setuptools"
+version=2.1.0
+revision=1
+build_style=python3-pep517
+hostmakedepends="hatchling"
 depends="python3-smartypants"
 short_desc="Filters to enhance web typography"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="BSD-3-Clause"
-homepage="https://github.com/mintchaos/typogrify"
-distfiles="https://github.com/mintchaos/typogrify/archive/refs/tags/$version.tar.gz"
-checksum=d5081966c1c1423157e240d5cfe7435b56ca30be57ff8c7fe6f90f6cc42295ee
+homepage="https://github.com/justinmayer/typogrify"
+distfiles="https://github.com/justinmayer/typogrify/archive/refs/tags/${version}.tar.gz"
+checksum=212603210fb5a55fd5bed4c34cd9043b96ab605b190d4e17e27396330147e523
 make_check=no # conflicting dependencies
 
 post_install() {


### PR DESCRIPTION
Switch to a maintained fork advertised in old upstream's website: https://github.com/mintchaos/typogrify/blob/master/README.rst

I have briefly reviewed [all commit the new forks adds on top of the original upstream](https://github.com/mintchaos/typogrify/compare/master...justinmayer:typogrify:main) and I have found nothing out of the ordinary.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
