### PR TITLE
New package: input-remapper-2.1.1

### DIFF
--- a/srcpkgs/input-remapper/template
+++ b/srcpkgs/input-remapper/template
@@ -1,0 +1,15 @@
+# Template file for 'input-remapper'
+pkgname=input-remapper
+version=2.1.1
+revision=1
+build_style=python3-module
+hostmakedepends="python3-setuptools gettext"
+makedepends="python3-devel"
+depends="python3-evdev gtksourceview4 python3-gobject python3-pydantic python3-pydbus python3-psutil
+	python3-setuptools"
+short_desc="Tool to modify input device behavior and remap inputs"
+maintainer="Rutpiv <roger_freitas@live.com>"
+license="GPL-3.0-or-later"
+homepage="https://github.com/sezanzeb/input-remapper"
+distfiles="https://github.com/sezanzeb/input-remapper/archive/${version}.tar.gz"
+checksum=060c919d0a3e9257d93595aa06826db1952991916f982bae78e72fb7cacf4297


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

#### Local build testing
- I built this PR locally for my native architecture (x86_64)
- I built this PR locally for these architectures using specific masterdirs:
  - x86_64-musl
  - i686
- I built this PR locally for these architectures (crossbuilds):
  - aarch64
  - aarch64-musl
  - armv7l
  - armv7l-musl
  - armv6l
  - armv6l-musl

---

I tried to run the tests, but they resulted in errors. However, I tested the package on my local machine (x86_64) and everything appears to be working properly. For the other architectures, I only performed local builds, and they completed without issues.