### PR TITLE
kdenlive: revbump due to qt6 issues

### DIFF
--- a/srcpkgs/kdenlive/template
+++ b/srcpkgs/kdenlive/template
@@ -1,7 +1,7 @@
 # Template file for 'kdenlive'
 pkgname=kdenlive
 version=25.08.2
-revision=1
+revision=2
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins -DFETCH_OTIO=OFF


### PR DESCRIPTION
kdenlive was broken by the recent qt6 issues.
A rebuild fixed that :)

#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
