### PR TITLE
kcachegrind: update to 25.04.2.

### DIFF
--- a/srcpkgs/kcachegrind/template
+++ b/srcpkgs/kcachegrind/template
@@ -1,6 +1,6 @@
 # Template file for 'kcachegrind'
 pkgname=kcachegrind
-version=25.04.1
+version=25.04.2
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
@@ -17,5 +17,5 @@ license="GPL-2.0-only, GFDL-1.2-only"
 homepage="https://kde.org/applications/development/kcachegrind/"
 changelog="https://kde.org/announcements/changelogs/gear/${version}/#kcachegrind"
 distfiles="${KDE_SITE}/release-service/${version}/src/kcachegrind-${version}.tar.xz"
-checksum=0b7349b84f5e90a9d9cb05b2642b2a79c27a629dacb85ba94e57b9528be1f975
+checksum=cf4f8d9471ffe24fc42537eed00a0bf9feea0e9d705334bf8c5c3176d8b7cc6b
 python_version=3


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture (x86_64)
- I built this PR locally for these architectures using specific masterdirs:
  - x86_64-musl
  - i686
- I built this PR locally for these architectures (crossbuilds):
  - aarch64
  - aarch64-musl
  - armv7l
  - armv7l-musl
  - armv6l
  - armv6l-musl