### PR TITLE
FeatherPad: update to 1.6.2.

### DIFF
--- a/srcpkgs/FeatherPad/template
+++ b/srcpkgs/FeatherPad/template
@@ -1,14 +1,14 @@
 # Template file for 'FeatherPad'
 pkgname=FeatherPad
-version=1.4.1
+version=1.6.2
 revision=1
 build_style=cmake
-hostmakedepends="qt5-qmake qt5-host-tools pkg-config"
-makedepends="libX11-devel libXext-devel qt5-x11extras-devel qt5-svg-devel hunspell-devel"
-short_desc="Lightweight Qt5 plain-text editor for Linux"
+hostmakedepends="qt6-tools qt6-base-devel pkg-config"
+makedepends="libX11-devel libXext-devel qt6-svg-devel hunspell-devel"
+short_desc="Lightweight Qt6 plain-text editor for Linux"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-3.0-or-later"
 homepage="https://github.com/tsujan/FeatherPad"
 changelog="https://github.com/tsujan/FeatherPad/raw/master/ChangeLog"
 distfiles="https://github.com/tsujan/FeatherPad/archive/V${version}.tar.gz"
-checksum=e60258388ca3039e434d7b661548113057a85443a1a288843b5ec6044b4206dc
+checksum=9753796b2a525a4d6b13696681e9fbb094edcc20e8aadffcd5bb6fe22d0a5fdb


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l
  - i686

Update version and checksum. Update dependencies from `qt5` to `qt6`.