### PR TITLE
containerd: fix typo in service

### DIFF
--- a/srcpkgs/containerd/files/containerd/run
+++ b/srcpkgs/containerd/files/containerd/run
@@ -1,4 +1,4 @@
 #!/bin/sh
 exec 2>&1
-env modeprobe overlay
+env modprobe overlay
 exec containerd


### PR DESCRIPTION
fixes #54772

corrected the commit from : [54793](https://github.com/void-linux/void-packages/pull/54793)
because OP did not respond, I tried to convey real authorship with:

From: John Taylor <email@johntaylor.hu>
Co-developed-by: John Taylor <email@johntaylor.hu>

Please advise if this is sufficient or not.

#### Testing the changes
- I tested the changes in this PR: **NO**

#### Local build testing
- I built this PR locally for my native architecture, (**NO**)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
