### PR TITLE
tree-sitter: update to 0.25.5

### DIFF
--- a/srcpkgs/tree-sitter/template
+++ b/srcpkgs/tree-sitter/template
@@ -1,6 +1,6 @@
 # Template file for 'tree-sitter'
 pkgname=tree-sitter
-version=0.25.4
+version=0.25.5
 revision=1
 build_style=cargo
 make_install_args="--path=cli"
@@ -10,7 +10,7 @@ license="MIT"
 homepage="https://tree-sitter.github.io"
 changelog="https://github.com/tree-sitter/tree-sitter/releases"
 distfiles="https://github.com/tree-sitter/tree-sitter/archive/refs/tags/v${version}.tar.gz"
-checksum=87eadc505905c70a692917c821958a819903f808f8d244068b1d273a033dc728
+checksum=17a72b9dd7525b01d8fabf9ebee0edd3203fe3058ccc73cbc5e2070ccbe26c0d
 make_check=no # tests require generating fixtures from remote repositories
 
 post_build() {


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
