### PR TITLE
bindfs: update to 1.18.1

### DIFF
--- a/srcpkgs/bindfs/template
+++ b/srcpkgs/bindfs/template
@@ -1,6 +1,6 @@
 # Template file for 'bindfs'
 pkgname=bindfs
-version=1.17.6
+version=1.18.1
 revision=1
 build_style=gnu-configure
 hostmakedepends="pkg-config"
@@ -11,6 +11,6 @@ license="GPL-2.0-or-later"
 homepage="https://bindfs.org"
 changelog="https://bindfs.org/docs/ChangeLog.utf8.txt"
 distfiles="https://bindfs.org/downloads/bindfs-${version}.tar.gz"
-checksum=d3beb3cc69bb2b6802cc539588e921fea973ed6191b133f2024719311d1cc18b
+checksum=2a7064d993a5f255c52d72385ef14e349c131bc44195766e2173428e06d279fd
 #cannot mount
 make_check=no


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
