### PR TITLE
New package: showtime-48.1

### DIFF
--- a/srcpkgs/showtime/template
+++ b/srcpkgs/showtime/template
@@ -1,0 +1,21 @@
+# Template file for 'showtime'
+pkgname=showtime
+version=48.1
+revision=1
+build_style=meson
+hostmakedepends="blueprint-compiler desktop-file-utils gettext glib-devel
+ gtk4-update-icon-cache pkg-config"
+makedepends="libadwaita-devel"
+depends="gst-libav gst-plugins-good1 gst-plugins-rs1 libadwaita python3-gobject"
+short_desc="Video player for GNOME"
+maintainer="chrysos349 <chrysostom349@gmail.com>"
+license="GPL-3.0-or-later"
+homepage="https://apps.gnome.org/Showtime/"
+distfiles="${GNOME_SITE}/showtime/${version%.*}/showtime-${version}.tar.xz"
+checksum=1b22202dbe540440797d5a065030c29c242b210e3d4ec5ceb42e320ecc544ab9
+
+pre_build() {
+	if [ "$CROSS_BUILD" ]; then
+		export GI_TYPELIB_PATH="${XBPS_CROSS_BASE}/usr/lib/girepository-1.0"
+	fi
+}


### PR DESCRIPTION
This is a new official video player for Gnome, which replaces Totem.

#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)