### PR TITLE
network-ups-tools: update to 2.8.4

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -1657,7 +1657,7 @@ libgdkglext-x11-1.0.so.0 gtkglext-1.2.0_4
 libXaw3d.so.8 libXaw3d-1.6.2_1
 libupsclient.so.7 libnetwork-ups-tools-2.8.3_1
 libnutclient.so.2 libnetwork-ups-tools-2.8.0_1
-libnutscan.so.3 libnetwork-ups-tools-2.8.3_1
+libnutscan.so.4 libnetwork-ups-tools-2.8.4_1
 libsphinxad.so.0 sphinxbase-0.8_1
 libsphinxbase.so.1 sphinxbase-0.8_1
 libpocketsphinx.so.1 libpocketsphinx-0.8_3

--- a/srcpkgs/network-ups-tools/template
+++ b/srcpkgs/network-ups-tools/template
@@ -1,6 +1,6 @@
 # Template file for 'network-ups-tools'
 pkgname=network-ups-tools
-version=2.8.3
+version=2.8.4
 revision=1
 build_style=gnu-configure
 configure_args="
@@ -8,7 +8,8 @@ configure_args="
  --datadir=/usr/share/ups --with-user=nut --with-group=nut --with-ssl
  --with-usb --with-dev --with-serial -with-avahi --with-udev-dir=/usr/lib/udev
  --with-libltdl --without-ipmi --without-freeipmi --without-systemdsystemunitdir
- --with-snmp --with-drvpath=/usr/libexec/nut $(vopt_with cgi) --with-statepath=/run/ups"
+ --with-snmp --with-drvpath=/usr/libexec/nut $(vopt_with cgi) --with-statepath=/run/ups
+ --enable-docs-changelog=no"
 hostmakedepends="pkg-config asciidoc python3-packaging-bootstrap"
 makedepends="avahi-libs-devel openssl-devel libusb-compat-devel neon-devel
  net-snmp-devel $(vopt_if cgi gd-devel) libltdl-devel"
@@ -21,10 +22,10 @@ conf_files="
 	/etc/ups/nut.conf"
 short_desc="UPS control and monitoring features (NUT)"
 maintainer="Orphaned <orphan@voidlinux.org>"
-license="GPL-2.0-or-later"
+license="GPL-2.0-or-later AND GPL-3.0-or-later"
 homepage="http://www.networkupstools.org/"
 distfiles="${homepage}source/${version%.*}/nut-${version}.tar.gz"
-checksum=d6ca17f0b39003bac7649eb17ab4a713e4d5fcaa8fd1aedca28357d59df095ed
+checksum=a2fe55bc2d90b4a848d6ff8bac361e6d1c97f899a545219cad707d17a27ff127
 system_accounts="nut"
 
 nopie=yes


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**
After installing the network-ups-tools package and rebooting, I checked two things:
- [ ] upsc myups@localhost (proper information about the UPS was output)
- [ ] upsmon -c fsd (a forced shutdown was performed without any issues)

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture: x86_64-glibc
