### PR TITLE
kdialog: update to 25.08.0.

### DIFF
--- a/srcpkgs/kdialog/template
+++ b/srcpkgs/kdialog/template
@@ -1,6 +1,6 @@
 # Template file for 'kdialog'
 pkgname=kdialog
-version=24.08.0
+version=25.08.0
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
@@ -15,4 +15,4 @@ license="GPL-2.0-or-later"
 homepage="https://invent.kde.org/utilities/kdialog"
 changelog="https://kde.org/announcements/changelogs/gear/${version}/#kdialog"
 distfiles="${KDE_SITE}/release-service/${version}/src/kdialog-${version}.tar.xz"
-checksum=fe76282996578f14e73b0c5cccec9b5028747d1d96681fda64f0cfa295f50854
+checksum=7772cdfe2acccfda420c627a8b1f4cf35acc1906f5155fc2166ee482e10755a3


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
