### PR TITLE
maddy: update to 0.8.1.

### DIFF
--- a/srcpkgs/maddy/INSTALL
+++ b/srcpkgs/maddy/INSTALL
@@ -1,0 +1,5 @@
+case "$ACTION" in
+post)
+	setcap 'cap_net_bind_service=+ep' /usr/bin/maddy
+	;;
+esac

--- a/srcpkgs/maddy/files/maddy/run
+++ b/srcpkgs/maddy/files/maddy/run
@@ -1,4 +1,6 @@
 #!/bin/sh
 umask 0027
 exec 2>&1
+mkdir -p /run/maddy
+chown _maddy:_maddy /run/maddy
 exec chpst -u _maddy:_maddy -C /var/lib/maddy -o 131072 -p 512 /usr/bin/maddy run

--- a/srcpkgs/maddy/template
+++ b/srcpkgs/maddy/template
@@ -1,6 +1,6 @@
 # Template file for 'maddy'
 pkgname=maddy
-version=0.7.1
+version=0.8.1
 revision=1
 build_style=go
 go_import_path="github.com/foxcpp/maddy"
@@ -9,12 +9,13 @@ go_package="$go_import_path/cmd/maddy
  $go_import_path/cmd/maddy-shadow-helper"
 hostmakedepends="scdoc"
 makedepends="pam-devel"
+depends="libcap-progs"	# For setcap(8)
 short_desc="Composable all-in-one mail server"
 maintainer="Michael Aldridge <maldridge@voidlinux.org>"
 license="GPL-3.0-or-later"
 homepage="https://maddy.email"
 distfiles="https://github.com/foxcpp/maddy/archive/refs/tags/v$version.tar.gz"
-checksum=541288477afb040a04a5cf17a1c3e3b7a81b287dc3a81c844b2d6ad66688c29e
+checksum=e31decff5df3e9f70aba9f27e4cb62d925263aa6e75671685236d08a589dfd8b
 make_dirs="/var/lib/maddy 0750 _maddy _maddy
  /etc/maddy 0750 _maddy _maddy"
 system_accounts="_maddy"


### PR DESCRIPTION
Also create /run/maddy required for maddy to run in the runit service
and set CAP_NET_BIND_SERVICE on the binary to allow listening on
privileged ports.

Cc: @the-maldridge

---

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
#### Local build testing
- I built this PR locally for my native architecture, (x86_64-musl)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64 (cross)
