### PR TITLE
nvidia-container-toolkit libnvidia-container fix and update to 1.17.5

### DIFF
--- a/srcpkgs/libnvidia-container/patches/fix-go1.24.patch
+++ b/srcpkgs/libnvidia-container/patches/fix-go1.24.patch
@@ -1,0 +1,46 @@
+From 1c680195fdc85948d635286b72a6ad9f823b5987 Mon Sep 17 00:00:00 2001
+From: Dmitry Sharshakov <dmitry.sharshakov@siderolabs.com>
+Date: Thu, 13 Feb 2025 10:18:59 +0100
+Subject: [PATCH] Fix building with Go 1.24
+
+Go 1.24 does not allow defining methods on C types anymore, so make convert a function, not a method.
+
+Fixes the following error when building with Go 1.24:
+`./main.go:35:10: cannot define new methods on non-local type CDeviceRule`
+
+Signed-off-by: Dmitry Sharshakov <dmitry.sharshakov@siderolabs.com>
+---
+ src/nvcgo/main.go | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/src/nvcgo/main.go b/src/nvcgo/main.go
+index 1523a06d..ed43be8e 100644
+--- a/src/nvcgo/main.go
++++ b/src/nvcgo/main.go
+@@ -32,7 +32,7 @@ func main() {}
+ type CDeviceRule = C.struct_device_rule
+ 
+ // Convert a C-based DeviceRule to a Go-based cgroup.DeviceRule
+-func (r *CDeviceRule) convert() cgroup.DeviceRule {
++func convert(r *CDeviceRule) cgroup.DeviceRule {
+ 	return cgroup.DeviceRule{
+ 		Allow:  bool(r.allow),
+ 		Type:   C.GoString(r._type),
+@@ -67,7 +67,7 @@ func GetDeviceCGroupMountPath(version C.int, procRootPath *C.char, pid C.pid_t,
+ 		return -1
+ 	}
+ 	*cgroupMountPath = C.CString(p)
+-	*cgroupRootPrefix= C.CString(r)
++	*cgroupRootPrefix = C.CString(r)
+ 
+ 	return 0
+ }
+@@ -100,7 +100,7 @@ func AddDeviceRules(version C.int, cgroupPath *C.char, crules []CDeviceRule, rer
+ 
+ 	rules := make([]cgroup.DeviceRule, len(crules))
+ 	for i, cr := range crules {
+-		rules[i] = cr.convert()
++		rules[i] = convert(&cr)
+ 	}
+ 
+ 	err = api.AddDeviceRules(C.GoString(cgroupPath), rules)

--- a/srcpkgs/libnvidia-container/template
+++ b/srcpkgs/libnvidia-container/template
@@ -1,7 +1,7 @@
 # Template file for 'libnvidia-container'
 pkgname=libnvidia-container
-version=1.16.1
-revision=2
+version=1.17.5
+revision=1
 archs="x86_64"
 hostmakedepends="tar xz curl bmake groff m4 pkg-config which go"
 makedepends="rpcsvc-proto libcap-devel libseccomp-devel libtirpc-devel"
@@ -10,7 +10,7 @@ maintainer="Quentin Freimanis <quentinfreimanis@gmail.com>"
 license="Apache-2.0"
 homepage="https://github.com/NVIDIA/libnvidia-container"
 distfiles="https://github.com/NVIDIA/libnvidia-container/archive/v${version}.tar.gz"
-checksum=cbc1dda7ee90b8b729c5f178292cd07b421863015d84b84c37e69c8d580ab3ff
+checksum=50903ef115908fe50ed199a4ae05d4e94bba7ab4ac8300ad46345ea8ee0149ba
 
 do_build() {
 	make dist prefix=/usr REVISION=${version} LIB_VERSION=${version}

--- a/srcpkgs/nvidia-container-toolkit/template
+++ b/srcpkgs/nvidia-container-toolkit/template
@@ -1,20 +1,21 @@
 # Template file for 'nvidia-container-toolkit'
 pkgname=nvidia-container-toolkit
-version=1.16.1
-revision=2
+version=1.17.5
+revision=1
 archs="x86_64"
 build_style=go
-go_import_path=github.com/NVIDIA/nvidia-container-toolkit
+go_import_path="github.com/NVIDIA/nvidia-container-toolkit"
 go_package="${go_import_path}/cmd/nvidia-container-runtime-hook
  ${go_import_path}/cmd/nvidia-container-runtime
- ${go_import_path}/cmd/nvidia-ctk"
+ ${go_import_path}/cmd/nvidia-ctk
+ ${go_import_path}/cmd/nvidia-cdi-hook"
 depends="libnvidia-container"
 short_desc="Build and run containers leveraging NVIDIA GPUs"
 maintainer="Quentin Freimanis <quentinfreimanis@gmail.com>"
 license="Apache-2.0"
 homepage="https://github.com/NVIDIA/nvidia-container-toolkit/"
 distfiles="https://github.com/NVIDIA/nvidia-container-toolkit/archive/v${version}.tar.gz"
-checksum=38a193444e0342c0a2c0d3664403e2c341eb77f1461b3f9172fd93c04de82165
+checksum=4e10f5248f4d7d0934b21bbde531379ff3b5940b5a3f753652f1590d8282791e
 
 post_install() {
 	ln -sf /usr/bin/nvidia-container-runtime-hook ${DESTDIR}/usr/bin/${pkgname}
@@ -22,4 +23,7 @@ post_install() {
 	${DESTDIR}/usr/bin/nvidia-ctk --quiet config                       \
 	 --config-file=${DESTDIR}/etc/nvidia-container-runtime/config.toml \
 	 --in-place
+}
+do_check() {
+	PATH+=":${GOPATH}/bin" go test ./...
 }


### PR DESCRIPTION
Alternative to #55088
Same: Fixes #55062, fixes the tests bin path.
Different: updates versions

#### Testing the changes
- I tested the changes in this PR: **briefly**


#### Local build testing
- I built this PR locally for my native architecture, x86_64

Note on building nvidia-container-toolkit:
Local tests still (current 1.16.1_2 does this too) error out on creating mock test control devices if an Nvidia GPU is present in the system.
With tests disabled builds and runs fine.