### PR TITLE
flacon: drop ffmpeg dependency

### DIFF
--- a/srcpkgs/flacon/template
+++ b/srcpkgs/flacon/template
@@ -6,7 +6,7 @@ build_style=cmake
 configure_args="-DUSE_QT6=ON -DUSE_QT5=OFF"
 hostmakedepends="pkg-config qt6-tools qt6-base"
 makedepends="qt6-tools-devel qt6-widgets uchardet-devel taglib-devel"
-depends="ffmpeg hicolor-icon-theme"
+depends="hicolor-icon-theme"
 short_desc="Audio File Encoder. Splits audio tracks into separate tracks"
 maintainer="travankor <travankor@tuta.io>"
 license="LGPL-2.1-or-later"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
I tested this PR locally on my native architecture, **x86_64 glibc**
I built this PR locally for these architectures:
Native:
- x86_64  
- x86_64-musl
- i686
- aarch64
- aarch64-musl

Cross from x86_64:
- armv6l
- armv6l-musl
- armv7l
- armv7l-musl
- aarch64
- aarch64-musl
