### PR TITLE
flake8: bump version to 7.1.2

### DIFF
--- a/srcpkgs/flake8/template
+++ b/srcpkgs/flake8/template
@@ -1,7 +1,7 @@
 # Template file for 'flake8'
 pkgname=flake8
-version=7.0.0
-revision=2
+version=7.1.2
+revision=0
 build_style=python3-pep517
 make_check_target="tests/unit"
 make_check_args="--ignore=tests/unit/plugins/pycodestyle_test.py
@@ -15,7 +15,7 @@ license="MIT"
 homepage="https://flake8.pycqa.org/"
 changelog="https://flake8.pycqa.org/en/latest/release-notes/index.html"
 distfiles="https://github.com/PyCQA/flake8/archive/refs/tags/${version}.tar.gz"
-checksum=9b649d29d4bc2562e2d814ffdc63b90828e3f43b50bc146021901b4446bae7fb
+checksum=60364d3593a8fd8a22f3ffcd751b29d0b61945e975754115bb9316bef157e03e
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### New version of package **flake8**
- New version for flake8 - 7.1.2 (Upstream launch: 2025-02-16)
- This new version fix three bugs in 7.0.0 ( [#1966](https://github.com/pycqa/flake8/pull/1966), [#1948](https://github.com/pycqa/flake8/issues/1948) and [#1949](https://github.com/pycqa/flake8/issues/1949))

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl


