### PR TITLE
python3-dbus-fast: update to 2.44.3.

### DIFF
--- a/srcpkgs/python3-dbus-fast/template
+++ b/srcpkgs/python3-dbus-fast/template
@@ -1,6 +1,6 @@
 # Template file for 'python3-dbus-fast'
 pkgname=python3-dbus-fast
-version=2.44.2
+version=2.44.3
 revision=1
 build_style=python3-pep517
 hostmakedepends="python3-setuptools python3-wheel python3-poetry-core python3-Cython"
@@ -12,7 +12,7 @@ license="MIT"
 homepage="https://github.com/bluetooth-devices/dbus-fast"
 changelog="https://github.com/bluetooth-devices/dbus-fast/raw/main/CHANGELOG.md"
 distfiles="${PYPI_SITE}/d/dbus-fast/dbus_fast-${version}.tar.gz"
-checksum=752f355c32e28468ba9f57b509e2694c4ba0d3d55ae6eb0035511c226438eb35
+checksum=962b36abbe885159e31135c57a7d9659997c61a13d55ecb070a61dc502dbd87e
 make_check=no # no tests included
 
 post_install() {


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86-64-LIBC)