### PR TITLE
nodejs: update to 22.11.0

### DIFF
--- a/srcpkgs/nodejs/template
+++ b/srcpkgs/nodejs/template
@@ -1,6 +1,6 @@
 # Template file for 'nodejs'
 pkgname=nodejs
-version=20.16.0
+version=22.11.0
 revision=1
 hostmakedepends="which pkg-config python3-setuptools"
 _make_depends="zlib-devel \
@@ -18,7 +18,7 @@ license="MIT"
 homepage="https://nodejs.org/"
 changelog="https://raw.githubusercontent.com/nodejs/node/main/doc/changelogs/CHANGELOG_V${version%%.*}.md"
 distfiles="https://nodejs.org/dist/v${version}/node-v${version}.tar.xz"
-checksum=cd6c8fc3ff2606aadbc7155db6f7e77247d2d0065ac18e2f7f049095584b8b46
+checksum=bbf0297761d53aefda9d7855c57c7d2c272b83a7b5bad4fea9cb29006d8e1d35
 python_version=3
 
 build_options="ssl libuv icu nghttp2 cares brotli"


### PR DESCRIPTION
Chromium 136 build requires this specific version of nodejs.

#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc