### PR TITLE
gn: update to 20250627

### DIFF
--- a/srcpkgs/gn/template
+++ b/srcpkgs/gn/template
@@ -1,8 +1,8 @@
 # Template file for 'gn'
 pkgname=gn
-version=0.0.20250402
+version=0.0.20250627
 revision=1
-_ref=6e8e0d6d4a151ab2ed9b4a35366e630c55888444
+_ref=97b68a0bb62b7528bc3491c7949d6804223c2b82
 create_wrksrc=yes
 hostmakedepends="python3 ninja"
 short_desc="Meta-build system that generates build files for Ninja"
@@ -10,7 +10,7 @@ maintainer="Duncaen <duncaen@voidlinux.org>"
 license="BSD-3-Clause"
 homepage="https://gn.googlesource.com/gn"
 distfiles="https://gn.googlesource.com/gn/+archive/${_ref}.tar.gz"
-checksum=@a0c07348d1e6bfb3cbedb19faa9e4907aa01891ab5f7cc7a368179b188a3370f
+checksum=@7a611aca6229b2ba931992166880d23f48f7601919f1d180abb27cb97657d36c
 
 do_configure() {
 	cat <<-EOF >src/gn/last_commit_position.h


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **NO**

An update of gn seems to be required to successfully build Chromium 138.