### PR TITLE
keychain: update to 2.9.5

### DIFF
--- a/srcpkgs/keychain/INSTALL.msg
+++ b/srcpkgs/keychain/INSTALL.msg
@@ -1,0 +1,5 @@
+Keychain no longer supports the '--agents' option as of version 2.9.0.
+The software now automatically detects and manages your SSH/GPG agents.
+If you are still using '--agents' in your configuration or shell scripts,
+please remove it to avoid errors. More info:
+https://github.com/funtoo/keychain/releases/tag/2.9.0

--- a/srcpkgs/keychain/template
+++ b/srcpkgs/keychain/template
@@ -1,13 +1,15 @@
 # Template file for 'keychain'
 pkgname=keychain
-version=2.8.5
-revision=2
+version=2.9.5
+revision=1
+build_style=gnu-makefile
+hostmakedepends="perl"
 short_desc="Keychain manager for ssh-agent and gpg-agent"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-only"
 homepage="http://www.funtoo.org/Keychain"
 distfiles="https://github.com/funtoo/keychain/archive/${version}.tar.gz"
-checksum=dcce703e5001211c8ebc0528f45b523f84d2bceeb240600795b4d80cb8475a0b
+checksum=c883f26db616bc1c81ba5ef3832c7ad912f3e8bd0baf6aaff981164c538a1411
 
 do_install() {
 	vbin keychain


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)

NOTE: I don't know if _hostmakedepends="perl"_  is the best solution. The problem is that keychain requires pod2man to generate the manual now, as it does not seem to come bundled anymore in the tar archive (or maybe im just a noob).