### PR TITLE
scc: update to 3.5.0

### DIFF
--- a/srcpkgs/scc/template
+++ b/srcpkgs/scc/template
@@ -1,7 +1,7 @@
 # Template file for 'scc'
 pkgname=scc
-version=3.3.5
-revision=2
+version=3.5.0
+revision=1
 build_style=go
 go_import_path="github.com/boyter/scc/v3"
 short_desc="Fast cloc replacement written in pure Go"
@@ -9,7 +9,7 @@ maintainer="Sami Pitkänen <bilebucket@airmail.cc>"
 license="MIT"
 homepage="https://github.com/boyter/scc"
 distfiles="https://github.com/boyter/scc/archive/v${version}.tar.gz"
-checksum=028869a7d053879a8e3f2872fdd792f165db13696918d08863475c638f08ef06
+checksum=161f5d9bb359c6440114b7d2e0f98d588c02aa66fbe474d7660b244687fefb70
 conflicts="sc-controller" # /usr/bin/scc
 
 post_install() {


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl
  - aarch64-musl
  - aarch64
  - i686-musl
  - i686
  - armv7l-musl
  - armv7l
  - armv6l-musl
  - armv6l