### PR TITLE
timewarrior: update to 1.8.0

### DIFF
--- a/srcpkgs/timewarrior/template
+++ b/srcpkgs/timewarrior/template
@@ -1,6 +1,6 @@
 # Template file for 'timewarrior'
 pkgname=timewarrior
-version=1.7.1
+version=1.8.0
 revision=1
 build_style=cmake
 hostmakedepends="ruby-asciidoctor"
@@ -11,12 +11,13 @@ license="MIT"
 homepage="https://timewarrior.net"
 changelog="https://raw.githubusercontent.com/GothenburgBitFactory/timewarrior/develop/ChangeLog"
 distfiles="https://github.com/GothenburgBitFactory/timewarrior/releases/download/v${version}/timew-${version}.tar.gz"
-checksum=5e0817fbf092beff12598537c894ec1f34b0a21019f5a3001fe4e6d15c11bd94
+checksum=1ea54302dcefa4aa658f89b6b825f0e8b49c04f15cf153a2e7d8bce5525920b4
 python_version=3
 
 post_install() {
 	vlicense LICENSE
 
+	vcompletion completion/timew.zsh zsh timew
 	vcompletion completion/timew-completion.bash bash timew
 	vcompletion completion/timew.fish fish timew
 }


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, x86_64
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64
  - armv7l
  - armv6l
  - i686
  - x86_64
