### PR TITLE
mu4e: upgrade to latest 1.12.xx release

### DIFF
--- a/srcpkgs/mu4e/patches/fix-root-test.patch
+++ b/srcpkgs/mu4e/patches/fix-root-test.patch
@@ -1,20 +1,29 @@
-Remove a test which fails when run as root.
+From 24f7cec6b4b84cc75b7de18b16fd73d85ee448f9 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Martin=20Kj=C3=A6r=20J=C3=B8rgensen?= <me@lagy.org>
+Date: Mon, 15 Sep 2025 11:37:57 +0200
+Subject: [PATCH] remove broken test for void
+
+---
+ lib/tests/test-mu-store.cc | 6 ------
+ 1 file changed, 6 deletions(-)
 
 diff --git a/lib/tests/test-mu-store.cc b/lib/tests/test-mu-store.cc
-index 872c56e3..c4e7eeb2 100644
+index b1573e7a..9d77d046 100644
 --- a/lib/tests/test-mu-store.cc
 +++ b/lib/tests/test-mu-store.cc
-@@ -470,13 +470,6 @@ test_store_fail()
+@@ -633,12 +633,6 @@ test_store_fail()
  		const auto store = Store::make("/root/non-existent-path/12345");
  		g_assert_false(!!store);
  	}
 -
 -	{
 -		const auto store = Store::make_new("/../../root/non-existent-path/12345",
--						   "/../../root/non-existent-path/54321",
--						   {}, {});
+-						   "/../../root/non-existent-path/54321");
 -		g_assert_false(!!store);
 -	}
  }
  
- int
+ 
+-- 
+2.51.0
+

--- a/srcpkgs/mu4e/template
+++ b/srcpkgs/mu4e/template
@@ -1,6 +1,6 @@
 # Template file for 'mu4e'
 pkgname=mu4e
-version=1.10.8
+version=1.12.13
 revision=1
 build_style=meson
 hostmakedepends="emacs libtool pkg-config texinfo glib-devel"
@@ -11,6 +11,6 @@ license="GPL-3.0-or-later"
 homepage="https://www.djcbsoftware.nl/code/mu/"
 changelog="https://github.com/djcb/mu/raw/master/NEWS.org"
 distfiles="https://github.com/djcb/mu/releases/download/v${version}/mu-${version}.tar.xz"
-checksum=6b11d8add2a7eeb0ebc4a5c7a6b9a9b3e1be8c5175c0c1c019a7ad8d7e363589
+checksum=7908078c5cc90afc7c038d4372b33b404f7fddfe466a27994413dc06f993a445
 replaces="mu<${version}"
 provides="mu-${version}_${revision}"


### PR DESCRIPTION
I felt like upgrading to latest mu-1.12 release. I use it daily as my email client and haven't come across any problems so far. I have also altered the root test patch, so that all the tests passes.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64

