### PR TITLE
etckeeper: update to 1.18.23

### DIFF
--- a/srcpkgs/etckeeper/template
+++ b/srcpkgs/etckeeper/template
@@ -1,7 +1,7 @@
 # Template file for 'etckeeper'
 pkgname=etckeeper
-version=1.18.21
-revision=2
+version=1.18.23
+revision=1
 build_style=gnu-makefile
 conf_files="/etc/etckeeper/etckeeper.conf"
 make_check_target=test
@@ -13,7 +13,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="https://etckeeper.branchable.com"
 distfiles="https://git.joeyh.name/index.cgi/etckeeper.git/snapshot/${pkgname}-${version}.tar.gz"
-checksum=a87c5e9c847c29f761da933c1cd907779545c7ddf92fb75de8ef692b90fc9e5d
+checksum=cfd068f1f7ae64702747e4ea77e089168743c8b889b941577eac8fc67c232e8c
 
 pre_install() {
 	sed -ni '/systemddir/!p' Makefile


### PR DESCRIPTION
This new release fixes a bug when used with xbps, where an error message would be produced by 'etckeeper post-install' after installing a package

Changelog: https://etckeeper.branchable.com/news/version_1.18.23/

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - armv6l
  - armv7l
