### PR TITLE
Vulkan-Tools: Add dependency on vulkan-loader

### DIFF
--- a/srcpkgs/Vulkan-Tools/template
+++ b/srcpkgs/Vulkan-Tools/template
@@ -1,7 +1,7 @@
 # Template file for 'Vulkan-Tools'
 pkgname=Vulkan-Tools
 version=1.4.313.0
-revision=1
+revision=2
 build_style=cmake
 configure_args="-DGLSLANG_INSTALL_DIR=/usr
  -DVULKAN_HEADERS_INSTALL_DIR=${XBPS_CROSS_BASE}/usr -Wno-dev
@@ -9,6 +9,7 @@ configure_args="-DGLSLANG_INSTALL_DIR=/usr
 hostmakedepends="python3 pkg-config glslang wayland-devel"
 makedepends="vulkan-loader-devel libxcb-devel libxkbcommon-devel
  wayland-devel wayland-protocols libXrandr-devel zeux-volk"
+depends="vulkan-loader"
 short_desc="Official Vulkan tools and utilities"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="Apache-2.0"


### PR DESCRIPTION
`vulkaninfo` in the `Vulkan-Tools` package apparently requires `vulkan-loader`.    
Installing `vulkan-loader` resolves the error displayed when running `vulkaninfo` without `vulkan-loader` installed.
```
$ vulkaninfo
ERROR at /builddir/Vulkan-Tools-1.4.313.0/vulkaninfo/./vulkaninfo.h:526: Failed to initialize: Vulkan loader is not installed, not found, or failed to load.
```

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
