### PR TITLE
New packages: ser2net & libgensio

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -4536,6 +4536,9 @@ libsfdo-desktop-file.so.0 libsfdo-0.1.3_1
 libsfdo-icon.so.0 libsfdo-0.1.3_1
 libKMahjongg6.so.6 libkmahjongg-24.08.2_1
 libflashrom.so.1 flashrom-1.4.0_1
+libgensiomdns.so.10 libgensio-2.8.15_1
+libgensioosh.so.10 libgensio-2.8.15_1
+libgensio.so.10 libgensio-2.8.15_1
 libpyside6.so.6.8 libpyside6-6.8.3_1
 libpyside6qml.so.6.8 libpyside6-6.8.3_1
 libshiboken6.so.6.8 libshiboken6-6.8.3_1

--- a/srcpkgs/libgensio-devel
+++ b/srcpkgs/libgensio-devel
@@ -1,0 +1,1 @@
+libgensio

--- a/srcpkgs/libgensio/template
+++ b/srcpkgs/libgensio/template
@@ -1,0 +1,30 @@
+# Template file for 'libgensio'
+pkgname=libgensio
+version=2.8.15
+revision=1
+build_style=gnu-configure
+hostmakedepends="swig pkg-config automake libtool"
+short_desc="Library to abstract stream I/O"
+maintainer="Vincent Legoll <vincent.legoll@gmail.com>"
+license="GPL-2.0-only AND LGPL-2.1-only"
+homepage="https://github.com/cminyard/gensio"
+changelog="https://github.com/cminyard/gensio/releases"
+distfiles="https://github.com/cminyard/gensio/releases/download/v${version}/gensio-${version}.tar.gz"
+checksum=1cfa7d6ef19b8d98808b1f4bce225454781299f885815c22ab59d85585f54ee3
+make_check=no # requires python-gensio which is not built
+
+pre_configure() {
+	autoreconf -fi
+}
+
+libgensio-devel_package() {
+	depends="${makedepends} ${sourcepkg}-${version}_${revision}"
+	short_desc+=" - development files"
+	pkg_install() {
+		vmove usr/lib/pkgconfig
+		vmove usr/include
+		vmove "usr/lib/*.a"
+		vmove "usr/lib/*.so"
+		vmove usr/share/man
+	}
+}

--- a/srcpkgs/ser2net/template
+++ b/srcpkgs/ser2net/template
@@ -1,0 +1,16 @@
+# Template file for 'ser2net'
+pkgname=ser2net
+version=4.6.5
+revision=1
+build_style=gnu-configure
+hostmakedepends="pkg-config"
+makedepends="libgensio-devel libyaml-devel"
+checkdepends="python"
+short_desc="Serial to network interface, allows TCP/UDP to serial port connections"
+maintainer="Vincent Legoll <vincent.legoll@gmail.com>"
+license="GPL-2.0-only"
+homepage="https://github.com/cminyard/ser2net"
+changelog="https://github.com/cminyard/ser2net/releases"
+distfiles="https://github.com/cminyard/ser2net/releases/download/v${version}/ser2net-${version}.tar.gz"
+checksum=96dfc3fd06b1bf4d7c1f46d7e8cc1eff555de64f419d76f57bd0346e000f9781
+make_check=no # requires python-gensio which is not built


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

Redirected a USB-serial adapter, connected to a HW serial console, to a
local tcp port, and used nc to interact with it successfully.

This is serial-over-LAN with any hardware capable of serial & network (i.e.: without expensive "real" BMC HW).
This should also make possible to redirect a serial port from a zigbee USB adapter, but I've not tested that yet.

Test suites are disabled globally, because they depend on parts not built, without checks for feature availabilty (or that's how I interpreted the results I saw)

Not completely sure about the licenses, I put a `AND` in libgensio to appease pkg linting...

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-musl): **YES**
- I built this PR locally for these architectures (all crossbuilds):
  - aarch64-musl
  - aarch64
  - x86_64
  - ppc64
  - ppc64-musl