### PR TITLE
azote: update to 1.16.0

### DIFF
--- a/srcpkgs/azote/template
+++ b/srcpkgs/azote/template
@@ -1,19 +1,18 @@
 # Template file for 'azote'
 pkgname=azote
-version=1.13.1
-revision=2
+version=1.16.0
+revision=1
 build_style=python3-module
 hostmakedepends="python3-setuptools"
 depends="gtk+3 libayatana-appindicator python3 python3-cairo python3-gobject
- python3-Pillow python3-send2trash python3-yaml"
+ python3-Pillow python3-pillow-avif python3-pillow_heif python3-send2trash python3-yaml"
 short_desc="Wallpaper & color manager for Sway, i3 and other WMs"
 maintainer="cinerea0 <cinerea0@protonmail.com>"
 license="BSD-3-Clause AND GPL-3.0-or-later"
 homepage="https://github.com/nwg-piotr/azote"
 changelog="https://github.com/nwg-piotr/azote/releases"
-distfiles="https://github.com/nwg-piotr/azote/archive/refs/tags/${version}.tar.gz"
-checksum=5902e13463d3ef60e17c81346fee106dcc61e921fa83602d434eab7e67406e08
-make_check=no # no tests provided
+distfiles="https://github.com/nwg-piotr/azote/archive/refs/tags/v${version}.tar.gz"
+checksum=d07ea0effa770fe796b4e44dd2a5b5e56af31db5500de318638d83ba8e7efe83
 
 post_install() {
 	vinstall dist/azote.svg 644 usr/share/azote

--- a/srcpkgs/python3-pillow-avif/template
+++ b/srcpkgs/python3-pillow-avif/template
@@ -1,0 +1,19 @@
+# Template file for 'python3-pillow-avif'
+pkgname=python3-pillow-avif
+version=1.5.2
+revision=1
+build_style=python3-module
+hostmakedepends="pkg-config python3-Pillow python3-setuptools"
+makedepends="python3-devel libavif-devel"
+depends="python3-Pillow"
+short_desc="Pillow plugin that adds avif support via libavif"
+maintainer="zenobit <zenobit@disroot.org>"
+license="BSD-2-Clause"
+homepage="https://github.com/fdintino/pillow-avif-plugin"
+changelog="https://raw.githubusercontent.com/fdintino/pillow-avif-plugin/refs/heads/main/CHANGELOG.rst"
+distfiles="https://github.com/fdintino/pillow-avif-plugin/archive/refs/tags/v${version}.tar.gz"
+checksum=ca224a3ba77cc2ccc5a4e3a7e081c2c0914ea1481fdeb4c4c007e04d8675c5fe
+
+post_install() {
+	vlicense LICENSE
+}


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, (x64 glibc)

Support:
- [x] azote
- [x] avif support (pillow-avif)
- [ ] jpeg support (pillow-jpegxl)