### PR TITLE
nwg-look: update to 1.0.6.

### DIFF
--- a/srcpkgs/nwg-look/template
+++ b/srcpkgs/nwg-look/template
@@ -1,19 +1,20 @@
 # Template file for 'nwg-look'
 pkgname=nwg-look
-version=0.2.7
-revision=2
+version=1.0.6
+revision=1
 build_style=go
 go_import_path=github.com/nwg-piotr/nwg-look
+make_check=no
 hostmakedepends="pkg-config"
 makedepends="cairo-devel gtk+3-devel libglib-devel pango-devel"
 depends="xcur2png"
 short_desc="GTK3 settings editor adapted to work in the wlroots environment"
-maintainer="cinerea0 <cinerea0@protonmail.com>"
+maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
 homepage="https://github.com/nwg-piotr/nwg-look"
 changelog="https://github.com/nwg-piotr/nwg-look/releases"
 distfiles="https://github.com/nwg-piotr/nwg-look/archive/refs/tags/v${version}.tar.gz"
-checksum=20a7773b1bae7ae013efa359e73dcefc89bfb516d45bba4375f59c8a9216c9c3
+checksum=ddaba674253fbbf8f3ee7392315e51408af445adb85ed4b0f70e50301801720d
 
 post_install() {
 	vinstall stuff/main.glade 644 /usr/share/nwg-look


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, x86_64
<!--
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->

#### Comments
Tested on my x86 machine for a few weeks now, the version in repos has no support for gtk-4.0, but the new one works flawlessly so far.
