### PR TITLE
zk: update to 0.15.1

### DIFF
--- a/srcpkgs/zk/template
+++ b/srcpkgs/zk/template
@@ -1,7 +1,7 @@
 # Template file for 'zk'
 pkgname=zk
-version=0.14.1
-revision=2
+version=0.15.1
+revision=1
 build_style=go
 go_import_path=github.com/zk-org/zk
 go_build_tags="fts5"
@@ -12,4 +12,4 @@ license="GPL-3.0-or-later"
 homepage="https://zk-org.github.io/zk/"
 changelog="https://raw.githubusercontent.com/zk-org/zk/main/CHANGELOG.md"
 distfiles="https://github.com/zk-org/zk/archive/refs/tags/v${version}.tar.gz"
-checksum=563331e1f5a03b4dd3a4ff642cc205cc7b6c3c350c98f627a3273067e7ec234c
+checksum=1f30aae497476342203b3cecb63edd92faf4d837860a894fdee4b372184e9ec4


### PR DESCRIPTION
Replaces #55576 , fixes the wrong revision number that the author didn't update

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86-64
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - armv7l-musl
