### PR TITLE
*: use relative paths in INSTALL

### DIFF
--- a/Manual.md
+++ b/Manual.md
@@ -1358,8 +1358,8 @@ esac
 subpackages can also have their own `INSTALL` and `REMOVE` files, simply create them
 as `srcpkgs/<pkgname>/<subpkg>.INSTALL` or `srcpkgs/<pkgname>/<subpkg>.REMOVE` respectively.
 
-> NOTE: always use paths relative to the current working directory, otherwise if the scripts cannot
-be executed via `chroot(2)` won't work correctly.
+> NOTE: always use paths relative to the xbps root directory (`/` or specified via the `-r` flag),
+otherwise if the scripts cannot be executed via `chroot(2)` they won't work correctly.
 
 > NOTE: do not use INSTALL/REMOVE scripts to print messages, see the next section for
 more information.

--- a/srcpkgs/NetAuth-ldap/INSTALL
+++ b/srcpkgs/NetAuth-ldap/INSTALL
@@ -3,7 +3,7 @@ post)
 	# Set CAP_NET_BIND_SERVICE capability or exit gracefully if we cannot set the capability
 	# due to invalid permissions (fakeroot install).
 	set +e
-	setcap 'cap_net_bind_service=+ep' /usr/bin/ldap
+	setcap 'cap_net_bind_service=+ep' usr/bin/ldap
 	if [ $? -ne 0 ]; then
 		echo "ERROR: failed to set cap_net_bind_service capability on ldap."
 		exit 0

--- a/srcpkgs/NetAuth-ldap/template
+++ b/srcpkgs/NetAuth-ldap/template
@@ -1,7 +1,7 @@
 # Template file for 'NetAuth-ldap'
 pkgname=NetAuth-ldap
 version=0.3.0
-revision=4
+revision=5
 build_style=go
 go_import_path=github.com/netauth/ldap
 go_ldflags="-X github.com/netauth/ldap/internal/buildinfo.Version=${version}"

--- a/srcpkgs/brother-brscan3/INSTALL
+++ b/srcpkgs/brother-brscan3/INSTALL
@@ -1,6 +1,6 @@
 case "${ACTION}" in
     post)
-	ln -sf /opt/Brother /usr/local/Brother
+	ln -sf /opt/Brother usr/local/Brother
 	# add brother 3 to /etc/sane.d/dll.conf
 	opt/Brother/sane/setupSaneScan3 -i
     ;;

--- a/srcpkgs/brother-brscan3/template
+++ b/srcpkgs/brother-brscan3/template
@@ -1,7 +1,7 @@
 # Template file for 'brother-brscan3'
 pkgname=brother-brscan3
 version=0.2.13
-revision=2
+revision=3
 archs="i686 x86_64"
 create_wrksrc=yes
 hostmakedepends="curl"

--- a/srcpkgs/cnijfilter2/INSTALL
+++ b/srcpkgs/cnijfilter2/INSTALL
@@ -1,6 +1,6 @@
 case "${ACTION}" in
 	post)
-		chown cups.lp /usr/lib/bjlib2/cnnet.ini 
-		chmod 0664 /usr/lib/bjlib2/cnnet.ini
+		chown cups.lp usr/lib/bjlib2/cnnet.ini
+		chmod 0664 usr/lib/bjlib2/cnnet.ini
 		;;
 esac

--- a/srcpkgs/cnijfilter2/template
+++ b/srcpkgs/cnijfilter2/template
@@ -1,7 +1,7 @@
 # Template file for 'cnijfilter2'
 pkgname=cnijfilter2
 version=6.60
-revision=2
+revision=3
 _uprevision=-1
 archs="i686 x86_64 aarch64"
 build_style=gnu-configure

--- a/srcpkgs/maddy/INSTALL
+++ b/srcpkgs/maddy/INSTALL
@@ -1,5 +1,5 @@
 case "$ACTION" in
 post)
-	setcap 'cap_net_bind_service=+ep' /usr/bin/maddy
+	setcap 'cap_net_bind_service=+ep' usr/bin/maddy
 	;;
 esac

