### PR TITLE
qtractor: update to 1.5.8

### DIFF
--- a/srcpkgs/qtractor/template
+++ b/srcpkgs/qtractor/template
@@ -1,6 +1,6 @@
 # Template file for 'qtractor'
 pkgname=qtractor
-version=1.5.7
+version=1.5.8
 revision=1
 _clap_tag=1.2.6
 _vst3sdk_tag=3.7.14_build_55
@@ -24,7 +24,7 @@ distfiles="https://github.com/rncbc/qtractor/archive/refs/tags/v${version}.tar.g
  https://github.com/steinbergmedia/vst3_base/archive/refs/tags/v${_vst3sdk_tag}.tar.gz>vst3_base-v${_vst3sdk_tag}.tar.gz
  https://github.com/steinbergmedia/vst3_pluginterfaces/archive/refs/tags/v${_vst3sdk_tag}.tar.gz>vst3_pluginterfaces-v${_vst3sdk_tag}.tar.gz
  https://github.com/steinbergmedia/vst3_public_sdk/archive/refs/tags/v${_vst3sdk_tag}.tar.gz>vst3_public_sdk-v${_vst3sdk_tag}.tar.gz"
-checksum="6c2f2790efcb788bee8f6293200e15d122f1d4dc246abe0c0393abb9aa5aa787
+checksum="cf0609666ed1a26f0e6deb0631ac29f1a56eaee6612900e2bca9eaa40e12a27a
  6548b5831ad9e92551c752753e535b18fead4001165ef1df8e643efefa7133b7
  657d8b0b8541e3835e73f63158b34b7fecd9a99703d132bcd5462568c90a8dd8
  84e5b334421c478a2cef3b4bd4484cbfe1c881b200a3fe409ddd2a2a1efeac02


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**
<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
