### PR TITLE
easyeffects: revbump for fmt 12.0.0

### DIFF
--- a/srcpkgs/easyeffects/template
+++ b/srcpkgs/easyeffects/template
@@ -1,7 +1,7 @@
 # Template file for 'easyeffects'
 pkgname=easyeffects
 version=7.2.5
-revision=1
+revision=2
 build_style=meson
 hostmakedepends="pkg-config gettext itstool glib-devel desktop-file-utils
  gtk4-update-icon-cache cmake appstream-glib"


### PR DESCRIPTION

#### Testing the changes
- I tested the changes in this PR: **yes**

#### Local build testing
- I built this PR locally for my native architecture, (x64 glibc)

# Can't update system because easyeffects was build with older fmt-devel
