### PR TITLE
[DRAFT] gedit: update to 48.2 and update dependencies

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -3682,7 +3682,7 @@ libqhttpengine.so.1 qhttpengine-1.0.1_1
 libqmdnsengine.so.0 qmdnsengine-0.1.0_1
 libyang.so.1 libyang-1.0r5_1
 libhtp.so.2 libhtp-0.5.30_1
-libgedit-48.1.so gedit-48.1_1
+libgedit-48.2.so gedit-48.2_1
 libgedit-amtk-5.so.0 libgedit-amtk-5.8.0_1
 libgedit-gtksourceview-300.so.3 libgedit-gtksourceview-299.4.0_1
 libgedit-gfls-1.so.0 libgedit-gfls-0.1.0_1

--- a/common/shlibs
+++ b/common/shlibs
@@ -3686,7 +3686,7 @@ libgedit-48.1.so gedit-48.1_1
 libgedit-amtk-5.so.0 libgedit-amtk-5.8.0_1
 libgedit-gtksourceview-300.so.3 libgedit-gtksourceview-299.4.0_1
 libgedit-gfls-1.so.0 libgedit-gfls-0.1.0_1
-libgedit-tepl-6.so.2 libgedit-tepl-6.12.0_1
+libgedit-tepl-6.so.3 libgedit-tepl-6.13.0_1
 libchewing.so.3 libchewing-0.5.1_1
 libdwarves.so.1 pahole-1.12_1
 libdwarves_emit.so.1 pahole-1.12_1

--- a/srcpkgs/enter-tex/template
+++ b/srcpkgs/enter-tex/template
@@ -1,7 +1,7 @@
 # Template file for 'enter-tex'
 pkgname=enter-tex
-version=3.47.0
-revision=3
+version=3.48.0
+revision=1
 build_helper="gir"
 build_style=meson
 configure_args="-Ddconf_migration=false $(vopt_bool gtk_doc gtk_doc)"
@@ -12,10 +12,10 @@ makedepends="gsettings-desktop-schemas-devel gspell-devel libgedit-gtksourceview
 short_desc="LaTeX editor for the GNOME desktop"
 maintainer="Enno Boland <gottox@voidlinux.org>"
 license="GPL-3.0-or-later"
-homepage="https://gitlab.gnome.org/swilmet/enter-tex"
-changelog="https://gitlab.gnome.org/swilmet/enter-tex/-/raw/main/NEWS"
-distfiles="${GNOME_SITE}/enter-tex/${version%.*}/enter-tex-${version}.tar.xz"
-checksum=a08caec9275c0abb9535674df5b9c16b92b14968cd21916d6ffc2fa0cb9dd76a
+homepage="https://gitlab.gnome.org/World/gedit/enter-tex"
+changelog="https://gitlab.gnome.org/World/gedit/enter-tex/-/raw/main/NEWS"
+distfiles="https://gitlab.gnome.org/World/gedit/enter-tex/-/archive/${version}/enter-tex-${version}.tar.gz"
+checksum=78a808d39bf31388afcc7030e509563e3ed23b3dac6d319a69005c36c10d0b8e
 
 build_options="gtk_doc"
 build_options_default=" "
@@ -29,7 +29,7 @@ post_install() {
 }
 
 pre_build() {
-	# https://gitlab.gnome.org/swilmet/enter-tex/-/blob/main/docs/more-information.md
+	# https://gitlab.gnome.org/World/gedit/enter-tex/-/blob/main/docs/more-information.md
 	ninja -C build src/gtex/Gtex-1.gir
 }
 

--- a/srcpkgs/gedit-plugins/template
+++ b/srcpkgs/gedit-plugins/template
@@ -1,20 +1,16 @@
 # Template file for 'gedit-plugins'
 # keep major version in sync with gedit
 pkgname=gedit-plugins
-version=48.1
+version=48.2
 revision=1
 build_style=meson
-pycompile_dirs="usr/lib/gedit/plugins"
-hostmakedepends="gettext glib-devel itstool pkg-config vala appstream-glib
- python3-gobject gucharmap-devel vte3-devel"
-makedepends="gedit-devel libgedit-gtksourceview-devel gtk+3-devel libgit2-glib-devel
- libglib-devel libpeas-devel python3-dbus-devel python3-devel"
-depends="python3-gobject gucharmap vte3"
+hostmakedepends="gettext glib-devel itstool pkg-config appstream-glib"
+makedepends="gedit-devel libgedit-gtksourceview-devel gtk+3-devel
+ libglib-devel libpeas-devel"
 short_desc="Set of plugins for Gedit"
 maintainer="Enno Boland <gottox@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="https://gitlab.gnome.org/World/gedit/gedit-plugins"
