### PR TITLE
mdadm: fix build failure on musl

### DIFF
--- a/srcpkgs/mdadm/template
+++ b/srcpkgs/mdadm/template
@@ -1,7 +1,7 @@
 # Template file for 'mdadm'
 pkgname=mdadm
 version=4.3
-revision=4
+revision=5
 hostmakedepends="pkg-config"
 makedepends="eudev-libudev-devel"
 short_desc="Tool for managing/monitoring Linux md device arrays"
@@ -16,7 +16,7 @@ pre_configure() {
 }
 do_build() {
 	make ${makejobs} CC=$CC \
-		CFLAGS="$CFLAGS -DNO_COROSYNC -DNO_DLM -Wno-error -DSendmail='\"sendmail -t\"'" \
+		CFLAGS="$CFLAGS -D_LARGEFILE64_SOURCE -DNO_COROSYNC -DNO_DLM -Wno-error -DSendmail='\"sendmail -t\"'" \
 		BINDIR=/usr/bin LDFLAGS="$LDFLAGS"
 }
 do_install() {


### PR DESCRIPTION
In various places the source depends on off64_t existing, and the most parsimonious way of ensuring it's defined everywhere is to ensure _LARGEFILE64_SOURCE is defined everywhere.

#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-musl)
