### PR TITLE
coturn, prosody: restrict access to configuration files

### DIFF
--- a/srcpkgs/coturn/INSTALL
+++ b/srcpkgs/coturn/INSTALL
@@ -1,5 +1,7 @@
 case "${ACTION}" in
 post)
 	setcap CAP_NET_BIND_SERVICE=+ep usr/bin/turnserver
+	chmod 640 etc/turnserver.conf
+	chown :_coturn etc/turnserver.conf
 	;;
 esac

--- a/srcpkgs/coturn/template
+++ b/srcpkgs/coturn/template
@@ -1,7 +1,7 @@
 # Template file for 'coturn'
 pkgname=coturn
 version=4.7.0
-revision=1
+revision=2
 build_style=configure
 configure_args="
  --prefix=/usr

--- a/srcpkgs/prosody/INSTALL
+++ b/srcpkgs/prosody/INSTALL
@@ -1,0 +1,6 @@
+case "${ACTION}" in
+post)
+	chmod 640 etc/prosody/prosody.cfg.lua
+	chown :prosody etc/prosody/prosody.cfg.lua
+	;;
+esac

--- a/srcpkgs/prosody/template
+++ b/srcpkgs/prosody/template
@@ -1,7 +1,7 @@
 # Template file for 'prosody'
 pkgname=prosody
 version=13.0.1
-revision=1
+revision=2
 build_style=configure
 configure_args="
  --ostype=linux


### PR DESCRIPTION
- **coturn: restrict access to the configuration file**
- **prosody: restrict access to the configuration file**

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
#### Local build testing
- I built this PR locally for my native architecture, (x86_64)
<!--
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
