### PR TITLE
tbb: enable cf-protection only on supported targets

### DIFF
--- a/srcpkgs/tbb/patches/stricter-disable-cf-protection.patch
+++ b/srcpkgs/tbb/patches/stricter-disable-cf-protection.patch
@@ -1,0 +1,22 @@
+From 65d46656f56200a7e89168824c4dbe4943421ff9 Mon Sep 17 00:00:00 2001
+From: lmarz <main@lmarz.org>
+Date: Wed, 2 Jul 2025 09:18:31 +0200
+Subject: [PATCH] Only enable fcf-protection on x86 based processors (#1768)
+
+---
+ cmake/compilers/GNU.cmake | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/cmake/compilers/GNU.cmake b/cmake/compilers/GNU.cmake
+index 4f55209142..d9eb1c4576 100644
+--- a/cmake/compilers/GNU.cmake
++++ b/cmake/compilers/GNU.cmake
+@@ -107,7 +107,7 @@ endif ()
+ set(TBB_COMMON_COMPILE_FLAGS ${TBB_COMMON_COMPILE_FLAGS} -fno-strict-overflow -fno-delete-null-pointer-checks -fwrapv)
+ set(TBB_COMMON_COMPILE_FLAGS ${TBB_COMMON_COMPILE_FLAGS} -Wformat -Wformat-security -Werror=format-security
+     -fstack-protector-strong )
+-if (NOT CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64" AND NOT EMSCRIPTEN)
++if (CMAKE_SYSTEM_PROCESSOR MATCHES "(AMD64|amd64|i.86|x86)" AND NOT EMSCRIPTEN)
+     set(TBB_LIB_COMPILE_FLAGS ${TBB_LIB_COMPILE_FLAGS} $<$<NOT:$<VERSION_LESS:${CMAKE_CXX_COMPILER_VERSION},8.0>>:-fcf-protection=full>)
+ endif ()
+ set(TBB_LIB_COMPILE_FLAGS ${TBB_LIB_COMPILE_FLAGS} $<$<NOT:$<VERSION_LESS:${CMAKE_CXX_COMPILER_VERSION},8.0>>:-fstack-clash-protection>)

--- a/srcpkgs/tbb/template
+++ b/srcpkgs/tbb/template
@@ -1,7 +1,7 @@
 # Template file for 'tbb'
 pkgname=tbb
 version=2022.2.0
-revision=1
+revision=2
 build_style=cmake
 configure_args="-DTBB_STRICT=OFF -DTBB_TEST=OFF"
 makedepends="libgomp-devel libhwloc-devel"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
