### PR TITLE
vale: update to 3.12.0.

### DIFF
--- a/srcpkgs/vale/template
+++ b/srcpkgs/vale/template
@@ -1,6 +1,6 @@
 # Template file for 'vale'
 pkgname=vale
-version=3.11.2
+version=3.12.0
 revision=1
 build_style=go
 go_import_path="github.com/errata-ai/vale/v3"
@@ -13,7 +13,7 @@ license="MIT"
 homepage="https://vale.sh"
 changelog="https://github.com/errata-ai/vale/releases"
 distfiles="https://github.com/errata-ai/vale/archive/refs/tags/v${version}.tar.gz"
-checksum=12795c72a5628ebc22d46a33b878519c5ba18e6d665271893bfa24cb1f864f73
+checksum=26b4c02024c441929e7fd2d79a9b1f94489f85d2e87cd25f9efa2057d10a65f3
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture: **x86_64**