### PR TITLE
New package: mangowc-0.11.0

### DIFF
--- a/srcpkgs/mangowc/template
+++ b/srcpkgs/mangowc/template
@@ -1,0 +1,19 @@
+# Template file for 'mangowc'
+pkgname=mangowc
+version=0.11.0
+revision=1
+conf_files="/etc/mango/config.conf"
+build_style=meson
+hostmakedepends="pkg-config wayland-devel"
+makedepends="wlroots0.19-devel pcre2-devel scenefx-devel"
+depends="$(vopt_if xwayland xorg-server-xwayland)"
+short_desc="Dwl-based wayland compositor using scenefx"
+maintainer="Emil Miler <em@0x45.cz>"
+license="GPL-3.0-or-later"
+homepage="https://github.com/DreamMaoMao/mangowc"
+changelog="https://github.com/DreamMaoMao/mangowc/releases"
+distfiles="https://github.com/DreamMaoMao/mangowc/archive/refs/tags/${version}.tar.gz"
+checksum=1b1422dd73564302800720cc49aeb854e0a849696b822ba54b8f49dd63d32949
+
+build_options="xwayland"
+desc_option_xwayland="Enable Xwayland support"


### PR DESCRIPTION
Closes #57731

#### Testing the changes
- I tested the changes in this PR: **YES**
- I'm not using any display manager, so cannot test startup from there

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

#### Local build testing
- I built this PR locally for my native architecture, **x86_64-glibc**

#### Notes

- Not sure whether `GPL-3.0-or-later` would suffice, see also https://github.com/DreamMaoMao/mangowc/issues/127 EDIT: After having a look at https://spdx.github.io/spdx-spec/v3.0.1/annexes/spdx-license-expressions/ I've opted for the `AND` expression:

> simultaneously comply with two or more licenses

- Added build option for xwayland, defaulting to "OFF" (I'm not using xwayland myself) - the window manager is working fine w/o xwayland present, and one could simply install `xorg-server-xwayland` since it is optional according to upstream.
- There may or may not be a [configuration overhaul](https://github.com/DreamMaoMao/mangowc/issues/463) yet
