### PR TITLE
dovecot: fix configuration parsing segfault on musl

### DIFF
--- a/srcpkgs/dovecot/patches/musl-segfault.patch
+++ b/srcpkgs/dovecot/patches/musl-segfault.patch
@@ -1,0 +1,26 @@
+From 9f3430be9133efe74e6f0c4943abc52b5a0ef789 Mon Sep 17 00:00:00 2001
+From: Timo Sirainen <timo.sirainen@open-xchange.com>
+Date: Thu, 15 May 2025 09:54:18 +0300
+Subject: [PATCH] config: Fix config filter sorting order
+
+It was somewhat luckily working in glibc, but broke with e.g. musl libc.
+This caused a crash at startup.
+
+Broken by 5acdd2b97ed6092d1f0204bdeb3e418180519370
+---
+ src/config/config-parser.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/config/config-parser.c b/src/config/config-parser.c
+index 7b95c31f94..0ae5e46ddb 100644
+--- a/src/config/config-parser.c
++++ b/src/config/config-parser.c
+@@ -2318,7 +2318,7 @@ static int config_parser_filter_cmp(struct config_filter_parser *const *f1,
+ 		return -1;
+ 	}
+ 	if ((*f2)->create_order <= 1)
+-		return -1;
++		return 1;
+ 
+ 	/* Next, order by the number of named list filters, so more specific
+ 	   filters are applied before less specific ones. (Applying is done in

--- a/srcpkgs/dovecot/template
+++ b/srcpkgs/dovecot/template
@@ -2,7 +2,7 @@
 # revbump dovecot-plugin-pigeonhole when updating dovecot!
 pkgname=dovecot
 version=2.4.1r4
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--with-moduledir=/usr/lib/dovecot/modules --with-sql=plugin
  --disable-static --with-pam --with-mysql --with-pgsql


### PR DESCRIPTION
Fix the segfault on musl mentioned in  #56113

Some tests do not pass on musl but this is not new.

#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-musl)