### PR TITLE
fuse3: update to 3.17.3.

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -162,7 +162,7 @@ libdbus-glib-1.so.2 dbus-glib-0.80_1
 libxml2.so.2 libxml2-2.7.0_1
 libxlsxwriter.so.6 libxlsxwriter-1.1.7_1
 libfuse.so.2 fuse-2.8.1_1
-libfuse3.so.3 fuse3-3.1.0_1
+libfuse3.so.4 fuse3-3.17.3_1
 libXext.so.6 libXext-1.0.5_1
 libulockmgr.so.1 fuse-2.9.7_1
 libXcomposite.so.1 libXcomposite-0.4.0_1

--- a/srcpkgs/acfgfs/template
+++ b/srcpkgs/acfgfs/template
@@ -2,7 +2,7 @@
 # !! keep synced with arcan
 pkgname=acfgfs
 version=0.6.3.3
-revision=1
+revision=2
 build_wrksrc=src/tools/acfgfs
 build_style=cmake
 hostmakedepends="pkg-config"

--- a/srcpkgs/android-file-transfer-linux/template
+++ b/srcpkgs/android-file-transfer-linux/template
@@ -1,7 +1,7 @@
 # Template file for 'android-file-transfer-linux'
 pkgname=android-file-transfer-linux
 version=4.5
-revision=2
+revision=3
 build_style=cmake
 build_helper="qmake6"
 configure_args="-DBUILD_SHARED_LIB=1"

--- a/srcpkgs/bindfs/template
+++ b/srcpkgs/bindfs/template
@@ -1,7 +1,7 @@
 # Template file for 'bindfs'
 pkgname=bindfs
 version=1.17.6
-revision=1
+revision=2
 build_style=gnu-configure
 hostmakedepends="pkg-config"
 makedepends="fuse3-devel"

--- a/srcpkgs/flatpak/template
+++ b/srcpkgs/flatpak/template
@@ -1,7 +1,7 @@
 # Template file for 'flatpak'
 pkgname=flatpak
 version=1.16.1
-revision=1
+revision=2
 build_style=meson
 build_helper="gir"
 configure_args="

--- a/srcpkgs/freerdp3/template
+++ b/srcpkgs/freerdp3/template
@@ -1,7 +1,7 @@
 # Template file for 'freerdp3'
 pkgname=freerdp3
 version=3.16.0
-revision=1
+revision=2
 build_style=cmake
 build_helper=qemu
 configure_args="-Wno-dev -DCMAKE_BUILD_TYPE=Release

--- a/srcpkgs/fuse-overlayfs/template
+++ b/srcpkgs/fuse-overlayfs/template
@@ -1,7 +1,7 @@
 # Template file for 'fuse-overlayfs'
 pkgname=fuse-overlayfs
 version=1.14
-revision=1
+revision=2
 build_style=gnu-configure
 hostmakedepends="autoconf automake pkg-config"
 makedepends="fuse3-devel"

--- a/srcpkgs/fuse-sshfs/template
+++ b/srcpkgs/fuse-sshfs/template
@@ -1,7 +1,7 @@
 # Template file for 'fuse-sshfs'
 pkgname=fuse-sshfs
 version=3.7.3
-revision=2
+revision=3
 build_style=meson
 configure_args="--sbindir=bin"
 hostmakedepends="pkg-config python3-docutils"

--- a/srcpkgs/fuse3/template
+++ b/srcpkgs/fuse3/template
@@ -1,6 +1,6 @@
 # Template file for 'fuse3'
 pkgname=fuse3
-version=3.16.2
+version=3.17.3
 revision=1
 build_style=meson
 configure_args="--sbindir=bin -Db_lto=false -Dexamples=false -Duseroot=false
@@ -13,7 +13,7 @@ license="GPL-2.0-or-later, LGPL-2.1-or-later"
 homepage="https://github.com/libfuse/libfuse"
 changelog="https://raw.githubusercontent.com/libfuse/libfuse/master/ChangeLog.rst"
 distfiles="https://github.com/libfuse/libfuse/releases/download/fuse-${version}/fuse-${version}.tar.gz"
-checksum=f797055d9296b275e981f5f62d4e32e089614fc253d1ef2985851025b8a0ce87
+checksum=de8190448909aa97a222d435bc130aae98331bed4215e9f4519b4b5b285a1d63
 conf_files="/etc/fuse.conf"
 # Tests require root
 make_check=no

