### PR TITLE
slirp4netns: update to 1.3.3.

### DIFF
--- a/srcpkgs/slirp4netns/template
+++ b/srcpkgs/slirp4netns/template
@@ -1,6 +1,6 @@
 # Template file for 'slirp4netns'
 pkgname=slirp4netns
-version=1.3.1
+version=1.3.3
 revision=1
 build_style=gnu-configure
 hostmakedepends="autoconf automake pkg-config"
@@ -11,7 +11,7 @@ license="GPL-2.0-only"
 homepage="https://github.com/rootless-containers/slirp4netns"
 changelog="https://github.com/rootless-containers/slirp4netns/releases"
 distfiles="https://github.com/rootless-containers/slirp4netns/archive/v${version}.tar.gz"
-checksum=a3b7c7b593b279c46d25a48b583371ab762968e98b6a46457d8d52a755852eb9
+checksum=8d24539967850bada944d56459eb9e9167357d57b39e864d95ed7d6c0dd0298d
 # tests fail due to use of unshare (unavailable with chroot util-linux)
 make_check=no
 


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **NO**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - armv6l
