### PR TITLE
which: update to 2.23.

### DIFF
--- a/srcpkgs/which/template
+++ b/srcpkgs/which/template
@@ -1,7 +1,7 @@
 # Template file for 'which'
 pkgname=which
-version=2.21
-revision=4
+version=2.23
+revision=1
 bootstrap=yes
 build_style=gnu-configure
 short_desc="Displays where a particular program in your path is located"
@@ -9,5 +9,5 @@ maintainer="Enno Boland <gottox@voidlinux.org>"
 license="GPL-3.0-or-later"
 homepage="http://savannah.gnu.org/projects/which"
 distfiles="${GNU_SITE}/$pkgname/$pkgname-$version.tar.gz"
-checksum=f4a245b94124b377d8b49646bf421f9155d36aa7614b6ebf83705d3ffc76eaad
+checksum=a2c558226fc4d9e4ce331bd2fd3c3f17f955115d2c00e447618a4ef9978a2a73
 CFLAGS="-D_LARGE_FILE_SOURCE=1 -D_FILE_OFFSET_BITS=64"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

`which which` finds where and which which is `which`...

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-musl)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64 (crossbuild)