### PR TITLE
bovo: update to 25.08.0

### DIFF
--- a/srcpkgs/bovo/template
+++ b/srcpkgs/bovo/template
@@ -1,6 +1,6 @@
 # Template file for 'bovo'
 pkgname=bovo
-version=25.04.3
+version=25.08.0
 revision=1
 build_style=cmake
 configure_args="-DKF6_HOST_TOOLING=/usr/lib/cmake"
@@ -14,4 +14,4 @@ license="GPL-2.0-or-later"
 homepage="https://apps.kde.org/bovo"
 changelog="https://invent.kde.org/games/bovo/-/raw/master/HISTORY"
 distfiles="${KDE_SITE}/release-service/${version}/src/bovo-${version}.tar.xz"
-checksum=c8ec6ad38dbe292a04c5bd768394165054a732a32782bb10a9195d482178e976
+checksum=3d1c143cae6ece288de8ae42899a962c9a3d4c454056f74bc9228351d77acc26


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)