### PR TITLE
biblioteq: update to 2025.05.26.

### DIFF
--- a/srcpkgs/biblioteq/template
+++ b/srcpkgs/biblioteq/template
@@ -1,6 +1,6 @@
 # Template file for 'biblioteq'
 pkgname=biblioteq
-version=2025.05.17
+version=2025.05.26
 revision=1
 build_style=qmake
 build_helper=qmake6
@@ -13,7 +13,7 @@ maintainer="Rutpiv <roger_freitas@live.com>"
 license="BSD-3-Clause"
 homepage="https://textbrowser.github.io/biblioteq/"
 distfiles="https://github.com/textbrowser/biblioteq/archive/${version}.tar.gz"
-checksum=9b6a72c3e502f5e2e765d09793beb0797271569d085340e1385b81f4f4c8b8cb
+checksum=1c383eb268ce5daa8fbeda710bb4b512e2249ae8c62631516e726a8db3b41c33
 conf_files="/etc/biblioteq.conf"
 
 # Set the appropriate build helper and dependencies based on architecture


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures using specific masterdirs:
  - x86_64-musl
  - i686
- I built this PR locally for these architectures (crossbuilds):
  - aarch64
  - aarch64-musl
  - armv7l
  - armv7l-musl
  - armv6l
  - armv6l-musl