### PR TITLE
New package: python3-pydot-4.0.0

### DIFF
--- a/srcpkgs/python3-pydot/template
+++ b/srcpkgs/python3-pydot/template
@@ -1,0 +1,18 @@
+# Template file for 'python3-pydot'
+pkgname=python3-pydot
+version=4.0.0
+revision=1
+build_style=python3-pep517
+hostmakedepends="python3-wheel"
+depends="python3 python3-parsing python3-graphviz"
+short_desc="Python 3 interface to Graphviz's Dot language"
+maintainer="strlst <satorialist@disroot.org>"
+license="MIT, Python-2.0"
+homepage="https://github.com/pydot/pydot"
+distfiles="${PYPI_SITE}/p/pydot/pydot-${version}.tar.gz"
+checksum=12f16493337cade2f7631b87c8ccd299ba2e251f3ee5d0732a058df2887afe97
+
+post_install() {
+	vlicense LICENSES/MIT.txt
+	vlicense LICENSES/Python-2.0.txt
+}


### PR DESCRIPTION
#### Reason for addition
- Pydot is a useful package building on graphviz and is required by the `gem5` simulator to generate visual output

#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_glibc