### PR TITLE
udiskie: update to 2.5.8.

### DIFF
--- a/srcpkgs/udiskie/template
+++ b/srcpkgs/udiskie/template
@@ -1,6 +1,6 @@
 # Template file for 'udiskie'
 pkgname=udiskie
-version=2.5.7
+version=2.5.8
 revision=1
 build_style=python3-module
 hostmakedepends="gettext asciidoc python3-setuptools"
@@ -13,7 +13,7 @@ license="MIT"
 homepage="https://github.com/coldfix/udiskie"
 changelog="https://raw.githubusercontent.com/coldfix/udiskie/master/CHANGES.rst"
 distfiles="https://github.com/coldfix/udiskie/archive/refs/tags/v${version}.tar.gz"
-checksum=9a70fc97b89c03c3c70b6c87f058acd5ef2f5eb5b8158fe52738fd1cc1b61ea7
+checksum=ade0b67392fe5cfbd3a84c502c1e76bc2edb66e3c7e1d0ccbe2e62421f699674
 make_check=ci-skip # privilege issue with keyring in container
 
 post_build() {


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture (x86_64)
- I built this PR locally for these architectures using specific masterdirs:
  - x86_64-musl
  - i686
- I built this PR locally for these architectures (crossbuilds):
  - aarch64
  - aarch64-musl
  - armv7l
  - armv7l-musl
  - armv6l
  - armv6l-musl