### PR TITLE
btop: update to 1.4.4.

### DIFF
--- a/srcpkgs/btop/template
+++ b/srcpkgs/btop/template
@@ -1,6 +1,6 @@
 # Template file for 'btop'
 pkgname=btop
-version=1.4.3
+version=1.4.4
 revision=1
 build_style=gnu-makefile
 hostmakedepends="lowdown"
@@ -10,4 +10,4 @@ license="Apache-2.0"
 homepage="https://github.com/aristocratos/btop"
 changelog="https://raw.githubusercontent.com/aristocratos/btop/main/CHANGELOG.md"
 distfiles="https://github.com/aristocratos/btop/archive/refs/tags/v${version}.tar.gz"
-checksum=81b133e59699a7fd89c5c54806e16452232f6452be9c14b3a634122e3ebed592
+checksum=98d464041015c888c7b48de14ece5ebc6e410bc00ca7bb7c5a8010fe781f1dd8


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

Ran the new btop during the aarch64 crossbuild (and a few other builds),
inside tmux, with (de-)zooming on a pane, with a few mouse clicks.
Also in a bare st terminal.

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-musl)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64 (crossbuild)
