### PR TITLE
wofi: update to 1.5, adopt

### DIFF
--- a/srcpkgs/wofi/template
+++ b/srcpkgs/wofi/template
@@ -1,13 +1,13 @@
 # Template file for 'wofi'
 pkgname=wofi
-version=1.4.1
+version=1.5
 revision=1
 build_style=meson
 hostmakedepends="pkg-config"
 makedepends="wayland-devel gtk+3-devel"
 short_desc="Program launcher for Wayland compositors"
-maintainer="Orphaned <orphan@voidlinux.org>"
+maintainer="skmpz <dem.procopiou@gmail.com>"
 license="GPL-3.0-or-later"
 homepage="https://hg.sr.ht/~scoopta/wofi"
 distfiles="https://hg.sr.ht/~scoopta/wofi/archive/v${version}.tar.gz"
-checksum=e95e35c03551c39178c16ad6213a88e3883a236e942d7f2666c780d934c270bb
+checksum=4d1bb206584c4592cb3e5b369cc10cab754427a20742bb9380f308eafae45523


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures:
  - i686-glibc
  - x86_64-musl
  - aarch64-glibc (x86_64-glibc)
  - aarch64-musl (x86_64-musl)
  - armv7l-glibc (x86_64-glibc)
  - armv6l-musl - x86_64-musl
