### PR TITLE
swayidle: add elogind vopt

### DIFF
--- a/srcpkgs/swayidle/template
+++ b/srcpkgs/swayidle/template
@@ -1,17 +1,21 @@
 # Template file for 'swayidle'
 pkgname=swayidle
-version=1.8.0
+version=1.9.0
 revision=1
 build_style=meson
-configure_args="-Dlogind-provider=elogind -Dwerror=false"
+configure_args="$(vopt_if elogind -Dlogind-provider=elogind)"
 hostmakedepends="pkg-config wayland-devel scdoc"
-makedepends="wayland-devel wayland-protocols elogind-devel"
+makedepends="wayland-devel wayland-protocols $(vopt_if elogind elogind-devel)"
 short_desc="Idle management daemon for Wayland"
 maintainer="Derriick <derriick.ensiie@yahoo.com>"
 license="MIT"
 homepage="https://swaywm.org"
-distfiles="https://github.com/swaywm/swayidle/archive/${version}.tar.gz"
-checksum=0fba74c520a2bd64acd00bc3bce7bc8c7b84a2609c0f66329d72dfb33cca03d7
+distfiles="https://github.com/swaywm/swayidle/archive/refs/tags/v${version}.tar.gz"
+checksum=161f5827b8c79bc486a472d27690e98d75da6615bb2dee9f24393cbbb13af656
+
+build_options="elogind"
+desc_option_png="Enable support for elogind"
+build_options_default="elogind"
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
- I tested the changes in this PR: **YES**
- I built this PR locally for my native architecture, (aarch64-glibc)

The default does not change, but at least it is possible to build it without elogind (and hence dbus) without editing the template.