### PR TITLE
libreoffice: replace nonexistent dependency

### DIFF
--- a/srcpkgs/libreoffice/template
+++ b/srcpkgs/libreoffice/template
@@ -1,7 +1,7 @@
 # Template file for 'libreoffice'
 pkgname=libreoffice
 version=25.8.2.2
-revision=1
+revision=2
 build_helper="gir"
 build_style=configure # hack, avoid sourcing common/.../gnu-configure-args.sh
 metapackage=yes
@@ -575,7 +575,7 @@ libreoffice-fonts_package() {
 	 culmus
 	 dejavu-fonts-ttf
 	 font-adobe-source-code-pro
-	 font-adobe-source-sans-pro-v2
+	 source-sans-pro
 	 font-adobe-source-serif-pro
 	 font-alef
 	 font-crosextra-caladea-ttf


### PR DESCRIPTION
Libreoffice currently cannot be installed, because it attempts to pull in a dependency that does not exist, specifically "font-adobe-source-sans-pro-v2."

I did some digging and my best educated guess is that the package [source-sans-pro](https://github.com/void-linux/void-packages/tree/master/srcpkgs/source-sans-pro) is probably the package the maintainer was trying to pull in. I'd do some extra research before I'd merge this, but to me it seems right.

#### Testing the changes
- I tested the changes in this PR: **NO**

#### Updated package
- This updated package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

[ci skip]