### PR TITLE
libutf8proc: update to 2.11.0

### DIFF
--- a/srcpkgs/libutf8proc/template
+++ b/srcpkgs/libutf8proc/template
@@ -1,6 +1,6 @@
 # Template file for 'libutf8proc'
 pkgname=libutf8proc
-version=2.10.0
+version=2.11.0
 revision=1
 build_style=cmake
 configure_args="-DBUILD_SHARED_LIBS=ON"
@@ -10,7 +10,7 @@ license="MIT"
 homepage="http://juliastrings.github.io/utf8proc/"
 changelog="https://raw.githubusercontent.com/JuliaStrings/utf8proc/master/NEWS.md"
 distfiles="https://github.com/JuliaStrings/utf8proc/archive/refs/tags/v${version}.tar.gz"
-checksum=6f4f1b639daa6dca9f80bc5db1233e9cbaa31a67790887106160b33ef743f136
+checksum=c24379b5fa0a429a1f9a3fc23b44a75f2b141a34c09146a529a55d20a5808070
 
 if [ -n "$XBPS_CHECK_PKGS" ]; then
 	configure_args+=" -DUTF8PROC_ENABLE_TESTING=ON"
@@ -25,6 +25,7 @@ libutf8proc-devel_package() {
 	short_desc+=" - development files"
 	pkg_install() {
 		vmove usr/include
+		vmove usr/lib/cmake
 		vmove usr/lib/pkgconfig
 		vmove "usr/lib/*.so"
 	}


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
