### PR TITLE
pycharm-community: update to 2025.1.1.1.

### DIFF
--- a/srcpkgs/pycharm-community/template
+++ b/srcpkgs/pycharm-community/template
@@ -1,15 +1,15 @@
 # Template file for 'pycharm-community'
 pkgname=pycharm-community
-version=2024.2.1
+version=2025.1.1.1
 revision=1
 archs="x86_64"
-depends="virtual?java-environment giflib libXtst hicolor-icon-theme"
+depends="openjdk21 giflib libXtst hicolor-icon-theme"
 short_desc="Python integrated development environment"
 maintainer="Felix Van der Jeugt <felix.vanderjeugt@gmail.com>"
 license="Apache-2.0"
 homepage="https://www.jetbrains.org/pycharm/"
 distfiles="https://download-cf.jetbrains.com/python/${pkgname}-${version}.tar.gz"
-checksum=232ddc3c15b138264534820a40049ea4b0108647ba2972294616bc2a3f22234b
+checksum=f3cc87ebc2a963cb13a770c112bd9b634913a5a5fef1981941589366b7afb4f1
 repository=nonfree
 nopie=yes
 python_version=3
@@ -23,9 +23,7 @@ do_install() {
 
 	vinstall product-info.json 644 /usr/lib/pycharm
 
-	local launcher_path="bin/pycharm.sh"
-	sed -i '1 s/$/\nPYCHARM_JDK=${PYCHARM_JDK:-${IDEA_JDK}}/' "${launcher_path}"
-	mv -v bin lib plugins ${DESTDIR}/usr/lib/pycharm
+	mv -v bin lib plugins jbr ${DESTDIR}/usr/lib/pycharm
 	mv -v license ${DESTDIR}/usr/share/doc/pycharm
 	rm -vf ${DESTDIR}/usr/lib/pycharm/bin/fsnotifier-arm
 	for i in _pydevd_bundle _pydevd_frame_eval; do
@@ -42,7 +40,7 @@ do_install() {
 	rm -vf ${DESTDIR}/usr/lib/pycharm/bin/fsnotifier
 	rm -vf ${DESTDIR}/usr/lib/pycharm/plugins/python-ce/helpers/pydev/pydevd_attach_to_process/attach_linux_x86.so
 
-	ln -sf /usr/lib/pycharm/bin/pycharm.sh ${DESTDIR}/usr/bin/pycharm
+	ln -sf /usr/lib/pycharm/bin/pycharm ${DESTDIR}/usr/bin/pycharm
 	ln -sf /usr/lib/pycharm/bin/pycharm.png ${DESTDIR}/usr/share/pixmaps
 	ln -sf /usr/lib/pycharm/bin/pycharm.svg ${DESTDIR}/usr/share/icons/hicolor/scalable/apps
 	vinstall ${FILESDIR}/pycharm.desktop 644 usr/share/applications


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)

Basically, in addition to updating the package to the latest version I made the following changes:
1) replaced `virtual?java-environment` with `openjdk21` because java 11 is no longer supported by PyCharm
2) Replaced the startup script `pycharm.sh` with the PyCharm binary itself; the PyCharm developers themselves recommend starting PyCharm with the binary and no longer with the script