### PR TITLE
minijail: update to v2025.07.02

### DIFF
--- a/srcpkgs/minijail/template
+++ b/srcpkgs/minijail/template
@@ -1,6 +1,6 @@
 # Template file for 'minijail'
 pkgname=minijail
-version=2024.05.22
+version=2025.07.02
 revision=1
 build_style=gnu-makefile
 makedepends="libcap-devel"
@@ -10,7 +10,7 @@ maintainer="Cameron Nemo <cam@nohom.org>"
 license="BSD-3-Clause"
 homepage="https://android.googlesource.com/platform/external/minijail"
 distfiles="https://github.com/google/minijail/archive/linux-v${version}.tar.gz"
-checksum=3136365ca3762da3e725f734fbdc544d8c82d6a763f803b2850ed3c993c216f0
+checksum=2fb5a44ea2ffcdeb2f7ce0d7471e0f5d3069595954267a012f5dd0a41ffd2e4c
 
 if [ "$XBPS_TARGET_ENDIAN" = "be" ]; then
 	broken="bpf.h:110:2: error: #error Unsupported endianness"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

Updates minijail to the latest released tag. As for testing, I'm currently using this quite [extensively](https://codeberg.org/gruf/dotfiles/src/branch/main/system/etc/sv) (on x86_64) myself without any issues.
