### PR TITLE
corectrl: update to 1.5.1.

### DIFF
--- a/srcpkgs/corectrl/template
+++ b/srcpkgs/corectrl/template
@@ -1,14 +1,13 @@
 # Template file for 'corectrl'
 pkgname=corectrl
-version=1.4.3
-revision=2
+version=1.5.1
+revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF" # requires https://github.com/rollbear/trompeloeil which isn't packaged
-hostmakedepends="pkg-config extra-cmake-modules qt5-host-tools qt5-qmake
- kcoreaddons kauth"
-makedepends="botan-devel kauth-devel karchive-devel qt5-charts-devel quazip-devel
- qt5-tools-devel libdrm-devel qt5-svg-devel spdlog pugixml-devel"
-depends="dbus hicolor-icon-theme qt5-quickcontrols2 qt5-svg glxinfo"
+hostmakedepends="pkg-config extra-cmake-modules qt6-tools qt6-base kcoreaddons kauth"
+makedepends="botan-devel kauth-devel karchive-devel qt6-charts-devel qt6-declarative-devel
+ quazip-qt6-devel qt6-qt5compat-devel libdrm-devel qt6-svg-devel spdlog pugixml-devel"
+depends="dbus hicolor-icon-theme qt6-svg glxinfo"
 checkdepends="catch2"
 short_desc="User-friendly hardware control application"
 maintainer="Orphaned <orphan@voidlinux.org>"
@@ -16,4 +15,4 @@ license="GPL-3.0-or-later"
 homepage="https://gitlab.com/corectrl/corectrl"
 changelog="https://gitlab.com/corectrl/corectrl/-/raw/master/CHANGELOG.md"
 distfiles="https://gitlab.com/corectrl/corectrl/-/archive/v${version}/corectrl-v${version}.tar.gz"
-checksum="33e5ab55eff77868a0fdf34d3a0d2b434ff7defd03e2997a2d36eae82230c7f4"
+checksum=fc69a79bebf9b0b1178adea8ec0ce36bf1c6a6c4e2d4cb2e6ab4d6e97e822425


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures using specific masterdirs:
  - x86_64-musl
  - i686
- I built this PR locally for these architectures (crossbuilds):
  - aarch64
  - aarch64-musl
  - armv7l
  - armv7l-musl
  - armv6l
  - armv6l-musl