### PR TITLE
librecad: update to 2.2.1.2.

### DIFF
--- a/srcpkgs/LibreCAD/template
+++ b/srcpkgs/LibreCAD/template
@@ -1,6 +1,6 @@
 # Template file for 'LibreCAD'
 pkgname=LibreCAD
-version=2.2.1.1
+version=2.2.1.2
 revision=1
 build_style=qmake
 hostmakedepends="qt5-qmake pkg-config ImageMagick qt5-host-tools"
@@ -10,7 +10,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-only"
 homepage="https://librecad.org"
 distfiles="https://github.com/librecad/librecad/archive/refs/tags/v${version}.tar.gz"
-checksum=29c2f6fca4e0018f1e99fe324a8e9177780c1b01c435c2950a2c52627a47fdbf
+checksum=2b961cb916a7415d97f427f824c1830e06d4832cc376fea38b27cb456ee95a8e
 
 if [ -n "$CROSS_BUILD" ]; then
 	configure_args+=" BOOST_DIR=${XBPS_CROSS_BASE}/usr"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

The testing done is described in issue: #55876.
I cannot reproduce the crash described in that issue, not with previous 2.2.1.1 version, nor with the new update: 2.2.1.2.

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-musl)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64 (crossbuild)