### PR TITLE
ouch: update to 0.6.1, orphan.

### DIFF
--- a/srcpkgs/ouch/template
+++ b/srcpkgs/ouch/template
@@ -1,17 +1,18 @@
 # Template file for 'ouch'
 pkgname=ouch
-version=0.5.1
+version=0.6.1
 revision=1
 build_style=cargo
-hostmakedepends="pkg-config"
+hostmakedepends="pkg-config clang"
 makedepends="liblzma-devel bzip2-devel libzip-devel libzstd-devel"
+checkdepends="git"
 short_desc="CLI utility for easily compressing and decompressing files and dirs"
-maintainer="Savoy <savoy@liberation.red>"
+maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
 homepage="https://github.com/ouch-org/ouch"
 changelog="https://raw.githubusercontent.com/ouch-org/ouch/main/CHANGELOG.md"
 distfiles="https://github.com/ouch-org/ouch/archive/refs/tags/${version}.tar.gz"
-checksum=46cc2b14f53de2f706436df59300eb90c5a58f08ac8c738fd976fcb8ec0cd335
+checksum=e6265071affab228ba7d3ca85f2206029445038b3a3d96036e9bf02b795ad651
 
 pre_build() {
 	export OUCH_ARTIFACTS_FOLDER=artifacts


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- Cross-build: aarch64-musl
