### PR TITLE
incus: update to 6.12.0.

### DIFF
--- a/srcpkgs/incus/template
+++ b/srcpkgs/incus/template
@@ -1,6 +1,6 @@
 # Template file for 'incus'
 pkgname=incus
-version=6.9.0
+version=6.12.0
 revision=1
 build_style=go
 build_helper=qemu
@@ -18,7 +18,7 @@ maintainer="dkwo <npiazza@disroot.org>"
 license="Apache-2.0"
 homepage="https://linuxcontainers.org/incus"
 distfiles="https://github.com/lxc/incus/archive/refs/tags/v${version}.tar.gz"
-checksum=7c50d4eb2ae5a33eab27821c95e01fc9a5d977c9b6b594a51571e6fefd4119d2
+checksum=98532b05b2083b3ff112a08c5f39643b7e744366bdd698a32cbe8b60decb42f3
 system_groups="_incus-admin _incus"
 make_dirs="
  /var/lib/incus 0755 root root


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**:
  - checked with `./xbps-src -Q pkg incus`
  - installed on a system with an incus-managed container and VM

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures
  - aarch64-musl
  - armv7l
  - armv6l-musl

With qemu 10.x, incus 6.9 can no longer launch VMs because of a removed (previously deprecated) command line option. Incus 6.12 includes a fix: https://github.com/lxc/incus/pull/1871

This is my first PR for void-packages. I took the liberty of updating this myself because it was broken on my system. If there's anything else I need to do, please let me know.