### PR TITLE
starship: update to 1.23.0

### DIFF
--- a/srcpkgs/starship/template
+++ b/srcpkgs/starship/template
@@ -1,6 +1,6 @@
 # Template file for 'starship'
 pkgname=starship
-version=1.22.1
+version=1.23.0
 revision=1
 build_style=cargo
 build_helper=qemu
@@ -13,7 +13,7 @@ license="ISC"
 homepage="https://starship.rs"
 changelog="https://raw.githubusercontent.com/starship/starship/master/CHANGELOG.md"
 distfiles="https://github.com/starship/starship/archive/refs/tags/v${version}.tar.gz"
-checksum=5434a3d1ca16987a1dd30146c36aaa4371dbe1c7f1a7995c0cf12ab3eb9326d7
+checksum=be3ba025a64bd808899dce256e1511145b55cc5eefc5fca82bf5537cd8e09c72
 make_check_pre="env HOME=${wrksrc}/fake-home"
 
 pre_check() {


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl
  - aarch64-musl
  - aarch64
  - i686
  - armv7l-musl
  - armv7l
  - armv6l-musl
  - armv6l


Local crossbuild for `i686-musl` fails during compilation of `perl-5.40.2`. Musl crossbuilds for `x86_64`, `aarch64`, `armv6l` and `armv7l` all works.
```
....
=> perl-5.40.2_1: running do_build ...
make crosspatch
make[1]: Entering directory '/builddir/perl-5.40.2'
make[1]: Nothing to be done for 'crosspatch'.
make[1]: Leaving directory '/builddir/perl-5.40.2'
make miniperl
make[1]: Entering directory '/builddir/perl-5.40.2'
gcc -DPERL_CORE -DUSE_CROSS_COMPILE  -D_GNU_SOURCE -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -fwrapv -fno-strict-aliasing -c -o locale.host.o locale.c
In file included from perl.h:4225,
                 from locale.c:387:
locale.c: In function 'Perl_init_i18nl10n':
perl.h:4284:36: error: static assertion failed: "(sizeof(lc_all_category_positions)/sizeof((lc_all_category_positions)[0])) == LC_ALL_INDEX_"
 4284 | #  define STATIC_ASSERT_DECL(COND) static_assert(COND, #COND)
      |                                    ^~~~~~~~~~~~~
....
```

