### PR TITLE
borg: repatch for python3-msgpack 1.1.2

### DIFF
--- a/srcpkgs/borg/patches/msgpack-1.1.2.patch
+++ b/srcpkgs/borg/patches/msgpack-1.1.2.patch
@@ -1,29 +1,29 @@
-From f6724bfef2515ed5bf66c9a0434655c60a82aae2 Mon Sep 17 00:00:00 2001
+From d35ec9396866ad5f19feb7a59e8bb913119267b1 Mon Sep 17 00:00:00 2001
 From: Thomas Waldmann <tw@waldmann-edv.de>
-Date: Fri, 6 Jun 2025 18:35:25 +0200
-Subject: [PATCH] msgpack: allow 1.1.1
+Date: Thu, 9 Oct 2025 13:16:20 +0200
+Subject: [PATCH] allow msgpack 1.1.2
 
-1.1.1rc1 looked good in testing, so hopefully 1.1.1 will also be ok.
+1.1.2 provides wheels for py 3.14.
 ---
  pyproject.toml              | 2 +-
  src/borg/helpers/msgpack.py | 2 +-
  2 files changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/pyproject.toml b/pyproject.toml
-index f1a3dffb6f..05102a0f0a 100644
+index 76ce84e2f3..6abc93843a 100644
 --- a/pyproject.toml
 +++ b/pyproject.toml
-@@ -35,7 +35,7 @@ dependencies = [
+@@ -36,7 +36,7 @@ dependencies = [
      # Please note:
      # using any other msgpack version is not supported by borg development and
      # any feedback related to issues caused by this will be ignored.
 -    "msgpack >=1.0.3, <=1.1.0",
-+    "msgpack >=1.0.3, <=1.1.1",
++    "msgpack >=1.0.3, <=1.1.2",
      "packaging",
  ]
  
 diff --git a/src/borg/helpers/msgpack.py b/src/borg/helpers/msgpack.py
-index 5c8cedde16..5c0d1a02b6 100644
+index 558b47e7e0..bc3caad465 100644
 --- a/src/borg/helpers/msgpack.py
 +++ b/src/borg/helpers/msgpack.py
 @@ -137,7 +137,7 @@ def is_slow_msgpack():
@@ -31,7 +31,7 @@ index 5c8cedde16..5c0d1a02b6 100644
      # DO NOT CHANGE OR REMOVE! See also requirements and comments in pyproject.toml.
      import msgpack
 -    return (1, 0, 3) <= msgpack.version <= (1, 1, 0) and \
-+    return (1, 0, 3) <= msgpack.version <= (1, 1, 1) and \
++    return (1, 0, 3) <= msgpack.version[:3] <= (1, 1, 2) and \
             msgpack.version not in []  # < add bad releases here to deny list
  
  

--- a/srcpkgs/borg/template
+++ b/srcpkgs/borg/template
@@ -1,7 +1,7 @@
 # Template file for 'borg'
 pkgname=borg
 version=1.4.1
-revision=2
+revision=3
 build_style=python3-module
 make_check_args="-k not((benchmark)or(readonly))"
 make_check_target="build/lib.*/borg/testsuite"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

@Vindaar re https://github.com/void-linux/void-packages/pull/57596#issuecomment-3421670758

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
