### PR TITLE
New Package: lxqt-wayland-session

### DIFF
--- a/srcpkgs/lxqt-wayland-session/template
+++ b/srcpkgs/lxqt-wayland-session/template
@@ -1,0 +1,15 @@
+# Template file for 'lxqt-wayland-session'
+pkgname=lxqt-wayland-session
+version=0.2.0
+revision=1
+build_style=cmake
+hostmakedepends="qt6-base lxqt-build-tools qt6-tools pkg-config xdg-user-dirs perl"
+makedepends="liblxqt-devel"
+depends="qtxdg-tools lxqt-session layer-shell-qt"
+short_desc="Files needed for the LXQt Wayland Session"
+maintainer="Rose <rose@pinkro.se>"
+license="LGPL-2.1-only, GPL-2.0-only, GPL-3.0-only, GPL-3.0-or-later,
+ BSD-3-Clause, CC-BY-SA-4.0, MIT"
+homepage="https://github.com/lxqt/lxqt-wayland-session"
+distfiles="https://github.com/lxqt/lxqt-wayland-session/archive/${version}.tar.gz"
+checksum=3c9819f7c93d09faa873f53b9fc7556b6d02ad772503c9e57eecb5b69535d3bd


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

tested with labwc (default), kwin_wayland, wayfire and niri

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-musl)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - armv6l-musl (cross)

It may also be nice to have this package depend on labwc, since that's the fallback compositor the session uses, but it's technically also possible to configure a default compositor from the terminal/tty