### PR TITLE
kodi-addon-peripheral-joystick: update to 20.1.0.

### DIFF
--- a/srcpkgs/kodi-addon-peripheral-joystick/template
+++ b/srcpkgs/kodi-addon-peripheral-joystick/template
@@ -1,8 +1,8 @@
 # Template file for 'kodi-addon-peripheral-joystick'
 pkgname=kodi-addon-peripheral-joystick
-version=1.7.1
+version=20.1.0
 revision=2
-_kodi_release="Matrix"
+_kodi_release="Nexus"
 build_style=cmake
 makedepends="kodi-devel kodi-platform-devel p8-platform-devel
  eudev-libudev-devel tinyxml-devel"
@@ -11,7 +11,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="https://github.com/xbmc/peripheral.joystick"
 distfiles="https://github.com/xbmc/peripheral.joystick/archive/${version}-${_kodi_release}.tar.gz"
-checksum=4dc63c6c5bdad25881eeba800765d97c53b2583addf28e71bbcd67775452ecdb
+checksum=cd55ceb9e4a064cd153e90d810d2cb3767ca033e2786066219ed673bc86984be
 
 if [ -n "${CROSS_BUILD}" ]; then
 	configure_args+=" -DCMAKE_MODULE_PATH=${XBPS_CROSS_BASE}/usr/share/kodi/cmake"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc