### PR TITLE
schismtracker: update to 20250415.

### DIFF
--- a/srcpkgs/schismtracker/template
+++ b/srcpkgs/schismtracker/template
@@ -1,6 +1,6 @@
 # Template file for 'schismtracker'
 pkgname=schismtracker
-version=20250208
+version=20250415
 revision=1
 build_style=gnu-configure
 hostmakedepends="pkg-config autoconf-archive automake SDL2-devel python3 git"
@@ -10,7 +10,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="https://schismtracker.org"
 distfiles="https://github.com/schismtracker/schismtracker/archive/${version}.tar.gz"
-checksum=b6dfa3dab4b2fabce004c08433007f84f06da8bb8f2d799dc23d2e79f29d263d
+checksum=ba9b8e4381e9f3a3110ae7bb4e7794ac2399e88bb26a50c86a6f45beed57c5f3
 
 pre_configure() {
 	autoreconf -fi


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, `x86_64-glibc`

#### Notes
- Tested out the new build by playing a couple of tracker songs. They all played back fine, and I haven't noticed any issues with the build.

