### PR TITLE
helix: update to 25.07.1

### DIFF
--- a/srcpkgs/helix/template
+++ b/srcpkgs/helix/template
@@ -1,6 +1,6 @@
 # Template file for 'helix'
 pkgname=helix
-version=25.01.1
+version=25.07.1
 revision=1
 build_style=cargo
 make_install_args="--path helix-term"
@@ -10,7 +10,7 @@ license="MPL-2.0"
 homepage="https://helix-editor.com/"
 changelog="https://raw.githubusercontent.com/helix-editor/helix/master/CHANGELOG.md"
 distfiles="https://github.com/helix-editor/helix/releases/download/${version}/helix-${version}-source.tar.xz"
-checksum=12508c4f5b9ae6342299bd40d281cd9582d3b51487bffe798f3889cb8f931609
+checksum=2d0cf264ac77f8c25386a636e2b3a09a23dec555568cc9a5b2927f84322f544e
 
 case "$XBPS_TARGET_MACHINE" in
 	ppc64*) ;;
@@ -23,6 +23,10 @@ esac
 export PATH="$PATH:/usr/libexec/chroot-git"
 
 export HELIX_DEFAULT_RUNTIME=/usr/lib/helix/runtime
+
+post_patch() {
+	cargo update --package cc@1.2.29 --precise 1.2.14
+}
 
 post_install() {
 	rm runtime/grammars/.gitkeep


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
