### PR TITLE
android-udev-rules: update to 20250314

### DIFF
--- a/srcpkgs/android-udev-rules/template
+++ b/srcpkgs/android-udev-rules/template
@@ -1,6 +1,6 @@
 # Template file for 'android-udev-rules'
 pkgname=android-udev-rules
-version=20241109
+version=20250314
 revision=1
 short_desc="Android udev rules list aimed to be the most comprehensive on the net"
 maintainer="Orphaned <orphan@voidlinux.org>"
@@ -8,7 +8,7 @@ license="GPL-3.0-or-later"
 homepage="https://github.com/M0Rf30/android-udev-rules"
 changelog="https://github.com/M0Rf30/android-udev-rules/releases"
 distfiles="https://github.com/M0Rf30/android-udev-rules/archive/${version}.tar.gz"
-checksum=178251de2683dfe27d8bfd2259bc0bc8e38e68b3bc780baca68b8ae9d3d18aca
+checksum=a1b3b6055cdb74a013fe3afcfe1e505bc6ca6339f05d64410660d37f1aca2c8d
 system_groups="adbusers"
 
 do_install() {


### PR DESCRIPTION
- I tested the changes in this PR: yes
- I built this PR locally for my native architecture, x86_64-glibc)