### PR TITLE
ncspot: update to 1.3.1.

### DIFF
--- a/srcpkgs/ncspot/template
+++ b/srcpkgs/ncspot/template
@@ -1,6 +1,6 @@
 # Template file for 'ncspot'
 pkgname=ncspot
-version=1.2.1
+version=1.3.1
 revision=1
 build_style=cargo
 build_helper="qemu"
@@ -14,14 +14,7 @@ license="BSD-2-Clause"
 homepage="https://github.com/hrkfdn/ncspot"
 changelog="https://raw.githubusercontent.com/hrkfdn/ncspot/main/CHANGELOG.md"
 distfiles="https://github.com/hrkfdn/ncspot/archive/refs/tags/v${version}.tar.gz"
-checksum=6bd08609a56aa5854a1964c9a872fe58b69a768d7d94c874d40d7a8848241213
-
-# FIXME: Workaround will be removed when https://github.com/aws/aws-lc-rs/issues/632 is resolved
-case "$XBPS_TARGET_MACHINE" in
-	armv[67]l)
-		export AWS_LC_SYS_CFLAGS="-Wno-stringop-overflow"
-		;;
-esac
+checksum=d767fbe4c742b18a3ef7203162cc55a0976e07e478295445a5de1660666e2f15
 
 post_build() {
 	cargo auditable build --release --target ${RUST_TARGET} --package xtask


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64
- I built this PR locally for these architectures:
  - x86_64-musl
  - aarch64 (cross)
  - aarch64-musl (cross)

The built packages are available for the above mentioned architectures in the following repository for testing: https://voidrepo.nordstadt.club/pr-update-ncspot

This repo is signed by 'Moabeat' with fingerprint 29:37:3f:88:73:9a:c2:6c:24:63:29:63:3b:e0:40:7d