### PR TITLE
tuxedo-drivers: update to 4.14.1

### DIFF
--- a/srcpkgs/tuxedo-drivers/template
+++ b/srcpkgs/tuxedo-drivers/template
@@ -1,6 +1,6 @@
 # Template file for 'tuxedo-drivers'
 pkgname=tuxedo-drivers
-version=4.14.0
+version=4.14.1
 revision=1
 depends="dkms"
 short_desc="TUXEDO hardware drivers"
@@ -8,7 +8,7 @@ maintainer="newbluemoon <blaumolch@mailbox.org>"
 license="GPL-3.0-or-later"
 homepage="https://gitlab.com/tuxedocomputers/development/packages/tuxedo-drivers"
 distfiles="https://gitlab.com/tuxedocomputers/development/packages/tuxedo-drivers/-/archive/v${version}/tuxedo-drivers-v${version}.tar.gz"
-checksum=da75ecffebccc5b65cd381e65f22760e95606acff3f1e4b794097154d8391613
+checksum=fbe2fb9979ed453521805e662056ddeb9750ff82ef3fd2f2b57c189456a0061d
 
 dkms_modules="tuxedo-drivers ${version}"
 


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)
- Built for kernels 6.1, 6.3–6.15; running on 6.15.2
