### PR TITLE
elogind: fix musl build

### DIFF
--- a/srcpkgs/elogind/template
+++ b/srcpkgs/elogind/template
@@ -1,7 +1,7 @@
 # Template file for 'elogind'
 pkgname=elogind
 version=252.9
-revision=2
+revision=3
 build_style=meson
 configure_args="-Dcgroup-controller=elogind -Ddefault-hierarchy=legacy
  -Ddefault-kill-user-processes=false -Dhalt-path=/usr/bin/halt
@@ -22,6 +22,8 @@ checksum=7af8caa8225a406e77fb99c9f33dba5e1f0a94f0e1277c9d91dcfc016f116d85
 conf_files="/etc/elogind/*.conf"
 # tests fail differently due to containerization and kernel features
 make_check=ci-skip
+
+CFLAGS+=" -D_LARGEFILE64_SOURCE"
 
 if [ "$XBPS_TARGET_LIBC" = "glibc" ]; then
 	makedepends+=" libxcrypt-devel"


### PR DESCRIPTION
I ran into an elogind build failure while building seatd (and dependencies) from source.
The problem and solution are similar to #57768.

#### Testing the changes
- I tested the changes in this PR: **NO** (but I have tested it yields a working seatd)

#### Local build testing
- I built this PR locally for my native architecture, x86_64-musl
