### PR TITLE
New package: subtile-ocr-0.2.6, tesseract-ocr: update to 5.5.1

### DIFF
--- a/srcpkgs/subtile-ocr/template
+++ b/srcpkgs/subtile-ocr/template
@@ -1,0 +1,14 @@
+# Template file for 'subtile-ocr'
+pkgname=subtile-ocr
+version=0.2.6
+revision=1
+build_style=cargo
+hostmakedepends="pkg-config clang19-devel"
+makedepends="leptonica-devel tesseract-ocr-devel"
+short_desc="Blazingly fast and accurate DVD VobSub to SRT subtitle conversion tool"
+maintainer="Mateusz Sylwestrzak <slymattz@gmail.com>"
+license="GPL-3.0-or-later"
+homepage="https://github.com/gwen-lg/subtile-ocr"
+changelog="https://raw.githubusercontent.com/gwen-lg/subtile-ocr/refs/heads/main/CHANGELOG.md"
+distfiles="https://github.com/gwen-lg/subtile-ocr/archive/refs/tags/v${version}.tar.gz"
+checksum=bfbb4e06e62168e36b99b7610acc3b30593e8f58855a7d8e7366778c36b8330e

--- a/srcpkgs/tesseract-ocr/template
+++ b/srcpkgs/tesseract-ocr/template
@@ -1,7 +1,7 @@
 # Template file for 'tesseract-ocr'
 pkgname=tesseract-ocr
-version=5.5.0
-revision=2
+version=5.5.1
+revision=1
 _tessdataver=4.1.0
 create_wrksrc=yes
 build_style=gnu-configure
@@ -17,7 +17,7 @@ homepage="https://github.com/tesseract-ocr/tesseract"
 distfiles="
  https://github.com/tesseract-ocr/tesseract/archive/${version}.tar.gz>${pkgname}-${version}.tar.gz
  https://github.com/tesseract-ocr/tessdata/archive/${_tessdataver}.tar.gz>tessdata-${_tessdataver}.tar.gz"
-checksum="f2fb34ca035b6d087a42875a35a7a5c4155fa9979c6132365b1e5a28ebc3fc11
+checksum="a7a3f2a7420cb6a6a94d80c24163e183cf1d2f1bed2df3bbc397c81808a57237
  990fffb9b7a9b52dc9a2d053a9ef6852ca2b72bd8dfb22988b0b990a700fd3c7"
 
 build_options="openmp"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

#### Local build testing
- I built this PR locally for my native architecture: x86_64-glibc

EDIT [WIP]: I'm looking into the cross-build failures.
EDIT2: OK, fixed.