### PR TITLE
vim: update to 9.1.1391

### DIFF
--- a/srcpkgs/vim/template
+++ b/srcpkgs/vim/template
@@ -1,7 +1,7 @@
 # Template file for 'vim'
 pkgname=vim
-version=9.1.1215
-revision=2
+version=9.1.1391
+revision=1
 create_wrksrc=required
 hostmakedepends="gettext glib-devel pkg-config"
 makedepends="acl-devel ncurses-devel
@@ -15,7 +15,7 @@ maintainer="Leah Neukirchen <leah@vuxu.org>"
 license="Vim"
 homepage="https://www.vim.org"
 distfiles="https://github.com/vim/vim/archive/refs/tags/v${version}.tar.gz"
-checksum=2f60d34f90a0c7854e9484c9b2fda4194b9b7996b938996b9838db38b548c7db
+checksum=67657a9a0de33b3e3d193c87208f5474bec44cb24d3852683a9d1fc6084027b4
 python_version=3
 
 build_options="x11 gtk3 huge"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl
  - i686
  - aarch64-musl
  - aarch64
  - armv7l-musl
  - armv7l
  - armv6l-musl
  - arm6l