### PR TITLE
biblioteq: update to 2025.07.05.

### DIFF
--- a/srcpkgs/biblioteq/template
+++ b/srcpkgs/biblioteq/template
@@ -1,6 +1,6 @@
 # Template file for 'biblioteq'
 pkgname=biblioteq
-version=2025.07.02
+version=2025.07.05
 revision=1
 build_style=qmake
 build_helper=qmake6
@@ -13,7 +13,7 @@ maintainer="Rutpiv <roger_freitas@live.com>"
 license="BSD-3-Clause"
 homepage="https://textbrowser.github.io/biblioteq/"
 distfiles="https://github.com/textbrowser/biblioteq/archive/${version}.tar.gz"
-checksum=0c8b2687f6dc69ed6932976610a0f2e2a29f85fd67fd465fec0192b6af9759ad
+checksum=ac31b66a01d66021cc843ae6d2671735a05cc361db8052d8ab9ad7424fad9514
 conf_files="/etc/biblioteq.conf"
 
 # Set the appropriate build helper and dependencies based on architecture


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures using specific masterdirs:
  - x86_64-musl
  - i686
- I built this PR locally for these architectures (crossbuilds):
  - aarch64
  - aarch64-musl
  - armv7l
  - armv7l-musl
  - armv6l
  - armv6l-musl