### PR TITLE
povray: update to 3.7.0.10., disable fast math optimisations

### DIFF
--- a/srcpkgs/povray/template
+++ b/srcpkgs/povray/template
@@ -1,7 +1,7 @@
 # Template file for 'povray'
 pkgname=povray
-version=3.7.0.8
-revision=11
+version=3.7.0.10
+revision=1
 build_style=gnu-configure
 _v=${version%.*.*}
 configure_args="COMPILED_BY=Void --disable-optimiz-arch"
@@ -16,10 +16,15 @@ maintainer="Brenton Horne <brentonhorne77@gmail.com>"
 license="AGPL-3.0-or-later"
 homepage="http://povray.org/"
 distfiles="https://github.com/POV-Ray/povray/archive/v${version}.tar.gz"
-checksum=53d11ebd2972fc452af168a00eb83aefb61387662c10784e81b63e44aa575de4
-nocross="Builds fail on ARM architectures
- Logs are at https://travis-ci.org/void-linux/void-packages/builds/412583835."
+checksum=7bee83d9296b98b7956eb94210cf30aa5c1bbeada8ef6b93bb52228bbc83abff
 LDFLAGS+=" -Wl,-z,stack-size=1048576"
+CXXFLAGS+=" -fno-fast-math"
+make_check=ci-skip # requires input
+
+case "$XBPS_TARGET_MACHINE" in
+	*-musl) broken="package fails to build under musl";;
+	arm*|aarch64*) broken="package fails to build under ARM architectures";;
+esac
 
 pre_configure() {
 	cd $wrksrc/unix


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc

Fixes #55478 by disabling fast math optimisations
