### PR TITLE
python3-uvicorn: update to 0.35.0

### DIFF
--- a/srcpkgs/python3-uvicorn/template
+++ b/srcpkgs/python3-uvicorn/template
@@ -1,6 +1,6 @@
 # Template file for 'python3-uvicorn'
 pkgname=python3-uvicorn
-version=0.34.2
+version=0.35.0
 revision=1
 build_style=python3-pep517
 hostmakedepends="hatchling"
@@ -9,9 +9,9 @@ short_desc="ASGI web server"
 maintainer="Emil Miler <em@0x45.cz>"
 license="BSD-3-Clause"
 homepage="https://www.uvicorn.org/"
-changelog="https://github.com/encode/uvicorn/blob/master/CHANGELOG.md"
+changelog="https://raw.githubusercontent.com/encode/uvicorn/refs/heads/master/docs/release-notes.md"
 distfiles="${PYPI_SITE}/u/uvicorn/uvicorn-${version}.tar.gz"
-checksum=0e929828f6186353a80b58ea719861d2629d766293b6d19baf086ba31d4f3328
+checksum=bc662f087f7cf2ce11a1d7fd70b90c9f98ef2e2831556dd078d131b96cc94a01
 
 post_install() {
 	vlicense LICENSE.md


### PR DESCRIPTION
- I tested the changes in this PR: **briefly**
- I built this PR locally for my native architecture, (x86_64-glibc)