### PR TITLE
json-glib: update to 1.10.8.

### DIFF
--- a/srcpkgs/json-glib/template
+++ b/srcpkgs/json-glib/template
@@ -1,6 +1,6 @@
 # Template file for 'json-glib'
 pkgname=json-glib
-version=1.10.6
+version=1.10.8
 revision=1
 build_style=meson
 build_helper="gir"
@@ -15,7 +15,7 @@ license="LGPL-2.1-or-later"
 homepage="https://live.gnome.org/JsonGlib"
 changelog="https://gitlab.gnome.org/GNOME/json-glib/-/raw/main/NEWS"
 distfiles="${GNOME_SITE}/json-glib/${version%.*}/json-glib-${version}.tar.xz"
-checksum=77f4bcbf9339528f166b8073458693f0a20b77b7059dbc2db61746a1928b0293
+checksum=55c5c141a564245b8f8fbe7698663c87a45a7333c2a2c56f06f811ab73b212dd
 
 # Package build options
 build_options="gir gtk_doc"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures:
  - [x] i686-glibc
  - [x] x86_64-musl
  - [x] aarch64-glibc (x86_64-glibc)
  - [x] aarch64-musl (x86_64-musl)
  - [x] armv7l-glibc (x86_64-glibc)
  - [x] armv6l-musl (x86_64-musl)