### PR TITLE
libdecor: update to 0.2.4

### DIFF
--- a/srcpkgs/libdecor/template
+++ b/srcpkgs/libdecor/template
@@ -1,6 +1,6 @@
 # Template file for 'libdecor'
 pkgname=libdecor
-version=0.2.2
+version=0.2.4
 revision=1
 build_style=meson
 configure_args="-Ddemo=false $(vopt_feature dbus dbus)"
@@ -10,9 +10,9 @@ makedepends="wayland-devel wayland-protocols pango-devel
 short_desc="Client-side decorations library for Wayland client"
 maintainer="Arda Demir <ddmirarda@gmail.com>"
 license="MIT"
-homepage="https://gitlab.gnome.org/jadahl/libdecor"
+homepage="https://gitlab.freedesktop.org/libdecor/libdecor"
 distfiles="https://gitlab.freedesktop.org/libdecor/libdecor/-/archive/${version}/libdecor-${version}.tar.gz"
-checksum=40a1d8be07d8b1f66e8fb98a1f4a84549ca6bf992407198a5055952be80a8525
+checksum=1fb3ee6c7c9e238d240772517753bedb2e09e29d21514fb86f19724fccb58cc1
 
 build_options="dbus"
 build_options_default="dbus"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, **x86_64-glibc**

Somebody running `gamescope` might want to test this, too.

cc @ardadem 