### PR TITLE
xbps-triggers: do not set PATH, fix search for dkms script

### DIFF
--- a/srcpkgs/xbps-triggers/files/dkms
+++ b/srcpkgs/xbps-triggers/files/dkms
@@ -18,8 +18,6 @@ PKGNAME="$3"
 VERSION="$4"
 UPDATE="$5"
 
-export PATH="usr/bin:usr/sbin:/usr/sbin:/usr/bin:/sbin:/bin"
-
 remove_modules() {
 	# Remove the specified modules from all kernels.
 	set -- ${dkms_modules}
@@ -120,15 +118,10 @@ targets)
 	echo "post-install pre-remove"
 	;;
 run)
-	if [ -x /usr/bin/dkms ]; then
-		DKMS=/usr/bin/dkms
-	elif [ -x /usr/sbin/dkms ]; then
-		DKMS=/usr/sbin/dkms
-	else
-		exit 0
-	fi
+	[ -z "${dkms_modules}" ] && exit 0
 
-	[ ! -x $DKMS -o -z "$dkms_modules" ] && exit 0
+	DKMS=usr/bin/dkms
+	[ -x "${DKMS}" ] || exit 0
 
 	case "$TARGET" in
 	post-install)

--- a/srcpkgs/xbps-triggers/template
+++ b/srcpkgs/xbps-triggers/template
@@ -1,6 +1,6 @@
 # Template file for 'xbps-triggers'
 pkgname=xbps-triggers
-version=0.128
+version=0.129
 revision=1
 bootstrap=yes
 short_desc="XBPS triggers for Void Linux"


### PR DESCRIPTION
Setting PATH to something relative breaks builds with new dkms, and isn't correct behavior because the dkms script changes directories.

Fixes: #56044.