### PR TITLE
python3-curl: update to 7.45.7.

### DIFF
--- a/srcpkgs/python3-curl/template
+++ b/srcpkgs/python3-curl/template
@@ -1,6 +1,6 @@
 # Template file for 'python3-curl'
 pkgname=python3-curl
-version=7.45.6
+version=7.45.7
 revision=1
 build_style=python3-module
 # hanging/failing tests
@@ -22,7 +22,7 @@ license="LGPL-2.1-or-later, MIT"
 homepage="http://pycurl.io/"
 changelog="https://raw.githubusercontent.com/pycurl/pycurl/master/ChangeLog"
 distfiles="${PYPI_SITE}/p/pycurl/pycurl-${version}.tar.gz"
-checksum=2b73e66b22719ea48ac08a93fc88e57ef36d46d03cb09d972063c9aa86bb74e6
+checksum=9d43013002eab2fd6d0dcc671cd1e9149e2fc1c56d5e796fad94d076d6cb69ef
 
 pre_build() {
 	vsed -i "/setup_args\['data_files'\] = /d" setup.py


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures:
  - [x] i686-glibc
  - [x] x86_64-musl
  - [x] aarch64-glibc (x86_64-glibc)
  - [x] aarch64-musl (x86_64-musl)
  - [x] armv7l-glibc (x86_64-glibc)
  - [x] armv6l-musl (x86_64-musl)