### PR TITLE
cronie: install empty /etc/crontab

### DIFF
--- a/srcpkgs/cronie/INSTALL
+++ b/srcpkgs/cronie/INSTALL
@@ -1,0 +1,11 @@
+case "$ACTION" in
+post)
+	# If this file doesn't exist, cronie-crond complains
+	# about it when editing a user's crontab.
+	# This cannot be done in the template because on update,
+	# an existing file would be overwritten.
+	if [ ! -e etc/crontab ]; then
+		touch etc/crontab
+		chmod 0644 /etc/crontab
+	fi
+esac

--- a/srcpkgs/cronie/template
+++ b/srcpkgs/cronie/template
@@ -1,7 +1,7 @@
 # Template file for 'cronie'
 pkgname=cronie
 version=1.7.2
-revision=2
+revision=3
 build_style=gnu-configure
 configure_args="--with-inotify --without-selinux --with-pam
  --enable-anacron --enable-pie --enable-relro"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

The use of the file `/etc/crontab` is deprecated, but if it doesn't exist, `cronie-crond` logs the error `(root) CAN'T OPEN (/etc/crontab): No such file or directory` when editing a user's crontab.

This flag disables support for `/etc/crontab`, so the daemon won't complain. Alternatively, installing an empty one would work as well.