### PR TITLE
python3-peewee: update to 3.18.2.

### DIFF
--- a/srcpkgs/python3-peewee/template
+++ b/srcpkgs/python3-peewee/template
@@ -1,6 +1,6 @@
 # Template file for 'python3-peewee'
 pkgname=python3-peewee
-version=3.18.1
+version=3.18.2
 revision=1
 build_style=python3-pep517
 hostmakedepends="python3-setuptools python3-wheel python3-Cython"
@@ -12,11 +12,9 @@ license="MIT"
 homepage="https://github.com/coleifer/peewee"
 changelog="https://raw.githubusercontent.com/coleifer/peewee/master/CHANGELOG.md"
 distfiles="https://github.com/coleifer/peewee/archive/${version}.tar.gz"
-checksum=9e32eca343d4fb3f76f2c828872c2d398b3302ec84a6bf95d1a29247f8aec1cc
-alternatives="peewee:pwiz:/usr/bin/pwiz.py3"
+checksum=20f5ca85d46f0c251cba5ab6f734b09e89ea77af56ad66708225bc7d4331f4c7
 make_check=no # tests require postgres instance
 
 post_install() {
-	mv $DESTDIR/usr/bin/pwiz.py $DESTDIR/usr/bin/pwiz.py3
 	vlicense LICENSE
 }


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-libc

I also received errors from invalid alternatives when running xbps-query and similar with pwiz. Is removing the alernatives line the correct course of action?
