### PR TITLE
cava: update to 0.10.4.

### DIFF
--- a/srcpkgs/cava/patches/iniparser-pkgconfig.patch
+++ b/srcpkgs/cava/patches/iniparser-pkgconfig.patch
@@ -1,15 +1,20 @@
 diff --git a/configure.ac b/configure.ac
-index 5aeda60..6913062 100644
+index 9b486f6..ef26b63 100644
 --- a/configure.ac
 +++ b/configure.ac
-@@ -423,16 +423,10 @@ dnl checking for iniparser
+@@ -423,21 +423,10 @@ dnl checking for iniparser
  dnl ######################
  
  AC_CHECK_LIB(iniparser,iniparser_load, have_iniparser=yes, have_iniparser=no)
 +    PKG_CHECK_MODULES(INIPARSER, iniparser, have_iniparser=yes, have_iniparser=no)
      if [[ $have_iniparser = "yes" ]] ; then
 -    LIBS="$LIBS -liniparser"
--      CPPFLAGS="$CPPFLAGS -I/usr/include/iniparser"
+-    if [[ $build_mac = "yes" ]] ; then
+-        CPPFLAGS="$CPPFLAGS -I/usr/local/include/iniparser/"
+-        CPPFLAGS="$CPPFLAGS -I/opt/homebrew/include/iniparser/"
+-    else
+-        CPPFLAGS="$CPPFLAGS -I/usr/include/iniparser"
+-    fi
 -    AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <iniparser.h>]],
 -      [[dictionary* ini;
 -      const char *keys[3];

--- a/srcpkgs/cava/template
+++ b/srcpkgs/cava/template
@@ -1,7 +1,7 @@
 # Template file for 'cava'
 pkgname=cava
-version=0.10.2
-revision=3
+version=0.10.4
+revision=1
 build_style=gnu-configure
 hostmakedepends="autoconf-archive automake libtool pkg-config"
 makedepends="fftw-devel iniparser-devel ncurses-devel SDL2-devel
@@ -13,7 +13,7 @@ license="MIT"
 homepage="https://github.com/karlstav/cava"
 changelog="https://github.com/karlstav/cava/releases"
 distfiles="https://github.com/karlstav/cava/archive/refs/tags/${version}.tar.gz"
-checksum=853ee78729ed3501d0cdf9c1947967ad3bfe6526d66a029b4ddf9adaa6334d4f
+checksum=5a2efedf2d809d70770f49349f28a5c056f1ba9b3f5476e78744291a468e206a
 build_options="alsa jack pipewire pulseaudio sndio"
 build_options_default="alsa jack pipewire pulseaudio sndio"
 


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures (crossbuilds):
  - aarch64
  - armv7l
  - armv6l
  - i686

#### Description
- update cava to version 0.10.4
- update checksum
- patch to force pkg-config for iniparser