### PR TITLE
Update some pallets' pkgs

### DIFF
--- a/srcpkgs/python3-Flask/template
+++ b/srcpkgs/python3-Flask/template
@@ -1,21 +1,21 @@
 # Template file for 'python3-Flask'
 pkgname=python3-Flask
-version=3.0.2
-revision=2
+version=3.1.1
+revision=1
 build_style=python3-pep517
 hostmakedepends="python3-flit_core"
 depends="python3-Werkzeug python3-Jinja2 python3-itsdangerous
- python3-click python3-blinker"
+ python3-click python3-blinker python3-MarkupSafe"
 checkdepends="${depends} python3-pytest python3-hypothesis"
 short_desc="Python3 web microframework"
 maintainer="Pulux <pulux@pf4sh.de>"
 license="BSD-3-Clause"
-homepage="http://flask.pocoo.org"
+homepage="https://palletsprojects.com/p/Flask"
 changelog="https://raw.githubusercontent.com/pallets/flask/main/CHANGES.rst"
 distfiles="https://github.com/pallets/flask/archive/${version}.tar.gz"
-checksum=48843a02c216f7386163b76e9b0d7226716bfbd5155a127cf00ae2094c6c2f16
+checksum=80af55cb764cb4d2303ea13877d752a4aa19af898d4e374e0bcdcf1e98fa56e0
 conflicts="python-Flask>=0"
 
 post_install() {
-	vlicense LICENSE.rst
+	vlicense LICENSE.txt
 }

--- a/srcpkgs/python3-Werkzeug/template
+++ b/srcpkgs/python3-Werkzeug/template
@@ -1,7 +1,7 @@
 # Template file for 'python3-Werkzeug'
 pkgname=python3-Werkzeug
-version=3.0.1
-revision=2
+version=3.1.3
+revision=1
 build_style=python3-pep517
 # Some tests depend on unpackaged dependencies
 make_check_args="
@@ -18,7 +18,7 @@ license="BSD-3-Clause"
 homepage="https://palletsprojects.com/p/werkzeug/"
 changelog="https://raw.githubusercontent.com/pallets/werkzeug/main/CHANGES.rst"
 distfiles="https://github.com/pallets/werkzeug/archive/${version}.tar.gz"
-checksum=d5aed0e7fe61a83cf385c94f7cf7f6c43a7affa7f81ef7b07bd632834756f4dc
+checksum=bee857f4423d7ebf0d6d8bf76c90c70470cc5acecd1187e9484f6dc899487d6d
 
 pre_check() {
 	# For some reason, --ignore doesn't work on this file
@@ -26,5 +26,5 @@ pre_check() {
 }
 
 post_install() {
-	vlicense LICENSE.rst
+	vlicense LICENSE.txt
 }

--- a/srcpkgs/python3-blinker/template
+++ b/srcpkgs/python3-blinker/template
@@ -1,7 +1,7 @@
 # Template file for 'python3-blinker'
 pkgname=python3-blinker
-version=1.7.0
-revision=2
+version=1.9.0
+revision=1
 build_style=python3-pep517
 hostmakedepends="python3-flit_core"
 makedepends="python3-devel"
@@ -9,13 +9,13 @@ depends="python3"
 checkdepends="python3-pytest-asyncio python3-pluggy python3-packaging
  python3-iniconfig"
 short_desc="Fast, simple object-to-object and broadcast signaling for Python3"
-maintainer="Orphaned <orphan@voidlinux.org>"
+maintainer="Komeil Parseh <komeilparseh@disroot.org>"
 license="MIT"
 homepage="https://blinker.readthedocs.io/en/stable/"
 changelog="https://raw.githubusercontent.com/pallets-eco/blinker/main/CHANGES.rst"
 distfiles="${PYPI_SITE}/b/blinker/blinker-${version}.tar.gz"
-checksum=e6820ff6fa4e4d1d8e2747c2283749c3f547e4fee112b98555cdcdae32996182
+checksum=b4ce2265a7abece45e7cc896e98dbebe6cead56bcf805a3d23136d145f5445bf
 
 post_install() {
-	vlicense LICENSE.rst
+	vlicense LICENSE.txt
 }

--- a/srcpkgs/python3-itsdangerous/template
+++ b/srcpkgs/python3-itsdangerous/template
@@ -1,18 +1,18 @@
 # Template file for 'python3-itsdangerous'
 pkgname=python3-itsdangerous
-version=2.1.2
-revision=4
-build_style=python3-module
-hostmakedepends="python3-setuptools"
-makedepends="python3-devel"
-depends="python3"
+version=2.2.0
+revision=1
+build_style=python3-pep517
+hostmakedepends="python3-flit_core"
+checkdepends="python3-freezegun python3-pytest"
 short_desc="Various helpers to pass trusted data to untrusted enviroments and back"
 maintainer="Markus Berger <pulux@pf4sh.de>"
 license="BSD-3-Clause"
-homepage="http://github.com/mitsuhiko/itsdangerous"
+homepage="https://palletsprojects.com/projects/itsdangerous"
+changelog="https://raw.githubusercontent.com/pallets/itsdangerous/refs/heads/main/CHANGES.rst"
 distfiles="${PYPI_SITE}/i/itsdangerous/itsdangerous-${version}.tar.gz"
-checksum=5dbbc68b317e5e42f327f9021763545dc3fc3bfe22e6deb96aaf1fc38874156a
+checksum=e0050c0b7da1eea53ffaf149c0cfbb5c6e2e2b69c4bef22c81fa6eb73e5f6173
 
 post_install() {
-	vlicense LICENSE.rst
+	vlicense LICENSE.txt
 }


### PR DESCRIPTION
- **python3-Flask: update to 3.1.1.**
- **python3-Werkzeug: update to 3.1.3.**
- **python3-itsdangerous: update to 2.2.0.**
- **python3-blinker: update to 1.9.0. adopt.**

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
#### Local build testing
- I built this PR locally for my native architecture, x86_64(glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
