### PR TITLE
angrysearch: update to 1.0.4

### DIFF
--- a/srcpkgs/angrysearch/template
+++ b/srcpkgs/angrysearch/template
@@ -1,7 +1,7 @@
 # Template file for 'angrysearch'
 pkgname=angrysearch
-version=1.0.3
-revision=3
+version=1.0.4
+revision=1
 pycompile_dirs="usr/share/angrysearch"
 hostmakedepends="python3"
 depends="python3-PyQt5 xdg-utils"
@@ -10,7 +10,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-only"
 homepage="https://github.com/dotheevo/angrysearch/"
 distfiles="http://github.com/dotheevo/angrysearch/archive/v${version}.tar.gz"
-checksum=bb20907d97804931863f377fe19ac2008a9e43c80517f775667f9fe49792c585
+checksum=35287f7232f3892308186b33c05369ca8123647fbae6b8be0bb43f28ff052de9
 python_version=3
 
 do_install() {


### PR DESCRIPTION
Long overdue update that fixes an issue which lead to angrysearch crashing at start.

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)