### PR TITLE
minikube: update to 1.36.0, adopt

### DIFF
--- a/srcpkgs/minikube/template
+++ b/srcpkgs/minikube/template
@@ -1,7 +1,7 @@
 # Template file for 'minikube'
 pkgname=minikube
-version=1.27.0
-revision=4
+version=1.36.0
+revision=1
 archs="x86_64* i686* aarch64*"
 build_style=go
 build_helper=qemu
@@ -12,12 +12,12 @@ hostmakedepends="go-bindata pkg-config"
 makedepends="libvirt-devel"
 depends="kubectl"
 short_desc="Tool to make it easy to run Kubernetes locally"
-maintainer="Orphaned <orphan@voidlinux.org>"
+maintainer="Emil Miler <em@0x45.cz>"
 license="Apache-2.0"
 homepage="https://github.com/kubernetes/minikube"
 changelog="https://raw.githubusercontent.com/kubernetes/minikube/master/CHANGELOG.md"
 distfiles="https://github.com/kubernetes/minikube/archive/v$version.tar.gz"
-checksum=8978a27cff9bf1450c0cd56e28306e8272150f599a017ba31c2bad57fd9248d2
+checksum=d78302d4ad1745341f5c26f49b1cfb42a3e78b486c371c279ae6820a73cd4c26
 
 pre_build() {
 	local storage_provisioner_tag= iso_version=


### PR DESCRIPTION
- I tested the changes in this PR: **YES**
- I built this PR locally for my native architecture, (x86_64-glibc)

Regarding testing, I am now deploying some Helm Charts and everything works fine.