### PR TITLE
cJSON: update to 1.7.19.

### DIFF
--- a/srcpkgs/cJSON/template
+++ b/srcpkgs/cJSON/template
@@ -1,14 +1,15 @@
 # Template file for 'cJSON'
 pkgname=cJSON
-version=1.7.18
-revision=2
+version=1.7.19
+revision=1
 build_style=cmake
+configure_args="-DCMAKE_POLICY_VERSION_MINIMUM=3.5"
 short_desc="Ultralightweight JSON parser in ANSI C"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
 homepage="https://github.com/DaveGamble/cJSON"
 distfiles="https://github.com/DaveGamble/cJSON/archive/v${version}.tar.gz"
-checksum=3aa806844a03442c00769b83e99970be70fbef03735ff898f4811dd03b9f5ee5
+checksum=7fa616e3046edfa7a28a32d5f9eacfd23f92900fe1f8ccd988c1662f30454562
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures:
  - [x] i686-glibc
  - [x] x86_64-musl
  - [x] aarch64-glibc (x86_64-glibc)
  - [x] aarch64-musl (x86_64-musl)
  - [x] armv7l-glibc (x86_64-glibc)
  - [x] armv6l-musl (x86_64-musl)