### PR TITLE
python3-s-tui: update to 1.2.0; stress-ng: update to 0.19.02.

### DIFF
--- a/srcpkgs/python3-s-tui/template
+++ b/srcpkgs/python3-s-tui/template
@@ -1,7 +1,7 @@
 # Template file for 'python3-s-tui'
 pkgname=python3-s-tui
-version=1.1.4
-revision=3
+version=1.2.0
+revision=1
 build_style=python3-module
 hostmakedepends="python3-setuptools"
 depends="stress-ng python3-urwid python3-psutil"
@@ -11,4 +11,4 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-only"
 homepage="https://amanusk.github.io/s-tui"
 distfiles="https://github.com/amanusk/s-tui/archive/v${version}.tar.gz"
-checksum=aeebcf7b04beb8526c98d675ae2b2f106fd1e00343b0c37c78b4a84c31561d0b
+checksum=bc02128cd8236d4e8ee9d5e01363c96402accb8310d1ada49e3fa6904f10d6c4

--- a/srcpkgs/stress-ng/template
+++ b/srcpkgs/stress-ng/template
@@ -1,6 +1,6 @@
 # Template file for 'stress-ng'
 pkgname=stress-ng
-version=0.19.01
+version=0.19.02
 revision=1
 build_style=gnu-makefile
 make_use_env=1
@@ -9,7 +9,7 @@ maintainer="Leah Neukirchen <leah@vuxu.org>"
 license="GPL-2.0-or-later"
 homepage="https://github.com/ColinIanKing/stress-ng/"
 distfiles="https://github.com/ColinIanKing/stress-ng/archive/refs/tags/V${version}.tar.gz"
-checksum=825e5004e6455dfb5a0483d810aeaeb0c96b8d2140e30629aaacea7292751198
+checksum=15a07030a14bbfd5991e9ba3fbfbc24ed3ae72a2c946b033c06b820bc16f41c4
 
 if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
 	makedepends+=" musl-legacy-compat"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures using specific masterdirs:
  - x86_64-musl
  - i686
- I built this PR locally for these architectures (crossbuilds):
  - aarch64
  - aarch64-musl
  - armv7l
  - armv7l-musl
  - armv6l
  - armv6l-musl