### PR TITLE
python3-pynitrokey: update to 0.9.0

### DIFF
--- a/srcpkgs/python3-pynitrokey/template
+++ b/srcpkgs/python3-pynitrokey/template
@@ -1,10 +1,10 @@
 # Template file for 'python3-pynitrokey'
 pkgname=python3-pynitrokey
-version=0.8.5
+version=0.9.0
 revision=1
 build_style=python3-pep517
 make_build_args="--skip-dependency-check"
-hostmakedepends="python3-wheel python3-flit_core"
+hostmakedepends="python3-poetry-core"
 depends="python3-cffi python3-click
  python3-click-aliases python3-semver python3-libusb1
  python3-crcmod python3-hidapi python3-pyserial
@@ -18,7 +18,7 @@ maintainer="Mateusz Sylwestrzak <slymattz@gmail.com>"
 license="LGPL-3.0-only, GPL-3.0-or-later, Apache-2.0, MIT"
 homepage="https://github.com/Nitrokey/pynitrokey"
 distfiles="https://github.com/Nitrokey/pynitrokey/archive/refs/tags/v${version}.tar.gz"
-checksum=74e222c7dd0408ffe8a1f1abf22cedf8a306c6f9c5b19e2fd7cb9dafa8b6d92c
+checksum=f9752401177d8d4cfa1b59774895e6d67cec1ef2cb669bee6c4591217af740cc
 
 post_install() {
 	vlicense LICENSES/MIT.txt


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**
<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

This release brings compatibility with python3-cryptography v45 which has been in the Void repo since May 19. 
https://github.com/Nitrokey/pynitrokey/commit/e529852ce900c9bc790d9be5920537ed00c10d93 

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture: x86_64-glibc