### PR TITLE
python3-h11: update to 0.16.0.

### DIFF
--- a/srcpkgs/python3-h11/template
+++ b/srcpkgs/python3-h11/template
@@ -1,8 +1,8 @@
 # Template file for 'python3-h11'
 pkgname=python3-h11
-version=0.14.0
-revision=3
-build_style=python3-module
+version=0.16.0
+revision=1
+build_style=python3-pep517
 hostmakedepends="python3-setuptools"
 depends="python3"
 checkdepends="python3-pytest"
@@ -11,7 +11,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
 homepage="https://github.com/python-hyper/h11"
 distfiles="https://github.com/python-hyper/h11/archive/v${version}.tar.gz"
-checksum=d65a85d094b76846653fa7c3b45abdaf8b4f055c643bb6eec623f1311636a474
+checksum=d164114d09552ea887b5c9ed206d5a8e5bc0bf07d33e07a32622f91f102182c2
 
 post_install() {
 	vlicense LICENSE.txt


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

This is missing to match the update of `python3-httpcore` to 1.0.9.

Running `pip check` gives
```
httpcore 1.0.9 has requirement h11>=0.16, but you have h11 0.14.0.
```
but the same information can be found using only `python3-build` as in:
```
$ python -c 'from build._util import check_dependency;print(*check_dependency("httpcore"),sep="\n")'
('httpcore', 'h11>=0.16')
```


#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
