### PR TITLE
konsole: update to 25.04.2

### DIFF
--- a/srcpkgs/konsole/template
+++ b/srcpkgs/konsole/template
@@ -1,6 +1,6 @@
 # Template file for 'konsole'
 pkgname=konsole
-version=25.04.0
+version=25.04.2
 revision=1
 build_style=cmake
 configure_args="-DKF6_HOST_TOOLING=/usr/lib/cmake
@@ -15,7 +15,7 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later, LGPL-2.0-or-later, GFDL-1.2-or-later"
 homepage="https://kde.org/applications/en/system/org.kde.konsole"
 distfiles="${KDE_SITE}/release-service/${version}/src/konsole-${version}.tar.xz"
-checksum=d326dba57b17331e5030ed6babdea1d33876bc011f9c9faa029f965ae73a79d1
+checksum=69cd6c7e84cbcb3df41227cd3115498a5aaddca6641802898d79e5b4e467bbfb
 replaces="konsole5>=0"
 
 do_check() {


### PR DESCRIPTION
Fixes: https://www.cve.org/CVERecord?id=CVE-2025-49091

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
