### PR TITLE
mame: update to 0276

### DIFF
--- a/srcpkgs/mame/template
+++ b/srcpkgs/mame/template
@@ -1,6 +1,6 @@
 # Template file for 'mame'
 pkgname=mame
-version=0272
+version=0276
 revision=1
 hostmakedepends="pkg-config python3 qt6-base"
 makedepends="qt6-base-devel SDL2_ttf-devel asio libutf8proc-devel libgomp-devel
@@ -11,7 +11,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="https://mamedev.org"
 distfiles="https://github.com/mamedev/mame/archive/mame${version}.tar.gz"
-checksum=cd83bff2f8acf72bdb105ba8e899b49ad09c25cee8a8a063ae27a954fe0dc097
+checksum=965dfc33d720b4c3c6e425d5959540bd0bac88e96b878a8560678c2f5b43c44f
 nodebug=yes
 replaces="sdlmame>=0 sdlmess>=0"
 


### PR DESCRIPTION
This includes an [upstream patch](https://github.com/Tencent/rapidjson/pull/719) for a rapidjson bug that causes some builds (including mame) to fail, and bumps mame version to the latest 0276.

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
