### PR TITLE
New package: rofi-wayland-1.7.9.

### DIFF
--- a/srcpkgs/rofi-wayland-devel
+++ b/srcpkgs/rofi-wayland-devel
@@ -1,0 +1,1 @@
+rofi-wayland

--- a/srcpkgs/rofi-wayland/template
+++ b/srcpkgs/rofi-wayland/template
@@ -1,0 +1,49 @@
+# Template file for 'rofi-wayland'
+pkgname=rofi-wayland
+version=1.7.9
+revision=1
+build_style=meson
+configure_args="$(vopt_feature x11 xcb)"
+hostmakedepends="flex glib-devel pkg-config"
+makedepends="librsvg-devel libxkbcommon-devel pango-devel wayland-devel
+ wayland-protocols $(vopt_if x11 libXinerama-devel)
+ $(vopt_if x11 startup-notification-devel) $(vopt_if x11 xcb-util-keysyms-devel)
+ $(vopt_if x11 xcb-util-wm-devel) $(vopt_if x11 xcb-util-xrm-devel)
+ $(vopt_if x11 xcb-util-cursor-devel)"
+checkdepends="check-devel"
+short_desc="Wayland fork of rofi"
+maintainer="Sebastian Ornig <seb@sornig.eu>"
+license="MIT"
+homepage="https://github.com/lbonn/rofi"
+changelog="https://github.com/lbonn/rofi/releases"
+distfiles="https://github.com/lbonn/rofi/releases/download/${version}+wayland1/rofi-${version}+wayland1.tar.xz"
+checksum=edeb12479e759de6a1734f62237605d79baef43d610d5af687b337e98756b74e
+conflicts="rofi>=0"
+provides="rofi-${version}_1"
+replaces="rofi>=0"
+
+# Package build options
+build_options="x11"
+desc_option_png="Enable support for X11/xcb"
+
+if [ "$XBPS_CHECK_PKGS" ]; then
+	configure_args+=" -Dcheck=enabled"
+else
+	configure_args+=" -Dcheck=disabled"
+fi
+
+post_install() {
+	vlicense COPYING
+}
+
+rofi-wayland-devel_package() {
+	short_desc+=" - development files"
+	depends="libglib-devel cairo-devel pango-devel"
+	conflicts="rofi-devel>=0"
+	provides="rofi-devel-${version}_1"
+	replaces="rofi-devel>=0"
+	pkg_install() {
+		vmove usr/include
+		vmove usr/lib/pkgconfig
+	}
+}


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc

---
**NOTE:** [lbonn/rofi](https://github.com/lbonn/rofi) is an actively maintained fork of [rofi](https://github.com/davatorium/rofi) that adds support for Wayland. The versions are in line with upstream. X11 support is still available by setting the `x11` build option (which is disabled by default for a wayland-only build).