### PR TITLE
mesa: Enable accelerated OpenGL for WSL / Hyper-V

### DIFF
--- a/srcpkgs/directx-headers-devel/template
+++ b/srcpkgs/directx-headers-devel/template
@@ -1,0 +1,17 @@
+# Template file for 'directx-headers-devel'
+pkgname=directx-headers-devel
+version=1.616.0
+revision=1
+archs="aarch64 x86_64"
+build_style=meson
+configure_args="-Db_lto=false -Dbuild-test=false"
+short_desc="Official open-source DirectX headers"
+maintainer="Matthias von Faber <mvf@gmx.eu>"
+license="MIT"
+homepage="https://github.com/microsoft/DirectX-Headers"
+distfiles="https://github.com/microsoft/DirectX-Headers/archive/refs/tags/v${version}.tar.gz"
+checksum=125f492802939b40223bfccb83badd3f599af2d3449613d6cb893720607b9025
+
+post_install() {
+	vlicense LICENSE
+}

--- a/srcpkgs/mesa/template
+++ b/srcpkgs/mesa/template
@@ -1,7 +1,7 @@
 # Template file for 'mesa'
 pkgname=mesa
 version=25.1.3
-revision=1
+revision=2
 build_style=meson
 _llvmver=19
 #Disable LTO flag should be present, see https://gitlab.freedesktop.org/mesa/mesa/-/issues/6911
@@ -75,6 +75,14 @@ case "$XBPS_TARGET_MACHINE" in
 		;;
 	armv[67]*|aarch64*)
 		_have_arm=yes
+		;;
+esac
+
+# Direct3D 12 for Hyper-V GPU-P / WSLg. This relies on additional
+# closed-source drivers which are only available on 64-bit glibc.
+case "$XBPS_TARGET_MACHINE" in
+	aarch64|x86_64)
+		_have_d3d12=yes
 		;;
 esac
 
@@ -163,6 +171,11 @@ if [ "$_have_hwdec" ]; then
 	subpackages+=" mesa-vaapi mesa-vdpau"
 else
 	configure_args+=" -Dgallium-vdpau=disabled -Dgallium-va=disabled"
+fi
+
+if [ "$_have_d3d12" ]; then
+	_gallium_drivers+=",d3d12"
+	makedepends+=" directx-headers-devel"
 fi
 
 # empty values introduced by leading comma are not allowed; the whole enumeration can be empty


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

----

This enables the D3D12 driver for paravirtualized OpenGL when running on the [Windows Subsystem for Linux](https://learn.microsoft.com/en-us/windows/wsl/tutorials/gui-apps#prerequisites). It also works in traditional Hyper-V VMs with some additional setup. 

I've been daily-driving this for the last 3 months on my corpo Windows 11 machine targeting both an Intel iGPU and dGPU. While there is some jank, the dramatically lower CPU load vs. software rendering is very much worth it.

`llvmpipe` remains the default. Users have to opt in through the environment ([Arch Wiki](https://wiki.archlinux.org/title/Install_Arch_Linux_on_WSL#Run_graphical_applications_with_WSLg)):
```
% glxinfo -B | grep -A3 Vendor:
    Vendor: Mesa (0xffffffff)
    Device: llvmpipe (LLVM 19.1.4, 256 bits) (0xffffffff)
    Version: 25.1.3
    Accelerated: no
% export GALLIUM_DRIVER=d3d12
% glxinfo -B | grep -A3 Vendor:
    Vendor: Microsoft Corporation (0xffffffff)
    Device: D3D12 (Intel(R) Arc(TM) Pro A30M Graphics) (0xffffffff)
    Version: 25.1.3
    Accelerated: yes
```

Only `aarch64` and `x86_64` are supported since the vendor driver libs provided by Windows are 64-bits glibc only. There's also a Vulkan ICD called `vulkan-dzn`, but from my testing its build flag is called `microsoft-experimental` for a reason, so it's left disabled.