### PR TITLE
jupyterlab: update to 4.4.0

### DIFF
--- a/srcpkgs/jupyterlab/template
+++ b/srcpkgs/jupyterlab/template
@@ -1,21 +1,23 @@
 # Template file for 'jupyterlab'
 pkgname=jupyterlab
-version=4.2.4
-revision=2
+version=4.4.0
+revision=1
 build_style=python3-pep517
 hostmakedepends="hatchling hatch-jupyter-builder"
 depends="nodejs python3-async-lru python3-httpx python3-ipython_ipykernel
- python3-jupyterlab_server python3-notebook_shim"
-checkdepends="$depends python3-pytest-jupyter python3-pytest-xdist"
+ python3-Jinja2 python3-jupyter_core python3-jupyter_server python3-tornado
+ python3-packaging python3-setuptools
+ python3-traitlets python3-jupyterlab_server python3-notebook_shim"
+checkdepends="${depends} python3-pytest-jupyter python3-pytest-xdist"
 short_desc="JupyterLab computational environment"
 maintainer="dkwo <npiazza@disroot.org>, Gonzalo Tornaría <tornaria@cmat.edu.uy>"
 license="custom:jupyterlab"
 homepage="https://github.com/jupyterlab/jupyterlab/"
 changelog="https://raw.githubusercontent.com/jupyterlab/jupyterlab/main/CHANGELOG.md"
 distfiles="${PYPI_SITE}/j/jupyterlab/jupyterlab-${version}.tar.gz"
-checksum=343a979fb9582fd08c8511823e320703281cd072a0049bcdafdc7afeda7f2537
+checksum=f1767d5f0104e40f3b4a63bf6892bbef8e4704dcabf0c78408a3bdc411792f04
 
-if [ "$XBPS_BUILD_ENVIRONMENT" = void-packages-ci ]; then
+if [ "${XBPS_BUILD_ENVIRONMENT}" = void-packages-ci ]; then
 	# this test fails on CI (network timeout)
 	make_check_args="
 	 --deselect=jupyterlab/tests/test_build_api.py::TestBuildAPI


### PR DESCRIPTION
- I tested the changes in this PR: yes
- I built this PR locally for my native architecture, (x86_64-glibc)

cc @tornaria I added a few depends. All tests pass. I decided not to package `jupyter_lsp`, not sure it is worth the effort.
edit: of course the lint fails. what to do?