### PR TITLE
[WIP] New package: nebula_dht-2.4.1

### DIFF
--- a/srcpkgs/nebula_dht/patches/justfile.patch
+++ b/srcpkgs/nebula_dht/patches/justfile.patch
@@ -1,0 +1,34 @@
+--- a/justfile
++++ b/justfile
+@@ -12,7 +12,6 @@
+ postgres_dbname_prefix := "nebula_"
+ postgres_pass_prefix := "password_"
+ 
+-COMMIT := `git rev-parse --short HEAD`
+ DATE := `date "+%Y-%m-%dT%H:%M:%SZ"`
+ USER := `id -un`
+ VERSION := `git describe --tags --abbrev=0 || true`
+@@ -23,22 +22,16 @@
+ 
+ # build a nebula executable to the ./dist/ folder
+ build:
+-	go build -ldflags "-X main.version={{VERSION}} -X main.commit={{COMMIT}} -X main.date={{DATE}} -X main.builtBy={{USER}}" -o dist/nebula github.com/dennis-tra/nebula-crawler/cmd/nebula
++	go build -ldflags "-X main.version={{VERSION}} -X main.date={{DATE}} -X main.builtBy={{USER}}" -o dist/nebula github.com/dennis-tra/nebula-crawler/cmd/nebula
+ 
+ # build a nebula docker image
+ docker platform="linux/amd64":
+ 	docker build --platform {{platform}} \
+ 	  --build-arg VERSION={{VERSION}} \
+-	  --build-arg COMMIT={{COMMIT}} \
+ 	  --build-arg BUILT_BY={{USER}} \
+ 	  --build-arg DATE={{DATE}} \
+-	  -t dennistra/nebula:{{COMMIT}} \
+ 	  .
+ 
+-# push a nebula image to docker hub
+-docker-push: docker
+-	docker push dennistra/nebula:{{COMMIT}}
+-
+ # start a clickhouse server
+ start-clickhouse env="local" detached="true":
+     @echo "Starting ClickHouse server..."

--- a/srcpkgs/nebula_dht/template
+++ b/srcpkgs/nebula_dht/template
@@ -1,0 +1,32 @@
+# Template file for 'nebula_dht'
+pkgname=nebula_dht
+version=2.4.1
+revision=1
+hostmakedepends="just go"
+depends="postgresql"
+checkdepends="${depends} docker"
+short_desc="DHT (and other network) crawler, monitor, measurement tool"
+maintainer="Jason Elswick <jason@jasondavid.us>"
+license="Apache-2.0"
+homepage="https://github.com/dennis-tra/nebula"
+distfiles="https://github.com/dennis-tra/nebula/archive/refs/tags/${version}.tar.gz"
+checksum=3862ff5ec17ace3ec3b9814bb04fb7fa4cf2b5db19e97a489bdab695f429242d
+nopie=yes
+make_check=no # need to figure out
+
+post_patch() {
+	sed -i "s|^VERSION \:\= \`.*\`$|VERSION := \"$version\"|" justfile
+}
+
+do_build() {
+	just build
+}
+
+do_install() {
+	vmkdir usr/bin/
+	vbin dist/nebula nebula_dht
+}
+
+do_check() {
+	just test
+}


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-libc

I've been wanting to build a template for a DHT crawler, but bitmagnet has been cumbersome. It had a segfault here on void, in addition to the janky configuration file issues found in my wall of text on https://github.com/void-linux/void-packages/pull/55514.

My main issue here is figuring out the testing of this, while I have postgresql and docker installed, the testing hangs on running a docker postgresql instance to test. May also need to package clickhouse to test as well.

I have tested nebula itself, and it works well with my own pgsql17 instance. I renamed the package and the binary to nebula_dht to not conflict with an unrelated existing package named nebula.
