### PR TITLE
pavucontrol: update to 6.2.

### DIFF
--- a/srcpkgs/pavucontrol/template
+++ b/srcpkgs/pavucontrol/template
@@ -1,6 +1,6 @@
 # Template file for 'pavucontrol'
 pkgname=pavucontrol
-version=6.1
+version=6.2
 revision=1
 build_style=meson
 hostmakedepends="pkg-config intltool lynx glib-devel"
@@ -10,5 +10,5 @@ short_desc="PulseAudio Volume Control"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="https://www.freedesktop.org/software/pulseaudio/pavucontrol"
-distfiles="${homepage}/pavucontrol-${version}.tar.xz"
-checksum=0dce61c1088eafa04c270e1fb79eb7aff47e98567f7d28c65a7bee6cd24e415d
+distfiles="${FREEDESKTOP_SITE}/pulseaudio/pavucontrol/pavucontrol-${version}.tar.xz"
+checksum=e93a7836c7307dcbc989e95fc7ec0878322514c475fabd90e89ed52fd4f15d32


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures:
  - [x] i686-glibc
  - [x] x86_64-musl
  - [x] aarch64-glibc (x86_64-glibc)
  - [x] aarch64-musl (x86_64-musl)
  - [x] armv7l-glibc (x86_64-glibc)
  - [x] armv6l-musl (x86_64-musl)