### PR TITLE
vips: update to 8.17.0, adopt.

### DIFF
--- a/srcpkgs/vips/template
+++ b/srcpkgs/vips/template
@@ -1,13 +1,12 @@
 # Template file for 'vips'
 pkgname=vips
-version=8.16.1
+version=8.17.0
 revision=1
 build_style=meson
 build_helper=gir
-configure_args="-Ddoxygen=true $(vopt_feature gir introspection)
- $(vopt_bool gtk_doc)"
+configure_args="-Dcpp-docs=true -Ddocs=true $(vopt_feature gir introspection)"
 hostmakedepends="pkg-config gettext glib-devel doxygen graphviz
- $(vopt_if gtk_doc gtk-doc) $(vopt_if gir gobject-introspection)"
+ gi-docgen $(vopt_if gir gobject-introspection)"
 makedepends="$(vopt_if hdf5 hdf5-devel) $(vopt_if hdf5 matio-devel)
  cfitsio-devel expat-devel fftw-devel fontconfig-devel giflib-devel
  glib-devel lcms2-devel libexif-devel libgsf-devel libimagequant-devel
@@ -15,21 +14,20 @@ makedepends="$(vopt_if hdf5 hdf5-devel) $(vopt_if hdf5 matio-devel)
  libwebp-devel libopenjpeg2-devel pango-devel libmagick-devel libheif-devel
  poppler-glib-devel libjxl-devel"
 short_desc="Fast image processing with low memory needs"
-maintainer="Orphaned <orphan@voidlinux.org>"
+maintainer="yosh <yosh-git@riseup.net>"
 license="LGPL-2.1-or-later"
 homepage="https://www.libvips.org/"
 changelog="https://raw.githubusercontent.com/libvips/libvips/master/ChangeLog"
 distfiles="https://github.com/libvips/libvips/archive/refs/tags/v${version}.tar.gz"
-checksum=df960c3df02da8ae16ee19e79c9428e955d178242a8f06064e07e0c417238e6e
+checksum=41dd9d302dc58d956b62aa991fc2a803b1757fe764a7e1c096ead7c1127fb568
 python_version=3
 
-build_options="gir gtk_doc hdf5"
+build_options="gir hdf5"
 build_options_default="gir"
-desc_option_gtk_doc="Build GTK-doc documentation"
 desc_option_hdf5="HDF5 support"
 
 if [ -z "$CROSS_BUILD" ]; then
-	build_options_default+=" gtk_doc hdf5"
+	build_options_default+=" hdf5"
 fi
 
 libvips_package() {
@@ -59,9 +57,6 @@ libvips-doc_package() {
 	short_desc+=" - documentation"
 	pkg_install() {
 		vmove usr/share/doc
-		if [ "$build_option_gtk_doc" ]; then
-			vmove usr/share/gtk-doc
-		fi
 	}
 }
 


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly** (converted some images with the command line) 

#### Local build testing
- I built this PR locally for my native architecture, `x86_64-glibc`
- I built this PR locally for these architectures:
  - `aarch64-glibc` (crossbuild)

docs stopped using gtk-doc, and in the meantime I decided to remove the docs build option since it didn't seem that useful to be there? no other distros have an option for that.