### PR TITLE
cryptsetup: update to 2.8.0

### DIFF
--- a/srcpkgs/cryptsetup/template
+++ b/srcpkgs/cryptsetup/template
@@ -1,7 +1,7 @@
 # Template file for 'cryptsetup'
 pkgname=cryptsetup
-version=2.7.5
-revision=2
+version=2.8.0
+revision=1
 build_style=gnu-configure
 configure_args="--with-crypto_backend=openssl --disable-asciidoc
  --enable-libargon2 $(vopt_enable pwquality)"
@@ -16,7 +16,7 @@ license="GPL-2.0-or-later"
 homepage="https://gitlab.com/cryptsetup/cryptsetup"
 changelog="https://gitlab.com/cryptsetup/cryptsetup/raw/master/docs/v${version}-ReleaseNotes"
 distfiles="${KERNEL_SITE}/utils/cryptsetup/v${version%.*}/cryptsetup-${version}.tar.xz"
-checksum=d2be4395b8f503b0ebf4b2d81db90c35a97050a358ee21fe62a0dfb66e5d5522
+checksum=cc9e2d37c25a871cea37520b28d532207b0c1670fb10fc54d68071f63f5243a2
 subpackages="libcryptsetup cryptsetup-devel"
 build_options="pwquality"
 desc_option_pwquality="Enable support for checking password quality via libpwquality"


### PR DESCRIPTION

- I tested the changes in this PR: **YES**
  - Tested on two machines, and using some of the new features in 2.8.0, without issue.
  - One of them has been running the AEGIS-128 cipher (newly supported in this version) for FDE, without any issue.
  - According to the [release notes](https://cdn.kernel.org/pub/linux/utils/cryptsetup/v2.8/v2.8.0-ReleaseNotes), version 2.8.0 introduced some extra checks to explicitly forbid some configurations. These could in theory maybe trigger for some users, but only for configurations that were already technically broken anyway, so I don't know if it matters much.

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [x] aarch64-musl (crossbuild)
  - [x] armv7l (crossbuild)
