### PR TITLE
libvpl: update to 2.15, adopt

### DIFF
--- a/srcpkgs/libvpl/template
+++ b/srcpkgs/libvpl/template
@@ -1,18 +1,18 @@
 # Template file for 'libvpl'
 pkgname=libvpl
-version=2.14.0
+version=2.15.0
 revision=1
 build_style=cmake
 configure_args="-DBUILD_EXAMPLES=ON"
 hostmakedepends="pkg-config"
 makedepends="libva-devel libX11-devel"
 short_desc="Intel oneAPI Video Processing Library"
-maintainer="Michael Aldridge <maldridge@voidlinux.org>"
+maintainer="zlice <zlice555@gmail.com>"
 license="MIT"
 homepage="https://github.com/intel/libvpl"
 changelog="https://github.com/intel/libvpl/blob/master/CHANGELOG.md"
 distfiles="https://github.com/intel/libvpl/archive/refs/tags/v${version}.tar.gz"
-checksum=7c6bff1c1708d910032c2e6c44998ffff3f5fdbf06b00972bc48bf2dd9e5ac06
+checksum=7218c3b8206b123204c3827ce0cf7c008d5c693c1f58ab461958d05fe6f847b3
 
 post_install() {
 	vlicense LICENSE
@@ -34,7 +34,8 @@ libvpl-examples_package() {
 	short_desc+=" - examples"
 	depends="${sourcepkg}>=${version}_${revision}"
 	pkg_install() {
-		vmove usr/bin
+		#they removed cmake lines that install bins in 2.15. not sure if accident?
+		#vmove usr/bin
 		vmove usr/share/vpl/examples
 	}
 }


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, **x86_64**

#### Comments

Adopting per maldridge's comment. https://github.com/void-linux/void-packages/pull/51496#issuecomment-3013921018

libvpl 2.15 seemed to remove the examples? I made an issue to ask if it was a mistake or intended, but I highly doubt anyone who cares will be heartbroken that they have to build the binaries manually.