### PR TITLE
perl-Authen-SASL: update to 2.1800.

### DIFF
--- a/srcpkgs/perl-Authen-SASL/template
+++ b/srcpkgs/perl-Authen-SASL/template
@@ -1,6 +1,6 @@
 # Template file for 'perl-Authen-SASL'
 pkgname=perl-Authen-SASL
-version=2.1700
+version=2.1800
 revision=1
 build_style=perl-module
 hostmakedepends="perl"
@@ -12,4 +12,4 @@ license="Artistic-1.0-Perl, GPL-1.0-or-later"
 homepage="https://metacpan.org/release/Authen-SASL"
 changelog="https://fastapi.metacpan.org/source/EHUELS/Authen-SASL-${version}/Changes"
 distfiles="${CPAN_SITE}/Authen/${pkgname/perl-/}-${version}.tar.gz"
-checksum=b86d5a576b8d387aee24f39f47a54afd14bb66b09003db5065001f1de03a8ece
+checksum=0b03686bddbbf7d5c6548e468d079a4051c9b73851df740ae28cfd2db234e922


### PR DESCRIPTION
Sources for 2.17 have been removed upstream, only keeping 2.16 and 2.18.

#### Testing the changes
- I tested the changes in this PR: **only via built-in tests**

Upstream changes appear to be inoffensive:
>  [Changed]
    - Minimum required Perl version 5.14+ (from 5.6.0);
      Digest::HMAC_MD5 was 5.8.1, making 5.8.1 the effective minimum
    - Move example code to the eg/ directory
>
>  [Added]
    - Mechanisms XOAUTH2 and OAUTHBEARER added
    - Include mechanisms available on server when
      negotiation fails on the client
    - Add `_acceptable()` function to allow mechanism
      implementation classes to decline selection based
      on the callback values

