### PR TITLE
mariadb: update to 11.8.3

### DIFF
--- a/srcpkgs/mariadb/template
+++ b/srcpkgs/mariadb/template
@@ -1,7 +1,7 @@
 # Template file for 'mariadb'
 pkgname=mariadb
-version=11.1.2
-revision=2
+version=11.8.3
+revision=1
 build_style=cmake
 build_helper=qemu
 configure_args="-DBUILD_CONFIG=mysql_release
@@ -16,10 +16,10 @@ configure_args="-DBUILD_CONFIG=mysql_release
  -DWITH_ZLIB=system -DWITH_SSL=system  -DWITH_LIBARCHIVE=system
  -DWITH_EMBEDDED_SERVER=ON -DPLUGIN_TOKUDB=NO -DPLUGIN_BLACKHOLE=YES
  -DPLUGIN_PARTITION=YES -DWITH_EXTRA_CHARSETS=complex -DWITH_LIBWRAP=OFF
- -DWITH_READLINE=ON -DWITH_SYSTEMD=no -DWITH_PCRE=system"
+ -DWITH_READLINE=ON -DWITH_SYSTEMD=no -DWITH_PCRE=system -DWITH_LIBFMT=system"
 hostmakedepends="bison perl flex pkg-config"
 makedepends="ncurses-devel gnutls-devel libaio-devel boost-devel-minimal pam-devel zlib-devel
- pcre2-devel fmt-devel"
+ pcre2-devel fmt-devel libxml2-devel"
 depends="perl"
 checkdepends="perl"
 short_desc="Fast SQL database server, drop-in replacement for MySQL"
@@ -27,7 +27,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-only"
 homepage="https://mariadb.com"
 distfiles="https://archive.mariadb.org/mariadb-${version}/source/mariadb-${version}.tar.gz"
-checksum=19a9e980e57fa332931f643b48ad7390528c889ff6ea8b0e16fd306aa3088238
+checksum=1014a85c768de8f9e9c6d4bf0b42617f3b1588be1ad371f71674ea32b87119c0
 lib32disabled=yes
 provides="mysql-${version}_${revision}"
 replaces="mysql>=0"


### PR DESCRIPTION
The older version did not build successfully against the latest version of libfmt (12.0.0), and an upgrade was the shortest path to making -DWITH_LIBFMT=system work correctly. It looks like the latest supported libfmt for 11.1.2 would have been 9.0.x or earlier. Building against the latest libfmt yields a build error because cmake decides it needs to use a vendored copy of libfmt, then bails when it can't download the vendored code. Providing -DWITH_LIBFMT=system guarantees that the build fails during the configuration step if it can't use the system libfmt, rather than failing much later on.

Some background: https://github.com/fmtlib/fmt/issues/4284

I am not a user of mariadb, but it is an indirect dependency of building git from source, so I have not tested these changes other than confirming that they build cleanly.

#### Testing the changes
- I tested the changes in this PR: **NO**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-musl

