### PR TITLE
python3-pytest-black: update to 0.6.0, adopt.

### DIFF
--- a/srcpkgs/python3-pytest-black/template
+++ b/srcpkgs/python3-pytest-black/template
@@ -1,17 +1,17 @@
 # Template file for 'python3-pytest-black'
 pkgname=python3-pytest-black
-version=0.3.12
-revision=3
+version=0.6.0
+revision=1
 build_style=python3-module
 hostmakedepends="python3-setuptools python3-setuptools_scm"
 depends="python3-pytest black python3-toml"
 checkdepends="${depends} flake8"
 short_desc="Pytest plugin to enable formatting checks with black"
-maintainer="Orphaned <orphan@voidlinux.org>"
+maintainer="Jason Elswick <jason@jasondavid.us>"
 license="MIT"
-homepage="https://github.com/shopkeep/pytest-black"
-distfiles="${PYPI_SITE}/p/pytest-black/pytest-black-${version}.tar.gz"
-checksum=1d339b004f764d6cd0f06e690f6dd748df3d62e6fe1a692d6a5500ac2c5b75a5
+homepage="https://github.com/coherent-oss/pytest-black"
+distfiles="${PYPI_SITE}/p/pytest-black/pytest_black-${version}.tar.gz"
+checksum=ecb77455f379805cb4bd8f45a813a3754c3bbee3199adf1b3665c0dfd086b511
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-libc
