### PR TITLE
dav1d: update to 1.5.1

### DIFF
--- a/srcpkgs/dav1d/template
+++ b/srcpkgs/dav1d/template
@@ -1,6 +1,6 @@
 # Template file for 'dav1d'
 pkgname=dav1d
-version=1.3.0
+version=1.5.1
 revision=1
 build_style=meson
 configure_args="-Denable_asm=true -Denable_tools=true -Dfuzzing_engine=none
@@ -11,7 +11,7 @@ license="BSD-2-Clause"
 homepage="https://code.videolan.org/videolan/dav1d"
 changelog="https://code.videolan.org/videolan/dav1d/raw/master/NEWS"
 distfiles="https://code.videolan.org/videolan/dav1d/-/archive/${version}/dav1d-${version}.tar.bz2"
-checksum=bde8db3d0583a4f3733bb5a4ac525556ffd03ab7dcd8a6e7c091bee28d9466b1
+checksum=4eddffd108f098e307b93c9da57b6125224dc5877b1b3d157b31be6ae8f1f093
 
 if [ "$XBPS_CHECK_PKGS" ]; then
 	configure_args+=" -Denable_tests=true"


### PR DESCRIPTION
#### I successfully tested:

- `mpv` decoding with `libdav1d` (at least according to the on-screen info script)
- Opening `.avif` files with `mpv`
- Opening `.avif` or `.svg` files with `swayimg`
- Rendering `.avif` or .`svg` files with `chafa` inside `foot` terminal

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
#### Local build testing
- I built this PR locally for my native architecture, (**x86_64-glibc**)

