### PR TITLE
p11-kit: update to 0.25.10

### DIFF
--- a/srcpkgs/p11-kit/template
+++ b/srcpkgs/p11-kit/template
@@ -1,7 +1,7 @@
 # Template file for 'p11-kit'
 pkgname=p11-kit
-version=0.25.5
-revision=2
+version=0.25.10
+revision=1
 build_style=meson
 build_helper="qemu"
 configure_args="-Dlibffi=enabled -Dsystemd=disabled -Dbash_completion=disabled
@@ -16,7 +16,7 @@ license="BSD-3-Clause"
 homepage="https://github.com/p11-glue/p11-kit"
 changelog="https://raw.githubusercontent.com/p11-glue/p11-kit/master/NEWS"
 distfiles="https://github.com/p11-glue/p11-kit/releases/download/${version}/p11-kit-${version}.tar.xz"
-checksum=04d0a86450cdb1be018f26af6699857171a188ac6d5b8c90786a60854e1198e5
+checksum=a62a137a966fb3a9bbfa670b4422161e369ddea216be51425e3be0ab2096e408
 conf_files="/etc/pkcs11/pkcs11.conf"
 
 if [ "$XBPS_CHECK_PKGS" ]; then
@@ -38,6 +38,8 @@ post_install() {
 
 	vcompletion bash-completion/p11-kit bash p11-kit
 	vcompletion bash-completion/trust bash trust
+	vcompletion zsh-completion/p11-kit.zsh zsh p11-kit
+	vcompletion zsh-completion/trust.zsh zsh trust
 }
 
 p11-kit-devel_package() {


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**
- `p11-kit` is a `gnutls` dep, which is a `chrony` dep on my system - `chrony-4.8` is still working as expected

#### Local build testing
- I built this PR locally for my native architecture, **x86_64-glibc**

[Changelog](https://raw.githubusercontent.com/p11-glue/p11-kit/master/NEWS)
