### PR TITLE
walker: update to 0.12.22.

### DIFF
--- a/srcpkgs/walker/template
+++ b/srcpkgs/walker/template
@@ -1,6 +1,6 @@
 # Template file for 'walker'
 pkgname=walker
-version=0.12.21
+version=0.12.22
 revision=1
 build_style=go
 build_helper="gir"
@@ -15,7 +15,7 @@ license="MIT"
 homepage="https://github.com/abenz1267/walker"
 changelog="https://github.com/abenz1267/walker/releases"
 distfiles="https://github.com/abenz1267/walker/archive/v${version}.tar.gz"
-checksum=7ba7a74f4fd2dd0d1fcf6b96adcb08032583f6557d2d66a73e7036c9f95a71fa
+checksum=8f60472dc9583a1abff3e114b680a593597c7210ed6fe1cfc743ec0c372aa891
 make_check=no # no tests and slog warnings make it fail
 
 do_build() {


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - i686
  - x86_64-musl
  - aarch64 (crossbuild)