### PR TITLE
cava: update to 0.10.6.

### DIFF
--- a/srcpkgs/cava/patches/iniparser-pkgconfig.patch
+++ b/srcpkgs/cava/patches/iniparser-pkgconfig.patch
@@ -1,29 +1,13 @@
 diff --git a/configure.ac b/configure.ac
-index 9b486f6..ef26b63 100644
+index 624e8d840b4..e6807ecb341 100644
 --- a/configure.ac
 +++ b/configure.ac
-@@ -423,21 +423,10 @@ dnl checking for iniparser
+@@ -422,7 +422,7 @@ dnl ######################
+ dnl checking for iniparser
  dnl ######################
- 
- AC_CHECK_LIB(iniparser,iniparser_load, have_iniparser=yes, have_iniparser=no)
-+    PKG_CHECK_MODULES(INIPARSER, iniparser, have_iniparser=yes, have_iniparser=no)
-     if [[ $have_iniparser = "yes" ]] ; then
--    LIBS="$LIBS -liniparser"
--    if [[ $build_mac = "yes" ]] ; then
--        CPPFLAGS="$CPPFLAGS -I/usr/local/include/iniparser/"
--        CPPFLAGS="$CPPFLAGS -I/opt/homebrew/include/iniparser/"
--    else
--        CPPFLAGS="$CPPFLAGS -I/usr/include/iniparser"
--    fi
--    AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <iniparser.h>]],
--      [[dictionary* ini;
--      const char *keys[3];
--      iniparser_getseckeys(ini, "eq", keys);]])],
--      [AC_MSG_RESULT(iniparser > 3.2 test OK)],
--      [AC_MSG_RESULT(iniparser > 3.2 test failed falling back to legacy iniparser mode)
--      CPPFLAGS="$CPPFLAGS -DLEGACYINIPARSER"])
-+      LIBS="$LIBS $INIPARSER_LIBS"
-+      CPPFLAGS="$CPPFLAGS $INIPARSER_CFLAGS"
-     fi
-     if [[ $have_iniparser = "no" ]] ; then
-       AC_MSG_ERROR([iniparser library is required!])
+
+-  PKG_CHECK_MODULES(INIPARSER, libiniparser, have_iniparser_pkg=yes, have_iniparser_pkg=no)
++  PKG_CHECK_MODULES(INIPARSER, iniparser, have_iniparser_pkg=yes, have_iniparser_pkg=no)
+   if [[ $have_iniparser_pkg = "yes" ]] ; then
+     LIBS="$LIBS $INIPARSER_LIBS"
+     CPPFLAGS="$CPPFLAGS $INIPARSER_CFLAGS"

--- a/srcpkgs/cava/template
+++ b/srcpkgs/cava/template
@@ -1,6 +1,6 @@
 # Template file for 'cava'
 pkgname=cava
-version=0.10.4
+version=0.10.6
 revision=1
 build_style=gnu-configure
 hostmakedepends="autoconf-archive automake libtool pkg-config"
@@ -13,7 +13,7 @@ license="MIT"
 homepage="https://github.com/karlstav/cava"
 changelog="https://github.com/karlstav/cava/releases"
 distfiles="https://github.com/karlstav/cava/archive/refs/tags/${version}.tar.gz"
-checksum=5a2efedf2d809d70770f49349f28a5c056f1ba9b3f5476e78744291a468e206a
+checksum=b1ce6653659a138cbaebf0ef2643a1569525559c597162e90bf9304ac8781398
 build_options="alsa jack pipewire pulseaudio sndio"
 build_options_default="alsa jack pipewire pulseaudio sndio"
 


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures:
  - [x] i686-glibc
  - [x] x86_64-musl
  - [x] aarch64-glibc (x86_64-glibc)
  - [x] aarch64-musl (x86_64-musl)
  - [x] armv7l-glibc (x86_64-glibc)
  - [x] armv6l-musl (x86_64-musl)