### PR TITLE
snappy: Enable rtti

### DIFF
--- a/srcpkgs/snappy/patches/rtti.patch
+++ b/srcpkgs/snappy/patches/rtti.patch
@@ -1,0 +1,57 @@
+From f73b11e87dfbe1cb4862b8ee489679d99534f40b Mon Sep 17 00:00:00 2001
+From: Tim Serong <tserong@suse.com>
+Date: Wed, 27 Oct 2021 18:49:04 +1100
+Subject: [PATCH] Re-enable RTTI (needed in order to subclass Source, etc.)
+
+Commit c98344f in snappy 1.1.9 disabled RTTI, which means the
+snappy library no longer exports typeinfo for snappy::Source,
+snappy::Sink, ..., so users of the library can't subclass these
+classes anymore.
+
+Here's a trivial reproducer:
+
+  #include <snappy-sinksource.h>
+  class MySource : snappy::Source {
+  public:
+    size_t Available() const override { return 0; }
+    const char *Peek(size_t *len) override { return NULL; }
+    void Skip(size_t n) override {}
+  };
+  int main(int argc, char **argv) {
+    MySource m;
+    return 0;
+  }
+
+Try `g++ -o snappy-test ./snappy-test.cc -lsnappy` with the above
+and the linker will fail with "undefined reference to `typeinfo
+for snappy::Source'" if RTTI was disabled in the snappy build.
+---
+ CMakeLists.txt | 7 -------
+ 1 file changed, 7 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 6eef485..755605d 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -51,10 +51,6 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+   string(REGEX REPLACE "/EH[a-z]+" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /EHs-c-")
+   add_definitions(-D_HAS_EXCEPTIONS=0)
+-
+-  # Disable RTTI.
+-  string(REGEX REPLACE "/GR" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /GR-")
+ else(MSVC)
+   # Use -Wall for clang and gcc.
+   if(NOT CMAKE_CXX_FLAGS MATCHES "-Wall")
+@@ -81,10 +77,6 @@ else(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+   # Disable C++ exceptions.
+   string(REGEX REPLACE "-fexceptions" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-exceptions")
+-
+-  # Disable RTTI.
+-  string(REGEX REPLACE "-frtti" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-rtti")
+ endif(MSVC)
+ 
+ # BUILD_SHARED_LIBS is a standard CMake variable, but we declare it here to make

--- a/srcpkgs/snappy/template
+++ b/srcpkgs/snappy/template
@@ -1,7 +1,7 @@
 # Template file for 'snappy'
 pkgname=snappy
 version=1.2.2
-revision=1
+revision=2
 build_style=cmake
 # Disable tests and benchmarks requiring bundled gtest dependency.
 # Upstream discourages enabling those for packaging:


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

Enabling RTTI since I've been running into this error: https://github.com/facebook/folly/issues/1606

Patch from Alpine: https://gitlab.alpinelinux.org/alpine/aports/-/blob/e3181ab96fc7acee910d2981adba1d5fe180033c/main/snappy/rtti.patch

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl
  - i686
  - aarch64 (cross)
  - aarch64-musl (cross)
  - armv7l (cross)
  - armv7l-musl (cross)
  - armv6l (cross)
  - armv6l-musl (cross)
