### PR TITLE
New package: libvibrant-1.1.1, libXnvctrl-575.57.08

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -135,6 +135,7 @@ libturbojpeg.so.0 libjpeg-turbo-1.3.0_2
 libpng16.so.16 libpng-1.6.2_1
 libXrender.so.1 libXrender-0.9.4_1
 libXrandr.so.2 libXrandr-1.3.0_1
+libXNVCtrl.so.0 libXnvctrl-575.57.08_1
 libGLU.so.1 glu-9.0.0_1
 libGL.so.1 libGL-7.11_1
 libEGL.so.1 libEGL-7.11_1

--- a/srcpkgs/libXnvctrl-devel
+++ b/srcpkgs/libXnvctrl-devel
@@ -1,0 +1,1 @@
+libXnvctrl

--- a/srcpkgs/libXnvctrl/patches/0001-XF86Config-parser-Remove-deprecated-index-usage.patch
+++ b/srcpkgs/libXnvctrl/patches/0001-XF86Config-parser-Remove-deprecated-index-usage.patch
@@ -1,0 +1,70 @@
+From e4589e267498c3d974619398397b0b121d740369 Mon Sep 17 00:00:00 2001
+From: meator <meator.dev@gmail.com>
+Date: Sat, 31 May 2025 20:41:49 +0200
+Subject: [PATCH] XF86Config-parser: Remove deprecated index() usage
+
+This strangely causes issues on armv6l-musl. index() is replaced with
+strchr(), which is identical and better standardized.
+---
+ src/XF86Config-parser/Files.c | 12 ++++++------
+ 1 file changed, 6 insertions(+), 6 deletions(-)
+
+diff --git a/src/XF86Config-parser/Files.c b/src/XF86Config-parser/Files.c
+index dac9335..8d23f4d 100644
+--- a/src/XF86Config-parser/Files.c
++++ b/src/XF86Config-parser/Files.c
+@@ -220,7 +220,7 @@ xconfigPrintFileSection (FILE * cf, XConfigFilesPtr ptr)
+     if (ptr->modulepath)
+     {
+         s = ptr->modulepath;
+-        p = index (s, ',');
++        p = strchr (s, ',');
+         while (p)
+         {
+             *p = '\000';
+@@ -228,14 +228,14 @@ xconfigPrintFileSection (FILE * cf, XConfigFilesPtr ptr)
+             *p = ',';
+             s = p;
+             s++;
+-            p = index (s, ',');
++            p = strchr (s, ',');
+         }
+         fprintf (cf, "    ModulePath      \"%s\"\n", s);
+     }
+     if (ptr->inputdevs)
+     {
+         s = ptr->inputdevs;
+-        p = index (s, ',');
++        p = strchr (s, ',');
+         while (p)
+         {
+             *p = '\000';
+@@ -243,14 +243,14 @@ xconfigPrintFileSection (FILE * cf, XConfigFilesPtr ptr)
+             *p = ',';
+             s = p;
+             s++;
+-            p = index (s, ',');
++            p = strchr (s, ',');
+         }
+         fprintf (cf, "    InputDevices      \"%s\"\n", s);
+     }
+     if (ptr->fontpath)
+     {
+         s = ptr->fontpath;
+-        p = index (s, ',');
++        p = strchr (s, ',');
+         while (p)
+         {
+             *p = '\000';
+@@ -258,7 +258,7 @@ xconfigPrintFileSection (FILE * cf, XConfigFilesPtr ptr)
+             *p = ',';
+             s = p;
+             s++;
+-            p = index (s, ',');
++            p = strchr (s, ',');
+         }
+         fprintf (cf, "    FontPath        \"%s\"\n", s);
+     }
+-- 
+2.49.0
+

