### PR TITLE
fluidsynth: update to 2.4.6.

### DIFF
--- a/srcpkgs/fluidsynth/template
+++ b/srcpkgs/fluidsynth/template
@@ -1,21 +1,21 @@
 # Template file for 'fluidsynth'
 pkgname=fluidsynth
-version=2.3.5
+version=2.4.6
 revision=1
 build_style=cmake
 make_check_target=check
 configure_args="-DLIB_SUFFIX=
- -DDEFAULT_SOUNDFONT:STRING=/usr/share/soundfonts/default.sf2"
+ -Denable-sdl2=1 -Denable-ladspa=ON -Denable-portaudio=ON"
 hostmakedepends="pkg-config"
 makedepends="SDL2-devel glib-devel jack-devel libsndfile-devel pipewire-devel pulseaudio-devel
- libinstpatch-devel readline-devel"
+ libinstpatch-devel readline-devel portaudio-devel ladspa-sdk"
 short_desc="Real-time software synthesizer based on the SoundFont 2 specifications"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="LGPL-2.1-or-later"
 homepage="https://www.fluidsynth.org/"
 changelog="https://github.com/FluidSynth/fluidsynth/releases"
 distfiles="https://github.com/FluidSynth/fluidsynth/archive/v${version}.tar.gz"
-checksum=f89e8e983ecfb4a5b4f5d8c2b9157ed18d15ed2e36246fa782f18abaea550e0d
+checksum=a6be90fd4842b9e7246500597180af5cf213c11bfa3998a3236dd8ff47961ea8
 
 libfluidsynth_package() {
 	short_desc+=" - runtime library"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**
- Tested out FluidSynth's functionality by running `fluidsynth -a pulseaudio gm.sf2` and then tested out FluidSynth's general MIDI functionality in a game, which relied on a general MIDI synthesizer to provide MIDI playback for its music. The audio worked in the game via FluidSynth, with no issues or regressions as far as I could tell.
- Played a MIDI file with FluidSynth, which seemingly went well.

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc