### PR TITLE
python3-regex: update to 2025.7.34.

### DIFF
--- a/srcpkgs/python3-regex/template
+++ b/srcpkgs/python3-regex/template
@@ -1,7 +1,7 @@
 # Template file for 'python3-regex'
 pkgname=python3-regex
-version=2024.9.11
-revision=2
+version=2025.7.34
+revision=1
 build_style=python3-module
 hostmakedepends="python3-devel python3-setuptools"
 makedepends="python3-devel"
@@ -12,7 +12,7 @@ license="CNRI-Python, Apache-2.0"
 homepage="https://github.com/mrabarnett/mrab-regex"
 changelog="https://raw.githubusercontent.com/mrabarnett/mrab-regex/hg/changelog.txt"
 distfiles="${PYPI_SITE}/r/regex/regex-${version}.tar.gz"
-checksum=6c188c307e8433bcb63dc1915022deb553b4203a70722fc542c363bf120a01fd
+checksum=9ead9765217afd04a86822dfcd4ed2747dfe426e887da413b15ff0ac2457e21a
 
 do_check() {
 	(cd build/lib* && python3 -m unittest regex/test_regex.py)


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures:
  - [x] i686-glibc
  - [x] x86_64-musl
  - [x] aarch64-glibc (x86_64-glibc)
  - [x] aarch64-musl (x86_64-musl)
  - [x] armv7l-glibc (x86_64-glibc)
  - [x] armv6l-musl (x86_64-musl)