### PR TITLE
utfcpp: update to 4.0.7

### DIFF
--- a/srcpkgs/utfcpp/template
+++ b/srcpkgs/utfcpp/template
@@ -1,15 +1,15 @@
 # Template file for 'utfcpp'
 pkgname=utfcpp
-version=4.0.6
+version=4.0.7
 revision=1
 build_style=cmake
-configure_args="-DUTF8_TESTS=OFF -DBUILD_SHARED_LIBS=ON"
+configure_args="-DBUILD_SHARED_LIBS=ON"
 short_desc="Generic library that handles UTF-8 encoded strings"
 maintainer="Mateusz Sylwestrzak <slymattz@gmail.com>"
 license="BSL-1.0"
 homepage="https://github.com/nemtrif/utfcpp"
 distfiles="https://github.com/nemtrif/utfcpp/archive/v${version}.tar.gz"
-checksum=6920a6a5d6a04b9a89b2a89af7132f8acefd46e0c2a7b190350539e9213816c0
+checksum=1afaa8090eea45ed81625ad3df3bf485f28abbb4393eca28b23d8a01880b34a6
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**
I successfully built taglib which, at this moment, is the only package that makedepends on utfcpp:
do_configure (relevant part):
```
...
-- Using utfcpp 4.0.7 from /usr/share/utf8cpp/cmake/utf8cppConfig.cmake
...
```



#### Local build testing
- I built this PR locally for my native architecture: x86_64-glibc
