### PR TITLE
openvpn: update to 2.6.15

### DIFF
--- a/srcpkgs/openvpn/template
+++ b/srcpkgs/openvpn/template
@@ -1,6 +1,6 @@
 # Template file for 'openvpn'
 pkgname=openvpn
-version=2.6.14
+version=2.6.15
 revision=1
 build_style=gnu-configure
 configure_args="$(vopt_enable pkcs11) --disable-systemd
@@ -16,7 +16,7 @@ license="GPL-2.0-only"
 homepage="https://www.openvpn.net"
 changelog="https://raw.githubusercontent.com/OpenVPN/openvpn/release/${version%.*}/Changes.rst"
 distfiles="https://build.openvpn.net/downloads/releases/openvpn-${version}.tar.gz"
-checksum=9eb6a6618352f9e7b771a9d38ae1631b5edfeed6d40233e243e602ddf2195e7a
+checksum=e35513ee15995e3c71adfd8891b9f33522896c70b3baa2ed9a23c7a42c4d7bde
 # t_net.sh fails on CI.
 make_check=ci-skip
 


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **yes**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - aarch64
  - i686
  - armv7l-musl
  - armv7l
  - armv6l-musl
  - armv6l