### PR TITLE
asciidoc: update to 10.2.1.

### DIFF
--- a/srcpkgs/asciidoc/template
+++ b/srcpkgs/asciidoc/template
@@ -1,7 +1,7 @@
 # Template file for 'asciidoc'
 pkgname=asciidoc
-version=10.2.0
-revision=3
+version=10.2.1
+revision=1
 build_style=python3-module
 hostmakedepends="docbook-xsl libxslt python3-setuptools"
 depends="docbook-xsl libxslt python3"
@@ -12,7 +12,7 @@ license="GPL-2.0-or-later"
 homepage="https://asciidoc-py.github.io"
 changelog="https://asciidoc-py.github.io/CHANGELOG.html"
 distfiles="https://github.com/asciidoc-py/asciidoc-py/releases/download/$version/asciidoc-$version.tar.gz"
-checksum=237b2ba5c35c0ae7ccd4cd44ebf1d87c20b2695dae01798954416d492ef7fa0e
+checksum=aa7be8ae894f6cc1e67784d76ffa6c6b9e9f96efdc695db43c6bd63820e5072b
 
 post_install() {
 	vman doc/a2x.1


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->
This update fixes annoying

```
<unknown>:1: SyntaxWarning: invalid escape sequence '\S'
```

warnings.

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