--- a/srcpkgs/maddy/template
+++ b/srcpkgs/maddy/template
@@ -1,7 +1,7 @@
 # Template file for 'maddy'
 pkgname=maddy
 version=0.8.1
-revision=1
+revision=2
 build_style=go
 go_import_path="github.com/foxcpp/maddy"
 go_package="$go_import_path/cmd/maddy

--- a/srcpkgs/radicale/INSTALL
+++ b/srcpkgs/radicale/INSTALL
@@ -3,10 +3,10 @@
 case ${ACTION} in
 post)
 	# fix permissions and owners
-	chown radicale:radicale /etc/radicale/config
-	chown radicale:radicale /etc/radicale/rights
-	chmod 644 /etc/radicale/config
-	chmod 640 /etc/radicale/rights
+	chown radicale:radicale etc/radicale/config
+	chown radicale:radicale etc/radicale/rights
+	chmod 644 etc/radicale/config
+	chmod 640 etc/radicale/rights
 	;;
 esac
 

--- a/srcpkgs/radicale/template
+++ b/srcpkgs/radicale/template
@@ -1,7 +1,7 @@
 # Template file for 'radicale'
 pkgname=radicale
 version=3.6.0
-revision=1
+revision=2
 build_style=python3-pep517
 hostmakedepends="python3-setuptools"
 depends="python3-vobject python3-dateutil python3-libpass python3-bcrypt

--- a/srcpkgs/runit-void/INSTALL
+++ b/srcpkgs/runit-void/INSTALL
@@ -12,7 +12,7 @@ post)
 		ln -sf default etc/runit/runsvdir/current
 	fi
 	for f in 1 2 3 4 5 6; do
-		[ -e /etc/sv/agetty-tty${f}/down ] || ln -sf /etc/sv/agetty-tty$f etc/runit/runsvdir/default
+		[ -e etc/sv/agetty-tty${f}/down ] || ln -sf /etc/sv/agetty-tty$f etc/runit/runsvdir/default
 	done
 	[ -e etc/sv/udevd/run ] && ln -sf /etc/sv/udevd etc/runit/runsvdir/default
 

--- a/srcpkgs/runit-void/runit-void-apparmor.INSTALL
+++ b/srcpkgs/runit-void/runit-void-apparmor.INSTALL
@@ -1,13 +1,13 @@
 case "$ACTION" in
 pre)
   # Fix incorrect path in /etc/default
-  if [ -e /etc/default/apparmor/rc.apparmor ]; then
-    mv /etc/default/apparmor/rc.apparmor /etc/default/rc.apparmor
-    rm -rf /etc/default/apparmor
-    mv /etc/default/rc.apparmor /etc/default/apparmor
+  if [ -e etc/default/apparmor/rc.apparmor ]; then
+    mv etc/default/apparmor/rc.apparmor etc/default/rc.apparmor
+    rm -rf etc/default/apparmor
+    mv etc/default/rc.apparmor etc/default/apparmor
   fi
-  if [ -d /etc/default/apparmor ]; then
-    rm -rf /etc/default/apparmor
+  if [ -d etc/default/apparmor ]; then
+    rm -rf etc/default/apparmor
   fi
 	;;
 esac

--- a/srcpkgs/runit-void/template
+++ b/srcpkgs/runit-void/template
@@ -1,7 +1,7 @@
 # Template file for 'runit-void'
 pkgname=runit-void
 version=20250212
-revision=2
+revision=3
 build_style=gnu-makefile
 short_desc="Void Linux runit scripts"
 maintainer="Enno Boland <gottox@voidlinux.org>"

--- a/srcpkgs/schilytools/cdrtools.INSTALL
+++ b/srcpkgs/schilytools/cdrtools.INSTALL
@@ -1,5 +1,5 @@
 if [ "$ACTION" = "post" ]; then
