### PR TITLE
wayland: update to 1.24.0

### DIFF
--- a/srcpkgs/wayland/template
+++ b/srcpkgs/wayland/template
@@ -1,6 +1,6 @@
 # Template file for 'wayland'
 pkgname=wayland
-version=1.23.1
+version=1.24.0
 revision=1
 build_style=meson
 # "Tests must not be built with NDEBUG defined, they rely on assert()."
@@ -12,7 +12,7 @@ maintainer="Érico Nogueira <ericonr@disroot.org>"
 license="MIT"
 homepage="https://wayland.freedesktop.org/"
 distfiles="https://gitlab.freedesktop.org/wayland/wayland/-/releases/${version}/downloads/wayland-${version}.tar.xz"
-checksum=864fb2a8399e2d0ec39d56e9d9b753c093775beadc6022ce81f441929a81e5ed
+checksum=82892487a01ad67b334eca83b54317a7c86a03a89cfadacfef5211f11a5d0536
 
 if [ "$XBPS_CHECK_PKGS" ]; then
 	configure_args+=" -Dtests=true"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

```
[*] Waybar-0.14.0_1         Polybar-like Wayland Bar for Sway and Wlroots based compositors
[*] cliphist-0.6.1_1        Wayland clipboard manager
[*] foot-1.23.1_1           Fast, lightweight and minimalistic Wayland terminal emulator
[*] foot-terminfo-1.23.1_1  Fast, lightweight and minimalistic Wayland terminal emulator -...
[*] grim-1.4.1_1            Grab images from a Wayland compositor
[*] gtk-layer-shell-0.9.2_1 Library to create panels and other desktop components for Wayl...
[*] labwc-0.9.1_1           Wayland window-stacking compositor
[*] libdecor-0.2.2_1        Client-side decorations library for Wayland client
[*] libinput-1.28.1_1       Provides handling input devices in Wayland compositors and X
[*] niri-25.05.1_1          Scrollable-tiling Wayland compositor
[*] slurp-1.5.0_1           Select a region in a Wayland compositor
[*] swaybg-1.2.1_1          Wallpaper tool for Wayland compositors
[*] swayidle-1.8.0_1        Idle management daemon for Wayland
[*] swayimg-4.5_1           Image viewer for Sway/Wayland
[*] swaylock-1.8.3_1        Screen locker for Wayland
[*] wayland-1.24.0_0        Core Wayland window system code and protocol
[*] wl-clipboard-2.2.1_1    Wayland clipboard utilities
[*] wlroots0.19-0.19.0_1    Modular Wayland compositor library 0.19
[*] wlsunset-0.4.0_1        Day/night gamma adjustments for Wayland compositors
[*] wob-0.16_1              Lightweight overlay volume/backlight/progress/anything bar for...
[*] wtype-0.4_1             Wayland version of xdotool
```

#### Local build testing
- I built this PR locally for my native architecture, (**x86_64-glibc**)

cc @ericonr 