### PR TITLE
python3-requests: update to 2.32.4, python3-pytest-httpbin: update to 2.1.0

### DIFF
--- a/srcpkgs/python3-pytest-httpbin/template
+++ b/srcpkgs/python3-pytest-httpbin/template
@@ -1,7 +1,7 @@
 # Template file for 'python3-pytest-httpbin'
 pkgname=python3-pytest-httpbin
-version=2.0.0
-revision=2
+version=2.1.0
+revision=1
 build_style=python3-pep517
 hostmakedepends="python3-setuptools"
 depends="python3-pytest python3-httpbin"
@@ -10,8 +10,8 @@ short_desc="Easily test your HTTP library against a local copy of httpbin.org"
 maintainer="Gonzalo Tornaría <tornaria@cmat.edu.uy>"
 license="MIT"
 homepage="https://github.com/kevin1024/pytest-httpbin"
-distfiles="${PYPI_SITE}/p/pytest-httpbin/pytest-httpbin-${version}.tar.gz"
-checksum=3e739cad9b8f8df58952df7329d9295fe17449d3a647f49c4ce634fd81d71b8e
+distfiles="${PYPI_SITE}/p/pytest-httpbin/pytest_httpbin-${version}.tar.gz"
+checksum=d40579838443228327f9fe4f08d9338bee8885c29fe933e5f2d58c20a26c33c6
 make_check=extended  # avoid a circular dependency
 
 if [ "$XBPS_CHECK_PKGS" = full ]; then

--- a/srcpkgs/python3-requests/template
+++ b/srcpkgs/python3-requests/template
@@ -1,12 +1,8 @@
 # Template file for 'python3-requests'
 pkgname=python3-requests
-version=2.32.3
-revision=2
+version=2.32.4
+revision=1
 build_style=python3-pep517
-# test_unicode_header_name hangs with urllib3 < 2.x
-# see: https://github.com/psf/requests/issues/6734
-make_check_args="
- --deselect tests/test_requests.py::TestRequests::test_unicode_header_name"
 hostmakedepends="python3-setuptools"
 depends="ca-certificates python3-charset-normalizer python3-urllib3 python3-idna"
 checkdepends="python3-pytest $depends python3-trustme python3-pytest-httpbin
@@ -17,7 +13,7 @@ license="Apache-2.0"
 homepage="https://python-requests.org/"
 changelog="https://raw.githubusercontent.com/psf/requests/master/HISTORY.md"
 distfiles="${PYPI_SITE}/r/requests/requests-${version}.tar.gz"
-checksum=55365417734eb18255590a9ff9eb97e9e1da868d4ccd6402399eaf68af20a760
+checksum=27d0316682c8a29834d3264820024b62a36942083d52caf2f14c0591336d3422
 
 post_patch() {
 	vsed -i '/certifi/d' setup.py


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**|**briefly**|**NO**

pytest-httpbin fixes tests in requests (see https://github.com/psf/requests/blob/91a3eabd3dcc4d7f36dd8249e4777a90ef9b4305/requirements-dev.txt#L4)

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture: x86_64-glibc