### PR TITLE
podman-compose: update to 1.4.0.

### DIFF
--- a/srcpkgs/podman-compose/template
+++ b/srcpkgs/podman-compose/template
@@ -1,6 +1,6 @@
 # Template file for 'podman-compose'
 pkgname=podman-compose
-version=1.3.0
+version=1.4.0
 revision=1
 build_style=python3-module
 hostmakedepends="python3-setuptools"
@@ -10,6 +10,6 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="https://github.com/containers/podman-compose"
 distfiles="https://github.com/containers/podman-compose/archive/v${version}.tar.gz"
-checksum=d2d641d23bead9cead06bdd2edb9d6a592a138fc8bb7ecb53f87e21e99d45af7
+checksum=167860361357f32e09660342756442ac6f9adf182f00ade1309b550de48ed494
 # Source distribution does not script unit tests
 make_check=no


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

podman-compose stack of 2 containers: mosquitto & zigbee2mqtt (with a passed-in USB zigbee dongle)
with podman 5.5.0 (as of pr #55337)

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-musl)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64 (crossbuild)