### PR TITLE
libblockdev: update to 3.3.1.

### DIFF
--- a/srcpkgs/libblockdev/template
+++ b/srcpkgs/libblockdev/template
@@ -1,6 +1,6 @@
 # Template file for 'libblockdev'
 pkgname=libblockdev
-version=3.3.0
+version=3.3.1
 revision=1
 build_style=gnu-configure
 make_check_target="test"
@@ -16,7 +16,7 @@ homepage="https://github.com/storaged-project/libblockdev"
 # changelog needs to be adjusted on major version changes
 changelog="https://raw.githubusercontent.com/storaged-project/libblockdev/master/NEWS.rst"
 distfiles="https://github.com/storaged-project/libblockdev/archive/refs/tags/${version}.tar.gz"
-checksum=84e333b172538bf458fec3acbe35a9fbe3b12ba1e467f67ff2970f04b89e858c
+checksum=7d313d790dbf2921d19bed0bba591fc3530113bc0f3e7818ee80f028c988a286
 conf_files="/etc/libblockdev/3/conf.d/10-lvm-dbus.cfg
  /etc/libblockdev/3/conf.d/00-default.cfg"
 # Requires root.


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **NO**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-libc

[CVE-2025-6019](https://github.com/advisories/GHSA-mpgj-hch9-5rvx)
