### PR TITLE
wlroots0.19: add fix for sway crash

### DIFF
--- a/srcpkgs/wlroots0.19/patches/backend-output-send-commit-events-after-applying-all.patch
+++ b/srcpkgs/wlroots0.19/patches/backend-output-send-commit-events-after-applying-all.patch
@@ -1,0 +1,73 @@
+From 7392b3313a7b483c61f4fea648ba8f2aa4ce8798 Mon Sep 17 00:00:00 2001
+From: Simon Ser <contact@emersion.fr>
+Date: Tue, 12 Aug 2025 19:00:11 +0200
+Subject: [PATCH] backend, output: send commit events after applying all in
+ wlr_backend_commit()
+
+We were iterating over involved outputs, applying the new state and
+sending the commit event for each one. This resulted in commit
+events being fired while we weren't done applying the new state for
+all outputs.
+
+Fix this by first applying all of the states, then firing all of
+the events.
+
+Closes: https://github.com/swaywm/sway/issues/8829
+---
+ backend/backend.c          | 5 +++++
+ include/types/wlr_output.h | 1 +
+ types/output/output.c      | 3 +++
+ 3 files changed, 9 insertions(+)
+
+diff --git a/backend/backend.c b/backend/backend.c
+index a130d9045a..3d84aa636f 100644
+--- a/backend/backend.c
++++ b/backend/backend.c
+@@ -485,5 +485,10 @@ bool wlr_backend_commit(struct wlr_backend *backend,
+ 		output_apply_commit(state->output, &state->base);
+ 	}
+ 
++	for (size_t i = 0; i < states_len; i++) {
++		const struct wlr_backend_output_state *state = &states[i];
++		output_send_commit_event(state->output, &state->base);
++	}
++
+ 	return true;
+ }
+diff --git a/include/types/wlr_output.h b/include/types/wlr_output.h
+index f901505afc..d59b05f0b9 100644
+--- a/include/types/wlr_output.h
++++ b/include/types/wlr_output.h
+@@ -27,6 +27,7 @@ void output_defer_present(struct wlr_output *output, struct wlr_output_event_pre
+ 
+ bool output_prepare_commit(struct wlr_output *output, const struct wlr_output_state *state);
+ void output_apply_commit(struct wlr_output *output, const struct wlr_output_state *state);
++void output_send_commit_event(struct wlr_output *output, const struct wlr_output_state *state);
+ 
+ void output_state_get_buffer_src_box(const struct wlr_output_state *state,
+ 	struct wlr_fbox *out);
+diff --git a/types/output/output.c b/types/output/output.c
+index 636d155d21..1fb0347a0b 100644
+--- a/types/output/output.c
++++ b/types/output/output.c
+@@ -759,7 +759,9 @@ void output_apply_commit(struct wlr_output *output, const struct wlr_output_stat
+ 	}
+ 
+ 	output_apply_state(output, state);
++}
+ 
++void output_send_commit_event(struct wlr_output *output, const struct wlr_output_state *state) {
+ 	struct timespec now;
+ 	clock_gettime(CLOCK_MONOTONIC, &now);
+ 	struct wlr_output_event_commit event = {
+@@ -801,6 +803,7 @@ bool wlr_output_commit_state(struct wlr_output *output,
+ 	}
+ 
+ 	output_apply_commit(output, &pending);
++	output_send_commit_event(output, &pending);
+ 
+ 	if (new_back_buffer) {
+ 		wlr_buffer_unlock(pending.buffer);
+-- 
+GitLab
+

--- a/srcpkgs/wlroots0.19/template
+++ b/srcpkgs/wlroots0.19/template
@@ -1,7 +1,7 @@
 # Template file for 'wlroots0.19'
 pkgname=wlroots0.19
 version=0.19.1
-revision=1
+revision=2
 build_style=meson
 # Follow upstream packaging recommendations:
 # https://gitlab.freedesktop.org/wlroots/wlroots/-/wikis/Packaging-recommendations


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

@rookiejet could you verify that this fixes #57560

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
