### PR TITLE
persepolis: update to 5.1.1

### DIFF
--- a/srcpkgs/persepolis/files/README.voidlinux
+++ b/srcpkgs/persepolis/files/README.voidlinux
@@ -1,0 +1,8 @@
+Persepolis recommends some optional dependencies
+
+For Youtube downloads: yt-dlp
+For audio mixing: ffmpeg
+For audio notifications: sound-theme-freedesktop
+For desktop notifications: python3-dasbus (not in void repository)
+For desktop notifications: libnotify
+For changing process names: python3-setproctitle

--- a/srcpkgs/persepolis/template
+++ b/srcpkgs/persepolis/template
@@ -1,15 +1,18 @@
 # Template file for 'persepolis'
 pkgname=persepolis
-version=3.2.0
-revision=8
-build_style=python3-module
-hostmakedepends="python3-setuptools python3-setproctitle python3-requests
- python3-psutil aria2 ffmpeg libnotify pulseaudio-utils youtube-dl
- sound-theme-freedesktop python3-PyQt5-tools qt5-svg"
-depends="${hostmakedepends/python3-setuptools/}"
-short_desc="Download manager and GUI for Aria2"
+version=5.1.1
+revision=1
+build_style=meson
+build_helper=python3
+depends="python3-pysocks python3-requests python3-pyside6 qt6-svg python3-urllib3
+ python3-psutil"
+short_desc="QT Download Manager"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-3.0-or-later"
 homepage="https://persepolisdm.github.io/"
-distfiles="https://github.com/persepolisdm/${pkgname}/archive/${version}.tar.gz"
-checksum=d27cf2a4e02b0fbe79b1903ca0ab32a6007493d51a8201443a8febb566750acd
+distfiles="https://github.com/persepolisdm/persepolis/archive/${version}.tar.gz"
+checksum=d787b4a45b3a38513f1e80e025c4059918f1390b815944c6a541bd07eeb0ccae
+
+post_install() {
+	vdoc "${FILESDIR}/README.voidlinux"
+}


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly** - downloaded a video, tested which dependencies were needed at runtime (because no packager can agree)

#### Local build testing
- I built this PR locally for my native architecture, x86_64
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl (cross)
  - armv7l (cross)
  - i686 (cross)

The project has changed dramatically since 2019, including changing to meson build system. 

Honestly not sure if it's still a relevant package, but it needed to be done to remove `youtube-dl` deps. Should also count towards #46170 