### PR TITLE
findutils: update to 4.10.0

### DIFF
--- a/srcpkgs/findutils/patches/fix-musl.patch
+++ b/srcpkgs/findutils/patches/fix-musl.patch
@@ -1,0 +1,11 @@
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -35,7 +35,7 @@ DISTCLEANFILES = tool-versions.txt
+ 
+ 
+ # "gnulib-tests" is the gnulib unit test dir.
+-SUBDIRS = gl build-aux lib find xargs locate doc po m4 gnulib-tests
++SUBDIRS = gl build-aux lib find xargs locate doc po m4
+ 
+ ALL_RECURSIVE_TARGETS =
+ 

--- a/srcpkgs/findutils/template
+++ b/srcpkgs/findutils/template
@@ -1,21 +1,27 @@
 # Template file for 'findutils'
 pkgname=findutils
-version=4.9.0
+version=4.10.0
 revision=1
 bootstrap=yes
 build_style=gnu-configure
 configure_args="--program-prefix=g"
+hostmakedepends="automake gettext"
 short_desc="GNU Find Utilities"
 maintainer="Enno Boland <gottox@voidlinux.org>"
 license="GPL-3.0-or-later"
 homepage="http://www.gnu.org/software/findutils"
 changelog="https://git.savannah.gnu.org/cgit/findutils.git/plain/NEWS"
 distfiles="${GNU_SITE}/${pkgname}/${pkgname}-${version}.tar.xz"
-checksum=a2bfb8c09d436770edc59f50fa483e785b161a3b7b9d547573cb08065fd462fe
+checksum=1387e0b67ff247d2abde998f90dfbf70c1491391a59ddfecb8ae698789f0a4f5
+
+case $XBPS_TARGET_MACHINE in
+	arm*) configure_args+=" --disable-year2038";;
+esac
 
 if [ "$XBPS_TARGET_LIBC" = musl ]; then
 	export ac_cv_lib_error_at_line=no
 	export ac_cv_header_sys_cdefs_h=no
+	checkdepends+=" musl-legacy-compat"
 fi
 
 alternatives="


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**|**briefly**|**NO**
- Personal `bash` scripts utilizing `find` or `xargs` are still working as expected
- Rerunning commands mentioned above (+ args) from my shell history are still working as expected
- Briefly tested `xdeptree` `xdiff` `xgrep` `xlocate` `xrevshlib` `xsrc`

#### Local build testing
- I built this PR locally for my native architecture, (**x86_64-glibc**)

[Changelog](https://git.savannah.gnu.org/cgit/findutils.git/plain/NEWS)
