### PR TITLE
gdbm: update to 1.26

### DIFF
--- a/srcpkgs/gdbm/template
+++ b/srcpkgs/gdbm/template
@@ -1,6 +1,6 @@
 # Template file for 'gdbm'
 pkgname=gdbm
-version=1.23
+version=1.26
 revision=1
 build_style=gnu-configure
 configure_args="--enable-libgdbm-compat --disable-rpath"
@@ -9,7 +9,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-3.0-or-later"
 homepage="http://www.gnu.org.ua/software/gdbm/"
 distfiles="${GNU_SITE}/${pkgname}/${pkgname}-${version}.tar.gz"
-checksum=74b1081d21fff13ae4bd7c16e5d6e504a4c26f7cde1dca0d963a484174bbcacd
+checksum=6a24504a14de4a744103dcb936be976df6fbe88ccff26065e54c1c47946f4a5e
 
 if [ "$CROSS_BUILD" ]; then
 	hostmakedepends="libtool automake gettext-devel"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**
- tested as `perl` and `python3` dep - system and programs (e.g. `git`) are still working as expected
- briefly tested basic functionality of `gdbmtool`

#### Local build testing
- I built this PR locally for my native architecture, **x86_64-glibc**

[Changelog](https://puszcza.gnu.org.ua/news/?group=gdbm)
