### PR TITLE
asahi-base: no need to force load module

### DIFF
--- a/srcpkgs/asahi-base/files/tinyramfs-hook-asahi.init
+++ b/srcpkgs/asahi-base/files/tinyramfs-hook-asahi.init
@@ -1,6 +1,6 @@
 modprobe apple-mailbox
 modprobe nvme-apple
-modprobe -f xhci-plat-hcd
+modprobe xhci-plat-hcd
 
 for i in $(seq 0 50); do
 	[ -e /sys/bus/platform/drivers/nvme-apple/*.nvme/nvme/nvme*/nvme*n1/ ] && break

--- a/srcpkgs/asahi-base/template
+++ b/srcpkgs/asahi-base/template
@@ -1,12 +1,12 @@
 # Template file for 'asahi-base'
 pkgname=asahi-base
-version=20250403
+version=20250603
 revision=1
 archs="aarch64*"
 build_style=meta
 depends="linux-asahi m1n1 asahi-uboot speakersafetyd dracut asahi-scripts"
 short_desc="Void Linux Apple Silicon support package"
-maintainer="Will Springer <skirmisher@protonmail.com>, dkwo <npiazza@disroot.org>"
+maintainer="dkwo <npiazza@disroot.org>, Will Springer <skirmisher@protonmail.com>"
 license="Public Domain"
 homepage="https://asahilinux.org"
 


### PR DESCRIPTION
- I tested the changes in this PR: yes
- I built this PR locally for my native architecture, (ARCH-LIBC)

No need to force load module and taint kernel; also, reorder maintainers, so that it appears in void-updates at the right place.