### PR TITLE
highway: update to 1.3.0.

### DIFF
--- a/srcpkgs/highway/template
+++ b/srcpkgs/highway/template
@@ -1,6 +1,6 @@
 # Template file for 'highway'
 pkgname=highway
-version=1.2.0
+version=1.3.0
 revision=1
 build_style=cmake
 configure_args="-DHWY_SYSTEM_GTEST=ON -DHWY_ENABLE_EXAMPLES=OFF -DBUILD_SHARED_LIBS=ON"
@@ -11,7 +11,7 @@ license="Apache-2.0"
 homepage="https://github.com/google/highway"
 changelog="https://raw.githubusercontent.com/google/highway/master/debian/changelog"
 distfiles="https://github.com/google/highway/archive/${version}.tar.gz"
-checksum=7e0be78b8318e8bdbf6fa545d2ecb4c90f947df03f7aadc42c1967f019e63343
+checksum=07b3c1ba2c1096878a85a31a5b9b3757427af963b1141ca904db2f9f4afe0bc2
 
 if [ -z "$XBPS_CHECK_PKGS" ]; then
 	configure_args+=" -DBUILD_TESTING=OFF"


### PR DESCRIPTION
### Testing the changes
- I tested the changes in this PR: **briefly**
  - encoded/decoded stuff with libjxl and vips; didn't use the highway lib directly myself

#### Local build testing
- I built this PR locally for my native architecture, `x86_64-glibc`
