### PR TITLE
freetype: update to 2.14.1

### DIFF
--- a/srcpkgs/freetype/template
+++ b/srcpkgs/freetype/template
@@ -1,6 +1,6 @@
 # Template file for 'freetype'
 pkgname=freetype
-version=2.13.3
+version=2.14.1
 revision=1
 build_style=gnu-configure
 configure_args="--enable-freetype-config"
@@ -13,7 +13,7 @@ homepage="https://www.freetype.org/"
 # Should be using NONGNU_SITE instead, but that often redirects to outdated
 # mirrors, causing fetching the distfile to fail.
 distfiles="https://download-mirror.savannah.gnu.org/releases/freetype/freetype-${version}.tar.xz"
-checksum=0550350666d427c74daeb85d5ac7bb353acba5f76956395995311a9c6f063289
+checksum=32427e8c471ac095853212a37aef816c60b42052d4d9e48230bab3bdf2936ccc
 
 post_patch() {
 	vsed -i -e "s/%PKG_CONFIG%/pkg-config/" builds/unix/freetype-config.in


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**
- fonts are still being rendered as expected everywhere after the update

#### Local build testing
- I built this PR locally for my native architecture, (**x86_64-glibc**)

[Changelog](https://freetype.org/index.html#news)