### PR TITLE
kde plasma: update to 6.4.4.

### DIFF
--- a/srcpkgs/aurorae/template
+++ b/srcpkgs/aurorae/template
@@ -1,6 +1,6 @@
 # Template file for 'aurorae'
 pkgname=aurorae
-version=6.4.3
+version=6.4.4
 revision=1
 build_style=cmake
 configure_args="-DKDE_INSTALL_QMLDIR=lib/qt6/qml
@@ -14,4 +14,4 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.0-or-later"
 homepage="https://invent.kde.org/plasma/aurorae"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=a53321c98a8181fe5e93cf5c87beaac60918c3280ddd983426306dfae700944f
+checksum=b358a775772052e46b4978c63ad765996ca4600af0db1189260129fd91de6589

--- a/srcpkgs/bluedevil/template
+++ b/srcpkgs/bluedevil/template
@@ -1,6 +1,6 @@
 # Template file for 'bluedevil'
 pkgname=bluedevil
-version=6.4.3
+version=6.4.4
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
@@ -14,4 +14,4 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later, LGPL-2.1-or-later"
 homepage="https://invent.kde.org/plasma/bluedevil"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=2760dbbd3ee785ce493d39f8f6272f479db184076a6e30f1f4646afbd8ca331d
+checksum=7e5d386a7c42a1b4ef00e79469c8f47300944c9c42023647f2efd3a12ecc3175

--- a/srcpkgs/breeze-gtk/template
+++ b/srcpkgs/breeze-gtk/template
@@ -1,6 +1,6 @@
 # Template file for 'breeze-gtk'
 pkgname=breeze-gtk
-version=6.4.3
+version=6.4.4
 revision=1
 build_style=cmake
 hostmakedepends="extra-cmake-modules sassc python3 python3-cairo
@@ -11,4 +11,4 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/plasma/breeze-gtk"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=db91ad2a462596bc715d3091b09e86c79da0060a13c6a0de1b0324ef060ee803
+checksum=b353cb1c5c36cc7493cb2d018b7cc5068fa4772345781f81d5f8108cf54b4e3f

--- a/srcpkgs/breeze-qt5/template
+++ b/srcpkgs/breeze-qt5/template
@@ -1,6 +1,6 @@
 # Template file for 'breeze-qt5'
 pkgname=breeze-qt5
-version=6.4.3
+version=6.4.4
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF -DBUILD_QT6=OFF -DKF5_HOST_TOOLING=/usr/lib/cmake"
@@ -13,7 +13,7 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later"
 homepage="https://invent.kde.org/plasma/breeze"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname%-qt5}-${version}.tar.xz"
-checksum=017a2dadf803a0c2d167489f5ba4d2a0011fc58fcf18c5e76fa6fc22f4844fbf
+checksum=307cfcb5505bd376d959b364f5231cac4a280af938a938ce3a4e3b7a9f71f70d
 replaces="breeze<6.0.0_1"
 
 post_install() {

--- a/srcpkgs/breeze-qt6/template
+++ b/srcpkgs/breeze-qt6/template
@@ -1,6 +1,6 @@
 # Template file for 'breeze-qt6'
 pkgname=breeze-qt6
-version=6.4.3
+version=6.4.4
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF -DBUILD_QT5=OFF
@@ -19,5 +19,5 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later"
 homepage="https://invent.kde.org/plasma/breeze"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname%-qt6}-${version}.tar.xz"
-checksum=017a2dadf803a0c2d167489f5ba4d2a0011fc58fcf18c5e76fa6fc22f4844fbf
+checksum=307cfcb5505bd376d959b364f5231cac4a280af938a938ce3a4e3b7a9f71f70d
 replaces="breeze<6.0.0_1 breeze-snow-cursor-theme>=0"

--- a/srcpkgs/discover/template
+++ b/srcpkgs/discover/template
@@ -1,6 +1,6 @@
 # Template file for 'discover'
 pkgname=discover
-version=6.4.3
+version=6.4.4
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake"
@@ -17,4 +17,4 @@ maintainer="1is7ac3 <isaac.qa13@gmail.com>"
 license="GPL-2.0-or-later"
 homepage="https://apps.kde.org/discover"
 distfiles="${KDE_SITE}/plasma/${version}/discover-${version}.tar.xz"
-checksum=c2dd8238aaa8c801a12c6f29d70f24467bad59209c5fc8fae97cbbbac45dde10
+checksum=baea19fadb3dee8e9516a402aa3bc16f1dd5f4b7dbe46a6ecd0617c508842e96

--- a/srcpkgs/flatpak-kcm/template
+++ b/srcpkgs/flatpak-kcm/template
@@ -1,6 +1,6 @@
 # Template file for 'flatpak-kcm'
 pkgname=flatpak-kcm
-version=6.4.3
+version=6.4.4
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
@@ -14,4 +14,4 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later, LGPL-2.1-or-later"
 homepage="https://invent.kde.org/plasma/flatpak-kcm"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=2b854759fd1125e47061cdad3aa164e3fec8bc101d4b6d3d1fa2d490774d2139
+checksum=b4ac5f4c64e2dcd80b610b1cab42f5d1cc96bbcbc14aa3e366b257407387c8f8

--- a/srcpkgs/kactivitymanagerd/template
+++ b/srcpkgs/kactivitymanagerd/template
@@ -1,6 +1,6 @@
 # Template file for 'kactivitymanagerd'
 pkgname=kactivitymanagerd
-version=6.4.3
+version=6.4.4
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins"
@@ -12,4 +12,4 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later"
 homepage="https://invent.kde.org/plasma/kactivitymanagerd"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=e9eb2b063bfc469d465a8afbdf0ec76a0410ca3f68f7666c50b5012315b6a68b
+checksum=38f24d9529810495db1a2d0f102a89885d22813f131fb6453b79d898bfcbe2a4

--- a/srcpkgs/kcm-wacomtablet/template
+++ b/srcpkgs/kcm-wacomtablet/template
@@ -1,6 +1,6 @@
 # Template file for 'kcm-wacomtablet'
 pkgname=kcm-wacomtablet
-version=6.4.3
+version=6.4.4
 revision=1
 build_style=cmake
 configure_args="-DKF6_HOST_TOOLING=/usr/lib/cmake