--- a/srcpkgs/libXnvctrl/patches/nvidia-settings-libxnvctrl_so.patch
+++ b/srcpkgs/libXnvctrl/patches/nvidia-settings-libxnvctrl_so.patch
@@ -1,0 +1,40 @@
+Build a shared lib (not only a static one) for libXNVCtrl.so.
+Source: https://aur.archlinux.org/cgit/aur.git/tree/nvidia-settings-libxnvctrl_so.patch?h=lib32-libxnvctrl&id=78b2ecde7e084a3a73a3637cbcda865223eb0b6d
+diff --git a/src/Makefile b/src/Makefile
+index 68eb140..6d0aab8 100644
+--- a/src/Makefile
++++ b/src/Makefile
+@@ -345,7 +345,7 @@ endif
+ 
+ ifdef BUILD_GTK3LIB
+ $(eval $(call DEBUG_INFO_RULES, $(GTK3LIB)))
+-$(GTK3LIB).unstripped: $(LIBXNVCTRL) $(GTK3_OBJS) $(XCP_OBJS) $(IMAGE_OBJS) $(VERSION_MK)
++$(GTK3LIB).unstripped: $(LIBXNVCTRL) $(LIBXNVCTRL_SHARED) $(GTK3_OBJS) $(XCP_OBJS) $(IMAGE_OBJS) $(VERSION_MK)
+ 	$(call quiet_cmd,LINK) -shared $(CFLAGS) $(LDFLAGS)  $(BIN_LDFLAGS) \
+ 	    $(LIBXNVCTRL) $(LIBS) $(GTK3_LIBS) \
+ 	    -Wl,--unresolved-symbols=ignore-all -o $@ \
+diff --git a/src/libXNVCtrl/xnvctrl.mk b/src/libXNVCtrl/xnvctrl.mk
+index e6be2ef..c0921c4 100644
+--- a/src/libXNVCtrl/xnvctrl.mk
++++ b/src/libXNVCtrl/xnvctrl.mk
+@@ -39,6 +39,11 @@ XNVCTRL_CFLAGS ?=
+ 
+ LIBXNVCTRL = $(OUTPUTDIR)/libXNVCtrl.a
+ 
++LIBXNVCTRL_SHARED = $(OUTPUTDIR)/libXNVCtrl.so
++LIBXNVCTRL_ABI_VERSION_MAJOR = 0
++LIBXNVCTRL_ABI_VERSION_MINOR = 0
++LIBXNVCTRL_LIBS += -lXext -lX11
++
+ LIBXNVCTRL_SRC = $(XNVCTRL_DIR)/NVCtrl.c
+ 
+ LIBXNVCTRL_OBJ = $(call BUILD_OBJECT_LIST,$(LIBXNVCTRL_SRC))
+@@ -47,3 +52,8 @@ $(eval $(call DEFINE_OBJECT_RULE,TARGET,$(LIBXNVCTRL_SRC)))
+ 
+ $(LIBXNVCTRL) : $(LIBXNVCTRL_OBJ)
+ 	$(call quiet_cmd,AR) ru $@ $(LIBXNVCTRL_OBJ)
++
++$(LIBXNVCTRL_SHARED) : $(LIBXNVCTRL_OBJ)
++	$(CC) -shared $(CFLAGS) $(LDFLAGS) -Wl,-soname=$(notdir $@).${LIBXNVCTRL_ABI_VERSION_MAJOR} -o $@.$(LIBXNVCTRL_ABI_VERSION_MAJOR).$(LIBXNVCTRL_ABI_VERSION_MINOR).0 $^ $(LIBXNVCTRL_LIBS)
++	ln -s $(notdir $@).$(LIBXNVCTRL_ABI_VERSION_MAJOR).$(LIBXNVCTRL_ABI_VERSION_MINOR).0 $@
++	ln -s $(notdir $@).$(LIBXNVCTRL_ABI_VERSION_MAJOR).$(LIBXNVCTRL_ABI_VERSION_MINOR).0 $@.$(LIBXNVCTRL_ABI_VERSION_MAJOR)

--- a/srcpkgs/libXnvctrl/template
+++ b/srcpkgs/libXnvctrl/template
@@ -1,0 +1,32 @@
+# Template file for 'libXnvctrl'
+pkgname=libXnvctrl
+version=575.57.08
+revision=1
+build_style=gnu-makefile
+make_use_env=yes
+# chdir into src/ to not build examples and docs (which do not cross compile well)
+make_build_args="-C src OUTPUTDIR=out NV_USE_BUNDLED_LIBJANSSON=0"
+hostmakedepends="pkg-config m4"
+makedepends="jansson-devel libX11-devel gtk+3-devel Vulkan-Headers libXv-devel libXxf86vm-devel libvdpau-devel"
+short_desc="Nvidia hardware monitoring library"
+maintainer="meator <meator.dev@gmail.com>"
+license="GPL-2.0-only"
+homepage="https://github.com/NVIDIA/nvidia-settings"
+distfiles="https://github.com/NVIDIA/nvidia-settings/archive/refs/tags/${version}.tar.gz"
+checksum=27e123373d0fa8e3cb5f308fa3af63c0f42cb252a18033da4de14d54a37618ef
+
+do_install() {
+	vcopy "src/out/libXNVCtrl.*" usr/lib
+	vmkdir usr/include/NVCtrl
+	vcopy "src/libXNVCtrl/*.h" usr/include/NVCtrl
+}
+
+libXnvctrl-devel_package() {
+	depends="${sourcepkg}>=${version}_${revision}"
+	short_desc+=" - development files"
+	pkg_install() {
+		vmove usr/include
+		vmove "usr/lib/*.a"
+		vmove "usr/lib/*.so"
+	}
+}

--- a/srcpkgs/libvibrant-devel
+++ b/srcpkgs/libvibrant-devel
@@ -1,0 +1,1 @@
+libvibrant

--- a/srcpkgs/libvibrant/template
+++ b/srcpkgs/libvibrant/template
@@ -1,0 +1,30 @@
+# Template file for 'libvibrant'
+pkgname=libvibrant
+version=1.1.1
+revision=1
+build_style=cmake
+makedepends="libX11-devel libXrandr-devel libXnvctrl-devel"
+short_desc="Adjust color vibrancy of X11 outputs"
+maintainer="meator <meator.dev@gmail.com>"
+license="GPL-3.0-or-later"
+homepage="https://github.com/libvibrant/libvibrant"
+distfiles="https://github.com/libvibrant/libvibrant/archive/refs/tags/${version}.tar.gz"
+checksum=8ab853c6c448101fd1aa931aef1fef1598b63136b6db341d4c1196df44a64439
+
+libvibrant-devel_package() {
+	depends="${sourcepkg}>=${version}_${revision}"
+	short_desc+=" - development files"
+	pkg_install() {
+		vmove usr/include
+		vmove usr/lib/pkgconfig
+		vmove "usr/lib/*.so"
+	}
+}
+
+vibrant-cli_package() {
+	depends="${sourcepkg}>=${version}_${revision}"
+	short_desc+=" - CLI frontend"
+	pkg_install() {
+		vmove usr/bin
+	}
+}

--- a/srcpkgs/vibrant-cli
+++ b/srcpkgs/vibrant-cli
@@ -1,0 +1,1 @@
+libvibrant


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

`libXnvctrl` is inspired by #44050

I don't have experience with packaging Nvidia things, but I vaguely remember the versions being important. I am packaging the latest version of `libXnvctrl` from `nvidia-settings 575.57.08`. [The AUR packages a lot of separate version of this package.](https://aur.archlinux.org/packages?O=0&K=libXnvctrl) Will this require further consideration on our side?

#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
