### PR TITLE
papirus-icon-theme: update to 20250501.

### DIFF
--- a/srcpkgs/papirus-icon-theme/template
+++ b/srcpkgs/papirus-icon-theme/template
@@ -1,16 +1,15 @@
 # Template file for 'papirus-icon-theme'
 pkgname=papirus-icon-theme
-version=20240501
+version=20250501
 revision=1
 short_desc="SVG icon theme for Linux, based on Paper Icon Set"
 maintainer="Giuseppe Fierro <gspe@ae-design.ws>"
 license="GPL-3.0-or-later"
 homepage="https://github.com/PapirusDevelopmentTeam/papirus-icon-theme"
 distfiles="https://github.com/PapirusDevelopmentTeam/papirus-icon-theme/archive/${version}.tar.gz"
-checksum=c12a64963639afffc5c5425c4d8fd09e9d5510bbc4c408a1fec9a1d617c5089b
+checksum=3831a487f813479ad3224fdbfb0c7023f23056899bc78c93737f341aa655558e
 
 do_install() {
 	vmkdir usr/share/icons
 	vcopy Papirus* usr/share/icons/
-	vcopy ePapirus usr/share/icons/
 }


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc

ePapirus(-Dark) theme removed upstream, use Papirus(-Dark) instead.
