### PR TITLE
python3-regex: update to 2026.1.15, orphan.

### DIFF
--- a/srcpkgs/python3-regex/template
+++ b/srcpkgs/python3-regex/template
@@ -1,21 +1,21 @@
 # Template file for 'python3-regex'
 pkgname=python3-regex
-version=2025.7.34
-revision=2
+version=2026.1.15
+revision=1
 build_style=python3-module
 hostmakedepends="python3-devel python3-setuptools"
 makedepends="python3-devel"
 depends="python3"
 short_desc="Alternative regular expression module (Python3)"
-maintainer="skmpz <dem.procopiou@gmail.com>"
+maintainer="Orphaned <orphan@voidlinux.org>"
 license="CNRI-Python, Apache-2.0"
 homepage="https://github.com/mrabarnett/mrab-regex"
 changelog="https://raw.githubusercontent.com/mrabarnett/mrab-regex/hg/changelog.txt"
 distfiles="${PYPI_SITE}/r/regex/regex-${version}.tar.gz"
-checksum=9ead9765217afd04a86822dfcd4ed2747dfe426e887da413b15ff0ac2457e21a
+checksum=164759aa25575cbc0651bef59a0b18353e54300d79ace8084c818ad8ac72b7d5
 
 do_check() {
-	(cd build/lib* && python3 -m unittest regex/test_regex.py)
+	(cd build/lib* && python3 -m unittest regex/tests/test_regex.py)
 }
 
 post_install() {


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures:
  - [x] i686-glibc
  - [x] x86_64-musl
  - [x] aarch64-glibc (x86_64-glibc)
  - [x] aarch64-musl (x86_64-musl)
  - [x] armv7l-glibc (x86_64-glibc)
  - [x] armv6l-musl (x86_64-musl)