### PR TITLE
paps: fix gcc14 build const char ptr

### DIFF
--- a/srcpkgs/paps/patches/gcc14.patch
+++ b/srcpkgs/paps/patches/gcc14.patch
@@ -1,0 +1,11 @@
+--- a/src/paps.cc
++++ b/src/paps.cc
+@@ -1073,7 +1073,7 @@
+                             const char *text)
+ {
+   const char *p = text;
+-  char *next;
++  const char *next;
+   gunichar wc;
+   GList *result = nullptr;
+   const char *last_para = text;


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **NO**

#### Local build testing
- I built this PR locally for my native architecture, **x86_64**

https://github.com/void-linux/void-packages/pull/56052

No revbump, just patch for future builds