### PR TITLE
eid-mw: update to 5.1.24

### DIFF
--- a/srcpkgs/eid-mw/template
+++ b/srcpkgs/eid-mw/template
@@ -1,7 +1,7 @@
 # Template file for 'eid-mw'
 pkgname=eid-mw
-version=5.0.23
-revision=2
+version=5.1.24
+revision=1
 build_style=gnu-configure
 hostmakedepends="pkg-config automake gettext gettext-devel libtool glib-devel
  gdk-pixbuf-devel libassuan-devel autoconf-archive"
@@ -12,8 +12,8 @@ short_desc="Middleware for Belgian eID"
 maintainer="Andrew Benson <abenson+void@gmail.com>"
 license="LGPL-3.0-or-later"
 homepage="https://eid.belgium.be/en"
-distfiles="https://github.com/Fedict/eid-mw/archive/v${version}.tar.gz"
-checksum=ea33f974ac203414cffb1e65378407e5e17f4cfafc10191727d1e2fcae6735f6
+distfiles="https://github.com/Fedict/eid-mw/archive/refs/tags/v${version}.tar.gz"
+checksum=ddd6e96fede0b0f1e8762d7af5bfbda443f950aac642a4eaa439555a546ad49a
 
 if [ "$XBPS_TARGET_LIBC" = "glibc" ]; then
 	makedepends+=" libbsd-devel"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture:
  - x86_64
  - aarch64-musl
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - i686 (crossbuild)
