### PR TITLE
Bear: update to 3.1.6.

### DIFF
--- a/srcpkgs/Bear/template
+++ b/srcpkgs/Bear/template
@@ -1,6 +1,6 @@
 # Template file for 'Bear'
 pkgname=Bear
-version=3.1.5
+version=3.1.6
 revision=1
 build_style=cmake
 hostmakedepends="pkg-config protobuf protobuf-devel grpc"
@@ -11,8 +11,17 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-3.0-or-later"
 homepage="https://github.com/rizsotto/Bear"
 distfiles="https://github.com/rizsotto/Bear/archive/${version}.tar.gz"
-checksum=4ac7b041222dcfc7231c6570d5bd76c39eaeda7a075ee2385b84256e7d659733
+checksum=99cd891eec6e89b734d7cafe0e623dd8c2f27d8cbf3ee9bc4807e69e5c8fb55c
 
 if [ -z "$XBPS_CHECK_PKGS" ]; then
 	configure_args="-DENABLE_FUNC_TESTS=OFF -DENABLE_UNIT_TESTS=OFF"
 fi
+
+post_patch() {
+	# Change STAGED_INSTALL_PREFIX to a path in ${wrksrc}
+	vsed -i 's|set(STAGED_INSTALL_PREFIX .*|set(STAGED_INSTALL_PREFIX "${CMAKE_SOURCE_DIR}/staged")|' CMakeLists.txt
+}
+
+post_install() {
+	rm -rf ${DESTDIR}/${wrksrc}/staged
+}


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures (crossbuilds):
  - aarch64
  - armv7l
  - armv6l
  - i686

#### Description
- Update Bear to version 3.1.6
- Updated checksum
- Adjusted build to work with Bear's CMake superbuild pattern
- No upstream patching required; final install paths are clean
- Package builds and runs correctly
