### PR TITLE
graphviz: update to 13.0.0.

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -1116,9 +1116,9 @@ libSDL_sound-1.0.so.1 SDL_sound-1.0.3_1
 libgtksourceview-2.0.so.0 gtksourceview2-2.10.5_1
 libxdot.so.4 graphviz-libs-2.28.0_6
 libgvpr.so.2 graphviz-libs-2.28.0_6
-libcgraph.so.6 graphviz-libs-2.28.0_6
-libgvc.so.6 graphviz-libs-2.28.0_6
-libcdt.so.5 graphviz-libs-2.28.0_6
+libcgraph.so.7 graphviz-libs-13.0.0_1
+libgvc.so.7 graphviz-libs-13.0.0_1
+libcdt.so.6 graphviz-libs-13.0.0_1
 libpathplan.so.4 graphviz-libs-2.28.0_6
 liblab_gamut.so.1 graphviz-libs-2.40.1_1
 libmowgli-2.so.0 libmowgli-2.1.3_8

--- a/srcpkgs/ImageMagick/template
+++ b/srcpkgs/ImageMagick/template
@@ -2,7 +2,7 @@
 pkgname=ImageMagick
 # Revbump php*-imagick with ImageMagick updates.
 version=7.1.1.47
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--disable-static --enable-opencl --with-modules --with-gslib
  --with-rsvg --with-wmf --with-dejavu-font-dir=/usr/share/fonts/TTF --with-openexr

--- a/srcpkgs/cutter/template
+++ b/srcpkgs/cutter/template
@@ -1,7 +1,7 @@
 # Template file for 'cutter'
 pkgname=cutter
 version=2.3.4
-revision=3
+revision=4
 build_style=cmake
 configure_args="-DCUTTER_EXTRA_PLUGIN_DIRS=/usr/lib/rizin/cutter/plugins
  -DCUTTER_ENABLE_PYTHON=ON -DCUTTER_ENABLE_PYTHON_BINDINGS=OFF

--- a/srcpkgs/edb-debugger/template
+++ b/srcpkgs/edb-debugger/template
@@ -1,7 +1,7 @@
 # Template file for 'edb-debugger'
 pkgname=edb-debugger
 version=1.4.0
-revision=2
+revision=3
 archs="x86_64* i686*"
 build_style=cmake
 hostmakedepends='pkg-config'

--- a/srcpkgs/graphviz/template
+++ b/srcpkgs/graphviz/template
@@ -1,12 +1,12 @@
 # Template file for 'graphviz'
 pkgname=graphviz
-version=12.2.1
+version=13.0.0
 revision=1
 build_style=gnu-configure
 configure_args="--with-gts --with-ann=no"
 make_build_args="HOSTCC=$BUILD_CC"
 hostmakedepends="automake flex libltdl-devel libtool perl pkg-config python3"
-makedepends="libpng-devel gd-devel gtk+-devel librsvg-devel libltdl-devel
+makedepends="libpng-devel gd-devel gtk+3-devel librsvg-devel libltdl-devel
  libXaw-devel gts-devel"
 depends="liberation-fonts-ttf"
 checkdepends="${depends}"
@@ -16,7 +16,7 @@ license="EPL-1.0"
 homepage="https://www.graphviz.org"
 changelog="https://gitlab.com/graphviz/graphviz/-/raw/main/CHANGELOG.md"
 distfiles="https://gitlab.com/graphviz/graphviz/-/archive/${version}/graphviz-${version}.tar.gz"
-checksum=91d444b4dabdaf5bfa7c6fcc3a1ee5d41e588af6079ebc030f0acb79e48a56ea
+checksum=1f55d96f413c911ffc6d1ce1b4e1d3bddfe65931b2de62f3c81206258f09a34a
 
 # `make check` is broken:
 # https://gitlab.com/graphviz/graphviz/-/issues/2112

--- a/srcpkgs/valadoc/template
+++ b/srcpkgs/valadoc/template
@@ -2,7 +2,7 @@
 pkgname=valadoc
 # Should be kept in sync with 'vala' (shared distfiles)
 version=0.56.18
-revision=2
+revision=3
 build_style=gnu-configure
 configure_args="--with-cgraph=yes GI_GIRDIR=/usr/share/gir-1.0"
 hostmakedepends="flex libxslt pkg-config automake libtool vala"


### PR DESCRIPTION
Move to GTK+3.<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
