### PR TITLE
luanti: update to 5.12.0, adopt.

### DIFF
--- a/srcpkgs/luanti/template
+++ b/srcpkgs/luanti/template
@@ -1,21 +1,21 @@
 # Template file for 'luanti'
 pkgname=luanti
-version=5.11.0
+version=5.12.0
 revision=1
 build_style=cmake
 configure_args="-DBUILD_SERVER=TRUE"
 hostmakedepends="pkg-config gettext"
 makedepends="MesaLib-devel freetype-devel gmp-devel libcurl-devel
  libjpeg-turbo-devel libopenal-devel libvorbis-devel LuaJIT-devel
- sqlite-devel libXi-devel"
+ sqlite-devel libXi-devel SDL2-devel"
 depends="desktop-file-utils hicolor-icon-theme"
 short_desc="Voxel game-creation platform with easy modding and game creation"
-maintainer="Orphaned <orphan@voidlinux.org>"
+maintainer="Piotr Danecki <i3riced@mailfence.com>"
 license="LGPL-2.1-or-later"
 homepage="https://www.luanti.org/"
 changelog="https://dev.luanti.org/changelog/"
 distfiles="https://github.com/minetest/minetest/archive/${version}.tar.gz"
-checksum=70e531d0776988ce6e579ea5490fdf6be3e349a4ade5281f5111aa4fdd8ee510
+checksum=876867ac874492f20968f2c2eb4e403231e8e9f29e0e06efa512200bd5152355
 
 minetest_package() {
 	depends="${sourcepkg}>=${version}_${revision}"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)

##### [Changelog](https://docs.luanti.org/about/changelog/#5110--5120)
##### [Release announcement](https://blog.luanti.org/2025/05/24/5.12.0-released/)
