### PR TITLE
kde framework: update to 6.17.0.

### DIFF
--- a/srcpkgs/breeze-icons/template
+++ b/srcpkgs/breeze-icons/template
@@ -1,6 +1,6 @@
 # Template file for 'breeze-icons'
 pkgname=breeze-icons
-version=6.14.0
+version=6.17.0
 revision=1
 build_style=cmake
 build_helper=qemu
@@ -13,7 +13,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-3.0-or-later"
 homepage="https://community.kde.org/Frameworks"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname}-${version}.tar.xz"
-checksum=cdf9cb67ce9d6eb9969ec324ce92556caf1a94f12770c56cf0c588dc2c681d2f
+checksum=4ffc75886e9a14a2a02da4871600b8c0b5a40756b8e99cbecfb515696d93c3b8
 nostrip=yes
 
 if [ -z "$CROSS_BUILD" ]; then

--- a/srcpkgs/extra-cmake-modules/template
+++ b/srcpkgs/extra-cmake-modules/template
@@ -1,6 +1,6 @@
 # Template file for 'extra-cmake-modules'
 pkgname=extra-cmake-modules
-version=6.14.0
+version=6.17.0
 revision=1
 build_style=cmake
 configure_args="-DBUILD_HTML_DOCS=ON -DBUILD_TESTING=ON"
@@ -14,7 +14,7 @@ maintainer="John <me@johnnynator.dev>"
 license="BSD-3-Clause"
 homepage="https://invent.kde.org/frameworks/extra-cmake-modules"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname}-${version}.tar.xz"
