### PR TITLE
network-ups-tools: update to 2.8.3

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -1652,9 +1652,9 @@ libosmoctrl.so.0 libosmocore-0.7.0_1
 libgtkglext-x11-1.0.so.0 gtkglext-1.2.0_4
 libgdkglext-x11-1.0.so.0 gtkglext-1.2.0_4
 libXaw3d.so.8 libXaw3d-1.6.2_1
-libupsclient.so.6 libnetwork-ups-tools-2.8.0_1
+libupsclient.so.7 libnetwork-ups-tools-2.8.3_1
 libnutclient.so.2 libnetwork-ups-tools-2.8.0_1
-libnutscan.so.2 libnetwork-ups-tools-2.8.0_1
+libnutscan.so.3 libnetwork-ups-tools-2.8.3_1
 libsphinxad.so.0 sphinxbase-0.8_1
 libsphinxbase.so.1 sphinxbase-0.8_1
 libpocketsphinx.so.1 libpocketsphinx-0.8_3

--- a/srcpkgs/network-ups-tools/template
+++ b/srcpkgs/network-ups-tools/template
@@ -1,7 +1,7 @@
 # Template file for 'network-ups-tools'
 pkgname=network-ups-tools
-version=2.8.2
-revision=2
+version=2.8.3
+revision=1
 build_style=gnu-configure
 configure_args="
  --sysconfdir=/etc/ups --with-doc=man --disable-static
@@ -9,7 +9,7 @@ configure_args="
  --with-usb --with-dev --with-serial -with-avahi --with-udev-dir=/usr/lib/udev
  --with-libltdl --without-ipmi --without-freeipmi --without-systemdsystemunitdir
  --with-snmp --with-drvpath=/usr/libexec/nut $(vopt_with cgi) --with-statepath=/run/ups"
-hostmakedepends="pkg-config asciidoc"
+hostmakedepends="pkg-config asciidoc python3-packaging-bootstrap"
 makedepends="avahi-libs-devel openssl-devel libusb-compat-devel neon-devel
  net-snmp-devel $(vopt_if cgi gd-devel) libltdl-devel"
 conf_files="
@@ -24,7 +24,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="http://www.networkupstools.org/"
 distfiles="${homepage}source/${version%.*}/nut-${version}.tar.gz"
-checksum=e4b4b0cbe7dd39ba9097be7f7d787bb2fffbe35df64dff53b5fe393d659c597d
+checksum=d6ca17f0b39003bac7649eb17ab4a713e4d5fcaa8fd1aedca28357d59df095ed
 system_accounts="nut"
 
 nopie=yes


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

After upgrading NUT and rebooting, I tested FSD by running `upsmon -c fsd` and it shut down the system properly.

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture: x86_64-glibc
