### PR TITLE
kubernetes: update to 1.33.2.

### DIFF
--- a/srcpkgs/kubernetes/template
+++ b/srcpkgs/kubernetes/template
@@ -1,6 +1,6 @@
 # Template file for 'kubernetes'
 pkgname=kubernetes
-version=1.33.1
+version=1.33.2
 revision=1
 archs="aarch64* x86_64* ppc64le*"
 build_style=go
@@ -12,7 +12,7 @@ maintainer="Andrea Brancaleoni <abc@pompel.me>"
 license="Apache-2.0"
 homepage="http://kubernetes.io"
 distfiles="https://$go_import_path/archive/v$version.tar.gz"
-checksum=f89203e326de4c827a23ef9aa430d8a3133f62cfa1f5a894e8c85784f01bf055
+checksum=5588bb13437c0e6881f58ede88d200301c3d28b8ce124d58d3e7ed781d1d8d40
 nocross=yes
 system_accounts="kube"
 make_dirs="/var/lib/kubelet 0755 kube kube"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**


#### Local build testing
- I built this PR locally for my native architecture: **x86_64 (libc)**

I got the same error as with [`kubernetes-kind`](https://github.com/void-linux/void-packages/pull/55987). It fails locally using `./xbps-src pkg -Q kubernetes`, but it builds fine with `./xbps-src pkg kubernetes` and runs correctly after `xi kubectl`.