### PR TITLE
btop: update to 1.4.3

### DIFF
--- a/srcpkgs/btop/template
+++ b/srcpkgs/btop/template
@@ -1,6 +1,6 @@
 # Template file for 'btop'
 pkgname=btop
-version=1.4.0
+version=1.4.3
 revision=1
 build_style=gnu-makefile
 hostmakedepends="lowdown"
@@ -10,4 +10,4 @@ license="Apache-2.0"
 homepage="https://github.com/aristocratos/btop"
 changelog="https://raw.githubusercontent.com/aristocratos/btop/main/CHANGELOG.md"
 distfiles="https://github.com/aristocratos/btop/archive/refs/tags/v${version}.tar.gz"
-checksum=ac0d2371bf69d5136de7e9470c6fb286cbee2e16b4c7a6d2cd48a14796e86650
+checksum=81b133e59699a7fd89c5c54806e16452232f6452be9c14b3a634122e3ebed592


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl
  - i686-musl
  - i686
  - aarch64-musl
  - aarch64
  - armv7l-musl
  - armv7l
  - armv6l-musl
  - arm6l