### PR TITLE
swirc: update to 3.5.5.

### DIFF
--- a/srcpkgs/swirc/template
+++ b/srcpkgs/swirc/template
@@ -1,6 +1,6 @@
 # Template file for 'swirc'
 pkgname=swirc
-version=3.5.4
+version=3.5.5
 revision=1
 build_style=configure
 configure_args="$(vopt_with notify libnotify)"
@@ -17,7 +17,7 @@ license="BSD-3-Clause, ISC, MIT"
 homepage="https://www.nifty-networks.net/swirc"
 changelog="https://raw.githubusercontent.com/uhlin/swirc/master/CHANGELOG.md"
 distfiles="https://www.nifty-networks.net/swirc/releases/swirc-${version}.tgz"
-checksum=09fbd13b26f16fe375f79052d2be679013803ae6b2fa6f0e315c32dfd81ee4a4
+checksum=c1fef61cc72a6430545682f34c3f51191b57cc8cdc64bb7260785fc9367ca2e0
 
 build_options="notify"
 build_options_default="notify"


### PR DESCRIPTION
Swirc 3.5.5 out.

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, **x86_64-musl**
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - armv6l-musl **cross**
