### PR TITLE
docker-cli: update to 28.3.1.

### DIFF
--- a/srcpkgs/docker-cli/template
+++ b/srcpkgs/docker-cli/template
@@ -1,7 +1,7 @@
 # Template file for 'docker-cli'
 # should be kept in sync with moby
 pkgname=docker-cli
-version=28.3.0
+version=28.3.1
 revision=1
 build_style=go
 go_package="github.com/docker/cli/cmd/docker"
@@ -16,7 +16,7 @@ maintainer="Andrea Brancaleoni <abc@pompel.me>"
 license="Apache-2.0"
 homepage="https://www.docker.com"
 distfiles="https://github.com/docker/cli/archive/v${version}.tar.gz"
-checksum=0ac18927138cd2582e02277d365174a118b962f10084a6bef500a58de705e094
+checksum=ef6808574ea7a4d02ec9715feb8fea419f253fb5b9f68a98020a9e39680baf35
 system_groups="docker"
 # tests seem designed to run in docker
 make_check=no


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**


#### Local build testing
- I built this PR locally for my native architecture: **x86_64 (libc)**