### PR TITLE
mise: update to 2025.8.4

### DIFF
--- a/srcpkgs/mise/template
+++ b/srcpkgs/mise/template
@@ -1,6 +1,6 @@
 # Template file for 'mise'
 pkgname=mise
-version=2025.7.1
+version=2025.8.4
 revision=1
 build_style=cargo
 hostmakedepends="pkg-config"
@@ -11,7 +11,7 @@ license="MIT"
 homepage="https://github.com/jdx/mise"
 changelog="https://github.com/jdx/mise/releases"
 distfiles="https://github.com/jdx/mise/archive/v${version}.tar.gz>${pkgname}-${version}.tar.gz"
-checksum=744235ded50ef72598b26a5cea7ca16d9d526be410ccffe19b9011e22fca46a5
+checksum=20fd1c91376305b0854f27f8cf180d3b0891e95da6b9967b6f5409b7ac9df6db
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc