### PR TITLE
New package: video-compare-20250420

### DIFF
--- a/srcpkgs/video-compare/template
+++ b/srcpkgs/video-compare/template
@@ -1,0 +1,23 @@
+# Template file for 'video-compare'
+pkgname=video-compare
+version=20250420
+revision=1
+build_style=gnu-makefile
+makedepends="ffmpeg6-devel SDL2-devel SDL2_ttf-devel"
+short_desc="Split screen video comparison tool using FFmpeg and SDL2"
+maintainer="sunshinehunter <sunshinehunterde@gmail.com>"
+license="GPL-2.0-only"
+homepage="https://github.com/pixop/video-compare"
+changelog="https://github.com/pixop/video-compare/releases"
+distfiles="https://github.com/pixop/video-compare/archive/refs/tags/${version}.tar.gz"
+checksum=cfb1de9608fa141defa44b62c10ff7a56ea668c87d6c2c102409bddcaa98cd83
+
+CXXFLAGS="-std=c++14 -D__STDC_CONSTANT_MACROS"
+
+pre_install() {
+	vmkdir usr/bin
+}
+
+do_install() {
+	make BINDIR=${DESTDIR}/usr/bin install
+}


### PR DESCRIPTION
This adds a new package for https://github.com/pixop/video-compare. I use it for easily comparing differences between encoded videos.

I'm not sure if the `pre_install` step or if my use of `make_use_env` is appropriate, but it works fine like this.

#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl

