### PR TITLE
dinit: update to 0.19.4.

### DIFF
--- a/srcpkgs/dinit/template
+++ b/srcpkgs/dinit/template
@@ -1,6 +1,6 @@
 # Template file for 'dinit'
 pkgname=dinit
-version=0.19.2
+version=0.19.4
 revision=1
 build_style=meson
 configure_args="
@@ -16,7 +16,7 @@ license="Apache-2.0"
 homepage="https://davmac.org/projects/dinit/"
 changelog="https://raw.githubusercontent.com/davmac314/dinit/master/NEWS"
 distfiles="https://github.com/davmac314/dinit/archive/v${version}.tar.gz"
-checksum=d5e390bc0450b93b0b1b3826de5d46acc19b227b0f93077ea5a6ac8a9c7e2ca5
+checksum=3c0f624eb958f8e884631be4ef687da1e475ebaa6241e7ee330b864e6cd9e30b
 
 post_install() {
 	vmkdir usr/share/doc/dinit


### PR DESCRIPTION
- I tested the changes in this PR: **YES**
- I built this PR locally for my native architecture, (aarch64)

@classabbyamp The recent turnstile update broke dinit backend, this update fixes it.