### PR TITLE
mkinitcpio: fix for new busybox.static

### DIFF
--- a/srcpkgs/mkinitcpio/patches/busybox.patch
+++ b/srcpkgs/mkinitcpio/patches/busybox.patch
@@ -1,0 +1,22 @@
+The busybox executable can show itself in the --list output, which will
+overwrite the executable previously copied with a self-referential symlink. By
+copying the executable *after* copying all the symlinks, we ensure that the
+problem is overwritten.
+
+--- a/install/base
++++ b/install/base
+@@ -4,12 +4,12 @@
+ build() {
+     local applet
+ 
+-    add_binary /usr/lib/initcpio/busybox /bin/busybox
+-
+     for applet in $(/usr/lib/initcpio/busybox --list); do
+         add_symlink "/usr/bin/$applet" busybox
+     done
+ 
++    add_binary /usr/lib/initcpio/busybox /bin/busybox
++
+     # add kmod with applet symlinks
+     add_binary kmod
+     for applet in {dep,ins,rm,ls}mod mod{probe,info}; do

--- a/srcpkgs/mkinitcpio/template
+++ b/srcpkgs/mkinitcpio/template
@@ -1,7 +1,7 @@
 # Template file for 'mkinitcpio'
 pkgname=mkinitcpio
 version=39.2
-revision=4
+revision=5
 build_style=gnu-makefile
 hostmakedepends="asciidoc"
 depends="busybox-static bsdtar bash zstd"


### PR DESCRIPTION
The busybox executable can show itself in the --list output, which will overwrite the executable previously copied with a self-referential symlink. By copying the executable *after* copying all the symlinks, we ensure that the problem is overwritten.

#### Testing the changes
- I tested the changes in this PR: **briefly**

cc: @classabbyamp @tranzystorekk 