### PR TITLE
dhcpcd: update to 10.2.4.

### DIFF
--- a/srcpkgs/dhcpcd/template
+++ b/srcpkgs/dhcpcd/template
@@ -1,6 +1,6 @@
 # Template file for 'dhcpcd'
 pkgname=dhcpcd
-version=10.1.0
+version=10.2.4
 revision=1
 build_style=configure
 make_check_target=test
@@ -15,7 +15,7 @@ license="BSD-2-Clause"
 homepage="https://roy.marples.name/projects/dhcpcd"
 changelog="https://github.com/NetworkConfiguration/dhcpcd/releases"
 distfiles="https://github.com/NetworkConfiguration/dhcpcd/archive/refs/tags/v${version}.tar.gz"
-checksum=e8a83208c2ff63a5a31d886f76bc717b4ec1938d18a2c8b88f328e710d2b515a
+checksum=85c8b2535ddf52091b30b31f29b0f9cafd9cd94dc6b78f1bd92db2afce4c1943
 lib32disabled=yes
 conf_files=/etc/dhcpcd.conf
 


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64
- I built this PR locally for these architectures:
  - x86_64-musl
  - i686
  - aarch64 (cross)
  - aarch64-musl (cross)
  - armv7l (cross)
  - armv7l-musl (cross)


