### PR TITLE
python3-fire: update to 0.7.1

### DIFF
--- a/srcpkgs/python3-fire/template
+++ b/srcpkgs/python3-fire/template
@@ -1,13 +1,14 @@
 # Template file for 'python3-fire'
 pkgname=python3-fire
-version=0.7.0
+version=0.7.1
 revision=1
 build_style=python3-pep517
-hostmakedepends="python3-flit_core python3-wheel"
-depends="python3-six python3-termcolor"
+hostmakedepends="python3-setuptools python3-wheel"
+depends="python3-termcolor"
+checkdepends="${depends} python3-hypothesis python3-Levenshtein python3-pytest"
 short_desc="Library for automatically generating command line interfaces"
 maintainer="Mateusz Sylwestrzak <slymattz@gmail.com>"
 license="Apache-2.0"
 homepage="https://github.com/google/python-fire"
 distfiles="${PYPI_SITE}/f/fire/fire-${version}.tar.gz"
-checksum=961550f07936eaf65ad1dc8360f2b2bf8408fad46abbfa4d2a3794f8d2a95cdf
+checksum=3b208f05c736de98fb343310d090dcc4d8c78b2a89ea4f32b837c586270a9cbf


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**|**briefly**|**NO**
py3-six [obsolete](https://github.com/google/python-fire/pull/541) as of [v. 0.7.0 ](https://github.com/google/python-fire/releases)

#### Local build testing
- I built this PR locally for my native architecture: x86_64-glibc
