### PR TITLE
EternalTerminal: update to 6.2.11

### DIFF
--- a/srcpkgs/EternalTerminal/template
+++ b/srcpkgs/EternalTerminal/template
@@ -1,6 +1,6 @@
 # Template file for 'EternalTerminal'
 pkgname=EternalTerminal
-version=6.2.9
+version=6.2.11
 revision=1
 # revisions used for the specific versions of submodules.
 # they can be found in the external/ directory of the source code.
@@ -19,7 +19,7 @@ homepage="https://eternalterminal.dev/"
 distfiles="https://github.com/MisterTea/EternalTerminal/archive/et-v${version}.tar.gz
  https://github.com/arsenm/sanitizers-cmake/archive/${_sanitizers_gitrev}.tar.gz
  https://github.com/progschj/ThreadPool/archive/${_threadpool_gitrev}.tar.gz"
-checksum="13bfb2722b011b5f0a28fa619508deca96deec9eee5e42b922add0c166d8185a
+checksum="e8e80800babc026be610d50d402a8ecbdfbd39e130d1cfeb51fb102c1ad63b0f
  f9cf386638f455c5d2e7a835b95941201387d2531b8682942d59827663b58341
  954e0ecdac1aa0da1e0fa78577ff0d352e53094df43762fbc1884f76a7e1dcd2"
 system_accounts="_eternal"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
