### PR TITLE
ruby-build: update to 20250916, adopt

### DIFF
--- a/srcpkgs/ruby-build/template
+++ b/srcpkgs/ruby-build/template
@@ -1,14 +1,14 @@
 # Template file for 'ruby-build'
 pkgname=ruby-build
-version=20240727
+version=20250916
 revision=1
 depends="bash"
 short_desc="Compile and install Ruby"
-maintainer="Orphaned <orphan@voidlinux.org>"
+maintainer="Hanshi <rvyhvn@tuta.io>"
 license="MIT"
 homepage="https://github.com/rbenv/ruby-build"
 distfiles="https://github.com/rbenv/ruby-build/archive/refs/tags/v${version}.tar.gz"
-checksum=c6359deb8694e19c00af37cadef239af7e3f00e63d89e9333870bbb0178d039c
+checksum=0317015d7257b2a8110b7aa3e046b4ccc3ba6691c8fadb1ef71f7ea445544c79
 
 do_install() {
 	vbin bin/ruby-build


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)