### PR TITLE
quickshell: set DHYPRLAND to ON

### DIFF
--- a/srcpkgs/quickshell/template
+++ b/srcpkgs/quickshell/template
@@ -4,7 +4,7 @@ version=0.2.1
 revision=2
 build_style=cmake
 configure_args="-DDISTRIBUTOR=Void -DDISTRIBUTOR_DEBUGINFO_AVAILABLE=YES
- -DINSTALL_QML_PREFIX=lib/qt6/qml -DCRASH_REPORTER=OFF -DHYPRLAND=OFF"
+ -DINSTALL_QML_PREFIX=lib/qt6/qml -DCRASH_REPORTER=OFF -DHYPRLAND=ON"
 hostmakedepends="pkg-config wayland-devel qt6-base qt6-declarative-devel
  qt6-shadertools"
 makedepends="cli11 qt6-base-private-devel qt6-declarative-private-devel


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
#### Local build testing
- I built this PR locally for my native architecture, (x86_64)

#### Explanation
While I'm aware that there is no hyprland in the void-packages repo, changing `-DHYPRLAND=OFF` to `-DHYPRLAND=ON` makes quite a lot of sense in my opinion since a lot of quickshell projects support multiple compositors (including hyprland) and if we keep `DHYPRLAND=OFF` those setups will not launch.