### PR TITLE
fftw: fix broken build against new-ish cmake

### DIFF
--- a/srcpkgs/fftw/template
+++ b/srcpkgs/fftw/template
@@ -1,7 +1,7 @@
 # Template file for 'fftw'
 pkgname=fftw
 version=3.3.10
-revision=4
+revision=3
 hostmakedepends="libtool automake cmake-bootstrap"
 makedepends="libgomp-devel"
 short_desc="Library for computing the discrete Fourier transform (DFT)"

--- a/srcpkgs/fftw/template
+++ b/srcpkgs/fftw/template
@@ -1,7 +1,7 @@
 # Template file for 'fftw'
 pkgname=fftw
 version=3.3.10
-revision=3
+revision=4
 hostmakedepends="libtool automake cmake-bootstrap"
 makedepends="libgomp-devel"
 short_desc="Library for computing the discrete Fourier transform (DFT)"
@@ -47,7 +47,7 @@ do_configure() {
 	cmake -B build -D CMAKE_INSTALL_PREFIX=/usr -D CMAKE_BUILD_TYPE=None \
 			-D ENABLE_OPENMP=ON -D ENABLE_THREADS=ON -D ENABLE_FLOAT=ON \
 			-D ENABLE_LONG_DOUBLE=ON -D ENABLE_QUAD_PRECISION=ON -D ENABLE_SSE=ON \
-			-D ENABLE_SSE2=ON -D ENABLE_AVX=ON -D ENABLE_AVX2=ON
+			-D ENABLE_SSE2=ON -D ENABLE_AVX=ON -D ENABLE_AVX2=ON -DCMAKE_POLICY_VERSION_MINIMUM=3.5
 	# fix broken IMPORTED_LOCATION: https://github.com/FFTW/fftw3/issues/130#issuecomment-1030280157
 	sed -e 's|\(IMPORTED_LOCATION_NONE\).*|\1 "/usr/lib/libfftw3.so.3"|' -i build/FFTW3LibraryDepends.cmake
 }


### PR DESCRIPTION
cmake (4.1.x) complains that it doesn't support scripts targeting cmake 3.5.
Builds work fine acknowledging the obsolescence of the scripts and continuing anyway.

(I ran into this bootstrapping a from-source build of chromium.)

#### Testing the changes
- I tested the changes in this PR: **NO** (but I have tested that it produces a working chromium)

#### Local build testing
- I built this PR locally for my native architecture, x86_64-musl