### PR TITLE
meld: update to 3.23.0

### DIFF
--- a/srcpkgs/meld/template
+++ b/srcpkgs/meld/template
@@ -1,9 +1,9 @@
 # Template file for 'meld'
 pkgname=meld
-version=3.22.3
+version=3.23.0
 revision=1
 build_style=meson
-hostmakedepends="pkg-config gettext python3-distro itstool
+hostmakedepends="desktop-file-utils pkg-config gettext python3-distro itstool
  gtk-update-icon-cache libxml2-python3 glib-devel"
 makedepends="python3-devel gtk+3-devel gtksourceview4-devel python3-gobject-devel"
 depends="python3-gobject gsettings-desktop-schemas gtksourceview4
@@ -13,4 +13,4 @@ maintainer="Helmut Pozimski <helmut@pozimski.eu>"
 license="GPL-2.0-or-later"
 homepage="http://meldmerge.org/"
 distfiles="${GNOME_SITE}/meld/${version%.*}/meld-${version}.tar.xz"
-checksum=37f7f29eb1ff0fec4d8b088d5483c556de1089f6d018fe6d481993caf2499d84
+checksum=983c2a4240e025a2109c7738198710e9d6b063c910b048332d14690cf538c2a6


### PR DESCRIPTION
I added the `desktop-file-utils` dependency, because this pkg's meson build system needs `update-desktop-database`.

#### Testing the changes
- I tested the changes in this PR: **briefly**

I tested running `meld .` from within a git repository with modifications and everything worked OK.

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-musl)
- I built this PR locally for these architectures (crossbuilt, but it's python...):
  - aarch64
  - aarch64-musl