### PR TITLE
cliflux: update to 1.8.0.

### DIFF
--- a/srcpkgs/cliflux/template
+++ b/srcpkgs/cliflux/template
@@ -1,6 +1,6 @@
 # Template file for 'cliflux'
 pkgname=cliflux
-version=1.4.4
+version=1.8.0
 revision=1
 build_style=cargo
 hostmakedepends="pkg-config"
@@ -10,8 +10,8 @@ maintainer="Anachron <gith@cron.world>"
 license="MIT"
 homepage="https://github.com/spencerwi/cliflux"
 distfiles="https://github.com/spencerwi/cliflux/archive/refs/tags/v${version}.tar.gz"
-checksum=89bbfe00f0bb3ccdba3668f8fd7c1867b89aa43a255fc4b8a998bdecfd8d1945
+checksum=1beceeb65af96b1dc586b4895942ec2b671b3c1604207e6a2e4a072c46362a28
 
-do_install() {
+post_install() {
 	vlicense LICENSE.md
 }


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x84_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-glibc
