### PR TITLE
Update glog and its dependents

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -2510,7 +2510,7 @@ libunibilium.so.4 unibilium-2.0.0_1
 libtermkey.so.1 libtermkey-0.17_1
 libKF5I18n.so.5 ki18n-5.26.0_1
 libKF5I18nLocaleData.so.5 ki18n-5.88.0_1
-libglog.so.1 glog-0.6.0_1
+libglog.so.2 glog-0.7.1_1
 libzita-convolver.so.4 zita-convolver-4.0.3_1
 libzita-alsa-pcmi.so.0 zita-alsa-pcmi-0.2.0_1
 libpugixml.so.1 pugixml-1.6_1

--- a/common/shlibs
+++ b/common/shlibs
@@ -3765,7 +3765,7 @@ libircclient.so.1 libircclient-1.10_5
 libFAudio.so.0 FAudio-19.05_1
 libqaccessibilityclient-qt6.so.0 libqaccessibilityclient-0.6.0_1
 libnitrokey.so.3 libnitrokey-3.4.1_1
-libceres.so.3 ceres-solver-2.1.0_1
+libceres.so.4 ceres-solver-2.2.0_1
 libgraphene-1.0.so.0 graphene-1.8.2_1
 libflite.so.1 flite-2.1_1
 libflite_cmu_us_kal.so.1 flite-2.1_1

--- a/srcpkgs/ceres-solver/template
+++ b/srcpkgs/ceres-solver/template
@@ -1,7 +1,7 @@
 # Template file for 'ceres-solver'
 pkgname=ceres-solver
-version=2.1.0
-revision=2
+version=2.2.0
+revision=1
 build_style=cmake
 configure_args="-DLIB_SUFFIX='' -DBUILD_SHARED_LIBS=ON"
 makedepends="eigen glog-devel lapack-devel libgomp-devel"
@@ -10,7 +10,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="BSD-3-Clause"
 homepage="http://ceres-solver.org/"
 distfiles="https://github.com/ceres-solver/ceres-solver/archive/${version}.tar.gz"
-checksum=ccbd716a93f65d4cb017e3090ae78809e02f5426dce16d0ee2b4f8a4ba2411a8
+checksum=12efacfadbfdc1bbfa203c236e96f4d3c210bed96994288b3ff0c8e7c6f350d4
 
 post_install() {
 	vlicense LICENSE

--- a/srcpkgs/glog/template
+++ b/srcpkgs/glog/template
@@ -1,8 +1,9 @@
 # Template file for 'glog'
 pkgname=glog
-version=0.6.0
-revision=2
+version=0.7.1
+revision=1
 build_style=cmake
+configure_args="-DWITH_PKGCONFIG=ON"
 makedepends="gflags-devel libunwind-devel"
 checkdepends="gtest-devel"
 short_desc="Logging library for C++"
@@ -10,7 +11,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="BSD-3-Clause"
 homepage="https://github.com/google/glog"
 distfiles="https://github.com/google/glog/archive/v${version}.tar.gz"
-checksum=8a83bf982f37bb70825df71a9709fa90ea9f4447fb3c099e1d720a439d88bad6
+checksum=00e4a87e87b7e7612f519a41e491f16623b12423620006f59f5688bfd8d13b08
 
 if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
 	makedepends+=" libucontext-devel"

--- a/srcpkgs/wmderland/patches/fix-glog-include.diff
+++ b/srcpkgs/wmderland/patches/fix-glog-include.diff
@@ -1,0 +1,25 @@
+diff --git a/src/log.h b/src/log.h
+index 6d953d0..63e489d 100644
+--- a/src/log.h
++++ b/src/log.h
+@@ -4,20 +4,8 @@
+ 
+ #include "config.h"
+ 
+-// If glog is not installed on the compiling machine,
+-// then these macros will do nothing.
+-#if GLOG_FOUND
+-#include <glog/logging.h>
+-#define WM_INIT_LOGGING(executable_name) google::InitGoogleLogging(executable_name)
+-#define WM_LOG(severity, msg)                \
+-  do {                                       \
+-    LOG(severity) << msg;                    \
+-    google::FlushLogFiles(google::severity); \
+-  } while (0)
+-#else
+ #define WM_INIT_LOGGING(executable_name)
+ #define WM_LOG(severity, msg)
+-#endif
+ 
+ 
+ #define WM_LOG_WITH_ERRNO(reason, errno)               \

--- a/srcpkgs/wmderland/template
+++ b/srcpkgs/wmderland/template
@@ -10,6 +10,7 @@ license="MIT"
 homepage="https://github.com/aesophor/wmderland"
 distfiles="${homepage}/archive/${version}.tar.gz"
 checksum=dde9e545fcd45d82ae4be8516c9e591eec71bf8d4ceef3915b03a5552cb04466
+patch_args="-Np1"
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (crossbuilds):
  - aarch64
  - armv7l
  - armv6l
  - i686

This updates `glog` to version 0.7.1 and updates the `shlibs` file to reflect the new `SONAME` (`libglog.so.2`). A dependent package `ceres-solver` was updated to version 2.2.0 and rebuilt successfully against the new `glog`. The other dependent, `wmderland`, was patched to disable `glog` support for now, as it relied on the older `libglog.so.1` and did not build correctly with the updated version.