### PR TITLE
cmark: update to 0.31.1.

### DIFF
--- a/srcpkgs/cmark/template
+++ b/srcpkgs/cmark/template
@@ -1,19 +1,21 @@
 # Template file for 'cmark'
 pkgname=cmark
-version=0.30.3
+version=0.31.1
 revision=1
 build_style=cmake
+configure_args="-DBUILD_SHARED_LIBS=ON"
 short_desc="CommonMark parsing and rendering library and program in C"
 maintainer="pancake <pancake@nopcode.org>"
 license="MIT"
 homepage="https://github.com/commonmark/cmark"
 distfiles="https://github.com/commonmark/cmark/archive/${version}.tar.gz"
-checksum=85e9fb515531cc2c9ae176d693f9871774830cf1f323a6758fb187a5148d7b16
+checksum=3da93db5469c30588cfeb283d9d62edfc6ded9eb0edc10a4f5bbfb7d722ea802
+conflicts="python3-commonmark"
 
 pre_configure() {
 	# Fix the SONAME version to use just the major number
 	vsed -i src/CMakeLists.txt \
-		 -e 's;\(SOVERSION ${PROJECT_VERSION_MAJOR}\).*;\1;'
+		-e 's/SOVERSION ${PROJECT_VERSION}/SOVERSION ${PROJECT_VERSION_MAJOR}/'
 }
 
 post_install() {
@@ -26,7 +28,6 @@ cmark-devel_package() {
 	pkg_install() {
 		vmove usr/include
 		vmove "usr/lib/*.so"
-		vmove "usr/lib/*.a"
 		vmove usr/lib/pkgconfig
 		vmove usr/lib/cmake
 		vmove usr/share/man/man3


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibx)
- I built this PR locally for these architectures (crossbuilds):
  - aarch64
  - armv7l
  - armv6l
  - i686

Updated version and checksum. Modify `pre_configure()` to fix SONAME version. Remove handling of `*.a` static library files during installation as upstream no longer builds static library files by default. Added CMake `BUILD_SHARED_LIBS` flag to control shared/static builds as per CMake recommendations, aligns with upstream changes. Added conflict with `python3-commonmark`.