### PR TITLE
virtualbox-ose: update to 7.1.10.

### DIFF
--- a/srcpkgs/virtualbox-ose/template
+++ b/srcpkgs/virtualbox-ose/template
@@ -1,6 +1,6 @@
 # Template file for 'virtualbox-ose'
 pkgname=virtualbox-ose
-version=7.1.8
+version=7.1.10
 revision=1
 short_desc="General-purpose full virtualizer for x86 hardware"
 maintainer="Orphaned <orphan@voidlinux.org>"
@@ -8,7 +8,7 @@ license="GPL-2.0-only, CDDL-1.0"
 homepage="https://www.virtualbox.org"
 changelog="https://www.virtualbox.org/wiki/Changelog"
 distfiles="http://download.virtualbox.org/virtualbox/${version%[a-z]*}/VirtualBox-${version}.tar.bz2"
-checksum=3f7132c55ac6c5f50585bfaa115d29e30b47ccf535cb0a12ff50214ddae2f63d
+checksum=7d60010a4c9102613554b46f61d17b825c30ee59d8be071e52d8aac664ca9869
 
 nopie=yes
 lib32disabled=yes
@@ -17,11 +17,11 @@ archs="x86_64"
 hostmakedepends="acpica-utils dev86 perl pkg-config qt6-tools tar yasm which glslang
  vulkan-loader"
 makedepends="device-mapper-devel docbook-xsl gsoap-devel libcap-devel libcurl-devel
- libIDL-devel libvpx-devel libXcomposite-devel libXcursor-devel qt6-tools-devel
+ libvpx-devel libXcomposite-devel libXcursor-devel qt6-tools-devel vde2-devel
  libXinerama-devel libxslt-devel opus-devel pam-devel qt6-base-devel qt6-scxml-devel
  sdl12-compat-devel xorg-server-devel libslirp-devel libtpms-devel libxml2-devel
  libvncserver-devel openssl-devel libpng-devel zlib-devel dbus-devel device-mapper-devel
- libglvnd-devel libX11-devel libXt-devel libXcursor-devel pam-devel vde2-devel SDL2-devel
+ libglvnd-devel libX11-devel libXt-devel libXcursor-devel pam-devel SDL2-devel
  SDL2_ttf-devel SDL2_gfx-devel SDL2_image-devel SDL2_net-devel SDL2_mixer-devel"
 
 if [ "$XBPS_MACHINE" = "x86_64" ]; then


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc

Support linux-6.15 and linux-6.16-rc0, no longer depends on libIDL.
