### PR TITLE
pgbackrest: update to 2.56.0.

### DIFF
--- a/srcpkgs/pgbackrest/template
+++ b/srcpkgs/pgbackrest/template
@@ -1,6 +1,6 @@
 # Template file for 'pgbackrest'
 pkgname=pgbackrest
-version=2.55.1
+version=2.56.0
 revision=1
 build_style=meson
 build_helper=qemu
@@ -13,7 +13,7 @@ maintainer="Anachron <gith@cron.world>"
 license="MIT"
 homepage="http://www.pgbackrest.org/"
 distfiles="https://github.com/pgbackrest/pgbackrest/archive/release/${version}.tar.gz"
-checksum=5f050ad751feb5b506cf3c58a5cf1674a7b502328abcb50b37756175f80990e9
+checksum=e4ed91be1c518817fd2909c99edc0d3661126fde86abf77a0d470da09741447f
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-glibc