### PR TITLE
tox: update to 4.27.0, and deps

### DIFF
--- a/srcpkgs/hatch-vcs/template
+++ b/srcpkgs/hatch-vcs/template
@@ -1,7 +1,7 @@
 # Template file for 'hatch-vcs'
 pkgname=hatch-vcs
-version=0.4.0
-revision=2
+version=0.5.0
+revision=1
 build_style=python3-pep517
 make_check_args="--deselect tests/test_build.py::test_basic
  --deselect tests/test_build.py::test_write
@@ -17,7 +17,7 @@ license="MIT"
 homepage="https://github.com/ofek/hatch-vcs"
 changelog="https://github.com/ofek/hatch-vcs/raw/master/HISTORY.md"
 distfiles="${PYPI_SITE}/h/${pkgname/-/_}/${pkgname/-/_}-${version}.tar.gz"
-checksum=093810748fe01db0d451fabcf2c1ac2688caefd232d4ede967090b1c1b07d9f7
+checksum=0395fa126940340215090c344a2bf4e2a77bcbe7daab16f41b37b98c95809ff9
 make_check_pre="env PYTHONPATH=./"
 
 post_install() {

--- a/srcpkgs/python3-cachetools/template
+++ b/srcpkgs/python3-cachetools/template
@@ -1,6 +1,6 @@
 # Template file for 'python3-cachetools'
 pkgname=python3-cachetools
-version=5.5.2
+version=6.1.0
 revision=1
 build_style=python3-pep517
 hostmakedepends="python3-setuptools python3-wheel"
@@ -12,7 +12,7 @@ license="MIT"
 homepage="https://github.com/tkem/cachetools/"
 changelog="https://raw.githubusercontent.com/tkem/cachetools/master/CHANGELOG.rst"
 distfiles="${PYPI_SITE}/c/cachetools/cachetools-${version}.tar.gz"
-checksum=1a661caa9175d26759571b2e19580f9d6393969e5dfca11fdb1f947a23e640d4
+checksum=b4c4f404392848db3ce7aac34950d17be4d864da4b8b66911008e430bc544587
 
 post_install() {
 	vlicense LICENSE

--- a/srcpkgs/python3-coverage/template
+++ b/srcpkgs/python3-coverage/template
@@ -1,6 +1,6 @@
 # Template file for 'python3-coverage'
 pkgname=python3-coverage
-version=7.8.0
+version=7.9.1
 revision=1
 build_style=python3-pep517
 # this counts files but our installed package has fewer files
@@ -14,7 +14,7 @@ license="Apache-2.0"
 homepage="https://github.com/nedbat/coveragepy"
 changelog="https://raw.githubusercontent.com/nedbat/coveragepy/master/CHANGES.rst"
 distfiles="${PYPI_SITE}/c/coverage/coverage-${version}.tar.gz"
-checksum=7a3d62b3b03b4b6fd41a085f3574874cf946cb4604d2b4d3e8dca8cd570ca501
+checksum=6cf43c78c4282708a28e466316935ec7489a9c487518a77fa68f716c67909cec
 
 pre_check() {
 	# required setup, see tox.ini

--- a/srcpkgs/python3-mock/template
+++ b/srcpkgs/python3-mock/template
@@ -1,7 +1,7 @@
 # Template file for 'python3-mock'
 pkgname=python3-mock
-version=5.1.0
-revision=3
+version=5.2.0
+revision=1
 build_style=python3-pep517
 hostmakedepends="python3-setuptools python3-wheel"
 depends="python3"
@@ -12,7 +12,7 @@ license="BSD-2-Clause"
 homepage="http://mock.readthedocs.org/en/latest/"
 changelog="https://raw.githubusercontent.com/testing-cabal/mock/master/CHANGELOG.rst"
 distfiles="${PYPI_SITE}/m/mock/mock-${version}.tar.gz"
-checksum=5e96aad5ccda4718e0a229ed94b2024df75cc2d55575ba5762d31f5767b8767d
+checksum=4e460e818629b4b173f32d08bf30d3af8123afbb8e04bb5707a1fd4799e503f0
 
 post_install() {
 	vlicense LICENSE.txt

--- a/srcpkgs/python3-platformdirs/template
+++ b/srcpkgs/python3-platformdirs/template
@@ -1,6 +1,6 @@
 # Template file for 'python3-platformdirs'
 pkgname=python3-platformdirs
-version=4.3.7
+version=4.3.8
 revision=1
 build_style=python3-pep517
 hostmakedepends="hatchling hatch-vcs"
@@ -12,7 +12,7 @@ license="MIT"
 homepage="https://platformdirs.rtfd.io/"
 changelog="https://raw.githubusercontent.com/platformdirs/platformdirs/main/CHANGES.rst"
 distfiles="${PYPI_SITE}/p/platformdirs/platformdirs-${version}.tar.gz"
-checksum=eb437d586b6a0986388f0d6f74aa0cde27b48d0e3d66843640bfb6bdcdb6e351
+checksum=3d512d96e16bcb959a814c9f348431070822a6496326a4be0911c40b5a74c2bc
 make_check_pre="env PYTHONPATH=src"
 
 post_install() {

--- a/srcpkgs/python3-pluggy/template
+++ b/srcpkgs/python3-pluggy/template
@@ -1,7 +1,7 @@
 # Template file for 'python3-pluggy'
 pkgname=python3-pluggy
-version=1.5.0
-revision=2
+version=1.6.0
+revision=1
 build_style=python3-pep517
 hostmakedepends="python3-setuptools_scm python3-wheel"
 depends="python3"
@@ -12,7 +12,7 @@ license="MIT"
 homepage="https://github.com/pytest-dev/pluggy"
 changelog="https://raw.githubusercontent.com/pytest-dev/pluggy/main/CHANGELOG.rst"
 distfiles="${PYPI_SITE}/p/pluggy/pluggy-${version}.tar.gz"
-checksum=2cffa88e94fdc978c4c574f15f9e59b7f4201d439195c3715ca9e2486f1d0cf1
+checksum=7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3
 
 post_install() {
 	vlicense LICENSE

--- a/srcpkgs/python3-pyproject-api/template
+++ b/srcpkgs/python3-pyproject-api/template
@@ -1,6 +1,6 @@
 # Template file for 'python3-pyproject-api'
 pkgname=python3-pyproject-api
-version=1.9.0
+version=1.9.1
 revision=1
 build_style=python3-pep517
 hostmakedepends="hatchling hatch-vcs"
@@ -12,7 +12,7 @@ license="MIT"
 homepage="https://github.com/tox-dev/pyproject-api"
 changelog="https://github.com/tox-dev/pyproject-api/releases"
 distfiles="${PYPI_SITE}/p/pyproject-api/pyproject_api-${version}.tar.gz"
-checksum=7e8a9854b2dfb49454fae421cb86af43efbb2b2454e5646ffb7623540321ae6e
+checksum=43c9918f49daab37e302038fc1aed54a8c7a91a9fa935d00b9a485f37e0f5335
 
 if [ "$XBPS_BUILD_ENVIRONMENT" = void-packages-ci ]; then
 	# this test fails on CI

--- a/srcpkgs/python3-pytest-asyncio/template
+++ b/srcpkgs/python3-pytest-asyncio/template
@@ -1,6 +1,6 @@
 # Template file for 'python3-pytest-asyncio'
 pkgname=python3-pytest-asyncio
-version=0.26.0
+version=1.0.0
 revision=1
 build_style=python3-pep517
 hostmakedepends="python3-setuptools_scm python3-wheel"
@@ -12,7 +12,7 @@ license="Apache-2.0"
 homepage="https://github.com/pytest-dev/pytest-asyncio"
 changelog="https://raw.githubusercontent.com/pytest-dev/pytest-asyncio/master/docs/source/reference/changelog.rst"
 distfiles="${PYPI_SITE}/p/pytest-asyncio/pytest_asyncio-${version}.tar.gz"
-checksum=c4df2a697648241ff39e7f0e4a73050b03f123f760673956cf0d72a4990e312f
+checksum=d15463d13f4456e1ead2594520216b225a16f781e144f8fdf6c5bb4667c48b3f
 
 if [ "$XBPS_BUILD_ENVIRONMENT" = void-packages-ci ]; then
 	# these tests fail on CI (bind to a tcp address)

--- a/srcpkgs/python3-pytest-cov/template
+++ b/srcpkgs/python3-pytest-cov/template
@@ -1,10 +1,10 @@
 # Template file for 'python3-pytest-cov'
 pkgname=python3-pytest-cov
-version=6.1.1
+version=6.2.1
 revision=1
 build_style=python3-pep517
 hostmakedepends="python3-setuptools"
-depends="python3-pytest python3-coverage"
+depends="python3-pytest python3-coverage python3-pluggy"
 checkdepends="$depends python3-fields python3-process-tests
  python3-pytest-xdist python3-virtualenv"
 short_desc="Pytest plugin for measuring coverage"
@@ -13,7 +13,7 @@ license="MIT"
 homepage="https://pytest-cov.readthedocs.io/en/latest/"
 changelog="https://raw.githubusercontent.com/pytest-dev/pytest-cov/master/CHANGELOG.rst"
 distfiles="${PYPI_SITE}/p/pytest-cov/pytest_cov-${version}.tar.gz"
-checksum=46935f7aaefba760e716c2ebfbe1c216240b9592966e7da99ea8292d4d3e2a0a
+checksum=25cc6cc0a5358204b8108ecedc51a9b57b34cc6b8c967cc2c01a4e00d8a67da2
 
 do_check() {
 	# Running via PYTHONPATH breaks a few tests so we use a venv

--- a/srcpkgs/python3-pytest-mock/template
+++ b/srcpkgs/python3-pytest-mock/template
@@ -1,7 +1,7 @@
 # Template file for 'python3-pytest-mock'
 pkgname=python3-pytest-mock
-version=3.14.0
-revision=2
+version=3.14.1
+revision=1
 build_style=python3-pep517
 hostmakedepends="python3-setuptools_scm python3-wheel"
 depends="python3-pytest"
@@ -11,8 +11,8 @@ maintainer="Gonzalo Tornaría <tornaria@cmat.edu.uy>"
 license="MIT"
 homepage="https://github.com/pytest-dev/pytest-mock/"
 changelog="https://raw.githubusercontent.com/pytest-dev/pytest-mock/main/CHANGELOG.rst"
-distfiles="${PYPI_SITE}/p/pytest-mock/pytest-mock-${version}.tar.gz"
-checksum=2719255a1efeceadbc056d6bf3df3d1c5015530fb40cf347c0f9afac88410bd0
+distfiles="${PYPI_SITE}/p/pytest-mock/pytest_mock-${version}.tar.gz"
+checksum=159e9edac4c451ce77a5cdb9fc5d1100708d2dd4ba3c3df572f14097351af80e
 
 post_install() {
 	vlicense LICENSE

--- a/srcpkgs/python3-pytest-timeout/template
+++ b/srcpkgs/python3-pytest-timeout/template
@@ -1,7 +1,7 @@
 # Template file for 'python3-pytest-timeout'
 pkgname=python3-pytest-timeout
-version=2.3.1
-revision=2
+version=2.4.0
+revision=1
 build_style=python3-pep517
 hostmakedepends="python3-setuptools"
 depends="python3-pytest"
@@ -10,8 +10,16 @@ short_desc="Pytest plugin which will terminate tests after a certain timeout"
 maintainer="Tim Sandquist <tim.sandquist@gmail.com>"
 license="MIT"
 homepage="https://github.com/pytest-dev/pytest-timeout/"
-distfiles="${PYPI_SITE}/p/pytest-timeout/pytest-timeout-${version}.tar.gz"
-checksum=12397729125c6ecbdaca01035b9e5239d4db97352320af155b3f5de1ba5165d9
+distfiles="${PYPI_SITE}/p/pytest-timeout/pytest_timeout-${version}.tar.gz"
+checksum=7e68e90b01f9eff71332b25001f85c75495fc4e3a836701876183c4bcfd0540a
+
+if [ "$XBPS_BUILD_ENVIRONMENT" = void-packages-ci ]; then
+	# these tests fail on CI (out of pty devices)
+	make_check_args="
+	 --deselect=test_pytest_timeout.py::test_suppresses_timeout_when_debugger_is_entered[pdb-set_trace()]
+	 --deselect=test_pytest_timeout.py::test_disable_debugger_detection_flag[pdb-set_trace()]
+	 "
+fi
 
 post_install() {
 	vlicense LICENSE

--- a/srcpkgs/python3-virtualenv/template
+++ b/srcpkgs/python3-virtualenv/template
@@ -1,7 +1,7 @@
 # Template file for 'python3-virtualenv'
 pkgname=python3-virtualenv
-version=20.30.0
-revision=2
+version=20.31.2
+revision=1
 build_style=python3-pep517
 hostmakedepends="hatchling hatch-vcs"
 depends="python3-platformdirs python3-distlib python3-filelock"
@@ -14,7 +14,7 @@ license="MIT"
 homepage="https://virtualenv.pypa.io/"
 changelog="https://virtualenv.pypa.io/en/latest/changelog.html"
 distfiles="${PYPI_SITE}/v/virtualenv/virtualenv-${version}.tar.gz"
-checksum=800863162bcaa5450a6e4d721049730e7f2dae07720e0902b0e4040bd6f9ada8
+checksum=e10c0a9d02835e592521be48b332b6caee6887f332c111aa79a09b9e79efc2af
 alternatives="virtualenv:virtualenv:/usr/bin/virtualenv3"
 
 post_install() {

--- a/srcpkgs/tox/template
+++ b/srcpkgs/tox/template
@@ -1,8 +1,13 @@
 # Template file for 'tox'
 pkgname=tox
-version=4.25.0
+version=4.27.0
 revision=1
 build_style=python3-pep517
+# these two tests fail with "OSError: out of pty devices"
+make_check_args="
+ --deselect=tests/execute/local_subprocess/test_local_subprocess.py::test_local_execute_terminal_size
+ --deselect=tests/execute/local_subprocess/test_local_subprocess.py::test_local_subprocess_tty[on]
+ "
 hostmakedepends="hatchling hatch-vcs"
 depends="python3-cachetools python3-chardet python3-colorama python3-filelock
  python3-packaging python3-platformdirs python3-pluggy python3-pyproject-api
@@ -16,7 +21,7 @@ license="MIT"
 homepage="https://tox.wiki/"
 changelog="https://raw.githubusercontent.com/tox-dev/tox/main/docs/changelog.rst"
 distfiles="${PYPI_SITE}/t/tox/tox-${version}.tar.gz"
-checksum=dd67f030317b80722cf52b246ff42aafd3ed27ddf331c415612d084304cf5e52
+checksum=b97d5ecc0c0d5755bcc5348387fef793e1bfa68eb33746412f4c60881d7f5f57
 
 do_check() {
 	# Running via PYTHONPATH breaks a few tests so we use a venv
@@ -25,7 +30,8 @@ do_check() {
 
 	local testpy="${testdir}/bin/python3"
 	"${testpy}" -m installer dist/*.whl
-	PATH="${testdir}/bin:${PATH}" "${testpy}" -m pytest -n ${XBPS_MAKEJOBS}
+	PATH="${testdir}/bin:${PATH}" "${testpy}" -m pytest -n ${XBPS_MAKEJOBS} \
+		${make_check_args}
 }
 
 post_install() {


### PR DESCRIPTION
- **python3-coverage: update to 7.9.1.**
- **python3-mock: update to 5.2.0.**
- **python3-pytest-asyncio: update to 1.0.0.**
- **python3-pytest-cov: update to 6.2.1.**
- **python3-pytest-mock: update to 3.14.1.**
- **python3-pytest-timeout: update to 2.4.0.**
- **hatch-vcs: update to 0.5.0.**
- **python3-cachetools: update to 6.1.0.**
- **python3-platformdirs: update to 4.3.8.**
- **python3-pluggy: update to 1.6.0.**
- **python3-pyproject-api: update to 1.9.1.**
- **python3-virtualenv: update to 20.31.2.**
- **tox: update to 4.27.0.**

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
