### PR TITLE
New package: python3-langdetect-1.0.9

### DIFF
--- a/srcpkgs/python3-langdetect/template
+++ b/srcpkgs/python3-langdetect/template
@@ -1,0 +1,14 @@
+# Template file for 'python3-langdetect'
+pkgname=python3-langdetect
+version=1.0.9
+revision=1
+build_style=python3-module
+hostmakedepends="python3-setuptools"
+depends="python3-six"
+checkdepends="python3-pytest"
+short_desc="Port of Google's language-detection library to Python"
+maintainer="dito cujo <git@cujo.casa>"
+license="Apache-2.0"
+homepage="https://github.com/Mimino666/langdetect"
+distfiles="${PYPI_SITE}/l/langdetect/langdetect-${version}.tar.gz"
+checksum=cbc1fef89f8d062739774bd51eda3da3274006b3661d199c2655f6b3f6d605a0


### PR DESCRIPTION
This package is necessary for the proper functioning of optional features offered by the `beets` package, specifically the `lyrics` plugin. Any necessary feedback is of course most welcomed.

#### Testing the changes
- I tested the changes in this PR: **YES**|**briefly**|**NO**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
