### PR TITLE
mediastreamer: disable ffmpeg support

### DIFF
--- a/srcpkgs/mediastreamer/template
+++ b/srcpkgs/mediastreamer/template
@@ -1,12 +1,12 @@
 # Template file for 'mediastreamer'
 pkgname=mediastreamer
 version=5.3.106
-revision=1
+revision=2
 build_style=cmake
 configure_args="-DENABLE_STRICT=0 -DENABLE_UNIT_TESTS=0 -DBUILD_SHARED_LIBS=TRUE
- -DENABLE_QT_GL=TRUE"
+ -DENABLE_QT_GL=TRUE -DENABLE_FFMPEG=0"
 hostmakedepends="python3 qt5-qmake qt5-host-tools"
-makedepends="bzrtp-devel ffmpeg-devel glew-devel libXv-devel libsrtp-devel
+makedepends="bzrtp-devel glew-devel libXv-devel libsrtp-devel
  libupnp-devel libvpx-devel mbedtls-devel opus-devel ortp-devel pulseaudio-devel
  libtheora-devel speex-devel v4l-utils-devel bcg729-devel bcmatroska2-devel libgsm-devel
  zxing-cpp-devel libaom-devel qt5-devel qt5-declarative-devel"


### PR DESCRIPTION
upstream has [deprecated it][1] and considers it [unmaintained][2]. only compatible with ffmpeg4.

cc maintainer @Johnnynator

[1]: https://gitlab.linphone.org/BC/public/mediastreamer2/-/commit/8261f82741f454d5b523f224aec3c66ee97e2fdc
[2]: https://gitlab.linphone.org/BC/public/mediastreamer2/-/commit/a455e96189eda038f4de51a8a0b874215ca86226

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**|**briefly**|**NO**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
