### PR TITLE
checkbashisms: update to 2.25.14, adopt

### DIFF
--- a/srcpkgs/checkbashisms/template
+++ b/srcpkgs/checkbashisms/template
@@ -1,16 +1,16 @@
 # Template file for 'checkbashisms'
 pkgname=checkbashisms
-version=2.23.7
+version=2.25.14
 revision=1
 depends="perl"
 checkdepends="shunit2 perl"
 short_desc="Debian script that checks for bash-isms"
-maintainer="Orphaned <orphan@voidlinux.org>"
+maintainer="TheGejr <maltegejr.korup@gmail.com>"
 license="GPL-2.0-or-later"
 homepage="https://tracker.debian.org/pkg/devscripts"
 changelog="https://salsa.debian.org/debian/devscripts/-/raw/master/debian/changelog"
 distfiles="${DEBIAN_SITE}/main/d/devscripts/devscripts_${version}.tar.xz"
-checksum=9ce9e5135472d8647e2ffb56655e00391e8e99aa7a4a8ae605cf0e1ffd9f3609
+checksum=cfde413a018d605be57aa0aff1ee81ed397dd713f38101e4731220e7999a5ef4
 
 pre_install() {
 	vsed -i "s|###VERSION###|${version}|" scripts/checkbashisms.pl


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **yes**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - aarch64
  - i686
  - armv7l-musl
  - armv7l
  - armv6l-musl
  - armv6l