-checksum=d02cbbb3269b39680884abf6f14ba68f448570c554173f5249da3b8761784c13
+checksum=dfecb17d0238f4de1dd3485b92a6606137d4a9c67b9e4ce40407fe0f2aec0a40
 python_version=3
 
 do_check() {

--- a/srcpkgs/kf6-kbookmarks/template
+++ b/srcpkgs/kf6-kbookmarks/template
@@ -1,6 +1,6 @@
 # Template file for 'kf6-kbookmarks'
 pkgname=kf6-kbookmarks
-version=6.14.0
+version=6.17.0
 revision=1
 build_style=cmake
 hostmakedepends="extra-cmake-modules qt6-tools qt6-base"
@@ -10,7 +10,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/kbookmarks"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=a3f0a61fcfcca6509f1d7d21289e32776616e7caddec07cb9e1ca81e2f78ea43
+checksum=041b9667d3d4851b0e6fa62a9fc112a9938a487b4ca520eedde1b535636217f2
 
 kf6-kbookmarks-devel_package() {
 	depends="$makedepends ${sourcepkg}>=${version}_${revision}"

--- a/srcpkgs/kf6-kcalendarcore/template
+++ b/srcpkgs/kf6-kcalendarcore/template
@@ -1,6 +1,6 @@
 # Template file for 'kf6-kcalendarcore'
 pkgname=kf6-kcalendarcore
-version=6.14.0
+version=6.17.0
 revision=1
 build_style=cmake
 configure_args="-DKDE_INSTALL_QMLDIR=lib/qt6/qml"
@@ -12,7 +12,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/kcalendarcore"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=702bfc2edfced4d0903365657434fd8c2dc0b8f66d0ce96e4ea0b6950ef8798b
+checksum=4a0675c6211caf183a067194b24093dc63015a1a59be07b864cf45f7acd18e13
 
 do_check() {
 	cd build

--- a/srcpkgs/kf6-kcmutils/template
+++ b/srcpkgs/kf6-kcmutils/template
@@ -1,6 +1,6 @@
 # Template file for 'kf6-kcmutils'
 pkgname=kf6-kcmutils
-version=6.14.0
+version=6.17.0
 revision=1
 build_style=cmake
 build_helper=qemu
@@ -16,7 +16,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/kcmutils"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=2336f05ee46668de2be70c301660c9d3a881c40046ef90d1205e408260b46005
+checksum=8f65ef0f4f4f325ad6e2a30cb14242220f811ab1e031416fd3faa544ac683e8a
 
 kf6-kcmutils-devel_package() {
 	depends="$makedepends ${sourcepkg}>=${version}_${revision}"

--- a/srcpkgs/kf6-kcodecs/template
+++ b/srcpkgs/kf6-kcodecs/template
@@ -1,6 +1,6 @@
 # Template file for 'kf6-kcodecs'
 pkgname=kf6-kcodecs
-version=6.14.0
+version=6.17.0
 revision=1
 build_style=cmake
 hostmakedepends="extra-cmake-modules qt6-tools qt6-base
@@ -11,7 +11,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/kcodecs"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=008f5912162d394498022d0e955c860c77c33867e8fa448e99448f3a364d6914
+checksum=07b1c6f6c30915629a99346f9fd5a854afe367291911fb61000932777f7e98f2
 
 kf6-kcodecs-devel_package() {
 	depends="$makedepends ${sourcepkg}>=${version}_${revision}"

--- a/srcpkgs/kf6-kcolorscheme/template
+++ b/srcpkgs/kf6-kcolorscheme/template
@@ -1,6 +1,6 @@
 # Template file for 'kf6-kcolorscheme'
 pkgname=kf6-kcolorscheme
-version=6.14.0
+version=6.17.0
 revision=1
 build_style=cmake
 hostmakedepends="extra-cmake-modules qt6-tools qt6-base
@@ -12,7 +12,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/kcolorscheme"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=601b304dd5cc2fb065d8e658bdb0b87e1e37021000cf6a6f5b2ee8a5bfbaf5c9
+checksum=c8bd45eb248fc38d816e4eb0fd949d909c09a3a5a90848ef6d4040c35973f7b4
 
 kf6-kcolorscheme-devel_package() {
 	depends="$makedepends ${sourcepkg}>=${version}_${revision}"

--- a/srcpkgs/kf6-kcompletion/template
+++ b/srcpkgs/kf6-kcompletion/template
@@ -1,6 +1,6 @@
 # Template file for 'kf6-kcompletion'
 pkgname=kf6-kcompletion
-version=6.14.0
+version=6.17.0
 revision=1
 build_style=cmake
 hostmakedepends="extra-cmake-modules qt6-tools qt6-base "
@@ -10,7 +10,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/kcompletion"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=d3ae6a9a365f13d1dae4040bb4c97ce86a74865ca6ed21f908111598a2138136
+checksum=f22e4c6facec812bde4ab8d56a05b38a243dd9362c8deb4f1367efb1b6e64663
 
 kf6-kcompletion-devel_package() {
 	depends="$makedepends ${sourcepkg}>=${version}_${revision}"

--- a/srcpkgs/kf6-kconfig/template
+++ b/srcpkgs/kf6-kconfig/template
@@ -1,6 +1,6 @@
 # Template file for 'kf6-kconfig'
 pkgname=kf6-kconfig
-version=6.14.0
+version=6.17.0
 revision=1
 build_style=cmake
 configure_args="-DKDE_INSTALL_QMLDIR=lib/qt6/qml
@@ -13,7 +13,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/kconfig"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=a1b27e762b78fbc34124f35fd4125711f4036ae532c79d3cf3dc683289c1e765
+checksum=067435b24ca9f7cf56a8ce5b108438a15607b26dc52905ae07dc187c7e2949de
 
 do_check() {
 	cd build

--- a/srcpkgs/kf6-kconfigwidgets/template
+++ b/srcpkgs/kf6-kconfigwidgets/template
@@ -1,6 +1,6 @@
 # Template file for 'kf6-kconfigwidgets'
 pkgname=kf6-kconfigwidgets
-version=6.14.0
+version=6.17.0
 revision=1
 build_style=cmake
 configure_args="-DKF6_HOST_TOOLING=/usr/lib/cmake"
@@ -13,7 +13,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/kconfigwidgets"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=02fee668592d52bb39294f999af67797d7977e3f1c61bb9c77c086730594319f
+checksum=0bc5366d38dcbe12aea32aa84e77e9c278d3c63aeed6f509af52848a30a41e21
 
 do_check() {
 	cd build

--- a/srcpkgs/kf6-kcontacts/template
+++ b/srcpkgs/kf6-kcontacts/template
@@ -1,6 +1,6 @@
 # Template file for 'kf6-kcontacts'
 pkgname=kf6-kcontacts
-version=6.14.0
+version=6.17.0
 revision=1
 build_style=cmake
 hostmakedepends="extra-cmake-modules qt6-tools qt6-base
@@ -12,7 +12,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/kcontacts"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=64fd6f2692dc5bea9bc720f52bfdb2880771d82db27e1c9c0f61ac846e503729
+checksum=198db25bdc7e7fee11766effed13ad4438f6a211be8a16a1cd1e815e3ebcf21a
 
 do_check() {
 	cd build

--- a/srcpkgs/kf6-kcoreaddons/template
+++ b/srcpkgs/kf6-kcoreaddons/template
@@ -1,20 +1,21 @@
 # Template file for 'kf6-kcoreaddons'
 pkgname=kf6-kcoreaddons
-version=6.14.0
+version=6.17.0
 revision=1
 build_style=cmake
 configure_args="-DKDE_INSTALL_QMLDIR=lib/qt6/qml
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins"
-hostmakedepends="extra-cmake-modules qt6-tools qt6-base
- qt6-declarative-host-tools"
-makedepends="qt6-declarative-devel"
+hostmakedepends="extra-cmake-modules qt6-tools qt6-base llvm
+ qt6-declarative-host-tools python3-build python3-setuptools shiboken6"
+makedepends="qt6-declarative-devel qt6-base-private-devel
+ libshiboken6-devel libpyside6-devel python3-devel"
 short_desc="KCoreAddons"
 maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/kcoreaddons"
 #changelog=""
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=9555d17295f4fece18b46e3d289055baf58b352e082e4da6e6e352d8d5c042ee
+checksum=0303d6d1e9e76cf9ec06a41acd1a52088a40df3a2805e97e1c327baf607842aa
 
 do_check() {
 	cd build

--- a/srcpkgs/kf6-kcrash/template
+++ b/srcpkgs/kf6-kcrash/template
@@ -1,6 +1,6 @@
 # Template file for 'kf6-kcrash'
 pkgname=kf6-kcrash
-version=6.14.0
+version=6.17.0
 revision=1
 build_style=cmake
 hostmakedepends="extra-cmake-modules qt6-tools qt6-base "
@@ -10,7 +10,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/kcrash"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=69d736be73bbe4a936f8996c3591a53c16816d4396d242d2e63dce079a268c34
+checksum=52f4bddc642e68e96f8f18b34bba803b8f9f93cb8cf5e1d1aabccfd3c5285e13
 
 kf6-kcrash-devel_package() {
 	depends="$makedepends ${sourcepkg}>=${version}_${revision}"

--- a/srcpkgs/kf6-kdav/template
+++ b/srcpkgs/kf6-kdav/template
@@ -1,6 +1,6 @@
 # Template file for 'kf6-kdav'
 pkgname=kf6-kdav
-version=6.14.0
+version=6.17.0
 revision=1
 build_style=cmake
 hostmakedepends="extra-cmake-modules qt6-tools qt6-base
@@ -11,7 +11,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/kdav"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=a92b95fb0612c79c5874e7a85f48369c3a00d2c1d2d94c77656229c945e77c2a
+checksum=8d8a3b03c5c53f58a2660b589b89731d182ba3bc622c76e07bfe6cbf50a693c7
 replaces="kdav>=0"
 
 kf6-kdav-devel_package() {

--- a/srcpkgs/kf6-kdbusaddons/template
+++ b/srcpkgs/kf6-kdbusaddons/template
@@ -1,6 +1,6 @@
 # Template file for 'kf6-kdbusaddons'
 pkgname=kf6-kdbusaddons
-version=6.14.0
+version=6.17.0
 revision=1
 build_style=cmake
 hostmakedepends="extra-cmake-modules qt6-tools qt6-base "
@@ -11,7 +11,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/kdbusaddons"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=f673c9f295df5998948def94caf92d487d63886452802ffb97ad151315627ee4
+checksum=57d640bfa11c1660b5dcd3c1c71d605a40542d1657e04d9bf867b761bfe772f4
 make_check_pre="dbus-run-session"
 
 kf6-kdbusaddons-devel_package() {

--- a/srcpkgs/kf6-kdeclarative/template
+++ b/srcpkgs/kf6-kdeclarative/template
@@ -1,6 +1,6 @@
 # Template file for 'kf6-kdeclarative'
 pkgname=kf6-kdeclarative
-version=6.14.0
+version=6.17.0
 revision=1
 build_style=cmake
 configure_args="-DKDE_INSTALL_QMLDIR=lib/qt6/qml"
@@ -13,7 +13,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/kdeclarative"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=ed0aa62653fe5a09bc44f584faaa633cb386f7a106cf9b5c930122ae86c0a1d0
+checksum=b5363dfc7354d1fa1ed49d7175a0334a8ef66e82bb389ba4baffe6f778f2e2ba
 
 kf6-kdeclarative-devel_package() {
 	depends="$makedepends ${sourcepkg}>=${version}_${revision}"

--- a/srcpkgs/kf6-kded/template
+++ b/srcpkgs/kf6-kded/template
@@ -1,6 +1,6 @@
 # Template file for 'kf6-kded'
 pkgname=kf6-kded
-version=6.14.0
+version=6.17.0
 revision=1
 build_style=cmake
 configure_args="-DKF6_HOST_TOOLING=/usr/lib/cmake"
@@ -13,7 +13,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/kded"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=59f1aec94bd0176eba8bffd35a6ad5925b6d40702e26ee1697a46b3a4617d1ca
+checksum=4f5f04b9dbcf3a0ba42815419d969b01a6624024d14994d540a973a6371cf277
 
 kf6-kded-devel_package() {
 	depends="$makedepends ${sourcepkg}>=${version}_${revision}"

--- a/srcpkgs/kf6-kdesu/template
+++ b/srcpkgs/kf6-kdesu/template
@@ -1,6 +1,6 @@
 # Template file for 'kf6-kdesu'
 pkgname=kf6-kdesu
-version=6.14.0
+version=6.17.0
 revision=1
 build_style=cmake
 hostmakedepends="extra-cmake-modules qt6-tools qt6-base
@@ -12,7 +12,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/kdesu"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=103a06311c035445fd5884845c57369f07229239f9bbebe91cc95b7ce8c5ca23
+checksum=666899ad546b7bd002e3fc1697032f8920ce7261df2ef519e81d4aae91971123
 
 kf6-kdesu-devel_package() {
 	depends="$makedepends ${sourcepkg}>=${version}_${revision}"

--- a/srcpkgs/kf6-kdnssd/template
+++ b/srcpkgs/kf6-kdnssd/template
@@ -1,6 +1,6 @@
 # Template file for 'kf6-kdnssd'
 pkgname=kf6-kdnssd
-version=6.14.0
+version=6.17.0
 revision=1
 build_style=cmake
 hostmakedepends="extra-cmake-modules qt6-tools qt6-base "
@@ -10,7 +10,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/kdnssd"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=ce903952b908566b99d50a4a549825ea4ef95d7544686cdccccf693b81106199
+checksum=6e1681a01a4cd09650ba4de1bbad4ec03d3f6452fc07ff4f74e24b24040f3e0a
 
 kf6-kdnssd-devel_package() {
 	depends="$makedepends ${sourcepkg}>=${version}_${revision}"

--- a/srcpkgs/kf6-kdoctools/template
+++ b/srcpkgs/kf6-kdoctools/template
@@ -1,6 +1,6 @@
 # Template file for 'kf6-kdoctools'
 pkgname=kf6-kdoctools
-version=6.14.0
+version=6.17.0
 revision=1
 build_style=cmake
 build_helper=qemu
@@ -13,7 +13,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/kdoctools"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=acb9c761e8e10c30f2c32061f64096965459a0513250edf4432f40831a0f536e
+checksum=27b0ecb023227837103e3fa6ade3de0aa4d5f56f4f6c97a996fe6ee74be89d2f
 
 post_patch() {
 	vsed -i -e '

--- a/srcpkgs/kf6-kfilemetadata/template
+++ b/srcpkgs/kf6-kfilemetadata/template
@@ -1,6 +1,6 @@
 # Template file for 'kf6-kfilemetadata'
 pkgname=kf6-kfilemetadata
-version=6.14.0
+version=6.17.0
 revision=1
 build_style=cmake
 configure_args="-DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins"
@@ -14,7 +14,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/kfilemetadata"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=925a9db27176519099d24625070bf7ebc1600fae7e7d06ae4eee3279a67d31e5
+checksum=2bb9a99846ab0f73636ec34fba244908a123591f7f7458bab91b8cfb23923044
 
 do_check() {
 	cd build

--- a/srcpkgs/kf6-kglobalaccel/template
+++ b/srcpkgs/kf6-kglobalaccel/template
@@ -1,6 +1,6 @@
 # Template file for 'kf6-kglobalaccel'
 pkgname=kf6-kglobalaccel
-version=6.14.0
+version=6.17.0
 revision=1
 build_style=cmake
 hostmakedepends="extra-cmake-modules qt6-tools qt6-base "
@@ -10,7 +10,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/kglobalaccel"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=e7aaca16bb4c5b5865af3ed4b48f2347c5163065d17c2b24be97752ff5e8c71d
+checksum=fc3d4055542639145b3e45068264745c611fc3ecf0d0144eaa3532038fa971f1
 
 kf6-kglobalaccel-devel_package() {
 	depends="${makedepends//private-} ${sourcepkg}>=${version}_${revision}"

--- a/srcpkgs/kf6-kguiaddons/template
+++ b/srcpkgs/kf6-kguiaddons/template
@@ -1,19 +1,20 @@
 # Template file for 'kf6-kguiaddons'
 pkgname=kf6-kguiaddons
-version=6.14.0
+version=6.17.0
 revision=1
 build_style=cmake
-hostmakedepends="extra-cmake-modules qt6-tools qt6-base
- wayland-devel pkg-config qt6-wayland-tools"
+hostmakedepends="extra-cmake-modules qt6-tools qt6-base shiboken6 llvm
+ python3-build python3-setuptools wayland-devel pkg-config qt6-wayland-tools"
 makedepends="qt6-wayland-devel plasma-wayland-protocols wayland-devel
- qt6-base-private-devel"
+ qt6-declarative-devel
+ qt6-base-private-devel libshiboken6-devel libpyside6-devel python3-devel"
 depends="kf6-kguiaddons-geo-uri-handler"
 short_desc="Addons to QtGui"
 maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/kguiaddons"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=3f3cc7e3748bd74d476a4a3616654786e7d861f7b391e8499aebc7c410f21ec5
+checksum=5d07dbc8e24ab1077de75b7830a1f362dff3710fb041d61b8da02c577056ab6b
 
 kf6-kguiaddons-geo-uri-handler_package() {
 	short_desc+=" - Geo URI handler"

--- a/srcpkgs/kf6-kholidays/template
+++ b/srcpkgs/kf6-kholidays/template
@@ -1,6 +1,6 @@
 # Template file for 'kf6-kholidays'
 pkgname=kf6-kholidays
-version=6.14.0
+version=6.17.0
 revision=1
 build_style=cmake
 configure_args="-DKDE_INSTALL_QMLDIR=lib/qt6/qml
@@ -13,7 +13,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/kholidays"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=6dd66fcbaafc8d45045aca27e334e1f60df6afd9a070b1f32996ba0497277177
+checksum=5b8e7df887bf790eddd6533910eefa9b00a77f2675260da71f36b95cb764fab2
 
 kf6-kholidays-devel_package() {
 	depends="$makedepends ${sourcepkg}>=${version}_${revision}"

--- a/srcpkgs/kf6-ki18n/template
+++ b/srcpkgs/kf6-ki18n/template
@@ -1,6 +1,6 @@
 # Template file for 'kf6-ki18n'
 pkgname=kf6-ki18n
-version=6.14.0
+version=6.17.0
 revision=1
 build_style=cmake
 configure_args="-DKDE_INSTALL_QMLDIR=lib/qt6/qml
@@ -14,7 +14,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/ki18n"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=2a5135412caf0a07eba4eeb60867ac6929df1c83c145ae757a6a1230f842e669
+checksum=50f867d948c15aad91c3c57fe2f6462cdbf3881fab6fd99b85b15616f073983e
 
 do_check() {
 	cd build

--- a/srcpkgs/kf6-kiconthemes/template
+++ b/srcpkgs/kf6-kiconthemes/template
@@ -1,6 +1,6 @@
 # Template file for 'kf6-kiconthemes'
 pkgname=kf6-kiconthemes
-version=6.14.0
+version=6.17.0
 revision=1
 build_style=cmake
 configure_args="-DKDE_INSTALL_QMLDIR=lib/qt6/qml
@@ -14,7 +14,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/kiconthemes"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=a98cd231bfca420519d55b0b88e4e089b4e27ec79b4a8542b81de8a5ff8af6d5
+checksum=5cf0b20628d300447770c4ab00edb225ecc85561792923ec0083f9bc9e0b4247
 
 kf6-kiconthemes-devel_package() {
 	depends="${makedepends//private-} ${sourcepkg}>=${version}_${revision}"

--- a/srcpkgs/kf6-kidletime/template
+++ b/srcpkgs/kf6-kidletime/template
@@ -1,6 +1,6 @@
 # Template file for 'kf6-kidletime'
 pkgname=kf6-kidletime
-version=6.14.0
+version=6.17.0
 revision=1
 build_style=cmake
 configure_args="-DKDE_INSTALL_QMLDIR=lib/qt6/qml
@@ -14,7 +14,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/kidletime"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=16775b2bdc3efd54c65a96bce6f27a001d119905531d84bb23e23215a196ecb8
+checksum=1f67d26749de9f09f4ab0dc4b23e53ecb84d921b1d52d612822fdc53c34c3b37
 
 kf6-kidletime-devel_package() {
 	depends="${sourcepkg}>=${version}_${revision} qt6-base-devel"

--- a/srcpkgs/kf6-kimageformats/template
+++ b/srcpkgs/kf6-kimageformats/template
@@ -1,6 +1,6 @@
 # Template file for 'kf6-kimageformats'
 pkgname=kf6-kimageformats
-version=6.14.0
+version=6.17.0
 revision=1
 build_style=cmake
 configure_args="-DKIMAGEFORMATS_HEIF=ON -DKDE_INSTALL_QMLDIR=lib/qt6/qml
@@ -14,7 +14,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/kimageformats"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=3a0f81be25e9a0eab7dc1373bc56480abcb3041ca1a5a8c7f0d6d52d221d5449
+checksum=180b670f766bae740340e5afd2044ea08242ea935459bb95bc80313d062066a8
 
 do_check() {
 	cd build

--- a/srcpkgs/kf6-kio/template
+++ b/srcpkgs/kf6-kio/template
@@ -1,6 +1,6 @@
 # Template file for 'kf6-kio'
 pkgname=kf6-kio
-version=6.14.0
+version=6.17.0
 revision=1
 build_style=cmake
 configure_args="-DKDE_INSTALL_QMLDIR=lib/qt6/qml
@@ -20,7 +20,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/kio"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=9b03746fd008504a96f569f37ad8ff902cc71495e7e123daa3c6de79ff2acc45
+checksum=d00d4952198f8e9ff44335b340714615e0124857edbd67c4964b50e0c913d62d
 
 do_check() {
 	cd build

--- a/srcpkgs/kf6-kirigami/template
+++ b/srcpkgs/kf6-kirigami/template
@@ -1,6 +1,6 @@
 # Template file for 'kf6-kirigami'
 pkgname=kf6-kirigami
-version=6.14.1
+version=6.17.0
 revision=1
 build_style=cmake
 configure_args="-DKDE_INSTALL_QMLDIR=lib/qt6/qml
@@ -14,7 +14,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/kirigami"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=2c91b4e2951444f7d6f3d6add96dc41c62bf9dbf747a8594d5d2fc918d27309f
+checksum=0b7fb719a231ffeb7fcc44c8ba903ead13b4358c419d5f0b15552d3fc84ed75b
 
 kf6-kirigami-devel_package() {
 	depends="${makedepends//private-} ${sourcepkg}>=${version}_${revision}"

--- a/srcpkgs/kf6-kitemmodels/template
+++ b/srcpkgs/kf6-kitemmodels/template
@@ -1,6 +1,6 @@
 # Template file for 'kf6-kitemmodels'
 pkgname=kf6-kitemmodels
-version=6.14.0
+version=6.17.0
 revision=1
 build_style=cmake
 configure_args="-DKDE_INSTALL_QMLDIR=lib/qt6/qml
@@ -13,7 +13,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/kitemmodels"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=1d694180464e1fd95e2425d84bb846157fad3c2a5009727ecdb6766d97db22e8
+checksum=b9004417b5e9bb3309434ab90819889590f6bfa32d4a65388d052df432c0b166
 
 kf6-kitemmodels-devel_package() {
 	depends="$makedepends ${sourcepkg}>=${version}_${revision}"

--- a/srcpkgs/kf6-kitemviews/template
+++ b/srcpkgs/kf6-kitemviews/template
@@ -1,6 +1,6 @@
 # Template file for 'kf6-kitemviews'
 pkgname=kf6-kitemviews
-version=6.14.0
+version=6.17.0
 revision=1
 build_style=cmake
 configure_args="$(vopt_bool designerplugin BUILD_DESIGNERPLUGIN)"
@@ -11,7 +11,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/kitemviews"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=997167402dbaa7885ae2aaa4cf8b5f409f57d50bce06a3b56c577e93a975ba4a
+checksum=31d1c8ff64b28eef216e63a443accdc621c53f51ec23e6a137d9e08629742fd1
 
 build_options="designerplugin"
 

--- a/srcpkgs/kf6-kjobwidgets/template
+++ b/srcpkgs/kf6-kjobwidgets/template
@@ -1,17 +1,19 @@
 # Template file for 'kf6-kjobwidgets'
 pkgname=kf6-kjobwidgets
-version=6.14.0
+version=6.17.0
 revision=1
 build_style=cmake
-hostmakedepends="extra-cmake-modules qt6-tools qt6-base "
+hostmakedepends="extra-cmake-modules qt6-tools qt6-base
+ python3-build python3-setuptools shiboken6 llvm"
 makedepends="kf6-kcoreaddons-devel kf6-knotifications-devel
- kf6-kwidgetsaddons-devel qt6-base-private-devel"
+ kf6-kwidgetsaddons-devel qt6-base-private-devel
+ libshiboken6-devel libpyside6-devel python3-devel"
 short_desc="Widgets for showing progress of asynchronous jobs"
 maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/kjobwidgets"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=8c47042afae57447945b43cc91d897fa353286237a63e35294be4eb4a4662abd
+checksum=0dc56de19bce3769b78c34dab1399588017180f298de8419eda1909a4211b624
 
 kf6-kjobwidgets-devel_package() {
 	depends="${makedepends//private-} ${sourcepkg}>=${version}_${revision}"

--- a/srcpkgs/kf6-knewstuff/template
+++ b/srcpkgs/kf6-knewstuff/template
@@ -1,6 +1,6 @@
 # Template file for 'kf6-knewstuff'
 pkgname=kf6-knewstuff
-version=6.14.0
+version=6.17.0
 revision=1
 build_style=cmake
 configure_args="-DKDE_INSTALL_QMLDIR=lib/qt6/qml
@@ -15,7 +15,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/knewstuff"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=1e44b71efc5dc4cb05cc7add344d9a55fc8c998de26e74867d300afbd16f8d04
+checksum=1059cb7cdb9ba8170de82a08c6833490007a152a46e4bdbe24304eeddc263d66
 
 kf6-knewstuff-devel_package() {
 	depends="$makedepends ${sourcepkg}>=${version}_${revision}"

--- a/srcpkgs/kf6-knotifications/template
+++ b/srcpkgs/kf6-knotifications/template
@@ -1,19 +1,22 @@
 # Template file for 'kf6-knotifications'
 pkgname=kf6-knotifications
-version=6.14.0
+version=6.17.0
 revision=1
 build_style=cmake
 configure_args="-DKDE_INSTALL_QMLDIR=lib/qt6/qml
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins"
 hostmakedepends="extra-cmake-modules qt6-tools qt6-base
- qt6-declarative-host-tools pkg-config"
-makedepends="kf6-kconfig-devel libcanberra-devel"
+ qt6-declarative-host-tools pkg-config python3-build
+ python3-setuptools shiboken6 llvm"
+makedepends="kf6-kconfig-devel libcanberra-devel
+ qt6-declarative-devel qt6-base-private-devel
+ libshiboken6-devel libpyside6-devel python3-devel"
 short_desc="KDE Desktop notifications"
 maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/knotifications"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=a76e95de74129e12f500b01f8ce2529bc6af93b75ff2cce99c827129523d7517
+checksum=b7801c546935e6082a72d4c7dd0387407b6a1905ab88de9bddaf369a8eca4141
 
 kf6-knotifications-devel_package() {
 	depends="$makedepends ${sourcepkg}>=${version}_${revision}"

--- a/srcpkgs/kf6-knotifyconfig/template
+++ b/srcpkgs/kf6-knotifyconfig/template
@@ -1,6 +1,6 @@
 # Template file for 'kf6-knotifyconfig'
 pkgname=kf6-knotifyconfig
-version=6.14.0
+version=6.17.0
 revision=1
 build_style=cmake
 hostmakedepends="extra-cmake-modules qt6-tools qt6-base
@@ -12,7 +12,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/knotifyconfig"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=067eba5c9965ab05cdd3e8a57d6afa25e8a9e77905d4d01a327536c11d4cca8b
+checksum=e5a08f7872ffb836fbfe9726eb86c104e30afc55996138d965731f5794981263
 
 kf6-knotifyconfig-devel_package() {
 	depends="$makedepends ${sourcepkg}>=${version}_${revision}"

--- a/srcpkgs/kf6-kpackage/template
+++ b/srcpkgs/kf6-kpackage/template
@@ -1,6 +1,6 @@
 # Template file for 'kf6-kpackage'
 pkgname=kf6-kpackage
-version=6.14.0
+version=6.17.0
 revision=1
 build_style=cmake
 hostmakedepends="extra-cmake-modules qt6-tools qt6-base
@@ -11,7 +11,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/kpackage"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=fb2e260f7a2e2b4cfda4559881485899a77cf5fbc3b8ae05d06444bec82ed1ab
+checksum=78d231a223394922d02957e17917a208de0e98224f21fc10e538ac971bdb42a4
 
 kf6-kpackage-devel_package() {
 	depends="$makedepends ${sourcepkg}>=${version}_${revision}"

--- a/srcpkgs/kf6-kparts/template
+++ b/srcpkgs/kf6-kparts/template
@@ -1,6 +1,6 @@
 # Template file for 'kf6-kparts'
 pkgname=kf6-kparts
-version=6.14.0
+version=6.17.0
 revision=1
 build_style=cmake
 hostmakedepends="extra-cmake-modules qt6-tools qt6-base
@@ -12,7 +12,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/kparts"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=96106102c4deb893307eb35580a8a45aa6841edc038b9a0fd38aa19d6e056bfa
+checksum=1e64d426ce47501a8ff1bac8c2366f0cd153e6cd4d440e827eb0015d9e38c3e9
 
 kf6-kparts-devel_package() {
 	depends="$makedepends ${sourcepkg}>=${version}_${revision}"

--- a/srcpkgs/kf6-kpeople/template
+++ b/srcpkgs/kf6-kpeople/template
@@ -1,6 +1,6 @@
 # Template file for 'kf6-kpeople'
 pkgname=kf6-kpeople
-version=6.14.0
+version=6.17.0
 revision=1
 build_style=cmake
 configure_args="-DKDE_INSTALL_QMLDIR=lib/qt6/qml
@@ -14,7 +14,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/kpeople"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=c9d2110daf2e4d59d58b4af63c54fd517bb0f46591a91c20789ffc715eeb62ce
+checksum=dd0ec4b9baed40a2f960ce4903bdc79073f551969393314e3aa97c75f730f7bf
 
 do_check() {
 	cd build

--- a/srcpkgs/kf6-kplotting/template
+++ b/srcpkgs/kf6-kplotting/template
@@ -1,6 +1,6 @@
 # Template file for 'kf6-kplotting'
 pkgname=kf6-kplotting
-version=6.14.0
+version=6.17.0
 revision=1
 build_style=cmake
 hostmakedepends="extra-cmake-modules qt6-tools qt6-base "
@@ -10,7 +10,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/kplotting"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=e6b63184f973bf0d12402779dfd1871f7685b7954e36898e4640ac86b9c977ac
+checksum=6654965b63d0857c31c21817e56931684c32dddf035e83169ca6ea7d6b9a2643
 
 kf6-kplotting-devel_package() {
 	depends="$makedepends ${sourcepkg}>=${version}_${revision}"

--- a/srcpkgs/kf6-kpty/template
+++ b/srcpkgs/kf6-kpty/template
@@ -1,6 +1,6 @@
 # Template file for 'kf6-kpty'
 pkgname=kf6-kpty
-version=6.14.0
+version=6.17.0
 revision=1
 build_style=cmake
 configure_args="-DUTEMPTER_EXECUTABLE=/usr/lib/utempter/utempter"
@@ -12,7 +12,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/kpty"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=979e0bb19cd7d9db843bf5df35115447eb492637a099eb53c345b82fc80bea65
+checksum=96a71687a8de0becc34a8157572d2440ba8d4b976fd5d0813331dfd86b92aabb
 
 kf6-kpty-devel_package() {
 	depends="$makedepends ${sourcepkg}>=${version}_${revision}"

--- a/srcpkgs/kf6-kquickcharts/template
+++ b/srcpkgs/kf6-kquickcharts/template
@@ -1,6 +1,6 @@
 # Template file for 'kf6-kquickcharts'
 pkgname=kf6-kquickcharts
-version=6.14.0
+version=6.17.0
 revision=1
 build_style=cmake
 configure_args="-DKDE_INSTALL_QMLDIR=lib/qt6/qml
@@ -13,7 +13,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/kquickcharts"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=dfb33c90eedc7c950e043fb2adf6c8a2df3745e79d2bbcd5e595757448fe98b7
+checksum=1e206a9684d882ce2c147e436392dc3ef6cda79e4bc2ddf5aa0398d2e2ddc5a4
 
 kf6-kquickcharts-devel_package() {
 	depends="$makedepends ${sourcepkg}>=${version}_${revision}"

--- a/srcpkgs/kf6-krunner/template
+++ b/srcpkgs/kf6-krunner/template
@@ -1,19 +1,19 @@
 # Template file for 'kf6-krunner'
 pkgname=kf6-krunner
-version=6.14.0
+version=6.17.0
 revision=1
 build_style=cmake
 hostmakedepends="extra-cmake-modules qt6-tools qt6-base
  gettext"
 makedepends="kf6-kconfig-devel kf6-kcoreaddons-devel kf6-ki18n-devel
- kf6-kitemmodels-devel"
+ kf6-kitemmodels-devel kf6-kwindowsystem-devel"
 checkdepends="dbus"
 short_desc="Framework for providing different actions given a string query"
 maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/krunner"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=138cfb98cd73392722f4499408d075a2c7705bdbf436ecc077360c3153db2fa6
+checksum=9d4a5c0c74b0cfa9e35c31de762633ddec0439c50fa44bc85bec28ada0106912
 
 do_check() {
 	cd build

--- a/srcpkgs/kf6-kservice/template
+++ b/srcpkgs/kf6-kservice/template
@@ -1,6 +1,6 @@
 # Template file for 'kf6-kservice'
 pkgname=kf6-kservice
-version=6.14.0
+version=6.17.0
 revision=1
 build_style=cmake
 configure_args="-DKF6_HOST_TOOLING=/usr/lib/cmake"
@@ -13,7 +13,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/kservice"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=5ef80f47034d582ce05a0becf01952663191fafc569cfb3ef7b85c24fd297a85
+checksum=b014697ea3ba359f46a6e9cf950d7bbd7a9cf09e95b36718c36b6605a9424aee
 
 do_check() {
 	cd build

--- a/srcpkgs/kf6-kstatusnotifieritem/template
+++ b/srcpkgs/kf6-kstatusnotifieritem/template
@@ -1,16 +1,18 @@
 # Template file for 'kf6-kstatusnotifieritem'
 pkgname=kf6-kstatusnotifieritem
-version=6.14.0
+version=6.17.0
 revision=1
 build_style=cmake
-hostmakedepends="extra-cmake-modules qt6-tools qt6-base "
-makedepends="kf6-kwindowsystem-devel qt6-base-private-devel"
+hostmakedepends="extra-cmake-modules qt6-tools qt6-base
+ python3-build python3-setuptools shiboken6 llvm"
+makedepends="kf6-kwindowsystem-devel qt6-base-private-devel
+ libshiboken6-devel libpyside6-devel python3-devel"
 short_desc="Implementation of Status Notifier Items"
 maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/kstatusnotifieritem"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=9d85c44a7704ad052740752106e59eb26e49d80467f9b1d3c92bd24b77395417
+checksum=678a9bfc870066d5413bbcfa09a56b82b0affd2bc222ce5701d02a8b129edd91
 
 kf6-kstatusnotifieritem-devel_package() {
 	depends="${makedepends//private-} ${sourcepkg}>=${version}_${revision}"

--- a/srcpkgs/kf6-ksvg/template
+++ b/srcpkgs/kf6-ksvg/template
@@ -1,6 +1,6 @@
 # Template file for 'kf6-ksvg'
 pkgname=kf6-ksvg
-version=6.14.0
+version=6.17.0
 revision=1
 build_style=cmake
 configure_args="-DKDE_INSTALL_QMLDIR=lib/qt6/qml
@@ -15,7 +15,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/ksvg"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=1456649ff2e1397e2a666ce24bbb6f074fda5cb96ada425d122bcc14744a5dce
+checksum=3728da966932f20f190a545a7f42edea2f9bdbe6d727a5bc1b557ef5155b7f94
 
 kf6-ksvg-devel_package() {
 	depends="$makedepends ${sourcepkg}>=${version}_${revision}"

--- a/srcpkgs/kf6-ktexteditor/template
+++ b/srcpkgs/kf6-ktexteditor/template
@@ -1,6 +1,6 @@
 # Template file for 'kf6-ktexteditor'
 pkgname=kf6-ktexteditor
-version=6.14.0
+version=6.17.0
 revision=1
 build_style=cmake
 configure_args="-DKF6_HOST_TOOLING=/usr/lib/cmake
@@ -19,7 +19,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/ktexteditor"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=b970d6bb7623921578d7909ebef18c6f7a798ea11c5b1e2453f7321695677651
+checksum=9904c0c5c933a368d6f492d9e116ccce201054d5a029b8b0fe0759ff87eb8ca3
 
 kf6-ktexteditor-devel_package() {
 	depends="$makedepends ${sourcepkg}>=${version}_${revision}"

--- a/srcpkgs/kf6-ktexttemplate/template
+++ b/srcpkgs/kf6-ktexttemplate/template
@@ -1,6 +1,6 @@
 # Template file for 'kf6-ktexttemplate'
 pkgname=kf6-ktexttemplate
-version=6.14.0
+version=6.17.0
 revision=1
 build_style=cmake
 configure_args="-DKDE_INSTALL_QMLDIR=lib/qt6/qml
@@ -13,7 +13,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/ktexttemplate"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=65a908aa573e40cf9884a9d42a4b8d5574baf2f402a19764cda2cccde27c897a
+checksum=15d75941d15eac3cd1243066b13a30d6c1451ca630b0c29b3624be34ad73e972
 
 kf6-ktexttemplate-devel_package() {
 	depends="$makedepends ${sourcepkg}>=${version}_${revision}"

--- a/srcpkgs/kf6-ktextwidgets/template
+++ b/srcpkgs/kf6-ktextwidgets/template
@@ -1,6 +1,6 @@
 # Template file for 'kf6-ktextwidgets'
 pkgname=kf6-ktextwidgets
-version=6.14.0
+version=6.17.0
 revision=1
 build_style=cmake
 hostmakedepends="extra-cmake-modules qt6-tools qt6-base
@@ -13,7 +13,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/ktextwidgets"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=4e24e6da477e08d0f71552f081206516fcd9ab4a593cf37d77ebd690856b76b5
+checksum=33d46ecdd03ff68582da5cef251921a8c6e7a5db7ad9bfd0432cb00712ac29e3
 
 kf6-ktextwidgets-devel_package() {
 	depends="$makedepends ${sourcepkg}>=${version}_${revision}"

--- a/srcpkgs/kf6-kunitconversion/template
+++ b/srcpkgs/kf6-kunitconversion/template
@@ -1,17 +1,17 @@
 # Template file for 'kf6-kunitconversion'
 pkgname=kf6-kunitconversion
-version=6.14.0
+version=6.17.0
 revision=1
 build_style=cmake
 hostmakedepends="extra-cmake-modules qt6-tools qt6-base
- gettext"
-makedepends="kf6-ki18n-devel"
+ gettext python3-build python3-setuptools shiboken6 llvm"
+makedepends="kf6-ki18n-devel libshiboken6-devel libpyside6-devel python3-devel"
 short_desc="KDE Converting physical units"
 maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/kunitconversion"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=d07d60ec2c5c21246f3aa9f89e01226e084c90fe99b62b08b651933c311cf08d
+checksum=f2625a4ba25b3329fb9730249073bcd349b7a346362148c7fa97989efc7e5cca
 
 kf6-kunitconversion-devel_package() {
 	depends="$makedepends ${sourcepkg}>=${version}_${revision}"

--- a/srcpkgs/kf6-kuserfeedback/template
+++ b/srcpkgs/kf6-kuserfeedback/template
@@ -1,6 +1,6 @@
 # Template file for 'kf6-kuserfeedback'
 pkgname=kf6-kuserfeedback
-version=6.14.0
+version=6.17.0
 revision=1
 build_style=cmake
 configure_args="-DKDE_INSTALL_QMLDIR=lib/qt6/qml
@@ -14,7 +14,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/kuserfeedback"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=24acd6d2b8582bdd6ae9bfca97278a96763ee184a6cdecbc0dcd64fd4fc238b2
+checksum=0f1b5361ffa6fff12ec3dfd7a3e4b1b2aa6ebadc4afcc03a9d31c2d49bec7caf
 
 do_check() {
 	cd build

--- a/srcpkgs/kf6-kwallet/template
+++ b/srcpkgs/kf6-kwallet/template
@@ -1,6 +1,6 @@
 # Template file for 'kf6-kwallet'
 pkgname=kf6-kwallet
-version=6.14.1
+version=6.17.0
 revision=1
 build_style=cmake
 configure_args="-DKF6_HOST_TOOLING=/usr/lib/cmake"
@@ -15,7 +15,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/kwallet"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=ef482be2d5211f711d578aa1d1f37f71e641a6a52fd37e11327e19915fd42127
+checksum=44caf691f47ba246f2efb13f9c8f7123c7e6745d4281560228b8158cc8b93d7d
 
 kf6-kwallet-devel_package() {
 	depends="$makedepends ${sourcepkg}>=${version}_${revision}"

--- a/srcpkgs/kf6-kwidgetsaddons/template
+++ b/srcpkgs/kf6-kwidgetsaddons/template
@@ -1,17 +1,18 @@
 # Template file for 'kf6-kwidgetsaddons'
 pkgname=kf6-kwidgetsaddons
-version=6.14.0
+version=6.17.0
 revision=1
 build_style=cmake
 configure_args="$(vopt_bool designerplugin BUILD_DESIGNERPLUGIN)"
-hostmakedepends="extra-cmake-modules qt6-tools qt6-base"
-makedepends="qt6-base-devel"
+hostmakedepends="extra-cmake-modules qt6-tools qt6-base
+ shiboken6 python3-build python3-setuptools llvm"
+makedepends="qt6-base-devel libshiboken6-devel libpyside6-devel python3-devel"
 short_desc="KWidgetsAddons"
 maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/kwidgetsaddons"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=602720bc3e86cba2384f0f45e16c8524a1974796a3d5b7c5c1ed90e768cf121f
+checksum=dcb33387953cd0429d4297d628b4872e7a3a970cce5ea84b446677d8b7487ea1
 
 build_options="designerplugin"
 

--- a/srcpkgs/kf6-kwindowsystem/template
+++ b/srcpkgs/kf6-kwindowsystem/template
@@ -1,6 +1,6 @@
 # Template file for 'kf6-kwindowsystem'
 pkgname=kf6-kwindowsystem
-version=6.14.0
+version=6.17.0
 revision=1
 build_style=cmake
 configure_args="-DKDE_INSTALL_QMLDIR=lib/qt6/qml
@@ -14,7 +14,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/kwindowsystem"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=6625f7d5a46cb9c72289bcaaa65ee74450a671e4dbf6eebefc772650f24cf2a6
+checksum=259abef58b09ad1a8022b5cb94831a98f3e5b5cc7c65f7a0b40be64361756f63
 
 post_install() {
 	sed -i -e 's:/usr/[a-z0-9-]*/usr/include;::' \

--- a/srcpkgs/kf6-kxmlgui/template
+++ b/srcpkgs/kf6-kxmlgui/template
@@ -1,18 +1,19 @@
 # Template file for 'kf6-kxmlgui'
 pkgname=kf6-kxmlgui
-version=6.14.0
+version=6.17.0
 revision=1
 build_style=cmake
 hostmakedepends="extra-cmake-modules qt6-tools qt6-base
- gettext"
+ gettext python3-build python3-setuptools shiboken6 llvm"
 makedepends="kf6-kconfig-devel kf6-kconfigwidgets-devel qt6-base-private-devel
- kf6-kitemviews-devel kf6-kiconthemes-devel kf6-kglobalaccel-devel"
+ kf6-kitemviews-devel kf6-kiconthemes-devel kf6-kglobalaccel-devel
+ libshiboken6-devel libpyside6-devel python3-devel"
 short_desc="KDE Framework for managing menu and toolbar actions"
 maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/kxmlgui"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=5f9a35d168e5be85c43e566f87bf7108c18e3a19420e1d9379b493e28880914b
+checksum=a1807169ca2c386a8d3e25cb2b066554e49663a6e3f632f1a1968ef5476430e3
 
 do_check() {
 	cd build

--- a/srcpkgs/kf6-modemmanager-qt/template
+++ b/srcpkgs/kf6-modemmanager-qt/template
@@ -1,6 +1,6 @@
 # Template file for 'kf6-modemmanager-qt'
 pkgname=kf6-modemmanager-qt
-version=6.14.0
+version=6.17.0
 revision=1
 build_style=cmake
 hostmakedepends="extra-cmake-modules qt6-tools qt6-base
@@ -12,7 +12,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/modemmanager-qt"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=c1f03a4df18c28c42540ba59d9f9b9962d59f4074cdf686bc787e2ff595783d9
+checksum=b41fe1dd9a0e146adb4d8098d569d6b11291f40c90df70dfbaa6ad1654e18d76
 
 do_check() {
 	cd build

--- a/srcpkgs/kf6-networkmanager-qt/template
+++ b/srcpkgs/kf6-networkmanager-qt/template
@@ -1,6 +1,6 @@
 # Template file for 'kf6-networkmanager-qt'
 pkgname=kf6-networkmanager-qt
-version=6.14.0
+version=6.17.0
 revision=1
 build_style=cmake
 configure_args="-DKDE_INSTALL_QMLDIR=lib/qt6/qml"
@@ -12,7 +12,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/networkmanager-qt"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=0c392bdf4f8dd85f1441f65ba931d8f49541c5567f2350c78e7b121434c3b126
+checksum=d83beae867fb7d669886f513893f8eec58b5d7a24b429d89dc5c6c08b7a3f4e0
 
 do_check() {
 	cd build

--- a/srcpkgs/kf6-prison/template
+++ b/srcpkgs/kf6-prison/template
@@ -1,6 +1,6 @@
 # Template file for 'kf6-prison'
 pkgname=kf6-prison
-version=6.14.0
+version=6.17.0
 revision=1
 build_style=cmake
 configure_args="-DKDE_INSTALL_QMLDIR=lib/qt6/qml"
@@ -13,7 +13,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/prison"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=b50454ab0a0d7891ac1f9b6c4e4e00ccd3269bad630a6a392f410c4e252ffb64
+checksum=5542dd0733e06beae6f8cf8bf27ff981f34205fe98125d910be2c53fff47007c
 
 kf6-prison-devel_package() {
 	depends="$makedepends ${sourcepkg}>=${version}_${revision}"

--- a/srcpkgs/kf6-purpose/template
+++ b/srcpkgs/kf6-purpose/template
@@ -1,6 +1,6 @@
 # Template file for 'kf6-purpose'
 pkgname=kf6-purpose
-version=6.14.0
+version=6.17.0
 revision=1
 build_style=cmake
 configure_args="-DKDE_INSTALL_QMLDIR=lib/qt6/qml
@@ -15,7 +15,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/purpose"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=dd9f23baf4c4a44f1c71f7d3b0bfe7fbfbcdda2002d74d4b49cd84631ac899e9
+checksum=689565d5eb0999e1ccd92e8f841fc8241ab02489ca6c339f48d541b5ba93764a
 
 kf6-purpose-devel_package() {
 	depends="$makedepends ${sourcepkg}>=${version}_${revision}"

--- a/srcpkgs/kf6-qqc2-desktop-style/template
+++ b/srcpkgs/kf6-qqc2-desktop-style/template
@@ -1,6 +1,6 @@
 # Template file for 'kf6-qqc2-desktop-style'
 pkgname=kf6-qqc2-desktop-style
-version=6.14.0
+version=6.17.0
 revision=1
 build_style=cmake
 configure_args="-DKDE_INSTALL_QMLDIR=lib/qt6/qml
@@ -13,7 +13,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/qqc2-desktop-style"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=9604b35cb553961c4646ddca69e207df42ff7ad9e3e1608387ff923d8d9f3cff
+checksum=631bd89d5c82a7f93ea26bc2079d1df81c32e75f177d3346a9cb10a9cd747797
 
 do_check() {
 	cd build

--- a/srcpkgs/kf6-solid/template
+++ b/srcpkgs/kf6-solid/template
@@ -1,6 +1,6 @@
 # Template file for 'kf6-solid'
 pkgname=kf6-solid
-version=6.14.0
+version=6.17.0
 revision=1
 build_style=cmake
 hostmakedepends="extra-cmake-modules qt6-tools qt6-base flex pkg-config"
@@ -13,7 +13,7 @@ license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/solid"
 #changelog=""
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=00996f063478863fe61b902d20c96c9eb4f4ac43353e59b779b466fa62b1a8c4
+checksum=17f0510ef134b66e647ee217b64870532d757c721c815f20c49567b979c9c725
 
 kf6-solid-devel_package() {
 	depends="qt6-base-devel ${sourcepkg}>=${version}_${revision}"

--- a/srcpkgs/kf6-sonnet/template
+++ b/srcpkgs/kf6-sonnet/template
@@ -1,6 +1,6 @@
 # Template file for 'kf6-sonnet'
 pkgname=kf6-sonnet
-version=6.14.0
+version=6.17.0
 revision=1
 build_style=cmake
 configure_args="$(vopt_bool designerplugin BUILD_DESIGNERPLUGIN)
@@ -14,7 +14,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/sonnet"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=a0de64c132c08d4986b00de9ee8e299615ad50008b14e26910fcefcad734afd3
+checksum=4afef6e9ca72edb6c22800b4acfb450df7121e5077c85213aca5f56ab9f4160b
 
 build_options="designerplugin"
 

--- a/srcpkgs/kf6-syndication/template
+++ b/srcpkgs/kf6-syndication/template
@@ -1,6 +1,6 @@
 # Template file for 'kf6-syndication'
 pkgname=kf6-syndication
-version=6.14.0
+version=6.17.0
 revision=1
 build_style=cmake
 hostmakedepends="extra-cmake-modules qt6-tools qt6-base"
@@ -10,7 +10,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/syndication"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=14e5ac6f632dc3022f6a32b9c8e5bd00896bdda5fad8585745023b2539561a19
+checksum=d5a714b09ef6a50b67f55d58f8c6eefa1bba552527ded1145848b5466330ea93
 
 kf6-syndication-devel_package() {
 	depends="$makedepends ${sourcepkg}>=${version}_${revision}"

--- a/srcpkgs/kf6-syntax-highlighting/template
+++ b/srcpkgs/kf6-syntax-highlighting/template
@@ -1,6 +1,6 @@
 # Template file for 'kf6-syntax-highlighting'
 pkgname=kf6-syntax-highlighting
-version=6.14.0
+version=6.17.0
 revision=1
 build_style=cmake
 configure_args="
@@ -15,7 +15,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/syntax-highlighting"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=dfdc025ac968a7d0cb430826e54f3e96b4ca8798cff4b5df7df493e2d0e4dfbc
+checksum=3d16bec0fbeb853be684c35f47550d59814db1f4b707ec77b862f3650f353fcc
 
 if [ "$CROSS_BUILD" ]; then
 	hostmakedepends+=" kf6-syntax-highlighting-devel"

--- a/srcpkgs/kf6-threadweaver/template
+++ b/srcpkgs/kf6-threadweaver/template
@@ -1,6 +1,6 @@
 # Template file for 'kf6-threadweaver'
 pkgname=kf6-threadweaver
-version=6.14.0
+version=6.17.0
 revision=1
 build_style=cmake
 hostmakedepends="extra-cmake-modules qt6-tools qt6-base "
@@ -10,7 +10,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/threadweaver"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=a8f71f7e69751e36dbc7fce9581f55b66844bc68df6af2e8a94c22c8fe9870ae
+checksum=771ff89c1c012a3ea2baed58c803ecd7e8b0b8928e3aebc11c07df5ccf054f44
 
 kf6-threadweaver-devel_package() {
 	depends="$makedepends ${sourcepkg}>=${version}_${revision}"


### PR DESCRIPTION
- **kf6-attica: update to 6.17.0.**
- **kf6-baloo: update to 6.17.0.**
- **kf6-bluez-qt: update to 6.17.0.**
- **kf6-frameworkintegration: update to 6.17.0.**
- **kf6-karchive: update to 6.17.0.**
- **kf6-kauth: update to 6.17.0.**
- **kf6-kbookmarks: update to 6.17.0.**
- **kf6-kcalendarcore: update to 6.17.0.**
- **kf6-kcmutils: update to 6.17.0.**
- **kf6-kcodecs: update to 6.17.0.**
- **kf6-kcolorscheme: update to 6.17.0.**
- **kf6-kcompletion: update to 6.17.0.**
- **kf6-kconfig: update to 6.17.0.**
- **kf6-kconfigwidgets: update to 6.17.0.**
- **kf6-kcontacts: update to 6.17.0.**
- **kf6-kcoreaddons: update to 6.17.0.**
- **kf6-kcrash: update to 6.17.0.**
- **kf6-kdav: update to 6.17.0.**
- **kf6-kdbusaddons: update to 6.17.0.**
- **kf6-kdeclarative: update to 6.17.0.**
- **kf6-kded: update to 6.17.0.**
- **kf6-kdesu: update to 6.17.0.**
- **kf6-kdnssd: update to 6.17.0.**
- **kf6-kdoctools: update to 6.17.0.**
- **kf6-kfilemetadata: update to 6.17.0.**
- **kf6-kglobalaccel: update to 6.17.0.**
- **kf6-kguiaddons: update to 6.17.0.**
- **kf6-kholidays: update to 6.17.0.**
- **kf6-ki18n: update to 6.17.0.**
- **kf6-kiconthemes: update to 6.17.0.**
- **kf6-kidletime: update to 6.17.0.**
- **kf6-kimageformats: update to 6.17.0.**
- **kf6-kio: update to 6.17.0.**
- **kf6-kirigami: update to 6.17.0.**
- **kf6-kitemmodels: update to 6.17.0.**
- **kf6-kitemviews: update to 6.17.0.**
- **kf6-kjobwidgets: update to 6.17.0.**
- **kf6-knewstuff: update to 6.17.0.**
- **kf6-knotifications: update to 6.17.0.**
- **kf6-knotifyconfig: update to 6.17.0.**
- **kf6-kpackage: update to 6.17.0.**
- **kf6-kparts: update to 6.17.0.**
- **kf6-kpeople: update to 6.17.0.**
- **kf6-kplotting: update to 6.17.0.**
- **kf6-kpty: update to 6.17.0.**
- **kf6-kquickcharts: update to 6.17.0.**
- **kf6-krunner: update to 6.17.0.**
- **kf6-kservice: update to 6.17.0.**
- **kf6-kstatusnotifieritem: update to 6.17.0.**
- **kf6-ksvg: update to 6.17.0.**
- **kf6-ktexteditor: update to 6.17.0.**
- **kf6-ktexttemplate: update to 6.17.0.**
- **kf6-ktextwidgets: update to 6.17.0.**
- **kf6-kunitconversion: update to 6.17.0.**
- **kf6-kuserfeedback: update to 6.17.0.**
- **kf6-kwallet: update to 6.17.0.**
- **kf6-kwidgetsaddons: update to 6.17.0.**
- **kf6-kwindowsystem: update to 6.17.0.**
- **kf6-kxmlgui: update to 6.17.0.**
- **kf6-modemmanager-qt: update to 6.17.0.**
- **kf6-networkmanager-qt: update to 6.17.0.**
- **kf6-prison: update to 6.17.0.**
- **kf6-purpose: update to 6.17.0.**
- **kf6-qqc2-desktop-style: update to 6.17.0.**
- **kf6-solid: update to 6.17.0.**
- **kf6-sonnet: update to 6.17.0.**
- **kf6-syndication: update to 6.17.0.**
- **kf6-syntax-highlighting: update to 6.17.0.**
- **kf6-threadweaver: update to 6.17.0.**
- **breeze-icons: update to 6.17.0.**
- **extra-cmake-modules: update to 6.17.0.**

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**|**briefly**|**NO**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
