### PR TITLE
wireshark: Add tshark sub-package

### DIFF
--- a/srcpkgs/tshark
+++ b/srcpkgs/tshark
@@ -1,0 +1,1 @@
+wireshark

--- a/srcpkgs/wireshark/template
+++ b/srcpkgs/wireshark/template
@@ -72,6 +72,14 @@ libwireshark-devel_package() {
 	}
 }
 
+tshark_package() {
+	short_desc+=" - tshark"
+	pkg_install() {
+		vmove usr/bin/tshark
+		vmove usr/share/man/man1/tshark.1
+	}
+}
+
 wireshark-qt_package() {
 	depends="${sourcepkg}>=${version}_${revision} desktop-file-utils"
 	short_desc+=" - Qt frontend"
@@ -79,5 +87,14 @@ wireshark-qt_package() {
 		vmove usr/bin/wireshark
 		vmove usr/share/man/man1/wireshark.1
 		vmove usr/share/applications/org.wireshark.Wireshark.desktop
+	}
+}
+
+libwireshark_package() {
+	short_desc+=" - library"
+	pkg_install() {
+		vmove "usr/lib/*.so.*"
+		vmove usr/lib/wireshark/extcap
+		vmove usr/lib/wireshark/plugins
 	}
 }


### PR DESCRIPTION
Avoid all the X dependencies on tshark.


#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)


