### PR TITLE
synapse: update to 1.144.0.

### DIFF
--- a/srcpkgs/synapse/patches/poetry-core.patch
+++ b/srcpkgs/synapse/patches/poetry-core.patch
@@ -1,13 +1,13 @@
 diff --git a/pyproject.toml b/pyproject.toml
-index 28de934..8e66234 100644
+index 246a1d2..af21607 100644
 --- a/pyproject.toml
 +++ b/pyproject.toml
-@@ -367,7 +367,7 @@ tomli = ">=1.2.3"
+@@ -376,7 +376,7 @@ tomli = ">=1.2.3"
  # runtime errors caused by build system changes.
  # We are happy to raise these upper bounds upon request,
  # provided we check that it's safe to do so (i.e. that CI passes).
--requires = ["poetry-core>=1.1.0,<=2.1.3", "setuptools_rust>=1.3,<=1.11.1"]
-+requires = ["poetry-core>=1.1.0,<=2.2.0", "setuptools_rust>=1.3,<=1.12.0"]
+-requires = ["poetry-core>=2.0.0,<=2.1.3", "setuptools_rust>=1.3,<=1.11.1"]
++requires = ["poetry-core>=2.0.0,<=2.2.0", "setuptools_rust>=1.3,<=1.12.0"]
  build-backend = "poetry.core.masonry.api"
  
  

--- a/srcpkgs/synapse/template
+++ b/srcpkgs/synapse/template
@@ -1,7 +1,7 @@
 # Template file for 'synapse'
 pkgname=synapse
-version=1.139.2
-revision=2
+version=1.144.0
+revision=1
 build_style=python3-pep517
 build_helper=rust
 make_check_target=tests
@@ -17,7 +17,8 @@ depends="python3-jsonschema python3-immutabledict python3-unpaddedbase64
  python3-psycopg2 python3-lxml python3-saml2 python3-treq python3-macaroons
  python3-sortedcontainers python3-typing_extensions python3-cryptography
  python3-ijson python3-matrix-common python3-packaging python3-pydantic
- python3-automat python3-python-multipart python3-setuptools-rust"
+ python3-automat python3-python-multipart python3-setuptools-rust
+ python3-rpds-py"
 checkdepends="$depends python3-parameterized python3-txredisapi python3-hiredis
  xmlsec1 unzip"
 short_desc="Matrix reference homeserver"
@@ -26,7 +27,7 @@ license="AGPL-3.0-or-later"
 homepage="https://element-hq.github.io/synapse"
 changelog="https://raw.githubusercontent.com/element-hq/synapse/develop/CHANGES.md"
 distfiles="https://github.com/element-hq/synapse/archive/refs/tags/v${version}.tar.gz"
-checksum=e2912f8fe1b8edc26305e92b458e99be301ea2dd16128cdb80036420b1239932
+checksum=5de2d0cfaa2a71ac6a1d00f79bd6fd82c2c20f2217c1435b4b935cd3f9498bb1
 
 system_accounts="synapse"
 synapse_homedir="/var/lib/synapse"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

Bumped `python3-rpds-py` and `python3-typing_extensions` as synapse requires newer versions of these deps

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
