### PR TITLE
scaleway-cli: update to 2.41.0

### DIFF
--- a/srcpkgs/scaleway-cli/template
+++ b/srcpkgs/scaleway-cli/template
@@ -1,20 +1,27 @@
 # Template file for 'scaleway-cli'
 pkgname=scaleway-cli
-version=2.34.0
+version=2.41.0
 revision=1
 build_style=go
 go_import_path=github.com/scaleway/scaleway-cli/v2
 go_package=github.com/scaleway/scaleway-cli/v2/cmd/scw
-go_ldflags="-X main.Version=$version"
+go_ldflags="-X main.Version=${version} -X main.GitBranch=${version} -X main.GitCommit=${version}"
 short_desc="Interact with the Scaleway API from the command line"
 maintainer="Sébastien Pondichy <sebastien.pondichy@gmail.com>"
 license="MIT"
 homepage="https://github.com/scaleway/scaleway-cli"
 distfiles="https://github.com/scaleway/scaleway-cli/archive/v${version}.tar.gz"
-checksum=ed2c62cffa0a68a4ed973a405eb190e42eb5a1aa3d021ad3729b1301f5646d70
-
-# Skip tests as they fail if SHELL=/bin/sh
+checksum=ba056eacd5a012a55789421d0d7579ee002ae298ca9a04a1d9a88eefb0d13ae7
+# Tests fail when run on i686
 make_check="no"
+
+pre_build() {
+	local _date
+	if [ "$SOURCE_DATE_EPOCH" ]; then
+		_date="$(date --utc --date "@SOURCE_DATE_EPOCH" "+%Y-%m-%d")"
+		go_ldflags+=" -X main.BuildDate=${_date}"
+	fi
+}
 
 post_install() {
 	vdoc README.md README


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64 glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64 musl
  - armv7l
  - i686


