### PR TITLE
FreeRADIUS: update to FreeRADIUS-3.0.27

### DIFF
--- a/srcpkgs/FreeRADIUS/template
+++ b/srcpkgs/FreeRADIUS/template
@@ -1,7 +1,7 @@
 # Template file for 'FreeRADIUS'
 pkgname=FreeRADIUS
-version=3.0.26
-revision=4
+version=3.0.27
+revision=1
 build_style=gnu-configure
 makedepends="talloc-devel openssl-devel mit-krb5-devel pam-devel \
  libmariadbclient-devel postgresql-libs-devel json-c-devel"
@@ -10,7 +10,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-only"
 homepage="http://freeradius.org"
 distfiles="https://github.com/FreeRADIUS/freeradius-server/archive/release_${version//./_}.tar.gz"
-checksum=6aea98d6126035e7ccca483d8b3faea447030169639807017ec98985b78fb2ca
+checksum=fd092b0a1c8b8d7e206c5aaccf56a64b7eb3750eb9901a1459b6d0d7fb3f97dd
 nocross=yes # Not supported by upstream
 system_accounts="_freeradius"
 make_dirs="/etc/raddb 0750 _freeradius _freeradius"


### PR DESCRIPTION
Minor version update for FreeRADIUS, this the last version of 3.0.x branch. 

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl
  - i686
