### PR TITLE
New package: rmpc-0.8.0

### DIFF
--- a/srcpkgs/rmpc/template
+++ b/srcpkgs/rmpc/template
@@ -1,0 +1,17 @@
+# Template file for 'rmpc'
+pkgname=rmpc
+version=0.8.0
+revision=1
+build_style=cargo
+depends="mpd"
+short_desc="Configurable, terminal based Media Player Client"
+maintainer="Omri H <omri.hermon@gmail.com>"
+license="BSD-3-Clause"
+homepage="https://mierak.github.io/rmpc/"
+changelog="https://mierak.github.io/rmpc/changelog/"
+distfiles="https://github.com/mierak/rmpc/archive/refs/tags/v${version}.tar.gz"
+checksum=f2ff534ad662d6bb033f1715c27406718eb7025655f5c30c94a6b051e3a1c371
+
+post_install() {
+	vlicense LICENSE
+}


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - aarch64
