### PR TITLE
[WIP] New package: bitmagnet-0.10.0

### DIFF
--- a/srcpkgs/bitmagnet/files/bitmagnet/conf
+++ b/srcpkgs/bitmagnet/files/bitmagnet/conf
@@ -1,0 +1,2 @@
+XDG_CONFIG_HOME=/etc
+XDG_STATE_HOME=/var/lib

--- a/srcpkgs/bitmagnet/files/bitmagnet/run
+++ b/srcpkgs/bitmagnet/files/bitmagnet/run
@@ -1,0 +1,4 @@
+#!/bin/sh
+[ -r conf ] && . ./conf
+exec 2>&1
+exec chpst -u _bitmagnet:_bitmagnet bitmagnet worker run --all

--- a/srcpkgs/bitmagnet/template
+++ b/srcpkgs/bitmagnet/template
@@ -1,0 +1,36 @@
+# Template file for 'bitmagnet'
+pkgname=bitmagnet
+version=0.10.0
+revision=1
+build_style=go
+go_import_path="github.com/bitmagnet-io/bitmagnet"
+go_package="${go_import_path}"
+go_build_tags="v0.10.0"
+go_ldflags="-compressdwarf=false -linkmode=external -X github.com/bitmagnet-io/bitmagnet/internal/version.GitTag=v${version}"
+hostmakedepends="git"
+depends="go glibc postgresql redis"
+short_desc="BitTorrent indexer, DHT crawler, and torrent search engine"
+maintainer="Jason Elswick <jason@jasondavid.us>"
+license="MIT"
+homepage="https://bitmagnet.io"
+distfiles="https://github.com/bitmagnet-io/bitmagnet/archive/refs/tags/v${version}.tar.gz"
+checksum=9a5783f1560442be76f7cd81a8b4a053a8864c17d6e57a8b0890ed784a1c18b8
+system_accounts="_bitmagnet"
+_bitmagnet_homedir="/var/lib/bitmagnet"
+make_dirs="
+	/etc/bitmagnet 0755 _bitmagnet _bitmagnet
+	/var/lib/bitmagnet 0755 _bitmagnet _bitmagnet
+	/var/log/bitmagnet 0755 _bitmagnet _bitmagnet
+"
+make_check=no # appears tests are not provided
+
+export GOFLAGS="-buildmode=pie -trimpath -mod=readonly -modcacherw"
+
+pre_build() {
+	go mod download
+}
+
+post_install() {
+	vsv bitmagnet
+	vlicense LICENSE
+}


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-libc

This is WIP, having the following issue when trying to run the service. It appears to be wanting to try and find ./config.yml , wherever the current working directory may be. I have also placed a proper config.yml in /etc/bitmagnet with my own postgres creds etc, and yet it won't find that. I am also contacting bitmagnet themselves on their discord.
```
[Fx] RUN        provide: fx.Annotated{Group: "config_resolvers", Target: 
github.com/bitmagnet-io/bitmagnet/internal/boilerplate/config/configfx.Ne
w.func3()} in 24.375µs from module "config"  
[Fx] Error returned: received non-nil error from function "github.com/bit
magnet-io/bitmagnet/internal/boilerplate/config/configfx".New.func3      
        github.com/bitmagnet-io/bitmagnet/internal/boilerplate/config/con
figfx/module.go:53:                                                      
open ./config.yml: permission denied 
[Fx] ERROR              Failed to initialize custom logger: could not bui
ld arguments for function "go.uber.org/fx".(*module).constructCustomLogge
r.func2                                                                  
        go.uber.org/fx@v1.23.0/module.go:294:                            
failed to build fxevent.Logger:     
could not build arguments for function "github.com/bitmagnet-io/bitmagnet
/internal/boilerplate/logging/loggingfx".WithLogger.func1
        github.com/bitmagnet-io/bitmagnet/internal/boilerplate/logging/lo
ggingfx/module.go:21:
failed to build *zap.Logger:
could not build arguments for function "github.com/bitmagnet-io/bitmagnet
/internal/boilerplate/logging".New
        github.com/bitmagnet-io/bitmagnet/internal/boilerplate/logging/lo
gger.go:23:
failed to build logging.Config:
could not build arguments for function "github.com/bitmagnet-io/bitmagnet
/internal/boilerplate/config/configfx".NewConfigModule[...].func2
        github.com/bitmagnet-io/bitmagnet/internal/boilerplate/config/con
figfx/factory.go:25:
failed to build config.ResolvedConfig:
could not build arguments for function "github.com/bitmagnet-io/bitmagnet
/internal/boilerplate/config".New
        github.com/bitmagnet-io/bitmagnet/internal/boilerplate/config/con
fig.go:28:
could not build value group configresolver.Resolver[group="config_resolve
rs"]:
received non-nil error from function "github.com/bitmagnet-io/bitmagnet/i
nternal/boilerplate/config/configfx".New.func3
        github.com/bitmagnet-io/bitmagnet/internal/boilerplate/config/con
figfx/module.go:53:
open ./config.yml: permission denied
```
