### PR TITLE
rpcbind: update to 1.2.8

### DIFF
--- a/srcpkgs/rpcbind/template
+++ b/srcpkgs/rpcbind/template
@@ -1,7 +1,7 @@
 # Template file for 'rpcbind'
 pkgname=rpcbind
-version=1.2.7
-revision=2
+version=1.2.8
+revision=1
 build_style=gnu-configure
 configure_args="--enable-warmstarts --with-statedir=/run --with-rpcuser=rpc
  --with-systemdsystemunitdir=no"
@@ -12,7 +12,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="BSD-3-Clause"
 homepage="https://rpcbind.sourceforge.net"
 distfiles="${SOURCEFORGE_SITE}/${pkgname}/${pkgname}-${version}.tar.bz2"
-checksum=f6edf8cdf562aedd5d53b8bf93962d61623292bfc4d47eedd3f427d84d06f37e
+checksum=964132c389918e8964d7334936b6dd10ef025b300c6b29e693ba0f29550e3de5
 system_accounts="rpc"
 
 post_install() {


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**
I tested it with nfs4 mounting. After installing the package, I rebooted. The newly added -v flag shows:
```
rpcbind -v
rpcbind 1.2.8
debug: no, libset debug: no, libwrap: no, nss modules: files, remote calls: no, statedir: /run, systemd: no, user: rpc, warm start: yes
```
There are no changes in the package structure:
```
$ xbps-query -Rf rpcbind
/etc/sv/rpcbind/log/run
/etc/sv/rpcbind/run
/usr/bin/rpcbind
/usr/bin/rpcinfo
/usr/share/licenses/rpcbind/COPYING
/usr/share/man/man8/rpcbind.8
/usr/share/man/man8/rpcinfo.8
/etc/sv/rpcbind/log/supervise -> /run/runit/supervise.rpcbind-log
/etc/sv/rpcbind/supervise -> /run/runit/supervise.rpcbind
```
vs
```
$ bsdtar tf rpcbind-1.2.8_1.x86_64.xbps 
./REMOVE
./INSTALL
./props.plist
./files.plist
./usr/share/man/man8/rpcinfo.8
./usr/share/man/man8/rpcbind.8
./usr/share/licenses/rpcbind/COPYING
./usr/bin/rpcinfo
./usr/bin/rpcbind
./etc/sv/rpcbind/supervise
./etc/sv/rpcbind/run
./etc/sv/rpcbind/log/supervise
./etc/sv/rpcbind/log/run
```


<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture,: x86_64-glibc
- I built this PR locally for these architectures: i686, aarch64-musl (crossbuild)

