### PR TITLE
New package: ifupdown-ng-0.12.1

### DIFF
--- a/srcpkgs/ifupdown-ng/patches/fix-tests.patch
+++ b/srcpkgs/ifupdown-ng/patches/fix-tests.patch
@@ -1,0 +1,37 @@
+--- a/tests/linux/tunnel_test
++++ b/tests/linux/tunnel_test
+@@ -17,9 +17,9 @@
+ 	atf_check -s exit:0 \
+ 		-o match:"ip -4 tunnel add tun0" \
+ 		-o match:"mode gre" \
+-		-o match:"ttl '255'" \
+-		-o match:"local '1.2.3.4'" \
+-		-o match:"remote '5.6.7.8'" \
++		-o match:"ttl 255" \
++		-o match:"local 1.2.3.4" \
++		-o match:"remote 5.6.7.8" \
+ 		${EXECUTOR}
+ }
+ 
+@@ -39,8 +39,8 @@
+ 	atf_check -s exit:0 \
+ 		-o match:"ip -4 link add foo" \
+ 		-o match:"type gretap" \
+-		-o match:"local '1.2.3.4'" \
+-		-o match:"remote '5.6.7.8'" \
++		-o match:"local 1.2.3.4" \
++		-o match:"remote 5.6.7.8" \
+ 		${EXECUTOR}
+ }
+ 
+@@ -58,8 +58,8 @@
+ 	atf_check -s exit:0 \
+ 		-o match:"ip -6 link add foo" \
+ 		-o match:"type gretap" \
+-		-o match:"local '2001:db8::aaaa'" \
+-		-o match:"remote '2001:db8::eeee'" \
++		-o match:"local 2001:db8::aaaa" \
++		-o match:"remote 2001:db8::eeee" \
+ 		${EXECUTOR}
+ }
+ 

--- a/srcpkgs/ifupdown-ng/template
+++ b/srcpkgs/ifupdown-ng/template
@@ -1,0 +1,25 @@
+# Template file for 'ifupdown-ng'
+pkgname=ifupdown-ng
+version=0.12.1
+revision=1
+build_style=gnu-makefile
+make_build_args="all docs"
+make_install_args="SBINDIR=/usr/bin"
+hostmakedepends="scdoc"
+checkdepends="kyua"
+short_desc="Flexible ifup/ifdown implementation"
+maintainer="Orphaned <orphan@voidlinux.org>"
+license="ISC"
+homepage="https://github.com/ifupdown-ng/ifupdown-ng"
+distfiles="https://github.com/ifupdown-ng/ifupdown-ng/archive/refs/tags/ifupdown-ng-${version}.tar.gz"
+checksum=d42c8c18222efbce0087b92a14ea206de4e865d5c9dde6c0864dcbb2b45f2d85
+
+conflicts="ifupdown"
+
+post_install() {
+	for man in doc/*.5 doc/*.7 doc/*.8; do
+		vman "$man"
+	done
+
+	vlicense COPYING
+}


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures:
  - aarch64-musl [crossbuild]
  - armv7l [crossbuild]
  - armv6l-musl [crossbuild]

NOTES: 
- ifupdown-ng is a network device manager which is backwards compatible with traditional ifup and ifdown as used on Debian and Alpine systems.
- Contemporary network configuration for Linux (by Aaron A. Glenn & Maximilian Wilhelm) - https://www.youtube.com/watch?v=m7dfP65JfPU
- Is there interest in having 15-ifupdown.sh file as well? (just like in the ifupdown package)
- Check tests fail, however it looks to be running fine. This may be because of libbsd?? The arch community prefers to link with libbsd-overlay (at the cost of one simple patch): https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=ifupdown-ng