### PR TITLE
m1n1: update to 1.5.0

### DIFF
--- a/srcpkgs/m1n1/template
+++ b/srcpkgs/m1n1/template
@@ -1,7 +1,7 @@
 # Template file for 'm1n1'
 pkgname=m1n1
-version=1.4.21
-revision=2
+version=1.5.0
+revision=1
 archs="aarch64*"
 hostmakedepends="ImageMagick void-artwork"
 short_desc="Asahi Linux bootloader"
@@ -9,22 +9,17 @@ maintainer="dkwo <npiazza@disroot.org>, Will Springer <skirmisher@protonmail.com
 license="MIT"
 homepage="https://asahilinux.org"
 distfiles="https://github.com/AsahiLinux/m1n1/archive/refs/tags/v${version}.tar.gz"
-checksum=5e0239ff497a8694eaf650d292254aba7d45611f37393053558ee36886db4111
+checksum=2122960e53788a97336f9c70183915c9d9a1120e3889410906677526f826f7a8
 conf_files="/etc/m1n1.conf /etc/default/m1n1-kernel-hook"
 
-post_extract() {
+pre_build() {
 	for size in 128 256; do
-		magick /usr/share/icons/hicolor/${size}x${size}/apps/void-logo.png \
-			-background black \
-			-flatten \
-			-depth 8 \
-			rgba:data/bootlogo_${size}.bin
+		cp /usr/share/icons/hicolor/${size}x${size}/apps/void-logo.png data/custom_${size}.png
 	done
 }
 
 do_build() {
-	unset CFLAGS CXXFLAGS CPPFLAGS LDFLAGS
-	make RELEASE=1 ARCH=${CROSS_BUILD:+${XBPS_CROSS_TRIPLET}-} build/m1n1.bin
+	make LOGO=custom RELEASE=1 ARCH=${CROSS_BUILD:+${XBPS_CROSS_TRIPLET}-} build/m1n1.bin
 }
 
 do_install() {


### PR DESCRIPTION
- I tested the changes in this PR: yes
- I built this PR locally for my native architecture, (aarch64-glibc)