### PR TITLE
qtcreator: enable charts and designer on cross

### DIFF
--- a/srcpkgs/qtcreator/patches/6.0.2--backtrace.patch
+++ b/srcpkgs/qtcreator/patches/6.0.2--backtrace.patch
@@ -1,14 +1,16 @@
-From f178b839d5137f2e8e1e728cbf877f6a3a73346e Mon Sep 17 00:00:00 2001
-From: Piotr Wójcik <chocimier@tlen.pl>
-Date: Sat, 21 Jan 2023 21:29:41 +0100
-Subject: backtrace
-
-
-diff --git a/src/libs/utils/qtcassert.cpp b/src/libs/utils/qtcassert.cpp
-index d371b6f6..40b4cd9b 100644
 --- a/src/libs/utils/qtcassert.cpp
 +++ b/src/libs/utils/qtcassert.cpp
-@@ -29,7 +29,7 @@ void dumpBacktrace(int maxdepth)
+@@ -11,7 +11,9 @@
+ #if defined(Q_OS_UNIX)
+ #include <stdio.h>
+ #include <signal.h>
++#ifdef __GLIBC__
+ #include <execinfo.h>
++#endif
+ #elif defined(_MSC_VER)
+ #ifdef QTCREATOR_PCH_H
+ #define CALLBACK WINAPI
+@@ -29,7 +31,7 @@ void dumpBacktrace(int maxdepth)
      const int ArraySize = 1000;
      if (maxdepth < 0 || maxdepth > ArraySize)
          maxdepth = ArraySize;
@@ -17,10 +19,26 @@ index d371b6f6..40b4cd9b 100644
      void *bt[ArraySize] = {nullptr};
      int size = backtrace(bt, maxdepth);
      char **lines = backtrace_symbols(bt, size);
-diff --git a/src/plugins/qmldesigner/designercore/exceptions/exception.cpp b/src/plugins/qmldesigner/designercore/exceptions/exception.cpp
-index ba8afd56..2ae4041a 100644
 --- a/src/plugins/qmldesigner/libs/designercore/exceptions/exception.cpp
 +++ b/src/plugins/qmldesigner/libs/designercore/exceptions/exception.cpp
+@@ -3,7 +3,7 @@
+ 
+ #include "exception.h"
+ 
+-#ifdef Q_OS_LINUX
++#if defined(Q_OS_LINUX) && defined(__GLIBC__)
+ #include <execinfo.h>
+ #include <cxxabi.h>
+ #endif
+@@ -30,7 +30,7 @@
+ 
+ namespace QmlDesigner {
+ 
+-#ifdef Q_OS_LINUX
++#if defined(Q_OS_LINUX) && defined(__GLIBC__)
+ const char* demangle(const char* name)
+ {
+    char buf[1024];
 @@ -75,7 +75,7 @@ bool Exception::warnAboutException()
      return s_warnAboutException;
  }
@@ -39,6 +57,3 @@ index ba8afd56..2ae4041a 100644
    , m_backTrace(getBackTrace())
    #endif
  {
--- 
-2.39.0
-

--- a/srcpkgs/qtcreator/patches/cross-designer.patch
+++ b/srcpkgs/qtcreator/patches/cross-designer.patch
@@ -1,0 +1,11 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -107,7 +107,7 @@ if (MSVC AND QT_FEATURE_static_runtime)
+ endif()
+ 
+ find_package(Qt6 OPTIONAL_COMPONENTS Quick QuickWidgets Designer DesignerComponentsPrivate
+-                                     Help SerialPort Svg Tools LinguistTools QUIET)
++                                     Help SerialPort Svg Tools Linguist LinguistTools QUIET)
+ 
+ find_package(Threads)
+ find_package(Clang QUIET)

--- a/srcpkgs/qtcreator/template
+++ b/srcpkgs/qtcreator/template
@@ -1,7 +1,7 @@
 # Template file for 'qtcreator'
 pkgname=qtcreator
 version=15.0.0
-revision=1
+revision=2
 build_style=cmake
 configure_args="$(vopt_bool qbs BUILD_QBS) -DWITH_DOCS=ON -DBUILD_WITH_PCH=OFF"
 hostmakedepends="clang llvm perl pkg-config python3 which
@@ -9,8 +9,8 @@ hostmakedepends="clang llvm perl pkg-config python3 which
 makedepends="qt6-declarative-private-devel qt6-base-private-devel
  qt6-quick3d-private-devel qt6-svg-devel qt6-plugin-odbc qt6-plugin-sqlite
  qt6-plugin-pgsql qt6-plugin-mysql qt6-qt5compat-devel libsecret-devel
- qt6-serialport-devel qt6-shadertools-devel
- clang llvm clang-tools-extra"
+ qt6-serialport-devel qt6-shadertools-devel qt6-charts-private-devel
+ qt6-tools-private-devel clang llvm clang-tools-extra"
 depends="qt6-plugin-sqlite mesa-dri"
 short_desc="Cross-platform IDE for Qt developers"
 maintainer="Piotr Wójcik <chocimier@tlen.pl>"
@@ -33,10 +33,6 @@ fi
 
 if [ "$XBPS_WORDSIZE$XBPS_WORDSIZE" = "64$XBPS_TARGET_WORDSIZE" ]; then
 	makedepends+=" qt6-webengine-devel"
-fi
-
-if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
-	makedepends+=" libexecinfo-devel"
 fi
 # broken="with Qt6-6.7.2"
 


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->
Fix #56804 
#### Testing the changes
- I tested the changes in this PR: **YES**|**briefly**|**NO**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
