### PR TITLE
gnupg: add support for tpm

### DIFF
--- a/srcpkgs/gnupg/template
+++ b/srcpkgs/gnupg/template
@@ -2,7 +2,7 @@
 # minor version updates (2.3-> 2.4) often need a fix in reverse dependencies
 pkgname=gnupg
 version=2.4.5
-revision=1
+revision=2
 # We're building outside of the source tree, because upstream told us to:
 # https://dev.gnupg.org/T6313#166339
 build_wrksrc=build
@@ -17,7 +17,7 @@ configure_script="../configure"
 hostmakedepends="pkg-config gettext"
 makedepends="bzip2-devel gnutls-devel libassuan-devel libcurl-devel
  libksba-devel libldap-devel libusb-compat-devel npth-devel sqlite-devel
- libgcrypt-devel libgpg-error-devel"
+ libgcrypt-devel libgpg-error-devel tpm2-tss-devel"
 depends="pinentry"
 short_desc="GNU Privacy Guard (2.x)"
 maintainer="Orphaned <orphan@voidlinux.org>"


### PR DESCRIPTION
This allows the use of the `keytotpm` function.

#### Testing the changes
- I tested the changes in this PR: **YES**
* I have the new version running on my computer


#### Local build testing
- I built this PR locally for my native architecture, (x86-64)
