### PR TITLE
incus: update to 6.17.0.

### DIFF
--- a/srcpkgs/incus/template
+++ b/srcpkgs/incus/template
@@ -1,6 +1,6 @@
 # Template file for 'incus'
 pkgname=incus
-version=6.15.0
+version=6.17.0
 revision=1
 build_style=go
 build_helper=qemu
@@ -18,7 +18,7 @@ maintainer="dkwo <npiazza@disroot.org>"
 license="Apache-2.0"
 homepage="https://linuxcontainers.org/incus"
 distfiles="https://github.com/lxc/incus/archive/refs/tags/v${version}.tar.gz"
-checksum=49091d8d16d21e2e891c82b19abfd860a1aa2bbcc3fb35e7d21f6ff6a9850abb
+checksum=19bcceaab1fad128ae1b91de4f4a3526ec77097de4df0cff057832d6fccb2404
 system_groups="_incus-admin _incus"
 make_dirs="
  /var/lib/incus 0755 root root


### PR DESCRIPTION
One day testing so far, LXCs and VMs, will keep poking.

#### Testing the changes
- I tested the changes in this PR: **YES**


#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
  - x86_64-glibc 
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl (CROSS)
  - armv6l (CROSS)
