### PR TITLE
gdk-pixbuf: bring back support for xpm, gif and other loaders

### DIFF
--- a/srcpkgs/gdk-pixbuf/template
+++ b/srcpkgs/gdk-pixbuf/template
@@ -1,11 +1,12 @@
 # Template file for 'gdk-pixbuf'
 pkgname=gdk-pixbuf
 version=2.42.12
-revision=1
+revision=2
 build_style=meson
 build_helper="gir"
 configure_args="$(vopt_feature gir introspection) -Dpng=enabled
- -Djpeg=enabled -Dtiff=enabled -Dinstalled_tests=false"
+ -Djpeg=enabled -Dtiff=enabled -Dgif=enabled -Dothers=enabled
+ -Dinstalled_tests=false"
 hostmakedepends="gettext-devel glib-devel pkg-config python3-docutils"
 makedepends="libglib-devel libpng-devel tiff-devel libjpeg-turbo-devel
  shared-mime-info"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Context
https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=285185
https://gitlab.gnome.org/GNOME/gdk-pixbuf/-/merge_requests/167/diffs

Claws-mail stopped displaying icons after the most recent update of gdk-pixbuf; hence the additional build flags. Other GTK packages could potentially be affected, too.

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture: x86_64-glibc
