### PR TITLE
xdg-desktop-portal: update to 1.20.3

### DIFF
--- a/srcpkgs/xdg-desktop-portal/template
+++ b/srcpkgs/xdg-desktop-portal/template
@@ -1,21 +1,23 @@
 # Template file for 'xdg-desktop-portal'
 pkgname=xdg-desktop-portal
-version=1.18.4
+version=1.20.3
 revision=1
 build_style=meson
-configure_args="-Dgeoclue=enabled -Dlibportal=enabled
- -Dsystemd=disabled"
-hostmakedepends="pkg-config gettext glib-devel bubblewrap flatpak python3-docutils"
+configure_args="-Dgeoclue=enabled -Dsystemd=disabled"
+hostmakedepends="pkg-config gettext glib-devel bubblewrap flatpak python3-docutils
+ gst-plugins-good1 gstreamer1 python3-dbusmock python3-gobject python3-pytest-xdist"
 makedepends="flatpak-devel fuse3-devel pipewire-devel geoclue2-devel
- libportal-devel polkit-devel"
-checkdepends="dbus python3-dbusmock"
+ polkit-devel gst-plugins-base1-devel libumockdev-devel"
+checkdepends="dbus python3-dbusmock umockdev"
 short_desc="Portal frontend service for Flatpak"
 maintainer="Duncaen <duncaen@voidlinux.org>"
 license="LGPL-2.1-or-later"
 homepage="https://github.com/flatpak/xdg-desktop-portal"
 changelog="https://github.com/flatpak/xdg-desktop-portal/raw/main/NEWS"
 distfiles="https://github.com/flatpak/xdg-desktop-portal/archive/refs/tags/${version}.tar.gz"
-checksum=028d5aec19a7f6fdbe76d6c7cf982cbc4e4ee290493ded3a16b67dfff5cad589
+checksum=01d2a8ceaab06fa1d0638abe541dbb415a0a19be271d9669a93ec1640f87ea4a
+# https://github.com/flatpak/xdg-desktop-portal/issues/1589
+make_check_pre="env XDP_VALIDATE_ICON_INSECURE=1 XDP_VALIDATE_SOUND_INSECURE=1"
 
 if [ "$XBPS_BUILD_ENVIRONMENT" = "void-packages-ci" ]; then
 	export TEST_IN_CI="true"


### PR DESCRIPTION
@Duncaen

required by gnome-48 (https://github.com/void-linux/void-packages/pull/54783)

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)