### PR TITLE
android-file-transfer-linux: fix makedepends

### DIFF
--- a/srcpkgs/android-file-transfer-linux/template
+++ b/srcpkgs/android-file-transfer-linux/template
@@ -1,12 +1,12 @@
 # Template file for 'android-file-transfer-linux'
 pkgname=android-file-transfer-linux
 version=4.5
-revision=1
+revision=2
 build_style=cmake
 build_helper="qmake6"
 configure_args="-DBUILD_SHARED_LIB=1"
 hostmakedepends="ninja pkg-config qt6-base qt6-tools"
-makedepends="file-devel fuse-devel readline-devel qt6-base-devel"
+makedepends="file-devel fuse3-devel readline-devel qt6-base-devel taglib-devel"
 depends="qt6-svg android-file-transfer-linux-cli android-file-transfer-linux-libs"
 short_desc="Android File Transfer for Linux"
 maintainer="Toyam Cox <Vaelatern@voidlinux.org>"


### PR DESCRIPTION
- I tested the changes in this PR: yes

The previous update had the wrong makedepends, which did not build the command `aft-mtp-mount`