### PR TITLE
New package: python3-btrfsutil-6.14

### DIFF
--- a/srcpkgs/python3-btrfsutil/template
+++ b/srcpkgs/python3-btrfsutil/template
@@ -1,0 +1,13 @@
+# Template file for 'python3-btrfsutil'
+pkgname=python3-btrfsutil
+version=6.14
+revision=1
+build_style=python3-module
+hostmakedepends="python3-setuptools"
+makedepends="python3-devel python3-setuptools libbtrfsutil-devel"
+short_desc="Library for managing Btrfs filesystems"
+maintainer="Yushi <github@yushi.one>"
+license="GPL-2.0-only"
+homepage="https://pypi.org/project/btrfsutil/"
+distfiles="${PYPI_SITE}/b/btrfsutil/btrfsutil-${version}.tar.gz"
+checksum=ddc8f43c987792197d05b6e97aff4d39bfa805f927b4abe8767659ecb9f2d1f1


### PR DESCRIPTION
Dependency of [snapper-rollback](https://github.com/void-linux/void-packages/pull/56729)

Credit to @elbachir-one 

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**


#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (aarch64-glibc)

