### PR TITLE
wine: update to 10.16

### DIFF
--- a/srcpkgs/wine/template
+++ b/srcpkgs/wine/template
@@ -1,6 +1,6 @@
 # Template file for 'wine'
 pkgname=wine
-version=10.15
+version=10.16
 revision=1
 _pkgver=${version/r/-r}
 create_wrksrc=yes
@@ -13,8 +13,8 @@ license="LGPL-2.1-or-later"
 homepage="http://www.winehq.org/"
 distfiles="https://dl.winehq.org/wine/source/${version%.*}.x/wine-${_pkgver}.tar.xz
  https://github.com/wine-staging/wine-staging/archive/v${_pkgver}.tar.gz"
-checksum="307e21237c6e8bdea266f946d31f09ed27b1957df9a03516d8271fd13e1c261d
- 2ecb37ea0a87b8a9a6c1f76e5bf1a5d64fac2a09ad3f7aecf00bfd917ae96420"
+checksum="c5ed2742bff208c63b005bcfb91a2fc6cc49af6c6695bc8c0cf0fe6f4da60446
+ 6c6db948edfae72820baa0e1a2a25190854061758a8792b5b8dce999ae55a0aa"
 
 # NOTE: wine depends on specific versions of wine-mono and wine-gecko,
 # check for updates to these packages when updating wine


### PR DESCRIPTION
@Hoshpak 

I only tested x86_64-glibc.

Worth noting that in this new version the new WoW64 mode now supports 16bit apps too, closing the feature parity gap.

Given that arch switched to those by default and there are many more testers, perhaps it's time to consider the transition as I expect it to fully mature promptly.