### PR TITLE
nftables, socklog-void: clean-up after xlint-ing

### DIFF
--- a/srcpkgs/nftables/template
+++ b/srcpkgs/nftables/template
@@ -20,14 +20,14 @@ post_extract() {
 }
 
 post_build() {
-        (
+	(
 		cd py
-                python -m build --no-isolation --wheel
+		python -m build --no-isolation --wheel
 	)
 }
 
 post_install() {
-        (
+	(
 		cd py
 		python -m installer --destdir ${DESTDIR} --no-compile-bytecode dist/*.whl
 	)

--- a/srcpkgs/socklog-void/template
+++ b/srcpkgs/socklog-void/template
@@ -3,7 +3,6 @@ pkgname=socklog-void
 version=20200115
 revision=2
 build_style=gnu-makefile
-system_groups="socklog"
 make_dirs="/var/log/socklog 2750 root socklog"
 conf_files="
  /var/log/socklog/cron/config
@@ -28,3 +27,4 @@ license="Public Domain"
 homepage="https://github.com/void-linux/socklog-void"
 distfiles="https://github.com/void-linux/${pkgname}/archive/${version}.tar.gz"
 checksum=2bbd906513584ef1d4b729cdaf19356eaacb37d00e29fd26f7f06e34f492ed5f
+system_groups="socklog"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **NO**

An unopinionated batch run of `xlint` on a list of local packages reported these "errors".
Not skipping checks since I didn't build the packages locally.

cc @leahneukirchen 