### PR TITLE
plattenalbum: update to 2.3.1.

### DIFF
--- a/srcpkgs/plattenalbum/template
+++ b/srcpkgs/plattenalbum/template
@@ -1,18 +1,18 @@
 # Template file for 'plattenalbum'
 pkgname=plattenalbum
-version=2.2.1
+version=2.3.1
 revision=1
 build_style=meson
 hostmakedepends="gettext pkg-config glib-devel gtk4-update-icon-cache desktop-file-utils"
 makedepends="gtk4-devel libadwaita-devel"
-depends="python3-mpd2 python3-gobject gtk4 libadwaita mpd"
+depends="python3-mpd2>=3.1.0 python3-gobject gtk4 libadwaita mpd"
 short_desc="Simple music browser for MPD"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-3.0-or-later"
 homepage="https://github.com/SoongNoonien/plattenalbum/"
 changelog="https://github.com/SoongNoonien/plattenalbum/releases"
 distfiles="https://github.com/SoongNoonien/plattenalbum/archive/refs/tags/v$version.tar.gz"
-checksum=38495a0989f3a5b8049e2ec0a17bfb94ea60ab892ec001ac2f12a9e9a6c4f80b
+checksum=501aec33f26065d1ccdeee3b2233a3148015d8d84599aa886dd0a1331a83b348
 
 mpdevil_package() {
 	metapackage=yes


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

I was informed by the upstream maintainer that one of the dependencies has to be newer than the one in the void-repos. Just updating the template accordingly.

the dependency is python3-mpd2 and I've emailed the maintainer requesting them to update the template