### PR TITLE
crispy-doom: update to 7.0.

### DIFF
--- a/srcpkgs/crispy-doom/template
+++ b/srcpkgs/crispy-doom/template
@@ -1,6 +1,6 @@
 # Template file for 'crispy-doom'
 pkgname=crispy-doom
-version=6.0
+version=7.0
 revision=1
 build_style=gnu-configure
 hostmakedepends="autoconf automake pkg-config python3"
@@ -10,17 +10,8 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="https://github.com/fabiangreffrath/crispy-doom"
 distfiles="https://github.com/fabiangreffrath/crispy-doom/archive/crispy-doom-${version}.tar.gz"
-checksum=2b85649c615efeac7573883370e9434255af301222b323120692cb9649b7f420
+checksum=25eea88fdbe1320ad0d1a3e0ed66ae8d985c39b79e442beab5fc36d9d5ddfc42
 
 pre_configure() {
 	autoreconf -fi
-}
-
-post_install() {
-	#Rename default.cfg(5), hexen.cfg(5) and heretic.cfg(5) man pages to avoid conflict
-	#with chocolate-doom
-	mv ${DESTDIR}/usr/share/man/man5/default.cfg.5 ${DESTDIR}/usr/share/man/man5/crispy_default.cfg.5
-	mv ${DESTDIR}/usr/share/man/man5/hexen.cfg.5 ${DESTDIR}/usr/share/man/man5/crispy_hexen.cfg.5
-	mv ${DESTDIR}/usr/share/man/man5/heretic.cfg.5 ${DESTDIR}/usr/share/man/man5/crispy_heretic.cfg.5
-	mv ${DESTDIR}/usr/share/man/man5/strife.cfg.5 ${DESTDIR}/usr/share/man/man5/crispy_strife.cfg.5
 }


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, `x86_64-glibc`
- Ran through a couple of levels of Doom 1 and 2, both games worked fine without any issues.

#### Notes
- Removed `post_install` stuff from the template, as it wasn't necessary anymore. we don't have to rename those files anymore to avoid conflicts with `chocolate-doom`, since upstream has done it for us.