### PR TITLE
evince: update to 48.1.

### DIFF
--- a/srcpkgs/evince/template
+++ b/srcpkgs/evince/template
@@ -1,6 +1,6 @@
 # Template file for 'evince'
 pkgname=evince
-version=48.0
+version=48.1
 revision=1
 build_helper="gir"
 build_style=meson
@@ -19,7 +19,7 @@ license="GPL-2.0-or-later"
 homepage="https://wiki.gnome.org/Apps/Evince"
 changelog="https://gitlab.gnome.org/GNOME/evince/-/raw/gnome-${version%%.*}/NEWS"
 distfiles="${GNOME_SITE}/evince/${version%%.*}/evince-${version}.tar.xz"
-checksum=cd2f658355fa9075fdf9e5b44aa0af3a7e0928c55614eb1042b36176cf451126
+checksum=7d8b9a6fa3a05d3f5b9048859027688c73a788ff6e923bc3945126884943fa10
 
 build_options="gir gtk_doc"
 build_options_default="gir gtk_doc"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds): X