### PR TITLE
lynis: update to 3.1.5

### DIFF
--- a/srcpkgs/lynis/template
+++ b/srcpkgs/lynis/template
@@ -1,6 +1,6 @@
 # Template file for 'lynis'
 pkgname=lynis
-version=3.1.4
+version=3.1.5
 revision=1
 short_desc="System and security auditing tool"
 maintainer="Johannes Heimansberg <git@jhe.dedyn.io>"
@@ -8,7 +8,7 @@ license="GPL-3.0-only"
 homepage="https://cisofy.com/lynis/"
 changelog="https://raw.githubusercontent.com/CISOfy/lynis/master/CHANGELOG.md"
 distfiles="https://github.com/CISOfy/lynis/archive/refs/tags/${version}.tar.gz"
-checksum=db00e26cfb1e04ca70af48d106c3e2968eb468adbef17a2ab18b0028a3d1e3b7
+checksum=02e16e452a926b6dbae5bfc28b0592d42c8af24c572180f444ac865e0e4f4bce
 
 do_install() {
 	vmkdir etc/lynis


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
