### PR TITLE
openresolv: update to 3.16.2

### DIFF
--- a/srcpkgs/openresolv/template
+++ b/srcpkgs/openresolv/template
@@ -1,6 +1,6 @@
 # Template file for 'openresolv'
 pkgname=openresolv
-version=3.16.0
+version=3.16.2
 revision=1
 build_style=gnu-configure
 configure_args="--bindir=/usr/bin"
@@ -10,7 +10,7 @@ maintainer="Andrea Brancaleoni <abc@pompel.me>"
 license="BSD-2-Clause"
 homepage="https://roy.marples.name/projects/openresolv"
 distfiles="https://github.com/NetworkConfiguration/openresolv/archive/refs/tags/v${version}.tar.gz"
-checksum=c63a747c39eef2ea505a6c2ae1f1dad8a286053f57dbd01820f2d14362cf635f
+checksum=747ffde6d2b6507a984f54946a16d02eb03f12c981869550950f7a025bc3136b
 conf_files="/etc/resolvconf.conf"
 
 post_install() {


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

This fixes an important issue from 3.16.0 where only the last DNS nameserver would make it into /etc/resolv.conf (more [here](https://github.com/NetworkConfiguration/openresolv/issues/35))