### PR TITLE
nfs-utils: update to 2.8.4

### DIFF
--- a/srcpkgs/nfs-utils/template
+++ b/srcpkgs/nfs-utils/template
@@ -1,7 +1,7 @@
 # Template file for 'nfs-utils'
 pkgname=nfs-utils
-version=2.8.3
-revision=3
+version=2.8.4
+revision=1
 build_style=gnu-configure
 configure_args="--with-statduser=nobody --enable-gss --enable-nfsv4
  --with-statedir=/var/lib/nfs --enable-libmount-mount --enable-svcgss
@@ -13,7 +13,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="https://www.linux-nfs.org/"
 distfiles="${KERNEL_SITE}/utils/${pkgname}/${version}/${pkgname}-${version}.tar.xz"
-checksum=11e7c5847a8423a72931c865bd9296e7fd56ff270a795a849183900961711725
+checksum=11c4cc598a434d7d340bad3e072a373ba1dcc2c49f855d44b202222b78ecdbf5
 replaces="rpcgen>=0"
 
 hostmakedepends="pkg-config libtirpc-devel rpcsvc-proto mit-krb5-devel"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
**YES** - it works fine both on the server and client sides 

nfs-utils linked fine against libtirpc that's currently in the repo (v. 1.3.6), but I also built it against v. 1.3.7 and encountered no issues during compilation (see https://github.com/void-linux/void-packages/pull/56959 for reference.)

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture: x86_64-glibc
- I built this PR locally for these architectures: x86_64-musl