### PR TITLE
New package: pam-tmpdir-0.11

### DIFF
--- a/srcpkgs/pam-tmpdir/template
+++ b/srcpkgs/pam-tmpdir/template
@@ -1,0 +1,29 @@
+# Template file for 'pam-tmpdir'
+pkgname=pam-tmpdir
+version=0.11
+revision=1
+build_style=gnu-configure
+hostmakedepends="autoconf automake libtool"
+makedepends="pam-devel"
+depends="pam"
+short_desc="Module for creating per-user temporary directories"
+maintainer="Odin Kroeger <odin.kroeger@zoho.com>"
+license="GPL-2.0-only"
+homepage="https://packages.debian.org/stable/libpam-tmpdir"
+#changelog=""
+distfiles="http://deb.debian.org/debian/pool/main/p/pam-tmpdir/pam-tmpdir_${version}.tar.gz"
+checksum=4ae30e292b10ebccc90618458bee6182dde792eb3bde687c8cc3d9866324cdf3
+
+# The tarball ships w/o a configure script
+pre_configure() {
+	libtoolize --force
+	aclocal
+	autoheader
+	automake --force-missing --add-missing
+	autoconf
+}
+
+# chown seems not to work w/ xbps-uunshare
+post_configure() {
+	sed -i.bak 's/^\t\(chown[[:blank:]]\)/\t#\1/' Makefile
+}


### PR DESCRIPTION
pam-tmpdir is a PAM module for creating per-user temporary directories. It is currently maintained upstream by Tollef Fog Heen as part of Debian.

More information can be found at:
<https://packages.debian.org/stable/admin/libpam-tmpdir>

#### Testing the changes

I dogfooded the package on my x86_64 system.

#### New package

The package is compiled and must be installed system-wide, so yes.

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-musl)
- I built this PR locally for these architectures:
  - aarch64-musl
  - armv6l
