### PR TITLE
dwarffortress: update to 53.02; Dwarf-Therapist: update to 42.1.21.

### DIFF
--- a/srcpkgs/Dwarf-Therapist/template
+++ b/srcpkgs/Dwarf-Therapist/template
@@ -1,6 +1,6 @@
 # Template file for 'Dwarf-Therapist'
 pkgname=Dwarf-Therapist
-version=42.1.15
+version=42.1.21
 revision=1
 build_style=cmake
 makedepends="qt5-declarative-devel libcap-devel hicolor-icon-theme"
@@ -10,7 +10,7 @@ maintainer="Rutpiv <roger_freitas@live.com>"
 license="GPL-3.0-or-later"
 homepage="https://github.com/Dwarf-Therapist/Dwarf-Therapist/"
 distfiles="https://github.com/Dwarf-Therapist/Dwarf-Therapist/archive/v${version}.tar.gz"
-checksum=f69813c2f0483f3036eabcd2f6e06a66ca68bdcc699ebe84dd4d02b0c4ff4bad
+checksum=654a3eedb805ec796440da2af9939960a77e20f6cb6fcc15f3d580db50a31bcb
 make_check=no # No tests available.
 
 post_build() {

--- a/srcpkgs/dwarffortress/INSTALL.msg
+++ b/srcpkgs/dwarffortress/INSTALL.msg
@@ -1,0 +1,9 @@
+Dwarf Fortress stores user data in:
+  ~/.local/share/dwarffortress/       (symlinks and runtime)
+  ~/.local/share/Bay 12 Games/Dwarf Fortress/  (saves, mods)
+
+To reset the runtime directory after a package update:
+  rm -rf ~/.local/share/dwarffortress
+
+If upgrading from version 51.x, old saves were stored in:
+  ~/.local/share/dwarffortress/data/save/

--- a/srcpkgs/dwarffortress/files/dwarffortress
+++ b/srcpkgs/dwarffortress/files/dwarffortress
@@ -1,83 +1,14 @@
 #!/bin/sh
-## dwarf fortress wrapper written and maintained by
-# Robert Stancil <robert.stancil@mavs.uta.edu>
-#
-# MIT License
-#
-# Copyright (c) 2019 Robert Stancil <robert.stancil@mavs.uta.edu>
-#
-# Modified by: Rutpiv <roger_freitas@live.com> in 2024 to adjust symlink
-# creation and preserve existing save data by backing up old directories.
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice (including the next
-# paragraph) shall be included in all copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-##
+# Dwarf Fortress wrapper for Void Linux
+DF_DIR="/opt/dwarffortress"
+DIRECTORY="${XDG_DATA_HOME:-$HOME/.local/share}/dwarffortress"
 
-usage() {
- printf "Usage:\n %s [-f]\noptions:\n -f\tforce/recreate user's game data directory. <Warning: this will erase all save data>" "${0}"
-}
-
-while getopts 'f' c
-do
- case $c in
-  f) _FORCE=yes ;;
-  *) usage ;;
- esac
-done
-
-if [ $(id -u) -eq 0 ]; then
- echo "Error, can't be run as root" >&2
- usage
- exit
+if [ ! -d "$DIRECTORY" ]; then
+	echo "Setting up $DIRECTORY"
+	mkdir -p "$DIRECTORY"
+	ln -s "$DF_DIR/data" "$DIRECTORY/data"
+	ln -s "$DF_DIR"/*.so* "$DIRECTORY/" 2>/dev/null
 fi
 
-if [ -z ${XDG_DATA_HOME:-$HOME/.local/share} ]; then
- echo "homedir unset"
- usage
- exit
-fi
-
-# Check if an existing 'dwarffortress' directory with the old structure is found.
-# If found, create a backup of the directory before removing it.
-# The backup is stored as a tar.gz archive with a timestamp to prevent overwriting.
-if [ -d "${XDG_DATA_HOME:-$HOME/.local/share}/dwarffortress" ] &&
-	 [ -f "${XDG_DATA_HOME:-$HOME/.local/share}/dwarffortress/df" ]; then
- echo "Existing old 'dwarffortress' directory found. Creating a backup..."
-
- timestamp=$(date +%Y%m%d%H%M%S)
- backup_file="${XDG_DATA_HOME:-$HOME/.local/share}/dwarffortress_backup_${timestamp}.tar.gz"
- tar -czf "$backup_file" -C "${XDG_DATA_HOME:-$HOME/.local/share}" dwarffortress
- echo "Backup created at $backup_file"
-
- rm -rf "${XDG_DATA_HOME:-$HOME/.local/share}/dwarffortress"
- echo "Old 'dwarffortress' directory removed."
-fi
-
-if [ ! -d ${XDG_DATA_HOME:-$HOME/.local/share}/dwarffortress ]; then
- _FORCE=yes
-fi
-if [ $_FORCE ]
-then
- rm -rf ${XDG_DATA_HOME:-$HOME/.local/share}/dwarffortress
- cp /usr/share/dwarffortress ${XDG_DATA_HOME:-$HOME/.local/share} -r
- for lib in /usr/lib/dwarffortress/libs/*; do
-        ln -s "$lib" "${XDG_DATA_HOME:-$HOME/.local/share}/dwarffortress/"
- done
- ln -s /usr/bin/dwarfort ${XDG_DATA_HOME:-$HOME/.local/share}/dwarffortress/
-fi
-
-${XDG_DATA_HOME:-$HOME/.local/share}/dwarffortress/run_df
+cd "$DIRECTORY" || exit 1
+LD_LIBRARY_PATH="${LD_LIBRARY_PATH:+$LD_LIBRARY_PATH:}$DF_DIR" exec "$DF_DIR/dwarfort" "$@"

--- a/srcpkgs/dwarffortress/template
+++ b/srcpkgs/dwarffortress/template
@@ -1,30 +1,26 @@
 # Template file for 'dwarffortress'
 pkgname=dwarffortress
-version=51.13
+version=53.02
 revision=1
 _urlver=${version//./_}
 archs="x86_64"
 depends="gtk+ SDL SDL_ttf SDL_image virtual?libGL glu"
 short_desc="Control a dwarven outpost in a randomly generated world"
 maintainer="Rutpiv <roger_freitas@live.com>"
-license="custom: Proprietary"
+license="custom:Proprietary"
 homepage="https://www.bay12games.com/dwarves/"
 distfiles="https://www.bay12games.com/dwarves/df_${_urlver}_linux.tar.bz2"
-checksum=15d6f7412f8fd312f8fd4d33ea7672321efc2951c38aef532377c5eac680c372
-
-nostrip_files="Dwarf_Fortress"
+checksum=81e0e27dfdfc43df5f5d5636162e6f60a081d093dab791d2199b05692914f6bc
 nopie="distfiles are precompiled as PIE"
 repository=nonfree
 noshlibprovides=yes
+nostrip=yes
 
 do_install() {
+	vmkdir /opt/dwarffortress
+	vcopy "*" /opt/dwarffortress
+	chmod 755 "${DESTDIR}"/opt/dwarffortress/{dwarfort,run_df,*.so*}
+
 	vbin ${FILESDIR}/dwarffortress
-	vbin dwarfort
-	rm dwarfort
-	vmkdir /usr/share/dwarffortress
-	vmkdir /usr/lib/dwarffortress/libs
-	vcopy lib* /usr/lib/dwarffortress/libs
-	rm lib*
-	vcopy * /usr/share/dwarffortress/
-	vlicense "readme.txt" dwarffortress.txt
+	vlicense readme.txt dwarffortress.txt
 }


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)

---

This update required modifying the wrapper script to handle versioning, since the `dwarfort` executable no longer works when symlinked. Because the binary must be replaced with each new release, I added logic in the template to echo the current version into a file. This version file is then used by the wrapper to compare against the version inside the game folder during execution, ensuring the game stays up-to-date for the user.

There were also changes regarding save file handling. In version 52, save data is now stored in a different location. The wrapper detects the older save folder structure and automatically creates a backup. Even if the user forces reinstallation using `-f`, no save data is lost because it's safely stored in a separate .local directory.

From the end user's perspective, everything should work as usual when launching the new version. However, if they wish to continue using their old 51.13 save with the new version, they will need to manually move it from the automatically created backup into the new save folder — but no save data is lost in the process.