-changelog="https://gitlab.gnome.org/GNOME/gedit-plugins/-/raw/master/NEWS"
-distfiles="${GNOME_SITE}/gedit-plugins/${version%.*}/gedit-plugins-${version}.tar.xz"
-checksum=9026bfe71a678f8c47f46316837437e7b357918fd6c3d4d65be27fc95b710e1c
-python_version=3
+changelog="https://gitlab.gnome.org/World/gedit/gedit-plugins/-/raw/master/NEWS"
+distfiles="https://gitlab.gnome.org/World/gedit/gedit-plugins/-/archive/${version}/gedit-plugins-${version}.tar.gz"
+checksum=01489951344218a103aa974cc05e2c3609f342a964743329be05e7fbe470c179

--- a/srcpkgs/gedit/template
+++ b/srcpkgs/gedit/template
@@ -1,26 +1,38 @@
 # Template file for 'gedit'
 # keep major version in sync with gedit-plugins
 pkgname=gedit
-version=48.1
-revision=2
+version=48.2
+revision=1
+_libgd_gitrev=3cccf99234288a6121b3945a25cd4ec3b7445c74
 build_helper="gir"
 build_style=meson
-pycompile_dirs="usr/lib/gedit/plugins"
 configure_args="-Dgtk_doc=false"
-hostmakedepends="itstool pkg-config glib-devel gdk-pixbuf perl gettext
+hostmakedepends="itstool pkg-config glib-devel gdk-pixbuf gettext
  gtk-update-icon-cache desktop-file-utils"
 makedepends="gsettings-desktop-schemas-devel gspell-devel libgedit-gtksourceview-devel
- libpeas-devel python3-gobject-devel libgedit-amtk-devel libgedit-tepl-devel"
+ libpeas-devel libgedit-amtk-devel libgedit-tepl-devel"
 depends="desktop-file-utils gsettings-desktop-schemas iso-codes"
 short_desc="Text editor for GNOME"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later"
-homepage="https://wiki.gnome.org/Apps/Gedit"
+homepage="https://gedit-text-editor.org"
 changelog="https://gitlab.gnome.org/World/gedit/gedit/-/raw/${version}/NEWS"
