### PR TITLE
feh: update to 3.11.2

### DIFF
--- a/srcpkgs/feh/template
+++ b/srcpkgs/feh/template
@@ -1,6 +1,6 @@
 # Template file for 'feh'
 pkgname=feh
-version=3.11.1
+version=3.11.2
 revision=1
 build_style=gnu-makefile
 make_use_env=yes
@@ -15,7 +15,7 @@ license="MIT-feh"
 homepage="https://feh.finalrewind.org"
 changelog="https://raw.githubusercontent.com/derf/feh/master/ChangeLog"
 distfiles="${homepage}/feh-${version}.tar.bz2"
-checksum=43d8e6742ec273ef3084bde82c5ead5a074348d9bfce28f1b0f8504623ca9b74
+checksum=020f8bce84c709333dcc6ec5fff36313782e0b50662754947c6585d922a7a7b2
 
 pre_build() {
 	vsed -i 's|doc/feh/examples|examples/feh|' config.mk


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, **x86_64**

#### Comments

https://feh.finalrewind.org/

https://github.com/void-linux/void-packages/pull/57020

3.11.1 breaks X11 smooth scroll and mouse warp
