### PR TITLE
sway: update to 1.11.

### DIFF
--- a/srcpkgs/sway/template
+++ b/srcpkgs/sway/template
@@ -1,12 +1,12 @@
 # Template file for 'sway'
 pkgname=sway
-version=1.10.1
+version=1.11
 revision=1
 build_style=meson
 configure_args="-Dwerror=false -Db_ndebug=false"
 conf_files="/etc/sway/config"
 hostmakedepends="pkg-config wayland-devel scdoc"
-makedepends="wlroots0.18-devel pcre2-devel json-c-devel pango-devel cairo-devel
+makedepends="wlroots0.19-devel pcre2-devel json-c-devel pango-devel cairo-devel
  gdk-pixbuf-devel libevdev-devel"
 depends="libcap-progs swaybg xorg-server-xwayland libxkbcommon>=1.5.0_1"
 short_desc="Tiling Wayland compositor compatible with i3"
@@ -15,7 +15,7 @@ license="MIT"
 homepage="https://swaywm.org"
 changelog="https://github.com/swaywm/sway/releases"
 distfiles="https://github.com/swaywm/sway/archive/refs/tags/${version}.tar.gz"
-checksum=8565ab3b359780f02b1dcb24dc48e5b6b82c64dd97ca795782c2fb4cab62457b
+checksum=034ec4519326d6af5275814700dde46e852c5174614109affe4c86b2fbee062a
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**
- I've been personally using Sway 1.11 on my system with this template for a while now, and it works fine. Haven't noticed any issues or regressions.

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
