### PR TITLE
checkbashisms: update to 2.25.15

### DIFF
--- a/srcpkgs/checkbashisms/template
+++ b/srcpkgs/checkbashisms/template
@@ -1,6 +1,6 @@
 # Template file for 'checkbashisms'
 pkgname=checkbashisms
-version=2.25.14
+version=2.25.15
 revision=1
 depends="perl"
 checkdepends="shunit2 perl"
@@ -8,9 +8,9 @@ short_desc="Debian script that checks for bash-isms"
 maintainer="TheGejr <maltegejr.korup@gmail.com>"
 license="GPL-2.0-or-later"
 homepage="https://tracker.debian.org/pkg/devscripts"
-changelog="https://salsa.debian.org/debian/devscripts/-/raw/master/debian/changelog"
+changelog="https://tracker.debian.org/media/packages/d/devscripts/changelog-${version}"
 distfiles="${DEBIAN_SITE}/main/d/devscripts/devscripts_${version}.tar.xz"
-checksum=cfde413a018d605be57aa0aff1ee81ed397dd713f38101e4731220e7999a5ef4
+checksum=4c00e31638a1b5278f286d4dc93bc420003da53f891d5dd199de15c489ccd0ac
 
 pre_install() {
 	vsed -i "s|###VERSION###|${version}|" scripts/checkbashisms.pl


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **yes**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - aarch64
  - i686
  - armv7l-musl
  - armv7l
  - armv6l-musl
  - armv6l