### PR TITLE
vnstat: make gd dependency optional.

### DIFF
--- a/srcpkgs/vnstat/template
+++ b/srcpkgs/vnstat/template
@@ -4,7 +4,7 @@ version=2.13
 revision=1
 build_style=gnu-configure
 hostmakedepends="pkg-config"
-makedepends="gd-devel sqlite-devel"
+makedepends="sqlite-devel $(vopt_if gd gd-devel)"
 checkdepends="check-devel"
 short_desc="Terminal based network traffic monitor"
 maintainer="Duncaen <duncaen@voidlinux.org>"
@@ -13,7 +13,9 @@ homepage="https://humdi.net/vnstat/"
 changelog="https://humdi.net/vnstat/CHANGES"
 distfiles="https://humdi.net/vnstat/vnstat-${version}.tar.gz"
 checksum=c9fe19312d1ec3ddfbc4672aa951cf9e61ca98dc14cad3d3565f7d9803a6b187
-
+build_options="gd"
+build_options_default="gd"
+desc_option_gd="Enable support for image output"
 conf_files="/etc/vnstat.conf"
 make_dirs="/var/lib/vnstat 0755 root root"
 


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, **x86-64_glibc** (and tested with enabled dependency)
- I built this PR locally as cross for **aarch64** (and tested, with disabled dependency)

This in turn drops dependencies for at least these:
`brotli libpng freetype fontconfig libXau libXdmcp libxcb libX11 libXext libICE libSM libXt libXpm x265 libde265 libaom libheif libjpeg-turbo libsharpyuv libwebp jbigkit-libs tiff`
Which, I thought, shouldn't be necessary on a VPS.
CC @Duncaen as maintainer