### PR TITLE
soft-serve: update to 0.8.5

### DIFF
--- a/srcpkgs/soft-serve/files/soft-serve/env/SOFT_SERVE_DATA_PATH
+++ b/srcpkgs/soft-serve/files/soft-serve/env/SOFT_SERVE_DATA_PATH
@@ -1,0 +1,1 @@
+/var/lib/soft-serve

--- a/srcpkgs/soft-serve/files/soft-serve/run
+++ b/srcpkgs/soft-serve/files/soft-serve/run
@@ -1,7 +1,3 @@
 #!/bin/sh
 exec 2>&1
-
-export HOME=/var/lib/soft-serve
-export SOFT_SERVE_DATA_PATH="${HOME}"
-
-exec chpst -u _softserve:_softserve soft serve
+exec chpst -e ./env -u _softserve:_softserve soft serve

--- a/srcpkgs/soft-serve/template
+++ b/srcpkgs/soft-serve/template
@@ -1,20 +1,21 @@
 # Template file for 'soft-serve'
 pkgname=soft-serve
-version=0.7.4
-revision=2
+version=0.8.5
+revision=1
 build_style=go
 build_helper=qemu
 go_import_path="github.com/charmbracelet/soft-serve"
 go_ldflags="-X main.Version=${version}"
 go_package="github.com/charmbracelet/soft-serve/cmd/soft"
 depends="git"
+checkdepends="git git-lfs openssh"
 short_desc="Tasty, self-hostable Git server for the command line"
 maintainer="zenobit <zenobit@disroot.org>"
 license="MIT"
 homepage="https://github.com/charmbracelet/soft-serve"
 changelog="https://github.com/charmbracelet/soft-serve/releases"
 distfiles="https://github.com/charmbracelet/soft-serve/archive/refs/tags/v${version}.tar.gz"
-checksum=56ba8a51446afa3b53d451a86f0fdbef0a4ce90d5072a0ef9359e3150c466d50
+checksum=e8a432e8d1a891d7ca6f8b16fa4455db57b3484b7728fdb1ae9a77d4fa0d7045
 
 system_accounts="_softserve"
 _softserve_homedir="/var/lib/soft-serve"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
#### Local build testing
- I built this PR locally for my native architecture, (x86_64)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64 (cross)
  - armv7l-musl (cross)
  - x86_64-musl
  - i686

cc @zen0bit

I rearranged setting the environment variables, `$HOME` doesn’t seem to be necessary since it is set in the template. And I added `SOFT_SERVE_INITIAL_ADMIN_KEYS` to make setting up the server a bit more convenient. Just add the path to the admin user's public ssh key to the env file before activating the service for the first time. I’m not sure if this would justify an `INSTALL.msg`?

I don’t know why the check fails for i686. It seems to build the binary a second time and fails. It get's built without problems in the do_build stage the first time. My go knowledge is too limited to find the cause ;)