### PR TITLE
Update openshot and its libraries

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -2714,7 +2714,7 @@ libax25io.so.0 libax25-0.0.12rc4_1
 libmill.so.18 libmill-1.14_1
 libges-1.0.so.0 gst1-editing-services-1.6.2_1
 libykneomgr.so.0 libykneomgr-0.1.8_1
-libopenshot-audio.so.9 libopenshot-audio-0.3.0_1
+libopenshot-audio.so.10 libopenshot-audio-0.4.0_1
 libopenshot.so.25 libopenshot-0.3.2_1
 libpqxx-6.3.so libpqxx-6.3.3_1
 libndpi.so.3 ndpi-3.4_1

--- a/common/shlibs
+++ b/common/shlibs
@@ -2715,7 +2715,7 @@ libmill.so.18 libmill-1.14_1
 libges-1.0.so.0 gst1-editing-services-1.6.2_1
 libykneomgr.so.0 libykneomgr-0.1.8_1
 libopenshot-audio.so.10 libopenshot-audio-0.4.0_1
-libopenshot.so.25 libopenshot-0.3.2_1
+libopenshot.so.27 libopenshot-0.4.0_1
 libpqxx-6.3.so libpqxx-6.3.3_1
 libndpi.so.3 ndpi-3.4_1
 libKF5WidgetsAddons.so.5 kwidgetsaddons-5.26.0_1

--- a/srcpkgs/libopenshot-audio-doc
+++ b/srcpkgs/libopenshot-audio-doc
@@ -1,0 +1,1 @@
+libopenshot-audio

--- a/srcpkgs/libopenshot-audio/patches/0001-Fix-musl-compilation-error-related-to-LFS64.patch
+++ b/srcpkgs/libopenshot-audio/patches/0001-Fix-musl-compilation-error-related-to-LFS64.patch
@@ -1,0 +1,45 @@
+From 35c6b259de5f4d4b47c850f0a33a37e8faac693d Mon Sep 17 00:00:00 2001
+From: meator <meator.dev@gmail.com>
+Date: Fri, 15 Aug 2025 10:54:13 +0200
+Subject: [PATCH] Fix musl compilation error related to LFS64
+
+Source: https://github.com/OpenShot/libopenshot-audio/pull/167
+
+LFS64 interfaces are deprecated in musl, since they are not needed
+there. See notes for musl-1.2.4.tar.gz in
+https://musl.libc.org/releases.html and also
+https://wiki.gentoo.org/wiki/Musl_porting_notes#error:_LFS64_interfaces_.28.2A64_undeclared_here.2C_ex._pread64.29
+---
+ CMakeLists.txt                                               | 5 +++++
+ .../modules/juce_core/native/juce_SharedCode_posix.h         | 2 +-
+ 2 files changed, 6 insertions(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index baefd119..9fbf6ee1 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -254,6 +254,11 @@ if(APPLE)
+     -flax-vector-conversions)
+ endif()
+ 
++# Enforce LFS64 in glibc.
++if(UNIX AND NOT APPLE)
++  target_compile_definitions(openshot-audio PUBLIC _FILE_OFFSET_BITS=64)
++endif()
++
+ # ALSA (Linux only)
+ if(UNIX AND NOT APPLE)
+   set(NEED_ALSA TRUE)
+diff --git a/JuceLibraryCode/modules/juce_core/native/juce_SharedCode_posix.h b/JuceLibraryCode/modules/juce_core/native/juce_SharedCode_posix.h
+index d61c4de3..87e8edc8 100644
+--- a/JuceLibraryCode/modules/juce_core/native/juce_SharedCode_posix.h
++++ b/JuceLibraryCode/modules/juce_core/native/juce_SharedCode_posix.h
+@@ -166,7 +166,7 @@ int juce_siginterrupt ([[maybe_unused]] int sig, [[maybe_unused]] int flag)
+ //==============================================================================
+ namespace
+ {
+-   #if JUCE_LINUX || (JUCE_IOS && (! TARGET_OS_MACCATALYST) && (! __DARWIN_ONLY_64_BIT_INO_T)) // (this iOS stuff is to avoid a simulator bug)
++   #if JUCE_IOS && (! TARGET_OS_MACCATALYST) && (! __DARWIN_ONLY_64_BIT_INO_T) // (this iOS stuff is to avoid a simulator bug)
+     using juce_statStruct = struct stat64;
+     #define JUCE_STAT  stat64
+    #else

--- a/srcpkgs/libopenshot-audio/patches/fix-musl.patch
+++ b/srcpkgs/libopenshot-audio/patches/fix-musl.patch
@@ -1,46 +1,53 @@
-diff --git a/JuceLibraryCode/modules/juce_core/juce_core.cpp b/JuceLibraryCode/modules/juce_core/juce_core.cpp
-index 8bac812..e23b422 100644
+This patch disables some glibc-specific features on musl. Upstream appears to support
+many different platforms, some of which also lack the features musl lacks, but
+upstream provides no musl specific checks. This means that no extra code has to be
+added to support musl, only some of the preprocessor conditional statements have to
+be altered to also take musl into consideration.
+
+This patch only fixes compilation errors, there may still be some musl-related
+runtime errors.
+
+This patch is inspired by
+void-linux/void-packages@da8876faa6fc1792f4d2ea2d4b667d3bbe46d868.
 --- a/JuceLibraryCode/modules/juce_core/juce_core.cpp
 +++ b/JuceLibraryCode/modules/juce_core/juce_core.cpp
-@@ -92,7 +92,7 @@
+@@ -102,7 +102,7 @@
   #include <net/if.h>
   #include <sys/ioctl.h>
  
-- #if ! JUCE_ANDROID
-+ #if ! JUCE_ANDROID && defined(__GLIBC__)
+- #if ! (JUCE_ANDROID || JUCE_WASM)
++ #if ! (JUCE_ANDROID || JUCE_WASM) && defined(__GLIBC__)
    #include <execinfo.h>
   #endif
  #endif
-diff --git a/JuceLibraryCode/modules/juce_core/native/juce_linux_SystemStats.cpp b/JuceLibraryCode/modules/juce_core/native/juce_linux_SystemStats.cpp
-index 2d7faa3..f132405 100644
---- a/JuceLibraryCode/modules/juce_core/native/juce_linux_SystemStats.cpp
-+++ b/JuceLibraryCode/modules/juce_core/native/juce_linux_SystemStats.cpp
-@@ -139,8 +139,15 @@ static String getLocaleValue (nl_item key)
-     return result;
- }
+--- a/JuceLibraryCode/modules/juce_core/native/juce_SystemStats_linux.cpp
++++ b/JuceLibraryCode/modules/juce_core/native/juce_SystemStats_linux.cpp
+@@ -198,7 +198,7 @@
  
