### PR TITLE
brother-brscan3: move to nonfree

### DIFF
--- a/srcpkgs/brother-brscan3/template
+++ b/srcpkgs/brother-brscan3/template
@@ -11,6 +11,7 @@ short_desc="SANE scanner driver for brscan3-compatible Brother scanners"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="custom:BrotherEULA"
 homepage="https://support.brother.com/"
+repository="nonfree"
 nopie=yes
 nodebug=yes
 _license_checksum=4ab8b9269a74377ee85458cc4dfbacfbf6d26665426572fe16f7102af214bd3c


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **NO** since this is only a clean-up thing. 

#### More information
This move to _nonfree_ goes in compliance to what is written in **Manual.md**, namely that closed source packages should belong to the aforementioned repository.

About Brother shipping broken tarballs:
https://www.linksysinfo.org/index.php?threads/brscan3-scanner-drivers-compile-manually.35600/

Please advise whether this should be revbumped.

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
