### PR TITLE
dssi: fix gcc14 compat, alsa include

### DIFF
--- a/srcpkgs/dssi/patches/alsa-include.patch
+++ b/srcpkgs/dssi/patches/alsa-include.patch
@@ -1,0 +1,13 @@
+diff --git a/dssi/dssi.h b/dssi/dssi.h
+index fe4a20b36b1..d8a8aee4f00 100644
+--- a/dssi/dssi.h
++++ b/dssi/dssi.h
+@@ -25,7 +25,7 @@
+ #define DSSI_INCLUDED
+ 
+ #include <ladspa.h>
+-#include <alsa/seq_event.h>
++#include <alsa/asoundlib.h>
+ 
+ #define DSSI_VERSION "1.0"
+ #define DSSI_VERSION_MAJOR 1

--- a/srcpkgs/dssi/patches/fix-incompatible-pointer.patch
+++ b/srcpkgs/dssi/patches/fix-incompatible-pointer.patch
@@ -1,0 +1,33 @@
+Source: https://gitweb.gentoo.org/repo/gentoo.git/commit/?id=b8edb9a54a2fd3276396f713745da0a4674e4799
+Modified to use public lo_message type directly instead of non-exported struct lo_message_ *.
+
+From b8edb9a54a2fd3276396f713745da0a4674e4799 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Miroslav=20=C5=A0ulc?= <fordfrog@gentoo.org>
+Date: Sat, 6 Jul 2024 12:35:11 +0200
+Subject: [PATCH] media-libs/dssi: fixed incompatible pointer
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Closes: https://bugs.gentoo.org/925497
+Signed-off-by: Miroslav Šulc <fordfrog@gentoo.org>
+--- a/jack-dssi-host/jack-dssi-host.c
++++ b/jack-dssi-host/jack-dssi-host.c
+@@ -119,7 +119,7 @@ LADSPA_Data get_port_default(const LADSPA_Descriptor *plugin, int port);
+ void osc_error(int num, const char *m, const char *path);
+ 
+ int osc_message_handler(const char *path, const char *types, lo_arg **argv, int
+-		      argc, void *data, void *user_data) ;
++		      argc, lo_message data, void *user_data) ;
+ int osc_debug_handler(const char *path, const char *types, lo_arg **argv, int
+ 		      argc, void *data, void *user_data) ;
+ 
+@@ -1919,7 +1919,7 @@ int osc_debug_handler(const char *path, const char *types, lo_arg **argv,
+ }
+ 
+ int osc_message_handler(const char *path, const char *types, lo_arg **argv,
+-                        int argc, void *data, void *user_data)
++                        int argc, lo_message data, void *user_data)
+ {
+     int i;
+     d3h_instance_t *instance = NULL;

--- a/srcpkgs/dssi/template
+++ b/srcpkgs/dssi/template
@@ -1,7 +1,7 @@
 # Template file for 'dssi'
 pkgname=dssi
 version=1.1.1
-revision=9
+revision=10
 build_style=gnu-configure
 hostmakedepends="pkg-config"
 makedepends="


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly** — built rev. deps for all platforms listed below, used one (calf) on x86_64

- I built this PR locally for my native architecture, x86_64

- I built this PR locally for these architectures:
  - x86_64-musl
  - i686
  - armv6l [Cross] 
  - armv6l-musl [Cross]
  - armv7l [Cross]
  - armv7l-musl [Cross]
  - aarch64 [Cross and native]
  - aarch64-musl [Cross and native]

~~With this change, `whysynth` builds on cross armv6l-musl, armv7l-musl and aarch64-musl, without it doesn't. The rest all build fine as-is.~~
Edit: Nevermind the above line, it was an issue in local builds, re-tested and build of whysynth prior to applying this PR completed successfully too.