### PR TITLE
python3-msgpack: update to 1.1.2.

### DIFF
--- a/srcpkgs/python3-msgpack/template
+++ b/srcpkgs/python3-msgpack/template
@@ -1,7 +1,7 @@
 # Template file for 'python3-msgpack'
 # Please ensure this version works with 'borg' before bumping!
 pkgname=python3-msgpack
-version=1.1.1
+version=1.1.2
 revision=1
 build_style=python3-module
 hostmakedepends="python3-setuptools"
@@ -14,4 +14,4 @@ license="Apache-2.0"
 homepage="https://github.com/msgpack/msgpack-python"
 changelog="https://raw.githubusercontent.com/msgpack/msgpack-python/main/ChangeLog.rst"
 distfiles="${PYPI_SITE}/m/msgpack/msgpack-${version}.tar.gz"
-checksum=77b79ce34a2bdab2594f490c8e80dd62a02d650b91a75159a63ec413b8d104cd
+checksum=3b60763c1373dd60f398488069bcdc703cd08a711477b5d480eecc9f9626f47e


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures:
  - [x] i686-glibc
  - [x] x86_64-musl
  - [x] aarch64-glibc (x86_64-glibc)
  - [x] aarch64-musl (x86_64-musl)
  - [x] armv7l-glibc (x86_64-glibc)
  - [x] armv6l-musl (x86_64-musl)