### PR TITLE
nfs-utils: add an option for NFSv4 server to not rely on statd or rpcbind

### DIFF
--- a/srcpkgs/nfs-utils/files/nfs-server/run
+++ b/srcpkgs/nfs-utils/files/nfs-server/run
@@ -1,14 +1,16 @@
 #!/bin/sh
 exec 2>&1
 
-# Make sure the statd service is running.
-sv check statd >/dev/null || exit 1
-
 # This was probably only used correctly to set PROCESSES
 [ -r /etc/conf.d/nfs-server.conf ] && . /etc/conf.d/nfs-server.conf
 
 # Settings in ./conf should be preferred over /etc/conf.d/nfs-server.conf
 [ -r ./conf ] && . ./conf
+
+# If this var is set, there's no need to enable statd and rpcbind services as they pertain to NFSv3
+if [ -z "$NFSV4_ONLY" ]; then
+	sv check statd >/dev/null || exit 1
+fi
 
 # Check/mount rpc_pipefs (loads sunrpc kernel module)
 if ! mountpoint -q /var/lib/nfs/rpc_pipefs; then

--- a/srcpkgs/nfs-utils/template
+++ b/srcpkgs/nfs-utils/template
@@ -1,7 +1,7 @@
 # Template file for 'nfs-utils'
 pkgname=nfs-utils
 version=2.8.3
-revision=2
+revision=3
 build_style=gnu-configure
 configure_args="--with-statduser=nobody --enable-gss --enable-nfsv4
  --with-statedir=/var/lib/nfs --enable-libmount-mount --enable-svcgss


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**
An NFSv4 server does not require statd or rpcbind. On the client side, these two services can also remain disabled.
A prerequisite for this to work is setting the NFSV4_ONLY var:
```
/etc/sv/nfs-server/conf
NFSV4_ONLY=yes
```
as well as disabling NFSv3:
```
/etc/nfs.conf 
[nfsd]
vers3=n
vers4=y
vers4.1=y
vers4.2=y
```
#### Void Documentation
I can create a PR documenting the changes https://github.com/void-linux/void-docs/commit/197ff670e6a068d401bc090421509d88beca6320

#### Resources
- https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/6/html/storage_administration_guide/ch-nfs#s1-nfs-how

> The mounting and locking protocols have been incorporated into the NFSv4 protocol. The server also listens on the well-known TCP port 2049. As such, NFSv4 does not need to interact with rpcbind [[3]](https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/6/html/storage_administration_guide/ch-nfs#ftn.fn-portmap2rpcbind), lockd, and rpc.statd daemons. The rpc.mountd daemon is required on the NFS server to set up the exports.

- https://www.suse.com/support/kb/doc/?id=000019530:

> some services (rpcbind, statd, lockd) are necessary for NFS v3/v2 Client functions, not just NFS v3/v2 Server functions.

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
