### PR TITLE
New package: passage

### DIFF
--- a/srcpkgs/passage/template
+++ b/srcpkgs/passage/template
@@ -1,0 +1,13 @@
+# Template file for 'passage'
+pkgname=passage
+version=1.7.4a2
+revision=1
+build_style=gnu-makefile
+make_install_args="WITH_BASHCOMP=yes WITH_ZSHCOMP=yes WITH_FISHCOMP=yes"
+depends="bash age tree git qrencode"
+short_desc="Stores, retrieves, generates, and synchronizes passwords securely"
+maintainer="dkwo <npiazza@disroot.org>"
+license="GPL-2.0-or-later"
+homepage="https://github.com/FiloSottile/passage"
+distfiles="https://github.com/FiloSottile/passage/archive/refs/tags/${version}.tar.gz"
+checksum=d4bd97be2eda4249b31c2042707ef70ba50385f6fb7791598f51be794168ee2c


### PR DESCRIPTION
- I tested the changes in this PR: yes
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**
- I built this PR locally for my native architecture, (aarch64-glibc)

This is a fork a pass that uses age instead of gnupg, maintained by the author of age.