### PR TITLE
felix: update to 2.16.1

### DIFF
--- a/srcpkgs/felix/template
+++ b/srcpkgs/felix/template
@@ -1,6 +1,6 @@
 # Template file for 'felix'
 pkgname=felix
-version=2.16.0
+version=2.16.1
 revision=1
 build_style=cargo
 hostmakedepends="pkg-config"
@@ -11,7 +11,7 @@ license="MIT"
 homepage="https://kyoheiu.dev/felix/"
 changelog="https://raw.githubusercontent.com/kyoheiu/felix/refs/heads/develop/CHANGELOG.md"
 distfiles="https://github.com/kyoheiu/felix/archive/refs/tags/v${version}.tar.gz"
-checksum=9fb0a1b120e3171883c8150792808e6871d052190ed8b9bcb0807970545285c6
+checksum=a001dfe81cdbdfa19ba653a4711a17e4c92aa528139739c895df5791a26ea9f5
 
 post_install() {
 	# Binary name conflict with fx


### PR DESCRIPTION
- I tested the changes in this PR: **YES**
- I built this PR locally for my native architecture, (x86_64-glibc)