### PR TITLE
vips: update to 8.17.1.

### DIFF
--- a/srcpkgs/vips/template
+++ b/srcpkgs/vips/template
@@ -1,6 +1,6 @@
 # Template file for 'vips'
 pkgname=vips
-version=8.17.0
+version=8.17.1
 revision=1
 build_style=meson
 build_helper=gir
@@ -19,7 +19,7 @@ license="LGPL-2.1-or-later"
 homepage="https://www.libvips.org/"
 changelog="https://raw.githubusercontent.com/libvips/libvips/master/ChangeLog"
 distfiles="https://github.com/libvips/libvips/archive/refs/tags/v${version}.tar.gz"
-checksum=41dd9d302dc58d956b62aa991fc2a803b1757fe764a7e1c096ead7c1127fb568
+checksum=79f54d367a485507c1421408ae13768e4734f473edc71af511472645f46dbd08
 python_version=3
 
 build_options="gir hdf5"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly** (saving to/from jxl, few basic image ops)

#### Local build testing
- I built this PR locally for my native architecture, `x86_64-glibc`