### PR TITLE
libxcb: update to 1.17.0.

### DIFF
--- a/srcpkgs/libxcb/template
+++ b/srcpkgs/libxcb/template
@@ -1,6 +1,6 @@
 # Template file for 'libxcb'
 pkgname=libxcb
-version=1.16.1
+version=1.17.0
 revision=1
 build_style=gnu-configure
 configure_args="--disable-build-docs --enable-xinput --enable-xkb"
@@ -12,7 +12,7 @@ license="MIT"
 homepage="https://gitlab.freedesktop.org/xorg/lib/libxcb"
 changelog="https://gitlab.freedesktop.org/xorg/lib/libxcb/-/raw/master/NEWS"
 distfiles="https://xorg.freedesktop.org/archive/individual/lib/libxcb-${version}.tar.xz"
-checksum=f24d187154c8e027b358fc7cb6588e35e33e6a92f11c668fe77396a7ae66e311
+checksum=599ebf9996710fea71622e6e184f3a8ad5b43d0e5fa8c4e407123c88a59a6d55
 
 if [ "$CROSS_BUILD" ]; then
 	makedepends+=" xcb-proto"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

xorg running with it since ~1h (and counting...)

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-musl)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64 (crossbuild)