### PR TITLE
OBS Studio: update to 31.1.0

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -4507,7 +4507,7 @@ libgrass_raster.8.3.so grass-8.3.0_1
 libgrass_vector.8.3.so grass-8.3.0_1
 libvpl.so.2 libvpl-2.14.0_1
 libusrsctp.so.2 usrsctp-0.9.5.0_1
-libdatachannel.so.0.20 libdatachannel-0.20.2_1
+libdatachannel.so.0.23 libdatachannel-0.23.1_1
 libgeotiff.so.5 libgeotiff-1.7.1_1
 libdraco.so.8 draco-1.5.6_1
 libpdalcpp.so.17 libpdal-2.7.0_1

--- a/srcpkgs/libdatachannel/template
+++ b/srcpkgs/libdatachannel/template
@@ -1,6 +1,6 @@
 # Template file for 'libdatachannel'
 pkgname=libdatachannel
-version=0.20.2
+version=0.23.1
 revision=1
 build_style=cmake
 configure_args="-DPREFER_SYSTEM_LIB=ON -DUSE_NICE=ON -DNO_EXAMPLES=ON"
@@ -10,7 +10,7 @@ maintainer="Michael Aldridge <maldridge@voidlinux.org>"
 license="MPL-2.0"
 homepage="https://libdatachannel.org/"
 distfiles="https://github.com/paullouisageneau/libdatachannel/archive/refs/tags/v$version.tar.gz"
-checksum=8a119064296e8c354f82b6c865306c088ccce0d9863b7cc038927bf10981304e
+checksum=63e14d619ac4d9cc310a0c7620b80e6da88abf878f27ccc78cd099f95d47b121
 
 libdatachannel-devel_package() {
 	short_desc+=" - development files"

--- a/srcpkgs/obs/patches/fix-double-free.patch
+++ b/srcpkgs/obs/patches/fix-double-free.patch
@@ -1,8 +1,8 @@
 https://github.com/obsproject/obs-studio/issues/11029#issuecomment-2249747587
 --- a/libobs/obs-nix.c
 +++ b/libobs/obs-nix.c
-@@ -67,22 +67,6 @@ static const struct obs_nix_hotkeys_vtable *hotkeys_vtable = NULL;
- 
+@@ -67,24 +67,6 @@ static const struct obs_nix_hotkeys_vtable *hotkeys_vtable = NULL;
+
  void add_default_module_paths(void)
  {
 -	char *module_bin_path = os_get_executable_path_ptr("../" OBS_PLUGIN_PATH);
@@ -10,11 +10,13 @@ https://github.com/obsproject/obs-studio/issues/11029#issuecomment-2249747587
 -
 -	if (module_bin_path && module_data_path) {
 -		char *abs_module_bin_path = os_get_abs_path_ptr(module_bin_path);
+-		char *abs_module_install_path = os_get_abs_path_ptr(OBS_INSTALL_PREFIX "/" OBS_PLUGIN_DESTINATION);
 -
 -		if (abs_module_bin_path &&
--		    strcmp(abs_module_bin_path, OBS_INSTALL_PREFIX "/" OBS_PLUGIN_DESTINATION) != 0) {
+-		    (!abs_module_install_path || strcmp(abs_module_bin_path, abs_module_install_path) != 0)) {
 -			obs_add_module_path(module_bin_path, module_data_path);
 -		}
+-		bfree(abs_module_install_path);
 -		bfree(abs_module_bin_path);
 -	}
 -

--- a/srcpkgs/obs/template
+++ b/srcpkgs/obs/template
@@ -1,7 +1,7 @@
 # Template file for 'obs'
 pkgname=obs
 version=31.0.2
-revision=6
+revision=7
 archs="i686* x86_64* ppc64le* aarch64* riscv64*"
 build_style=cmake
 configure_args="-DOBS_VERSION_OVERRIDE=${version} -DENABLE_JACK=ON

--- a/srcpkgs/obs/template
+++ b/srcpkgs/obs/template
@@ -1,7 +1,7 @@
 # Template file for 'obs'
 pkgname=obs
-version=31.0.2
-revision=7
+version=31.1.1
+revision=1
 archs="i686* x86_64* ppc64le* aarch64* riscv64*"
 build_style=cmake
 configure_args="-DOBS_VERSION_OVERRIDE=${version} -DENABLE_JACK=ON
@@ -18,7 +18,7 @@ makedepends="$(vopt_if luajit LuaJIT-devel) fdk-aac-devel
  v4l-utils-devel vlc-devel qt6-svg-devel x264-devel mbedtls-devel
  jansson-devel wayland-devel pipewire-devel libxkbcommon-devel
  pciutils-devel librist-devel srt-devel libdatachannel-devel
- libvpl-devel uthash qt6-base-private-devel json-c++
+ libvpl-devel uthash qt6-base-private-devel json-c++ extra-cmake-modules
  $(vopt_if nvenc nv-codec-headers)"
 depends="xset xdg-desktop-portal"
 short_desc="Open Broadcaster Software"
@@ -27,7 +27,7 @@ license="GPL-2.0-or-later"
 homepage="https://obsproject.com"
 changelog="https://github.com/obsproject/obs-studio/releases"
 distfiles="https://github.com/obsproject/obs-studio/archive/refs/tags/$version.tar.gz"
-checksum=74563ebbee5fcd448e6a790569cf3ca1a01bdcbc6bc2b3f61a9421ff8dfa6eb2
+checksum=39751f067bacc13d44b116c5138491b5f1391f91516d3d590d874edd21292291
 
 build_options="luajit qsv nvenc"
 case $XBPS_TARGET_MACHINE in


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

PipeWire screen capture appears dim/darkened, but this issue is resolved by adding a color correction filter, even if it is set to make no adjustments. Virtual camera only seems to work when v4l2loopback is loaded with `exclusive_caps=1`.

I may report these issues to OBS and v4l2loopback, respectively, but I document them here should any other Void users come searching for answers.

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - i686

This PR requires libdatachannel to be updated (https://github.com/void-linux/void-packages/pull/56221).