### PR TITLE
incus: update to 6.15.0.

### DIFF
--- a/srcpkgs/incus/files/README.voidlinux
+++ b/srcpkgs/incus/files/README.voidlinux
@@ -14,4 +14,4 @@ variable in `/etc/rc.conf` be set to `unified`.
 Optional dependencies:
 
 To run virtual machines, install `qemu` and `edk2-ovmf`.
-To run OCI containers, install `skopeo` and `umoci`.
+To run OCI containers, install `skopeo`.

--- a/srcpkgs/incus/template
+++ b/srcpkgs/incus/template
@@ -1,6 +1,6 @@
 # Template file for 'incus'
 pkgname=incus
-version=6.12.0
+version=6.15.0
 revision=1
 build_style=go
 build_helper=qemu
@@ -18,7 +18,7 @@ maintainer="dkwo <npiazza@disroot.org>"
 license="Apache-2.0"
 homepage="https://linuxcontainers.org/incus"
 distfiles="https://github.com/lxc/incus/archive/refs/tags/v${version}.tar.gz"
-checksum=98532b05b2083b3ff112a08c5f39643b7e744366bdd698a32cbe8b60decb42f3
+checksum=49091d8d16d21e2e891c82b19abfd860a1aa2bbcc3fb35e7d21f6ff6a9850abb
 system_groups="_incus-admin _incus"
 make_dirs="
  /var/lib/incus 0755 root root


### PR DESCRIPTION
Hi, just making an update build for incus @dkwo 

Removed umoci from the readme because [6.13](https://discuss.linuxcontainers.org/t/incus-6-13-has-been-released/23899) removed it as a dependency. 

I will also make a PR to remove it from the void docs. 

(if there is a consensus on whether we want this info in only one place, I can adjust this PR to remove the README or adjust void docs to not have the redundant information) @classabbyamp 

#### Testing the changes
- I tested the changes in this PR: **YES**


<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC) x86_64 both glibc and musl
- Crossbuilt:
-armv7l
-aarch64
-->
