### PR TITLE
nanomsg: update to 1.2.

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -3130,7 +3130,7 @@ libappstream-compose.so.0 AppStream-compose-1.0.2_1
 libappstream-glib.so.8 appstream-glib-0.6.13_1
 libappstream-builder.so.8 appstream-glib-0.6.13_1
 libflatpak.so.0 flatpak-0.9.3_2
-libnanomsg.so.5 nanomsg-1.1.3_1
+libnanomsg.so.6 nanomsg-1.2.0_1
 libscanmem.so.1 libscanmem-0.17_5
 libsctp.so.1 lksctp-tools-1.0.17_1
 libwithsctp.so.1 lksctp-tools-1.0.17_1

--- a/srcpkgs/nanomsg/template
+++ b/srcpkgs/nanomsg/template
@@ -1,15 +1,15 @@
 # Template file for 'nanomsg'
 pkgname=nanomsg
-version=1.1.5
-revision=2
+version=1.2
+revision=1
 build_style=cmake
-short_desc='Simple, high-performance implementation of \"scalability protocols\"'
+short_desc='Simple, high-performance implementation of scalability protocols'
 maintainer="Toyam Cox <Vaelatern@voidlinux.org>"
 license="MIT"
 homepage='http://nanomsg.org/'
-#changelog="https://github.com/nanomsg/nanomsg/releases"
+changelog="https://github.com/nanomsg/nanomsg/releases"
 distfiles="https://github.com/nanomsg/nanomsg/archive/$version.tar.gz>nanomsg-${version}.tar.gz"
-checksum=218b31ae1534ab897cb5c419973603de9ca1a5f54df2e724ab4a188eb416df5a
+checksum=6ef7282e833df6a364f3617692ef21e59d5c4878acea4f2d7d36e21c8858de67
 
 post_install() {
 	vlicense COPYING


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture (x86_64)
- I built this PR locally for these architectures using specific masterdirs:
  - x86_64-musl
  - i686
- I built this PR locally for these architectures (crossbuilds):
  - aarch64
  - aarch64-musl
  - armv7l
  - armv7l-musl
  - armv6l
  - armv6l-musl
 
---

[Criterion](https://github.com/void-linux/void-packages/pull/50109) builds and works fine with nanomsg 1.1.5, but its meson wrap expects version 1.2.

Updating ensures compatibility and avoids potential issues, especially since there was a SONAME change in the library. This was tested to ensure Criterion builds correctly with the updated version.
