### PR TITLE
tuxedo-yt6801: update to 1.0.30tux2

### DIFF
--- a/srcpkgs/tuxedo-yt6801/template
+++ b/srcpkgs/tuxedo-yt6801/template
@@ -1,6 +1,6 @@
 # Template file for 'tuxedo-yt6801'
 pkgname=tuxedo-yt6801
-version=1.0.30tux1
+version=1.0.30tux2
 revision=1
 depends="dkms"
 short_desc="Kernel module for Motorcomm YT6801 ethernet controller (DKMS)"
@@ -9,7 +9,7 @@ license="GPL-2.0-or-later"
 homepage="https://gitlab.com/tuxedocomputers/development/packages/tuxedo-yt6801"
 changelog="https://gitlab.com/tuxedocomputers/development/packages/tuxedo-yt6801/-/raw/main/debian/changelog"
 distfiles="https://gitlab.com/tuxedocomputers/development/packages/tuxedo-yt6801/-/archive/v${version}/tuxedo-yt6801-v${version}.tar.gz"
-checksum=9f021ddb6378d6e021fca0b13ed6820c474ee6a2d5cc41482dd79b503499f357
+checksum=1ef1a5d05f964855691de147168c09d7589155c85633e388cf910ce1a48b69e4
 
 dkms_modules="tuxedo-yt6801 ${version}"
 


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)
- Built for kernels 6.6, 6.12, 6.14, 6.15, running on 6.15.6

@suturar 