### PR TITLE
scaleway-cli: update to 2.42.0

### DIFF
--- a/srcpkgs/scaleway-cli/template
+++ b/srcpkgs/scaleway-cli/template
@@ -1,6 +1,6 @@
 # Template file for 'scaleway-cli'
 pkgname=scaleway-cli
-version=2.41.0
+version=2.42.0
 revision=1
 build_style=go
 go_import_path=github.com/scaleway/scaleway-cli/v2
@@ -11,7 +11,7 @@ maintainer="Sébastien Pondichy <sebastien.pondichy@gmail.com>"
 license="MIT"
 homepage="https://github.com/scaleway/scaleway-cli"
 distfiles="https://github.com/scaleway/scaleway-cli/archive/v${version}.tar.gz"
-checksum=ba056eacd5a012a55789421d0d7579ee002ae298ca9a04a1d9a88eefb0d13ae7
+checksum=40cafbdedc8b956a4b7da331bae7c6ec26f891a40e789348d36bcddea9c88ee3
 # Tests fail when run on i686
 make_check="no"
 


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - i686
  - x86_64-musl
  - aarch64
  - armv7l
 
