### PR TITLE
lua52-BitOp: fix double-slash in distfiles causing 404.

### DIFF
--- a/srcpkgs/lua52-BitOp/template
+++ b/srcpkgs/lua52-BitOp/template
@@ -10,8 +10,8 @@ depends="lua52>=5.2"
 short_desc="C extension module for Lua which adds bitwise operations on numbers"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
-homepage="http://bitop.luajit.org/"
-distfiles="${homepage}/download/LuaBitOp-${version}.tar.gz"
+homepage="https://bitop.luajit.org"
+distfiles="https://bitop.luajit.org/download/LuaBitOp-${version}.tar.gz"
 checksum=1207c9293dcd52eb9dca6538d1b87352bd510f4e760938f5048433f7f272ce99
 replaces="lua-BitOp>=0"
 

--- a/srcpkgs/lua52-BitOp/update
+++ b/srcpkgs/lua52-BitOp/update
@@ -1,2 +1,2 @@
-site="${homepage}download.html"
+site="https://bitop.luajit.org/download.html"
 pkgname=LuaBitOp


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **no, only built the template to verify**
