### PR TITLE
New package: python3-mailcap_fix-1.0.1

### DIFF
--- a/srcpkgs/python3-mailcap_fix/template
+++ b/srcpkgs/python3-mailcap_fix/template
@@ -1,0 +1,12 @@
+# Template file for 'python3-mailcap_fix'
+pkgname=python3-mailcap_fix
+version=1.0.1
+revision=1
+build_style=python3-module
+hostmakedepends="python3-setuptools"
+short_desc="Mailcap module that conforms to RFC 1524"
+maintainer="c4llv07e <igor@c4llv07e.xyz>"
+license="Unlicense"
+homepage="https://github.com/michael-lazar/mailcap_fix"
+distfiles="${PYPI_SITE}/m/mailcap_fix/mailcap-fix-${version}.tar.gz"
+checksum=113c0b36091ac0b8181c33f2cd4905280e1bb316383d3c3fcae98c6df094910a


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86-64 glibc)

telegram-tg doesn't work with python3.13 because mailcap was removed there. New version uses [mailcap_fix](https://pypi.org/project/mailcap-fix/) package to replicate its behaviour, so it's required for updating tg.