### PR TITLE
New package: kompose-1.36.0

### DIFF
--- a/srcpkgs/kompose/template
+++ b/srcpkgs/kompose/template
@@ -1,0 +1,22 @@
+# Template file for 'kompose'
+pkgname=kompose
+version=1.36.0
+revision=1
+build_style=go
+build_helper=qemu
+go_import_path="github.com/kubernetes/kompose"
+checkdepends="git"
+short_desc="Tool to convert Docker Compose to Kubernetes"
+maintainer="Filip Rojek <filip@filiprojek.cz>"
+license="Apache-2.0"
+homepage="https://kompose.io/"
+changelog="https://github.com/kubernetes/kompose/releases"
+distfiles="https://github.com/kubernetes/kompose/archive/v${version}.tar.gz"
+checksum=b97616e412f29b7bc7a7a6431f27c9ad565c05298f7927d9bb588321e5da53d7
+
+post_install() {
+	for shell in bash zsh fish; do
+		vtargetrun ${DESTDIR}/usr/bin/kompose completion $shell > kompose.${shell}
+		vcompletion kompose.${shell} ${shell}
+	done
+}


### PR DESCRIPTION
Kompose is a conversion tool for Docker Compose to container orchestrators such as Kubernetes (or OpenShift). 
 - https://github.com/kubernetes/kompose
 - https://kompose.io/

Closes #27231 

#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl

