### PR TITLE
cups: update to 2.4.13.

### DIFF
--- a/srcpkgs/cups/template
+++ b/srcpkgs/cups/template
@@ -1,6 +1,6 @@
 # Template file for 'cups'
 pkgname=cups
-version=2.4.11
+version=2.4.13
 revision=1
 build_style=gnu-configure
 make_install_args="BUILDROOT=${DESTDIR}"
@@ -14,7 +14,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="Apache-2.0 WITH custom:GPL-2.0-LGPL-2.0-Exception, Zlib"
 homepage="https://github.com/OpenPrinting/cups"
 distfiles="https://github.com/OpenPrinting/cups/releases/download/v${version}/cups-${version}-source.tar.gz"
-checksum=9a88fe1da3a29a917c3fc67ce6eb3178399d68e1a548c6d86c70d9b13651fd71
+checksum=8255ecf037be72660de24a73bcada042fc5bf509fc87bc8ad16cd0675735c1a8
 
 if [ "$XBPS_TARGET_LIBC" = "glibc" ]; then
 	makedepends+=" libxcrypt-devel"


### PR DESCRIPTION
Fix for
[CVE-2025-58060 cups: Authentication bypass with AuthType Negotiate](https://seclists.org/oss-sec/2025/q3/165)
[CVE-2025-58364 cups: Remote DoS via null dereference](https://seclists.org/oss-sec/2025/q3/166)

#### Testing the changes
- I tested the changes in this PR: **briefly** (only that is starts)

#### Local build testing
- I built this PR locally for my native architecture, (x86-84-LIBC)