### PR TITLE
New package: loderunner-ng-0.1.4

### DIFF
--- a/srcpkgs/loderunner-ng/template
+++ b/srcpkgs/loderunner-ng/template
@@ -1,0 +1,13 @@
+# Template file for 'loderunner-ng'
+pkgname=loderunner-ng
+version=0.1.4
+revision=1
+build_style=cmake
+configure_args="-DCMAKE_INSTALL_PREFIX=/usr"
+makedepends="SDL2-devel SDL2_image-devel SDL2_mixer-devel"
+short_desc="Classic Apple II Lode Runner game remake"
+maintainer="biopsin <biopsin@tuta.com>"
+license="GPL-3.0-or-later"
+homepage="https://github.com/vchimishuk/loderunner-ng"
+distfiles="https://github.com/vchimishuk/loderunner-ng/archive/refs/tags/$version.tar.gz"
+checksum=ee7d9828a8acfc535255ed50c6dd1b9d1040aebc4a6eb72df853e72c65c6e7ba


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Description
- loderunner-ng is a classic Lode Runner game remake heavily based on [LodeRunner_TotalRecall](https://github.com/SimonHung/LodeRunner_TotalRecall) implementation by Simon Hung.

#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl [ok]
  - armv7l [ok]
  - armv6l-musl [ok]
  - i686 [ok]

