### PR TITLE
docker-compose: update to 2.39.1

### DIFF
--- a/srcpkgs/docker-compose/template
+++ b/srcpkgs/docker-compose/template
@@ -1,6 +1,6 @@
 # Template file for 'docker-compose'
 pkgname=docker-compose
-version=2.37.1
+version=2.39.1
 revision=1
 build_style=go
 go_import_path="github.com/docker/compose/v2"
@@ -13,7 +13,7 @@ license="Apache-2.0"
 homepage="https://docs.docker.com/compose/"
 changelog="https://github.com/docker/compose/releases"
 distfiles="https://github.com/docker/compose/archive/refs/tags/v${version}.tar.gz"
-checksum=63fc8a368a900bbba654ca0411cf4d875a3fedcb6a5d89aa8e817495e927a493
+checksum=35287aff54d826241fb727b3024b1cb46849770ac8dd166f0702f8aa2b5f7e30
 
 post_install() {
 	vmkdir usr/libexec/docker/cli-plugins


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64musl
