### PR TITLE
SDL2_image: add missing libavif dependency

### DIFF
--- a/srcpkgs/SDL2_image/template
+++ b/srcpkgs/SDL2_image/template
@@ -1,11 +1,11 @@
 # Template file for 'SDL2_image'
 pkgname=SDL2_image
 version=2.8.8
-revision=1
+revision=2
 build_style=cmake
 configure_args="-DSDL2IMAGE_WEBP=ON"
 hostmakedepends="pkg-config"
-makedepends="SDL2-devel libjpeg-turbo-devel libpng-devel libwebp-devel
+makedepends="SDL2-devel libavif-devel libjpeg-turbo-devel libpng-devel libwebp-devel
  tiff-devel zlib-devel"
 short_desc="Load images as SDL surfaces (SDL 2.x)"
 maintainer="Orphaned <orphan@voidlinux.org>"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
