### PR TITLE
atari800: update to 5.2.0

### DIFF
--- a/srcpkgs/atari800/template
+++ b/srcpkgs/atari800/template
@@ -1,6 +1,6 @@
 # Template file for 'atari800'
 pkgname=atari800
-version=4.1.0
+version=5.2.0
 revision=1
 build_style=gnu-configure
 configure_args="--disable-sdltest --with-x --enable-clipsound
@@ -12,8 +12,8 @@ short_desc="Emulator of Atari 800/800XL/130XE/5200 with various extensions"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="https://atari800.github.io"
-distfiles="${SOURCEFORGE_SITE}/atari800/atari800/${version}/atari800-${version}-src.tgz"
-checksum=fedfe2ec94dc6f29b467e8c419efff64a7451aa4bbd60ffbd4709cb4da6276c0
+distfiles="https://github.com/atari800/atari800/releases/download/ATARI800_${version//./_}/atari800-${version}-src.tgz"
+checksum=3874d02b89d83c8089f75391a4c91ecb4e94001da2020c2617be088eba1f461f
 
 post_install() {
 	vdoc "${FILESDIR}/README.voidlinux"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

- Emulator starts
- Few games checked to be working
- Cartridge functionality works (Action!, Sparta DOS X)
- Alternative basics works (Turbo Basic XL, Advan Basic, etc)

#### Local build testing
- I built this PR locally for my native architecture, (x86-64)
