### PR TITLE
miniserve: update to 0.32.0.

### DIFF
--- a/srcpkgs/miniserve/template
+++ b/srcpkgs/miniserve/template
@@ -1,6 +1,6 @@
 # Template file for 'miniserve'
 pkgname=miniserve
-version=0.29.0
+version=0.32.0
 revision=1
 build_style=cargo
 build_helper=qemu
@@ -17,7 +17,7 @@ license="MIT"
 homepage="https://github.com/svenstaro/miniserve"
 changelog="https://raw.githubusercontent.com/svenstaro/miniserve/master/CHANGELOG.md"
 distfiles="https://github.com/svenstaro/miniserve/archive/refs/tags/v${version}.tar.gz"
-checksum=48351a8165bd51f3c855695af1c25032b502f873c80f52f98a538174951cbb9f
+checksum=30cfabd398f0c17c2eff3fdab115b5681e21fb048f363955a064249d14cd5869
 make_check=ci-skip  # port binding succeeds locally but fails in CI
 
 case "$XBPS_TARGET_MACHINE" in


### PR DESCRIPTION

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
