### PR TITLE
firejail: add patch to fix xkeyboard config in profiles

### DIFF
--- a/srcpkgs/firejail/patches/musl.patch
+++ b/srcpkgs/firejail/patches/musl.patch
@@ -1,0 +1,73 @@
+--- a/src/libtrace/libtrace.c
++++ b/src/libtrace/libtrace.c
+@@ -447,7 +447,7 @@
+ 	return rv;
+ }
+ 
+-#ifndef stat64
++#ifdef HAVE_STAT64
+ typedef int (*orig_stat64_t)(const char *pathname, struct stat64 *statbuf);
+ static orig_stat64_t orig_stat64 = NULL;
+ int stat64(const char *pathname, struct stat64 *statbuf) {
+@@ -472,7 +472,7 @@
+ 	return rv;
+ }
+ 
+-#ifndef lstat64
++#ifdef HAVE_STAT64
+ typedef int (*orig_lstat64_t)(const char *pathname, struct stat64 *statbuf);
+ static orig_lstat64_t orig_lstat64 = NULL;
+ int lstat64(const char *pathname, struct stat64 *statbuf) {
+--- a/src/libtracelog/libtracelog.c
++++ b/src/libtracelog/libtracelog.c
+@@ -565,7 +565,7 @@
+ 	return rv;
+ }
+ 
+-#ifndef stat64
++#ifdef HAVE_STAT64
+ typedef int (*orig_stat64_t)(const char *pathname, struct stat64 *buf);
+ static orig_stat64_t orig_stat64 = NULL;
+ int stat64(const char *pathname, struct stat64 *buf) {
+@@ -601,7 +601,7 @@
+ 	return rv;
+ }
+ 
+-#ifndef lstat64
++#ifdef HAVE_STAT64
+ typedef int (*orig_lstat64_t)(const char *pathname, struct stat64 *buf);
+ static orig_lstat64_t orig_lstat64 = NULL;
+ int lstat64(const char *pathname, struct stat64 *buf) {
+--- a/config.mk.in
++++ b/config.mk.in
+@@ -22,6 +22,8 @@
+ mandir=@mandir@
+ sysconfdir=@sysconfdir@
+ 
++HAVE_STAT64=@HAVE_STAT64@
++
+ # Misc flags
+ BUSYBOX_WORKAROUND=@BUSYBOX_WORKAROUND@
+ HAVE_CONTRIB_INSTALL=@HAVE_CONTRIB_INSTALL@
+@@ -99,7 +101,7 @@
+ 	-fstack-protector-all \
+ 	-DPREFIX='"$(prefix)"' -DSYSCONFDIR='"$(sysconfdir)/firejail"' \
+ 	-DLIBDIR='"$(libdir)"' -DBINDIR='"$(bindir)"' \
+-	-DVARDIR='"/var/lib/firejail"'
++	-DVARDIR='"/var/lib/firejail"' $(HAVE_STAT64)
+ 
+ PROG_CFLAGS = \
+ 	$(COMMON_CFLAGS) \
+--- a/configure.ac
++++ b/configure.ac
+@@ -298,6 +298,10 @@
+ AC_CHECK_HEADER([linux/seccomp.h], [],
+     [AC_MSG_ERROR([*** SECCOMP support is not installed (/usr/include/linux/seccomp.h missing) ***])])
+ 
++AC_SUBST([HAVE_STAT64])
++AC_CHECK_FUNC(stat64, [
++	HAVE_STAT64="-DHAVE_STAT64"],)
++
+ # set sysconfdir
+ if test "$prefix" = /usr; then
+ 	test "$sysconfdir" = '${prefix}/etc' && sysconfdir="/etc"

--- a/srcpkgs/firejail/patches/profiles-fix-xkeyboard-config.patch
+++ b/srcpkgs/firejail/patches/profiles-fix-xkeyboard-config.patch
@@ -1,0 +1,12 @@
+diff --git a/etc/inc/whitelist-usr-share-common.inc b/etc/inc/whitelist-usr-share-common.inc
+index 03653cc1673..ed5367208e0 100644
+--- a/etc/inc/whitelist-usr-share-common.inc
++++ b/etc/inc/whitelist-usr-share-common.inc
+@@ -70,6 +70,7 @@ whitelist /usr/share/thumbnail.so
+ whitelist /usr/share/uim
+ whitelist /usr/share/vulkan
+ whitelist /usr/share/X11
++whitelist /usr/share/xkeyboard-config-2
+ whitelist /usr/share/xml
+ whitelist /usr/share/zenity
+ whitelist /usr/share/zoneinfo

--- a/srcpkgs/firejail/template
+++ b/srcpkgs/firejail/template
@@ -1,10 +1,10 @@
 # Template file for 'firejail'
 pkgname=firejail
 version=0.9.74
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--enable-apparmor"
-hostmakedepends="pkg-config"
+hostmakedepends="pkg-config autoconf automake"
 makedepends="libapparmor-devel"
 short_desc="SUID security sandbox program"
 maintainer="Duncaen <duncaen@voidlinux.org>"
@@ -16,3 +16,7 @@ checksum=fa54d64d1a6c9d45d72c37d1b8135c50f6e9468e75db7b2dd5ee66983f5a23dd
 conf_files="/etc/firejail/* /etc/apparmor.d/local/firejail-default"
 
 nocross=yes
+
+pre_configure() {
+	autoreconf -fi
+}


### PR DESCRIPTION
https://github.com/netblue30/firejail/issues/6773

#### Testing the changes
- I tested the changes in this PR: **YES**
- Prior to applying this patch`firefox` and `zathura` wouldn't launch after the recent `xkeyboard-config-2.45_1` update

#### Local build testing
- I built this PR locally for my native architecture, (**x86_64-glibc**)

cc @Duncaen 
