### PR TITLE
v4l2loopback: update to 0.15.0

### DIFF
--- a/srcpkgs/v4l2loopback/template
+++ b/srcpkgs/v4l2loopback/template
@@ -1,6 +1,6 @@
 # Template file for 'v4l2loopback'
 pkgname=v4l2loopback
-version=0.13.2
+version=0.15.0
 revision=1
 hostmakedepends="help2man"
 depends="dkms"
@@ -9,7 +9,7 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later"
 homepage="https://github.com/umlaeute/v4l2loopback"
 distfiles="https://github.com/umlaeute/v4l2loopback/archive/v${version}.tar.gz"
-checksum=1e57e1e382d7451aa2a88d63cc9f146eab1f425b90e76104d4c3d73127e34771
+checksum=a4c259d07fa7eb94c42d56fdac2c21f0eb1dabca2b87dcd8e51f0b4f5ebdd856
 dkms_modules="v4l2loopback ${version}"
 
 do_install() {


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

Tested it out on the latest version of obs-studio and looked at v4l2loopback-ctl, everything seems to work fine.

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64 (crossbuild)

NOTE: The current version of v4l2loopback on the repos, (0.13.2) doesn't seem to build correctly on the mainline kernel and 0.15.0 fixes this.
