### PR TITLE
python3-peewee: update to 3.18.1.

### DIFF
--- a/srcpkgs/python3-peewee/template
+++ b/srcpkgs/python3-peewee/template
@@ -1,7 +1,7 @@
 # Template file for 'python3-peewee'
 pkgname=python3-peewee
-version=3.17.8
-revision=2
+version=3.18.1
+revision=1
 build_style=python3-pep517
 hostmakedepends="python3-setuptools python3-wheel python3-Cython"
 makedepends="python3-devel sqlite-devel"
@@ -12,7 +12,7 @@ license="MIT"
 homepage="https://github.com/coleifer/peewee"
 changelog="https://raw.githubusercontent.com/coleifer/peewee/master/CHANGELOG.md"
 distfiles="https://github.com/coleifer/peewee/archive/${version}.tar.gz"
-checksum=92131e0c8b69fd66234f5d60ceaa7e9daadd337a2f9fcc12bb2d3886e3e985d8
+checksum=9e32eca343d4fb3f76f2c828872c2d398b3302ec84a6bf95d1a29247f8aec1cc
 alternatives="peewee:pwiz:/usr/bin/pwiz.py3"
 make_check=no # tests require postgres instance
 


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

Tested using the following code:
```
#!/usr/bin/python

import peewee
import datetime

db = peewee.SqliteDatabase('test.db')

class Note(peewee.Model):

    text = peewee.CharField()
    created = peewee.DateField(default=datetime.date.today)

    class Meta:

        database = db
        db_table = 'notes'

Note.create_table()

note1 = Note.create(text='Went to the cinema')
note1.save()

note2 = Note.create(text='Exercised in the morning',
        created=datetime.date(2018, 10, 20))
note2.save()

note3 = Note.create(text='Worked in the garden',
        created=datetime.date(2018, 10, 22))
note3.save()

note4 = Note.create(text='Listened to music')
note4.save()

data = [
    { 'text': 'Tai chi in the morning', 'created': datetime.date(2018, 10, 20) },
    { 'text': 'Visited friend', 'created': datetime.date(2018, 10, 12) },
    { 'text': 'Went to cinema', 'created': datetime.date(2018, 10, 5) },
    { 'text': 'Listened to music', 'created': datetime.date(2018, 10, 28) },
    { 'text': 'Watched TV all day', 'created': datetime.date(2018, 10, 14) },
    { 'text': 'Worked in the garden', 'created': datetime.date(2018, 10, 22) },
    { 'text': 'Walked for a hour', 'created': datetime.date(2018, 10, 28) }
]

with db.atomic():

    query = Note.insert_many(data)
    query.execute()

print(db)

notes = Note.select()

for note in notes:
    print('{} on {}'.format(note.text, note.created))

notes_again = Note.select().where((Note.id > 2) & (Note.id < 6))
```

#### Local build testing
- I built this PR locally for my native architecture, x86_64-libc
