### PR TITLE
gnome-network-displays: update to 0.97.0

### DIFF
--- a/srcpkgs/gnome-network-displays/template
+++ b/srcpkgs/gnome-network-displays/template
@@ -1,6 +1,6 @@
 # Template file for 'gnome-network-displays'
 pkgname=gnome-network-displays
-version=0.96.0
+version=0.97.0
 revision=1
 build_style=meson
 hostmakedepends="desktop-file-utils gettext glib-devel gtk4-update-icon-cache
@@ -14,4 +14,4 @@ license="GPL-3.0-or-later"
 homepage="https://gitlab.gnome.org/GNOME/gnome-network-displays"
 changelog="https://gitlab.gnome.org/GNOME/gnome-network-displays/-/raw/master/NEWS"
 distfiles="${GNOME_SITE}/gnome-network-displays/${version%.*}/gnome-network-displays-${version}.tar.xz"
-checksum=3c1e44b1324710ede5fb8bb10598d85f9734c923e268cdc248760563deeaa497
+checksum=cdec68c8f9b326baaee545374a8c2b93ca919e48f4b8a42461cb0eb2398dab27


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)