-	setcap cap_sys_resource,cap_dac_override,cap_sys_admin,cap_sys_nice,cap_net_bind_service,cap_ipc_lock,cap_sys_rawio+ep /usr/bin/cdrecord
-	setcap cap_dac_override,cap_sys_admin,cap_sys_nice,cap_net_bind_service,cap_sys_rawio+ep /usr/bin/cdda2wav
-	setcap cap_dac_override,cap_sys_admin,cap_net_bind_service,cap_sys_rawio+ep /usr/bin/readcd
+	setcap cap_sys_resource,cap_dac_override,cap_sys_admin,cap_sys_nice,cap_net_bind_service,cap_ipc_lock,cap_sys_rawio+ep usr/bin/cdrecord
+	setcap cap_dac_override,cap_sys_admin,cap_sys_nice,cap_net_bind_service,cap_sys_rawio+ep usr/bin/cdda2wav
+	setcap cap_dac_override,cap_sys_admin,cap_net_bind_service,cap_sys_rawio+ep usr/bin/readcd
 fi

--- a/srcpkgs/schilytools/template
+++ b/srcpkgs/schilytools/template
@@ -1,7 +1,7 @@
 # Template file for 'schilytools'
 pkgname=schilytools
 version=2024.03.21
-revision=1
+revision=2
 metapackage=yes
 build_helper="qemu"
 makedepends="acl-devel attr-devel e2fsprogs-devel libcap-progs m4"

--- a/srcpkgs/stubby/INSTALL
+++ b/srcpkgs/stubby/INSTALL
@@ -3,7 +3,7 @@ post)
 	# Set CAP_NET_BIND_SERVICE capability or exit gracefully if we cannot set the capability
 	# due to invalid permissions (fakeroot install).
 	set +e
-	setcap 'cap_net_bind_service=+ep' /usr/bin/stubby
+	setcap 'cap_net_bind_service=+ep' usr/bin/stubby
 	if [ $? -ne 0 ]; then
 		echo "ERROR: failed to set cap_net_bind_service capability on stubby."
 		exit 0

--- a/srcpkgs/stubby/template
+++ b/srcpkgs/stubby/template
@@ -1,7 +1,7 @@
 # Template file for 'stubby'
 pkgname=stubby
 version=0.4.0
-revision=1
+revision=2
 build_style=cmake
 conf_files="/etc/stubby/stubby.yml"
 makedepends="getdns-devel libyaml-devel openssl-devel"

--- a/srcpkgs/texlive2014-bin/INSTALL
+++ b/srcpkgs/texlive2014-bin/INSTALL
@@ -1,6 +1,6 @@
 case "${ACTION}" in
 post)
-	cd /opt/texlive2014-installer
+	cd opt/texlive2014-installer
 	./install-tl -repository ftp://ftp.tug.org/texlive/historic/2014/tlnet-final/ -profile void.profile
 esac
 

--- a/srcpkgs/texlive2014-bin/template
+++ b/srcpkgs/texlive2014-bin/template
@@ -1,7 +1,7 @@
 # Template file for 'texlive2014-bin'
 pkgname=texlive2014-bin
 version=2014
-revision=10
+revision=11
 archs="x86_64* i686 aarch64 arm*"
 create_wrksrc=yes
 depends="cairo pixman graphite gd poppler libsigsegv

--- a/srcpkgs/vault-acme/INSTALL
+++ b/srcpkgs/vault-acme/INSTALL
@@ -3,7 +3,7 @@ post)
 	# Set CAP_IPC_LOCK capability or exit gracefully if we cannot
 	# set the capability due to invalid permissions (fakeroot
 	# install).
-	setcap 'cap_ipc_lock=+ep' /usr/libexec/vault/acme
+	setcap 'cap_ipc_lock=+ep' usr/libexec/vault/acme
 	if [ $? -ne 0 ]; then
 		echo "ERROR: failed to set cap_ipc_lock capability on vault-acme."
 		exit 0

--- a/srcpkgs/vault-acme/template
+++ b/srcpkgs/vault-acme/template
@@ -1,7 +1,7 @@
 # Template file for 'vault-acme'
 pkgname=vault-acme
 version=0.0.9
-revision=2
+revision=3
 build_style=go
 go_import_path=github.com/remilapeyre/vault-acme
 go_package="$go_import_path/cmd/acme $go_import_path/cmd/sidecar"

