### PR TITLE
openvpn: update to 2.6.14, adopt

### DIFF
--- a/srcpkgs/openvpn/template
+++ b/srcpkgs/openvpn/template
@@ -1,7 +1,7 @@
 # Template file for 'openvpn'
 pkgname=openvpn
-version=2.6.12
-revision=2
+version=2.6.14
+revision=1
 build_style=gnu-configure
 configure_args="$(vopt_enable pkcs11) --disable-systemd
  $(vopt_if mbedtls --with-crypto-library=mbedtls)"
@@ -11,12 +11,12 @@ makedepends="$(vopt_if mbedtls mbedtls-devel openssl-devel) libcap-ng-devel
  $(vopt_if pkcs11 pkcs11-helper-devel)"
 checkdepends="cmocka-devel"
 short_desc="Easy-to-use, robust, and highly configurable VPN"
-maintainer="Orphaned <orphan@voidlinux.org>"
+maintainer="TheGejr <maltegejr.korup@gmail.com>"
 license="GPL-2.0-only"
 homepage="https://www.openvpn.net"
 changelog="https://raw.githubusercontent.com/OpenVPN/openvpn/release/${version%.*}/Changes.rst"
 distfiles="https://build.openvpn.net/downloads/releases/openvpn-${version}.tar.gz"
-checksum=1c610fddeb686e34f1367c347e027e418e07523a10f4d8ce4a2c2af2f61a1929
+checksum=9eb6a6618352f9e7b771a9d38ae1631b5edfeed6d40233e243e602ddf2195e7a
 # t_net.sh fails on CI.
 make_check=ci-skip
 


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl
  - aarch64-musl
  - aarch64
  - i686
  - armv7l-musl
  - armv7l
  - armv6l-musl
  - armv6l