### PR TITLE
New package: networkmanager-dmenu-2.6.1

### DIFF
--- a/srcpkgs/networkmanager-dmenu/template
+++ b/srcpkgs/networkmanager-dmenu/template
@@ -1,0 +1,18 @@
+# Template file for 'networkmanager-dmenu'
+pkgname=networkmanager-dmenu
+version=2.6.1
+revision=1
+depends="python3 NetworkManager python3-gobject"
+short_desc="Control NetworkManager via dmenu"
+maintainer="Yushi <github@yushi.one>"
+license="MIT"
+homepage="https://github.com/firecat53/networkmanager-dmenu"
+distfiles="https://github.com/firecat53/networkmanager-dmenu/archive/refs/tags/v${version}.tar.gz"
+checksum=287a771875e441c4a57ab4e18eca64b0abe34693cb03bbbca36b77f17779433d
+
+do_install() {
+	vbin networkmanager_dmenu
+	vlicense LICENSE.txt
+	vsconf config.ini.example
+	vinstall networkmanager_dmenu.desktop 644 /usr/share/applications
+}


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (aarch64-glibc)

