### PR TITLE
tree-sitter: update to 0.25.3

### DIFF
--- a/srcpkgs/tree-sitter/template
+++ b/srcpkgs/tree-sitter/template
@@ -1,6 +1,6 @@
 # Template file for 'tree-sitter'
 pkgname=tree-sitter
-version=0.25.2
+version=0.25.3
 revision=1
 build_style=cargo
 make_install_args="--path=cli"
@@ -10,7 +10,7 @@ license="MIT"
 homepage="https://tree-sitter.github.io"
 changelog="https://github.com/tree-sitter/tree-sitter/releases"
 distfiles="https://github.com/tree-sitter/tree-sitter/archive/refs/tags/v${version}.tar.gz"
-checksum=26791f69182192fef179cd58501c3226011158823557a86fe42682cb4a138523
+checksum=862fac52653bc7bc9d2cd0630483e6bdf3d02bcd23da956ca32663c4798a93e3
 make_check=no # tests require generating fixtures from remote repositories
 
 post_build() {


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
