### PR TITLE
tuxedo-drivers: add udev rules

### DIFF
--- a/srcpkgs/tuxedo-drivers/template
+++ b/srcpkgs/tuxedo-drivers/template
@@ -1,7 +1,7 @@
 # Template file for 'tuxedo-drivers'
 pkgname=tuxedo-drivers
 version=4.15.4
-revision=1
+revision=2
 depends="dkms"
 short_desc="TUXEDO hardware drivers"
 maintainer="newbluemoon <blaumolch@mailbox.org>"
@@ -17,6 +17,7 @@ do_install() {
 	vmkdir usr/src/${pkgname}-${version}
 	vcopy src/* usr/src/${pkgname}-${version}
 	vinstall etc/modprobe.d/tuxedo_keyboard.conf 644 usr/lib/modprobe.d/
+	vcopy usr/lib/udev usr/lib
 }
 
 tuxedo-keyboard_package() {


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**
<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)
- Built for kernels 6.1, 6.3–6.15; running on 6.16.8

The source tarball contains now some udev rules, add them to the package.