### PR TITLE
libslirp: update to 4.9.1.

### DIFF
--- a/srcpkgs/libslirp/template
+++ b/srcpkgs/libslirp/template
@@ -1,6 +1,6 @@
 # Template file for 'libslirp'
 pkgname=libslirp
-version=4.8.0
+version=4.9.1
 revision=1
 build_style=meson
 hostmakedepends="pkg-config"
@@ -11,7 +11,7 @@ license="BSD-3-Clause"
 homepage="https://gitlab.freedesktop.org/slirp/libslirp"
 changelog="https://gitlab.freedesktop.org/slirp/libslirp/-/blob/master/CHANGELOG.md"
 distfiles="https://gitlab.freedesktop.org/slirp/libslirp/-/archive/v${version}/libslirp-v${version}.tar.gz"
-checksum=2a98852e65666db313481943e7a1997abff0183bd9bea80caec1b5da89fda28c
+checksum=3970542143b7c11e6a09a4d2b50f30a133473c41f15ed0bdcc3b7a1c450d9a5c
 
 pre_configure() {
 	printf '%s\n' "${version}" > .tarball-version


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **NO**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - i686
  - aarch64
  - armv7l
  - x86_64-musl
  - armv6l-musl
  - aarch64-musl