--- a/srcpkgs/vault-acme/template
+++ b/srcpkgs/vault-acme/template
@@ -12,6 +12,7 @@ license="MPL-2.0"
 homepage="https://github.com/remilapeyre/vault-acme"
 distfiles="https://github.com/remilapeyre/vault-acme/archive/refs/tags/v$version.tar.gz"
 checksum=e1c8a3ef30ece81670f3e2a084fe3298433f7ad10fbb3aa531331a4a943a3e06
+make_check=no # requires https://github.com/letsencrypt/pebble which isn't packaged
 
 case "$XBPS_TARGET_MACHINE" in
 	i686*) broken="/usr/lib/go/pkg/tool/linux_386/link: mapping output file failed: cannot allocate memory";;

--- a/srcpkgs/vault/INSTALL
+++ b/srcpkgs/vault/INSTALL
@@ -3,7 +3,7 @@ post)
 	# Set CAP_IPC_LOCK capability or exit gracefully if we cannot
 	# set the capability due to invalid permissions (fakeroot
 	# install).
-	setcap 'cap_ipc_lock=+ep' /usr/bin/vault
+	setcap 'cap_ipc_lock=+ep' usr/bin/vault
 	if [ $? -ne 0 ]; then
 		echo "ERROR: failed to set cap_ipc_lock capability on vault."
 		exit 0

--- a/srcpkgs/vault/template
+++ b/srcpkgs/vault/template
@@ -1,7 +1,7 @@
 # Template file for 'vault'
 pkgname=vault
 version=1.20.0
-revision=1
+revision=2
 build_style=go
 go_import_path="github.com/hashicorp/vault"
 go_build_tags="release"

--- a/srcpkgs/vault/template
+++ b/srcpkgs/vault/template
@@ -18,6 +18,7 @@ system_accounts="_vault"
 make_dirs="/var/lib/vault 0700 _vault _vault
  /etc/vault 0750 root _vault"
 repository=nonfree
+make_check=no # requires docker to run
 
 case "$XBPS_TARGET_MACHINE" in
 	i686*) broken="/usr/lib/go/pkg/tool/linux_386/link: mapping output file failed: cannot allocate memory";;

--- a/srcpkgs/waydroid/INSTALL
+++ b/srcpkgs/waydroid/INSTALL
@@ -1,6 +1,6 @@
 case "$ACTION" in
 post)
-	if [ -f /var/lib/waydroid/waydroid_base.prop ]; then
+	if [ -f var/lib/waydroid/waydroid_base.prop ]; then
 		echo "Regenerating Waydroid configs..."
 		waydroid upgrade --offline || :
 	fi

--- a/srcpkgs/waydroid/template
+++ b/srcpkgs/waydroid/template
@@ -1,7 +1,7 @@
 # Template file for 'waydroid'
 pkgname=waydroid
 version=1.6.1
-revision=1
+revision=2
 # https://developer.android.com/ndk/guides/abis#sa
 archs="aarch64* armv7* i686* x86_64*"
 build_style=gnu-makefile


### PR DESCRIPTION
- **NetAuth-ldap: use relative paths in INSTALL**
- **brother-brscan3: use relative paths in INSTALL**
- **cnijfilter2: use relative paths in INSTALL**
- **maddy: use relative paths in INSTALL**
- **peshming: use relative paths in INSTALL**
- **radicale: use relative paths in INSTALL**
- **runit-void: use relative paths in INSTALL**
- **schilytools: use relative paths in INSTALL**
- **stubby: use relative paths in INSTALL**
- **texlive2014-bin: use relative paths in INSTALL**
- **vault-acme: use relative paths in INSTALL**
- **vault: use relative paths in INSTALL**
- **waydroid: use relative paths in INSTALL**
- **Manual: elaborate note on INSTALL script paths**

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **NO**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
#### Local build testing
- I built this PR locally for my native architecture, (x86_64)
<!--
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->

I have not bumped peshming as the distfile seems to be gone -- @jcgruenhage, is it still available somewhere? I also have not bumped vault as the test suite didn't pass for me, possibly it requires docker to run?

Cc: @classabbyamp
