### PR TITLE
gzdoom: update to 4.14.2, ZMusic: update to 1.1.14

### DIFF
--- a/srcpkgs/ZMusic/template
+++ b/srcpkgs/ZMusic/template
@@ -1,6 +1,6 @@
 # Template file for 'ZMusic'
 pkgname=ZMusic
-version=1.1.12
+version=1.1.14
 revision=1
 build_style=cmake
 configure_args="-DDYN_SNDFILE=OFF -DDYN_FLUIDSYNTH=OFF -DDYN_MPG123=OFF"
@@ -11,7 +11,7 @@ maintainer="Érico Nogueira <ericonr@disroot.org>"
 license="GPL-3.0-or-later"
 homepage="https://github.com/coelckers/ZMusic"
 distfiles="https://github.com/coelckers/ZMusic/archive/${version}.tar.gz"
-checksum=da818594b395aa9174561a36362332b0ab8e7906d2e556ec47669326e67613d4
+checksum=f04410fe4ea08136f37703e7715c27df4c8532ace1e721cf40c6f303a93acc54
 
 if [ "$XBPS_TARGET_LIBC" = musl ]; then
 	makedepends+=" musl-fts-devel"

--- a/srcpkgs/gzdoom/patches/pk3location.patch
+++ b/srcpkgs/gzdoom/patches/pk3location.patch
@@ -1,21 +1,21 @@
 diff --git a/src/gameconfigfile.cpp b/src/gameconfigfile.cpp
-index 0b3931e..c6856cc 100644
+index b61279ebc..3577442be 100644
 --- a/src/gameconfigfile.cpp
 +++ b/src/gameconfigfile.cpp
 @@ -124,6 +124,8 @@ FGameConfigFile::FGameConfigFile ()
  		SetValueForKey ("Path", "/usr/local/share/doom", true);
  		SetValueForKey ("Path", "/usr/local/share/games/doom", true);
  		SetValueForKey ("Path", "/usr/share/doom", true);
-+                // Adds the correct locations of the pk3file for Voidlinux
++		// Adds the correct locations of the pk3file for Void Linux
 +		SetValueForKey ("Path", "/usr/share/gzdoom", true);
  		SetValueForKey ("Path", "/usr/share/games/doom", true);
- #endif
- 	}
-@@ -146,6 +148,8 @@ FGameConfigFile::FGameConfigFile ()
+ 		SetValueForKey ("Path", SHARE_DIR "/doom", true);
+ 		SetValueForKey ("Path", SHARE_DIR "/games/doom", true);
+@@ -151,6 +153,8 @@ FGameConfigFile::FGameConfigFile ()
  		SetValueForKey ("Path", "/usr/local/share/doom", true);
  		SetValueForKey ("Path", "/usr/local/share/games/doom", true);
  		SetValueForKey ("Path", "/usr/share/doom", true);
-+                // Adds the correct locations of the pk3file for Voidlinux
++		// Adds the correct locations of the pk3file for Void Linux
 +		SetValueForKey ("Path", "/usr/share/gzdoom", true);
  		SetValueForKey ("Path", "/usr/share/games/doom", true);
  #endif

--- a/srcpkgs/gzdoom/template
+++ b/srcpkgs/gzdoom/template
@@ -1,7 +1,7 @@
 # Template file for 'gzdoom'
 pkgname=gzdoom
-version=4.12.2
-revision=2
+version=4.14.2
+revision=1
 archs="x86_64* aarch64*"
 build_style=cmake
 configure_args="-DINSTALL_PK3_PATH=share/gzdoom -DDYN_GTK=OFF -DDYN_OPENAL=OFF"
@@ -14,8 +14,8 @@ homepage="https://www.zdoom.org"
 # WARNING: watch out for new submodules
 distfiles="https://github.com/ZDoom/gzdoom/archive/g${version}.tar.gz
  https://github.com/ZDoom/gzdoom/releases/download/g${version}/gzdoom_${version}_amd64.deb"
-checksum="864c5a1ec976dd6068f9cd93f92c5404c662824996101f1411ddb25a54afc732
- c173bcbf8a3e6a4885b6f5d75173160af3a2344c290bc342a3542dcc0a283475"
+checksum="2c4fbb0c5b06787c8a2ade9fbbbe2fa5eaa7c49cf7f62a73627c381f8f890156
+ 15762da40d310d3688fb8a44ded3759424aa51a24277a024488a5b8aea573e2f"
 skip_extraction="${pkgname}_${version}_amd64.deb"
 nocross=yes
 


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc

#### Additional notes
 - Updated `pk3location.patch` because it failed to patch with GZDoom 4.14.2. The patch should still make the same changes.
 - I included ZMusic in the same PR because it was updated with GZDoom 4.14.