### PR TITLE
Soapy SDR plugins update

### DIFF
--- a/srcpkgs/SoapyAirspy/template
+++ b/srcpkgs/SoapyAirspy/template
@@ -1,7 +1,7 @@
 # Template file for 'SoapyAirspy'
 pkgname=SoapyAirspy
-version=0.1.2
-revision=2
+version=0.2.0
+revision=1
 build_style=cmake
 hostmakedepends="pkg-config"
 makedepends="SoapySDR-devel libairspy-devel"
@@ -10,7 +10,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
 homepage="https://github.com/pothosware/SoapyAirspy"
 distfiles="${homepage}/archive/soapy-airspy-${version}.tar.gz"
-checksum=3c0bafd27063df1cbc7913c0b5d3d1d9a0624d25d290f0818261ae52d0f29ee8
+checksum=4279ab4278fab699ef8325f3f921b2307496130a56028d33022be10916b6ccff
 
 post_install() {
 	vlicense LICENSE.txt LICENSE

--- a/srcpkgs/SoapyHackRF/template
+++ b/srcpkgs/SoapyHackRF/template
@@ -1,7 +1,7 @@
 # Template file for 'SoapyHackRF'
 pkgname=SoapyHackRF
-version=0.3.3
-revision=3
+version=0.3.4
+revision=1
 build_style=cmake
 hostmakedepends="pkg-config"
 makedepends="SoapySDR-devel libhackrf-devel"
@@ -10,7 +10,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
 homepage="https://github.com/pothosware/SoapyHackRF"
 distfiles="${homepage}/archive/soapy-hackrf-${version}.tar.gz"
-checksum=7b24a47cee42156093bf82982b4fc6184a7c86101c3b8ee450274e57ee1c4b90
+checksum=c7a1b8aee7af9d9e11e42aa436eae8508f19775cdc8bc52e565a5d7f2e2e43ed
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (crossbuilds):
  - aarch64
  - armv7l
  - armv6l
  - i686

Update versions and checksums for Soapy SDR plugins: `SoapyHackRF` and `SoapyAirspy`