### PR TITLE
acpi: update to acpi-1.8

### DIFF
--- a/srcpkgs/acpi/template
+++ b/srcpkgs/acpi/template
@@ -1,11 +1,11 @@
 # Template file for 'acpi'
 pkgname=acpi
-version=1.7
-revision=4
+version=1.8
+revision=1
 build_style=gnu-configure
 short_desc="Informations about ACPI devices (battery, thermal sensors and power)"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="https://sourceforge.net/projects/acpiclient/"
 distfiles="${SOURCEFORGE_SITE}/acpiclient/acpi-${version}.tar.gz"
-checksum=d7a504b61c716ae5b7e81a0c67a50a51f06c7326f197b66a4b823de076a35005
+checksum=e64c6e00b53cd797427ea32a160513425b03ed4f077733f71f1f09ff340f230b


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl
  - i686

#### Changelog
- Allow different output formats for (dis)charge information.
- Display estimated end time for {,dis}charging, too.
- fix: battery runtime estimation with negative sysfs values.