### PR TITLE
afl++: update to 4.33c

### DIFF
--- a/srcpkgs/afl++/template
+++ b/srcpkgs/afl++/template
@@ -1,6 +1,6 @@
 # Template file for 'afl++'
 pkgname=afl++
-version=4.30c
+version=4.33c
 revision=1
 archs="i686* x86_64* aarch64*"
 build_helper="qemu"
@@ -12,7 +12,7 @@ maintainer="Leah Neukirchen <leah@vuxu.org>"
 license="Apache-2.0"
 homepage="https://aflplus.plus/"
 distfiles="https://github.com/AFLplusplus/AFLplusplus/archive/refs/tags/v${version}.tar.gz"
-checksum=7c08c81f59b6c1f0bc2428fdee9fb880520e72c50be0683072e66bcde662b480
+checksum=98903c8036282c8908b1d8cc0d60caf3ea259db4339503a76449b47acce58d1d
 conflicts="afl>=0"
 replaces="afl>=0"
 


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
<!--
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
