### PR TITLE
sbctl: update to 0.17.

### DIFF
--- a/srcpkgs/sbctl/template
+++ b/srcpkgs/sbctl/template
@@ -1,7 +1,7 @@
 # Template file for 'sbctl'
 pkgname=sbctl
-version=0.16
-revision=2
+version=0.17
+revision=1
 build_style=go
 build_helper=qemu
 go_import_path="github.com/foxboron/sbctl"
@@ -14,7 +14,7 @@ maintainer="Érico Nogueira <ericonr@disroot.org>"
 license="MIT"
 homepage="https://github.com/Foxboron/sbctl"
 distfiles="https://github.com/Foxboron/sbctl/archive/${version}.tar.gz"
-checksum=ca6d810b1b6e63318ba34320043e8b95d8b40df6e140f5170c4a673ed0954ee1
+checksum=c42dee85939944fdf8b504b7d891569c6b33c9ea1bdfcfb36d9a5302db375e98
 make_dirs="/var/lib/sbctl 0700 root root"
 export GOFLAGS="-buildmode=pie"
 


### PR DESCRIPTION
This update adds the Microsoft 2023 Secure Boot Certificates. The current 2011 certificates are set to expire next year.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
-->