### PR TITLE
New package: libva-intel-driver-irql 2.4.4

### DIFF
--- a/srcpkgs/libva-intel-driver-irql/template
+++ b/srcpkgs/libva-intel-driver-irql/template
@@ -1,9 +1,8 @@
 # Template file for 'libva-intel-driver-irql'
 pkgname=libva-intel-driver-irql
-version=2.4.4
+version=2.4.5
 revision=1
 archs="i686* x86_64*"
-conflicts="libva-intel-driver"
 build_style=meson
 hostmakedepends="pkg-config"
 makedepends="libX11-devel libva-glx-devel libdrm-devel wayland-devel MesaLib-devel"
@@ -13,14 +12,14 @@ license="MIT"
 homepage="https://github.com/irql-notlessorequal/intel-vaapi-driver"
 changelog="https://github.com/irql-notlessorequal/intel-vaapi-driver/master/NEWS"
 distfiles="https://github.com/irql-notlessorequal/intel-vaapi-driver/archive/refs/tags/${version}.tar.gz"
-checksum=ddb13866c399622d95fa2d8b372f8f8d7dc738432cc20dff52a74159fac12b9c
+checksum=f89f77bc46ec6f46392c1b90b9bf34d09f908bf33c9d16d385897b1fe282bacc
+conflicts="libva-intel-driver"
 
 pre_configure() {
         # Only relevant if intel-gpu-tools is installed,
         # since then the shaders will be recompiled
         sed -i '1s/python$/&2/' src/shaders/gpp.py
 }
-
 post_install() {
         vlicense LICENSE
 }


### PR DESCRIPTION
Testing the changes

    I tested the changes in this PR: YES

Local build testing

    I built this PR locally for my native architecture, (x86_64-glibc , x86_64-musl)
 
------------------------------------------------------------------------------
Intel VA-API driver for legacy hardware.

This is a fork with many changes, including but not limited to:
https://github.com/irql-notlessorequal/intel-vaapi-driver?tab=readme-ov-file#intel-va-api-driver-for-legacy-hardware

    Functioning Chromium support [✻]
    Fix JPEG decoding of oddly encoded files on gen7/8 (https://github.com/intel/intel-vaapi-driver/pull/514)
    fix exporting buffers with 3 planes and VA_EXPORT_SURFACE_SEPARATE_LAYERS (https://github.com/intel/intel-vaapi-driver/pull/530)
    i965_pci_ids: Add CFL PCI ID found on Xeon W-1290P (https://github.com/intel/intel-vaapi-driver/pull/548)
    Make wl_drm optional (https://github.com/intel/intel-vaapi-driver/pull/566)
    Expose VAConfigAttribMaxPictureWidth and VAConfigAttribMaxPictureHeight.
    Full support for vaSyncBuffer, vaSyncSurface2 and vaMapBuffer2. (enabling async_depth in FFMPEG)
    More accurate per-codec limits.
    Improved hybrid codec driver support.
    Expose ARGB format support. (https://github.com/intel/intel-vaapi-driver/issues/500)
   The NEWS file contains a more detailed changelog.
  [✻] Works on IVB and newer, broken on SNB and ILK (for now)
