### PR TITLE
dictd: update to 1.13.3

### DIFF
--- a/srcpkgs/dictd/template
+++ b/srcpkgs/dictd/template
@@ -1,18 +1,18 @@
 # Template file for 'dictd'
 pkgname=dictd
-version=1.13.1
+version=1.13.3
 revision=1
 build_style=gnu-configure
 configure_args="--enable-dictorg --sysconfdir=/etc/dict"
 conf_files="/etc/dict/dictd.conf /etc/dict/site.info"
 hostmakedepends="flex libtool"
-makedepends="zlib-devel libmaa-devel"
+makedepends="zlib-devel libmaa-devel libfl-devel"
 short_desc="DICT protocol server"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="http://sourceforge.net/projects/dict/"
 distfiles="${SOURCEFORGE_SITE}/dict/dictd-${version}.tar.gz"
-checksum=e4f1a67d16894d8494569d7dc9442c15cc38c011f2b9631c7f1cc62276652a1b
+checksum=192129dfb38fa723f48a9586c79c5198fc4904fec1757176917314dd073f1171
 system_accounts="dictd"
 
 post_install() {


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
#### Local build testing
- I built this PR locally for my native architecture, (**x86_64-glibc**)

Attempt # 3

Previous [conversation](https://github.com/void-linux/void-packages/pull/55580)