### PR TITLE
libqmi: update to 1.34.0

### DIFF
--- a/srcpkgs/libqmi/template
+++ b/srcpkgs/libqmi/template
@@ -1,25 +1,18 @@
 # Template file for 'libqmi'
 pkgname=libqmi
-version=1.30.8
-revision=2
-build_style=gnu-configure
+version=1.34.0
+revision=1
+build_style=meson
 build_helper=gir
-configure_args="--disable-static --enable-mbim-qmux --enable-qrtr
- $(vopt_enable gir introspection)"
-hostmakedepends="pkg-config"
+configure_args="-Dqrtr=true -Dmbim_qmux=true -Dbash_completion=false -Dcollection=full -Dman=false"
+hostmakedepends="pkg-config glib-devel"
 makedepends="glib-devel libgudev-devel libmbim-devel libqrtr-glib-devel"
 short_desc="QMI modem protocol helper library"
-maintainer="Orphaned <orphan@voidlinux.org>"
+maintainer="Arseniy <me@adomerle.pw>"
 license="GPL-2.0-or-later, LGPL-2.1-or-later"
 homepage="http://www.freedesktop.org/wiki/Software/libqmi/"
-distfiles="${FREEDESKTOP_SITE}/${pkgname}/${pkgname}-${version}.tar.xz"
-checksum=862482ce9e3ad0bd65d264334ee311cdb94b9df2863b5b7136309b41b8ac1990
-build_options="gir"
-build_options_default="gir"
-
-if [ "$CROSS_BUILD" ]; then
-	hostmakedepends+=" glib-devel"
-fi
+distfiles="https://github.com/linux-mobile-broadband/libqmi/archive/refs/tags/${version}.tar.gz"
+checksum=8690d25b4d110b6df28b31da0a8bf16c7e966d31abcfeeb854f2753451e7a400
 
 libqmi-devel_package() {
 	depends="${makedepends} ${sourcepkg}-${version}_${revision}"


### PR DESCRIPTION
This package was without maintainer and it has several versions behind. Source code was moved to github and also build system was changed to meson. 

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64
  - armv7l