### PR TITLE
git-cola: depend on python3-pyqt6-network

### DIFF
--- a/srcpkgs/git-cola/template
+++ b/srcpkgs/git-cola/template
@@ -1,11 +1,11 @@
 # Template file for 'git-cola'
 pkgname=git-cola
 version=4.15.1
-revision=2
+revision=3
 build_style=python3-pep517
 hostmakedepends="python3 python3-build python3-packaging python3-setuptools python3-setuptools_scm python3-wheel"
 depends="git qt6-svg python3-pyqt6-gui python3-pyqt6-widgets
- python3-QtPy python3-packaging python3-polib"
+ python3-pyqt6-network python3-QtPy python3-packaging python3-polib"
 short_desc="Highly caffeinated Git GUI"
 maintainer="Andrea Brancaleoni <abc@pompel.me>"
 license="GPL-2.0-only"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->

---

Fixes startup failing with:

```
$ git cola
Traceback (most recent call last):
  File "/usr/bin/git-cola", line 5, in <module>
    from cola.main import main
  File "/usr/lib/python3.13/site-packages/cola/main.py", line 5, in <module>
    from . import app
  File "/usr/lib/python3.13/site-packages/cola/app.py", line 49, in <module>
    from .widgets import startup
  File "/usr/lib/python3.13/site-packages/cola/widgets/startup.py", line 13, in <module>
    from .. import guicmds
  File "/usr/lib/python3.13/site-packages/cola/guicmds.py", line 18, in <module>
    from .widgets.browse import BrowseBranch
  File "/usr/lib/python3.13/site-packages/cola/widgets/browse.py", line 24, in <module>
    from .selectcommits import select_commits
  File "/usr/lib/python3.13/site-packages/cola/widgets/selectcommits.py", line 14, in <module>
    from .diff import DiffTextEdit
  File "/usr/lib/python3.13/site-packages/cola/widgets/diff.py", line 22, in <module>
    from .. import gravatar
  File "/usr/lib/python3.13/site-packages/cola/gravatar.py", line 7, in <module>
    from qtpy import QtNetwork
  File "/usr/lib/python3.13/site-packages/qtpy/QtNetwork.py", line 16, in <module>
    from PyQt6.QtNetwork import *
ModuleNotFoundError: No module named 'PyQt6.QtNetwork'
```

Maintainer ping @thypon 
