### PR TITLE
perl-CGI: update to 4.69

### DIFF
--- a/srcpkgs/perl-CGI/template
+++ b/srcpkgs/perl-CGI/template
@@ -1,6 +1,6 @@
 # Template file for 'perl-CGI'
 pkgname=perl-CGI
-version=4.68
+version=4.69
 revision=1
 build_style=perl-module
 hostmakedepends="perl"
@@ -12,4 +12,4 @@ maintainer="newbluemoon <blaumolch@mailbox.org>"
 license="Artistic-1.0-Perl, GPL-1.0-or-later"
 homepage="https://metacpan.org/release/CGI"
 distfiles="${CPAN_SITE}/CGI/CGI-${version}.tar.gz"
-checksum=12fb5a5b392032413571169257f98533488005550774bcbd0715be687a590cf2
+checksum=1bde0b1034eaa32a53dab05dd4c2ddefd3504b951daf91b3e317a5bcf100d259


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

reverts 4.68 which breaks backward compatibility

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64 (cross)
  - armv7l-musl (cross)
  - x86_64-musl
  - i686

