### PR TITLE
typos-lsp: update to 0.1.39

### DIFF
--- a/srcpkgs/typos-lsp/template
+++ b/srcpkgs/typos-lsp/template
@@ -1,17 +1,16 @@
 # Template file for 'typos-lsp'
 pkgname=typos-lsp
-version=0.1.37
+version=0.1.39
 revision=1
 build_style=cargo
 make_install_args="--path crates/typos-lsp"
-depends="typos"
 short_desc="LSP server for source code spell checking"
 maintainer="Bnyro <bnyro@tutanota.com>"
 license="MIT"
 homepage="https://github.com/tekumara/typos-lsp"
 changelog="https://raw.githubusercontent.com/tekumara/typos-lsp/refs/heads/main/CHANGELOG.md"
 distfiles="https://github.com/tekumara/typos-lsp/archive/refs/tags/v${version}.tar.gz"
-checksum=a1fc610814752811bccac1cc2a75b86a2475df7546a6051f4618c5625d286a1d
+checksum=e947770d7f12b06886db41ac8a10fd5686c1dbb6042f9898dd899d0900d59762
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

cc @Bnyro

Turns out this doesn't need the `typos` tool separately, since it pulls in the necessary typos crates instead.

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
