### PR TITLE
upower: update to 1.90.9

### DIFF
--- a/srcpkgs/upower/template
+++ b/srcpkgs/upower/template
@@ -1,6 +1,6 @@
 # Template file for 'upower'
 pkgname=upower
-version=1.90.4
+version=1.90.9
 revision=1
 build_helper="gir"
 build_style=meson
@@ -18,7 +18,7 @@ license="GPL-2.0-or-later"
 homepage="https://gitlab.freedesktop.org/upower/upower"
 changelog="https://gitlab.freedesktop.org/upower/upower/-/raw/master/NEWS"
 distfiles="https://gitlab.freedesktop.org/upower/upower/-/archive/v${version}/upower-v${version}.tar.bz2"
-checksum=bfd0ff3be2be3176c64b78b24b6c7c0782f97777b4d9cb538509b5444ca135e1
+checksum=ca6018535817c2ea687e389e6b47583342154123c0eea0497b409c49dff319b6
 
 provides="upower0-${version}_${revision}"
 replaces="upower0>=0"
@@ -29,6 +29,8 @@ build_options_default="gir"
 
 if [ -z "$CROSS_BUILD" ]; then
 	build_options_default+=" gtk_doc"
+else
+	hostmakedepends+=" polkit"
 fi
 
 libupower-glib3_package() {


### PR DESCRIPTION
@cinerea0 

required by gnome-48 (https://github.com/void-linux/void-packages/pull/54783)

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)