### PR TITLE
openssl: update to 3.5.1

### DIFF
--- a/srcpkgs/openssl/template
+++ b/srcpkgs/openssl/template
@@ -1,6 +1,6 @@
 # Template file for 'openssl'
 pkgname=openssl
-version=3.5.0
+version=3.5.1
 revision=1
 bootstrap=yes
 build_style=configure
@@ -17,7 +17,7 @@ maintainer="John <me@johnnynator.dev>"
 license="Apache-2.0"
 homepage="https://openssl-library.org"
 distfiles="https://github.com/openssl/openssl/releases/download/openssl-${version}/openssl-${version}.tar.gz"
-checksum=344d0a79f1a9b08029b0744e2cc401a43f9c90acd1044d09a530b4885a8e9fc0
+checksum=529043b15cffa5f36077a4d0af83f3de399807181d607441d734196d889b641f
 conf_files="/etc/ssl/openssl.cnf"
 replaces="libressl>=0"
 


### PR DESCRIPTION
- I tested the changes in this PR: yes
- I built this PR locally for my native architecture, (aarch64-glibc)