### PR TITLE
nethack: fix musl build

### DIFF
--- a/srcpkgs/nethack/template
+++ b/srcpkgs/nethack/template
@@ -1,7 +1,7 @@
 # Template file for 'nethack'
 pkgname=nethack
 version=3.6.7
-revision=1
+revision=2
 conf_files="/etc/nethack/sysconf"
 make_dirs="/var/games/nethack/save 0775 nethack nethack"
 hostmakedepends="flex"
@@ -10,7 +10,7 @@ depends="gzip"
 short_desc="Exploring The Mazes of Menace"
 maintainer="Leah Neukirchen <leah@vuxu.org>"
 license="NGPL"
-homepage="http://www.nethack.org/"
+homepage="https://www.nethack.org/"
 distfiles="https://www.nethack.org/download/${version}/nethack-${version//./}-src.tgz"
 checksum=98cf67df6debf9668a61745aa84c09bcab362e5d33f5b944ec5155d44d2aacb2
 nocross=yes
@@ -21,7 +21,7 @@ do_configure() {
 }
 
 do_build() {
-	make all dungeon \
+	make \
 		CC="$CC" LINK="$CC" LFLAGS="$LDFLAGS" LEX=flex \
 		HACKDIR="/var/games/nethack"
 }
@@ -42,16 +42,16 @@ do_install() {
 		GAMEPERM=0755 \
 		DIRPERM=0775 \
 		VARDIRPERM=0775 \
-		CHOWN=: CHGRP=: FLEX=lex
+		CHOWN=: CHGRP=: LEX=flex
 
 	mv $DESTDIR/usr/lib/nethack/nhdat $DESTDIR/var/games/nethack
 	mv $DESTDIR/usr/lib/nethack/symbols $DESTDIR/var/games/nethack
 	mv $DESTDIR/usr/lib/nethack/sysconf $DESTDIR/etc/nethack
 	rm $DESTDIR/var/games/nethack/{logfile,perm,record,xlogfile}
 
-	sed -i	-e 's,^HACKDIR=.*,HACKDIR=/var/games/nethack,' \
+	vsed 	-e 's,^HACKDIR=.*,HACKDIR=/var/games/nethack,' \
 		-e 's,^HACK=.*,HACK=/usr/lib/nethack/nethack,' \
-		$DESTDIR/usr/bin/nethack
+		-i $DESTDIR/usr/bin/nethack
 
 	vdoc doc/Guidebook.txt
 	vlicense dat/license LICENSE


### PR DESCRIPTION
The "dungeon" target of Makefile requires `col`, which is not included in the musl build of util-linux. Fix this by just building the default target. The list of files in the final package is unchanged.

Also:
- use vsed()
- fix typo: "FLEX=lex" -> "LEX=flex"


@leahneukirchen

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
