### PR TITLE
xorg-server: update to 21.1.18.

### DIFF
--- a/srcpkgs/xorg-server/template
+++ b/srcpkgs/xorg-server/template
@@ -1,7 +1,7 @@
 # Template file for 'xorg-server'
 pkgname=xorg-server
-version=21.1.16
-revision=2
+version=21.1.18
+revision=1
 build_style=meson
 configure_args="-Dipv6=true -Dxorg=true -Dxnest=true -Dxephyr=true
  -Dxvfb=true -Dhal=false -Dudev=true -Dxkb_dir=/usr/share/X11/xkb
@@ -24,7 +24,7 @@ maintainer="Leah Neukirchen <leah@vuxu.org>"
 license="MIT, BSD-3-Clause"
 homepage="https://gitlab.freedesktop.org/xorg/xserver"
 distfiles="${XORG_SITE}/xserver/${pkgname}-${version}.tar.xz"
-checksum=b14a116d2d805debc5b5b2aac505a279e69b217dae2fae2dfcb62400471a9970
+checksum=c878d1930d87725d4a5bf498c24f4be8130d5b2646a9fd0f2994deff90116352
 lib32disabled=yes
 provides="xserver-abi-extension-10_1 xserver-abi-input-24_1
  xserver-abi-video-25_1 xf86-video-modesetting-1_1"


### PR DESCRIPTION
Looks like .18 has some security fixes, testing it now...

#### Testing the changes
- I tested the changes in this PR: **briefly**

Version 21.1.17 was running OK, still running OK with 21.1.18.

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-musl)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64 (crossbuild)
  - armv7hf (crossbuild)
