### PR TITLE
bibiman: update to 0.12.3

### DIFF
--- a/srcpkgs/bibiman/template
+++ b/srcpkgs/bibiman/template
@@ -1,6 +1,6 @@
 # Template file for 'bibiman'
 pkgname=bibiman
-version=0.12.2
+version=0.12.3
 revision=1
 build_style=cargo
 short_desc="TUI for managing and working with BibLaTeX files"
@@ -8,4 +8,4 @@ maintainer="lukeflo <lukeflo_git@posteo.de>"
 license="GPL-3.0-or-later"
 homepage="https://codeberg.org/lukeflo/bibiman"
 distfiles="https://codeberg.org/lukeflo/bibiman/archive/v${version}.tar.gz"
-checksum=cfdcf35b30752ac5aa1a3e8639cea20b8fc53e5cacd9ad1e81b4536e1c295ccb
+checksum=534e22fc10058f07c8ee42093d9f766651e0850dd3a974ee4d92cf84b124e37a


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (x86_64 glibc)

Minor bugfix regarding expansion of tilde into home dir, which was broken after the last release two days ago.