### PR TITLE
gtest: update to 1.17.0.

### DIFF
--- a/srcpkgs/gtest/template
+++ b/srcpkgs/gtest/template
@@ -1,6 +1,6 @@
 # Template file for 'gtest'
 pkgname=gtest
-version=1.16.0
+version=1.17.0
 revision=1
 build_style=cmake
 make_cmd=make # using make to avoid a cycle: ninja -> gtest -> ninja
@@ -11,7 +11,7 @@ maintainer="Enno Boland <gottox@voidlinux.org>"
 license="BSD-3-Clause"
 homepage="https://github.com/google/googletest"
 distfiles="https://github.com/google/googletest/archive/v${version}.tar.gz"
-checksum=78c676fc63881529bf97bf9d45948d905a66833fbfa5318ea2cd7478cb98f399
+checksum=65fab701d9829d38cb77c14acdc431d2108bfdbf8979e40eb8ae567edf10b27c
 
 export CMAKE_GENERATOR="Unix Makefiles"
 


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture (x86_64)
- I built this PR locally for these architectures using specific masterdirs:
  - x86_64-musl
  - i686
- I built this PR locally for these architectures (crossbuilds):
  - aarch64
  - aarch64-musl
  - armv7l
  - armv7l-musl
  - armv6l
  - armv6l-musl
  
---

Tested the update of the package using [Cockatrice PR#54508](https://github.com/void-linux/void-packages/pull/54508) compilation. Everything builds and works as expected.