### PR TITLE
gnutls: update to 3.8.10

### DIFF
--- a/srcpkgs/gnutls/template
+++ b/srcpkgs/gnutls/template
@@ -1,6 +1,6 @@
 # Template file for 'gnutls'
 pkgname=gnutls
-version=3.8.6
+version=3.8.10
 revision=1
 build_style=gnu-configure
 configure_args="--disable-static --disable-valgrind-tests
@@ -21,7 +21,7 @@ license="GPL-3.0-only, LGPL-2.1-or-later"
 homepage="https://gnutls.org"
 changelog="https://gitlab.com/gnutls/gnutls/-/raw/master/NEWS"
 distfiles="https://www.gnupg.org/ftp/gcrypt/gnutls/v${version%.*}/gnutls-${version}.tar.xz"
-checksum=2e1588aae53cb32d43937f1f4eca28febd9c0c7aa1734fc5dd61a7e81e0ebcdd
+checksum=db7fab7cce791e7727ebbef2334301c821d79a550ec55c9ef096b610b03eb6b7
 # same as $PASS in tests/cert-tests/certtool.sh
 make_check_pre="env GNUTLS_PIN=1234"
 


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64
- I built this PR locally for these architectures:
  - x86_64-musl
  - aarch64 (cross)
  - aarch64-musl (cross)

The built packages are available for the above mentioned architectures in the following repository for testing: https://voidrepo.nordstadt.club/pr-update-gnutls

This repo is signed by 'Moabeat' with fingerprint 29:37:3f:88:73:9a:c2:6c:24:63:29:63:3b:e0:40:7d