### PR TITLE
ethtool: update to 6.15.

### DIFF
--- a/srcpkgs/ethtool/template
+++ b/srcpkgs/ethtool/template
@@ -1,6 +1,6 @@
 # Template file for 'ethtool'
 pkgname=ethtool
-version=6.14
+version=6.15
 revision=1
 build_style=gnu-configure
 hostmakedepends="pkg-config"
@@ -11,4 +11,4 @@ license="GPL-2.0-only"
 homepage="https://www.kernel.org/pub/software/network/ethtool/"
 changelog="https://git.kernel.org/pub/scm/network/ethtool/ethtool.git/plain/NEWS"
 distfiles="https://www.kernel.org/pub/software/network/ethtool/ethtool-${version}.tar.xz"
-checksum=9338bb00e492878d3bbe3cd2894e60db35813634c208db0b20f5c7ee84da69b1
+checksum=9477c365114d910120aaec5336a1d16196c833d8486f7c6da67bedef57880ade


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

Ran the new ethtool on:
- MoBo-integrated intel PCIe 1Gbe
- USB realtek 2.5Gbe
- PCIe mellanox Connect-X3 10Gb

but only for showing infos, no interface configuration changes

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-musl)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64 (crossbuild)
