### PR TITLE
scaleway-cli: update to 2.45.0

### DIFF
--- a/srcpkgs/scaleway-cli/template
+++ b/srcpkgs/scaleway-cli/template
@@ -1,6 +1,6 @@
 # Template file for 'scaleway-cli'
 pkgname=scaleway-cli
-version=2.43.0
+version=2.45.0
 revision=1
 build_style=go
 go_import_path=github.com/scaleway/scaleway-cli/v2
@@ -11,7 +11,7 @@ maintainer="Sébastien Pondichy <sebastien.pondichy@gmail.com>"
 license="MIT"
 homepage="https://github.com/scaleway/scaleway-cli"
 distfiles="https://github.com/scaleway/scaleway-cli/archive/v${version}.tar.gz"
-checksum=cc9aabee888c671094e40ab8c17ff727fb819890fad3868c8450b626f30c75fe
+checksum=8c9d56d752d06e35abccb0f626e7df2418a17a22b27cb1a49a2638370f0f2c83
 # Tests fail when run on i686
 make_check="no"
 


### PR DESCRIPTION
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64
  - armv7l
  - i686
  - x86_64-musl
 
