### PR TITLE
gnome-mahjongg: update to 49.0.1

### DIFF
--- a/srcpkgs/gnome-mahjongg/template
+++ b/srcpkgs/gnome-mahjongg/template
@@ -1,6 +1,6 @@
 # Template file for 'gnome-mahjongg'
 pkgname=gnome-mahjongg
-version=48.1
+version=49.0.1
 revision=1
 build_style=meson
 hostmakedepends="gettext glib-devel itstool pkg-config vala
@@ -11,5 +11,5 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="https://gitlab.gnome.org/GNOME/gnome-mahjongg"
 changelog="https://gitlab.gnome.org/GNOME/gnome-mahjongg/-/raw/master/NEWS"
-distfiles="${GNOME_SITE}/${pkgname}/${version%.*}/${pkgname}-${version}.tar.xz"
-checksum=dd48e0f81aca34beada46c5d221b32591b8ed81e9d361c3a258df9f6b2222c84
+distfiles="${GNOME_SITE}/${pkgname}/${version%%.*}/${pkgname}-${version}.tar.xz"
+checksum=45b3a48dcb1ed6189a63b6bf55508e8b38eb5a956657a7fe2a5225cc2f8bc132


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **yes**

#### Local build testing
- I built this PR locally for my native architecture, x86_64
- I crossbuilded this PR locally for these architectures:
  - armv7l
  - armv6l-musl
  - aarch64-musl