### PR TITLE
python3-pynitrokey: update to 0.8.5

### DIFF
--- a/srcpkgs/python3-pynitrokey/template
+++ b/srcpkgs/python3-pynitrokey/template
@@ -1,6 +1,6 @@
 # Template file for 'python3-pynitrokey'
 pkgname=python3-pynitrokey
-version=0.8.4
+version=0.8.5
 revision=1
 build_style=python3-pep517
 make_build_args="--skip-dependency-check"
@@ -18,7 +18,7 @@ maintainer="Mateusz Sylwestrzak <slymattz@gmail.com>"
 license="LGPL-3.0-only, GPL-3.0-or-later, Apache-2.0, MIT"
 homepage="https://github.com/Nitrokey/pynitrokey"
 distfiles="https://github.com/Nitrokey/pynitrokey/archive/refs/tags/v${version}.tar.gz"
-checksum=2a00d682b7de0a02d2a0d4b8c6c6201690ecf39ec6964670f31be67afe14f2fb
+checksum=74e222c7dd0408ffe8a1f1abf22cedf8a306c6f9c5b19e2fd7cb9dafa8b6d92c
 
 post_install() {
 	vlicense LICENSES/MIT.txt


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

https://github.com/Nitrokey/pynitrokey/compare/v0.8.4...v0.8.5

> This release fixes a bug in nk3 secrets when handling base32 secrets if
> the length is a multiple of 8.

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
#### Local build testing
- I built this PR locally for my native architecture: x86_64-glibc
