### PR TITLE
gamescope: update to 3.16.12.

### DIFF
--- a/srcpkgs/gamescope/template
+++ b/srcpkgs/gamescope/template
@@ -1,7 +1,8 @@
 # Template file for 'gamescope'
 pkgname=gamescope
-version=3.16.3
+version=3.16.12
 revision=1
+_glm_hash=0af55ccecd98d4e5a8d1fad7de25ba429d60e863
 _stb_hash=5736b15f7ea0ffb08dd38af21067c314d6a3aae9
 _vkroots_hash=5106d8a0df95de66cc58dc1ea37e69c99afc9540
 _reshade_hash=696b14cd6006ae9ca174e6164450619ace043283
@@ -15,7 +16,7 @@ hostmakedepends="glslang pkg-config wayland-devel hwids"
 makedepends="pipewire-devel SPIRV-Headers libX11-devel
  libXdamage-devel libXcomposite-devel libXrender-devel libXxf86vm-devel
  libXtst-devel libXres-devel libXmu-devel libdrm-devel vulkan-loader-devel
- libxkbcommon-devel libcap-devel LuaJIT-devel SDL2-devel glm benchmark-devel pixman-devel
+ libxkbcommon-devel libcap-devel LuaJIT-devel SDL2-devel benchmark-devel pixman-devel
  libinput-devel libseat-devel libavif-devel libei-devel xcb-util-wm-devel
  wayland-protocols xorg-server-xwayland"
 depends="xorg-server-xwayland"
@@ -24,6 +25,7 @@ maintainer="Dexter Gaon-Shatford <dexter.gaonshatford@gmail.com>"
 license="BSD-2-Clause, BSD-3-Clause, MIT"
 homepage="https://github.com/ValveSoftware/gamescope"
 distfiles="https://github.com/ValveSoftware/gamescope/archive/refs/tags/${version}.tar.gz
+ https://github.com/g-truc/glm/archive/${_glm_hash}.tar.gz
  https://github.com/nothings/stb/archive/${_stb_hash}.tar.gz
  https://github.com/Joshua-Ashton/vkroots/archive/${_vkroots_hash}.tar.gz
  https://github.com/Joshua-Ashton/reshade/archive/${_reshade_hash}.tar.gz
@@ -31,7 +33,8 @@ distfiles="https://github.com/ValveSoftware/gamescope/archive/refs/tags/${versio
  https://gitlab.freedesktop.org/emersion/libdisplay-info/-/archive/${_libdisplay_info_hash}/libdisplay-info-${_libdisplay_info_hash}.tar.gz
  https://gitlab.freedesktop.org/emersion/libliftoff/-/archive/${_libliftoff_hash}/libliftoff-${_libliftoff_hash}.tar.gz
  https://github.com/Joshua-Ashton/wlroots/archive/${_wlroots_hash}.tar.gz"
-checksum="756c6b52f85dcca31da2f1a66e084fb28dd5e67a6cd4950e3bf105d6291c0534
+checksum="e141e7aa1a3d58d88c132e53b3b9a58f060f8c397520bb01e625a6cfc9da1309
+ e7f187d83523f505eb38dd25d297ea6c0d4ed856d733e808f18253f5a8fa88a0
  d00921d49b06af62aa6bfb97c1b136bec661dd11dd4eecbcb0da1f6da7cedb4c
  37b77586e91f7ebee70380dcddd73bf01ae4acef1053e6be41d0485ede022422
  3aa6feda7773cc8ffa8fb012fe95e6207c776101e29198d0e0d34a0c5e339f6a
@@ -39,7 +42,8 @@ checksum="756c6b52f85dcca31da2f1a66e084fb28dd5e67a6cd4950e3bf105d6291c0534
  bca0664e23671572311b3b91f3b2fff3fd6501940320a8daff5e11b5219554a4
  8de28aee6f90f47b7fc7037dcd2360166197c0b5d2033f3afdbd34f2ea1bf216
  41272ce410c2815de1e268f5baa906b26286bb910e514677d15b8e69f81c5a04"
-skip_extraction="${_stb_hash}.tar.gz
+skip_extraction="${_glm_hash}.tar.gz
+ ${_stb_hash}.tar.gz
  ${_vkroots_hash}.tar.gz
  ${_reshade_hash}.tar.gz
  ${_spirv_hash}.tar.gz
@@ -60,6 +64,8 @@ if [ "$XBPS_CHECK_PKGS" ]; then
 fi
 
 post_extract() {
+	vsrcextract -C subprojects/glm "${_glm_hash}.tar.gz"
+	cp subprojects/packagefiles/glm/meson.build subprojects/glm
 	vsrcextract -C subprojects/stb "${_stb_hash}.tar.gz"
 	cp subprojects/packagefiles/stb/meson.build subprojects/stb
 	vsrcextract -C subprojects/vkroots "${_vkroots_hash}.tar.gz"


### PR DESCRIPTION
Hey there! 👋🏻 

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture: **x86_64 (libc)**

`glm` is now used as a subproject, so I removed it from the `makedepends` array and included it the same way as `stb`.

Reference:
- https://github.com/ValveSoftware/gamescope/commit/0fed8f3d69203c5bea20c73eb526574260f4ebd7
