### PR TITLE
pcre2: update to 10.46

### DIFF
--- a/srcpkgs/pcre2/template
+++ b/srcpkgs/pcre2/template
@@ -1,6 +1,6 @@
 # Template file for 'pcre2'
 pkgname=pcre2
-version=10.45
+version=10.46
 revision=1
 build_style=gnu-configure
 configure_args="--with-pic --enable-pcre2-16 --enable-pcre2-32
@@ -13,7 +13,7 @@ license="BSD-3-Clause"
 homepage="https://www.pcre.org/"
 changelog="https://raw.githubusercontent.com/PCRE2Project/pcre2/master/NEWS"
 distfiles="https://github.com/PhilipHazel/pcre2/releases/download/pcre2-${version}/pcre2-${version}.tar.bz2"
-checksum=21547f3516120c75597e5b30a992e27a592a31950b5140e7b8bfde3f192033c4
+checksum=15fbc5aba6beee0b17aecb04602ae39432393aba1ebd8e39b7cabf7db883299f
 
 post_install() {
 	vlicense LICENCE.md


### PR DESCRIPTION
[Security-only release](https://raw.githubusercontent.com/PCRE2Project/pcre2/master/NEWS)
Addresses CVE-2025-58050.

#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, (**x86_64-glibc**)

cc @Gottox 
