### PR TITLE
libidn2: update to 2.3.8

### DIFF
--- a/srcpkgs/libidn2/template
+++ b/srcpkgs/libidn2/template
@@ -1,6 +1,6 @@
 # Template file for 'libidn2'
 pkgname=libidn2
-version=2.3.4
+version=2.3.8
 revision=1
 build_style=gnu-configure
 hostmakedepends="gettext-devel libtool pkg-config gtk-doc"
@@ -11,7 +11,7 @@ license="GPL-3.0-or-later, LGPL-3.0-or-later"
 homepage="https://www.gnu.org/software/libidn/#libidn2"
 changelog="https://gitlab.com/libidn/libidn2/-/raw/master/NEWS"
 distfiles="${GNU_SITE}/libidn/libidn2-${version}.tar.gz"
-checksum=93caba72b4e051d1f8d4f5a076ab63c99b77faee019b72b9783b267986dbb45f
+checksum=f557911bf6171621e1f72ff35f5b1825bb35b52ed45325dcdee931e5d3c0787a
 
 libidn2-devel_package() {
 	depends="${sourcepkg}>=${version}_${revision}"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**
- `chrony` `curl` and `dnsmasq` are still working as expected after the update

#### Local build testing
- I built this PR locally for my native architecture, (**x86_64-glibc**)

cc @Gottox 