-distfiles="${GNOME_SITE}/gedit/${version%.*}/gedit-${version}.tar.xz"
-checksum=971e7ac26bc0a3a3ded27a7563772415687db0e5a092b4547e5b10a55858b30a
-python_version=3
-shlib_provides="libgedit-48.1.so"
+distfiles="https://gitlab.gnome.org/World/gedit/gedit/-/archive/${version}/gedit-${version}.tar.gz
+ https://gitlab.gnome.org/GNOME/libgd/-/archive/${_libgd_gitrev}/libgd-${_libgd_gitrev}.tar.gz"
+checksum="a47f400d63222efdf9ad104c9dcc7c3939a6eb24fd882be5a5fa229e1ac19893
+ bb1387edfd79a764241b60e1288fe1da7277137328d4b412333e2ca2cb817586"
+skip_extraction="libgd-${_libgd_gitrev}.tar.gz"
+shlib_provides="libgedit-48.2.so"
+
+# gedit tarballs are no longer being produced for download.gnome.org.
+# See: https://gitlab.gnome.org/World/gedit/gedit/-/issues/611
+# The tarballs from gitlab don't automatically include git submodules.
+# libgd is not versioned and is intended to be included in projects directly.
+# This works around the issue by downloading the revision corresponding to
+# the latest git head at the time of relesase.
+post_extract() {
+	vsrcextract -C subprojects/libgd "libgd-${_libgd_gitrev}.tar.gz"
+}
 
 gedit-devel_package() {
 	depends="${sourcepkg}>=${version}_${revision} gtk+3-devel libglib-devel

--- a/srcpkgs/libgedit-amtk/template
+++ b/srcpkgs/libgedit-amtk/template
@@ -1,6 +1,6 @@
 # Template file for 'libgedit-amtk'
 pkgname=libgedit-amtk
-version=5.9.0
+version=5.9.1
 revision=1
 build_helper="gir"
 build_style=meson
@@ -12,8 +12,8 @@ maintainer="Matt Boehlke <git@mtboehlke.com>"
 license="LGPL-3.0-or-later"
 homepage="https://gitlab.gnome.org/World/gedit/libgedit-amtk"
 changelog="https://gitlab.gnome.org/World/gedit/libgedit-amtk/-/raw/main/NEWS"
-distfiles="${GNOME_SITE}/libgedit-amtk/${version%.*}/libgedit-amtk-${version}.tar.xz"
-checksum=7fc3348bef242e08967bdbb9a6698cf39f7810f95051fd8132910f36ed2d6d15
+distfiles="https://gitlab.gnome.org/World/gedit/libgedit-amtk/-/archive/${version}/libgedit-amtk-${version}.tar.gz"
+checksum=185c960789b7b448f3c6b7d0e15da5785906930a2bb5fddb45dfc0bd3d1b0798
 
 libgedit-amtk-devel_package() {
 	depends="${sourcepkg}>=${version}_${revision} gtk+3-devel libglib-devel"

--- a/srcpkgs/libgedit-gfls/template
+++ b/srcpkgs/libgedit-gfls/template
@@ -1,6 +1,6 @@
 # Template file for 'libgedit-gfls'
 pkgname=libgedit-gfls
-version=0.2.1
+version=0.3.0
 revision=1
 build_style=meson
 build_helper=gir
@@ -12,8 +12,8 @@ maintainer="chrysos349 <chrysostom349@gmail.com>"
 license="GPL-3.0-or-later"
 homepage="https://gitlab.gnome.org/World/gedit/libgedit-gfls"
 changelog="https://gitlab.gnome.org/World/gedit/libgedit-gfls/-/raw/main/NEWS"
-distfiles="${GNOME_SITE}/libgedit-gfls/${version%.*}/libgedit-gfls-${version}.tar.xz"
-checksum=b3c8e07facb4d0c444648a934ff5236d22b74154556235b90aa7828ba4816e1d
+distfiles="https://gitlab.gnome.org/World/gedit/libgedit-gfls/-/archive/${version}/libgedit-gfls-${version}.tar.gz"
+checksum=fe408efc98d3ff86bcaa36d7c10d5859bf3cd4e868700d08796cfcb4d5389017
 
 build_options="gir gtk_doc"
 build_options_default="gir"

--- a/srcpkgs/libgedit-gtksourceview/template
+++ b/srcpkgs/libgedit-gtksourceview/template
@@ -1,6 +1,6 @@
 # Template file for 'libgedit-gtksourceview'
 pkgname=libgedit-gtksourceview
-version=299.4.0
+version=299.5.0
 revision=1
 build_helper="gir"
 build_style=meson
@@ -13,8 +13,8 @@ maintainer="Matt Boehlke <git@mtboehlke.com>"
 license="LGPL-2.1-or-later"
 homepage="https://gitlab.gnome.org/World/gedit/libgedit-gtksourceview"
 changelog="https://gitlab.gnome.org/World/gedit/libgedit-gtksourceview/-/raw/main/NEWS"
-distfiles="${GNOME_SITE}/libgedit-gtksourceview/${version%%.*}/libgedit-gtksourceview-${version}.tar.xz"
-checksum=20c17ff89e2031aed5dc1107fe9a93fd50f92b569be2954b119c86f9e2fd85d6
+distfiles="https://gitlab.gnome.org/World/gedit/libgedit-gtksourceview/-/archive/${version}/libgedit-gtksourceview-${version}.tar.gz"
+checksum=49b66fe7e2d33dbf643107ae16fe324edf91bb21e86a927b2c5981f63f4cbb12
 make_check_pre="xvfb-run"
 
 libgedit-gtksourceview-devel_package() {

--- a/srcpkgs/libgedit-tepl/template
+++ b/srcpkgs/libgedit-tepl/template
@@ -1,6 +1,6 @@
 # Template file for 'libgedit-tepl'
 pkgname=libgedit-tepl
-version=6.12.0
+version=6.13.0
 revision=1
 build_style=meson
 build_helper=gir
@@ -15,9 +15,8 @@ maintainer="Enno Boland <gottox@voidlinux.org>"
 license="LGPL-3.0-or-later"
 homepage="https://gitlab.gnome.org/World/gedit/libgedit-tepl"
 changelog="https://gitlab.gnome.org/World/gedit/libgedit-tepl/-/raw/main/NEWS"
-distfiles="${GNOME_SITE}/libgedit-tepl/${version%.*}/libgedit-tepl-${version}.tar.xz"
-#distfiles="${GNOME_SITE}/tepl/${version%.*}/tepl-${version}.tar.xz"
-checksum=90874d755051199e25823623ff2772027f8664a39746fb82d0f8d44f12d2a3f2
+distfiles="https://gitlab.gnome.org/World/gedit/libgedit-tepl/-/archive/${version}/libgedit-tepl-${version}.tar.gz"
+checksum=39d97a69c6f75a1e86f72976159a4ec3f51996971d1cc5b7289df1315a7d6bab
 make_check_pre="xvfb-run"
 
 build_options="gir gtk_doc"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

**PLEASE NOTE**: plugins implemented in python are no longer supported.
The official plugins written in python have been removed.

See [https://gitlab.gnome.org/World/gedit/gedit/-/issues/614](https://gitlab.gnome.org/World/gedit/gedit/-/issues/614)
for more details.

Also see [https://gitlab.gnome.org/World/gedit/gedit/-/issues/618](https://gitlab.gnome.org/World/gedit/gedit/-/issues/618)
concerning the status for third-party plugins.

It seems support for third-party python plugins [may return](https://gedit-text-editor.org/blog/2025-07-14-mid-july-news.html)?
Either way, it looks like going forward official plugins will be written in C or Rust or something else.

If python support is desired, it may be best to skip this version.  Python support should work in gedit 48.1 until pygobject is bumped to 3.52, according to the first report above.
<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
