### PR TITLE
pixman: update to 0.46.4

### DIFF
--- a/srcpkgs/pixman/template
+++ b/srcpkgs/pixman/template
@@ -1,6 +1,6 @@
 # Template file for 'pixman'
 pkgname=pixman
-version=0.46.2
+version=0.46.4
 revision=1
 build_style=meson
 # gtk is only necessary for demos, disabled to avoid dependency loop
@@ -14,7 +14,7 @@ maintainer="Érico Nogueira <ericonr@disroot.org>"
 license="MIT"
 homepage="http://pixman.org/"
 distfiles="https://www.cairographics.org/releases/pixman-${version}.tar.gz"
-checksum=3e0de5ba6e356916946a3d958192f15505dcab85134771bfeab4ce4e29bbd733
+checksum=d09c44ebc3bd5bee7021c79f922fe8fb2fb57f7320f55e97ff9914d2346a591c
 
 # set stacksize for musl: https://gitlab.gnome.org/GNOME/librsvg/-/issues/595
 LDFLAGS="-Wl,-z,stack-size=2097152"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, (**x86_64-glibc**)

A single [commit](https://gitlab.freedesktop.org/pixman/pixman/-/commit/2558d935672cb985956b4f643d03d6ddaeabc528) since 0.46.2 which is supposed to prevent
possible crashes under X that weren't detected during tests, afaiu.

cc @ericonr @zlice
