### PR TITLE
fuse-sshfs: fix manpage generation while cross-compiling

### DIFF
--- a/srcpkgs/fuse-sshfs/template
+++ b/srcpkgs/fuse-sshfs/template
@@ -1,11 +1,11 @@
 # Template file for 'fuse-sshfs'
 pkgname=fuse-sshfs
 version=3.7.3
-revision=1
+revision=2
 build_style=meson
 configure_args="--sbindir=bin"
-hostmakedepends="pkg-config"
-makedepends="fuse3-devel libglib-devel python3-docutils"
+hostmakedepends="pkg-config python3-docutils"
+makedepends="fuse3-devel libglib-devel"
 depends="openssh"
 checkdepends="python3-pytest which"
 short_desc="FUSE client based on the SSH File Transfer Protocol"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64
