### PR TITLE
qrencode: fix distfiles.

### DIFF
--- a/srcpkgs/qrencode/template
+++ b/srcpkgs/qrencode/template
@@ -3,18 +3,22 @@ pkgname=qrencode
 version=4.1.1
 revision=1
 build_style=gnu-configure
-hostmakedepends="pkg-config"
+hostmakedepends="automake libtool pkg-config"
 makedepends="libpng-devel"
 short_desc="Library for encoding data in a QR Code symbol"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="LGPL-2.1-or-later"
 homepage="https://fukuchi.org/works/qrencode/index.html.en"
-distfiles="https://fukuchi.org/works/qrencode/qrencode-${version}.tar.bz2"
-checksum=e455d9732f8041cf5b9c388e345a641fd15707860f928e94507b1961256a6923
+distfiles="https://github.com/fukuchi/libqrencode/archive/refs/tags/v${version}.tar.gz"
+checksum=5385bc1b8c2f20f3b91d258bf8ccc8cf62023935df2d2676b5b67049f31a049c
 
 if [ "$XBPS_CHECK_PKGS" ]; then
 	configure_args+=" --with-tests"
 fi
+
+pre_configure() {
+	./autogen.sh
+}
 
 qrencode-devel_package() {
 	depends="libqrencode-${version}_${revision}"


### PR DESCRIPTION
tarballs no longer accessible on their personal website, source releases don't include configure scripts.

#### Testing the changes
- I tested the changes in this PR: **briefly**
#### Local build testing
- I built this PR locally for my native architecture, x86_64