### PR TITLE
android-udev-rules: update to 20250525

### DIFF
--- a/srcpkgs/android-udev-rules/template
+++ b/srcpkgs/android-udev-rules/template
@@ -1,6 +1,6 @@
 # Template file for 'android-udev-rules'
 pkgname=android-udev-rules
-version=20250314
+version=20250525
 revision=1
 short_desc="Android udev rules list aimed to be the most comprehensive on the net"
 maintainer="Orphaned <orphan@voidlinux.org>"
@@ -8,7 +8,7 @@ license="GPL-3.0-or-later"
 homepage="https://github.com/M0Rf30/android-udev-rules"
 changelog="https://github.com/M0Rf30/android-udev-rules/releases"
 distfiles="https://github.com/M0Rf30/android-udev-rules/archive/${version}.tar.gz"
-checksum=a1b3b6055cdb74a013fe3afcfe1e505bc6ca6339f05d64410660d37f1aca2c8d
+checksum=582bf8daa23f318047e77ece4c101c8696fd9151c459f695dca56cf4a40a72a2
 system_groups="adbusers"
 
 do_install() {


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**
<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (x86-64-glibc)
