### PR TITLE
kbd: update to 2.9.0

### DIFF
--- a/srcpkgs/kbd/template
+++ b/srcpkgs/kbd/template
@@ -1,6 +1,6 @@
 # Template file for 'kbd'
 pkgname=kbd
-version=2.6.4
+version=2.9.0
 revision=1
 build_style=gnu-configure
 configure_args="--datadir=/usr/share/kbd --localedir=/usr/share/kbd/locale"
@@ -12,7 +12,7 @@ license="GPL-2.0-or-later"
 homepage="https://www.kbd-project.org/"
 changelog="https://github.com/legionus/kbd/releases"
 distfiles="${KERNEL_SITE}/utils/kbd/kbd-${version}.tar.xz"
-checksum=519f8d087aecca7e0a33cd084bef92c066eb19731666653dcc70c9d71aa40926
+checksum=fb3197f17a99eb44d22a3a1a71f755f9622dd963e66acfdea1a45120951b02ed
 replaces="kbd-data>=0"
 
 post_patch() {


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**|**briefly**|**NO**

#### Local build testing
- I built this PR locally for my native architecture, **x86_64-glibc**
- patches are still valid afaict from looking at the source, as well as:

```
post_patch() {
	# Rename keymap files with the same names
	# this is needed because when only name of keymap is specified
	# loadkeys loads the first keymap it can find, which is bad
	# this should be removed when upstream adopts the change
	mv data/keymaps/i386/qwertz/cz{,-qwertz}.map
	mv data/keymaps/i386/olpc/es{,-olpc}.map
	mv data/keymaps/i386/olpc/pt{,-olpc}.map
	mv data/keymaps/i386/fgGIod/trf{,-fgGIod}.map
	mv data/keymaps/i386/colemak/{en-latin9,colemak}.map
```

Notes:

This being the first time I compiled `kbd` I learned that my terminal of choice `foot` does not qualify for "being a console" and thus failing that test, meaning that I could build `kbd` only from inside a `tty`.
This may or may not be the case depending on the setup: https://github.com/legionus/kbd/issues/143

That being said, the following observations are true for both `kbd-2.6.4_1` (current) and `kbd-2.9.0_1` (update) on my system (default: `de-latin1` running `linux6.17-6.17.1_1`):

- issuing `showconsolefont` from `foot` reports: `Couldn't get a file descriptor referring to the console.` (and printing the expected keymap when issued from a `tty`)
- issuing e.g. `# loadkeys -C /dev/tty3 us` from `foot` will successfully load those keys on `tty3`
- basically all keys are working as expected after the update

cc @Gottox 