### PR TITLE
libliftoff: update to 0.5.0 (needs testing)

### DIFF
--- a/srcpkgs/libliftoff/template
+++ b/srcpkgs/libliftoff/template
@@ -1,6 +1,6 @@
 # Template file for 'libliftoff'
 pkgname=libliftoff
-version=0.4.1
+version=0.5.0
 revision=1
 build_style=meson
 hostmakedepends="pkg-config"
@@ -10,7 +10,7 @@ maintainer="Dexter Gaon-Shatford <dexter.gaonshatford@gmail.com>"
 license="MIT"
 homepage="https://gitlab.freedesktop.org/emersion/libliftoff"
 distfiles="https://gitlab.freedesktop.org/emersion/libliftoff/-/archive/v${version}/libliftoff-v${version}.tar.gz"
-checksum=44ec5cfdd0df040d1023d4d6a48b23c31f21ce61ee2347da9e1ca244fe24dd1c
+checksum=3309218c3137a70faada653690802b514e4e46d9b38e7d9d5948ffcc4831f3b1
 
 CFLAGS="-Wno-error=unused-but-set-variable"
 


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **NO**

#### Local build testing
- I built this PR locally for my native architecture, **x86_64**

https://github.com/void-linux/void-packages/pull/56052

currently does not build

should revbump gamescope/wlroots and tes