### PR TITLE
gnome-text-editor: update to 48.3

### DIFF
--- a/srcpkgs/gnome-text-editor/template
+++ b/srcpkgs/gnome-text-editor/template
@@ -1,6 +1,6 @@
 # Template file for 'gnome-text-editor'
 pkgname=gnome-text-editor
-version=48.2
+version=48.3
 revision=1
 build_style=meson
 hostmakedepends="pkg-config gettext itstool glib-devel
@@ -14,4 +14,4 @@ homepage="https://gitlab.gnome.org/GNOME/gnome-text-editor"
 #changelog="https://gitlab.gnome.org/GNOME/gnome-text-editor/-/raw/main/NEWS"
 changelog="https://gitlab.gnome.org/GNOME/gnome-text-editor/-/raw/gnome-48/NEWS"
 distfiles="${GNOME_SITE}/gnome-text-editor/${version%.*}/gnome-text-editor-$version.tar.xz"
-checksum=fc1f5d475bdd27d4c0439a5b8fe10d6e401b42f1dba3d04b7567839036ee202b
+checksum=3f9e9722394edb4d2145c06d69210b3d3fca5cd2b90d632643be750843d556ba


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)