### PR TITLE
libnpupnp: update to 6.2.1.

### DIFF
--- a/srcpkgs/libnpupnp/template
+++ b/srcpkgs/libnpupnp/template
@@ -1,8 +1,8 @@
 # Template file for 'libnpupnp'
 pkgname=libnpupnp
-version=6.1.1
+version=6.2.1
 revision=1
-build_style=gnu-configure
+build_style=meson
 hostmakedepends="pkg-config"
 makedepends="expat-devel libcurl-devel libmicrohttpd-devel"
 short_desc="UPnP library based on libupnp, but extensively rewritten"
@@ -11,7 +11,7 @@ license="BSD-3-Clause"
 homepage="https://www.lesbonscomptes.com/upmpdcli/npupnp-doc/libnpupnp.html"
 changelog="https://www.lesbonscomptes.com/upmpdcli/pages/releases.html"
 distfiles="https://www.lesbonscomptes.com/upmpdcli/downloads/libnpupnp-${version}.tar.gz"
-checksum=393b81824c77946b30b42be9d93247523ba39e1faabdd2e4c1927106604c6f54
+checksum=1cc1222512d480826d2923cc7b98b7361183a2add8c6b646a7fa32c2f34b32b3
 
 post_install() {
 	vlicense COPYING


### PR DESCRIPTION
6.1.1 wouldn't build due to gcc14 compat, updated to 6.2.1
Upstream switched to meson: https://www.lesbonscomptes.com/upmpdcli/pages/releases.html#_2024_04_03_switching_the_build_tools_from_gnu_autotools_to_meson

#### Testing the changes
- I tested the changes in this PR: **briefly**

- I built this PR locally for my native architecture, x86_64