### PR TITLE
walker: update to 0.13.25.

### DIFF
--- a/srcpkgs/walker/template
+++ b/srcpkgs/walker/template
@@ -1,6 +1,6 @@
 # Template file for 'walker'
 pkgname=walker
-version=0.13.22
+version=0.13.25
 revision=1
 build_style=go
 build_helper="gir"
@@ -15,7 +15,7 @@ license="MIT"
 homepage="https://github.com/abenz1267/walker"
 changelog="https://github.com/abenz1267/walker/releases"
 distfiles="https://github.com/abenz1267/walker/archive/v${version}.tar.gz"
-checksum=e47007244c3eecb968eedeed758a9c13204265efa134a68dca11d7d917c06fd1
+checksum=ad8f3570b67bf27ecb42e647f65715ffda2212db58870e6b23ea206d209859d8
 make_check=no # no tests and slog warnings make it fail
 
 do_build() {


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - i686
  - x86_64-musl
