### PR TITLE
magic-wormhole: update to 0.22.0

### DIFF
--- a/srcpkgs/magic-wormhole/template
+++ b/srcpkgs/magic-wormhole/template
@@ -1,19 +1,21 @@
 # Template file for 'magic-wormhole'
 pkgname=magic-wormhole
-version=0.15.0
-revision=3
+version=0.22.0
+revision=1
 build_style=python3-pep517
-hostmakedepends="python3 python3-build python3-setuptools python3-wheel"
+hostmakedepends="python3 python3-build python3-setuptools python3-wheel
+ python3-versioneer"
 depends="python3-autobahn python3-cffi python3-click python3-humanize
- python3-idna python3-pynacl python3-service_identity python3-spake2
- python3-tqdm python3-txtorcon python3-iterable-io python3-zipstream-ng"
+ python3-idna python3-pynacl python3-service_identity python3-spake2 python3-tqdm
+ python3-txtorcon python3-iterable-io python3-zipstream-ng python3-qrcode
+ python3-Twisted python3-attrs python3-automat python3-cryptography"
 short_desc="Get things from one computer to another, safely"
 maintainer="travankor <travankor@tuta.io>"
 license="MIT"
 homepage="https://magic-wormhole.readthedocs.io/en/latest/"
 changelog="https://raw.githubusercontent.com/magic-wormhole/magic-wormhole/master/NEWS.md"
-distfiles="https://github.com/warner/magic-wormhole/archive/${version}.tar.gz"
-checksum=bc77b7280876ad0e9611498cdee1aebb3d0ec0a9236bf7356dc8967f2d6ce201
+distfiles="https://github.com/magic-wormhole/magic-wormhole/archive/${version}.tar.gz"
+checksum=14a6029263c49109d71b0d0a82737690645d33f4067513bce2c7cca20da837ab
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures:
  - x86_64-musl

0.20.0 now requires python3-versioneer as a hostmake dependency to build and adds a runtime dependency on python3-qrcode in addition to the rest.
~Sub-dependencies like python3-Twisted get pulled in as part of magic-wormhole's dependencies.~
Added these dependencies explicitly.