### PR TITLE
tcc: update to 0.9.27.20250312.

### DIFF
--- a/srcpkgs/tcc/template
+++ b/srcpkgs/tcc/template
@@ -1,8 +1,8 @@
 # Template file for 'tcc'
 pkgname=tcc
-version=0.9.27.20221203
+version=0.9.27.20250312
 revision=1
-_gitrev=ab39d34dde9212c36dda2718bec4735fc0428636
+_gitrev=006174449e1d40b5e7937398e4947d7b13b8e675
 build_style=configure
 configure_args="--prefix=/usr --libdir=\${prefix}/lib$XBPS_TARGET_WORDSIZE"
 make_check_target="test"
@@ -12,13 +12,14 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="LGPL-2.1-or-later"
 homepage="http://bellard.org/tcc/"
 distfiles="http://repo.or.cz/tinycc.git/snapshot/${_gitrev}.tar.gz"
-checksum=28c745f26754451f64b0b21824fa4f7f9113bafc28acd41efb961d5f3224fb70
+checksum=f09e1e2785532f28e0fd2f99297d0f0071cec6b2f925281082bdd3b404416c30
 nopie=yes
 nocross=yes
 
 case "$XBPS_TARGET_MACHINE" in
 	ppc*) broken="ftbfs";;
-	*-musl) configure_args+=" --config-musl";;
+	*-musl) configure_args+=" --config-musl" depends+=" musl-devel";;
+	*)	 depends+=" glibc-devel";;
 esac
 
 do_build() {


### PR DESCRIPTION
Closes #30630. Picked because it's the first reviewed version that is ready for gcc14
Development is still somewhat active and it seems like upstream is talking about releasing 0.9.28 still: [14th Feb 2025](https://lists.nongnu.org/archive/html/tinycc-devel/2025-02/msg00006.html)
#### Testing the changes
- I tested the changes in this PR: **briefly** — that is, a bit beside the integrated tests

#### Local build testing
- I built this PR locally for my native architecture, x86_64 glibc
- I have **not** built this PR locally for other architectures (unsupported)