### PR TITLE
iso-codes: update to 4.18.0.

### DIFF
--- a/srcpkgs/iso-codes/template
+++ b/srcpkgs/iso-codes/template
@@ -1,6 +1,6 @@
 # Template file for 'iso-codes'
 pkgname=iso-codes
-version=4.17.0
+version=4.18.0
 revision=1
 build_style=gnu-configure
 hostmakedepends="gettext python3"
@@ -10,4 +10,4 @@ license="LGPL-2.1-or-later"
 homepage="https://salsa.debian.org/iso-codes-team/iso-codes"
 changelog="https://salsa.debian.org/iso-codes-team/iso-codes/-/raw/main/CHANGELOG.md"
 distfiles="${DEBIAN_SITE}/main/i/iso-codes/iso-codes_${version}.orig.tar.xz"
-checksum=0fe126a5d3903790ae0d839280f4b590415bf4ad20e39facf186b35304ac9603
+checksum=066bc4df7bf299561856a07119cde01d563c8c4c39906537a39363bb833d466c


### PR DESCRIPTION
4.17.0 sources no longer available

#### Testing the changes
- I tested the changes in this PR: **briefly**