### PR TITLE
mpv: add patch to fix clipboard polling on wayland

### DIFF
--- a/srcpkgs/mpv/patches/fix-clipboard-polling.patch
+++ b/srcpkgs/mpv/patches/fix-clipboard-polling.patch
@@ -1,0 +1,16 @@
+https://github.com/mpv-player/mpv/pull/16140
+--- a/player/clipboard/clipboard-wayland.c
++++ b/player/clipboard/clipboard-wayland.c
+@@ -348,6 +348,12 @@ static bool clipboard_wayland_dispatch_events(struct clipboard_wayland_priv *wl,
+     if (fds[1].revents & POLLIN)
+         return false;
+ 
++    if (fds[2].revents & (POLLERR | POLLHUP | POLLNVAL))
++        destroy_offer(wl->selection_offer);
++
++    if (fds[3].revents & (POLLERR | POLLHUP | POLLNVAL))
++        destroy_offer(wl->primary_selection_offer);
++
+     if (fds[2].revents & POLLIN)
+         get_selection_data(wl, wl->selection_offer, false);
+ 

--- a/srcpkgs/mpv/template
+++ b/srcpkgs/mpv/template
@@ -1,7 +1,7 @@
 # Template file for 'mpv'
 pkgname=mpv
 version=0.40.0
-revision=2
+revision=3
 build_style=meson
 configure_args="-Dcdda=enabled -Ddvbin=enabled -Ddvdnav=enabled
  -Dlibmpv=true -Dcplugins=enabled


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (**x86_64-glibc**)

After digging deeper trying to pinpoint seemingly random high cpu usage for weeks, it turned out that I was experiencing: https://github.com/mpv-player/mpv/issues/16139