### PR TITLE
ffmpeg6: add '--enable-libsoxr'

### DIFF
--- a/srcpkgs/ffmpeg6/template
+++ b/srcpkgs/ffmpeg6/template
@@ -2,11 +2,11 @@
 # audacity also needs to be bumped when a new ffmpeg version bumps libavformat's soname!
 pkgname=ffmpeg6
 version=6.1.3
-revision=1
+revision=2
 hostmakedepends="pkg-config perl"
 makedepends="zlib-devel bzip2-devel freetype-devel alsa-lib-devel libXfixes-devel
  libXext-devel libXvMC-devel libxcb-devel lame-devel libtheora-devel
- libvorbis-devel x264-devel xvidcore-devel jack-devel SDL2-devel
+ libvorbis-devel x264-devel xvidcore-devel jack-devel SDL2-devel libsoxr-devel
  libcdio-paranoia-devel librtmp-devel libopenmpt-devel gnutls-devel
  speex-devel celt-devel harfbuzz-devel libass-devel opus-devel ocl-icd-devel
  libbs2b-devel libvidstab-devel vmaf-devel libbluray-devel pulseaudio-devel
@@ -92,7 +92,7 @@ do_configure() {
 		--enable-libspeex --enable-libcelt --enable-libass \
 		--enable-libopus --enable-librtmp --enable-libjack \
 		--disable-libopencore_amrnb --disable-libopencore_amrwb \
-		--disable-libopenjpeg --enable-libbluray \
+		--disable-libopenjpeg --enable-libbluray --enable-libsoxr \
 		--enable-postproc --enable-opencl --enable-libvmaf ${_args} \
 		--enable-libx265 --enable-libv4l2 --enable-libaom \
 		--enable-libbs2b --enable-libvidstab --enable-libdav1d \


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)

Hi. Adding `-enable-libsoxr` is a nice addition. Most ffmpeg pkgs come with it on other distros and most "Tonmeisters" use sox because there's no reason not to  ( :smile: ) 

How are you feeling about adding it to the build?

Thanks!
