### PR TITLE
syncplay: update to 1.7.4, support TLS

### DIFF
--- a/srcpkgs/syncplay/template
+++ b/srcpkgs/syncplay/template
@@ -1,15 +1,15 @@
 # Template file for 'syncplay'
 pkgname=syncplay
-version=1.7.3
-revision=2
+version=1.7.4
+revision=1
 build_style=gnu-makefile
 pycompile_dirs="usr/lib/syncplay/syncplay"
 depends="desktop-file-utils python3-pyside6 python3-Twisted
- qt6-declarative python3-service_identity"
+ qt6-declarative python3-service_identity python3-pem"
 short_desc="Free software that synchronises media players"
-maintainer="KeepBotting <branon.mcclellan@gmail.com>"
+maintainer="KeepBotting <branon@branon.me>"
 license="Apache-2.0"
 homepage="https://syncplay.pl/"
 distfiles="https://github.com/syncplay/syncplay/archive/v${version}.tar.gz"
-checksum=5aaea59dab1a9f673019b6e59742ec8bb94248b7913b5f57423775ca905f1c0e
+checksum=ec97045bed0a8e185f7daada179fb6b6d71d9457122d0ede29c5be1235ff551d
 python_version=3


### PR DESCRIPTION
Update to latest, add missing dependency required to support TLS connections to SyncPlay servers, and update my maintainer email

#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc