### PR TITLE
radicale: update to 3.5.6.

### DIFF
--- a/srcpkgs/radicale/template
+++ b/srcpkgs/radicale/template
@@ -1,6 +1,6 @@
 # Template file for 'radicale'
 pkgname=radicale
-version=3.5.4
+version=3.5.6
 revision=1
 build_style=python3-pep517
 hostmakedepends="python3-setuptools"
@@ -14,7 +14,7 @@ license="GPL-3.0-or-later"
 homepage="https://radicale.org"
 changelog="https://raw.githubusercontent.com/Kozea/Radicale/master/CHANGELOG.md"
 distfiles="https://github.com/Kozea/Radicale/archive/refs/tags/v${version}.tar.gz"
-checksum=dcbfb7ab0b2f89cab0f566ea179d768a5016597b0c1f177431a123de57509b3b
+checksum=700ddd24139da88c155d1757f41dd8ae01079c401997b528ec159825f2d9671f
 conf_files="
  /etc/radicale/config
  /etc/radicale/rights"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-libc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - i686-libc
