### PR TITLE
tuxedo-yt6801: update to 1.0.29tux1

### DIFF
--- a/srcpkgs/tuxedo-yt6801/template
+++ b/srcpkgs/tuxedo-yt6801/template
@@ -1,14 +1,15 @@
 # Template file for 'tuxedo-yt6801'
 pkgname=tuxedo-yt6801
-version=1.0.29tux0
+version=1.0.29tux1
 revision=1
 depends="dkms"
 short_desc="Kernel module for Motorcomm YT6801 ethernet controller (DKMS)"
 maintainer="Seth <sutura-git@qkco.os>"
 license="GPL-2.0-or-later"
 homepage="https://gitlab.com/tuxedocomputers/development/packages/tuxedo-yt6801"
+changelog="https://gitlab.com/tuxedocomputers/development/packages/tuxedo-yt6801/-/raw/main/debian/changelog"
 distfiles="https://gitlab.com/tuxedocomputers/development/packages/tuxedo-yt6801/-/archive/v${version}/tuxedo-yt6801-v${version}.tar.gz"
-checksum=ecbf5b80bf14784cadef81d05c8dd31329448d205822c627d7661ee0fa529c82
+checksum=5a4cc003d5eacb2247c3733bdf3d4cb70bfa194796e73a61be35266b13ee0827
 
 dkms_modules="tuxedo-yt6801 ${version}"
 


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)

Built for kernels 6.6 and 6.10, 6.12–6.14; running on 6.14.8
