### PR TITLE
libarchive: update to 3.8.2

### DIFF
--- a/srcpkgs/libarchive/template
+++ b/srcpkgs/libarchive/template
@@ -1,6 +1,6 @@
 # Template file for 'libarchive'
 pkgname=libarchive
-version=3.8.1
+version=3.8.2
 revision=1
 bootstrap=yes
 build_style=gnu-configure
@@ -18,7 +18,7 @@ license="BSD-2-Clause"
 homepage="https://www.libarchive.org/"
 changelog="https://github.com/libarchive/libarchive/releases"
 distfiles="https://github.com/libarchive/libarchive/releases/download/v${version}/libarchive-${version}.tar.xz"
-checksum=19f917d42d530f98815ac824d90c7eaf648e9d9a50e4f309c812457ffa5496b5
+checksum=db0dee91561cbd957689036a3a71281efefd131d35d1d98ebbc32720e4da58e2
 
 build_options="acl expat lzo lz4 ssl zstd"
 build_options_default="acl ssl lz4 zstd"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, **x86_64-glibc**

Bugfix and security [release](https://github.com/libarchive/libarchive/releases)