### PR TITLE
gtk-layer-shell: update to 0.10.0

### DIFF
--- a/srcpkgs/gtk-layer-shell/template
+++ b/srcpkgs/gtk-layer-shell/template
@@ -1,19 +1,19 @@
 # Template file for 'gtk-layer-shell'
 pkgname=gtk-layer-shell
-version=0.9.2
+version=0.10.0
 revision=1
 build_style=meson
 build_helper="gir"
 hostmakedepends="gobject-introspection pkg-config wayland-devel"
-makedepends="gtk+3-devel wayland-devel wayland-protocols"
+makedepends="gtk+3-devel"
 checkdepends="cantarell-fonts xvfb-run"
 short_desc="Library to create panels and other desktop components for Wayland"
 maintainer="travankor <travankor@tuta.io>"
-license="LGPL-3.0-or-later, MIT"
+license="LGPL-3.0-or-later AND MIT"
 homepage="https://github.com/wmww/gtk-layer-shell"
 changelog="https://raw.githubusercontent.com/wmww/gtk-layer-shell/master/CHANGELOG.md"
 distfiles="https://github.com/wmww/gtk-layer-shell/archive/refs/tags/v${version}.tar.gz"
-checksum=526dd95c083e2a73eafd8baa1f5d676a36cb80fc8e7b304cbe3efebd62f0600c
+checksum=ed9bb801d6d9252defba41104820ace595dac824dc8972a758ee2ad134e10505
 make_check_pre="xvfb-run"
 
 if [ "$XBPS_CHECK_PKGS" ]; then


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**
- tested as `Waybar` dep - `Waybar` is still working as expected

#### Local build testing
- I built this PR locally for my native architecture, **x86_64-glibc**

[Changelog](https://raw.githubusercontent.com/wmww/gtk-layer-shell/master/CHANGELOG.md)

cc @travankor 
