### PR TITLE
libiio: update to 0.26

### DIFF
--- a/srcpkgs/libiio/template
+++ b/srcpkgs/libiio/template
@@ -1,7 +1,7 @@
 # Template file for 'libiio'
 pkgname=libiio
-version=0.25
-revision=3
+version=0.26
+revision=1
 build_style=cmake
 configure_args="-DUDEV_RULES_INSTALL_DIR=/usr/lib/udev/rules.d -DWITH_DOC=YES
  -DWITH_SERIAL_BACKEND=YES -DHAVE_DNS_SD=YES -DPYTHON_BINDINGS=YES"
@@ -13,7 +13,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="LGPL-2.1-or-later"
 homepage="https://analogdevicesinc.github.io/libiio"
 distfiles="https://github.com/analogdevicesinc/libiio/archive/v${version}.tar.gz"
-checksum=21972599a3c143ab1f98002ad2b3f28f4aff927fde5f677478311cd4e517730c
+checksum=fb445fb860ef1248759f45d4273a4eff360534480ec87af64c6b8db3b99be7e5
 
 libiio-devel_package() {
 	depends="${sourcepkg}>=${version}_${revision}"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
