### PR TITLE
Vulkan/SPIR-V packages update to 1.4.313.0.

### DIFF
--- a/srcpkgs/SPIRV-Headers/template
+++ b/srcpkgs/SPIRV-Headers/template
@@ -1,7 +1,7 @@
 # Template file for 'SPIRV-Headers'
 pkgname=SPIRV-Headers
-reverts="1.5.4.raytracing.fixed_1 1.5.3_2 1.5.3_1 1.5.1_1 1.4.1_1"
-version=1.3.296.0
+reverts="1.5.4.raytracing.fixed_1 1.5.3_2 1.5.3_1 1.5.1_1"
+version=1.4.313.0
 revision=1
 build_style=cmake
 short_desc="Machine-readable files for the SPIR-V Registry"
@@ -9,7 +9,7 @@ maintainer="Daniel Martinez <danielmartinez@cock.li>"
 license="MIT"
 homepage="https://github.com/KhronosGroup/SPIRV-Headers"
 distfiles="https://github.com/KhronosGroup/SPIRV-Headers/archive/vulkan-sdk-${version}.tar.gz"
-checksum=1423d58a1171611d5aba2bf6f8c69c72ef9c38a0aca12c3493e4fda64c9b2dc6
+checksum=f68be549d74afb61600a1e3a7d1da1e6b7437758c8e77d664909f88f302c5ac1
 
 post_install() {
 	vlicense LICENSE

--- a/srcpkgs/SPIRV-Headers/update
+++ b/srcpkgs/SPIRV-Headers/update
@@ -1,1 +1,1 @@
-pattern="/sdk-\K[0-9.]+(?=.tar.gz)"
+pattern="/vulkan-sdk-\K[0-9.]+(?=.tar.gz)"

--- a/srcpkgs/SPIRV-LLVM-Translator/template
+++ b/srcpkgs/SPIRV-LLVM-Translator/template
@@ -1,6 +1,6 @@
 # Template file for 'SPIRV-LLVM-Translator'
 pkgname=SPIRV-LLVM-Translator
-version=18.1.3
+version=18.1.13
 revision=1
 build_style=cmake
 configure_args="-Wno-dev -DLLVM_LINK_LLVM_DYLIB=ON -DCMAKE_SKIP_RPATH=ON
@@ -13,7 +13,7 @@ maintainer="Daniel Martinez <danielmartinez@cock.li>"
 license="NCSA"
 homepage="https://github.com/KhronosGroup/SPIRV-LLVM-Translator"
 distfiles="https://github.com/KhronosGroup/SPIRV-LLVM-Translator/archive/refs/tags/v${version}.tar.gz"
-checksum=d896f35102c3ba9e16ead7b4db53b75e6131982cdb36a3324f17c68a43598759
+checksum=786ae5dd473091b8d984581f70ace2ad6580bef5a7a1f60b6d21274f550daf7e
 
 alternatives="llvm-spirv:llvm-spirv:/usr/bin/llvm-spirv-${version%.*.*}"
 

--- a/srcpkgs/SPIRV-LLVM-Translator19/template
+++ b/srcpkgs/SPIRV-LLVM-Translator19/template
@@ -1,6 +1,6 @@
 # Template file for 'SPIRV-LLVM-Translator19'
 pkgname=SPIRV-LLVM-Translator19
-version=19.1.2
+version=19.1.8
 revision=1
 _llvm_ver=${version%%.*}
 build_style=cmake
@@ -16,7 +16,7 @@ maintainer="Daniel Martinez <danielmartinez@cock.li>"
 license="NCSA"
 homepage="https://github.com/KhronosGroup/SPIRV-LLVM-Translator"
 distfiles="https://github.com/KhronosGroup/SPIRV-LLVM-Translator/archive/refs/tags/v${version}.tar.gz"
-checksum=67be5fd119a0a575b82289f870064198484eb41f0591f557166a6c1884c906bf
+checksum=9b1c4a0cf164061f7680b82a6733026518c50b2b298ce0927aa5220222eaa7b5
 
 alternatives="llvm-spirv:llvm-spirv:/usr/bin/llvm-spirv-${_llvm_ver}"
 

--- a/srcpkgs/SPIRV-Tools/template
+++ b/srcpkgs/SPIRV-Tools/template
@@ -1,6 +1,6 @@
 # Template file for 'SPIRV-Tools'
 pkgname=SPIRV-Tools
-version=2024.4
+version=2025.1
 revision=1
 build_style=cmake
 configure_args="-DSPIRV_SKIP_TESTS=ON -DSPIRV_WERROR=OFF
@@ -13,7 +13,7 @@ license="Apache-2.0"
 homepage="https://github.com/KhronosGroup/SPIRV-Tools"
 changelog="https://raw.githubusercontent.com/KhronosGroup/SPIRV-Tools/master/CHANGES"
 distfiles="https://github.com/KhronosGroup/SPIRV-Tools/archive/refs/tags/v${version}.rc1.tar.gz"
-checksum=7f44b9bc780a5b8c54637b722e4f9f2a2b7dd04840a79890dd4bcf615faf6b0c
+checksum=b04b1f00960664319321a58f513fd33eecca19a1460047bbdf3da8fd0c46d2f2
 LDFLAGS="-Wl,--no-undefined"
 
 SPIRV-Tools-devel_package() {

--- a/srcpkgs/SPIRV-Tools/update
+++ b/srcpkgs/SPIRV-Tools/update
@@ -1,0 +1,1 @@
+pattern="/v\K[0-9.]+(?=.tar.gz)"

--- a/srcpkgs/Vulkan-Headers/template
+++ b/srcpkgs/Vulkan-Headers/template
@@ -1,6 +1,6 @@
 # Template file for 'Vulkan-Headers'
 pkgname=Vulkan-Headers
-version=1.3.296.0
+version=1.4.313.0
 revision=1
 build_style=cmake
 short_desc="Vulkan header files"
@@ -8,4 +8,4 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="Apache-2.0"
 homepage="https://www.khronos.org/vulkan/"
 distfiles="https://github.com/KhronosGroup/Vulkan-Headers/archive/vulkan-sdk-${version}.tar.gz"
-checksum=1e872a0be3890784bbe68dcd89b7e017fed77ba95820841848718c98bda6dc33
+checksum=20743c99a96c07290f24377360e7a12bdd2c465ba202e0c7ef2ec25d446cf61d

--- a/srcpkgs/Vulkan-Headers/update
+++ b/srcpkgs/Vulkan-Headers/update
@@ -1,1 +1,1 @@
-pattern="/sdk-\K[0-9.]+(?=.tar.gz)"
+pattern="/vulkan-sdk-\K[0-9.]+(?=.tar.gz)"

--- a/srcpkgs/Vulkan-Tools/template
+++ b/srcpkgs/Vulkan-Tools/template
@@ -1,6 +1,6 @@
 # Template file for 'Vulkan-Tools'
 pkgname=Vulkan-Tools
-version=1.3.296.0
+version=1.4.313.0
 revision=1
 build_style=cmake
 configure_args="-DGLSLANG_INSTALL_DIR=/usr
@@ -14,4 +14,4 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="Apache-2.0"
 homepage="https://www.khronos.org/vulkan/"
 distfiles="https://github.com/KhronosGroup/Vulkan-Tools/archive/vulkan-sdk-${version}.tar.gz"
-checksum=6f90bff4a908688cb6baf076933613a8ee8589e21c7dc3c3ba843afbd7dd84e3
+checksum=6b88045c8cad7bd042e202826d8b597c657b9a422ca1f89fc3b0ab2dd64c5a0f

--- a/srcpkgs/Vulkan-Tools/update
+++ b/srcpkgs/Vulkan-Tools/update
@@ -1,1 +1,1 @@
-pattern="/sdk-\K[0-9.]+(?=.tar.gz)"
+pattern="/vulkan-sdk-\K[0-9.]+(?=.tar.gz)"

--- a/srcpkgs/Vulkan-Utility-Libraries/template
+++ b/srcpkgs/Vulkan-Utility-Libraries/template
@@ -1,6 +1,6 @@
 # Template file for 'Vulkan-Utility-Libraries'
 pkgname=Vulkan-Utility-Libraries
-version=1.3.296.0
+version=1.4.313.0
 revision=1
 build_style=cmake
 configure_args="-Wno-dev -DVULKAN_HEADERS_INSTALL_DIR=${XBPS_CROSS_BASE}/usr"
@@ -11,4 +11,4 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="Apache-2.0"
 homepage="https://www.khronos.org/vulkan/"
 distfiles="https://github.com/KhronosGroup/Vulkan-Utility-Libraries/archive/vulkan-sdk-${version}.tar.gz"
-checksum=d9f15c444b0cc596a9c49ffef8e67336ec08a793f7afd7ebb64aec9f6c218423
+checksum=3e04f32c6023997c153ad4b63e2fd344257e40a57ff5229ab7373e08a4fa2dd2

--- a/srcpkgs/Vulkan-Utility-Libraries/update
+++ b/srcpkgs/Vulkan-Utility-Libraries/update
@@ -1,0 +1,1 @@
+pattern="/vulkan-sdk-\K[0-9.]+(?=.tar.gz)"

--- a/srcpkgs/Vulkan-ValidationLayers/template
+++ b/srcpkgs/Vulkan-ValidationLayers/template
@@ -1,6 +1,6 @@
 # Template file for 'Vulkan-ValidationLayers'
 pkgname=Vulkan-ValidationLayers
-version=1.3.296.0
+version=1.4.313.0
 revision=1
 build_style=cmake
 configure_args="-Wno-dev
@@ -15,4 +15,4 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="Apache-2.0"
 homepage="https://www.khronos.org/vulkan/"
 distfiles="https://github.com/KhronosGroup/Vulkan-ValidationLayers/archive/vulkan-sdk-${version}.tar.gz"
-checksum=dea290d614c71eeb512452dff1555f907a405a5a21baefcf41b5548d5d0fe157
+checksum=49b8ee6c2352157b12b1c87eb1165bc0f82a885bc2135ad97041ac84f79aacd0

--- a/srcpkgs/Vulkan-ValidationLayers/update
+++ b/srcpkgs/Vulkan-ValidationLayers/update
@@ -1,1 +1,1 @@
-pattern="/sdk-\K[0-9.]+(?=.tar.gz)"
+pattern="/vulkan-sdk-\K[0-9.]+(?=.tar.gz)"

--- a/srcpkgs/vulkan-loader/template
+++ b/srcpkgs/vulkan-loader/template
@@ -1,7 +1,7 @@
 # Template file for 'vulkan-loader'
 pkgname=vulkan-loader
-version=1.3.261.1
-revision=2
+version=1.4.313.0
+revision=1
 build_style=cmake
 configure_args="-Wno-dev -DVULKAN_HEADERS_INSTALL_DIR=${XBPS_CROSS_BASE}/usr
  -DBUILD_TESTS=OFF"
@@ -12,8 +12,8 @@ short_desc="Vulkan Installable Client Driver (ICD) loader"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="Apache-2.0"
 homepage="https://www.khronos.org/vulkan/"
-distfiles="https://github.com/KhronosGroup/Vulkan-Loader/archive/sdk-${version}.tar.gz"
-checksum=f85f0ea57b63750d4ddaf6c8649df781c4777006daa3cd772b01e7b5ed02f3f2
+distfiles="https://github.com/KhronosGroup/Vulkan-Loader/archive/vulkan-sdk-${version}.tar.gz"
+checksum=c736fa79d974c3513f5573b74249ed002aab59f1d15d1c13fc1d00644830869a
 
 vulkan-loader-devel_package() {
 	depends="${sourcepkg}>=${version}_${revision} Vulkan-Headers"

--- a/srcpkgs/vulkan-loader/update
+++ b/srcpkgs/vulkan-loader/update
@@ -1,3 +1,3 @@
 _pkgname=Vulkan-Loader
 site="https://github.com/KhronosGroup/${_pkgname}/tags"
-pattern="/releases/tag/sdk-\K\d.\d.\d+.\d(?=)"
+pattern="/releases/tag/vulkan-sdk-\K\d.\d.\d+.\d(?=)"

--- a/srcpkgs/zeux-volk/template
+++ b/srcpkgs/zeux-volk/template
@@ -1,6 +1,6 @@
 # Template file for 'zeux-volk'
 pkgname=zeux-volk
-version=1.3.296.0
+version=1.4.313.0
 revision=1
 build_style=cmake
 configure_args="-DVULKAN_HEADERS_INSTALL_DIR=${XBPS_CROSS_BASE}/usr -DVOLK_INSTALL=ON -Wno-dev"
@@ -10,7 +10,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
 homepage="https://github.com/zeux/volk"
 distfiles="https://github.com/zeux/volk/archive/vulkan-sdk-${version}.tar.gz"
-checksum=8ffd0e81e29688f4abaa39e598937160b098228f37503903b10d481d4862ab85
+checksum=d86bcf1aff499f41a3e445b55df5e393a5ce49b1bda689eb7335b0a0a54a3c0b
 
 post_install() {
 	vlicense LICENSE.md

--- a/srcpkgs/zeux-volk/update
+++ b/srcpkgs/zeux-volk/update
@@ -1,0 +1,1 @@
+pattern="/vulkan-sdk-\K[0-9.]+(?=.tar.gz)"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (crossbuilds):
  - aarch64
  - armv7l
  - armv6l
  - i686

#### Description
- Updated packages to `Vulkan SDK 1.4.313.0.`
- Updated/created `update` pattern for automated update checks.