### PR TITLE
rustup: update to 1.28.2

### DIFF
--- a/srcpkgs/rustup/template
+++ b/srcpkgs/rustup/template
@@ -1,6 +1,6 @@
 # Template file for 'rustup'
 pkgname=rustup
-version=1.28.1
+version=1.28.2
 revision=1
 # rustup doesn't recognize this target
 archs="~armv*-musl"
@@ -16,7 +16,7 @@ license="Apache-2.0 OR MIT"
 homepage="https://www.rustup.rs"
 changelog="https://raw.githubusercontent.com/rust-lang/rustup/master/CHANGELOG.md"
 distfiles="https://github.com/rust-lang/rustup/archive/refs/tags/${version}.tar.gz"
-checksum=2def2f9a0a4a21c80f862c0797c2d76e765e0e7237e1e41f28324722ab912bac
+checksum=5987dcb828068a4a5e29ba99ab26f2983ac0c6e2e4dc3e5b3a3c0fafb69abbc0
 
 do_install() {
 	vbin target/${RUST_TARGET}/release/rustup-init


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
