### PR TITLE
diffutils: update to 3.12.

### DIFF
--- a/srcpkgs/diffutils/template
+++ b/srcpkgs/diffutils/template
@@ -1,6 +1,6 @@
 # Template file for 'diffutils'
 pkgname=diffutils
-version=3.10
+version=3.12
 revision=1
 bootstrap=yes
 build_style=gnu-configure
@@ -11,7 +11,7 @@ maintainer="Enno Boland <gottox@voidlinux.org>"
 license="GPL-3.0-or-later"
 homepage="https://www.gnu.org/software/diffutils"
 distfiles="${GNU_SITE}/diffutils/diffutils-${version}.tar.xz"
-checksum=90e5e93cc724e4ebe12ede80df1634063c7a855692685919bfe60b556c9bd09e
+checksum=7c8b7f9fc8609141fdea9cece85249d308624391ff61dedaf528fcb337727dfd
 
 CFLAGS="-D_FILE_OFFSET_BITS=64 -D_TIME_BITS=64"
 
@@ -23,6 +23,8 @@ fi
 if [ "$CROSS_BUILD" ]; then
 	# Tell configure we have GNU getopt
 	configure_args+=" gl_cv_func_getopt_gnu=yes"
+	# Tell configure that our strcasecmp works
+	configure_args+=" gl_cv_func_strcasecmp_works=yes"
 fi
 
 pre_check() {


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

A quick diff & cmp on a bunch of files ran OK.

And `xbp-src check diffutils` output:
```
[...]
============================================================================
Testsuite summary for GNU diffutils 3.12
============================================================================
# TOTAL: 344
# PASS:  279
# SKIP:  65
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
```

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-musl)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - NOPE, tried aarch64 (crossbuild) but that fails