### PR TITLE
ispc: update to 1.28.2.

### DIFF
--- a/srcpkgs/ispc/template
+++ b/srcpkgs/ispc/template
@@ -1,6 +1,6 @@
 # Template file for 'ispc'
 pkgname=ispc
-version=1.27.0
+version=1.28.2
 revision=1
 _llvmver=19
 archs="aarch64* x86_64*"
@@ -14,7 +14,7 @@ maintainer="Andrea Brancaleoni <abc@pompel.me>"
 license="BSD-3-Clause"
 homepage="https://ispc.github.io"
 distfiles="https://github.com/ispc/ispc/archive/v${version}.tar.gz"
-checksum=c41ae29e4f6b1d37154610e68e9b7a0eb225cd7c080242ab56fa0119e49dbd7a
+checksum=0b7d1d73afa93c015814b99c97b88fa45bce822d7904e8fc4a95666ba8e3fb92
 nocross=yes
 nopie=yes
 


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**
  - compiled [bc7enc](https://github.com/richgel999/bc7enc_rdo) externally as well as `openimagedenoise` and `embree` in void-packages

#### Local build testing
- I built this PR locally for my native architecture, `x86_64-glibc`
- Also built for `x86_64-musl`