### PR TITLE
qgit: update to 2.12, switch to qt6

### DIFF
--- a/srcpkgs/qgit/template
+++ b/srcpkgs/qgit/template
@@ -1,17 +1,14 @@
 # Template file for 'qgit'
 pkgname=qgit
-version=2.11
+version=2.12
 revision=1
 build_style=cmake
-makedepends="qt5-devel"
-depends="git"
+hostmakedepends="qt6-base"
+makedepends="qt6-base-devel qt6-qt5compat-devel"
+depends="git qt6-svg"
 short_desc="Qt-based Git GUI"
 maintainer="Matthias von Faber <mvf@gmx.eu>"
 license="GPL-2.0-or-later"
 homepage="https://github.com/tibirna/qgit"
 distfiles="${homepage}/archive/${pkgname}-${version}.tar.gz"
-checksum=1c488a2328030641e3560cb86fb8891d2e8cdc934d910e73a0f19f9c8ee15a7d
-
-if [ "$CROSS_BUILD" ]; then
-	hostmakedepends+=" qt5-host-tools qt5-qmake"
-fi
+checksum=49f4c7aeb326ae7f983928f5c98500b55adba9b75430dea262a9af584186bb99


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