@@ -17,7 +17,7 @@ maintainer="Piraty <mail@piraty.dev>"
 license="GPL-2.0-or-later"
 homepage="https://invent.kde.org/plasma/wacomtablet"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname#kcm-}-${version}.tar.xz"
-checksum=353d43f5a9f7ab045c1f018abd54addc638fb094eec5375f1ff6316919033398
+checksum=79c3d6b2ac730de0abec46db272bfcb07a89a382a4981bd3d3ce494d625f5469
 
 do_check() {
 	cd build

--- a/srcpkgs/kde-cli-tools/template
+++ b/srcpkgs/kde-cli-tools/template
@@ -1,6 +1,6 @@
 # Template file for 'kde-cli-tools'
 pkgname=kde-cli-tools
-version=6.4.3
+version=6.4.4
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
@@ -15,7 +15,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later, GPL-2.0-or-later"
 homepage="https://invent.kde.org/plasma/kde-cli-tools"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=d54cc42f8c955ef8322976655a1ed003cca24b42c1a8f517bc1c27ce17af6e28
+checksum=1cd1e21cacc1c73f4a25d5e98f3fbe8425ba8f2faa13e4aad83030cbf21fcf4c
 
 post_install() {
 	ln -sf ../libexec/kf6/kdesu ${DESTDIR}/usr/bin

--- a/srcpkgs/kde-gtk-config/template
+++ b/srcpkgs/kde-gtk-config/template
@@ -1,6 +1,6 @@
 # Template file for 'kde-gtk-config'
 pkgname=kde-gtk-config
-version=6.4.3
+version=6.4.4
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF
@@ -15,7 +15,7 @@ maintainer="Luciogi <githubvoidlinux.supremacy429@passinbox.com>"
 license="GPL-2.0-or-later, LGPL-2.1-or-later"
 homepage="https://invent.kde.org/plasma/kde-gtk-config"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=22f72253bc801bb1757b7d56ab36bb279c1a1255ef888cadc950c5b2559b5912
+checksum=d54957d02240a91393f1a14c3d929ab385954dba9b315ecf54af79445a68e25a
 
 kde-gtk-config5_package() {
 	short_desc+=" - (Dummy transitional package)"

--- a/srcpkgs/kdeplasma-addons/template
+++ b/srcpkgs/kdeplasma-addons/template
@@ -1,7 +1,7 @@
 # Template file for 'kdeplasma-addons'
 pkgname=kdeplasma-addons
-version=6.4.3
-revision=2
+version=6.4.4
+revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
  -DKDE_INSTALL_QMLDIR=lib/qt6/qml -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins"
@@ -19,7 +19,7 @@ maintainer="Luciogi <githubvoidlinux.supremacy429@passinbox.com>"
 license="GPL-2.0-or-later, LGPL-2.1-or-later"
 homepage="https://invent.kde.org/plasma/kdeplasma-addons"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=7dad9176fee99f4e95f6573aab18326eeff6742609e8739b9b59c2e9f2aad19b
+checksum=1561a31c4092d0b697ae95d4fc51b82dec70013114d26e0b69c878f17d65b4f8
 
 if [ "$XBPS_WORDSIZE$XBPS_WORDSIZE" = "64$XBPS_TARGET_WORDSIZE" ]; then
 	makedepends+=" qt6-webengine-devel"

--- a/srcpkgs/kf6-kdecoration/template
+++ b/srcpkgs/kf6-kdecoration/template
@@ -1,6 +1,6 @@
 # Template file for 'kf6-kdecoration'
 pkgname=kf6-kdecoration
-version=6.4.3
+version=6.4.4
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF"
@@ -11,7 +11,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/plasma/kdecoration"
 distfiles="${KDE_SITE}/plasma/${version}/kdecoration-${version}.tar.xz"
-checksum=bd0f99bdf487a859da8b1227e3443259ad28e90f110bd3a7bcecc386fded7824
+checksum=a02ac71ea8ee7ad6ab34578f1b50f32b91347a05a932cfc50b253729ccadee6f
 
 kf6-kdecoration-devel_package() {
 	conflicts="kdecoration-devel>=0"

--- a/srcpkgs/kf6-kwayland/template
+++ b/srcpkgs/kf6-kwayland/template
@@ -1,6 +1,6 @@
 # Template file for 'kf6-kwayland'
 pkgname=kf6-kwayland
-version=6.4.3
+version=6.4.4
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF"
@@ -13,7 +13,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/plasma/kwayland"
 distfiles="${KDE_SITE}/plasma/${version}/kwayland-${version}.tar.xz"
-checksum=ff507d3c435407b3831ead1ea63f6dea6c778ba6a1f5b45895d5fec6f5c1f982
+checksum=f458ae7ed1118e1a2165a37378c8ce0e9fff80d1a4cfe86217f06cf24ca49f9b
 
 kf6-kwayland-devel_package() {
 	short_desc+=" - development"

--- a/srcpkgs/kgamma/template
+++ b/srcpkgs/kgamma/template
@@ -1,6 +1,6 @@
 # Template file for 'kgamma'
 pkgname=kgamma
-version=6.4.3
+version=6.4.4
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
@@ -14,7 +14,7 @@ maintainer="Luciogi <githubvoidlinux.supremacy429@passinbox.com>"
 license="GPL-2.0-or-later"
 homepage="https://invent.kde.org/plasma/kgamma"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=d85f86f6fd9b0173395623b518a4060951c10f7506c561b999818e819b13ec0e
+checksum=1bc752415d4711580f483f774a62d8959583686b93b164484a89d7d5571334a6
 
 kgamma5_package() {
 	metapackage=yes

--- a/srcpkgs/kglobalacceld/template
+++ b/srcpkgs/kglobalacceld/template
@@ -1,6 +1,6 @@
 # Template file for 'kglobalacceld'
 pkgname=kglobalacceld
-version=6.4.3
+version=6.4.4
 revision=1
 build_style=cmake
 configure_args="-DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins"
@@ -13,7 +13,7 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-3.0-or-later"
 homepage="https://invent.kde.org/plasma/kglobalacceld"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=a69c787e1b133ad5e99f3f83d1a195721f27e5200cc60cdba70d8dc03acc4378
+checksum=89f72bbfb520b0dc8dfc6cbc81bdcfcf3b74217551b3ca81d0b96d9d35a09bcf
 
 do_check() {
 	cd build

--- a/srcpkgs/kinfocenter/template
+++ b/srcpkgs/kinfocenter/template
@@ -1,6 +1,6 @@
 # Template file for 'kinfocenter'
 pkgname=kinfocenter
-version=6.4.3
+version=6.4.4
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
@@ -16,4 +16,4 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later, LGPL-2.1-or-later, GFDL-1.2-only"
 homepage="https://invent.kde.org/plasma/kinfocenter"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=4d5f499470772a74b4f229f676feb7aefd12ec2b2d36458b8483d8dca3a48a79
+checksum=27629f287c4361e3f127daac38f01d0abb23355ca6da3822f418b398bf0ea0b1

--- a/srcpkgs/kmenuedit/template
+++ b/srcpkgs/kmenuedit/template
@@ -1,6 +1,6 @@
 # Template file for 'kmenuedit'
 pkgname=kmenuedit
-version=6.4.3
+version=6.4.4
 revision=1
 build_style=cmake
 configure_args="-DKF6_HOST_TOOLING=/usr/lib/cmake"
@@ -14,4 +14,4 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later"
 homepage="https://invent.kde.org/plasma/kmenuedit"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=94fb26effce185240a88f82bbf756a6b3b6f0a2d0556529c4a27a7f62aa79c89
+checksum=2af771dfedc334aaaac0976d66bf9c8c8e830030ad6d2a328b36be44bbc9eec9

--- a/srcpkgs/kpipewire/template
+++ b/srcpkgs/kpipewire/template
@@ -1,6 +1,6 @@
 # Template file for 'kpipewire'
 pkgname=kpipewire
-version=6.4.3
+version=6.4.4
 revision=1
 build_style=cmake
 configure_args="-DKDE_INSTALL_QMLDIR=lib/qt6/qml"
@@ -16,7 +16,7 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-3.0-or-later"
 homepage="https://invent.kde.org/plasma/kpipewire"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=1866d966ce61bb83ed1d45dcc0db1a8ba91971762681368a3357d86438fa9642
+checksum=097f9971580cc7ce3bd89e73ced7606e3978347bd44131d6744fe02d8a1b3ea6
 
 do_check() {
 	cd build

--- a/srcpkgs/krdp/template
+++ b/srcpkgs/krdp/template
@@ -1,6 +1,6 @@
 # Template file for 'krdp'
 pkgname=krdp
-version=6.4.3
+version=6.4.4
 revision=1
 build_style=cmake
 configure_args="-DKF6_HOST_TOOLING=/usr/lib/cmake
@@ -17,4 +17,4 @@ maintainer="Luciogi <githubvoidlinux.supremacy429@passinbox.com>"
 license="LGPL-2.0-or-later"
 homepage="https://invent.kde.org/plasma/krdp"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=b04950393620f14b3520dc676e81632a3188f92e50da84dde33f0081c587b787
+checksum=228d8630ff2e14fa899ad611d1865399f9e6128538f9df91273ab3968f7cec84

--- a/srcpkgs/kscreen/template
+++ b/srcpkgs/kscreen/template
@@ -1,6 +1,6 @@
 # Template file for 'kscreen'
 pkgname=kscreen
-version=6.4.3
+version=6.4.4
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
@@ -17,4 +17,4 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later, LGPL-2.1-or-later"
 homepage="https://invent.kde.org/plasma/kscreen"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=37ef7032a2136293cfeceb41faeff525de80c7119cd8c854116b8b300efa60a9
+checksum=5890d24614ac6f93cc97964f9ca8b1bef95ec14508408dc87f3904d03b3af876

--- a/srcpkgs/kscreenlocker/template
+++ b/srcpkgs/kscreenlocker/template
@@ -1,6 +1,6 @@
 # Template file for 'kscreenlocker'
 pkgname=kscreenlocker
-version=6.4.3
+version=6.4.4
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
@@ -16,7 +16,7 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later"
 homepage="https://invent.kde.org/plasma/kscreenlocker"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=3441174426fd18524ca59fa2246f9ee99c31dec0fd89eaa79705e6a32d1dcac3
+checksum=5cc1dd23be325f1ddcf005556f0ac14077789524aa0b3e1e83b97ff77d4932a8
 
 kscreenlocker-devel_package() {
 	short_desc+=" - development files"

--- a/srcpkgs/ksshaskpass/template
+++ b/srcpkgs/ksshaskpass/template
@@ -1,6 +1,6 @@
 # Template file for 'ksshaskpass'
 pkgname=ksshaskpass
-version=6.4.3
+version=6.4.4
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake"
@@ -12,5 +12,5 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later"
 homepage="https://invent.kde.org/plasma/ksshaskpass"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=965f89a01aa91c07ed5b8aed2be3521f88e98b22e1277846f12440c9760baf10
+checksum=ab47b94b6024fab148c9a7a8f8c4403a81edea96eabbb0d5f805a120fc5df230
 alternatives="ssh-askpass:/usr/libexec/ssh-askpass:/usr/bin/ksshaskpass"

--- a/srcpkgs/ksystemstats/template
+++ b/srcpkgs/ksystemstats/template
@@ -1,6 +1,6 @@
 # Template file for 'ksystemstats'
 pkgname=ksystemstats
-version=6.4.3
+version=6.4.4
 revision=1
 build_style=cmake
 configure_args="-DKDE_INSTALL_QMLDIR=lib/qt6/qml
@@ -13,7 +13,7 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-3.0-only,LGPL-3.0-only"
 homepage="https://invent.kde.org/plasma/ksystemstats"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=0d1bdb518fd723555110f8dc4ed9b509b03b267e40cc2d709587af2c4ce8da0c
+checksum=9a3a74d2cea2077dd87533dc85edfe011b6f6fc2ef1ab0a0a35d550319454667
 
 do_check() {
 	cd build

--- a/srcpkgs/kwallet-pam/template
+++ b/srcpkgs/kwallet-pam/template
@@ -1,6 +1,6 @@
 # Template file for 'kwallet-pam'
 pkgname=kwallet-pam
-version=6.4.3
+version=6.4.4
 revision=1
 build_style=cmake
 hostmakedepends="extra-cmake-modules qt6-base qt6-tools pkg-config"
@@ -11,5 +11,5 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/plasma/kwallet-pam"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=08151ca03e7b8a8e7696927e3aadc3095cf48081748c983798dac35ab5fd0cde
+checksum=e464f9bc73a4db2b593d1b19e1e8aee385d155513e58b6b11470fa78c52efbc1
 conflicts="kwallet<=5.115.0_1"

--- a/srcpkgs/kwayland-integration/template
+++ b/srcpkgs/kwayland-integration/template
@@ -1,6 +1,6 @@
 # Template file for 'kwayland-integration'
 pkgname=kwayland-integration
-version=6.4.3
+version=6.4.4
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins"
@@ -14,4 +14,4 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/plasma/kwayland-integration"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=9baf2134e2d32e9d4d417894fa63911fa94bca86198ef8e16e461d5989b6e2d0
+checksum=d009b0b8f0da57607880f56d48e997b6bcbd414096ad31a4f2cd3bdf77d44869

--- a/srcpkgs/kwin-x11/template
+++ b/srcpkgs/kwin-x11/template
@@ -1,6 +1,6 @@
 # Template file for 'kwin-x11'
 pkgname=kwin-x11
-version=6.4.3
+version=6.4.4
 revision=1
 build_style=cmake
 build_helper=qemu
@@ -21,7 +21,7 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later AND MIT"
 homepage="https://invent.kde.org/plasma/kwin-x11"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=4f2b60193967c24a067b9dda82d59f811f5663f5783d59e03424fc0281ccd188
+checksum=987e207c2f2ab60e51421b5846ca03e69ef875ac20698022f5e8bdd1e1055ed9
 
 kwin-x11-devel_package() {
 	depends="${sourcepkg}>=${version}_${revision}"

--- a/srcpkgs/kwin/template
+++ b/srcpkgs/kwin/template
@@ -1,6 +1,6 @@
 # Template file for 'kwin'
 pkgname=kwin
-version=6.4.3
+version=6.4.4
 revision=1
 build_style=cmake
 build_helper=qemu
@@ -28,7 +28,7 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later"
 homepage="https://invent.kde.org/plasma/kwin"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=a13568c918eca7803eb44a3a2778b860edc3f03b36797851c4f3aeeed4b502a8
+checksum=b0742a12133b052519cb5af09132114ebf4d96b44e320015cc0d2d0bf055dae6
 replaces="kwayland-server>=0"
 
 kwin-devel_package() {

--- a/srcpkgs/kwrited/template
+++ b/srcpkgs/kwrited/template
@@ -1,6 +1,6 @@
 # Template file for 'kwrited'
 pkgname=kwrited
-version=6.4.3
+version=6.4.4
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins"
@@ -11,4 +11,4 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later"
 homepage="https://invent.kde.org/plasma/kwrited"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=fe144b5ed4270cbd45f71187b970e4c4e3e0035c1afc40719b1c862b8adb098b
+checksum=0e15ad25a5d6b0856add87e463607fef209a1184fd13f865e398e8173ec3c351

--- a/srcpkgs/layer-shell-qt/template
+++ b/srcpkgs/layer-shell-qt/template
@@ -1,6 +1,6 @@
 # Template file for 'layer-shell-qt'
 pkgname=layer-shell-qt
-version=6.4.3
+version=6.4.4
 revision=1
 build_style=cmake
 configure_args="-DKDE_INSTALL_QMLDIR=lib/qt6/qml
@@ -14,7 +14,7 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-3.0-or-later"
 homepage="https://invent.kde.org/plasma/layer-shell-qt"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=33e64ec0cd2d9e9547c3c3faa9c4d6a2006bf681fac361511f441b51f9dddb7c
+checksum=84b31a3e73b150fa611fb51150987600eddd0edc578888e953e7fd37f550643d
 
 layer-shell-qt-devel_package() {
 	depends="${sourcepkg}>=${version}_${revision}"

--- a/srcpkgs/libkf6screen/template
+++ b/srcpkgs/libkf6screen/template
@@ -1,6 +1,6 @@
 # Template file for 'libkf6screen'
 pkgname=libkf6screen
-version=6.4.3
+version=6.4.4
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF
@@ -14,7 +14,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/plasma/libkscreen"
 distfiles="${KDE_SITE}/plasma/${version}/libkscreen-${version}.tar.xz"
-checksum=a25f0604110652c847e000ede6fde9f277eb38850edeabde3e3a41d2eb81b06b
+checksum=dc9fee7a8334c24b4f94c33d9f31b093c13cd8fb7de06314e8edfa3a28cab4f6
 
 libkf6screen-devel_package() {
 	short_desc+=" - development"

--- a/srcpkgs/libksysguard/template
+++ b/srcpkgs/libksysguard/template
@@ -1,6 +1,6 @@
 # Template file for 'libksysguard'
 pkgname=libksysguard
-version=6.4.3
+version=6.4.4
 revision=1
 build_style=cmake
 configure_args="-DKF6_HOST_TOOLING=/usr/lib/cmake
@@ -17,7 +17,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/plasma/libksysguard"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=57a353315fd20b0e466ee399d8ec6af9e7b574328311fa8717731267beb732e2
+checksum=f12fd2e11d2d504d57556cb520a442ed9660f59c7d4b1fbbb17bee02eba0fb2f
 
 build_options="webengine"
 

--- a/srcpkgs/libplasma/template
+++ b/srcpkgs/libplasma/template
@@ -1,6 +1,6 @@
 # Template file for 'libplasma'
 pkgname=libplasma
-version=6.4.3
+version=6.4.4
 revision=1
 build_style=cmake
 configure_args="-DKF6_HOST_TOOLING=/usr/lib/cmake
@@ -20,7 +20,7 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-3.0-or-later"
 homepage="https://invent.kde.org/plasma/libplasma"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=f508ceced32a114462e5e31195600ee440a1a21b8eb77ba20033cfb892bb0cc8
+checksum=ab0f4b426829821e0abf479052f326a5ce01c3b604e890c9f79949c3eb5fdebe
 
 do_check() {
 	cd build

--- a/srcpkgs/milou/template
+++ b/srcpkgs/milou/template
@@ -1,6 +1,6 @@
 # Template file for 'milou'
 pkgname=milou
-version=6.4.3
+version=6.4.4
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF -DKDE_INSTALL_QMLDIR=lib/qt6/qml"
@@ -14,4 +14,4 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later, LGPL-2.1-or-later"
 homepage="https://invent.kde.org/plasma/milou"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=d679c95b62aeb8149bd368af1d831fee79ebaaac3ee479da67c450e80fd35ff1
+checksum=a644e5965b33c20f82ce51660fa3b7c2d41810b068cf21f77658824cb3ea6b1e

--- a/srcpkgs/ocean-sound-theme/template
+++ b/srcpkgs/ocean-sound-theme/template
@@ -1,6 +1,6 @@
 # Template file for 'ocean-sound-theme'
 pkgname=ocean-sound-theme
-version=6.4.3
+version=6.4.4
 revision=1
 build_style=cmake
 hostmakedepends="extra-cmake-modules qt6-base"
@@ -10,4 +10,4 @@ maintainer="Rose <rose@pinkro.se>"
 license="CC-BY-SA-4.0"
 homepage="https://invent.kde.org/plasma/ocean-sound-theme"
 distfiles="${KDE_SITE}/plasma/${version}/ocean-sound-theme-${version}.tar.xz"
-checksum=b3f8200026ef4be6023795db3d9aff2e4f86ac75d51fc0233ea269ba65428432
+checksum=ddd87c9021947a5eff06e2f92566b9d81fe06ea444430745e896d647994e37eb

--- a/srcpkgs/oxygen-qt5/template
+++ b/srcpkgs/oxygen-qt5/template
@@ -1,6 +1,6 @@
 # Template file for 'oxygen-qt5'
 pkgname=oxygen-qt5
-version=6.4.3
+version=6.4.4
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF -DBUILD_QT6=OFF"
@@ -14,7 +14,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later, GPL-2.0-or-later"
 homepage="https://invent.kde.org/plasma/oxygen"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname%-qt5}-${version}.tar.xz"
-checksum=7fe55d35db7e1ac019bac85b55d5026dcf99c1f4bbf18e5aef38a75bc01dcf68
+checksum=7f045afa9d321e86fcda814037bbf991fe4cffe34b3cd48c70678db7406f28fb
 
 post_install() {
 	rm -rf ${DESTDIR}/usr/share

--- a/srcpkgs/oxygen-qt6/template
+++ b/srcpkgs/oxygen-qt6/template
@@ -1,6 +1,6 @@
 # Template file for 'oxygen-qt6'
 pkgname=oxygen-qt6
-version=6.4.3
+version=6.4.4
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF -DBUILD_QT5=OFF
@@ -15,4 +15,4 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later, GPL-2.0-or-later"
 homepage="https://invent.kde.org/plasma/oxygen"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname%-qt6}-${version}.tar.xz"
-checksum=7fe55d35db7e1ac019bac85b55d5026dcf99c1f4bbf18e5aef38a75bc01dcf68
+checksum=7f045afa9d321e86fcda814037bbf991fe4cffe34b3cd48c70678db7406f28fb

--- a/srcpkgs/oxygen-sounds/template
+++ b/srcpkgs/oxygen-sounds/template
@@ -1,6 +1,6 @@
 # Template file for 'oxygen-sounds'
 pkgname=oxygen-sounds
-version=6.4.3
+version=6.4.4
 revision=1
 build_style=cmake
 hostmakedepends="extra-cmake-modules"
@@ -9,4 +9,4 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-3.0-or-later"
 homepage="https://invent.kde.org/plasma/oxygen-sounds"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=440566f9a84c9ce90e04b561ab97909838b519c83f7deeb574d05c933baf2e2b
+checksum=511b0d8a7a377677c2c0fd37d8d4d099dafb7fc74c34a2fa1dabbc327c8c5391

--- a/srcpkgs/plasma-activities-stats/template
+++ b/srcpkgs/plasma-activities-stats/template
@@ -1,6 +1,6 @@
 # Template file for 'plasma-activities-stats'
 pkgname=plasma-activities-stats
-version=6.4.3
+version=6.4.4
 revision=1
 build_style=cmake
 hostmakedepends="extra-cmake-modules qt6-base qt6-tools"
@@ -11,7 +11,7 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-3.0-or-later"
 homepage="https://invent.kde.org/plasma/plasma-activities-stats"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=991002e3da9b5969b9583cd169050a23aacbe02f2d7d4ab1a19f5bd7c72b3b6b
+checksum=dd43899617b0cc0e927a13bfb88146b761f7390c1fba568e2e4522f07f0f5901
 
 plasma-activities-stats-devel_package() {
 	depends="${sourcepkg}>=${version}_${revision}"

--- a/srcpkgs/plasma-activities/template
+++ b/srcpkgs/plasma-activities/template
@@ -1,6 +1,6 @@
 # Template file for 'plasma-activities'
 pkgname=plasma-activities
-version=6.4.3
+version=6.4.4
 revision=1
 build_style=cmake
 configure_args="-DKDE_INSTALL_QMLDIR=lib/qt6/qml
@@ -15,7 +15,7 @@ maintainer="John <me@johnnynator.dev>"
 license="(LGPL-2.1-only OR LGPL-3.0-only) AND GPL-2.0-or-later"
 homepage="https://invent.kde.org/plasma/plasma-activities"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=1c8dca746602defacd495b9ae637c1700d3be7e7e3cc5d499a5fd669a0b98ef0
+checksum=ab810aa594ed3386f6a8564705ea2a46cc62ec367de2039625e030f6af955fe8
 
 plasma-activities-devel_package() {
 	depends="${sourcepkg}>=${version}_${revision}"

--- a/srcpkgs/plasma-browser-integration/template
+++ b/srcpkgs/plasma-browser-integration/template
@@ -1,6 +1,6 @@
 # Template file for 'plasma-browser-integration'
 pkgname=plasma-browser-integration
-version=6.4.3
+version=6.4.4
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF
@@ -15,4 +15,4 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-3.0-or-later"
 homepage="https://invent.kde.org/plasma/plasma-browser-integration"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=58cce717ab4ec3ae9418be05e867c2c83d23286d1dc68f2650cea18b3179abcb
+checksum=efdd5b9bf1acfbe16edcb31b029c7f91b20616598bbfc6a0959fefd698b638cf

--- a/srcpkgs/plasma-desktop/template
+++ b/srcpkgs/plasma-desktop/template
@@ -1,6 +1,6 @@
 # Template file for 'plasma-desktop'
 pkgname=plasma-desktop
-version=6.4.3
+version=6.4.4
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF
@@ -31,6 +31,6 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later, LGPL-2.0-or-later, LGPL-2.1-or-later, GFDL-1.2-or-later"
 homepage="https://invent.kde.org/plasma/plasma-desktop"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=190a3f558f6b3fa92164c3f269e70ffd1e981e352dd718a43a4cb007245aa525
+checksum=4d70b9bf99f59b3bdea7b8240a0b7df803bd16c0ae9cc534ca3617a9f9c54013
 replaces="user-manager>=0"
 python_version=3

--- a/srcpkgs/plasma-disks/template
+++ b/srcpkgs/plasma-disks/template
@@ -1,6 +1,6 @@
 # Template file for 'plasma-disks'
 pkgname=plasma-disks
-version=6.4.3
+version=6.4.4
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake -Wno-dev
@@ -16,4 +16,4 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later"
 homepage="https://invent.kde.org/plasma/plasma-disks"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=bd6e63475642afe7222862d72d454cd9ca6c7f391f481c2b145c2ab79346c213
+checksum=38f984261fb84b03e7c37ddf8b5fb9cb34644e714a6b547c14771aa5458bfaa0

--- a/srcpkgs/plasma-firewall/template
+++ b/srcpkgs/plasma-firewall/template
@@ -1,6 +1,6 @@
 # Template file for 'plasma-firewall'
 pkgname=plasma-firewall
-version=6.4.3
+version=6.4.4
 revision=1
 build_style=cmake
 configure_args="-DKF6_HOST_TOOLING=/usr/lib/cmake
@@ -14,4 +14,4 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-only, GPL-3.0-only"
 homepage="https://invent.kde.org/network/plasma-firewall"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=bc780047b6566ab1238275b02c120e2a7454222cb45c47fcb29600308683c68c
+checksum=6b7b29043d8b0979da99f92ed7f9db9074b8da42d025c3ed497f2df862898842

--- a/srcpkgs/plasma-integration/template
+++ b/srcpkgs/plasma-integration/template
@@ -1,6 +1,6 @@
 # Template file for 'plasma-integration'
 pkgname=plasma-integration
-version=6.4.3
+version=6.4.4
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF -DBUILD_QT5=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
@@ -16,4 +16,4 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.0-or-later"
 homepage="https://invent.kde.org/plasma/plasma-integration"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=71f3e643d7b7f33fc2e473850424dcfb00c3258d7fe2e271a032621333288bd7
+checksum=0d384ff9528d7fe7fd474d01008b256806e0c6cf0e79ccc81f34a08dbc449b2f

--- a/srcpkgs/plasma-nm/template
+++ b/srcpkgs/plasma-nm/template
@@ -1,6 +1,6 @@
 # Template file for 'plasma-nm'
 pkgname=plasma-nm
-version=6.4.3
+version=6.4.4
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
@@ -19,7 +19,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/plasma/plasma-nm"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=67c38e3c0a54e90ae1237991142b9206463d43c2ead8edf5dd5bb7a16a46a13e
+checksum=850638d1f4cc3b0a1012f049af5e1203ef57a1ef1fc21e5082c82bdf13bcb657
 
 build_options="openconnect"
 

--- a/srcpkgs/plasma-pa/template
+++ b/srcpkgs/plasma-pa/template
@@ -1,6 +1,6 @@
 # Template file for 'plasma-pa'
 pkgname=plasma-pa
-version=6.4.3
+version=6.4.4
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake -Wno-dev
@@ -18,4 +18,4 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/plasma/plasma-pa"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=6b0e3d3ab469cf86fc18d211fcbf41251aa33a3014a32b77ec41905fd2fa4e21
+checksum=2e18bb284a1cba07e43b19ae7a192b574aaef94bc635d751d1eb21fcd569ca8a

--- a/srcpkgs/plasma-sdk/template
+++ b/srcpkgs/plasma-sdk/template
@@ -1,6 +1,6 @@
 # Template file for 'plasma-sdk'
 pkgname=plasma-sdk
-version=6.4.3
+version=6.4.4
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
@@ -15,4 +15,4 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later, LGPL-2.1-or-later"
 homepage="https://invent.kde.org/plasma/plasma-sdk"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=9b7ce36459b3f2cd91bbe0941ada3ebb38eff0149939c59dab2d0b0d3928c064
+checksum=f10c7aec9f2a26b6f8a04d3ea1e11e8851baf3918fd93a1b7cef07f935a4096c

--- a/srcpkgs/plasma-systemmonitor/template
+++ b/srcpkgs/plasma-systemmonitor/template
@@ -1,6 +1,6 @@
 # Template file for 'plasma-systemmonitor'
 pkgname=plasma-systemmonitor
-version=6.4.3
+version=6.4.4
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
@@ -17,7 +17,7 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-only, GPL-3.0-only, LGPL-2.1-only, LGPL-3.0-only"
 homepage="https://invent.kde.org/plasma/plasma-systemmonitor"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=6856e399265526332ee9389fbcf819d3d07a0ea2ed4567d545ae088e4895d230
+checksum=c9d4a27ef93f1ec29a9b181c56dbf16ce81aa1a6ad30c837ff987c3552888e78
 
 ksysguard_package() {
 	metapackage=yes

--- a/srcpkgs/plasma-thunderbolt/template
+++ b/srcpkgs/plasma-thunderbolt/template
@@ -1,6 +1,6 @@
 # Template file for 'plasma-thunderbolt'
 pkgname=plasma-thunderbolt
-version=6.4.3
+version=6.4.4
 revision=1
 build_style=cmake
 configure_args="-DKF6_HOST_TOOLING=/usr/lib/cmake
@@ -14,7 +14,7 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-3.0-or-later"
 homepage="https://invent.kde.org/plasma/plasma-thunderbolt"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=6989f9d61aa8b4fa21da23de00b23164ed15375986d27160191a90b5ac133f52
+checksum=d1387fb93834decfb27c716e562de4af6b0a9367d2729f413226884227a539e6
 
 do_check() {
 	: # Requires running dbus and bolt services

--- a/srcpkgs/plasma-vault/template
+++ b/srcpkgs/plasma-vault/template
@@ -1,6 +1,6 @@
 # Template file for 'plasma-vault'
 pkgname=plasma-vault
-version=6.4.3
+version=6.4.4
 revision=1
 build_style=cmake
 configure_args="-DKF6_HOST_TOOLING=/usr/lib/cmake
@@ -15,4 +15,4 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later, LGPL-2.0-or-later, LGPL-2.1-or-later"
 homepage="https://github.com/KDE/plasma-vault"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=b9790e1c6606505043cd0c5f58960fe5de1d1a04f539ace3b986d96d47034ec7
+checksum=2d843b1e37cb41b099c74142ad0d746942fdb447186d3e372ca6b7a3b051bc81

--- a/srcpkgs/plasma-workspace-wallpapers/template
+++ b/srcpkgs/plasma-workspace-wallpapers/template
@@ -1,6 +1,6 @@
 # Template file for 'plasma-workspace-wallpapers'
 pkgname=plasma-workspace-wallpapers
-version=6.4.3
+version=6.4.4
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF"
@@ -10,4 +10,4 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later"
 homepage="https://invent.kde.org/plasma/plasma-workspace-wallpapers"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=f5d21dabb54edb4483b578a1a7e7e82f0e71fcad974bef24412134d4d43ac9c4
+checksum=e203932d6d21f3509e7033af051c4aedc939b364f39210c9b2aa98f4fcca3b29

--- a/srcpkgs/plasma-workspace/template
+++ b/srcpkgs/plasma-workspace/template
@@ -1,6 +1,6 @@
 # Template file for 'plasma-workspace'
 pkgname=plasma-workspace
-version=6.4.3
+version=6.4.4
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF -DKDE_INSTALL_QMLDIR=lib/qt6/qml
@@ -31,7 +31,7 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later, GFDL-1.2-or-later, LGPL-2.1-or-later"
 homepage="https://invent.kde.org/plasma/plasma-workspace"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=7254f285a91ec802b0612a7adb242d98362accdff866fc1285bb65b8048dedb8
+checksum=de53b4eef688b59b7c56090485d41e7f8be3d3b99f1cf1358a7d3f4da9eebcb2
 
 if [ "$XBPS_TARGET_LIBC" = "glibc" ]; then
 	makedepends+=" libxcrypt-devel"

--- a/srcpkgs/plasma5support/template
+++ b/srcpkgs/plasma5support/template
@@ -1,6 +1,6 @@
 # Template file for 'plasma5support'
 pkgname=plasma5support
-version=6.4.3
+version=6.4.4
 revision=1
 build_style=cmake
 configure_args="-DKDE_INSTALL_QMLDIR=lib/qt6/qml
@@ -15,7 +15,7 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-3.0-or-later"
 homepage="https://invent.kde.org/plasma/plasma5support"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=1e89a8935d18d98a8fcbe02ff3477489385bb42a804e543bbb24f043f5cd8cf6
+checksum=066c0456149bacad6dfd99eb36783fb61f1918df91b9d70ff4aeac56e3d43bf5
 
 do_check() {
 	cd build

--- a/srcpkgs/polkit-kde-agent/template
+++ b/srcpkgs/polkit-kde-agent/template
@@ -1,6 +1,6 @@
 # Template file for 'polkit-kde-agent'
 pkgname=polkit-kde-agent
-version=6.4.3
+version=6.4.4
 revision=1
 build_style=cmake
 hostmakedepends="extra-cmake-modules qt6-base qt6-tools gettext"
@@ -11,4 +11,4 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later"
 homepage="https://commits.kde.org/polkit-kde-agent"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-1-${version}.tar.xz"
-checksum=22731b0fa02e9fdcbd5926a3c5386100f20acd7a0263967216579b08445682e7
+checksum=2c218f4e66f5f933b9cdd0c6886f53625a2bf7f1c8df64bb485835ae72877e3d

--- a/srcpkgs/powerdevil/template
+++ b/srcpkgs/powerdevil/template
@@ -1,6 +1,6 @@
 # Template file for 'powerdevil'
 pkgname=powerdevil
-version=6.4.3
+version=6.4.4
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
@@ -18,4 +18,4 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later"
 homepage="https://invent.kde.org/plasma/powerdevil"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=c247d0c414905de09f1c0133028481fb0f1ecfa26d89372acefaffab15052bd6
+checksum=caaf0b4dc6547c9490f499f46ba3cde750d8f4d393776a1fff652b1be9810028

--- a/srcpkgs/print-manager/template
+++ b/srcpkgs/print-manager/template
@@ -1,7 +1,7 @@
 # Template file for 'print-manager'
 pkgname=print-manager
 reverts="23.08.5_1 22.12.1_1 22.04.1_1 21.12.3_1 21.12.2_1 21.08.0_1 20.12.2_1"
-version=6.4.3
+version=6.4.4
 revision=1
 build_style=cmake
 configure_args="-DKF6_HOST_TOOLING=/usr/lib/cmake
@@ -17,4 +17,4 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="https://invent.kde.org/plasma/print-manager"
 distfiles="${KDE_SITE}/plasma/${version}/print-manager-${version}.tar.xz"
-checksum=fdfd7fe3686d937e75c28a4cb901b93f4fa289677ef2eca94a50d83553a32d34
+checksum=23daaa8a939bdb89047576f9e24461a3d16efd8a4556e4d1f0ece576dc2ef79f

--- a/srcpkgs/sddm-kcm/template
+++ b/srcpkgs/sddm-kcm/template
@@ -1,6 +1,6 @@
 # Template file for 'sddm-kcm'
 pkgname=sddm-kcm
-version=6.4.3
+version=6.4.4
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
@@ -15,4 +15,4 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later"
 homepage="https://invent.kde.org/plasma/sddm-kcm"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=5314123ac55388f7015621639b8d8367cc829ecef25356889298d6be548f8cf6
+checksum=83366c4d58042d1c0993d8e3197c19c33a7eedccde642263a26812b5c4b16bfb

--- a/srcpkgs/spectacle/template
+++ b/srcpkgs/spectacle/template
@@ -1,7 +1,7 @@
 # Template file for 'spectacle'
 pkgname=spectacle
 reverts="24.12.1_1 24.12.0_1 24.08.1_2 24.08.1_1 24.08.0_1 24.05.0_4 24.05.0_3 24.05.0_2 24.05.0_2 24.05.0_2 24.05.0_1 24.02.2_1 23.08.5_1 23.08.4_1 23.08.3_1 23.08.2_1 23.08.0_1 23.04.2_1 23.04.0_1 22.12.1_1 22.08.2_1 22.08.1_1 22.04.3_1 22.04.1_1 21.12.3_1 21.12.2_1 21.12.1_1 21.12.0_1 21.08.3_1 21.08.2_1 21.08.1_1 21.08.0_1 21.04.3_1 21.04.2_1 21.04.1_1 21.04.0_1 20.12.3_1 20.12.2_1 20.12.1_1 20.12.0_1 20.08.3_1 20.08.2_1 20.08.1_1 20.08.0_1 20.04.3_1 20.04.2_1 20.04.2_1 20.04.1_1 20.04.0_1"
-version=6.4.3
+version=6.4.4
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake"
@@ -18,4 +18,4 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.0-or-later, GPL-2.0-or-later"
 homepage="https://apps.kde.org/spectacle/"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=9986fc091f913a3f0e1520bd8b3a33e9c174e03f48b4b2af3192bd8a31bb29d8
+checksum=9108a739c1acc43b23e0a6aa17ba4194a564ab1548c6887328c76a073bf3d373

--- a/srcpkgs/systemsettings/template
+++ b/srcpkgs/systemsettings/template
@@ -1,6 +1,6 @@
 # Template file for 'systemsettings'
 pkgname=systemsettings
-version=6.4.3
+version=6.4.4
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
@@ -15,4 +15,4 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later, GFDL-1.2-only"
 homepage="https://invent.kde.org/plasma/systemsettings"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=cc1cdcd710f3f5fd242486edca94d7193d45db417803ed629ac7627eb2305556
+checksum=6b14788bf19397f58f0231cb9ccd57c3218ca71afd2d9f1c745581e13fa57748

--- a/srcpkgs/xdg-desktop-portal-kde/template
+++ b/srcpkgs/xdg-desktop-portal-kde/template
@@ -1,6 +1,6 @@
 # Template file for 'xdg-desktop-portal-kde'
 pkgname=xdg-desktop-portal-kde
-version=6.4.3
+version=6.4.4
 revision=1
 build_style=cmake
 configure_args="-DWaylandScanner_EXECUTABLE=/usr/bin/wayland-scanner"
@@ -17,7 +17,7 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-3.0-or-later"
 homepage="https://invent.kde.org/plasma/xdg-desktop-portal-kde"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=3fec71e005abe83b3d593a74bc3304c178d605883fe3b77f915c64cf45c1fc27
+checksum=dcd501b11a785c0b0f0b30bf1d09ba120d83885276841c47feed51d77e1440a5
 
 do_check() {
 	cd build


### PR DESCRIPTION
- **aurorae: update to 6.4.4.**
- **bluedevil: update to 6.4.4.**
- **breeze-gtk: update to 6.4.4.**
- **breeze-qt5: update to 6.4.4.**
- **breeze-qt6: update to 6.4.4.**
- **discover: update to 6.4.4.**
- **flatpak-kcm: update to 6.4.4.**
- **kactivitymanagerd: update to 6.4.4.**
- **kcm-wacomtablet: update to 6.4.4.**
- **kde-cli-tools: update to 6.4.4.**
- **kde-gtk-config: update to 6.4.4.**
- **kdeplasma-addons: update to 6.4.4.**
- **kf6-kdecoration: update to 6.4.4.**
- **kf6-kwayland: update to 6.4.4.**
- **kgamma: update to 6.4.4.**
- **kglobalacceld: update to 6.4.4.**
- **kinfocenter: update to 6.4.4.**
- **kmenuedit: update to 6.4.4.**
- **kpipewire: update to 6.4.4.**
- **krdp: update to 6.4.4.**
- **kscreen: update to 6.4.4.**
- **kscreenlocker: update to 6.4.4.**
- **ksshaskpass: update to 6.4.4.**
- **ksystemstats: update to 6.4.4.**
- **kwallet-pam: update to 6.4.4.**
- **kwayland-integration: update to 6.4.4.**
- **kwin-x11: update to 6.4.4.**
- **kwin: update to 6.4.4.**
- **kwrited: update to 6.4.4.**
- **layer-shell-qt: update to 6.4.4.**
- **libkf6screen: update to 6.4.4.**
- **libksysguard: update to 6.4.4.**
- **libplasma: update to 6.4.4.**
- **milou: update to 6.4.4.**
- **ocean-sound-theme: update to 6.4.4.**
- **oxygen-qt5: update to 6.4.4.**
- **oxygen-qt6: update to 6.4.4.**
- **oxygen-sounds: update to 6.4.4.**
- **plasma-activities-stats: update to 6.4.4.**
- **plasma-activities: update to 6.4.4.**
- **plasma-browser-integration: update to 6.4.4.**
- **plasma-desktop: update to 6.4.4.**
- **plasma-disks: update to 6.4.4.**
- **plasma-firewall: update to 6.4.4.**
- **plasma-integration: update to 6.4.4.**
- **plasma-nm: update to 6.4.4.**
- **plasma-pa: update to 6.4.4.**
- **plasma-sdk: update to 6.4.4.**
- **plasma-systemmonitor: update to 6.4.4.**
- **plasma-thunderbolt: update to 6.4.4.**
- **plasma-vault: update to 6.4.4.**
- **plasma-workspace-wallpapers: update to 6.4.4.**
- **plasma-workspace: update to 6.4.4.**
- **plasma5support: update to 6.4.4.**
- **polkit-kde-agent: update to 6.4.4.**
- **powerdevil: update to 6.4.4.**
- **print-manager: update to 6.4.4.**
- **sddm-kcm: update to 6.4.4.**
- **spectacle: update to 6.4.4.**
- **systemsettings: update to 6.4.4.**
- **xdg-desktop-portal-kde: update to 6.4.4.**

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**|**briefly**|**NO**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
