### PR TITLE
tuxedo-drivers: update to 4.14.3

### DIFF
--- a/srcpkgs/tuxedo-drivers/template
+++ b/srcpkgs/tuxedo-drivers/template
@@ -1,6 +1,6 @@
 # Template file for 'tuxedo-drivers'
 pkgname=tuxedo-drivers
-version=4.14.2
+version=4.14.3
 revision=1
 depends="dkms"
 short_desc="TUXEDO hardware drivers"
@@ -8,7 +8,7 @@ maintainer="newbluemoon <blaumolch@mailbox.org>"
 license="GPL-3.0-or-later"
 homepage="https://gitlab.com/tuxedocomputers/development/packages/tuxedo-drivers"
 distfiles="https://gitlab.com/tuxedocomputers/development/packages/tuxedo-drivers/-/archive/v${version}/tuxedo-drivers-v${version}.tar.gz"
-checksum=9bb93fbe8460d06573b05509b5894f80fe51f217f62c5176062054be16415aa6
+checksum=fe451a9dc7bdb406ca10129220ee72cfc3567c68a89622922d358dce056924ba
 
 dkms_modules="tuxedo-drivers ${version}"
 


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)
- Built for kernels 6.1, 6.3–6.15; running on 6.15.6
