### PR TITLE
Fix 09-apparmor.sh in runit-void

### DIFF
--- a/srcpkgs/runit-void/files/09-apparmor.sh
+++ b/srcpkgs/runit-void/files/09-apparmor.sh
@@ -18,7 +18,7 @@ if [ -n "$APPARMOR" ]; then
 	[ "$APPARMOR" = "complain" ] && AACOMPLAIN="-C"
 
 	if [ -d /etc/apparmor.d -a -x /usr/bin/apparmor_parser ]; then
-		apparmor_parser -a $AACOMPLAIN $(find /etc/apparmor.d -maxdepth 1 -type f ! -name '*.new-*_*')
+		apparmor_parser -a $AACOMPLAIN $(find /etc/apparmor.d -maxdepth 1 -type f ! -name '*.new-*_*') /dev/null
 	else
 		printf '! AppArmor installation problem - ensure you have installed apparmor package\n'
 	fi


### PR DESCRIPTION
When no profile exists in `/etc/apparmor.d`, apparmor_parser receives zero path arguments and so it expects to be given a profile via the standard input. In this case, the `09-apparmor.sh` core-service effectively "hangs" the boot process.

Adding `/dev/null` to apparmor_parser's arguments ensures a fallback empty profile, thus preventing it from "hanging". In the normal case where `/etc/apparmor.d` is not void (huh) of profiles, this empty profile will be completely harmless.

#### Testing the changes
- I tested the changes in this PR: **briefly**