### PR TITLE
hooks/pre-build: add missing pcre2-config wrapper

### DIFF
--- a/common/hooks/pre-configure/02-script-wrapper.sh
+++ b/common/hooks/pre-configure/02-script-wrapper.sh
@@ -225,6 +225,7 @@ hook() {
 	generic_wrapper imlib2-config
 	generic_wrapper libmikmod-config
 	generic_wrapper pcre-config
+	generic_wrapper pcre2-config
 	generic_wrapper net-snmp-config
 	generic_wrapper wx-config
 	generic_wrapper wx-config-3.0

--- a/srcpkgs/zsh/template
+++ b/srcpkgs/zsh/template
@@ -1,7 +1,7 @@
 # Template file for 'zsh'
 pkgname=zsh
 version=5.9
-revision=4
+revision=5
 build_style=gnu-configure
 make_build_target="all info"
 make_install_args="install.info"


### PR DESCRIPTION
#### Newb

I'm a total newb to void, and I learned just enough about the packaging process to find and fix this bug. I apologize if I missed anything in the contributing guidelines.

----

#### Initial problem

<!-- Uncomment relevant sections and delete options which are not applicable -->

I noticed this bug only because the `=~` operator in zsh fails with the following error on ARM platforms:

```
zsh: failed to load module `zsh/pcre': /usr/lib32/zsh/5.9/zsh/pcre.so: cannot open shared object file: No such file or directory
zsh: -pcre-match not available for regex
```

I bumped only the `zsh` package, in order to fix this problem. Let me know if I should bump some/all of the 351 (!!) other packages that depend on `pcre2-devel`.

----

#### Testing the changes
- I tested the changes in this PR: **YES**

Prior to this change, cross-compiles of the `zsh` package for ARM platforms (v6, v7, and aarch64) failed to include `usr/lib/zsh/$version/zsh/pcre.so`. Adding it here fixes that.

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

----

#### Local build testing
- I built this PR locally for my native architecture, (x86-64/gcc)
- I built this PR locally for these architectures (all crossbuilds):
  - aarch64
  - aarch64-musl
  - armv7l
  - armv6l