### PR TITLE
New package: river-bedload-0.1.1

### DIFF
--- a/srcpkgs/river-bedload/template
+++ b/srcpkgs/river-bedload/template
@@ -1,0 +1,15 @@
+# Template file for 'river-bedload'
+pkgname=river-bedload
+version=0.1.1
+revision=1
+build_style=zig-build
+configure_args="-Doptimize=ReleaseSafe"
+hostmakedepends="pkg-config wayland-devel"
+makedepends="wayland-devel wayland-protocols"
+short_desc="Display information about river Wayland compositor in json in the STDOUT"
+maintainer="Yushi <github@yushi.one>"
+license="GPL-3.0-or-later"
+homepage="https://git.sr.ht/~novakane/river-bedload"
+distfiles="https://git.sr.ht/~novakane/river-bedload/refs/download/v${version}/river-bedload-v${version}.tar.gz"
+checksum=f0ecde0b7d393207eb6c8e7d375ca967388accc16b0f741c280f0844c0e63d82
+nopie=yes


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**


<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)

