### PR TITLE
New package: shadowsocks-rust-1.23.2

### DIFF
--- a/srcpkgs/shadowsocks-rust/files/shadowsocks-rust-client/run
+++ b/srcpkgs/shadowsocks-rust/files/shadowsocks-rust-client/run
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+exec 2>&1
+exec setpriv --reuid _shadowsocks --regid _shadowsocks --clear-groups \
+	--ambient-caps -all,+net_bind_service \
+	--inh-caps -all,+net_bind_service \
+	--bounding-set -all,+net_bind_service \
+	--no-new-privs -- ssservice local -c /etc/shadowsocks-rust/config.json

--- a/srcpkgs/shadowsocks-rust/files/shadowsocks-rust-server/run
+++ b/srcpkgs/shadowsocks-rust/files/shadowsocks-rust-server/run
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+exec 2>&1
+exec setpriv --reuid _shadowsocks --regid _shadowsocks --clear-groups \
+	--ambient-caps -all,+net_bind_service \
+	--inh-caps -all,+net_bind_service \
+	--bounding-set -all,+net_bind_service \
+	--no-new-privs -- ssservice server -c /etc/shadowsocks-rust/config.json

--- a/srcpkgs/shadowsocks-rust/template
+++ b/srcpkgs/shadowsocks-rust/template
@@ -1,0 +1,25 @@
+# Template file for 'shadowsocks-rust'
+pkgname=shadowsocks-rust
+version=1.23.4
+revision=1
+build_style=cargo
+hostmakedepends="pkg-config"
+makedepends="libzstd-devel"
+short_desc="Rust port of shadowsocks, a fast lightweight obfuscated tunnel proxy"
+maintainer="JkktBkkt <apkabikov@gmail.com>"
+license="MIT"
+homepage="https://github.com/shadowsocks/shadowsocks-rust"
+changelog="https://github.com/shadowsocks/shadowsocks-rust/releases"
+distfiles="https://github.com/shadowsocks/shadowsocks-rust/archive/refs/tags/v${version}.tar.gz"
+checksum=8a91836256989e3a56409d0e83da6549ecf727e2d6642cd4e707993d9c8a23d3
+
+system_accounts="_shadowsocks"
+make_dirs="/etc/shadowsocks-rust 0755 root root"
+
+post_install() {
+	vlicense LICENSE
+	vsv shadowsocks-rust-server
+	vsv shadowsocks-rust-client
+	vsconf examples/config.json
+	vsconf examples/config_ext.json
+}


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**: system, compiled

Both new and old, this is the currently actively developed and maintained port of shadowsocks. Currently void provides the libev version, which received 1 commit in 2.5 years and hasn't had a release for nearly 4.5.

A few things I'd want to ask for guidance on:
1. Current template is modeled closely after the libev one, but considering that shadowsocks is commonly used with binary plugins these days, running the service as separate user requires adding the capabilities to plugins similar to how it's done with shadowsocks's binaries, i.e. `setcap cap_net_bind_service+ep simple-tls` or no longer switching to root user. 
Should some kind of message mentioning this be added, or perhaps it's better to simply drop the system account?

2. From what I know, typical functionality, being simple client+server configs, can be used as a drop-in replacement (that said, binaries are named differently). I'm unsure whether it would be best to keep both completely separately for now or try to transition configurations, system accounts and paths from -libev into -rust somehow.

#### Local build testing
- I built and tested this PR locally for my native architectures, x86_64 glibc (as `sslocal` and `ssservice local`) and tested cross-built aarch64 glibc version (as `ssserver` and `ssservice server`)

I have cross-built but haven't tested for these architectures:
- aarch64-musl
- armv6l (-musl)
- armv7l (-musl)


