### PR TITLE
gnome-control-center: update to 48.4

### DIFF
--- a/srcpkgs/gnome-control-center/template
+++ b/srcpkgs/gnome-control-center/template
@@ -1,6 +1,6 @@
 # Template file for 'gnome-control-center'
 pkgname=gnome-control-center
-version=48.3
+version=48.4
 revision=1
 build_style=meson
 build_helper="gir"
@@ -25,7 +25,7 @@ homepage="https://gitlab.gnome.org/GNOME/gnome-control-center"
 changelog="https://gitlab.gnome.org/GNOME/gnome-control-center/-/raw/gnome-48/NEWS"
 #changelog="https://gitlab.gnome.org/GNOME/gnome-control-center/-/raw/main/NEWS"
 distfiles="${GNOME_SITE}/gnome-control-center/${version%%.*}/gnome-control-center-${version}.tar.xz"
-checksum=c0698245a6420badd077c16ffb218860e457cd7300612718eabf9aba47222bae
+checksum=2a20eee6e05c8d3addaeefa524dce1ee9f88a77d838e3fd1edef3c0c2e467ad2
 make_check=no # needs X11 and requires altered filesystem
 
 pre_build() {


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)