### PR TITLE
nestopia: update to 1.53.1.

### DIFF
--- a/srcpkgs/nestopia/template
+++ b/srcpkgs/nestopia/template
@@ -1,6 +1,6 @@
 # Template file for 'nestopia'
 pkgname=nestopia
-version=1.52.0
+version=1.53.1
 revision=1
 build_style=gnu-configure
 hostmakedepends="autoconf-archive automake pkg-config"
@@ -13,7 +13,7 @@ license="GPL-2.0-only"
 homepage="http://0ldsk00l.ca/nestopia/"
 changelog="https://raw.githubusercontent.com/0ldsk00l/nestopia/master/ChangeLog"
 distfiles="https://github.com/0ldsk00l/nestopia/archive/${version}.tar.gz"
-checksum=eae1d2f536ae8585edb8d723caf905f4ae65349edee4ffbee45f9f52b5e3b06c
+checksum=21aa45f6c608fe290d73fdec0e6f362538a975455b16a4cc54bcdd10962fff3e
 
 pre_configure() {
 	autoreconf -vif


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, `x86_64-glibc`

#### Notes
- Tested out the new build by emulating various different games, which all worked properly, and I couldn't notice any issues or regressions with the program itself.