### PR TITLE
Revert "dino: update to 0.5.0."

### DIFF
--- a/srcpkgs/dino/template
+++ b/srcpkgs/dino/template
@@ -1,10 +1,11 @@
 # Template file for 'dino'
 pkgname=dino
-version=0.5.0
-revision=1
-build_style=meson
-configure_args="-Dplugin-notification-sound=enabled"
-hostmakedepends="ninja gettext unzip pkg-config vala glib-devel"
+reverts=0.5.0_1
+version=0.4.5
+revision=2
+build_style=cmake
+configure_args="-DDINO_PLUGIN_ENABLED_notification-sound=ON -DUSE_SOUP3=ON"
+hostmakedepends="cmake ninja gettext unzip pkg-config vala glib-devel"
 makedepends="glib-devel qrencode-devel gtk4-devel gpgme-devel libgee-devel
  libgcrypt-devel libsoup3-devel libsignal-protocol-c-devel sqlite-devel
  libcanberra-devel gspell-devel libsrtp-devel libnice-devel gnutls-devel
@@ -14,7 +15,16 @@ maintainer="Leah Neukirchen <leah@vuxu.org>"
 license="GPL-3.0-or-later"
 homepage="https://github.com/dino/dino"
 distfiles="https://github.com/dino/dino/archive/v${version}.tar.gz"
-checksum=4c57f20677f47f41b440b7d6eebb697ee89d5d8c38d334ad47c6b5de19894768
+checksum=80761b625c4cb4cf6ed1a368dbd24a9df06b47a1c6379495aca4ed7e033d08be
+
+if [ "${XBPS_CHECK_PKGS}" ]; then
+	configure_args+=" -DBUILD_TESTS=ON"
+fi
+
+do_check() {
+	build/xmpp-vala-test
+	build/signal-protocol-vala-test
+}
 
 post_install() {
 	rm -rf ${DESTDIR}/usr/include


### PR DESCRIPTION
This reverts commit dcbc483c864c3a7f34c5b35bdaee686b8492968b. Dino
migrated from libsignal-c to their own fork libomemo-c for OMEMO
support, the latter is however not packaged and the change was not
reflected in the above update leading to the loss of support for OMEMO
and thus the inability to decrypt messages in encrypted chats and so
ultimately message loss for such Dino sessions.

---

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
#### Local build testing
- I built this PR locally for my native architecture, (x86_64-musl)
<!--
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
