### PR TITLE
Signal-Desktop: update to 7.69.0

### DIFF
--- a/srcpkgs/Signal-Desktop/template
+++ b/srcpkgs/Signal-Desktop/template
@@ -1,6 +1,6 @@
 # Template file for 'Signal-Desktop'
 pkgname=Signal-Desktop
-version=7.64.0
+version=7.69.0
 revision=1
 # *-musl could potentially work based on the Alpine port:
 # https://git.alpinelinux.org/aports/tree/testing/signal-desktop
@@ -14,7 +14,7 @@ maintainer="dkwo <npiazza@disroot.org>"
 license="AGPL-3.0-only"
 homepage="https://github.com/signalapp/Signal-Desktop"
 distfiles="https://github.com/signalapp/Signal-Desktop/archive/v${version}.tar.gz"
-checksum=2ca8675a9049c7c02c2de2d006d6f71704dcbc4e7ddb8ad4dfeb3e9132878bd8
+checksum=543efa9d93afdb753c5286b4851071531ef8ccab19bc36948fd0d9f2ca098a9c
 nostrip_files="signal-desktop"
 nocross="gyp -> aarch64-linux-gnu-gcc: error: unrecognized command-line option '-m64'"
 


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark
crossbuilds):
  - x86_64-glibc

## Summary
- Update Signal-Desktop from previous version to 7.69.0
- Update checksum for new tarball