### PR TITLE
xfce4-plugins: update to 1.4, adopt.

### DIFF
--- a/srcpkgs/xfce4-plugins/template
+++ b/srcpkgs/xfce4-plugins/template
@@ -1,7 +1,7 @@
 # Template file for 'xfce4-plugins'
 pkgname=xfce4-plugins
-version=1.3
-revision=4
+version=1.4
+revision=1
 build_style=meta
 depends="
 	xfce4-battery-plugin
@@ -24,10 +24,11 @@ depends="
 	xfce4-wavelan-plugin
 	xfce4-weather-plugin
 	xfce4-whiskermenu-plugin
-	xfce4-xkb-plugin"
+	xfce4-xkb-plugin
+	xfce4-smartbookmark-plugin"
 short_desc="Plugins for the Xfce4 Desktop Environment"
-maintainer="Orphaned <orphan@voidlinux.org>"
-license="BSD-2-Clause"
+maintainer="louka <louka.menard.blondin@pm.me>"
+license="Public Domain"
 homepage="https://goodies.xfce.org/"
 replaces="xfce4-kbdleds-plugin>=0
  xfce4-notes-plugin>=0


### PR DESCRIPTION
Also adds in the missing `xfce4-smartbookmark-plugin` from XFCE's goodies ecosystem.

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
