### PR TITLE
jinja-lsp: update to 0.1.89.

### DIFF
--- a/srcpkgs/jinja-lsp/template
+++ b/srcpkgs/jinja-lsp/template
@@ -1,6 +1,6 @@
 # Template file for 'jinja-lsp'
 pkgname=jinja-lsp
-version=0.1.86
+version=0.1.89
 revision=1
 build_style=cargo
 make_install_args="--path ./jinja-lsp"
@@ -10,7 +10,7 @@ license="MIT"
 homepage="https://github.com/uros-5/jinja-lsp"
 changelog="https://github.com/uros-5/jinja-lsp/releases"
 distfiles="https://github.com/uros-5/jinja-lsp/archive/refs/tags/v${version}.tar.gz"
-checksum=8875b61c41f5390c207cd1639c2530587c5f1b4da6aa249db75ec023a79202f5
+checksum=76faacf78e0b1cc489bc7f498b8918cef499ac989178878ecfa3c7f0393bcfe0
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
