### PR TITLE
xone: update to 0.4.8

### DIFF
--- a/srcpkgs/xone/template
+++ b/srcpkgs/xone/template
@@ -1,6 +1,6 @@
 # Template file for 'xone'
 pkgname=xone
-version=0.4.1
+version=0.4.8
 revision=1
 depends="curl cabextract dkms"
 short_desc="Modern Linux driver for Xbox One and Xbox Series X|S controllers"
@@ -8,7 +8,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-only"
 homepage="https://github.com/dlundqvist/xone"
 distfiles="https://github.com/dlundqvist/xone/archive/refs/tags/v${version}.tar.gz"
-checksum="81062412307ead3553b10364039ea76d4fa038b5b1dcc62e1acc2e5a2587deba"
+checksum=6da2ad1d250b41b2f232a3a253042788ac863cbc4af444cbb8c312017257ebf9
 
 dkms_modules="${pkgname} ${version}"
 


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl