### PR TITLE
electrum: update to 4.6.2.

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -3686,7 +3686,7 @@ libdwarves_emit.so.1 pahole-1.12_1
 libdwarves_reorganize.so.1 pahole-1.12_1
 libclthreads.so.2 clthreads-2.4.2_1
 libclxclient.so.3 clxclient-3.9.2_1
-libsecp256k1.so.2 libsecp256k1-0.3.2_1
+libsecp256k1.so.6 libsecp256k1-0.7.0_1
 libltc.so.11 libltc-1.3.1_1
 libvpd-2.2.so.2 libvpd-2.2.6_1
 libvpd_cxx-2.2.so.2 libvpd-2.2.6_1

--- a/srcpkgs/electrum-aionostr/template
+++ b/srcpkgs/electrum-aionostr/template
@@ -1,0 +1,20 @@
+# Template file for 'electrum-aionostr'
+pkgname=electrum-aionostr
+version=0.0.11
+revision=1
+build_style=python3-pep517
+hostmakedepends="python3-setuptools python3-wheel"
+makedepends="python3-devel"
+depends="electrum-ecc python3-aiohttp python3-aiohttp_socks python3-aiorpcx"
+checkdepends="$depends python3-pytest python3-click python3-cryptography
+ python3-pytest-cov"
+short_desc="Asyncio Nostr client for Python"
+maintainer="Arjan Mossel <arjanmossel@gmail.com>"
+license="BSD-3-Clause"
+homepage="https://electrum.org/"
+distfiles="https://github.com/spesmilo/electrum-aionostr/archive/${version}.tar.gz"
+checksum=37c8ac0cd373662cf801aba5e2d8c06530c1d20936a3f165d78f72d89a0cf46d
+
+post_install() {
+	vlicense LICENSE
+}

--- a/srcpkgs/electrum-ecc/template
+++ b/srcpkgs/electrum-ecc/template
@@ -1,0 +1,22 @@
+# Template file for 'electrum-ecc'
+pkgname=electrum-ecc
+version=0.0.6
+revision=1
+build_style=python3-pep517
+hostmakedepends="python3-setuptools python3-wheel"
+makedepends="python3-devel libsecp256k1-devel"
+depends="python3 libsecp256k1"
+checkdepends="$depends python3-pytest"
+short_desc="Python ctypes wrapper for libsecp256k1"
+maintainer="Arjan Mossel <arjanmossel@gmail.com>"
+license="MIT"
+homepage="https://electrum.org/"
+distfiles="https://github.com/spesmilo/electrum-ecc/archive/${version}.tar.gz"
+checksum=d51c6a2433d5784359e9c6ace9641d3fe73a97ec9d17d62cc5de5474e0681174
+
+# Use system libsecp256k1 library
+export ELECTRUM_ECC_DONT_COMPILE=1
+
+post_install() {
+	vlicense LICENSE.txt
+}

--- a/srcpkgs/electrum/template
+++ b/srcpkgs/electrum/template
@@ -1,7 +1,7 @@
 # Template file for 'electrum'
 pkgname=electrum
-version=4.5.8
-revision=2
+version=4.6.2
+revision=1
 build_style=python3-module
 hostmakedepends="python3-setuptools python3-pyqt6-devel-tools"
 depends="python3-aiohttp python3-aiohttp_socks python3-aiorpcx
@@ -9,7 +9,8 @@ depends="python3-aiohttp python3-aiohttp_socks python3-aiorpcx
  python3-protobuf python3-pyaes python3-pycryptodomex python3-pyqt6
  python3-qrcode python3-socks python3-cryptography libsecp256k1
  python3-async-timeout python3-certifi python3-jsonpatch libzbar
- python3-pyqt6-declarative python3-pyqt6-gui python3-pyqt6-network"
+ python3-pyqt6-declarative python3-pyqt6-gui python3-pyqt6-network
+ python3-attrs electrum-ecc electrum-aionostr"
 # Optional dependencies:
 #  btchip - BTChip hardware wallet support
 #  trezor - TREZOR hardware wallet support
@@ -22,7 +23,7 @@ license="MIT"
 homepage="https://electrum.org/"
 changelog="https://raw.githubusercontent.com/spesmilo/electrum/master/RELEASE-NOTES"
 distfiles="https://github.com/spesmilo/electrum/archive/${version}.tar.gz"
-checksum=84221054e6452ea11d4b80cb4bf6e0c539c57dbff3c414c1a44e5442dc9e1caf
+checksum=a51e091e993ebaaa3f9952531c9a8c9a07b6a4e6ea21833a4b7e644dc01ce4be
 
 post_install() {
 	vsed -i -e 's|electrum %u|electrum|' \

--- a/srcpkgs/libsecp256k1/template
+++ b/srcpkgs/libsecp256k1/template
@@ -1,6 +1,6 @@
 # Template file for 'libsecp256k1'
 pkgname=libsecp256k1
-version=0.5.1
+version=0.7.0
 revision=1
 build_style=gnu-configure
 configure_args="--disable-benchmark --disable-coverage --enable-experimental
@@ -12,7 +12,7 @@ maintainer="Arjan Mossel <arjanmossel@gmail.com>"
 license="MIT"
 homepage="https://github.com/bitcoin-core/secp256k1"
 distfiles="https://github.com/bitcoin-core/secp256k1/archive/v${version}.tar.gz"
-checksum="081f4730becba2715a6b0fd198fedd9e649a6caaa6a7d6d3cf0f9fa7483f2cf1"
+checksum="073d19064f3600014750d6949b31a0c957aa7b98920fb4aaa495be07e8e7cd00"
 
 pre_configure() {
 	./autogen.sh

--- a/srcpkgs/python3-aiorpcx/template
+++ b/srcpkgs/python3-aiorpcx/template
@@ -1,7 +1,7 @@
 # Template file for 'python3-aiorpcx'
 pkgname=python3-aiorpcx
-version=0.22.1
-revision=4
+version=0.25.0
+revision=1
 build_style=python3-module
 hostmakedepends="python3-setuptools"
 depends="python3-attrs"
@@ -13,7 +13,7 @@ license="MIT"
 homepage="https://github.com/kyuupichan/aiorpcX"
 # missing license in PyPI tarball
 distfiles="https://github.com/kyuupichan/aiorpcX/archive/${version}.tar.gz"
-checksum=f72034c4854daf32d83c06ca940d39336908d55ad6a2fe17c039124d51b89430
+checksum=64982de255cc6e008dd3dbd7fa46525a2d8573206275289b705dbfbae107cd72
 make_check=ci-skip # Tests using IPv6 fail on Github Actions, pass locally
 
 post_install() {


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-libc)

python3-aiorpcx-0.25.0 is needed for electrum runtime and tests (Python 3.13 compatibility, old version gives `TypeError: BaseEventLoop.create_connection() got an unexpected keyword argument 'transport'`), but I did not get all its own tests to pass locally, issues with websockets.

@lemmi.