### PR TITLE
cppman: update to 0.5.7.

### DIFF
--- a/srcpkgs/cppman/template
+++ b/srcpkgs/cppman/template
@@ -1,7 +1,7 @@
 # Template file for 'cppman'
 pkgname=cppman
-version=0.5.6
-revision=3
+version=0.5.7
+revision=1
 build_style=python3-module
 hostmakedepends="python3-setuptools"
 depends="python3-BeautifulSoup4 python3-html5lib python3-lxml"
@@ -12,7 +12,7 @@ license="GPL-3.0-or-later"
 homepage="https://github.com/aitjcize/cppman"
 changelog="https://raw.githubusercontent.com/aitjcize/cppman/master/ChangeLog"
 distfiles="https://github.com/aitjcize/cppman/archive/refs/tags/${version}.tar.gz"
-checksum=bfd80bf239e881a79421e8ef50d4365043b18bf13e61f4d7405730bbc92dc407
+checksum=df42088a9c8601289e18589aba3506a803eba8bb31446c183153de6936700526
 
 post_install() {
 	mv ${DESTDIR}/usr/share/bash-completion/completions/cppman{.bash,}


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->
I am slowly but surely continuing on my mission[^1] to fix all the annoying `SyntaxWarning`s printed by Python packages. This is a juicy one:

```
Byte-compiling python3.13 code for module cppman...
usr/lib/python3.13/site-packages/cppman/formatter/cppreference.py:47: SyntaxWarning: invalid escape sequence '\['
  '^(.*?)(\[(?:(?:since|until) )?C\+\+\d+\]\s*(,\s*)?)+$', head)
usr/lib/python3.13/site-packages/cppman/formatter/cppreference.py:115: SyntaxWarning: invalid escape sequence '\s'
  lambda x: re.sub('\s*</span><span>\s*', r', ', x.group(0)), re.S),
usr/lib/python3.13/site-packages/cppman/formatter/tableparser.py:147: SyntaxWarning: invalid escape sequence '\^'
  fd.write('\^%s' % ('|' if i < total - 1 else ''))
usr/lib/python3.13/site-packages/cppman/main.py:126: SyntaxWarning: invalid escape sequence '\.'
  self.add_url_filter('\.(jpg|jpeg|gif|png|js|css|swf|svg)$')
usr/lib/python3.13/site-packages/cppman/main.py:396: SyntaxWarning: invalid escape sequence '\s'
  if re.match("\s*Type\s*", tds[0].get_text()):
usr/lib/python3.13/site-packages/cppman/main.py:399: SyntaxWarning: invalid escape sequence '\s'
  res = re.search('^\s*(\S*)\s+.*$', tds[0].get_text())
usr/lib/python3.13/site-packages/cppman/main.py:417: SyntaxWarning: invalid escape sequence '\S'
  res = re.search('^.* (\S+)\s*=.*$', text)
usr/lib/python3.13/site-packages/cppman/main.py:430: SyntaxWarning: invalid escape sequence '\S'
  res = re.search('^.* (\S+)\s*=.*$', text)
usr/lib/python3.13/site-packages/cppman/main.py:580: SyntaxWarning: invalid escape sequence '\('
  pat = re.compile('(.*?)(%s)(.*?)( \(.*\))?$' %
usr/lib/python3.13/site-packages/cppman/formatter/cppreference.py:47: SyntaxWarning: invalid escape sequence '\['
  '^(.*?)(\[(?:(?:since|until) )?C\+\+\d+\]\s*(,\s*)?)+$', head)
usr/lib/python3.13/site-packages/cppman/formatter/cppreference.py:115: SyntaxWarning: invalid escape sequence '\s'
  lambda x: re.sub('\s*</span><span>\s*', r', ', x.group(0)), re.S),
usr/lib/python3.13/site-packages/cppman/formatter/tableparser.py:147: SyntaxWarning: invalid escape sequence '\^'
  fd.write('\^%s' % ('|' if i < total - 1 else ''))
usr/lib/python3.13/site-packages/cppman/main.py:126: SyntaxWarning: invalid escape sequence '\.'
  self.add_url_filter('\.(jpg|jpeg|gif|png|js|css|swf|svg)$')
usr/lib/python3.13/site-packages/cppman/main.py:396: SyntaxWarning: invalid escape sequence '\s'
  if re.match("\s*Type\s*", tds[0].get_text()):
usr/lib/python3.13/site-packages/cppman/main.py:399: SyntaxWarning: invalid escape sequence '\s'
  res = re.search('^\s*(\S*)\s+.*$', tds[0].get_text())
usr/lib/python3.13/site-packages/cppman/main.py:417: SyntaxWarning: invalid escape sequence '\S'
  res = re.search('^.* (\S+)\s*=.*$', text)
usr/lib/python3.13/site-packages/cppman/main.py:430: SyntaxWarning: invalid escape sequence '\S'
  res = re.search('^.* (\S+)\s*=.*$', text)
usr/lib/python3.13/site-packages/cppman/main.py:580: SyntaxWarning: invalid escape sequence '\('
  pat = re.compile('(.*?)(%s)(.*?)( \(.*\))?$' %
```

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->

[^1]: My PR fixing this issue was merged and released into cppman: https://github.com/aitjcize/cppman/pull/170