### PR TITLE
python3-nethsm: update to 1.4.0

### DIFF
--- a/srcpkgs/python3-nethsm/template
+++ b/srcpkgs/python3-nethsm/template
@@ -1,6 +1,6 @@
 # Template file for 'python3-nethsm'
 pkgname=python3-nethsm
-version=1.3.0
+version=1.4.0
 revision=1
 build_style=python3-pep517
 hostmakedepends="python3-flit_core"
@@ -10,4 +10,4 @@ maintainer="Mateusz Sylwestrzak <slymattz@gmail.com>"
 license="Apache-2.0"
 homepage="https://github.com/Nitrokey/nethsm-sdk-py"
 distfiles="${PYPI_SITE}/n/nethsm/nethsm-${version}.tar.gz"
-checksum=1748d2953ff133cc5a4167d4a7cee9fb6458ffc846eef46af3f549e1ae45921c
+checksum=71b18487982f2fef59c6fd378319cde5c5c2e1bffe7d4b6b35d540f3942626f3


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**|**briefly**|**NO**

This minor update satisfies python3-pynitrokey's dependency on "nethsm >=1.4.0, <2" for users of Nitrokey NetHSM hardware.
https://github.com/Nitrokey/pynitrokey/commit/2b067ae48f68b8f6b0e249a4c6a4fd6be769d2c9

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

#### Local build testing
- I built this PR locally for my native architecture: x86_64-glibc
