### PR TITLE
libewf: update to 20240506.

### DIFF
--- a/srcpkgs/libewf/template
+++ b/srcpkgs/libewf/template
@@ -1,15 +1,16 @@
 # Template file for 'libewf'
 pkgname=libewf
-version=20230212
+version=20240506
 revision=1
 build_style=gnu-configure
-makedepends="zlib-devel bzip2-devel libuuid-devel fuse-devel"
+hostmakedepends="pkg-config flex byacc autoconf automake gettext-devel libtool"
+makedepends="zlib-devel bzip2-devel libuuid-devel fuse-devel openssl-devel"
 short_desc="Libewf and tooling to access the Expert Witness Compression Format"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="LGPL-3.0-or-later"
 homepage="https://github.com/libyal/libewf"
 distfiles="https://github.com/libyal/libewf/releases/download/${version}/libewf-experimental-${version}.tar.gz"
-checksum=d22eecbd962c3d7d646ccfba131fc3c07e6a07da37dc163b6ecbb1348db16101
+checksum=247d8ee9572392a2404be514d1137f099970f41f240c1134ddc3f04322281c67
 
 libewf-devel_package() {
 	depends="${sourcepkg}>=${version}_${revision}"


### PR DESCRIPTION
Version bump because distfile no longe exists.
Added deps.

#### Testing the changes
- I tested the changes in this PR: **briefly**
- XBPS_CHECK_PKGS failed because there are not test images. But i tested the finished build with testimages of my own


#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- Built for armv6l failed, no idea why

#### Dep Testing
- Package sleuthkit depends on this.
- Rebuilt sleuthkit with this version (libewf-devel), compiles fine, briefly tested.