### PR TITLE
libmpeg2: fix distfiles.

### DIFF
--- a/srcpkgs/libmpeg2/patches/global-symbol-test.patch
+++ b/srcpkgs/libmpeg2/patches/global-symbol-test.patch
@@ -1,0 +1,60 @@
+Rewrite the public symbol check to verify the shared libraries, to check for
+more things, and to avoid duplication; fixes make check on ARM
+
+--- a/test/globals
++++ b/test/globals
+@@ -1,4 +1,8 @@
+ #!/bin/sh
++# TODO
++# - fix checking of .a libs; problem is that "nm -g --defined-only" lists
++#   internal symbols; this can be solved by using objdump, but it's probably
++#   good enough to just run the tests on the shared lib
+ 
+ if test x"$srcdir" != x""; then
+     builddir="."	# running from make check, but it does not define that
+@@ -14,22 +18,30 @@
+ 
+ error=0
+ 
+-bad_globals=`nm -g --defined-only $builddir/../libmpeg2/*.o |\
+-    awk '{if ($3) print $3}' | grep -v '^_\?mpeg2_'`
+-
+-if test x"$bad_globals" != x""; then
+-    echo BAD GLOBAL SYMBOLS:
+-    for s in $bad_globals; do echo $s; done
++# check_bad_public_symbols <symbol prefix> <lib file> [<lib file>...]
++#
++# checks public symbols in shared libs:
++# - allow prefix_anything
++# - reject _prefixanything
++# - allow _anything
++# - reject anything else
++#
++# NB: skips missing files
++check_bad_public_symbols() {
++    symbols_prefix="$1"
++    shift
++    lib_files=`ls "$@" 2>/dev/null`
++    [ -z "$lib_files" ] && return
++    bad_globals=`nm -g --defined-only $lib_files |
++        awk '{if ($3) print $3}' |
++        sed -n "/^${symbols_prefix}_/ d; /^_${symbols_prefix}/ { p; d }; /^_/ d; p"`
++    [ -z "$bad_globals" ] && return
+     error=1
+-fi
+-
+-bad_globals=`nm -g --defined-only $builddir/../libmpeg2/convert/*.o |\
+-    awk '{if ($3) print $3}' | grep -v '^_\?mpeg2convert_'`
++    echo BAD GLOBAL SYMBOLS in $lib_files:
++    echo "$bad_globals"
++}
+ 
+-if test x"$bad_globals" != x""; then
+-    echo BAD GLOBAL SYMBOLS:
+-    for s in $bad_globals; do echo $s; done
+-    error=1
+-fi
++check_bad_public_symbols mpeg2 $builddir/../libmpeg2/.libs/libmpeg2.so
++check_bad_public_symbols mpeg2convert $builddir/../libmpeg2/convert/.libs/libmpeg2convert.so
+ 
+ exit $error

--- a/srcpkgs/libmpeg2/template
+++ b/srcpkgs/libmpeg2/template
@@ -1,16 +1,16 @@
 # Template file for 'libmpeg2'
 pkgname=libmpeg2
 version=0.5.1
-revision=11
+revision=12
 build_style=gnu-configure
 configure_args="--enable-shared"
 hostmakedepends="pkg-config"
 makedepends="libXext-devel libXv-devel sdl12-compat-devel"
 short_desc="Library for decoding MPEG-2 and MPEG-1 video streams"
 maintainer="Orphaned <orphan@voidlinux.org>"
-license="GPL-2"
+license="GPL-2.0-or-later"
 homepage="http://libmpeg2.sourceforge.net/"
-distfiles="http://libmpeg2.sourceforge.net/files/libmpeg2-${version}.tar.gz"
+distfiles="http://deb.debian.org/debian/pool/main/m/mpeg2dec/mpeg2dec_${version}.orig.tar.gz"
 checksum=dee22e893cb5fc2b2b6ebd60b88478ab8556cb3b93f9a0d7ce8f3b61851871d4
 
 case "$XBPS_TARGET_MACHINE" in


### PR DESCRIPTION
~~Internals are identical to those of the original source (found on archive.org), according to diff -r~~
EDIT: switched to debian-hosted distfiles, hash matches previous version. Added patch of test from [gentoo](https://gitweb.gentoo.org/repo/gentoo.git/tree/media-libs/libmpeg2/files/libmpeg2-0.5.1-global-symbol-test.patch)

#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, x86-64
