### PR TITLE
ghostscript: update to 10.05.1

### DIFF
--- a/srcpkgs/ghostscript/template
+++ b/srcpkgs/ghostscript/template
@@ -1,6 +1,6 @@
 # Template file for 'ghostscript'
 pkgname=ghostscript
-version=10.03.1
+version=10.05.1
 revision=1
 hostmakedepends="automake libtool pkg-config"
 makedepends="$(vopt_if cups cups-devel) dbus-devel fontconfig-devel jasper-devel jbig2dec-devel
@@ -13,7 +13,7 @@ homepage="https://www.ghostscript.com/"
 changelog="https://ghostscript.readthedocs.io/en/latest/News.html"
 changelog="https://ghostscript.readthedocs.io/en/gs10.02.0/News.html"
 distfiles="https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs${version//./}/ghostscript-${version}.tar.xz"
-checksum=157212edc96b8ccc409475dce2e49833fb4427f150c455258ded9632c106abee
+checksum=22f2bdca15c28830c9715cddc5c296ea66898bfdab0b604a4e0bcfeb03af6cad
 
 build_options="cups"
 build_options_default="cups"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

#### What this minor update fixes
This update fixes some weird issues I encountered when trying to force-ocr one specific pdf (other PDFs work fine)
Curiously enough, qpdf showed no errors for this specific pdf file:
```
$ qpdf --check reported_speech.pdf 
checking reported_speech.pdf
PDF Version: 1.7
File is not encrypted
File is not linearized
No syntax or stream encoding errors found; the file may still contain
errors that qpdf cannot detect

```
**ghostscript 10.03.1**
```
$ ocrmypdf --force-ocr reported_speech.pdf repo.pdf
Scanning contents     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 6/6 0:00:00
Start processing 6 pages concurrently                                                                                                                                                                                                                                                                                                                           ocr.py:96
    1 page already has text! - rasterizing text and running OCR anyway                                                                                                                                                                                                                                                                                   _pipeline.py:331
    2 page already has text! - rasterizing text and running OCR anyway                                                                                                                                                                                                                                                                                   _pipeline.py:331
    3 page already has text! - rasterizing text and running OCR anyway                                                                                                                                                                                                                                                                                   _pipeline.py:331
    4 page already has text! - rasterizing text and running OCR anyway                                                                                                                                                                                                                                                                                   _pipeline.py:331
    5 page already has text! - rasterizing text and running OCR anyway                                                                                                                                                                                                                                                                                   _pipeline.py:331
    6 page already has text! - rasterizing text and running OCR anyway                                                                                                                                                                                                                                                                                   _pipeline.py:331
    4 [tesseract] lots of diacritics - possibly poor OCR                                                                                                                                                                                                                                                                                                 tesseract.py:241
OCR                   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 6/6 0:00:00
Postprocessing...                                                                                                                                                                                                                                                                                                                                              ocr.py:144
GPL Ghostscript 10.03.1 (2024-05-02)                                                                                                                                                                                                                                                                                                                   ghostscript.py:311
Copyright (C) 2024 Artifex Software, Inc.  All rights reserved.
This software is supplied under the GNU AGPLv3 and comes with NO WARRANTY:
see the file COPYING for details.
Error: /undefined in --runpdf--
Operand stack:   --nostringval--   --nostringval--   --nostringval--   --nostringval--
Execution stack:   %interp_exit   .runexec2   --nostringval--   runpdf   --nostringval--   2   %stopped_push   --nostringval--   runpdf   runpdf   false   1   %stopped_push   1933   1   3   %oparray_pop   1932   1   3   %oparray_pop   1917   1   3   %oparray_pop   1918   1   3   %oparray_pop   runpdf   runpdf   runpdf   runpdf
Dictionary stack:   --dict:756/1123(ro)(G)--   --dict:0/20(G)--   --dict:87/200(L)--   --dict:6/10(L)--
Current allocation mode is local
GPL Ghostscript 10.03.1: Unrecoverable error, exit code 1

SubprocessOutputError: Ghostscript PDF/A rendering failed                                                                                                                                                                                                                                                                                                  _common.py:273
[1]    8180 exit 7     ocrmypdf --force-ocr reported_speech.pdf repo.pdf
```
vs
**ghostscript 10.05.1**
```
$ ocrmypdf --force-ocr reported_speech.pdf repo.pdf
Scanning contents     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 6/6 0:00:00
Start processing 6 pages concurrently                                                                                                                                                                                                                                                                                                                           ocr.py:96
    1 page already has text! - rasterizing text and running OCR anyway                                                                                                                                                                                                                                                                                   _pipeline.py:331
    2 page already has text! - rasterizing text and running OCR anyway                                                                                                                                                                                                                                                                                   _pipeline.py:331
    3 page already has text! - rasterizing text and running OCR anyway                                                                                                                                                                                                                                                                                   _pipeline.py:331
    4 page already has text! - rasterizing text and running OCR anyway                                                                                                                                                                                                                                                                                   _pipeline.py:331
    5 page already has text! - rasterizing text and running OCR anyway                                                                                                                                                                                                                                                                                   _pipeline.py:331
    6 page already has text! - rasterizing text and running OCR anyway                                                                                                                                                                                                                                                                                   _pipeline.py:331
    4 [tesseract] lots of diacritics - possibly poor OCR                                                                                                                                                                                                                                                                                                 tesseract.py:241
OCR                   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 6/6 0:00:00
Postprocessing...                                                                                                                                                                                                                                                                                                                                              ocr.py:144
PDF/A conversion      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 6/6 0:00:00
Linearizing           ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 100/100 0:00:00
Recompressing JPEGs   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━   0% 0/0 -:--:--
Deflating JPEGs       ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 6/6 0:00:00
JBIG2                 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━   0% 0/0 -:--:--
Image optimization ratio: 1.39 savings: 27.9%                                                                                                                                                                                                                                                                                                           _pipeline.py:1002
Total file size ratio: 0.67 savings: -50.3%                                                                                                                                                                                                                                                                                                             _pipeline.py:1005
Output file is a PDF/A-2B (as expected)                                                                                                                                                                                                                                                                                                                    _common.py:474
The output file size is 1.50× larger than the input file.                                                                                                                                                                                                                                                                                              _validation.py:358
Possible reasons for this include:
--force-ocr was issued, causing transcoding.
PDF/A conversion was enabled. (Try `--output-type pdf`.)
```
<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture: x86_64-glibc
- I built this PR locally for aarch64-musl (cross build)
