### PR TITLE
blocky: update to 0.28.1

### DIFF
--- a/srcpkgs/blocky/template
+++ b/srcpkgs/blocky/template
@@ -1,6 +1,6 @@
 # Template file for 'blocky'
 pkgname=blocky
-version=0.26.2
+version=0.28.1
 revision=1
 build_style=go
 go_import_path=github.com/0xERR0R/blocky
@@ -11,7 +11,7 @@ license="Apache-2.0"
 homepage="https://0xerr0r.github.io/blocky/latest"
 changelog="https://github.com/0xERR0R/blocky/releases"
 distfiles="https://github.com/0xERR0R/blocky/archive/v${version}.tar.gz"
-checksum=b6aadd53253fe51d1bd41a1c19911091b944657fd034cd3dfad8c139ac5870b3
+checksum=28afb06551a0d76790db86a90783abde287531d2dc095164c0bd8647e78bcb36
 # test requires existing docker socket
 make_check=extended
 


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-musl