### PR TITLE
New package: mpdris2-rs-1.0.2

### DIFF
--- a/srcpkgs/mpdris2-rs/template
+++ b/srcpkgs/mpdris2-rs/template
@@ -1,0 +1,12 @@
+# Template file for 'mpdris2-rs'
+pkgname=mpdris2-rs
+version=1.0.2
+revision=1
+build_style=cargo
+depends="dbus"
+short_desc="Exposing MPRIS V2.1 D-Bus interface for mpd"
+maintainer="Stefan <s@omfm.ru>"
+license="GPL-3.0-only"
+homepage="https://github.com/szclsya/mpdris2-rs"
+distfiles="https://github.com/szclsya/mpdris2-rs/archive/refs/tags/v${version}.tar.gz"
+checksum=465d5662df14156eb9994d1fc88d51144b14bcf568f4f7cebd930a591bf7840b


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**


<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures:
  - aarch64

<hr>

https://github.com/eonpatapon/mpDris2/ which is in the repo is old. Author hasn't released any new versions in 4 years. And it has worked kinda bumpy with dbus from my experience.

This new package works like a charm either started through WM or via turnstile user service.

