### PR TITLE
spice: update to 0.16.0

### DIFF
--- a/srcpkgs/spice-protocol/template
+++ b/srcpkgs/spice-protocol/template
@@ -1,15 +1,15 @@
 # Template file for 'spice-protocol'
 pkgname=spice-protocol
-version=0.14.4
+version=0.14.5
 revision=1
 build_style=meson
 short_desc="SPICE protocol headers"
-maintainer="Orphaned <orphan@voidlinux.org>"
+maintainer="Anachron <gith@cron.world>"
 license="BSD-3-Clause"
 homepage="https://www.spice-space.org/"
 changelog="https://gitlab.freedesktop.org/spice/spice-protocol/-/raw/master/CHANGELOG.md"
 distfiles="https://gitlab.freedesktop.org/spice/spice-protocol/-/archive/v${version}/spice-protocol-v${version}.tar.gz"
-checksum=9c31fa533ad531d1b816ffd0c24b4785d133e7bb397f72d35f7a6d59bcd7d53a
+checksum=1be179b3dfbb23946432275f4b7a4b59bb5e9acc25c3128bc930b8264a9f0a20
 
 post_install() {
 	vlicense COPYING

--- a/srcpkgs/spice/template
+++ b/srcpkgs/spice/template
@@ -1,6 +1,6 @@
 # Template file for 'spice'
 pkgname=spice
-version=0.15.2
+version=0.16.0
 revision=1
 build_style=gnu-configure
 configure_args="--disable-tunnel --disable-opengl --enable-smartcard
@@ -17,7 +17,7 @@ license="LGPL-2.1-or-later"
 homepage="https://www.spice-space.org/"
 changelog="https://gitlab.freedesktop.org/spice/spice/-/raw/master/CHANGELOG.md"
 distfiles="https://www.spice-space.org/download/releases/spice-server/spice-${version}.tar.bz2"
-checksum=6d9eb6117f03917471c4bc10004abecff48a79fb85eb85a1c45f023377015b81
+checksum=0a6ec9528f05371261bbb2d46ff35e7b5c45ff89bb975a99af95a5f20ff4717d
 
 if [ "$XBPS_TARGET_ENDIAN" != "le" ]; then
 	broken="SPICE server only works on little endian architectures"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-gblic)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-glibc
