### PR TITLE
znc: update to 1.10.1, adopt.

### DIFF
--- a/srcpkgs/znc/template
+++ b/srcpkgs/znc/template
@@ -1,7 +1,7 @@
 # Template file for 'znc'
 pkgname=znc
-version=1.9.1
-revision=4
+version=1.10.1
+revision=1
 build_style=cmake
 configure_args="-DWANT_PYTHON=YES -DWANT_PERL=YES -DWANT_TCL=YES
  -DWANT_ARGON=YES -DWANT_I18N=YES"
@@ -9,12 +9,12 @@ hostmakedepends="pkg-config perl gettext"
 makedepends="openssl-devel python3-devel tcl-devel libsasl-devel
  icu-devel zlib-devel perl libargon2-devel boost-devel"
 short_desc="Advanced IRC Bouncer"
-maintainer="Orphaned <orphan@voidlinux.org>"
+maintainer="Komeil Parseh <komeilparseh@disroot.org>"
 license="Apache-2.0"
 homepage="https://znc.in/"
 changelog="https://github.com/znc/znc/raw/master/ChangeLog.md"
 distfiles="https://znc.in/releases/${pkgname}-${version}.tar.gz"
-checksum=e8a7cf80e19aad510b4e282eaf61b56bc30df88ea2e0f64fadcdd303c4894f3c
+checksum=4e6e76851dbf2606185972b53ec5decad68fe53b63a56e4df8b8b3c0a6c46800
 
 system_accounts="znc"
 znc_homedir="/var/lib/znc"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

### Local build testing
- I built this PR locally for my native architecture, `x86_64`
- I built this PR locally for these architectures (if supported. mark crossbuilds): `aarch64`

Functionality has been tested and confirmed on x86_64 and aarch64. While the package builds successfully for all target architectures, runtime testing has not been performed on other platforms (e.g., `arm*`, `i686`).

cc: @Duncaen 