### PR TITLE
Vulkan-Utility-Libraries: update to 1.4.313.0.

### DIFF
--- a/srcpkgs/Vulkan-Utility-Libraries/template
+++ b/srcpkgs/Vulkan-Utility-Libraries/template
@@ -1,6 +1,6 @@
 # Template file for 'Vulkan-Utility-Libraries'
 pkgname=Vulkan-Utility-Libraries
-version=1.3.296.0
+version=1.4.313.0
 revision=1
 build_style=cmake
 configure_args="-Wno-dev -DVULKAN_HEADERS_INSTALL_DIR=${XBPS_CROSS_BASE}/usr"
@@ -11,4 +11,4 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="Apache-2.0"
 homepage="https://www.khronos.org/vulkan/"
 distfiles="https://github.com/KhronosGroup/Vulkan-Utility-Libraries/archive/vulkan-sdk-${version}.tar.gz"
-checksum=d9f15c444b0cc596a9c49ffef8e67336ec08a793f7afd7ebb64aec9f6c218423
+checksum=3e04f32c6023997c153ad4b63e2fd344257e40a57ff5229ab7373e08a4fa2dd2

--- a/srcpkgs/Vulkan-Utility-Libraries/update
+++ b/srcpkgs/Vulkan-Utility-Libraries/update
@@ -1,0 +1,1 @@
+pattern="/vulkan-sdk-\K[0-9.]+(?=.tar.gz)"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (crossbuilds):
  - aarch64
  - armv7l
  - armv6l
  - i686

#### Description
- Update version
- Update checksum
- Add pattern for automated update checks
- Depends on `Vulkan-Headers 1.4.313.0` (updated in #55643)