### PR TITLE
gamescope: update to 3.16.3. closes #54145

### DIFF
--- a/srcpkgs/gamescope/template
+++ b/srcpkgs/gamescope/template
@@ -1,6 +1,6 @@
 # Template file for 'gamescope'
 pkgname=gamescope
-version=3.16.1
+version=3.16.3
 revision=1
 _stb_hash=5736b15f7ea0ffb08dd38af21067c314d6a3aae9
 _vkroots_hash=5106d8a0df95de66cc58dc1ea37e69c99afc9540
@@ -31,7 +31,7 @@ distfiles="https://github.com/ValveSoftware/gamescope/archive/refs/tags/${versio
  https://gitlab.freedesktop.org/emersion/libdisplay-info/-/archive/${_libdisplay_info_hash}/libdisplay-info-${_libdisplay_info_hash}.tar.gz
  https://gitlab.freedesktop.org/emersion/libliftoff/-/archive/${_libliftoff_hash}/libliftoff-${_libliftoff_hash}.tar.gz
  https://github.com/Joshua-Ashton/wlroots/archive/${_wlroots_hash}.tar.gz"
-checksum="acaa77c80670357ed29b8aacd59cc960b7314eb092ca8f2a2f127c456d2ae281
+checksum="756c6b52f85dcca31da2f1a66e084fb28dd5e67a6cd4950e3bf105d6291c0534
  d00921d49b06af62aa6bfb97c1b136bec661dd11dd4eecbcb0da1f6da7cedb4c
  37b77586e91f7ebee70380dcddd73bf01ae4acef1053e6be41d0485ede022422
  3aa6feda7773cc8ffa8fb012fe95e6207c776101e29198d0e0d34a0c5e339f6a


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, **x86_64**

####

Fixes weird graphical glitch with A770 and solitare https://github.com/void-linux/void-packages/issues/54145