-+#if defined(__GLIBC__)
- String SystemStats::getUserLanguage()     { return getLocaleValue (_NL_IDENTIFICATION_LANGUAGE); }
- String SystemStats::getUserRegion()       { return getLocaleValue (_NL_IDENTIFICATION_TERRITORY); }
-+#else
-+// The identifiers _NL_INDENTIFICATION_LANGUAGE and _TERRIRTORY are not defined in musl libc.
-+// TODO: Find a better fix than just returning nonsense. Inspect env("LANG") perhaps?
-+String SystemStats::getUserLanguage()     { return String("en"); }
-+String SystemStats::getUserRegion()       { return String("US"); }
-+#endif
- String SystemStats::getDisplayLanguage()  { return getUserLanguage() + "-" + getUserRegion(); }
+ String SystemStats::getUserLanguage()
+ {
+-   #if JUCE_BSD
++   #if JUCE_BSD || !defined(__GLIBC__)
+     if (auto langEnv = getenv ("LANG"))
+         return String::fromUTF8 (langEnv).upToLastOccurrenceOf (".UTF-8", false, true);
  
- //==============================================================================
-diff --git a/JuceLibraryCode/modules/juce_core/system/juce_SystemStats.cpp b/JuceLibraryCode/modules/juce_core/system/juce_SystemStats.cpp
-index 757ea24..6b61e16 100644
+@@ -210,7 +210,7 @@
+ 
+ String SystemStats::getUserRegion()
+ {
+-   #if JUCE_BSD
++   #if JUCE_BSD || !defined(__GLIBC__)
+     return {};
+    #else
+     return getLocaleValue (_NL_ADDRESS_COUNTRY_AB2);
 --- a/JuceLibraryCode/modules/juce_core/system/juce_SystemStats.cpp
 +++ b/JuceLibraryCode/modules/juce_core/system/juce_SystemStats.cpp
-@@ -138,7 +138,7 @@ String SystemStats::getStackBacktrace()
+@@ -178,7 +178,7 @@
  {
      String result;
  
--   #if JUCE_ANDROID || JUCE_MINGW
-+   #if JUCE_ANDROID || JUCE_MINGW || !defined(__GLIBC__)
+-   #if JUCE_ANDROID || JUCE_MINGW || JUCE_WASM
++   #if JUCE_ANDROID || JUCE_MINGW || JUCE_WASM || !defined(__GLIBC__)
      jassertfalse; // sorry, not implemented yet!
  
     #elif JUCE_WINDOWS

--- a/srcpkgs/libopenshot-audio/template
+++ b/srcpkgs/libopenshot-audio/template
@@ -22,3 +22,10 @@ libopenshot-audio-devel_package() {
 		vmove "usr/lib/*.so"
 	}
 }
+
+libopenshot-audio-doc_package() {
+	short_desc+=" - documentation"
+	pkg_install() {
+		vmove usr/share/doc
+	}
+}

--- a/srcpkgs/libopenshot-audio/template
+++ b/srcpkgs/libopenshot-audio/template
@@ -1,6 +1,6 @@
 # Template file for 'libopenshot-audio'
 pkgname=libopenshot-audio
-version=0.3.2
+version=0.4.0
 revision=1
 build_style=cmake
 hostmakedepends="doxygen"
@@ -11,7 +11,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-3.0-or-later"
 homepage="https://github.com/OpenShot/libopenshot-audio"
 distfiles="https://github.com/OpenShot/libopenshot-audio/archive/v${version}.tar.gz"
-checksum=f09d5251c934e6c14d98217b44574c508318c8575e47f5c48ffaf54d9bbce3e9
+checksum=1abdedf9c8686c972c42225a283f518ed2ade445c2e454996b6709d8cc8d1704
 
 libopenshot-audio-devel_package() {
 	short_desc+=" - development files"

--- a/srcpkgs/libopenshot/template
+++ b/srcpkgs/libopenshot/template
@@ -1,7 +1,7 @@
 # Template file for 'libopenshot'
 pkgname=libopenshot
-version=0.3.2
-revision=4
+version=0.4.0
+revision=1
 build_style=cmake
 # Builds fail with Ruby-2.4.1
 configure_args="-DENABLE_RUBY=OFF -DUSE_SYSTEM_JSONCPP=ON"
@@ -16,7 +16,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="LGPL-3.0-or-later"
 homepage="https://github.com/OpenShot/libopenshot"
 distfiles="https://github.com/OpenShot/libopenshot/archive/v${version}.tar.gz"
-checksum=58765cfc8aec199814346e97ce31a5618a261260b380670a6fb2bf6f68733638
+checksum=be0e760d81275543f7fbbf87863645748c3fe8aa8f4b5b771ff45a5d026bc9cc
 
 libopenshot-devel_package() {
 	short_desc+=" - development files"

--- a/srcpkgs/openshot/template
+++ b/srcpkgs/openshot/template
@@ -1,7 +1,7 @@
 # Template file for 'openshot'
 pkgname=openshot
-version=3.1.1
-revision=4
+version=3.3.0
+revision=1
 build_style=python3-module
 hostmakedepends="python3 python3-setuptools"
 makedepends="ffmpeg6-devel python3-PyQt5"
@@ -12,5 +12,5 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-3.0-or-later"
 homepage="https://www.openshot.org"
 distfiles="https://github.com/OpenShot/openshot-qt/archive/v${version}.tar.gz"
-checksum=2b67cb4fc78863911b0263364240947b6331a976aad74943e8f6e46221b52e91
+checksum=f5471eec94d59830ea58351b93e69d4c56b42874d927fbd6482f83b9bb545d4f
 make_check=no # tests are broken


### PR DESCRIPTION
This PR updates openshot and its libraries + it adapts `libopenshot-audio`'s musl patch to the newer version.

#### Testing the changes
- I tested the changes in this PR: **NO** (testing would be appreciated)

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
