### PR TITLE
gsmartcontrol: update to 2.0.2

### DIFF
--- a/srcpkgs/gsmartcontrol/template
+++ b/srcpkgs/gsmartcontrol/template
@@ -1,8 +1,8 @@
 # Template file for 'gsmartcontrol'
 pkgname=gsmartcontrol
-version=1.1.4
+version=2.0.2
 revision=1
-build_style=gnu-configure
+build_style=cmake
 hostmakedepends="pkg-config"
 makedepends="gtkmm-devel pcre-devel desktop-file-utils"
 depends="smartmontools hicolor-icon-theme"
@@ -10,8 +10,8 @@ short_desc="GUI to smartmontools"
 maintainer="yopito <pierre.bourgin@free.fr>"
 license="GPL-2.0-or-later"
 homepage="https://gsmartcontrol.shaduri.dev"
-distfiles="https://github.com/ashaduri/gsmartcontrol/releases/download/v${version}/${pkgname}-${version}.tar.bz2"
-checksum=fc409f2b8a84cc40bb103d6c82401b9d4c0182d5a3b223c93959c7ad66191847
+distfiles="https://github.com/ashaduri/gsmartcontrol/archive/refs/tags/v${version}.tar.gz"
+checksum=7cebd83fd34883d51e143389aa88f8173ea7b67c760b12b7de847f3c3c8cee34
 
 post_install() {
 	# license files uneeded


### PR DESCRIPTION
Long overdue update which brings nvme support.

Testing the changes
I tested the changes in this PR: YES
Local build testing
I built this PR locally for my native architecture, (x86_64-glibc)

Someone please check the template. I had to make some changes via try&error due to upstream changes: the download url is different due to no tar.bz2 file available anymore, and the build-style changed according to these changes since v2.0.0:

A lot of code has been refactored and modernized using C++17 and C++20 features, removing much of the custom library code.
The build process requires a C++20-compliant compiler now (GCC 13+, Clang 17+, Apple Clang 15+).
CMake (3.14+) is now used as a build system instead of autotools.
That's why I made the lucky guess to change the build_style to cmake.

It builds and runs on my system, but someone who actually knows how to correctly create a template file better check if what I did is ok. :-)
Thanks!