### PR TITLE
connman: drop wpa_supplicant dependency

### DIFF
--- a/srcpkgs/connman/INSTALL.msg
+++ b/srcpkgs/connman/INSTALL.msg
@@ -1,3 +1,3 @@
-ConnMan's dependency on 'wpa_supplicant' will be removed in a future
-version. If you would like to keep using 'wpa_supplicant' as a Wi-Fi
-backend, please manually install it.
+ConnMan's dependency on 'wpa_supplicant' HAS BEEN REMOVED.
+If you would like to keep using 'wpa_supplicant' as a Wi-Fi
+backend, please install it MANUALLY.

--- a/srcpkgs/connman/template
+++ b/srcpkgs/connman/template
@@ -1,7 +1,7 @@
 # Template file for 'connman'
 pkgname=connman
 version=1.45
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--enable-polkit --enable-client --enable-pie --enable-ethernet
  --enable-wifi --enable-bluetooth --enable-loopback --enable-nmcompat
@@ -11,7 +11,7 @@ configure_args="--enable-polkit --enable-client --enable-pie --enable-ethernet
 hostmakedepends="automake iptables libtool pkg-config"
 makedepends="gnutls-devel iptables-devel libglib-devel libmnl-devel
  openconnect-devel readline-devel"
-depends="dbus wpa_supplicant"
+depends="dbus"
 short_desc="Open Source CONNection MANager"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-only"


### PR DESCRIPTION
Resolves #56953

#### Testing the changes
- I tested the changes in this PR: **YES**
- To be clear, I'm not using `connman` myself - I just tested the changes in _this_ PR

#### Local build testing
- I built this PR locally for my native architecture, (**x86_64-glibc**)
