### PR TITLE
xbps-src: document -Q non-recursiveness

### DIFF
--- a/xbps-src
+++ b/xbps-src
@@ -231,9 +231,10 @@ $(print_cross_targets)
     Variable is split and each word is printed in separate line by default.
     In order to print the whole value in one line, append asterisk to variable name.
 
--Q  Enable running the check stage.
+-Q  Enable running the check stage, for the target package only.
 
 -K  Enable running the check stage with longer tests.
+    Unlike -Q, this will also run the check stage on built dependencies.
 
 -q  Suppress informational output of xbps-src (build output is still printed).
 


### PR DESCRIPTION
Document in usage that running check with -Q is not recursive,
and running check with -K is recursive.

This behaviour was implemented in #54633.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**|**briefly**|**NO**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
