### PR TITLE
New package: wthrr-1.2.1

### DIFF
--- a/srcpkgs/wthrr/patches/fix-builds.patch
+++ b/srcpkgs/wthrr/patches/fix-builds.patch
@@ -1,0 +1,22 @@
+--- a/src/modules/localization.rs
++++ b/src/modules/localization.rs
+@@ -265,19 +265,3 @@ impl Locales {
+ 		Ok(date)
+ 	}
+ }
+-
+-#[cfg(test)]
+-mod tests {
+-	use super::*;
+-
+-	#[tokio::test]
+-	async fn translate_string() -> Result<()> {
+-		let (target_lang, input) = ("de_DE", "tongue-twister");
+-
+-		let res = Locales::translate_str(target_lang, input).await?;
+-
+-		assert!(res.contains("Zungenbrecher"));
+-
+-		Ok(())
+-	}
+-}

--- a/srcpkgs/wthrr/template
+++ b/srcpkgs/wthrr/template
@@ -1,0 +1,18 @@
+# Template file for 'wthrr'
+pkgname=wthrr
+version=1.2.1
+revision=1
+build_style=cargo
+hostmakedepends="pkg-config"
+makedepends="openssl-devel"
+short_desc="Weather companion for the terminal"
+maintainer="Orphaned <orphan@voidlinux.org>"
+license="MIT"
+homepage="https://github.com/ttytm/wthrr-the-weathercrab"
+changelog="https://github.com/ttytm/wthrr-the-weathercrab/releases"
+distfiles="https://github.com/ttytm/wthrr-the-weathercrab/archive/refs/tags/v${version}.tar.gz"
+checksum=ff5b47f2046ebefa9ff28cb52ece49a06f7b89230578801c338c77802aa721e0
+
+post_install() {
+	vlicense LICENSE
+}


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**
- I've been using the app for a couple years now

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

#### Local build testing
- I built this PR locally for my native architecture, (**x86_64-glibc**)

https://github.com/ttytm/wthrr-the-weathercrab
https://github.com/ttytm/wthrr-the-weathercrab/blob/main/INSTALL.md

> To display symbols correctly, the used terminal must be configured to use a NerdFont.

Since terminal configuration is up to the user, I did not add a hard dependency on a special font, and the app runs fine without.

The included patch removes a failing test from `src/modules/localization.rs` until there is a response/fix from upstream.

`wthrr` being a leaf package I <strike>would</strike> prefer to use `Orphaned <orphan@voidlinux.org>`, since I'm not sure whether I'll have a (stable) internet connection in the near future. That being said, I still think that `wthrr` would be a neat addition to the repo, but don't mind if it gets rejected, either.



