### PR TITLE
lego: update to 4.23.1.

### DIFF
--- a/srcpkgs/lego/template
+++ b/srcpkgs/lego/template
@@ -1,6 +1,6 @@
 # Template file for 'lego'
 pkgname=lego
-version=4.22.2
+version=4.23.1
 revision=1
 build_style=go
 go_import_path="github.com/go-acme/lego/v4"
@@ -11,7 +11,7 @@ license="MIT"
 homepage="https://go-acme.github.io/lego"
 changelog="https://raw.githubusercontent.com/go-acme/lego/master/CHANGELOG.md"
 distfiles="https://github.com/go-acme/lego/archive/v${version}.tar.gz"
-checksum=d4d5a3032d1ed99a5cdf551b2555288c3fcd961be536e58f477dce35d22c8702
+checksum=e86e62946397964d6f2db2a2487cc75acac08e9ad7811c2302d56c35ca521699
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-glibc
