### PR TITLE
rclone: update to 1.72.1

### DIFF
--- a/srcpkgs/rclone/template
+++ b/srcpkgs/rclone/template
@@ -1,9 +1,9 @@
 # Template file for 'rclone'
 pkgname=rclone
-version=1.69.0
+version=1.72.1
 revision=1
 build_style=go
-build_helper=qemu
+build_helper="qemu"
 go_import_path=github.com/rclone/rclone
 go_build_tags="noselfupdate"
 go_ldflags="-extldflags=-fuse-ld=bfd -X github.com/rclone/rclone/fs.Version=v${version}"
@@ -13,12 +13,10 @@ short_desc="Rsync for cloud storage"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
 homepage="https://rclone.org/"
-changelog="https://rclone.org/changelog/"
+changelog="https://raw.githubusercontent.com/rclone/rclone/master/docs/content/changelog.md"
 distfiles="https://downloads.rclone.org/v${version}/rclone-v${version}.tar.gz"
-checksum=45e6a329af4f98e0c71233511ab8543e454eaa22adeeb73179bfdb22456a2123
-make_check_pre="env RCLONE_CONFIG=/notfound"
-# some tests fail on CI
-make_check=ci-skip
+checksum=227b84024e7e72056f716ee520c4db8b88ec5f80dc83f0899b431b2ce2b25f9b
+make_check_pre="env RCLONE_CONFIG=/notfound CI=1"
 
 pre_build() {
 	if [ "$CROSS_BUILD" ] && [ "$XBPS_TARGET_LIBC" = musl ]; then
@@ -30,15 +28,10 @@ pre_build() {
 }
 
 pre_check() {
-	rm cmd/serve/docker/docker_test.go
-	rm cmd/mount/mount_test.go
-	rm cmd/mount2/mount_test.go
-
-	# could time out on i686 and it's deprecated
-	# https://github.com/rclone/rclone/issues/5784#issuecomment-961520934
-	rm backend/cache/cache_test.go
+	rm -f cmd/mount/mount_test.go
+	rm -f cmd/mount2/mount_test.go
+	rm -f cmd/gitannex/e2e_test.go
 }
-
 
 post_install() {
 	ln -sf rclone ${DESTDIR}/usr/bin/mount.rclone


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

@r-ricci ping

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture: x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl (crossbuild)
  - i686
  - x86_64-musl
- In addition, I tested `./xbps-src check` for the above architectures

EDIT: 11/22/25: updated to rclone 1.72.0
bisync is no longer considered BETA

EDIT 12/16/25: updated to rclone 1.72.1