--- a/srcpkgs/gnome-connections/template
+++ b/srcpkgs/gnome-connections/template
@@ -1,7 +1,7 @@
 # Template file for 'gnome-connections'
 pkgname=gnome-connections
 version=48.0
-revision=1
+revision=2
 build_style=meson
 build_helper="gir"
 hostmakedepends="pkg-config gettext itstool vala desktop-file-utils glib-devel"

--- a/srcpkgs/gnome-remote-desktop/template
+++ b/srcpkgs/gnome-remote-desktop/template
@@ -1,7 +1,7 @@
 # Template file for 'gnome-remote-desktop'
 pkgname=gnome-remote-desktop
 version=48.1
-revision=1
+revision=2
 build_style=meson
 configure_args="-Drdp=true -Dvnc=true -Dsystemd=false
  -Dsystemd_user_unit_dir=/usr/lib/systemd/user -Dtests=false"

--- a/srcpkgs/gvfs/template
+++ b/srcpkgs/gvfs/template
@@ -1,7 +1,7 @@
 # Template file for 'gvfs'
 pkgname=gvfs
 version=1.56.1
-revision=1
+revision=2
 build_style=meson
 configure_args="-Dsystemduserunitdir=no -Dtmpfilesdir=no -Dlogind=false
  -Dman=true"

--- a/srcpkgs/python3-pyfuse3/template
+++ b/srcpkgs/python3-pyfuse3/template
@@ -1,7 +1,7 @@
 # Template file for 'python3-pyfuse3'
 pkgname=python3-pyfuse3
 version=3.4.0
-revision=1
+revision=2
 build_style=python3-module
 hostmakedepends="pkg-config python3-setuptools"
 makedepends="fuse3-devel python3-devel"

--- a/srcpkgs/rage/template
+++ b/srcpkgs/rage/template
@@ -1,7 +1,7 @@
 # Template file for 'rage'
 pkgname=rage
 version=0.11.1
-revision=2
+revision=3
 build_style=cargo
 make_install_args="--path rage"
 configure_args="--features mount"

--- a/srcpkgs/sqsh-tools/template
+++ b/srcpkgs/sqsh-tools/template
@@ -1,7 +1,7 @@
 # Template file for 'sqsh-tools'
 pkgname=sqsh-tools
 version=1.5.1
-revision=1
+revision=2
 build_style=meson
 build_helper=qemu
 hostmakedepends="pkg-config"

--- a/srcpkgs/tup/template
+++ b/srcpkgs/tup/template
@@ -1,7 +1,7 @@
 # Template file for 'tup'
 pkgname=tup
 version=0.7.11
-revision=1
+revision=2
 hostmakedepends="fuse3-devel pkg-config"
 makedepends="fuse3-devel pcre-devel sqlite-devel"
 short_desc="File-based build system"

--- a/srcpkgs/wimlib/template
+++ b/srcpkgs/wimlib/template
@@ -1,7 +1,7 @@
 # Template file for 'wimlib'
 pkgname=wimlib
 version=1.14.4
-revision=1
+revision=2
 build_style=gnu-configure
 hostmakedepends="pkg-config"
 makedepends="libxml2-devel ntfs-3g-devel fuse3-devel"

--- a/srcpkgs/xdg-desktop-portal/template
+++ b/srcpkgs/xdg-desktop-portal/template
@@ -1,7 +1,7 @@
 # Template file for 'xdg-desktop-portal'
 pkgname=xdg-desktop-portal
 version=1.20.3
-revision=1
+revision=2
 build_style=meson
 configure_args="-Dgeoclue=enabled -Dsystemd=disabled"
 hostmakedepends="pkg-config gettext glib-devel bubblewrap flatpak python3-docutils


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

Also rebuilt (native+cross aarch64) all the revbump'ed packages.

Used sshfs without problems.

Tested `aft-mtp-mount` my phone, copied a file to, and listed files there:
```
$ aft-mtp-mount --version
using FUSE kernel interface version 7.40
fusermount3 version: 3.17.3
$ mount | grep aft
aft-mtp-mount on /home/user/mnt/phone type fuse.aft-mtp-mount (rw,nosuid,nodev,relatime,user_id=1000,group_id=1000)
ls -laR ~/mnt/phone > /dev/null
```
After a while I get IOErrors on that mount, but not sure this is related to the update/revbumps.
I often had problems with MTP in the past...

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-musl)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64
