### PR TITLE
New package: notepadnext-0.12

### DIFF
--- a/srcpkgs/notepadnext/patches/cstdint.patch
+++ b/srcpkgs/notepadnext/patches/cstdint.patch
@@ -1,0 +1,13 @@
+diff --git a/src/scintilla/include/ScintillaTypes.h b/src/scintilla/include/ScintillaTypes.h
+index 71e2be3..9f00f3c 100644
+--- a/src/scintilla/include/ScintillaTypes.h
++++ b/src/scintilla/include/ScintillaTypes.h
+@@ -11,6 +11,8 @@
+ #ifndef SCINTILLATYPES_H
+ #define SCINTILLATYPES_H
+
++#include <cstdint>
++
+ namespace Scintilla {
+
+ // Enumerations

--- a/srcpkgs/notepadnext/template
+++ b/srcpkgs/notepadnext/template
@@ -1,0 +1,46 @@
+# Template file for 'notepadnext'
+pkgname=notepadnext
+version=0.12
+revision=1
+_qtads_ver=c020f82a6cfc43e7127e315b1a8f0e05e8a7113f
+_qtsimpup_ver=8e7017f7fbdc2b4b1a26ed1eef9ebcba6a50639c
+_qteditcfg_ver=ab62f0554abf2bbe4d45427b36a8b2f81ca7b4ab
+_qtsingleapp_ver=494772e98cef0aa88124f154feb575cc60b08b38
+_uchardet_ver=ae6302a016088ad07177f86d417b20010053632b
+build_style=qmake
+build_helper=qmake6
+hostmakedepends="pkg-config qt6-tools qt6-base git"
+makedepends="qt6-base-devel qt6-qt5compat-devel hicolor-icon-theme libxcb-devel"
+short_desc="Cross-platform reimplementation of Notepad++"
+maintainer="zlice <zlice555@gmail.com>"
+license="GPL-3.0-only"
+homepage="https://github.com/dail8859/NotepadNext"
+distfiles="https://github.com/dail8859/NotepadNext/archive/refs/tags/v${version}.tar.gz
+ https://github.com/githubuser0xFFFF/Qt-Advanced-Docking-System/archive/${_qtads_ver}.tar.gz>qtads-${_qtads_ver}.tar.gz
+ https://github.com/alex-spataru/QSimpleUpdater/archive/${_qtsimpup_ver}.tar.gz>qtsimpup-${_qtsimpup_ver}.tar.gz
+ https://github.com/editorconfig/editorconfig-core-qt/archive/${_qteditcfg_ver}.tar.gz>qteditcfg-${_qteditcfg_ver}.tar.gz
+ https://github.com/itay-grudev/SingleApplication/archive/${_qtsingleapp_ver}.tar.gz>qtsingleapp-${_qtsingleapp_ver}.tar.gz
+ https://gitlab.freedesktop.org/uchardet/uchardet/-/archive/${_uchardet_ver}/uchardet-${_uchardet_ver}.tar.gz>uchardet-${_uchardet_ver}.tar.gz"
+checksum="938d16c642b30755d304f92f7560a81ad8b4fe7b8d5688c13392fc88dec2768b
+ 5a5f73edf8f2f7c22c6943272e3b4e8eb4952e5845a3a22d8259b81259092c54
+ 74d09013a05f33359217fe238b624ddc04c4bb12402ae3c4f391df2049c49cf8
+ 17d305ffa59647477217ed5b36db2c2ef0a9b279a5bc4b01de0dbc7282665ceb
+ e1a3625c3e60413847b1e74d2e2fabcabe5863686d26b16ee76f011f0521e535
+ 26f7fe5032ce3f481b5a8881bcab54e27c21386c300bf8e737c7391f105ab8b4"
+skip_extraction="qtads-${_qtads_ver}.tar.gz
+ qtsimpup-${_qtsimpup_ver}.tar.gz
+ qteditcfg-${_qteditcfg_ver}.tar.gz
+ qtsingleapp-${_qtsingleapp_ver}.tar.gz
+ uchardet-${_uchardet_ver}.tar.gz"
+
+pre_configure() {
+	vsrcextract -C src/ads qtads-${_qtads_ver}.tar.gz
+	vsrcextract -C src/QSimpleUpdate qtsimpup-${_qtsimpup_ver}.tar.gz
+	vsrcextract -C src/editorconfig-core-qt qteditcfg-${_qteditcfg_ver}.tar.gz
+	vsrcextract -C src/singleapplication qtsingleapp-${_qtsingleapp_ver}.tar.gz
+	vsrcextract -C src/uchardet uchardet-${_uchardet_ver}.tar.gz
+}
+
+do_configure() {
+	qmake6 src/NotepadNext.pro
+}


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

#### Local build testing
- I built this PR locally for my native architecture, **x86_64**
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - **aarch64-musl**

#### Comments

it notepad's ++ ? will use in place of gedit and test

![woo](https://github.com/user-attachments/assets/1364f3a0-f877-4c09-b471-e7294af67c96)
