### PR TITLE
New package: bluetui-0.6

### DIFF
--- a/srcpkgs/bluetui/template
+++ b/srcpkgs/bluetui/template
@@ -1,0 +1,19 @@
+# Template file for 'bluetui'
+pkgname=bluetui
+version=0.6
+revision=1
+build_style=cargo
+hostmakedepends="pkg-config"
+makedepends="dbus-devel"
+depends="dbus bluez"
+short_desc="TUI for managing bluetooth devices"
+maintainer="Orphaned <orphan@voidlinux.org>"
+license="GPL-3.0-only"
+homepage="https://github.com/pythops/bluetui"
+changelog="https://github.com/pythops/bluetui/blob/master/Release.md"
+distfiles="https://github.com/pythops/bluetui/archive/refs/tags/v${version}.tar.gz"
+checksum=142102957ff30439f9938e4b57750b5c399f33e94a20416cfbcbe239b20cdba8
+
+post_install() {
+	vdoc Readme.md
+}


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86-64-glibc)
- I built this PR locally for these architectures (all crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
