### PR TITLE
libgcrypt: update to 1.11.2.

### DIFF
--- a/srcpkgs/libgcrypt/template
+++ b/srcpkgs/libgcrypt/template
@@ -1,6 +1,6 @@
 # Template file for 'libgcrypt'
 pkgname=libgcrypt
-version=1.11.1
+version=1.11.2
 revision=1
 build_style=gnu-configure
 configure_args="--enable-static --without-capabilities"
@@ -10,7 +10,7 @@ maintainer="skmpz <dem.procopiou@gmail.com>"
 license="LGPL-2.1-or-later"
 homepage="https://www.gnupg.org"
 distfiles="https://gnupg.org/ftp/gcrypt/libgcrypt/libgcrypt-${version}.tar.bz2"
-checksum=24e91c9123a46c54e8371f3a3a2502f1198f2893fbfbf59af95bc1c21499b00e
+checksum=6ba59dd192270e8c1d22ddb41a07d95dcdbc1f0fb02d03c4b54b235814330aac
 
 if [ "$CROSS_BUILD" ]; then
 	configure_args+=" ac_cv_sys_symbol_underscore=no"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures:
  - [x] i686-glibc
  - [x] x86_64-musl
  - [x] aarch64-glibc (x86_64-glibc)
  - [x] aarch64-musl (x86_64-musl)
  - [x] armv7l-glibc (x86_64-glibc)
  - [x] armv6l-musl (x86_64-musl)
