### PR TITLE
tcc: update to 0.9.27.20250903.

### DIFF
--- a/srcpkgs/tcc/template
+++ b/srcpkgs/tcc/template
@@ -1,8 +1,8 @@
 # Template file for 'tcc'
 pkgname=tcc
-version=0.9.27.20221203
+version=0.9.27.20250903
 revision=1
-_gitrev=ab39d34dde9212c36dda2718bec4735fc0428636
+_gitrev=8c3396a76f1a49eb2209206cf1274c9fc00a7506
 build_style=configure
 configure_args="--prefix=/usr --libdir=\${prefix}/lib$XBPS_TARGET_WORDSIZE"
 make_check_target="test"
@@ -12,7 +12,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="LGPL-2.1-or-later"
 homepage="http://bellard.org/tcc/"
 distfiles="http://repo.or.cz/tinycc.git/snapshot/${_gitrev}.tar.gz"
-checksum=28c745f26754451f64b0b21824fa4f7f9113bafc28acd41efb961d5f3224fb70
+checksum=43d9e2cba03ea2df7d3c3cf3fb28969c554fee8bb99c6a038fcce5d4835ef3ce
 nopie=yes
 nocross=yes
 


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly** *Seems to fix segfault on `musl`.*

#### Local build testing

```
pkg      host         target        cross  result
tcc      x86_64       x86_64        n      OK
tcc      x86_64-musl  x86_64-musl   n      OK
tcc      i686         i686          n      OK
```