### PR TITLE
qjackctl: update to 1.0.4, switch to qt6, adopt

### DIFF
--- a/srcpkgs/qjackctl/template
+++ b/srcpkgs/qjackctl/template
@@ -1,20 +1,19 @@
 # Template file for 'qjackctl'
 pkgname=qjackctl
-version=0.9.9
+version=1.0.4
 revision=1
 build_style=cmake
 configure_args="$(vopt_bool jack_session CONFIG_JACK_SESSION)"
-hostmakedepends="pkg-config qt5-qmake qt5-host-tools"
-makedepends="alsa-lib-devel qt5-devel jack-devel portaudio-devel
- qt5-tools-devel qt5-svg-devel"
-depends="desktop-file-utils hicolor-icon-theme jack"
+hostmakedepends="pkg-config qt6-base qt6-tools"
+makedepends="alsa-lib-devel jack-devel portaudio-devel qt6-base-devel qt6-svg-devel"
+depends="desktop-file-utils hicolor-icon-theme qt6-svg"
 short_desc="JACK Audio Connection Kit - Qt GUI Interface"
-maintainer="Orphaned <orphan@voidlinux.org>"
+maintainer="Matthias von Faber <mvf@gmx.eu>"
 license="GPL-2.0-or-later"
 homepage="https://qjackctl.sourceforge.io"
 changelog="https://qjackctl.sourceforge.io/qjackctl-downloads.html"
 distfiles="${SOURCEFORGE_SITE}/qjackctl/qjackctl-${version}.tar.gz"
-checksum=4c2a9f6a1c24c7e73fb6aaa801ef9fbc2d3a8d6ffb51a9a54a4a07140b12008a
+checksum=e3eb6f989d947dcd97b4fe774294347106a0a6829c0480a965393ebca97514ae
 
 build_options="jack_session"
 build_options_default="jack_session"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
