### PR TITLE
Update mixxx to `2.5.1`

### DIFF
--- a/srcpkgs/libdjinterop/template
+++ b/srcpkgs/libdjinterop/template
@@ -1,0 +1,26 @@
+# Template file for 'libdjinterop'
+pkgname=libdjinterop
+version=0.26.1
+revision=1
+build_style=cmake
+configure_args="-DCMAKE_INSTALL_PREFIX=/usr"
+hostmakedepends="pkg-config"
+makedepends="zlib-devel sqlite-devel"
+short_desc="Library for parsing Denon DJ music databases"
+maintainer="Tony Ivanov <telamohn@pm.me>"
+license="LGPL-3.0-or-later"
+homepage="https://github.com/xsco/libdjinterop"
+distfiles="https://github.com/xsco/libdjinterop/archive/refs/tags/${version}.tar.gz"
+checksum=f4fbe728783c14acdc999b74ce3f03d680f9187e1ff676d6bf1233fdb64ae7b2
+
+#libdjinterop-devel_package() {
+#	depends="libdjinterop-${version}_${revision}"
+#	short_desc+=" - development files"
+#	pkg_install() {
+#		vmove usr/include
+#		vmove usr/lib/pkgconfig
+#		vmove usr/lib/cmake
+#		vmove "usr/lib/*.a"
+#		vmove "usr/lib/*.so"
+#	}
+#}

--- a/srcpkgs/libmsgsl-devel/template
+++ b/srcpkgs/libmsgsl-devel/template
@@ -1,0 +1,18 @@
+# Template for 'ms-gsl'
+pkgname=libmsgsl-devel
+version=4.2.0
+revision=1
+wrksrc="GSL-${version}"
+build_style=meta
+short_desc="Microsoft's Guidelines Support Library (header-only)"
+maintainer="you <you@example.com>"
+license="MIT"
+homepage="https://github.com/microsoft/GSL"
+distfiles="https://github.com/microsoft/GSL/archive/refs/tags/v${version}.tar.gz"
+checksum=SKIP
+
+do_install() {
+  vmkdir usr/include
+  cp -r include/gsl ${DESTDIR}/usr/include/
+}
+checksum=2c717545a073649126cb99ebd493fa2ae23120077968795d2c69cbab821e4ac6

--- a/srcpkgs/mixxx/template
+++ b/srcpkgs/mixxx/template
@@ -1,22 +1,65 @@
 # Template file for 'mixxx'
 pkgname=mixxx
-version=2.3.3
-revision=8
+version=2.5.1
+revision=9
 build_style=cmake
-configure_args="-DCMAKE_BUILD_TYPE=Release"
-hostmakedepends="extra-cmake-modules pkg-config protobuf qt5-host-tools qt5-qmake"
-makedepends="chromaprint-devel faad2-devel ffmpeg6-devel libkeyfinder-devel glu-devel
- lame-devel libid3tag-devel libmad-devel libmodplug-devel libusb-devel
- opusfile-devel libflac-devel libogg-devel libsndfile-devel libvorbis-devel
- wavpack-devel portaudio-devel portmidi-devel protobuf-devel qt5-script-devel
- qt5-svg-devel qt5-xmlpatterns-devel rubberband-devel taglib-devel upower-devel
- vamp-plugin-sdk-devel lv2 lilv-devel qt5-x11extras-devel hidapi-devel libtheora-devel
- speex-devel soundtouch-devel qtkeychain-qt5-devel qt5-plugin-mysql qt5-plugin-odbc
- qt5-plugin-pgsql qt5-plugin-sqlite qt5-plugin-tds libebur128-devel"
-depends="qt5-plugin-sqlite"
+configure_args="-DCMAKE_BUILD_TYPE=Release -DENGINEPRIME=OFF -DBUILD_TESTING=OFF"
+hostmakedepends="extra-cmake-modules pkg-config qt6-tools-devel protobuf"
+makedepends="
+  chromaprint-devel
+  faad2-devel
+  ffmpeg6-devel
+  glu-devel
+  gtest-devel
+  hidapi-devel
+  lame-devel
+  libdjinterop
+  libebur128-devel
+  libflac-devel
+  libid3tag-devel
+  libkeyfinder-devel
+  libmad-devel
+  libmodplug-devel
+  libmp4v2-devel
+  libmsgsl-devel
+  libogg-devel
+  libsndfile-devel
+  libtheora-devel
+  libusb-devel
+  libvorbis-devel
+  lilv-devel
+  lv2
+  opusfile-devel
+  portaudio-devel
+  portmidi-devel
+  protobuf-devel
+  qt6-base
+  qt6-base-devel
+  qt6-base-private-devel
+  qt6-declarative-devel
+  qt6-declarative-private-devel
+  qt6-plugin-mysql
+  qt6-plugin-odbc
+  qt6-plugin-pgsql
+  qt6-plugin-sqlite
+  qt6-qt5compat-devel
+  qt6-shadertools-devel
+  qt6-svg-devel
+  qt6-tools-devel
+  qtkeychain-qt6-devel
+  rubberband-devel
+  soundtouch-devel
+  speex-devel
+  taglib-devel
+  upower-devel
+  vamp-plugin-sdk-devel
+  wavpack-devel
+"
+
+depends="qt6-plugin-sqlite"
 short_desc="Open source digital DJing software that allows mixing music"
 maintainer="prez <prez@national.shitposting.agency>"
 license="GPL-2.0-or-later"
 homepage="https://www.mixxx.org"
 distfiles="https://github.com/mixxxdj/mixxx/archive/${version}.tar.gz"
-checksum=8e3a5a545175982336bb07c81a3839897a007c43689b93641242db662f6beb9c
+checksum=626f7a64292c1ef77d8aace4a746140f455596d44a6984db9d1e4caf4c4ce09d


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (x64-libc)

#### Note
updated to support new controllers such as  `FLX-4`
I rewrote the template as it's sub-dependencies had changed; 
Also non-essential dependencies were pruned.
The `libdjinterop` subdep i failed to split into a separate `-devel` package, no clue why.

_edit_: I'm a user not a maintainer; if anyone wishes to satisfy the CI-requirements be my guest.