### PR TITLE
libayatana-appindicator: update to 0.5.94.

### DIFF
--- a/srcpkgs/libayatana-appindicator/template
+++ b/srcpkgs/libayatana-appindicator/template
@@ -1,6 +1,6 @@
 # Template file for 'libayatana-appindicator'
 pkgname=libayatana-appindicator
-version=0.5.93
+version=0.5.94
 revision=1
 build_helper="gir"
 build_style=cmake
@@ -12,7 +12,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="LGPL-3.0-or-later"
 homepage="https://ayatanaindicators.github.io/"
 distfiles="https://github.com/AyatanaIndicators/libayatana-appindicator/archive/${version}.tar.gz"
-checksum=cbefed7a918a227bf71286246e237fcd3a9c8499b3eaac4897811a869409edf0
+checksum=884a6bc77994c0b58c961613ca4c4b974dc91aa0f804e70e92f38a542d0d0f90
 
 build_options="vala"
 build_options_default="vala"


### PR DESCRIPTION
mainly deprecation changes

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures:
  - i686-glibc
  - x86_64-musl
  - aarch64-glibc (x86_64-glibc)
  - aarch64-musl (x86_64-musl)
  - armv7l-glibc (x86_64-glibc)
  - armv6l-musl - x86_64-musl