### PR TITLE
python3-hidapi: update to 0.14.0.post4, switch backend to libusb

### DIFF
--- a/srcpkgs/python3-hidapi/template
+++ b/srcpkgs/python3-hidapi/template
@@ -1,23 +1,18 @@
 # Template file for 'python3-hidapi'
 pkgname=python3-hidapi
-version=0.14.0.post2
+version=0.14.0.post4
 revision=1
 build_style=python3-module
-make_build_args="--with-system-hidapi"
+make_build_args="--with-libusb"
 hostmakedepends="python3-setuptools python3-wheel python3-Cython pkg-config"
-makedepends="eudev-libudev-devel hidapi-devel libusb-devel python3-devel"
+makedepends="eudev-libudev-devel libusb-devel python3-devel"
 depends="python3 hidapi python3-setuptools"
 short_desc="Cython interface to the hidapi"
 maintainer="Mateusz Sylwestrzak <slymattz@gmail.com>"
 license="GPL-3.0-or-later, BSD-3-Clause"
 homepage="https://github.com/trezor/cython-hidapi"
 distfiles="${PYPI_SITE}/h/hidapi/hidapi-${version}.tar.gz"
-checksum=6c0e97ba6b059a309d51b495a8f0d5efbcea8756b640d98b6f6bb9fdef2458ac
-
-if [ $CROSS_BUILD ]; then
-	# without the following line, the compiler complains about the lack of hidapi.h
-	hostmakedepends+=" hidapi-devel"
-fi
+checksum=48fce253e526d17b663fbf9989c71c7ef7653ced5f4be65f1437c313fb3dbdf6
 
 post_install() {
 	vlicense LICENSE-bsd.txt


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**
I tested it specifically with Nitrokey devices in mind. After updating to `python3-hidapi 0.14.0.post4` and rebooting my computer I'm still able to access hidraw devices as a non-root user. Non-elogind users belonging to _plugdev_ should also be able to access such devices:
```
$ ls -la /dev/hidraw*
crw-rw----+ 1 root plugdev 239, 0 May 31 16:31 /dev/hidraw0
crw-------  1 root root    239, 1 May 31 16:31 /dev/hidraw1
crw-------  1 root root    239, 2 May 31 16:31 /dev/hidraw2
crw-------  1 root root    239, 3 May 31 16:31 /dev/hidraw3
crw-------  1 root root    239, 4 May 31 16:31 /dev/hidraw4
crw-------  1 root root    239, 5 May 31 16:31 /dev/hidraw5
crw-------  1 root root    239, 6 May 31 16:31 /dev/hidraw6
crw-------  1 root root    239, 7 May 31 16:31 /dev/hidraw7
crw-------  1 root root    239, 8 May 31 16:31 /dev/hidraw8
```
```
$ nitropy nk3 list  
Command line tool to interact with Nitrokey devices 0.8.4
:: 'NK3' keys
/dev/hidraw0: Nitrokey [SERIALNUMBER]

```
EDIT 5/31/25: I made `--with-libusb` explicit and removed the unnecessary makedepend and hostmakedepend for cross building. Then I installed the update, rebooted and tested it. Works as expected.
<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture: x86_64-glibc
- I built this PR locally for these architectures:
  - aarch64-musl (cross build)

