### PR TITLE
asahi-uboot: update to 2025.07+1

### DIFF
--- a/srcpkgs/asahi-uboot/template
+++ b/srcpkgs/asahi-uboot/template
@@ -1,6 +1,6 @@
 # Template file for 'asahi-uboot'
 pkgname=asahi-uboot
-version=2025.04+1
+version=2025.07+1
 revision=1
 archs="aarch64*"
 hostmakedepends="bison flex which python3 swig python3-devel
@@ -9,11 +9,11 @@ hostmakedepends="bison flex which python3 swig python3-devel
 depends="m1n1"
 checkdepends="python3-pytest dtc-devel python3-filelock"
 short_desc="Das U-Boot for Apple Silicon Macs"
-maintainer="Will Springer <skirmisher@protonmail.com>, dkwo <npiazza@disroot.org>"
+maintainer="dkwo <npiazza@disroot.org>, Will Springer <skirmisher@protonmail.com>"
 license="GPL-2.0-or-later, MIT"
 homepage="https://asahilinux.org"
 distfiles="https://github.com/AsahiLinux/u-boot/archive/refs/tags/asahi-v${version/+/-}.tar.gz"
-checksum=82d21cbaf94d1212d6f1a851931d25163ed5e6247b9e60db8d39a3cf238dfd43
+checksum=ca6f8f8a4ca1f5ddd51b855d7cd1cd4629677bf1a31e6643b66cf6a33fd6d9e6
 make_check=no # missing python3-libfdt ?
 
 if [ "$CROSS_BUILD" ]; then


### PR DESCRIPTION
- I tested the changes in this PR: yes
- I built this PR locally for my native architecture, (aarch64-glibc)