### PR TITLE
freeorion: update to 0.5.1.1.

### DIFF
--- a/srcpkgs/freeorion/patches/fix-gigi-config-file-finding.patch
+++ b/srcpkgs/freeorion/patches/fix-gigi-config-file-finding.patch
@@ -1,0 +1,13 @@
+diff --git a/GG/GG/CMakeLists.txt b/GG/GG/CMakeLists.txt
+index 606c8e9cb..4026dc6b9 100644
+--- a/GG/GG/CMakeLists.txt
++++ b/GG/GG/CMakeLists.txt
+@@ -18,7 +18,7 @@ target_sources(GiGi
+         ${CMAKE_CURRENT_LIST_DIR}/Button.h
+         ${CMAKE_CURRENT_LIST_DIR}/ClrConstants.h
+         ${CMAKE_CURRENT_LIST_DIR}/Clr.h
+-        ${CMAKE_CURRENT_LIST_DIR}/Config.h
++        ${CMAKE_CURRENT_BINARY_DIR}/Config.h
+         ${CMAKE_CURRENT_LIST_DIR}/Control.h
+         ${CMAKE_CURRENT_LIST_DIR}/Cursor.h
+         ${CMAKE_CURRENT_LIST_DIR}/DeferredLayout.h

--- a/srcpkgs/freeorion/template
+++ b/srcpkgs/freeorion/template
@@ -1,6 +1,6 @@
 # Template file for 'freeorion'
 pkgname=freeorion
-version=0.5.1
+version=0.5.1.1
 revision=1
 build_style=cmake
 hostmakedepends="cppcheck doxygen python3-pycodestyle"
@@ -12,8 +12,8 @@ maintainer="Emil Tomczyk <emru@emru.xyz>"
 license="GPL-2.0-or-later"
 homepage="https://freeorion.org/index.php/Main_Page"
 changelog="https://raw.githubusercontent.com/freeorion/freeorion/master/ChangeLog.md"
-distfiles="https://github.com/freeorion/freeorion/releases/download/v${version}/FreeOrion_v${version}_Source.tar.gz"
-checksum=75cca4aa0895b8988e800f7c75e0f4fbffd302dfd5fb64f0a7f509123c43cbbb
+distfiles="https://github.com/freeorion/freeorion/releases/download/v${version}/FreeOrion-v${version}_Source.tar.gz"
+checksum=bf6c578ddf1c48021016341dc910f038c80f651fc6f1874390aadb36448b410e
 replaces="freeorion-data>=0"
 
 pre_configure() {


### PR DESCRIPTION
Source code URL changed a bit.
Added a patch for build failure (cmake cannot find `GG/GG/Config.h`) Reported upstream as: https://github.com/freeorion/freeorion/pull/5259

#### Testing the changes
- I tested the changes in this PR: **briefly**

Ran a few turns of a new game.

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-musl)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64
