### PR TITLE
khal: orphan [ci skip]

### DIFF
--- a/srcpkgs/khal/template
+++ b/srcpkgs/khal/template
@@ -16,7 +16,7 @@ depends="$_rundeps"
 checkdepends="python3-pytest-xdist python3-freezegun python3-hypothesis
  vdirsyncer $depends"
 short_desc="Command-line calendar build around CalDAV"
-maintainer="Anachron <gith@cron.world>"
+maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
 homepage="http://lostpackets.de/khal/"
 changelog="https://raw.githubusercontent.com/pimutils/khal/master/CHANGELOG.rst"


### PR DESCRIPTION
I am not using the package anymore and trying to update it wasn't easy, as it required new dependencies and versions.