### PR TITLE
grml-zsh-config: update to 0.19.18, adopt

### DIFF
--- a/srcpkgs/grml-zsh-config/template
+++ b/srcpkgs/grml-zsh-config/template
@@ -1,14 +1,15 @@
 # Template file for 'grml-zsh-config'
 pkgname=grml-zsh-config
-version=0.19.4
+version=0.19.18
 revision=1
-hostmakedepends="make txt2tags"
+hostmakedepends="ruby-asciidoctor"
+depends="zsh"
 short_desc="Grml's zsh setup"
-maintainer="Orphaned <orphan@voidlinux.org>"
+maintainer="menaechmi <menaechmi+dev@protonmail.com>"
 license="GPL-2.0-only"
 homepage="https://grml.org/zsh/"
 distfiles="https://github.com/grml/grml-etc-core/archive/refs/tags/v${version}.tar.gz"
-checksum=b3a896bb8f16f4069881e1ae2ee6d7d9220a49b05ecbaab573db038310042ad7
+checksum=0193f913de0dffcc8d4ca5584e3621a33cd257ca8f3acd70ac366546be4da5ce
 
 pre_build() {
 	make -C doc/ grmlzshrc.5


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing

- [x] I built this PR locally for my native architecture, (x86_64)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
- [x] aarch64-musl
- [x] armv6l
- [x] i686

(it's only building docs, so as expected no issues)

zsh is also added as a dependency. 

EDIT: It was pointed out I forgot to mention docs-generation changed from txt2tags to asciidoctor.

## Orphaned
The maintainers last contribution to void was in December of 2019, so I am marking it orphaned. ~~I would adopt it, but I wanted to give @meator a chance as he has updated it a lot and I am less proven as a void contributor. If we get another update and no maintainer, I will do it.~~ I'll just adopt it, given an offline conversation with meator - unless any Void Maintainer disagrees.