### PR TITLE
rmpc: update to 0.9.0

### DIFF
--- a/srcpkgs/rmpc/template
+++ b/srcpkgs/rmpc/template
@@ -1,6 +1,6 @@
 # Template file for 'rmpc'
 pkgname=rmpc
-version=0.8.0
+version=0.9.0
 revision=1
 build_style=cargo
 short_desc="TUI MPD client with album art support"
@@ -9,7 +9,7 @@ license="BSD-3-Clause"
 homepage="https://mierak.github.io/rmpc"
 changelog="https://raw.githubusercontent.com/mierak/rmpc/refs/heads/master/CHANGELOG.md"
 distfiles="https://github.com/mierak/rmpc/archive/refs/tags/v${version}.tar.gz"
-checksum="f2ff534ad662d6bb033f1715c27406718eb7025655f5c30c94a6b051e3a1c371"
+checksum=c0dca5f4be1222591a69b82e77d6fe42df259e6130ea7ea7dd6372515b5f4357
 
 post_install() {
 	vman "target/man/rmpc.1"


### PR DESCRIPTION
Tagging the maintainer @wreedb 

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl

