### PR TITLE
update plan9port to 20250405

### DIFF
--- a/srcpkgs/plan9port/template
+++ b/srcpkgs/plan9port/template
@@ -1,8 +1,8 @@
 # Template file for 'plan9port'
 pkgname=plan9port
-version=20220813
+version=20250405
 revision=1
-_githash=93f814360076ccf28d33c9cb909fca7200ba4a7d
+_githash=9da5b4451365e33c4f561d74a99ad5c17ff20fed
 hostmakedepends="perl which"
 makedepends="libX11-devel libXt-devel libXext-devel freetype-devel fontconfig-devel"
 short_desc="Port of many Plan 9 programs to Unix-like operating systems"
@@ -11,7 +11,7 @@ license="MIT, bzip2-1.0.6, Public Domain, custom:Bigelow & Holmes,
  custom:Bigelow & Holmes Inc and URW++ GmbH, Bitstream-Vera"
 homepage="https://9fans.github.io/plan9port/"
 distfiles="https://github.com/9fans/plan9port/archive/${_githash}.tar.gz"
-checksum=b89174eff5aa5034b6c1cf4e7839ab13a388d90810c64e9b59fc94cf07766c07
+checksum=38f755a62e52281b0c7ec8d9d43a9fb67a7c252b6d5c0c7ffbdc8ee5d6256cb0
 nocross=yes
 
 CFLAGS="-fcommon"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES** (for the past 2 months, `$PLAN9/bin` is at the front of my path)


#### Local build testing
- I built this PR locally for my native architecture, (x86_64-musl)
