### PR TITLE
obs: ENABLE_NVENC under `nvenc` option for x86_64

### DIFF
--- a/srcpkgs/nv-codec-headers/template
+++ b/srcpkgs/nv-codec-headers/template
@@ -1,7 +1,6 @@
 # Template file for 'nv-codec-headers'
 pkgname=nv-codec-headers
-reverts="12.2.72.0_1"
-version=12.0.16.1
+version=13.0.19.0
 revision=1
 build_style=gnu-makefile
 short_desc="FFmpeg version of headers required to interface with Nvidias codec APIs"
@@ -9,7 +8,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
 homepage="http://git.videolan.org/?p=ffmpeg/nv-codec-headers.git"
 distfiles="https://github.com/FFmpeg/nv-codec-headers/archive/n${version}.tar.gz"
-checksum=37e31c7ed0c9bf2da74646a3ec426c38a6d29e60b1fb7bff3e03a99b9412e050
+checksum=86d15d1a7c0ac73a0eafdfc57bebfeba7da8264595bf531cf4d8db1c22940116
 
 post_install() {
 	sed -n '4,25p' include/ffnvcodec/nvEncodeAPI.h > LICENSE

--- a/srcpkgs/obs/template
+++ b/srcpkgs/obs/template
@@ -1,14 +1,15 @@
 # Template file for 'obs'
 pkgname=obs
 version=31.0.2
-revision=3
+revision=4
 archs="i686* x86_64* ppc64le* aarch64* riscv64*"
 build_style=cmake
 configure_args="-DOBS_VERSION_OVERRIDE=${version} -DENABLE_JACK=ON
  -DCMAKE_INSTALL_DATAROOTDIR=share -DENABLE_RNNOISE=OFF
  -DENABLE_VST=OFF -DENABLE_AJA=OFF
  -DENABLE_SCRIPTING_LUA=$(vopt_if luajit 'ON' 'OFF')
- -DENABLE_NVENC=OFF -DENABLE_QSV11=$(vopt_if 'ON' 'OFF')
+ -DENABLE_NVENC=$(vopt_if nvenc 'ON' 'OFF')
+ -DENABLE_QSV11=$(vopt_if 'ON' 'OFF')
  -DCMAKE_COMPILE_WARNING_AS_ERROR=OFF"
 hostmakedepends="pkg-config swig python3-devel qt6-base"
 makedepends="$(vopt_if luajit LuaJIT-devel) fdk-aac-devel
@@ -17,7 +18,8 @@ makedepends="$(vopt_if luajit LuaJIT-devel) fdk-aac-devel
  v4l-utils-devel vlc-devel qt6-svg-devel x264-devel mbedtls-devel
  jansson-devel wayland-devel pipewire-devel libxkbcommon-devel
  pciutils-devel librist-devel srt-devel libdatachannel-devel
- oneVPL-devel uthash qt6-base-private-devel json-c++"
+ oneVPL-devel uthash qt6-base-private-devel json-c++
+ $(vopt_if nvenc nv-codec-headers)"
 depends="xset xdg-desktop-portal"
 short_desc="Open Broadcaster Software"
 maintainer="lemmi <lemmi@nerd2nerd.org>"
@@ -27,10 +29,10 @@ changelog="https://github.com/obsproject/obs-studio/releases"
 distfiles="https://github.com/obsproject/obs-studio/archive/refs/tags/$version.tar.gz"
 checksum=74563ebbee5fcd448e6a790569cf3ca1a01bdcbc6bc2b3f61a9421ff8dfa6eb2
 
-build_options="luajit qsv"
+build_options="luajit qsv nvenc"
 case $XBPS_TARGET_MACHINE in
 	riscv64*);;
-	x86_64*) build_options_default="luajit qsv";;
+	x86_64*) build_options_default="luajit qsv nvenc";;
 	*) build_options_default="luajit";;
 esac
 


### PR DESCRIPTION
requires an additional version bump to `nv-codec-headers` to include a missing enum.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
