### PR TITLE
[WIP] milkytracker: update to 1.06.

### DIFF
--- a/srcpkgs/milkytracker/patches/cmake-4-compat.patch
+++ b/srcpkgs/milkytracker/patches/cmake-4-compat.patch
@@ -1,0 +1,25 @@
+From 517b27faf6e1471c2ccb25c3c22f78eb862cd552 Mon Sep 17 00:00:00 2001
+From: "Kowalski Dragon (kowalski7cc)" <kowalski7cc@users.noreply.github.com>
+Date: Sun, 14 Sep 2025 14:38:11 +0200
+Subject: [PATCH] Build: SET CMP0004 OLD only if CMake < 4.0
+
+Signed-off-by: Kowalski Dragon (kowalski7cc) <kowalski7cc@users.noreply.github.com>
+---
+ CMakeLists.txt | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index a7456337e8f5d07448e0a388446f0b7e19e46960..4021d672111d42d1b18e629a6f096f82a7355146 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -164,7 +164,9 @@ elseif(HAIKU)
+ else()
+     # Workaround for SDL bug #3295, which occurs in SDL2 <2.0.5
+     # https://bugzilla.libsdl.org/show_bug.cgi?id=3295
+-    cmake_policy(SET CMP0004 OLD)
++    if(${CMAKE_VERSION} VERSION_LESS "4.0.0")
++        cmake_policy(SET CMP0004 OLD)
++    endif()
+ 
+     find_package(SDL2 REQUIRED)
+ endif()

--- a/srcpkgs/milkytracker/template
+++ b/srcpkgs/milkytracker/template
@@ -1,6 +1,6 @@
 # Template file for 'milkytracker'
 pkgname=milkytracker
-version=1.05.01
+version=1.06
 revision=1
 build_style=cmake
 hostmakedepends="pkg-config"
@@ -11,7 +11,7 @@ maintainer="Rutpiv <roger_freitas@live.com>"
 license="GPL-3.0-only"
 homepage="http://milkytracker.titandemo.org/"
 distfiles="https://github.com/milkytracker/MilkyTracker/archive/v${version}.tar.gz"
-checksum=c487fccf6c97c483f5a624c3a408377393fa45a27cca27323425ad71ee689e16
+checksum=6e70590dfed324e6d6ac813e33d9f9dcfaa13b2f57fdec9e178e9dda05538cb0
 
 post_install() {
 	vinstall resources/milkytracker.desktop 644 usr/share/applications


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures using specific masterdirs:
  - x86_64-musl
  - i686
- I built this PR locally for these architectures (crossbuilds):
  - aarch64
  - aarch64-musl
  - armv7l
  - armv7l-musl
  - armv6l
  - armv6l-musl

---

This version seems to be a [beta](https://github.com/milkytracker/MilkyTracker/issues/383) (tagged, not officially [released?](https://milkytracker.org/)), as there is no official release with finalized changelog available.
Leaving this as a draft while I continue testing and waiting for a proper release.
