### PR TITLE
meson: update to 1.9.1

### DIFF
--- a/srcpkgs/meson/patches/musl-tests.patch
+++ b/srcpkgs/meson/patches/musl-tests.patch
@@ -1,0 +1,79 @@
+# see https://gitlab.alpinelinux.org/alpine/aports/-/blob/master/main/meson/skip-broken-tests.patch
+# more specifically https://github.com/mesonbuild/meson/issues/8283
+# previously there was a vsed in the post_patch() of the template
+--- a/mesonbuild/utils/universal.py
++++ b/mesonbuild/utils/universal.py
+@@ -19,6 +19,7 @@
+ from functools import lru_cache, wraps
+ from itertools import tee
+ from tempfile import TemporaryDirectory, NamedTemporaryFile
++from packaging.tags import sys_tags
+ import typing as T
+ import textwrap
+ import pickle
+@@ -115,6 +116,7 @@
+     'is_aix',
+     'is_android',
+     'is_ascii_string',
++    'is_musl',
+     'is_cygwin',
+     'is_debianlike',
+     'is_dragonflybsd',
+@@ -650,6 +652,10 @@
+ def is_wsl() -> bool:
+     return is_linux() and 'microsoft' in platform.release().lower()
+
++def is_musl() -> bool:
++    tags = list(sys_tags() )
++    return "musl" in tags[0].platform
++
+ def is_cygwin() -> bool:
+     return sys.platform == 'cygwin'
+
+--- a/unittests/linuxliketests.py
++++ b/unittests/linuxliketests.py
+@@ -23,7 +23,7 @@
+ import mesonbuild.coredata
+ import mesonbuild.modules.gnome
+ from mesonbuild.mesonlib import (
+-    MachineChoice, is_windows, is_osx, is_cygwin, is_openbsd, is_haiku,
++    MachineChoice, is_windows, is_osx, is_musl, is_cygwin, is_openbsd, is_haiku,
+     is_sunos, windows_proof_rmtree, version_compare, is_linux,
+     EnvironmentException
+ )
+@@ -309,6 +309,8 @@
+
+     @skip_if_not_base_option('b_sanitize')
+     def test_generate_gir_with_address_sanitizer(self):
++        if is_musl():
++            raise SkipTest('asan not available on musl')
+         if is_cygwin():
+             raise SkipTest('asan not available on Cygwin')
+         if is_openbsd():
+@@ -453,6 +455,8 @@
+         included on the linker command line when c_link_args is
+         set but c_args is not.
+         '''
++        if is_musl():
++            raise SkipTest('asan not available on musl')
+         if is_cygwin():
+             raise SkipTest('asan not available on Cygwin')
+         if is_openbsd():
+@@ -1005,6 +1009,8 @@
+
+     @skip_if_not_base_option('b_sanitize')
+     def test_env_cflags_ldflags(self):
++        if is_musl():
++            raise SkipTest('asan not available on musl')
+         if is_cygwin():
+             raise SkipTest('asan not available on Cygwin')
+         if is_openbsd():
+@@ -1021,6 +1027,8 @@
+
+     @skip_if_not_base_option('b_sanitize')
+     def test_pch_with_address_sanitizer(self):
++        if is_musl():
++            raise SkipTest('asan not available on musl')
+         if is_cygwin():
+             raise SkipTest('asan not available on Cygwin')
+         if is_openbsd():

--- a/srcpkgs/meson/template
+++ b/srcpkgs/meson/template
@@ -1,6 +1,6 @@
 # Template file for 'meson'
 pkgname=meson
-version=1.6.1
+version=1.9.1
 revision=1
 build_style=python3-module
 hostmakedepends="python3-devel python3-setuptools"
@@ -14,19 +14,12 @@ license="Apache-2.0"
 homepage="https://mesonbuild.com"
 changelog="https://raw.githubusercontent.com/mesonbuild/meson/master/docs/markdown/Release-notes-for-${version%.*}.0.md"
 distfiles="https://github.com/mesonbuild/meson/releases/download/${version}/meson-${version}.tar.gz"
-checksum=1eca49eb6c26d58bbee67fd3337d8ef557c0804e30a6d16bfdf269db997464de
+checksum=4e076606f2afff7881d195574bddcd8d89286f35a17b4977a216f535dc0c74ac
 
 # XXX: sanitizers aren't available on musl
 if [ "$XBPS_TARGET_LIBC" = glibc ]; then
 	checkdepends+=" libsanitizer-devel"
 fi
-
-post_patch() {
-	if [ "$XBPS_TARGET_LIBC" = musl ]; then
-		vsed -e 's/test_pch_with_address_sanitizer/_&/' \
-			-i unittests/linuxliketests.py
-	fi
-}
 
 do_check() {
 	# meson depends on trillion of things to perform actual tests


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

mesa and wlroots worked

#### Local build testing
- I built this PR locally for my native architecture, **x86_64**, cross **i686** (mesa)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
 - **x86_64-musl**


#### Comments

~~didn't do the same as meson 1.8.2 https://github.com/void-linux/void-packages/pull/56014 with cflags/sanitizer in post-patch~~. obviously replaces that PR

~~budgie-desktop: updated to 10.9.3 and added some dev deps, wasn't building in 1.8.2 previously~~ removed changes, but for reference [budgie-desktop-template.txt](https://github.com/user-attachments/files/23062382/budgie-desktop-template.txt)
