### PR TITLE
libei: update to 1.4.1

### DIFF
--- a/srcpkgs/libei/template
+++ b/srcpkgs/libei/template
@@ -1,6 +1,6 @@
 # Template file for 'libei'
 pkgname=libei
-version=1.2.1
+version=1.4.1
 revision=1
 build_style=meson
 configure_args="-Dtests=disabled"
@@ -11,7 +11,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-3.0-or-later"
 homepage="https://gitlab.freedesktop.org/libinput/libei"
 distfiles="https://gitlab.freedesktop.org/libinput/libei/-/archive/${version}/libei-${version}.tar.gz"
-checksum=7e06f06aa4dd1f7d170a0e5194644fe5cc889adc9b7be16bed5f2c39145569a4
+checksum=d0e8f18eb3617fbcc3d860bb54a47e17709e94e8e7cb0ae01ae221c67f000872
 
 libei-devel_package() {
 	depends="elogind-devel ${sourcepkg}>=${version}_${revision}"


### PR DESCRIPTION
required by gnome-48 (https://github.com/void-linux/void-packages/pull/54783)

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)