### PR TITLE
podman: update to 5.5.0

### DIFF
--- a/srcpkgs/podman/template
+++ b/srcpkgs/podman/template
@@ -1,6 +1,6 @@
 # Template file for 'podman'
 pkgname=podman
-version=5.3.1
+version=5.5.0
 revision=1
 build_style=go
 go_import_path="github.com/containers/podman/v5"
@@ -17,7 +17,7 @@ license="Apache-2.0"
 homepage="https://podman.io/"
 changelog="https://raw.githubusercontent.com/containers/podman/main/RELEASE_NOTES.md"
 distfiles="https://github.com/containers/podman/archive/v${version}.tar.gz"
-checksum=5b4e9ddce69cc2c8c8b8529e90093ae3ea9cb2959e2fceb98469b282dbffbcc7
+checksum=a4abfc72ef9a59ba80d081ea604ad2976ff967ae526e50e234edc1d2481bd9d1
 
 if [ "$CROSS_BUILD" ]; then
 	go_build_tags+=" containers_image_openpgp"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl
  - aarch64-musl
  - aarch64
  - i686
  - armv7l-musl
  - armv7l
  - armv6l-musl
  - armv6l

