### PR TITLE
docker-compose: update to 2.36.2

### DIFF
--- a/srcpkgs/docker-compose/template
+++ b/srcpkgs/docker-compose/template
@@ -1,7 +1,7 @@
 # Template file for 'docker-compose'
 pkgname=docker-compose
-version=2.29.1
-revision=2
+version=2.36.2
+revision=1
 build_style=go
 go_import_path="github.com/docker/compose/v2"
 go_package="${go_import_path}/cmd"
@@ -13,10 +13,16 @@ license="Apache-2.0"
 homepage="https://docs.docker.com/compose/"
 changelog="https://github.com/docker/compose/releases"
 distfiles="https://github.com/docker/compose/archive/refs/tags/v${version}.tar.gz"
-checksum=9749d621b1b8bc1f5881741e0cbad20b5133a0aeedb9339af06b0187be8141b1
+checksum=a093a9bbc646f3f6772eb4e2096a3df02618b394568325e4972b9382b0dd67e8
 
 post_install() {
 	vmkdir usr/libexec/docker/cli-plugins
 	mv ${DESTDIR}/usr/bin/cmd ${DESTDIR}/usr/libexec/docker/cli-plugins/docker-compose
 	ln -s /usr/libexec/docker/cli-plugins/docker-compose ${DESTDIR}/usr/bin/docker-compose
+}
+
+do_check() {
+	for d in $(go list ./... | grep -v '/pkg/e2e'); do
+		go test "$d"
+	done
 }


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl

