### PR TITLE
leptonica: add required image support

### DIFF
--- a/srcpkgs/leptonica/template
+++ b/srcpkgs/leptonica/template
@@ -1,10 +1,11 @@
 # Template file for 'leptonica'
 pkgname=leptonica
 version=1.85.0
-revision=1
+revision=2
 build_style=gnu-configure
 hostmakedepends="pkg-config automake libtool"
-makedepends="libopenjpeg2-devel libwebp-devel"
+makedepends="libopenjpeg2-devel libwebp-devel libjpeg-turbo-devel tiff-devel
+ libpng-devel zlib-devel giflib-devel"
 checkdepends="which gnuplot"
 short_desc="Image processing and analysis library"
 maintainer="Orphaned <orphan@voidlinux.org>"
@@ -13,11 +14,7 @@ homepage="http://leptonica.org/"
 changelog="http://leptonica.org/source/version-notes.html"
 distfiles="https://github.com/DanBloomberg/leptonica/archive/${version}.tar.gz"
 checksum=c01376bce0379d4ea4bc2ec5d5cbddaa49e2f06f88242619ab8c059e21adf233
-
-case "$XBPS_TARGET_MACHINE" in
-	x86_64*|i686) make_check=no # a good portion of tests fail on these archs
-	;;
-esac
+make_check=no # a good portion of tests fail
 
 pre_check() {
 	# disable failing tests


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

The -devel packages used to be pulled in by libwebp-devel until @Johnnynator cleaned this mess up in Aug 2024. leptonica didn't get a rebuild until now.

This fixes, for instance, errors produced by tesseract-ocr like:
```
Error in pixReadMemTiff: function not present
Error in pixReadMem: tiff: no pix returned
Error in pixaGenerateFontFromString: pix not made
Error in bmfCreate: font pixa not made
Error in pixReadStreamPng: function not present
Error in pixReadStream: png: no pix returned
Leptonica Error in pixRead: pix not read: img.png
Error during processing.
```
 

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture: x86_64-glibc
