### PR TITLE
Signal-Desktop: update to 7.56.0.

### DIFF
--- a/srcpkgs/Signal-Desktop/template
+++ b/srcpkgs/Signal-Desktop/template
@@ -1,20 +1,20 @@
 # Template file for 'Signal-Desktop'
 pkgname=Signal-Desktop
-version=7.54.0
+version=7.56.0
 revision=1
 # Signal officially only supports x86_64
 # x86_64-musl could potentially work based on the Alpine port:
 # https://git.alpinelinux.org/aports/tree/testing/signal-desktop
 # ARM: https://github.com/signalapp/Signal-Desktop/issues/3410
 archs="x86_64"
-hostmakedepends="git git-lfs nodejs-lts python3 python3-distutils-extra tar pnpm"
+hostmakedepends="git git-lfs nodejs-lts python3 python3-distutils-extra tar pnpm xz"
 depends="cairo gtk+3 libvips pango desktop-file-utils hicolor-icon-theme"
 short_desc="Signal Private Messenger for Linux"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="AGPL-3.0-only"
 homepage="https://github.com/signalapp/Signal-Desktop"
 distfiles="https://github.com/signalapp/Signal-Desktop/archive/v${version}.tar.gz"
-checksum=335d01d309421d857cc7afa00e826bbf4239b43efff9942797a34aaf066c8b64
+checksum=fba7bbe97fb96766965227eb50d17a15c0eca7c666cf27d8330f808bb248b962
 nostrip_files="signal-desktop"
 
 post_extract() {


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc