### PR TITLE
New package: cotp-1.9.7

### DIFF
--- a/srcpkgs/cotp/template
+++ b/srcpkgs/cotp/template
@@ -1,0 +1,17 @@
+# Template file for 'cotp'
+pkgname=cotp
+version=1.9.7
+revision=1
+build_style=cargo
+short_desc="Command line TOTP/HOTP authenticator"
+maintainer="Emil Miler <em@0x45.cz>"
+license="GPL-3.0-or-later"
+homepage="https://github.com/replydev/cotp"
+changelog="https://github.com/replydev/cotp/raw/main/CHANGELOG.md"
+distfiles="https://github.com/replydev/cotp/archive/refs/tags/v${version}.tar.gz"
+checksum=6234805a8eb20a71d2acb07ad8d7827bd5c98c653b7eb733bab0f90cbb9f6212
+
+post_install() {
+	vmkdir /usr/share/cotp
+	vcopy converters /usr/share/cotp
+}


### PR DESCRIPTION
Command line TOTP/HOTP authenticator: https://github.com/replydev/cotp

Since [OTPClient](https://github.com/void-linux/void-packages/blob/master/srcpkgs/OTPClient/template), a GTK program, is the only simple OTP authenticator currently available in Void repositories, I reckon this package could be a good addition for users without a graphical environment. Upstream development is active.

#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
