### PR TITLE
libevdev: update to 1.13.4.

### DIFF
--- a/srcpkgs/libevdev/template
+++ b/srcpkgs/libevdev/template
@@ -1,17 +1,17 @@
 # Template file for 'libevdev'
 pkgname=libevdev
-version=1.13.2
+version=1.13.4
 revision=1
 build_style=gnu-configure
 configure_args="--disable-gcov"
-hostmakedepends="python3"
-checkdepends="pkg-config check-devel"
+hostmakedepends="pkg-config python3"
+checkdepends="check-devel"
 short_desc="Wrapper library for evdev devices"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
 homepage="https://www.freedesktop.org/wiki/Software/libevdev/"
 distfiles="${FREEDESKTOP_SITE}/libevdev/libevdev-${version}.tar.xz"
-checksum=3eca86a6ce55b81d5bce910637fc451c8bbe373b1f9698f375c7f1ad0de3ac48
+checksum=f00ab8d42ad8b905296fab67e13b871f1a424839331516642100f82ad88127cd
 
 post_install() {
 	vlicense COPYING


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Changes
Moved pkg-config to host as
```
checking pkg-config is at least version 0.9.0... ./configure: line 13354: pkg-config: command not found
configure: error: pkg-config not found
```


#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l [ok]
  - armv6l-musl

