### PR TITLE
rmpc: update to 0.9.0

### DIFF
--- a/srcpkgs/rmpc/template
+++ b/srcpkgs/rmpc/template
@@ -1,6 +1,6 @@
 # Template file for 'rmpc'
 pkgname=rmpc
-version=0.8.0
+version=0.9.0
 revision=1
 build_style=cargo
 short_desc="TUI MPD client with album art support"
@@ -9,7 +9,7 @@ license="BSD-3-Clause"
 homepage="https://mierak.github.io/rmpc"
 changelog="https://raw.githubusercontent.com/mierak/rmpc/refs/heads/master/CHANGELOG.md"
 distfiles="https://github.com/mierak/rmpc/archive/refs/tags/v${version}.tar.gz"
-checksum="f2ff534ad662d6bb033f1715c27406718eb7025655f5c30c94a6b051e3a1c371"
+checksum=c0dca5f4be1222591a69b82e77d6fe42df259e6130ea7ea7dd6372515b5f4357
 
 post_install() {
 	vman "target/man/rmpc.1"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-gnu)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - aarch64
  - armv6l-musl
  - armv6l
  - i686