### PR TITLE
shadowsocks-rust: update to 1.24.0.

### DIFF
--- a/srcpkgs/shadowsocks-rust/template
+++ b/srcpkgs/shadowsocks-rust/template
@@ -1,6 +1,6 @@
 # Template file for 'shadowsocks-rust'
 pkgname=shadowsocks-rust
-version=1.23.4
+version=1.24.0
 revision=1
 build_style=cargo
 hostmakedepends="pkg-config"
@@ -11,10 +11,13 @@ license="MIT"
 homepage="https://github.com/shadowsocks/shadowsocks-rust"
 changelog="https://github.com/shadowsocks/shadowsocks-rust/releases"
 distfiles="https://github.com/shadowsocks/shadowsocks-rust/archive/refs/tags/v${version}.tar.gz"
-checksum=8a91836256989e3a56409d0e83da6549ecf727e2d6642cd4e707993d9c8a23d3
+checksum=a89865d1c5203de1b732017dd032e85f943d1592e8d3152eb7d2c4f3fca387bf
 
 system_accounts="_shadowsocks"
 make_dirs="/etc/shadowsocks-rust 0755 root root"
+
+# periodically hangs while trying to connect to www.example.com:80
+make_check_args="-- --skip=http_proxy"
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built and tested this PR locally with my native architectures, x86_64 glibc and aarch64 glibc
- I built this PR cross for these architectures:
  - x86_64-musl (masterdir)
  - aarch64 (cross and native)
  - aarch64-musl (cross and masterdir)
  - i686 (masterdir)
  - armv7l (cross)
  - armv7l-musl (cross)
  - armv6l (cross)
  - armv6l-musl (cross)
