### PR TITLE
onefetch: update to 2.25.0

### DIFF
--- a/srcpkgs/onefetch/template
+++ b/srcpkgs/onefetch/template
@@ -1,6 +1,6 @@
 # Template file for 'onefetch'
 pkgname=onefetch
-version=2.24.0
+version=2.25.0
 revision=1
 build_style=cargo
 build_helper=qemu
@@ -14,7 +14,7 @@ license="MIT"
 homepage="https://onefetch.dev"
 changelog="https://github.com/o2sh/onefetch/raw/main/CHANGELOG.md"
 distfiles="https://github.com/o2sh/onefetch/archive/refs/tags/${version}.tar.gz"
-checksum=41f457c9a8145de94980bcae497d84a56cd75c1598a6a9eeb45984947bf4f1f8
+checksum=c9ade471eff5f57e5a6506a08293d8e7ebc54c27e99e33c965313a7108562f35
 
 if [ "$XBPS_TARGET_ENDIAN" = "be" ]; then
 	broken="exr crate unimplemented for BE"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures:
  - x86_64-musl

