### PR TITLE
podman-tui: update to 1.6.1

### DIFF
--- a/srcpkgs/podman-tui/template
+++ b/srcpkgs/podman-tui/template
@@ -1,6 +1,6 @@
 # Template file for 'podman-tui'
 pkgname=podman-tui
-version=1.5.0
+version=1.6.1
 revision=1
 build_style=go
 go_import_path="github.com/containers/podman-tui"
@@ -12,7 +12,7 @@ license="Apache-2.0"
 homepage="https://github.com/containers/podman-tui"
 changelog="https://github.com/containers/podman-tui/releases"
 distfiles="https://github.com/containers/podman-tui/archive/refs/tags/v${version}.tar.gz"
-checksum=d9ba16d37f959d7ae5ca6650c3ccc7b0e1a726215791c99604f8f5955ee8f61d
+checksum=a241119e1099711f889bae6fa7061130869317b711a96e3e9df2fed45e6fc979
 
 post_install() {
 	vdoc docs/README.md


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl
  - aarch64-musl
  - aarch64
  - i686
  - armv7l-musl
  - armv7l
  - armv6l-musl
  - armv6l

