### PR TITLE
kwallet-cli: port to KDE 6

### DIFF
--- a/srcpkgs/kwallet-cli/patches/kwallet6.patch
+++ b/srcpkgs/kwallet-cli/patches/kwallet6.patch
@@ -1,0 +1,63 @@
+--- a/GNUmakefile
++++ b/GNUmakefile
+@@ -35,32 +35,15 @@ OBJS=		charconv.o main.o
+ 
+ PKG_CONFIG?=	pkg-config
+ 
+-KDE_VER:=	3
+-ifeq (${KDE_VER},3)
+-KDE_INCS?=	-I/usr/include/qt3 -I/usr/include/kde
+-SRCS+=		kwif3.cc
+-OBJS+=		kwif3.o
+-LDADD+=		-lkwalletclient -lkdecore -lqt-mt
+-else
+-ifeq (${KDE_VER},4)
+-KDE_INCS?=	-I/usr/include/qt4 -I/usr/include/qt4/QtCore
+-SRCS+=		kwif4.cc
+-OBJS+=		kwif4.o
+-LDADD+=		-lkdeui -lkdecore -lQtCore
+-else
+-ifeq (${KDE_VER},5)
+-KDE_INCS?=	$(shell ${PKG_CONFIG} --cflags Qt5Gui) \
+-		-I/usr/include/KF5/KI18n \
+-		-I/usr/include/KF5/KCoreAddons \
+-		-I/usr/include/KF5/KWallet
++KDE_VER:=	6
++KDE_INCS?=	$(shell ${PKG_CONFIG} --cflags Qt6Widgets) \
++		-I/usr/include/KF6/KI18n \
++		-I/usr/include/KF6/KCoreAddons \
++		-I/usr/include/KF6/KWallet
+ SRCS+=		kwif5.cc
+ OBJS+=		kwif5.o
+-LDADD+=		-lKF5CoreAddons -lKF5Wallet -lKF5I18n -lQt5Core -lQt5Widgets
+-else
+-$(error unknown KDE_VER)
+-endif
+-endif
+-endif
++LDADD+=		-lKF6CoreAddons -lKF6Wallet -lKF6I18n -lQt6Core -lQt6Widgets
++LDADD+=		$(shell ${PKG_CONFIG} --libs Qt6Widgets)
+ 
+ CPPFLAGS+=	${KDE_INCS} -fPIC -D_GNU_SOURCE
+ LDFLAGS+=	-fPIC
+--- a/kwif5.cc
++++ b/kwif5.cc
+@@ -25,7 +25,6 @@
+  */
+ 
+ #include <qstring.h>
+-#include <QtWidgets/qdesktopwidget.h>
+ #include <QtWidgets/qapplication.h>
+ #include <klocalizedstring.h>
+ #include <kaboutdata.h>
+@@ -68,9 +67,7 @@ kw_io(const char *fld, const char *ent,
+ 	KAboutData::setApplicationData(aboutData);
+ 
+ 	localwallet = KWallet::Wallet::LocalWallet();
+-	wallet = KWallet::Wallet::openWallet(localwallet,
+-	    /* https://lists.qt-project.org/pipermail/interest/2020-November/035993.html */
+-	    QApplication::desktop()->screen()->winId());
++	wallet = KWallet::Wallet::openWallet(localwallet, 0);
+ 
+ 	if (!wallet) {
+ 		rv = KWE_NOWALLET;

--- a/srcpkgs/kwallet-cli/template
+++ b/srcpkgs/kwallet-cli/template
@@ -1,21 +1,24 @@
 # Template file for 'kwallet-cli'
 pkgname=kwallet-cli
 version=3.03
-revision=1
+revision=2
 build_style=gnu-makefile
-make_build_args="KDE_VER=5"
+make_build_args="KDE_VER=6"
 hostmakedepends="pkg-config"
-makedepends="kwallet-devel qt5-devel"
+makedepends="kf6-kwallet-devel"
 depends="mksh"
 short_desc="Command-line interface to the KDE Wallet"
 maintainer="Louis Dupré Bertoni <contact@louis.xyz>"
 license="MirOS, LGPL-3.0-or-later"
 homepage="https://www.mirbsd.org/kwalletcli.htm"
 distfiles="http://www.mirbsd.org/MirOS/dist/hosted/kwalletcli/kwalletcli-${version}.tar.gz"
+distfiles="${DEBIAN_SITE}/main/k/kwalletcli/kwalletcli_${version}.orig.tar.gz"
 checksum=f228e5b179f6eb92289b9635382e676990dd58cd193ce42b61d3150c8a06b12d
 
 post_patch() {
-	vsed -i GNUmakefile -e "s|-I/usr/include|-I${XBPS_CROSS_BASE}/usr/include|g"
+	if [ "$CROSS_BUILD" ]; then
+		sed -i GNUmakefile -e "s|-I/usr/include|-I${XBPS_CROSS_BASE}/usr/include|g"
+	fi
 }
 
 pre_install() {


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
