### PR TITLE
tuxedo-drivers: update to 4.18.2

### DIFF
--- a/srcpkgs/tuxedo-drivers/template
+++ b/srcpkgs/tuxedo-drivers/template
@@ -1,14 +1,14 @@
 # Template file for 'tuxedo-drivers'
 pkgname=tuxedo-drivers
-version=4.15.4
-revision=2
+version=4.18.2
+revision=1
 depends="dkms"
 short_desc="TUXEDO hardware drivers"
 maintainer="newbluemoon <blaumolch@mailbox.org>"
 license="GPL-3.0-or-later"
 homepage="https://gitlab.com/tuxedocomputers/development/packages/tuxedo-drivers"
 distfiles="https://gitlab.com/tuxedocomputers/development/packages/tuxedo-drivers/-/archive/v${version}/tuxedo-drivers-v${version}.tar.gz"
-checksum=b39929e850aab91934b7456c74323ebb6d5dd9b616120dd862c14980fc47c368
+checksum=f32433d3b8d45fbf866e7a4a10a23bc6f64b4cfe2f1f07b5a05f690fb748f224
 
 dkms_modules="tuxedo-drivers ${version}"
 
@@ -16,7 +16,7 @@ do_install() {
 	sed "s/#MODULE_VERSION#/${version}/" debian/tuxedo-drivers.dkms > src/dkms.conf
 	vmkdir usr/src/${pkgname}-${version}
 	vcopy src/* usr/src/${pkgname}-${version}
-	vinstall etc/modprobe.d/tuxedo_keyboard.conf 644 usr/lib/modprobe.d/
+	vcopy usr/lib/modprobe.d usr/lib
 	vcopy usr/lib/udev usr/lib
 }
 


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**
<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)
- Built for kernels 6.1, 6.3–6.18; running on 6.18.2