### PR TITLE
Komikku: update to 1.79.1.

### DIFF
--- a/srcpkgs/Komikku/template
+++ b/srcpkgs/Komikku/template
@@ -1,24 +1,24 @@
 # Template file for 'Komikku'
 pkgname=Komikku
-version=1.75.0
+version=1.79.1
 revision=1
 build_style=meson
 build_helper=gir
 hostmakedepends="gettext glib-devel pkg-config desktop-file-utils
  gtk-update-icon-cache blueprint-compiler"
 makedepends="gtk4-devel libadwaita-devel"
-depends="gtk4 libadwaita>=1.7.0 libnotify libsecret python3-BeautifulSoup4 python3-Brotli
+depends="gtk4 libadwaita libnotify libsecret python3-BeautifulSoup4 python3-Brotli
  python3-Pillow python3-Unidecode python3-requests python3-dateparser
  python3-gobject python3-keyring python3-lxml python3-magic python3-rarfile
  python3-natsort python3-pure-protobuf python3-emoji libwebkitgtk60
- python3-piexif python3-colorthief python3-pillow_heif"
+ python3-piexif python3-modern_colorthief python3-pillow_heif"
 checkdepends="appstream-glib desktop-file-utils"
 short_desc="Online/offline manga reader for GNOME"
-maintainer="fanyx <fanyx@posteo.net>"
+maintainer="Hendrik Boll <fanyx@posteo.net>"
 license="GPL-3.0-or-later"
 homepage="https://codeberg.org/valos/Komikku"
 distfiles="https://codeberg.org/valos/Komikku/archive/v${version}.tar.gz"
-checksum=f650e87bd794d39a4e5cde54d0f8d88f7febf3db0edb77dbe7ca15a253a1a0c3
+checksum=c5561d701816411b404fd77fe5f25b5f45c653b3c55b8b0a0043b1547eba246a
 
 if [ "$CROSS_BUILD" ]; then
 	export GI_TYPELIB_PATH="${XBPS_CROSS_BASE}/usr/lib/girepository-1.0"

--- a/srcpkgs/python3-modern_colorthief/template
+++ b/srcpkgs/python3-modern_colorthief/template
@@ -1,0 +1,19 @@
+# Template file for 'python3-modern_colorthief'
+pkgname=python3-modern_colorthief
+version=0.1.7
+revision=1
+build_helper=rust
+build_style=python3-pep517
+hostmakedepends="maturin cargo"
+makedepends="python3 rust-std"
+depends="python3"
+short_desc="Colorthief but with modern codes"
+maintainer="Hendrik Boll <fanyx@posteo.net>"
+license="MIT"
+homepage="https://github.com/baseplate-admin/modern_colorthief"
+distfiles="${PYPI_SITE}/m/modern-colorthief/modern_colorthief-${version}.tar.gz"
+checksum=2ff10dcb9a7c4cfbd1aeba899e3fe60d8ac652bc492f013784e05aafa2fa6a23
+
+post_install() {
+	vlicense LICENSE
+}


### PR DESCRIPTION
Added `python3-modern_colorthief`.

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- crossbuilt on:
  - armv7l-musl
