### PR TITLE
vips: update to 8.17.3.

### DIFF
--- a/srcpkgs/vips/template
+++ b/srcpkgs/vips/template
@@ -1,6 +1,6 @@
 # Template file for 'vips'
 pkgname=vips
-version=8.17.2
+version=8.17.3
 revision=1
 build_style=meson
 build_helper=gir
@@ -12,14 +12,14 @@ makedepends="$(vopt_if hdf5 hdf5-devel) $(vopt_if hdf5 matio-devel)
  glib-devel lcms2-devel libexif-devel libgsf-devel libimagequant-devel
  libjpeg-turbo-devel libopenexr-devel libpng-devel librsvg-devel tiff-devel
  libwebp-devel libopenjpeg2-devel pango-devel libmagick-devel libheif-devel
- poppler-glib-devel libjxl-devel"
+ poppler-glib-devel libjxl-devel highway-devel"
 short_desc="Fast image processing with low memory needs"
 maintainer="yosh <yosh-git@riseup.net>"
 license="LGPL-2.1-or-later"
 homepage="https://www.libvips.org/"
 changelog="https://raw.githubusercontent.com/libvips/libvips/master/ChangeLog"
 distfiles="https://github.com/libvips/libvips/archive/refs/tags/v${version}.tar.gz"
-checksum=66e2c8f0a716a08cf99e46a27535ef4938f1cae110dd9207cf8e992616b36ba7
+checksum=c1180d13f33742685c513ac42c0556dd1ce9e2b79cdb248a807576e2d8b63b32
 python_version=3
 
 build_options="gir hdf5"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**
  - encoded/decoded some images in various formats using the CLI & .NET bindings

#### Local build testing
- native architecture: `x86_64-glibc`

also made the `highway` dependency explicit in vips rather than implicit via `libjxl`