### PR TITLE
gradle: revert to 8.11.1

### DIFF
--- a/srcpkgs/gradle/template
+++ b/srcpkgs/gradle/template
@@ -1,7 +1,8 @@
 # Template file for 'gradle'
 pkgname=gradle
-version=8.14.1
-revision=1
+reverts="8.14.1_1"
+version=8.11.1
+revision=2
 depends="virtual?java-environment"
 short_desc="Build system for Java/C/C++ software"
 maintainer="Bnyro <bnyro@tutanota.com>"
@@ -9,7 +10,7 @@ license="Apache-2.0"
 homepage="https://gradle.org/"
 changelog="https://docs.gradle.org/${version}/release-notes.html"
 distfiles="https://services.gradle.org/distributions/gradle-${version}-bin.zip"
-checksum=845952a9d6afa783db70bb3b0effaae45ae5542ca2bb7929619e8af49cb634cf
+checksum=f397b287023acdba1e9f6fc5ea72d22dd63669d59ed4a289a29b1a76eee151c6
 
 do_install() {
 	vmkdir "usr/lib/gradle"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc (cross with -musl masterdir)

It appears that starting with gradle 8.12, musl builds no longer work: see https://github.com/gradle/gradle/issues/31939.

To reproduce:
```
$ ./xbps-src binary-bootstrap -A x86_64-musl
$ ./xbps-src pkg Apktool -A x86_64-musl
```
For more context, see https://github.com/void-linux/void-packages/pull/51361.