### PR TITLE
spotify-player: update to 0.20.5

### DIFF
--- a/srcpkgs/spotify-player/template
+++ b/srcpkgs/spotify-player/template
@@ -1,6 +1,6 @@
 # Template file for 'spotify-player'
 pkgname=spotify-player
-version=0.20.4
+version=0.20.5
 revision=1
 build_style=cargo
 make_install_args="--path spotify_player"
@@ -11,14 +11,7 @@ maintainer="Rodrigo Oliveira <mdkcore@qtrnn.io>"
 license="MIT"
 homepage="https://github.com/aome510/spotify-player"
 distfiles="https://github.com/aome510/spotify-player/archive/refs/tags/v${version}.tar.gz"
-checksum=1d13f47ef4df3415835736f32629d57e331707d781507007ea04217a7dc735d8
-
-# FIXME: Workaround will be removed when https://github.com/aws/aws-lc-rs/issues/632 is resolved
-case "$XBPS_TARGET_MACHINE" in
-	armv[67]l)
-	export AWS_LC_SYS_CFLAGS="-Wno-stringop-overflow"
-	;;
-esac
+checksum=06a409144461fa965916d7d92817fda4be3801402eff8278a3fc7a38448d54e1
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
Seems the [aws-lc-sys](https://github.com/aws/aws-lc-rs/issues/632) issue was fixed upstream, so removing the workaround that was introduced before.

#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture: x86_64-libc
- I built this PR locally for these architectures:
  - armv7l (crossbuild)