### PR TITLE
libheif: update to 1.20.1

### DIFF
--- a/srcpkgs/libheif/template
+++ b/srcpkgs/libheif/template
@@ -1,7 +1,7 @@
 # Template file for 'libheif'
 pkgname=libheif
-version=1.19.7
-revision=2
+version=1.20.1
+revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF"
 makedepends="libjpeg-turbo-devel libpng-devel libde265-devel x265-devel
@@ -12,7 +12,7 @@ license="LGPL-3.0-or-later"
 homepage="https://github.com/strukturag/libheif"
 changelog="https://github.com/strukturag/libheif/releases"
 distfiles="https://github.com/strukturag/libheif/archive/v${version}.tar.gz"
-checksum=8334c7c418f82c30c9bec1f46e6abfd5a8d3c420a3210d5505eb1868696ce0cc
+checksum=9d3d601ec7a55281217aaa6c773cf6645757b062bc7e9680b664bbd8e481112d
 
 libheif-devel_package() {
 	short_desc+=" - development files"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**
- Opening `.avif` files with `swayimg`

#### Local build testing
- I built this PR locally for my native architecture, (**x86_64-glibc**)
