### PR TITLE
Lz4: update to 1.10.0

### DIFF
--- a/srcpkgs/lz4/template
+++ b/srcpkgs/lz4/template
@@ -1,21 +1,22 @@
 # Template file for 'lz4'
 pkgname=lz4
 reverts="131_1 130_1 129_1 128_1 127_1 126_1 125_1 124_1 123_1 122_1"
-version=1.9.4
+version=1.10.0
 revision=1
 bootstrap=yes
 build_style=gnu-makefile
-make_check_target=test
 checkdepends="python3"
-short_desc="LZ4 compression utilities"
+short_desc="Extremely fast compression algorithm"
 maintainer="Orphaned <orphan@voidlinux.org>"
-license="BSD-2-Clause, GPL-2.0-or-later"
+# all files under source 'lib' directory are BSD-2, others are GPLv2+
+license="BSD-2-Clause AND GPL-2.0-or-later"
 homepage="https://lz4.github.io/lz4"
-changelog="https://raw.githubusercontent.com/lz4/lz4/dev/NEWS"
-distfiles="https://github.com/lz4/lz4/archive/v${version}.tar.gz"
-checksum=0b0e3aa07c8c063ddf40b082bdf7e37a1562bda40a0ff5272957f3e987e0e54b
+changelog="https://github.com/lz4/lz4/raw/refs/heads/dev/NEWS"
+distfiles="https://github.com/lz4/lz4/releases/download/v${version}/lz4-${version}.tar.gz"
+checksum="537512904744b35e232912055ccf8ec66d768639ff3abe5788d90d792ec5f48b"
 
 post_install() {
+	# BSD-2-Clause must be installed
 	vlicense lib/LICENSE
 }
 


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-gnu)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - aarch64
  - armv5tel-musl
  - armv5tel
  - armv6l-musl
  - armv6l
  - armv7l-musl
  - armv7l
  - i686-musl
  - i686
  - mips-musl
  - mipsel-musl
  - mipselhf-musl
  - mipshf-musl
  - ppc-musl
  - ppc
  - ppc64-musl
  - ppc64
  - ppc64le-musl
  - ppc64le
  - x86_64-musl

I had [#55155](https://github.com/void-linux/void-packages/pull/55155), and I seem to have done something incorrectly during my force push, and the pull request became closed. I understand from the contributing document that this is unwanted behavior, so for that I sincerely apologize. All suggested changes from 55155 are present in this commit. Again, sorry for the issues with my original PR.