### PR TITLE
taglib: update to 2.1

### DIFF
--- a/srcpkgs/taglib/template
+++ b/srcpkgs/taglib/template
@@ -1,7 +1,7 @@
 # Template file for 'taglib'
 pkgname=taglib
-version=2.0.2
-revision=2
+version=2.1
+revision=1
 build_style=cmake
 configure_args="-DWITH_MP4=ON -DWITH_ASF=ON -DBUILD_SHARED_LIBS=ON"
 hostmakedepends="pkg-config"
@@ -11,7 +11,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="LGPL-2.1-or-later, MPL-1.1"
 homepage="https://taglib.github.io/"
 distfiles="https://github.com/taglib/taglib/archive/v${version}.tar.gz"
-checksum=0de288d7fe34ba133199fd8512f19cc1100196826eafcb67a33b224ec3a59737
+checksum=95b788b39eaebab41f7e6d1c1d05ceee01a5d1225e4b6d11ed8976e96ba90b0c
 
 taglib-devel_package() {
 	depends="${sourcepkg}>=${version}_${revision} zlib-devel"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**
I tested taglib with strawberry, kid3 and vlc. All of them work fine when reading and writing tags.
Neither ABI or API break with this update so no need to bump SHLIBS and/or rebuild the reversed dependencies.

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture: x86_64-glibc
