### PR TITLE
strongswan: fix ipsec command not found

### DIFF
--- a/srcpkgs/strongswan/template
+++ b/srcpkgs/strongswan/template
@@ -1,13 +1,13 @@
 # Template file for 'strongswan'
 pkgname=strongswan
 version=6.0.1
-revision=1
+revision=2
 build_style=gnu-configure
 # tpm support waits on libtss2
 configure_args="--disable-static --enable-blowfish --enable-curl --enable-md4
  --enable-eap-radius --enable-eap-mschapv2 --enable-eap-md5
  --enable-eap-identity --enable-eap-dynamic --enable-led --enable-ha --enable-dhcp
- --enable-mediation --disable-soup --enable-chapoly --enable-nm
+ --enable-mediation --disable-soup --enable-chapoly --enable-nm --enable-stroke
  --enable-pkcs11 --with-capabilities=libcap"
 hostmakedepends="pkg-config automake flex bison python3"
 makedepends="libldns-devel unbound-devel libcurl-devel


### PR DESCRIPTION
#### Testing the changes
I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-musl

EDIT:
I took the solution for this patch after finding out here https://github.com/strongswan/strongswan/discussions/2551

EDIT2:
This fixes #54763 

