### PR TITLE
libedit: update to 20251016.3.1

### DIFF
--- a/srcpkgs/libedit/template
+++ b/srcpkgs/libedit/template
@@ -1,6 +1,6 @@
 # Template file for 'libedit'
 pkgname=libedit
-version=20250104.3.1
+version=20251016.3.1
 revision=1
 build_style=gnu-configure
 # only check if man support nroff format
@@ -12,7 +12,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="BSD-3-Clause"
 homepage="https://www.thrysoee.dk/editline/"
 distfiles="https://www.thrysoee.dk/editline/libedit-${version%%.*}-${version#*.}.tar.gz"
-checksum=23792701694550a53720630cd1cd6167101b5773adddcb4104f7345b73a568ac
+checksum=21362b00653bbfc1c71f71a7578da66b5b5203559d43134d2dd7719e313ce041
 
 post_install() {
 	vlicense COPYING


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**
- `chrony-4.8`, `openssh` and `sqlite` are still working as expected after the update

#### Local build testing
- I built this PR locally for my native architecture, **x86_64-glibc**
