### PR TITLE
common/xbps-src/shutils/common: automatically binary-bootstrap if not already done

### DIFF
--- a/common/xbps-src/shutils/common.sh
+++ b/common/xbps-src/shutils/common.sh
@@ -501,8 +501,9 @@ setup_pkg() {
 
     # Check if base-chroot is already installed.
     if [ -z "$bootstrap" -a -z "$CHROOT_READY" -a "z$show_problems" != "zignore-problems" ]; then
-        msg_red "${pkg} is not a bootstrap package and cannot be built without it.\n"
-        msg_error "Please install bootstrap packages and try again.\n"
+        msg_red "${pkg} is not a bootstrap package and cannot be built without bootstrapping first.\n"
+        msg_normal "binary bootstrapping for ${XBPS_MACHINE} in ${XBPS_MASTERDIR}...\n"
+        install_base_chroot "$XBPS_MACHINE"
     fi
 
     sourcepkg="${pkgname}"


### PR DESCRIPTION
so many people ask how to fix this error, especially now that `-a` implies the matching libc's `-A`, so let's make it more clear

#### Testing the changes
- I tested the changes in this PR: **YES**

2 routes:
```
$ ./xbps-src pkg -a aarch64-musl chezmoi
=> ERROR: chezmoi is not a bootstrap package and cannot be built without it.
=> Would you like to binary-bootstrap for aarch64 in /path/to/void/packages/masterdir-aarch64? [Y/n] n
=> ERROR: Please run 'xbps-src -A x86_64-musl binary-bootstrap' or install bootstrap packages, then try again.
```
```
$ ./xbps-src pkg -A aarch64 chezmoi
=> ERROR: chezmoi is not a bootstrap package and cannot be built without it.
=> Would you like to binary-bootstrap for aarch64 in /path/to/void/packages/masterdir-aarch64? [Y/n] 
=> binary bootstrapping for aarch64 in /path/to/void/packages/masterdir-aarch64...
=> xbps-src: installing base-chroot...
...
```
