### PR TITLE
gopls: update to 0.18.1

### DIFF
--- a/srcpkgs/gopls/template
+++ b/srcpkgs/gopls/template
@@ -1,16 +1,17 @@
 # Template file for 'gopls'
 pkgname=gopls
-version=0.17.1
+version=0.18.1
 revision=1
 build_wrksrc=gopls
 build_style=go
 go_import_path=golang.org/x/tools/gopls
+makedepends="git"
 short_desc="Official language server for the Go language"
 maintainer="Bnyro <bnyro@tutanota.com>"
 license="BSD-3-Clause"
 homepage="https://github.com/golang/tools/tree/master/gopls"
 distfiles="https://github.com/golang/tools/archive/refs/tags/gopls/v${version}.tar.gz"
-checksum=5794ebd3302ef4fd08de284834b22810dbb17b7e08efeeaa9b96d5c94eb90d6d
+checksum=e49fae5dd964432a0ea1661868e858acd2aa66aaf7e1c1d646fb8506f15c8e52
 
 post_install() {
 	vlicense ../LICENSE


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl
  - aarch64-musl
  - aarch64
  - i686
  - armv7l-musl
  - armv7l
  - armv6l-musl
  - armv6l

----

Added `git` as a make dependency as it is required for one of the test cases in `gopls`