### PR TITLE
jupyterlab: update to 4.4.9, and deps

### DIFF
--- a/srcpkgs/hatch-fancy-pypi-readme/template
+++ b/srcpkgs/hatch-fancy-pypi-readme/template
@@ -1,7 +1,7 @@
 # Template file for 'hatch-fancy-pypi-readme'
 pkgname=hatch-fancy-pypi-readme
-version=24.1.0
-revision=2
+version=25.1.0
+revision=1
 build_style=python3-pep517
 hostmakedepends="hatchling"
 depends="hatchling"
@@ -12,7 +12,7 @@ license="MIT"
 homepage="https://github.com/hynek/hatch-fancy-pypi-readme"
 changelog="https://github.com/hynek/hatch-fancy-pypi-readme/blob/main/CHANGELOG.md"
 distfiles="${PYPI_SITE}/h/hatch-fancy-pypi-readme/hatch_fancy_pypi_readme-${version}.tar.gz"
-checksum=44dd239f1a779b9dcf8ebc9401a611fd7f7e3e14578dcf22c265dfaf7c1514b8
+checksum=9c58ed3dff90d51f43414ce37009ad1d5b0f08ffc9fc216998a06380f01c0045
 
 post_install() {
 	vlicense LICENSE.txt

--- a/srcpkgs/hatch-nodejs-version/template
+++ b/srcpkgs/hatch-nodejs-version/template
@@ -1,7 +1,7 @@
 # Template file for 'hatch-nodejs-version'
 pkgname=hatch-nodejs-version
-version=0.3.2
-revision=3
+version=0.4.0
+revision=1
 build_style=python3-pep517
 hostmakedepends="hatchling"
 depends="hatchling"
@@ -12,7 +12,7 @@ license="MIT"
 homepage="https://github.com/agoose77/hatch-nodejs-version"
 changelog="https://github.com/agoose77/hatch-nodejs-version/releases"
 distfiles="https://github.com/agoose77/hatch-nodejs-version/archive/refs/tags/v${version}.tar.gz"
-checksum=c01dae87afcb7b6db421b5248154de26c556e569e2631e9f146bc5c78447eee6
+checksum=c48b44fb67efa2c1e82f31ac9b5fd1b8213578510d541599a4c55ff4c7f372d5
 
 post_install() {
 	vlicense LICENSE.txt

--- a/srcpkgs/jupyterlab/template
+++ b/srcpkgs/jupyterlab/template
@@ -1,6 +1,6 @@
 # Template file for 'jupyterlab'
 pkgname=jupyterlab
-version=4.4.2
+version=4.4.9
 revision=1
 build_style=python3-pep517
 hostmakedepends="hatchling hatch-jupyter-builder"
@@ -15,7 +15,7 @@ license="custom:jupyterlab"
 homepage="https://github.com/jupyterlab/jupyterlab/"
 changelog="https://raw.githubusercontent.com/jupyterlab/jupyterlab/main/CHANGELOG.md"
 distfiles="${PYPI_SITE}/j/jupyterlab/jupyterlab-${version}.tar.gz"
-checksum=afa9caf28c0cb966488be18e5e8daba9f018a1c4273a406b7d5006344cbc6d16
+checksum=ea55aca8269909016d5fde2dc09b97128bc931230183fe7e2920ede5154ad9c2
 
 if [ "${XBPS_BUILD_ENVIRONMENT}" = void-packages-ci ]; then
 	# this test fails on CI (network timeout)

--- a/srcpkgs/python3-BeautifulSoup4/template
+++ b/srcpkgs/python3-BeautifulSoup4/template
@@ -1,6 +1,6 @@
 # Template file for 'python3-BeautifulSoup4'
 pkgname=python3-BeautifulSoup4
-version=4.13.4
+version=4.14.2
 revision=1
 build_style=python3-pep517
 hostmakedepends="hatchling"
@@ -12,9 +12,8 @@ license="MIT"
 homepage="https://www.crummy.com/software/BeautifulSoup"
 changelog="https://git.launchpad.net/beautifulsoup/plain/CHANGELOG"
 distfiles="${PYPI_SITE}/b/beautifulsoup4/beautifulsoup4-${version}.tar.gz"
-checksum=dbb3c4e1ceae6aefebdaf2423247260cd062430a410e38c66f2baa50a8437195
+checksum=2a98ab9f944a11acee9cc848508ec28d9228abfd522ef0fad6a02a72e0ded69e
 
 post_install() {
 	vlicense LICENSE
-	rm -r ${DESTDIR}/${py3_sitelib}/bs4/tests
 }

--- a/srcpkgs/python3-anyio/template
+++ b/srcpkgs/python3-anyio/template
@@ -1,6 +1,6 @@
 # Template file for 'python3-anyio'
 pkgname=python3-anyio
-version=4.9.0
+version=4.10.0
 revision=1
 build_style=python3-pep517
 # This file needs python module `exceptiongroup`
@@ -15,7 +15,7 @@ license="MIT"
 homepage="https://github.com/agronholm/anyio"
 changelog="https://raw.githubusercontent.com/agronholm/anyio/master/docs/versionhistory.rst"
 distfiles="${PYPI_SITE}/a/anyio/anyio-${version}.tar.gz"
-checksum=673c0c244e15788651a4ff38710fea9675823028a6f08a5eda409e0c9840a028
+checksum=3f3fae35c96039744587aa5b8371e7e8e603c0702999535961dd336026973ba6
 
 if [ "$XBPS_BUILD_ENVIRONMENT" = void-packages-ci ]; then
 	# these tests fail on CI

--- a/srcpkgs/python3-argon2-cffi-bindings/template
+++ b/srcpkgs/python3-argon2-cffi-bindings/template
@@ -1,7 +1,7 @@
 # Template file for 'python3-argon2-cffi-bindings'
 pkgname=python3-argon2-cffi-bindings
-version=21.2.0
-revision=2
+version=25.1.0
+revision=1
 build_style=python3-pep517
 hostmakedepends="python3-setuptools_scm python3-wheel python3-cffi"
 makedepends="python3-devel libargon2-devel"
@@ -12,8 +12,8 @@ maintainer="Gonzalo Tornaría <tornaria@cmat.edu.uy>"
 license="MIT"
 homepage="https://github.com/hynek/argon2-cffi-bindings"
 changelog="https://raw.githubusercontent.com/hynek/argon2-cffi-bindings/main/CHANGELOG.md"
-distfiles="${PYPI_SITE}/a/argon2-cffi-bindings/argon2-cffi-bindings-${version}.tar.gz"
-checksum=bb89ceffa6c791807d1305ceb77dbfacc5aa499891d2c55661c6459651fc39e3
+distfiles="${PYPI_SITE}/a/argon2-cffi-bindings/argon2_cffi_bindings-${version}.tar.gz"
+checksum=b957f3e6ea4d55d820e40ff76f450952807013d361a65d7f28acc0acbf29229d
 
 export ARGON2_CFFI_USE_SYSTEM=1
 

--- a/srcpkgs/python3-blockbuster/template
+++ b/srcpkgs/python3-blockbuster/template
@@ -1,6 +1,6 @@
 # Template file for 'python3-blockbuster'
 pkgname=python3-blockbuster
-version=1.5.24
+version=1.5.25
 revision=1
 build_style=python3-pep517
 hostmakedepends="hatchling"
@@ -12,4 +12,4 @@ license="Apache-2.0"
 homepage="https://github.com/cbornet/blockbuster"
 changelog="https://github.com/cbornet/blockbuster/releases"
 distfiles="${PYPI_SITE}/b/blockbuster/blockbuster-${version}.tar.gz"
-checksum=97645775761a5d425666ec0bc99629b65c7eccdc2f770d2439850682567af4ec
+checksum=b72f1d2aefdeecd2a820ddf1e1c8593bf00b96e9fdc4cd2199ebafd06f7cb8f0

--- a/srcpkgs/python3-calver/template
+++ b/srcpkgs/python3-calver/template
@@ -1,15 +1,15 @@
 # Template file for 'python3-calver'
 pkgname=python3-calver
-version=2022.6.26
-revision=3
+version=2025.4.17
+revision=1
 build_style=python3-pep517
 hostmakedepends="python3-setuptools python3-wheel"
 depends="python3"
+checkdepends="python3-pytest python3-pretend"
 short_desc="Setuptools extension for CalVer package versions"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="Apache-2.0"
 homepage="https://github.com/di/calver"
 changelog="https://github.com/di/calver/releases"
 distfiles="${PYPI_SITE}/c/calver/calver-${version}.tar.gz"
-checksum=e05493a3b17517ef1748fbe610da11f10485faa7c416b9d33fd4a52d74894f8b
-make_check=no # PyPI tarball has no tests.
+checksum=460702737d620f5c3d4175450485180a1b7f7a422c5db0e6af3e655c7395ec7e

--- a/srcpkgs/python3-charset-normalizer/template
+++ b/srcpkgs/python3-charset-normalizer/template
@@ -1,9 +1,9 @@
 # Template file for 'python3-charset-normalizer'
 pkgname=python3-charset-normalizer
-version=3.3.2
-revision=2
-build_style=python3-module
-hostmakedepends="python3-setuptools"
+version=3.4.3
+revision=1
+build_style=python3-pep517
+hostmakedepends="python3-setuptools_scm"
 depends="python3"
 checkdepends="python3-pytest"
 short_desc="Encoding and language detection"
@@ -12,11 +12,7 @@ license="MIT"
 homepage="https://charset-normalizer.readthedocs.io/"
 changelog="https://raw.githubusercontent.com/Ousret/charset_normalizer/master/CHANGELOG.md"
 distfiles="https://github.com/Ousret/charset_normalizer/archive/refs/tags/$version.tar.gz"
-checksum=9948e5c17831916ef192cf3f26c744d539eb6f4e9e3b02eea649552c52b10d91
-
-pre_check() {
-	vsed -i "s/--cov=charset_normalizer --cov-report=term-missing//" setup.cfg
-}
+checksum=a8e48df4c97e52bc516e27edb301cd837684bb7266ce44a3532a9eed429c9e1c
 
 post_install() {
 	vlicense LICENSE

--- a/srcpkgs/python3-fastjsonschema/template
+++ b/srcpkgs/python3-fastjsonschema/template
@@ -1,6 +1,6 @@
 # Template file for 'python3-fastjsonschema'
 pkgname=python3-fastjsonschema
-version=2.21.1
+version=2.21.2
 revision=1
 build_style=python3-pep517
 hostmakedepends="python3-setuptools python3-wheel"
@@ -12,7 +12,7 @@ license="BSD-3-Clause"
 homepage="https://github.com/horejsek/python-fastjsonschema"
 changelog="https://raw.githubusercontent.com/horejsek/python-fastjsonschema/master/CHANGELOG.txt"
 distfiles="https://github.com/horejsek/python-fastjsonschema/archive/refs/tags/v${version}.tar.gz"
-checksum=20891fd6659d94ce18dcf075afd6cd6b817bf39013a25a4d11a2162d2fa0daa0
+checksum=3757b049728580d516c0af50e11eed050c8e2c1815b221954c635bde455dcc78
 
 post_install() {
 	vlicense LICENSE

--- a/srcpkgs/python3-json5/template
+++ b/srcpkgs/python3-json5/template
@@ -1,6 +1,6 @@
 # Template file for 'python3-json5'
 pkgname=python3-json5
-version=0.12.0
+version=0.12.1
 revision=1
 build_style=python3-pep517
 hostmakedepends="python3-setuptools python3-wheel"
@@ -11,4 +11,4 @@ maintainer="dkwo <npiazza@disroot.org>, Gonzalo Tornaría <tornaria@cmat.edu.uy>
 license="Apache-2.0"
 homepage="https://github.com/dpranke/pyjson5"
 distfiles="${homepage}/archive/refs/tags/v${version}.tar.gz"
-checksum=39b21785fc12c61716a3634b466e3faffc5c679148c2d9cbbef9cc0c15772b6f
+checksum=c729b79398a116a9eec40c71d8ad84e0e9e52d502377639d7ca67dd630266674

--- a/srcpkgs/python3-jsonpath-ng/template
+++ b/srcpkgs/python3-jsonpath-ng/template
@@ -1,0 +1,15 @@
+# Template file for 'python3-jsonpath-ng'
+pkgname=python3-jsonpath-ng
+version=1.7.0
+revision=1
+build_style=python3-pep517
+hostmakedepends="python3-setuptools"
+depends="python3-ply"
+checkdepends="$depends python3-pytest"
+short_desc="Implementation of JSONPath for Python"
+maintainer="Gonzalo Tornaría <tornaria@cmat.edu.uy>"
+license="Apache-2.0"
+homepage="https://github.com/h2non/jsonpath-ng"
+changelog="https://raw.githubusercontent.com/h2non/jsonpath-ng/refs/heads/master/History.md"
+distfiles="${PYPI_SITE}/j/jsonpath-ng/jsonpath-ng-${version}.tar.gz"
+checksum=f6f5f7fd4e5ff79c785f1573b394043b39849fb2bb47bcead935d12b00beab3c

--- a/srcpkgs/python3-jsonschema-specifications/template
+++ b/srcpkgs/python3-jsonschema-specifications/template
@@ -1,7 +1,7 @@
 # Template file for 'python3-jsonschema-specifications'
 pkgname=python3-jsonschema-specifications
-version=2024.10.1
-revision=2
+version=2025.9.1
+revision=1
 build_style=python3-pep517
 hostmakedepends="hatchling hatch-vcs"
 depends="python3-referencing"
@@ -11,7 +11,7 @@ maintainer="Gonzalo Tornaría <tornaria@cmat.edu.uy>"
 license="MIT"
 homepage="https://github.com/python-jsonschema/jsonschema-specifications"
 distfiles="${PYPI_SITE}/j/jsonschema-specifications/jsonschema_specifications-${version}.tar.gz"
-checksum=0f38b83639958ce1152d02a7f062902c41c8fd20d558b0c34344292d417ae272
+checksum=b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d
 
 post_install() {
 	vlicense COPYING

--- a/srcpkgs/python3-jsonschema/template
+++ b/srcpkgs/python3-jsonschema/template
@@ -1,20 +1,20 @@
 # Template file for 'python3-jsonschema'
 pkgname=python3-jsonschema
-version=4.23.0
-revision=3
+version=4.25.1
+revision=1
 build_style=python3-pep517
 hostmakedepends="hatchling hatch-vcs hatch-fancy-pypi-readme"
 depends="python3-attrs python3-jsonschema-specifications python3-referencing
  python3-rpds-py"
 checkdepends="${depends} python3-pytest python3-idna python3-jsonpointer
- python3-pip python3-rfc3339-validator python3-rfc3987"
+ python3-pip python3-rfc3339-validator python3-rfc3987 python3-jsonpath-ng"
 short_desc="Implementation of JSON Schema for Python3"
 maintainer="Gonzalo Tornaría <tornaria@cmat.edu.uy>"
 license="MIT"
 homepage="https://github.com/Julian/jsonschema"
 changelog="https://raw.githubusercontent.com/Julian/jsonschema/master/CHANGELOG.rst"
 distfiles="${PYPI_SITE}/j/jsonschema/jsonschema-${version}.tar.gz"
-checksum=d71497fef26351a33265337fa77ffeb82423f3ea21283cd9467bb03999266bc4
+checksum=e4a9655ce0da0c0b67a085847e00a3a51449e1157f4f75e9fb5aa545e122eb85
 
 post_install() {
 	vlicense COPYING LICENSE

--- a/srcpkgs/python3-jupyter_notebook/template
+++ b/srcpkgs/python3-jupyter_notebook/template
@@ -1,6 +1,6 @@
 # Template file for 'python3-jupyter_notebook'
 pkgname=python3-jupyter_notebook
-version=7.4.2
+version=7.4.7
 revision=1
 build_style=python3-pep517
 hostmakedepends="hatchling hatch-jupyter-builder jupyterlab"
@@ -13,7 +13,7 @@ license="BSD-3-Clause"
 homepage="https://github.com/jupyter/notebook"
 changelog="https://raw.githubusercontent.com/jupyter/notebook/main/CHANGELOG.md"
 distfiles="${PYPI_SITE}/n/notebook/notebook-${version}.tar.gz"
-checksum=e739defd28c3f615a6bfb0a2564bd75018a9cc6613aa00bbd9c15e68eed2de1b
+checksum=3f0a04027dfcee8a876de48fba13ab77ec8c12f72f848a222ed7f5081b9e342a
 
 post_install() {
 	mv ${DESTDIR}/usr/etc ${DESTDIR}

--- a/srcpkgs/python3-jupyter_qtconsole/template
+++ b/srcpkgs/python3-jupyter_qtconsole/template
@@ -1,13 +1,13 @@
 # Template file for 'python3-jupyter_qtconsole'
 pkgname=python3-jupyter_qtconsole
-version=5.6.1
-revision=2
+version=5.7.0
+revision=1
 build_style=python3-pep517
 hostmakedepends="python3-setuptools python3-wheel"
 depends="python3-traitlets python3-jupyter_core python3-jupyter_client
  python3-Pygments python3-ipython_ipykernel python3-pyqt6-svg python3-QtPy
  python3-pyqt6-gui python3-pyqt6-widgets python3-pyqt6-printsupport
- python3-packaging"
+ python3-packaging python3-ipython-pygments-lexers"
 checkdepends="$depends python3-pytest-qt python3-flaky"
 short_desc="Jupyter Qt console"
 maintainer="Gonzalo Tornaría <tornaria@cmat.edu.uy>"
@@ -15,7 +15,7 @@ license="BSD-3-Clause"
 homepage="https://github.com/jupyter/qtconsole"
 changelog="https://raw.githubusercontent.com/jupyter/qtconsole/master/docs/source/changelog.rst"
 distfiles="${PYPI_SITE}/q/qtconsole/qtconsole-${version}.tar.gz"
-checksum=5cad1c7e6c75d3ef8143857fd2ed28062b4b92b933c2cc328252d18a9cfd0be5
+checksum=0d33371ce9ef554c7022ee300564ba9ffbd615e304ee615f6769d4068e063171
 conflicts="python-jupyter_qtconsole<=4.4.3_2"
 
 post_install() {

--- a/srcpkgs/python3-jupyter_qtconsole/update
+++ b/srcpkgs/python3-jupyter_qtconsole/update
@@ -1,1 +1,0 @@
-ignore="*a* *b* *rc*"

--- a/srcpkgs/python3-jupyter_server/template
+++ b/srcpkgs/python3-jupyter_server/template
@@ -1,6 +1,6 @@
 # Template file for 'python3-jupyter_server'
 pkgname=python3-jupyter_server
-version=2.16.0
+version=2.17.0
 revision=1
 build_style=python3-pep517
 hostmakedepends="hatchling hatch-jupyter-builder"
@@ -18,7 +18,7 @@ license="BSD-3-Clause"
 homepage="https://github.com/jupyter-server/jupyter_server"
 changelog="https://raw.githubusercontent.com/jupyter-server/jupyter_server/main/CHANGELOG.md"
 distfiles="${PYPI_SITE}/j/jupyter-server/jupyter_server-${version}.tar.gz"
-checksum=65d4b44fdf2dcbbdfe0aa1ace4a842d4aaf746a2b7b168134d5aaed35621b7f6
+checksum=c38ea898566964c888b4772ae1ed58eca84592e88251d2cfc4d171f81f7e99d5
 
 if [ "$XBPS_BUILD_ENVIRONMENT" = void-packages-ci ]; then
 	# these tests fail on CI (connect to a tcp address)
@@ -28,6 +28,12 @@ if [ "$XBPS_BUILD_ENVIRONMENT" = void-packages-ci ]; then
 	 --deselect=tests/extension/test_launch.py::test_token_file
 	 "
 fi
+
+post_patch() {
+	# this test is very flaky, allow more runs
+	vsed -e 's/^@flaky$/@flaky(max_runs=5)/' \
+		-i tests/services/kernels/test_execution_state.py
+}
 
 post_install() {
 	vlicense LICENSE

--- a/srcpkgs/python3-jupyterlab-lsp/template
+++ b/srcpkgs/python3-jupyterlab-lsp/template
@@ -1,6 +1,6 @@
 # Template file for 'python3-jupyterlab-lsp'
 pkgname=python3-jupyterlab-lsp
-version=5.1.0
+version=5.2.0
 revision=1
 build_style=python3-pep517
 hostmakedepends="python3-setuptools"
@@ -10,8 +10,8 @@ maintainer="dkwo <npiazza@disroot.org>, Gonzalo Tornaría <tornaria@cmat.edu.uy>
 license="BSD-3-Clause"
 homepage="https://github.com/jupyter-lsp/jupyterlab-lsp"
 changelog="https://github.com/jupyter-lsp/jupyterlab-lsp/releases"
-distfiles="${PYPI_SITE}/j/jupyterlab-lsp/jupyterlab-lsp-${version}.tar.gz"
-checksum=aeac84093ada6d20ef57ae0e97811cc5796a0cab7237b32f8eddf993c0bb0356
+distfiles="${PYPI_SITE}/j/jupyterlab-lsp/jupyterlab_lsp-${version}.tar.gz"
+checksum=63684885b35c1dc9d83e54b4b06380c9375ad7d751a2975649b357308c8d30b9
 make_check=no  # Upstream defines no tests
 
 post_install() {

--- a/srcpkgs/python3-lxml/template
+++ b/srcpkgs/python3-lxml/template
@@ -1,6 +1,6 @@
 # Template file for 'python3-lxml'
 pkgname=python3-lxml
-version=6.0.0
+version=6.0.2
 revision=1
 build_style=python3-pep517
 make_build_args="-C--build-option=--with-cython"
@@ -14,7 +14,7 @@ license="BSD-3-Clause, custom:ElementTree"
 homepage="https://lxml.de/"
 changelog="https://raw.githubusercontent.com/lxml/lxml/master/CHANGES.txt"
 distfiles="https://github.com/lxml/lxml/archive/lxml-${version}.tar.gz"
-checksum=5560ee7bd3bcea0e64221bbb23f4ee1d222296ef25ba217e327a5f1d963005d9
+checksum=21f2931fc1aa3c26f2caa40742e9dd491d3c368f1ceec3c341929abff3023535
 
 do_check() {
 	make test

--- a/srcpkgs/python3-lxml/update
+++ b/srcpkgs/python3-lxml/update
@@ -1,2 +1,1 @@
 pkgname=lxml
-ignore="*b*"

--- a/srcpkgs/python3-mistune/template
+++ b/srcpkgs/python3-mistune/template
@@ -1,6 +1,6 @@
 # Template file for 'python3-mistune'
 pkgname=python3-mistune
-version=3.1.3
+version=3.1.4
 revision=1
 build_style=python3-pep517
 hostmakedepends="python3-setuptools python3-wheel"
@@ -12,7 +12,7 @@ license="BSD-3-Clause"
 homepage="https://mistune.lepture.com/"
 changelog="https://raw.githubusercontent.com/lepture/mistune/master/docs/changes.rst"
 distfiles="${PYPI_SITE}/m/mistune/mistune-${version}.tar.gz"
-checksum=a7035c21782b2becb6be62f8f25d3df81ccb4d6fa477a6525b15af06539f02a0
+checksum=b5a7f801d389f724ec702840c11d8fc48f2b33519102fc7ee739e8177b672164
 
 post_install() {
 	vlicense LICENSE

--- a/srcpkgs/python3-nbclassic/template
+++ b/srcpkgs/python3-nbclassic/template
@@ -1,6 +1,6 @@
 # Template file for 'python3-nbclassic'
 pkgname=python3-nbclassic
-version=1.3.1
+version=1.3.3
 revision=1
 build_style=python3-pep517
 hostmakedepends="hatchling hatch-jupyter-builder python3-jupyter_server
@@ -14,7 +14,7 @@ license="BSD-3-Clause"
 homepage="https://github.com/jupyter/nbclassic"
 changelog="https://raw.githubusercontent.com/jupyter/nbclassic/main/CHANGELOG.md"
 distfiles="${PYPI_SITE}/n/nbclassic/nbclassic-${version}.tar.gz"
-checksum=4c52da8fc88f9f73ef512cc305091d5ce726bdca19f44ed697cb5ba12dcaad3c
+checksum=434228763f8cee754318cd6dfa42370db191af630dabab8e30bafc8c1aa3eee6
 
 post_install() {
 	vlicense LICENSE

--- a/srcpkgs/python3-pytest-asyncio/template
+++ b/srcpkgs/python3-pytest-asyncio/template
@@ -1,9 +1,9 @@
 # Template file for 'python3-pytest-asyncio'
 pkgname=python3-pytest-asyncio
-version=1.0.0
+version=1.2.0
 revision=1
 build_style=python3-pep517
-hostmakedepends="python3-setuptools_scm python3-wheel"
+hostmakedepends="python3-setuptools_scm"
 depends="python3-pytest"
 checkdepends="$depends python3-hypothesis"
 short_desc="Pytest plugin for asyncio"
@@ -12,7 +12,12 @@ license="Apache-2.0"
 homepage="https://github.com/pytest-dev/pytest-asyncio"
 changelog="https://raw.githubusercontent.com/pytest-dev/pytest-asyncio/master/docs/source/reference/changelog.rst"
 distfiles="${PYPI_SITE}/p/pytest-asyncio/pytest_asyncio-${version}.tar.gz"
-checksum=d15463d13f4456e1ead2594520216b225a16f781e144f8fdf6c5bb4667c48b3f
+checksum=c609a64a2a8768462d0c99811ddb8bd2583c33fd33cf7f21af1c142e824ffb57
+
+post_patch() {
+	# see https://github.com/pytest-dev/pytest-asyncio/pull/1192
+	rm setup.cfg
+}
 
 if [ "$XBPS_BUILD_ENVIRONMENT" = void-packages-ci ]; then
 	# these tests fail on CI (bind to a tcp address)

--- a/srcpkgs/python3-pytest-mock/template
+++ b/srcpkgs/python3-pytest-mock/template
@@ -1,9 +1,9 @@
 # Template file for 'python3-pytest-mock'
 pkgname=python3-pytest-mock
-version=3.14.1
+version=3.15.1
 revision=1
 build_style=python3-pep517
-hostmakedepends="python3-setuptools_scm python3-wheel"
+hostmakedepends="python3-setuptools_scm"
 depends="python3-pytest"
 checkdepends="python3-pytest-asyncio python3-mock"
 short_desc="Pytest plugin for mock"
@@ -12,7 +12,7 @@ license="MIT"
 homepage="https://github.com/pytest-dev/pytest-mock/"
 changelog="https://raw.githubusercontent.com/pytest-dev/pytest-mock/main/CHANGELOG.rst"
 distfiles="${PYPI_SITE}/p/pytest-mock/pytest_mock-${version}.tar.gz"
-checksum=159e9edac4c451ce77a5cdb9fc5d1100708d2dd4ba3c3df572f14097351af80e
+checksum=1849a238f6f396da19762269de72cb1814ab44416fa73a8686deac10b0d87a0f
 
 post_install() {
 	vlicense LICENSE

--- a/srcpkgs/python3-requests/template
+++ b/srcpkgs/python3-requests/template
@@ -1,10 +1,10 @@
 # Template file for 'python3-requests'
 pkgname=python3-requests
-version=2.32.4
+version=2.32.5
 revision=1
 build_style=python3-pep517
 hostmakedepends="python3-setuptools"
-depends="ca-certificates python3-charset-normalizer python3-urllib3 python3-idna"
+depends="python3-certifi python3-charset-normalizer python3-urllib3 python3-idna"
 checkdepends="python3-pytest $depends python3-trustme python3-pytest-httpbin
  python3-pytest-mock python3-pysocks python3-pytest-xdist"
 short_desc="Python3 HTTP library for human beings"
@@ -13,8 +13,4 @@ license="Apache-2.0"
 homepage="https://python-requests.org/"
 changelog="https://raw.githubusercontent.com/psf/requests/master/HISTORY.md"
 distfiles="${PYPI_SITE}/r/requests/requests-${version}.tar.gz"
-checksum=27d0316682c8a29834d3264820024b62a36942083d52caf2f14c0591336d3422
-
-post_patch() {
-	vsed -i '/certifi/d' setup.py
-}
+checksum=dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf

--- a/srcpkgs/python3-rpds-py/template
+++ b/srcpkgs/python3-rpds-py/template
@@ -1,6 +1,6 @@
 # Template file for 'python3-rpds-py'
 pkgname=python3-rpds-py
-version=0.24.0
+version=0.27.1
 revision=1
 build_style=python3-pep517
 build_helper=rust
@@ -14,7 +14,7 @@ license="MIT"
 homepage="https://github.com/crate-py/rpds"
 changelog="https://github.com/crate-py/rpds/releases"
 distfiles="${PYPI_SITE}/r/rpds-py/rpds_py-${version}.tar.gz"
-checksum=772cc1b2cd963e7e17e6cc55fe0371fb9c704d63e44cacec7b9b7f523b78919e
+checksum=26a1c73171d10b7acccbded82bf6a586ab8203601e565badc74bbbf8bc5a10f8
 
 post_install() {
 	vlicense LICENSE

--- a/srcpkgs/python3-soupsieve/template
+++ b/srcpkgs/python3-soupsieve/template
@@ -1,6 +1,6 @@
 # Template file for 'python3-soupsieve'
 pkgname=python3-soupsieve
-version=2.7
+version=2.8
 revision=1
 build_style=python3-pep517
 hostmakedepends="hatchling"
@@ -13,7 +13,7 @@ license="MIT"
 homepage="https://facelessuser.github.io/soupsieve/"
 changelog="https://raw.githubusercontent.com/facelessuser/soupsieve/refs/heads/main/docs/src/markdown/about/changelog.md"
 distfiles="${PYPI_SITE}/s/soupsieve/soupsieve-${version}.tar.gz"
-checksum=ad282f9b6926286d2ead4750552c8a6142bc4c783fd66b0293547c8fe6ae126a
+checksum=e2dd4a40a628cb5f28f6d4b0db8800b8f581b65bb380b97de22ba5ca8d72572f
 
 post_install() {
 	vlicense LICENSE.md

--- a/srcpkgs/python3-trove-classifiers/template
+++ b/srcpkgs/python3-trove-classifiers/template
@@ -1,8 +1,10 @@
 # Template file for 'python3-trove-classifiers'
 pkgname=python3-trove-classifiers
-version=2024.7.2
-revision=2
+version=2025.9.11.17
+revision=1
 build_style=python3-pep517
+# this test assumes trove-classifiers is installed in /usr/bin
+make_check_args="--ignore tests/test_cli.py"
 hostmakedepends="python3-setuptools python3-wheel python3-calver"
 depends="python3"
 checkdepends="${depends} python3-pytest"
@@ -12,4 +14,4 @@ license="Apache-2.0"
 homepage="https://github.com/pypa/trove-classifiers"
 changelog="https://github.com/pypa/trove-classifiers/releases"
 distfiles="${PYPI_SITE}/t/trove-classifiers/trove_classifiers-${version}.tar.gz"
-checksum=8328f2ac2ce3fd773cbb37c765a0ed7a83f89dc564c7d452f039b69249d0ac35
+checksum=931ca9841a5e9c9408bc2ae67b50d28acf85bef56219b56860876dd1f2d024dd


### PR DESCRIPTION
- **python3-calver: update to 2025.4.17.**
- **python3-trove-classifiers: update to 2025.9.11.17.**
- **hatch-fancy-pypi-readme: update to 25.1.0.**
- **hatch-nodejs-version: update to 0.4.0.**
- **python3-rpds-py: update to 0.27.1.**
- **python3-jsonschema-specifications: update to 2025.9.1.**
- **New package: python3-jsonpath-ng-1.7.0**
- **python3-jsonschema: update to 4.25.1.**
- **python3-fastjsonschema: update to 2.21.2.**
- **python3-lxml: update to 6.0.2.**
- **python3-soupsieve: update to 2.8.**
- **python3-BeautifulSoup4: update to 4.14.2.**
- **python3-mistune: update to 3.1.4.**
- **python3-pytest-asyncio: update to 1.2.0.**
- **python3-pytest-mock: update to 3.15.0.**
- **python3-blockbuster: update to 1.5.25.**
- **python3-anyio: update to 4.10.0.**
- **python3-charset-normalizer: update to 3.4.3.**
- **python3-requests: update to 2.32.5.**
- **python3-argon2-cffi-bindings: update to 25.1.0.**
- **python3-json5: update to 0.12.1.**
- **python3-jupyter_server: update to 2.17.0.**
- **python3-nbclassic: update to 1.3.3.**
- **jupyterlab: update to 4.4.9.**
- **python3-jupyterlab-lsp: update to 5.2.0.**
- **python3-jupyter_notebook: update to 7.4.7.**

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**|**briefly**|**NO**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
