### PR TITLE
libvirt: add dmidecode package to dependencies

### DIFF
--- a/srcpkgs/libvirt/template
+++ b/srcpkgs/libvirt/template
@@ -1,7 +1,7 @@
 # Template file for 'libvirt'
 pkgname=libvirt
 version=10.5.0
-revision=3
+revision=4
 build_style=meson
 configure_args="-Dqemu_user=libvirt -Dqemu_group=libvirt -Drunstatedir=/run
  -Dpolkit=enabled"
@@ -13,7 +13,7 @@ makedepends="readline-devel libcap-ng-devel attr-devel gnutls-devel
  device-mapper-devel eudev-libudev-devel libblkid-devel libpciaccess-devel
  avahi-libs-devel polkit-devel yajl-devel jansson-devel python3-devel
  libssh2-devel fuse-devel libtirpc-devel libapparmor-devel"
-depends="iptables dnsmasq"
+depends="iptables dnsmasq dmidecode"
 short_desc="Virtualization API for controlling virtualization engines"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="LGPL-2.1-or-later"


### PR DESCRIPTION
Hi! First commit here in Void. 

Recently I install virt-manager/libvirt and dmidecode package is not installed by default. In other OS (ex: Gentoo) libvirt pull dmidecode package, otherwise libvirtd show errors in logs. 

This change add dmidecode to run-dependencies and fix this issue. 

This change is minor but I tested this in x86_64-glibc (host) and x86_64-musl (only build packages), not problems. 