### PR TITLE
linux-asahi: uniform to distro

### DIFF
--- a/srcpkgs/linux-asahi/files/mv-debug
+++ b/srcpkgs/linux-asahi/files/mv-debug
@@ -4,4 +4,5 @@ mkdir -p usr/lib/debug/${mod%/*}
 $OBJCOPY --only-keep-debug --compress-debug-sections $mod usr/lib/debug/$mod
 $OBJCOPY --add-gnu-debuglink=${DESTDIR}/usr/lib/debug/$mod $mod
 /usr/bin/$STRIP --strip-debug $mod
-gzip -9 $mod
+$SIGN_FILE $mod
+zstd -T1 --rm -f -q $mod

--- a/srcpkgs/linux-asahi/template
+++ b/srcpkgs/linux-asahi/template
@@ -94,7 +94,7 @@ do_install() {
 	# Run depmod after compressing modules - makes depmod.sh a noop
 	sed -i '2iexit 0' scripts/depmod.sh
 	vmkdir usr/lib
-	ln -s usr/lib/ ${DESTDIR}
+	ln -sf usr/lib/ ${DESTDIR}
 
 	# Install kernel, firmware and modules
 	make ${makejobs} ARCH=${arch} INSTALL_MOD_PATH=${DESTDIR} ${_cross} modules_install


### PR DESCRIPTION
[ci skip]
Uniformize `linux-asahi` to the other kernel packages.
cc @Piraty 

I wonder if it would be simpler to have a `linux-kernel` build style.