### PR TITLE
caddy: update to 2.10.0.

### DIFF
--- a/srcpkgs/caddy/template
+++ b/srcpkgs/caddy/template
@@ -1,6 +1,6 @@
 # Template file for 'caddy'
 pkgname=caddy
-version=2.9.1
+version=2.10.0
 revision=1
 build_style=go
 go_import_path=github.com/caddyserver/caddy/v2
@@ -13,7 +13,7 @@ license="Apache-2.0"
 homepage="https://caddyserver.com"
 changelog="https://github.com/caddyserver/caddy/releases"
 distfiles="https://github.com/caddyserver/caddy/archive/v${version}.tar.gz"
-checksum=beb52478dfb34ad29407003520d94ee0baccbf210d1af72cebf430d6d7dd7b63
+checksum=e07e2747c394a6549751950ec8f7457ed346496f131ee38538ae39cf89ebcc68
 
 system_accounts="caddy"
 caddy_homedir="/var/lib/caddy"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86-64-libc
