### PR TITLE
ytcc: update to 2.8.0

### DIFF
--- a/srcpkgs/ytcc/template
+++ b/srcpkgs/ytcc/template
@@ -1,18 +1,19 @@
 # Template file for 'ytcc'
 pkgname=ytcc
-version=2.7.2
+version=2.8.0
 revision=1
 build_style=python3-pep517
 make_check_args="-m not(flaky)"
 hostmakedepends="python3-build hatchling python3-installer python3-wheel"
-depends="mpv yt-dlp python3-click python3-wcwidth python3-defusedxml"
+depends="yt-dlp python3-click python3-wcwidth python3-defusedxml"
 checkdepends="${depends} python3-pytest"
 short_desc="Cmdline tool to track your youtube channels"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-3.0-or-later"
 homepage="https://github.com/woefe/ytcc"
 distfiles="https://github.com/woefe/ytcc/archive/refs/tags/v${version}.tar.gz"
-checksum=06827c92906326498034c3be2fb89b873f58298b78914036538e676a19d6d7a4
+checksum=7d865c783452fdfe56c089e854f02049f13e6dec987065f56ece433dcc2f05ab
+make_check_args+=" --ignore tests/test_cli.py" # https://github.com/pallets/click/issues/2939
 
 post_install() {
 	vcompletion scripts/completions/bash/ytcc.completion.sh bash


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (**x86_64-glibc**)

#### Notes

- Ignoring `tests/test_cli.py` until https://github.com/pallets/click/issues/2939 is resolved (which _should_  affect older versions too, so we may just as well update to 2.8.0 - personally, I haven't experienced any issues at runtime, so far)
- Removed `mpv` (optional) from `depends` - the app does what is advertised without a media player present

[Changelog](https://github.com/woefe/ytcc/releases/tag/v2.8.0)