### PR TITLE
libde265: disable execstack for glibc-2.41

### DIFF
--- a/srcpkgs/libde265/template
+++ b/srcpkgs/libde265/template
@@ -1,7 +1,7 @@
 # Template file for 'libde265'
 pkgname=libde265
 version=1.0.16
-revision=1
+revision=2
 build_style=gnu-configure
 hostmakedepends="pkg-config"
 short_desc="Open h.265 video codec implementation"
@@ -11,6 +11,8 @@ homepage="https://www.libde265.org"
 changelog="https://github.com/strukturag/libde265/releases"
 distfiles="https://github.com/strukturag/libde265/releases/download/v${version}/libde265-${version}.tar.gz"
 checksum=b92beb6b53c346db9a8fae968d686ab706240099cdd5aff87777362d668b0de7
+
+LDFLAGS+=" -Wl,-z,noexecstack"
 
 post_install() {
 	# Why is this installed anyway?


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->

Fixes https://github.com/void-linux/void-packages/issues/56252. Maybe we should gate the LDFLAGS to only armv7l, but also haven't tested to see if the issue occurs on other machine types...
