### PR TITLE
tvheadend: update to 4.3

### DIFF
--- a/srcpkgs/tvheadend/template
+++ b/srcpkgs/tvheadend/template
@@ -1,21 +1,21 @@
 # Template file for 'tvheadend'
 pkgname=tvheadend
-version=4.2.8
-revision=7
+version=4.3
+revision=1
 build_style=gnu-configure
 configure_args="--enable-dvbscan --disable-ffmpeg_static
 --disable-hdhomerun_static --disable-bintray_cache --disable-libx264_static
 --disable-libx265_static --disable-libvpx_static --disable-libtheora_static
 --disable-libvorbis_static --disable-libfdkaac_static"
 hostmakedepends="gettext pkg-config python3 git which"
-makedepends="avahi-libs-devel openssl-devel zlib-devel libcurl-devel ffmpeg-devel"
+makedepends="avahi-libs-devel openssl-devel zlib-devel libcurl-devel ffmpeg6-devel"
 short_desc="TV streaming server"
 maintainer="lemmi <lemmi@nerd2nerd.org>"
 license="GPL-3.0-only"
 homepage="http://tvheadend.org"
 changelog="https://tvheadend.org/projects/tvheadend/wiki/Releases"
 distfiles="https://github.com/tvheadend/tvheadend/archive/v${version}.tar.gz"
-checksum=1aef889373d5fad2a7bd2f139156d4d5e34a64b6d38b87b868a2df415f01f7ad
+checksum=9385388926154d03984d650b511a7e490707abbc51ec2590f2d84ca7757e8b4d
 
 CFLAGS="-fcommon"
 


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, **x86_64**

#### Comments

ffmpeg6 - [see ffmpeg 4 migration tracking 51522](https://github.com/void-linux/void-packages/issues/51522)

4.3 is considered 'stable rolling' from downloads page now https://tvheadend.org/p/downloads

```
Tvheadend v4.2.x is no longer supported and Tvheadend v4.3.x is our current stable "rolling" release: meaning there are no formal release announcements, the "latest" build number increments each time we commit changes, and the "odd = development, even = stable" numbering scheme is no longer used. In the future the release number will bump to v4.4, but this will be nothing more than a number change.
```
<img width="1147" height="322" alt="tvheadend" src="https://github.com/user-attachments/assets/1dee7ce5-57fd-4ffc-b2c5-d73343d06b3c" />

#### Issues / testing

Would be better for someone who uses this regularly to test.

With no config and just running it starts its server but segfaults on ctrl+c. Going to its webpage on `:9981` seems to prevent the segfault. Will try to look into it more and see if there's a related bug or make a new bug report.
