### PR TITLE
rio: update to 0.2.28, orphan

### DIFF
--- a/srcpkgs/rio/template
+++ b/srcpkgs/rio/template
@@ -1,6 +1,6 @@
 # Template file for 'rio'
 pkgname=rio
-version=0.2.27
+version=0.2.28
 revision=1
 build_style=cargo
 build_wrksrc="frontends/rioterm"
@@ -8,12 +8,12 @@ hostmakedepends="pkg-config scdoc"
 makedepends="libglvnd-devel libxcb-devel libxkbcommon-devel wayland-devel"
 depends="rio-terminfo-${version}_${revision}"
 short_desc="Hardware-accelerated GPU terminal emulator powered by WebGPU"
-maintainer="tranzystorekk <tranzystorek.io@protonmail.com>"
+maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
 homepage="https://raphamorim.io/rio/"
 changelog="https://raw.githubusercontent.com/raphamorim/rio/main/CHANGELOG.md"
 distfiles="https://github.com/raphamorim/rio/archive/refs/tags/v${version}.tar.gz"
-checksum=87d82f4fe3c4530252df9a2102e694ed953bc171ebb3b2b00bbdc849f874b94d
+checksum=cd0a72997a1dfb3d2d05b22a6cf6d22d512dfa8a2946f2fefcdcf6fbebbb485c
 
 case "${XBPS_TARGET_MACHINE}" in
 	i686*)


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
