### PR TITLE
zig: update to 0.14.0

### DIFF
--- a/srcpkgs/zig/template
+++ b/srcpkgs/zig/template
@@ -1,6 +1,6 @@
 # Template file for 'zig'
 pkgname=zig
-version=0.13.0
+version=0.14.0
 revision=1
 archs="x86_64* aarch64*"
 build_style=cmake
@@ -8,13 +8,13 @@ configure_args="-DZIG_TARGET_MCPU=baseline"
 make_cmd=make
 # we add xml2, zstd, zlib and ncurses
 # because our lld is static-only and requires those to work
-makedepends="clang18-devel llvm18-devel lld18-devel libxml2-devel libzstd-devel ncurses-devel zlib-devel"
+makedepends="clang19-devel llvm19-devel lld19-devel libxml2-devel libzstd-devel ncurses-devel zlib-devel"
 short_desc="Programming language designed for robustness, optimality, and clarity"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
 homepage="https://ziglang.org"
 distfiles="https://ziglang.org/download/${version}/zig-${version}.tar.xz"
-checksum=06c73596beeccb71cc073805bdb9c0e05764128f16478fa53bf17dfabc1d4318
+checksum=c76638c03eb204c4432ae092f6fa07c208567e110fbd4d862d131a7332584046
 nopie=yes
 nocross=yes
 


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-gnu)

I was able to build river (upstream v0.3.9) and the master branch of Ghostty with it.