### PR TITLE
perl-Number-Format: update to 1.76

### DIFF
--- a/srcpkgs/perl-Number-Format/template
+++ b/srcpkgs/perl-Number-Format/template
@@ -1,7 +1,7 @@
 # Template file for 'perl-Number-Format'
 pkgname=perl-Number-Format
-version=1.75
-revision=2
+version=1.76
+revision=1
 build_style=perl-module
 hostmakedepends="perl"
 makedepends="perl"
@@ -11,4 +11,10 @@ maintainer="newbluemoon <blaumolch@mailbox.org>"
 license="Artistic-1.0-Perl, GPL-1.0-or-later"
 homepage="https://metacpan.org/release/Number-Format"
 distfiles="${CPAN_SITE}/Number/${pkgname#perl-}-${version}.tar.gz"
-checksum=82d659cb16461764fd44d11a9ce9e6a4f5e8767dc1069eb03467c6e55de257f3
+checksum=0e0060eb363635a885706c6a26f5fcaafeae759f7b2acae49dda70e195dd44d6
+
+case "$XBPS_TARGET_MACHINE" in
+	# radix char and thousands separator are not localizable in musl, yet
+	# locale check fails because of RADIXCHAR and THOUSEP
+	*-musl) make_check=no ;;
+esac


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

v1.75 has been broken since Perl 5.38

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64 (cross)
  - armv7l-musl (cross)
  - x86_64-musl
  - i686

Tests on *-musl disabled because radix character and thousand separator are not localizable, yet:
```
#   Failed test 'euros'
#   at t/locale.t line 37.
#          got: '123,456.79 USD'
#     expected: '123.456,79 USD'

#   Failed test 'rubles'
#   at t/locale.t line 56.
#                   'USD 123,456.79'
#     doesn't match '(?^:^123,456.79 RU[RB] $)'
# Looks like you failed 2 tests of 12.
t/locale.t ........... 
Dubious, test returned 2 (wstat 512, 0x200)
Failed 2/12 subtests 
```