### PR TITLE
Signal-Desktop: update to 7.62.0.

### DIFF
--- a/srcpkgs/Signal-Desktop/template
+++ b/srcpkgs/Signal-Desktop/template
@@ -1,6 +1,6 @@
 # Template file for 'Signal-Desktop'
 pkgname=Signal-Desktop
-version=7.61.0
+version=7.62.0
 revision=1
 # Signal officially only supports x86_64
 # x86_64-musl could potentially work based on the Alpine port:
@@ -14,7 +14,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="AGPL-3.0-only"
 homepage="https://github.com/signalapp/Signal-Desktop"
 distfiles="https://github.com/signalapp/Signal-Desktop/archive/v${version}.tar.gz"
-checksum=c4c42bc6cbcc04863e1d632db5cf097440ad7781333df8ae60fc720952dc3672
+checksum=59b5468eefa9199f0c4becf15ce86a9525cda3decaac5b8fc2b0241d2a3c38db
 nostrip_files="signal-desktop"
 
 post_extract() {


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc

While #56323 is still pending, let's update the package the old way