### PR TITLE
siril: update to 1.2.6

### DIFF
--- a/srcpkgs/siril/patches/musl.patch
+++ b/srcpkgs/siril/patches/musl.patch
@@ -1,0 +1,38 @@
+#https://gitlab.com/ncopa/siril/-/blob/7f09478f4522b65b476c788a696159e5a4974286/src/io/avi_pipp/pipp_utf8.h
+--- a/src/io/avi_pipp/pipp_utf8.h
++++ b/src/io/avi_pipp/pipp_utf8.h
+@@ -31,27 +31,15 @@
+ #endif
+
+ // 64-bit fseek for various platforms
+-#ifdef __linux__
+-#define fseek64 fseeko64  // Linux
+-#define ftell64 ftello64  // Linux
+-#elif defined (OS_OSX)
+-#define fseek64 fseeko  // OS X
+-#define ftell64 ftello  // OS X
+-#elif defined(BSD)
+-#define fseek64 fseeko  // DragonFly BSD, FreeBSD, OpenBSD, NetBSD
+-#define ftell64 ftello  // DragonFly BSD, FreeBSD, OpenBSD, NetBSD
+-#elif defined (__FreeBSD_kernel__) && defined (__GLIBC__)
+-#define fseek64 fseeko64  // KFreeBSD
+-#define ftell64 ftello64  // KFreeBSD
+-#elif defined (__gnu_hurd__)
+-#define fseek64 fseeko64  // GNU/Hurd
+-#define ftell64 ftello64  // GNU/Hurd
+-#elif defined(__CYGWIN__)
+-#define fseek64 fseeko  // CYGWIN
+-#define ftell64 ftello  // CYGWIN
+-#else
++#if defined(__GLIBC__) || defined(__gnu_hurd__)
++#define fseek64 fseeko64  // GNU
++#define ftell64 ftello64  // GNU
++#elif defined(_WIN32)
+ #define fseek64 _fseeki64  // Windows
+ #define ftell64 _ftelli64  // Windows
++#else // POSIX
++#define fseek64 fseeko  // OS X, DragonFly BSD, FreeBSD, OpenBSD, NetBSD, musl
++#define ftell64 ftello  // OS X, DragonFly BSD, FreeBSD, OpenBSD, NetBSD, musl
+ #endif
+
+ #endif  // PIPP_UTF8_H

--- a/srcpkgs/siril/template
+++ b/srcpkgs/siril/template
@@ -1,19 +1,20 @@
 # Template file for 'siril'
 pkgname=siril
-version=0.9.12
-revision=13
-build_style=gnu-configure
-hostmakedepends="pkg-config intltool autoconf automake gettext-devel"
+version=1.2.6
+revision=1
+build_style=meson
+meson_builddir=mbuild
+hostmakedepends="pkg-config cmake"
 makedepends="fftw-devel libconfig-devel libopencv-devel libffms2-devel
- gsl-devel libraw-devel tiff-devel libpng-devel libcurl-devel
- ffmpeg6-devel gtk+3-devel cfitsio-devel gsl-devel libgomp-devel"
+ gsl-devel libraw-devel tiff-devel libpng-devel libcurl-devel exiv2-devel
+ ffmpeg6-devel gtk+3-devel cfitsio-devel gsl-devel libgomp-devel libheif-devel"
 depends="gnuplot"
 short_desc="Free astronomical image processing software"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-3.0-or-later"
 homepage="https://www.siril.org/"
 distfiles="https://free-astro.org/download/${pkgname}-${version}.tar.bz2"
-checksum=9fb7f8a10630ea028137e8f213727519ae9916ea1d88cd8d0cc87f336d8d53b1
+checksum=312f82e78599f796d163a6d1c90589df1ed920b9ff2bb7ab5b808e43872817fa
 
 if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
 	makedepends+=" libexecinfo-devel"
@@ -21,11 +22,8 @@ fi
 
 CFLAGS="-fcommon"
 
-post_extract() {
-	# add missing check target in this subdir to fix do_check()
-	echo 'check:' >> deps/kplot/Makefile
-}
-
 pre_configure() {
-	NOCONFIGURE=1 ./autogen.sh
+	if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
+		vsed -e "s|rdynamic..|&\n  siril_link_arg += ['-lexecinfo']|" -i meson.build
+	fi
 }


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

![sirilui](https://github.com/user-attachments/assets/1291f2aa-9de1-416d-addf-c7d5c8170cdb)


#### Local build testing
- I built this PR locally for my native architecture, **x86_64**
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - **aarch64-musl**
  - **x86_64-musl**

#### Comments

Saw a [opencv PR](https://github.com/void-linux/void-packages/pull/55041), realized this is not building at all now with musl errors (old and new version both need the patch).

https://gitlab.com/ncopa/siril/-/blob/7f09478f4522b65b476c788a696159e5a4974286/src/io/avi_pipp/pipp_utf8.h

if there's a better way to tell meson to link execinfo for musl lmk