### PR TITLE
frp: service scripts

### DIFF
--- a/srcpkgs/frp/files/frpc/run
+++ b/srcpkgs/frp/files/frpc/run
@@ -1,3 +1,3 @@
 #!/bin/sh
 exec 2>&1
-exec /usr/bin/frpc -c /etc/frp/frpc.ini
+exec /usr/bin/frpc -c /etc/frp/frpc.toml

--- a/srcpkgs/frp/files/frps/run
+++ b/srcpkgs/frp/files/frps/run
@@ -1,3 +1,3 @@
 #!/bin/sh
 exec 2>&1
-exec /usr/bin/frps -c /etc/frp/frps.ini
+exec /usr/bin/frps -c /etc/frp/frps.toml

--- a/srcpkgs/frp/files/frps/run
+++ b/srcpkgs/frp/files/frps/run
@@ -1,3 +1,3 @@
 #!/bin/sh
 exec 2>&1
-exec /usr/bin/frps -c /etc/frp/frps.toml
+exec /usr/bin/frps -c /etc/frp/frps.toml --disable-log-color

--- a/srcpkgs/frp/template
+++ b/srcpkgs/frp/template
@@ -1,7 +1,7 @@
 # Template file for 'frp'
 pkgname=frp
 version=0.62.1
-revision=1
+revision=2
 build_style=go
 go_import_path=github.com/fatedier/frp
 go_package="${go_import_path}/cmd/frpc ${go_import_path}/cmd/frps"


### PR DESCRIPTION
The runit services defined in this package use INI config files, which are deprecated in new versions of frp, and the package comes with TOML config files anyway. Also, frp prints logs in colour and only closes the colour tags when it exits, which makes your terminal light blue when you read logs. Disabling colour output is only possible for frps, though.

I also think that both the frp server and client shouldn't need to be run as root. I start them with `chpst -u nobody:nogroup` myself, but I'd like to get a second opinion on that. I can imagine someone wanting to use privileged ports with frp, but not sure how common that usecase is.

#### Testing the changes
- I tested the changes in this PR: **briefly**
