### PR TITLE
kwin-effects-forceblur: update to 1.4.0

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -4566,4 +4566,5 @@ libngtcp2_crypto_ossl.so.0 ngtcp2-1.13.0_1
 libprom.so prometheus-client-c-0.1.3_1
 libqlementine.so.1 qlementine-1.2.2_1
 libkwin.so.6 kwin-6.3.3.1_1
+libkwin-x11.so.6 kwin-x11-6.4.3_1
 libdatovka.so.8 libdatovka-0.7.0_1

--- a/srcpkgs/kwin-effects-forceblur/template
+++ b/srcpkgs/kwin-effects-forceblur/template
@@ -1,6 +1,6 @@
 # Template file for 'kwin-effects-forceblur'
 pkgname=kwin-effects-forceblur
-version=1.3.6
+version=1.4.0
 revision=1
 build_style=cmake
 configure_args="-DFORCE_CROSSCOMPILED_TOOLS=ON -DKF6_HOST_TOOLING=/usr/lib/cmake
@@ -12,11 +12,11 @@ makedepends="qt6-base-devel qt6-tools-devel kf6-kconfig-devel
  kf6-kglobalaccel-devel kf6-ki18n-devel kf6-kio-devel kf6-kservice-devel
  kf6-knotifications-devel kf6-kservice-devel kf6-kwidgetsaddons-devel
  kf6-kwindowsystem-devel kf6-kguiaddons-devel kf6-kcmutils-devel
- kf6-kdecoration-devel kwin-devel"
-depends="kde-plasma>=6.0.0_1"
+ kf6-kdecoration-devel kwin-devel kwin-x11-devel"
+depends="plasma-desktop>=6.4.0"
 short_desc="Fork of the KWin Blur effect for Plasma 6"
 maintainer="Cass Spencer <casscardboard@gmail.com>"
 license="GPL-3.0-or-later"
 homepage="https://github.com/taj-ny/kwin-effects-forceblur"
 distfiles="https://github.com/taj-ny/kwin-effects-forceblur/archive/refs/tags/v${version}.tar.gz"
-checksum=1d22d18b5d3a9d2f7f7f6d8fbfadc180dfcdaa633b34dc2ee666ec7fcd148e1a
+checksum=24a7e2426cd5252336b8fe283adbc077b428158f40a51aa25c67759ce43fd0d4


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

This does need the updated kde-plasma packages that I don't think are built yet at the time of writing, but I built it on my machine since it's on the void-packages git and it works.

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
