### PR TITLE
skanpage: depend on sane-airscan

### DIFF
--- a/srcpkgs/skanpage/template
+++ b/srcpkgs/skanpage/template
@@ -9,7 +9,7 @@ hostmakedepends="extra-cmake-modules gettext qt6-base qt6-tools kf6-kcoreaddons 
 makedepends="qt6-base-devel libksane6-devel kf6-kcoreaddons-devel kf6-ki18n-devel
  kf6-kirigami-devel kf6-kcrash-devel ksanecore6-devel kf6-kconfig-devel kf6-purpose-devel
  kf6-kxmlgui-devel kquickimageeditor-devel leptonica-devel tesseract-ocr-devel libgomp-devel qt6-pdf-devel"
-depends="kf6-kirigami kf6-qqc2-desktop-style kquickimageeditor"
+depends="kf6-kirigami kf6-qqc2-desktop-style kquickimageeditor sane-airscan"
 short_desc="Multi-page scanning application"
 maintainer="Enrico Belleri <idesmi@protonmail.com>"
 license="GPL-2.0-or-later"


### PR DESCRIPTION
"Driverless" (WSD) network scanning is not functional in Skanpage unless `sane-airscan` is installed. This package provides critical functionality to Skanpage and should be included as a dependency.

Currently there are no revdeps for `sane-airscan`, so the only way to get this package is to troubleshoot Skanpage until you realize it's required, and then install it manually.

The Flatpak distribution of Skanpage is capable of WSD scanning out of the box, but Void's version is missing features comparatively without this change!

#### Testing the changes
- I tested the changes in this PR: **YES**
