### PR TITLE
gcc: update to 14.3.0, isl: update to 0.27

### DIFF
--- a/srcpkgs/gcc/template
+++ b/srcpkgs/gcc/template
@@ -3,16 +3,16 @@
 # which use the version number.
 
 pkgname=gcc
-version=14.2.1+20250405
-revision=2
+version=14.3.0
+revision=1
 bootstrap=yes
 _patchver="${version%+*}"
 _minorver="${version%.*}"
 _majorver="${_minorver%.*}"
 _gmp_version=6.3.0
-_mpfr_version=4.2.1
+_mpfr_version=4.2.2
 _mpc_version=1.3.1
-_isl_version=0.26
+_isl_version=0.27
 short_desc="GNU Compiler Collection"
 maintainer="Enno Boland <gottox@voidlinux.org>"
 homepage="http://gcc.gnu.org"
@@ -26,11 +26,11 @@ distfiles+="
  ${GNU_SITE}/mpfr/mpfr-${_mpfr_version}.tar.xz
  ${GNU_SITE}/mpc/mpc-${_mpc_version}.tar.gz
  ${SOURCEFORGE_SITE}/libisl/isl-${_isl_version}.tar.bz2"
-checksum="9a84b0947d8fb18197eef3fce8e255e30a61f7f382cebb961b1705c1d99214a3
+checksum="e0dc77297625631ac8e50fa92fffefe899a4eb702592da5c32ef04e2293aca3a
  a3c2b80201b89e68616f4ad30bc66aee4927c3ce50e33929ca819d5c43538898
- 277807353a6726978996945af13e52829e3abd7a9a5b7fb2793894e18f1fcbb2
+ b67ba0383ef7e8a8563734e2e889ef5ec3c3b898a01d00fa0a6869ad81c6ce01
  ab642492f5cf882b74aa0cb730cd410a81edcdbec895183ce930e706c1c759b8
- 5eac8664e9d67be6bd0bee5085d6840b8baf738c06814df47eaf4166d9776436"
+ 626335529331f7c89fec493de929e2e92fb3d8cc860fc7af554e0518ee0029ee"
 skip_extraction="gmp-${_gmp_version}.tar.xz mpfr-${_mpfr_version}.tar.xz
  mpc-${_mpc_version}.tar.gz isl-${_isl_version}.tar.bz2"
 

--- a/srcpkgs/isl/template
+++ b/srcpkgs/isl/template
@@ -1,6 +1,6 @@
 # Template file for 'isl'
 pkgname=isl
-version=0.26
+version=0.27
 revision=1
 build_style=gnu-configure
 makedepends="gmp-devel"
@@ -10,7 +10,7 @@ license="MIT"
 homepage="https://libisl.sourceforge.io/"
 changelog="https://repo.or.cz/isl.git/blob_plain/HEAD:/ChangeLog"
 distfiles="${SOURCEFORGE_SITE}/libisl/isl-${version}.tar.bz2"
-checksum=5eac8664e9d67be6bd0bee5085d6840b8baf738c06814df47eaf4166d9776436
+checksum=626335529331f7c89fec493de929e2e92fb3d8cc860fc7af554e0518ee0029ee
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)

Note: As isl is a dependency of gcc and also has a new version available, I thought it would be a good idea to update both in order to not have to compile gcc again against isl when it eventually gets updated.