### PR TITLE
bind: update to bind-9.20.10

### DIFF
--- a/srcpkgs/bind/files/named.conf
+++ b/srcpkgs/bind/files/named.conf
@@ -6,7 +6,6 @@ options {
 	directory "/var/named";
 	pid-file "/var/run/named/named.pid";
 	auth-nxdomain yes;
-	datasize default;
 // Uncomment these to enable IPv6 connections support
 // IPv4 will still work:
 //	listen-on-v6 { any; };

--- a/srcpkgs/bind/template
+++ b/srcpkgs/bind/template
@@ -1,24 +1,25 @@
 # Template file for 'bind'
 pkgname=bind
-version=9.16.22
-revision=4
+version=9.20.10
+revision=1
 _fullver="${version}${_patchver:+-${_patchver}}"
 build_style=gnu-configure
-configure_args="--disable-static --enable-largefile --with-libtool
- --sysconfdir=/etc/named --enable-epoll --with-openssl=${XBPS_CROSS_BASE}/usr
- --with-gssapi=/usr/bin --with-readline --with-tuning=default --without-python
- --with-libidn2 --disable-backtrace"
+configure_args="--disable-static --enable-largefile
+ --sysconfdir=/etc/named  --with-openssl=${XBPS_CROSS_BASE}/usr
+ --with-readline  --with-libidn2 --with-lmdb --with-json-c
+ --with-gssapi=yes --with-libxml2"
 hostmakedepends="automake libtool perl pkg-config"
-makedepends="openssl-devel libxml2-devel libcap-devel readline-devel mit-krb5-devel
- libidn2-devel libuv-devel $(vopt_if geoip geoip-devel)"
+makedepends="jemalloc-devel json-c-devel libcap-devel
+ libidn2-devel liburcu-devel libuv-devel libxml2-devel lmdb-devel
+ mit-krb5-devel nghttp2-devel openssl-devel readline-devel"
 checkdepends="python3-pytest"
 short_desc="Berkeley Internet Name Domain server"
 maintainer="Randy McCaskill <randy@mccaskill.us>"
 license="MPL-2.0"
 homepage="https://www.isc.org/downloads/bind/"
-changelog="https://gitlab.isc.org/isc-projects/bind9/-/blob/v9_16/CHANGES"
+changelog="https://gitlab.isc.org/isc-projects/bind9/-/blob/v9.20.10/doc/changelog/changelog-9.20.10.rst"
 distfiles="https://ftp.isc.org/isc/bind9/${_fullver}/bind-${_fullver}.tar.xz"
-checksum=65e7b2af6479db346e2fc99bcfb6ec3240066468e09dbec575ebc7c57d994061
+checksum=0fb3ba2c337bb488ca68f5df296c435cd255058fb63d0822e91db0235c905716
 # guarantee subpackage ordering
 subpackages="bind-libs bind-utils bind-devel"
 # requires special network setup
@@ -38,7 +39,7 @@ post_install() {
 	vinstall ${FILESDIR}/named.logrotate 600 etc/logrotate.d named
 	vinstall ${FILESDIR}/named.conf 640 etc/named
 
-	vinstall bin/tests/system/common/root.hint 640 var/named
+	vinstall bin/tests/system/_common/root.hint 640 var/named
 	vinstall ${FILESDIR}/127.0.0.zone 640 var/named
 	vinstall ${FILESDIR}/localhost.zone 640 var/named
 	vlicense COPYRIGHT LICENSE


### PR DESCRIPTION
This is a new and complete version for BIND package. The actual BIND package in repos is 9.16, and is no longer supported for upstream. This new version ESV (9.20) have support to Q2 2028. 

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl
  - i686


