### PR TITLE
taglib: update to 2.1.1

### DIFF
--- a/srcpkgs/taglib/template
+++ b/srcpkgs/taglib/template
@@ -1,6 +1,6 @@
 # Template file for 'taglib'
 pkgname=taglib
-version=2.1
+version=2.1.1
 revision=1
 build_style=cmake
 configure_args="-DWITH_MP4=ON -DWITH_ASF=ON -DBUILD_SHARED_LIBS=ON"
@@ -10,8 +10,9 @@ short_desc="Library for accessing ID tags in various media files"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="LGPL-2.1-or-later, MPL-1.1"
 homepage="https://taglib.github.io/"
+changelog="https://raw.githubusercontent.com/taglib/taglib/master/CHANGELOG.md"
 distfiles="https://github.com/taglib/taglib/archive/v${version}.tar.gz"
-checksum=95b788b39eaebab41f7e6d1c1d05ceee01a5d1225e4b6d11ed8976e96ba90b0c
+checksum=bd57924496a272322d6f9252502da4e620b6ab9777992e8934779ebd64babd6e
 
 taglib-devel_package() {
 	depends="${sourcepkg}>=${version}_${revision} zlib-devel"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**
This is a minor release update, so no need for revbumps. I tested it with strawberry, vlc and kid-qt from the repo. Reading and writing metadata to audio files works as expected. I added the changelog line. 

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture: x86_64-glibc
