### PR TITLE
watchexec: fix update-check

### DIFF
--- a/srcpkgs/watchexec/update
+++ b/srcpkgs/watchexec/update
@@ -1,0 +1,2 @@
+site='https://github.com/watchexec/watchexec/releases'
+pattern='CLI v\K[\d.]+'


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

Currently, library updates are also detected as new release although we only care about the CLI.

cc @cinerea0 
