### PR TITLE
spotify: update to 1.2.36

### DIFF
--- a/srcpkgs/spotify/template
+++ b/srcpkgs/spotify/template
@@ -1,8 +1,8 @@
 # Template file for 'spotify'
 pkgname=spotify
-version=1.2.60
+version=1.2.63
 revision=1
-_subver=564.gcc6305cb
+_subver=394.g126b0d89
 archs="x86_64"
 create_wrksrc=yes
 hostmakedepends="libcurl"
@@ -12,7 +12,7 @@ maintainer="Stefan Mühlinghaus <jazzman@alphabreed.com>"
 license="custom:Proprietary"
 homepage="https://www.spotify.com"
 distfiles="http://repository.spotify.com/pool/non-free/s/spotify-client/spotify-client_${version}.${_subver}_amd64.deb"
-checksum=43737ac2124c8935ddb62e3fd1a637efdd4595c5e1cb9fc5e2f746e385ad4a67
+checksum=99c229f829ccb9c2a188be80d1241d2b8c8fd35f1e8d773438c0f612d68e940e
 repository=nonfree
 restricted=yes
 nostrip=yes


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
