### PR TITLE
python3-starlette: update to 0.48.0

### DIFF
--- a/srcpkgs/python3-starlette/template
+++ b/srcpkgs/python3-starlette/template
@@ -1,16 +1,16 @@
 # Template file for 'python3-starlette'
 pkgname=python3-starlette
-version=0.38.5
-revision=2
+version=0.48.0
+revision=1
 build_style=python3-pep517
-hostmakedepends="hatchling"
-depends="python3"
+hostmakedepends="hatchling python3-pluggy"
+depends="python3 python3-anyio"
 short_desc="Lightweight ASGI framework for building async web services"
 maintainer="Emil Miler <em@0x45.cz>"
 license="BSD-3-Clause"
 homepage="https://github.com/encode/starlette"
 distfiles="${PYPI_SITE}/s/starlette/starlette-${version}.tar.gz"
-checksum=04a92830a9b6eb1442c766199d62260c3d4dc9c4f9188360626b1e0273cb7077
+checksum=7e8cee469a8ab2352911528110ce9088fdc6a37d9876926e73da7ce4aa4c7a46
 # Many modules needed for testing are not available
 make_check=no
 


### PR DESCRIPTION
- I tested the changes in this PR: **NO**
- I built this PR locally for my native architecture, (x86_64-glibc)