### PR TITLE
manpages-pt-br: update to 4.27.0.

### DIFF
--- a/srcpkgs/manpages-pt-br/template
+++ b/srcpkgs/manpages-pt-br/template
@@ -1,6 +1,6 @@
 # Template file for 'manpages-pt-br'
 pkgname=manpages-pt-br
-version=4.17.0
+version=4.27.0
 revision=1
 build_style=gnu-configure
 configure_args="--enable-compression=none"
@@ -12,7 +12,7 @@ license="GPL-3.0-or-later"
 homepage="https://manpages-l10n-team.pages.debian.net/manpages-l10n/"
 changelog="https://salsa.debian.org/manpages-l10n-team/manpages-l10n/-/raw/master/CHANGES.md"
 distfiles="https://salsa.debian.org/manpages-l10n-team/manpages-l10n/-/archive/${version}/manpages-l10n-v${version}.tar.gz"
-checksum=0afbe8196b091d37bb25702185a903ff69622e3dfbbf400f54ccc1260dcaa4c4
+checksum=ca64939b3ce023d328bbe93ebf7966a4bbb06cf291d8d7e8c559de5cc4d42abe
 
 post_install() {
 	find $DESTDIR -name '*systemd*' -delete


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**
Checked some polish manpages, looks OK

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc


I think that this package needs more customization in the future, like removing pages relevant for systemd (`/usr/share/man/pl/man8/shutdown.8` for example). I'm not sure if this is relevant only for polish manpages, or maybe for other languages also.
