### PR TITLE
python3-peewee: update to 3.18.3.

### DIFF
--- a/srcpkgs/python3-peewee/template
+++ b/srcpkgs/python3-peewee/template
@@ -1,6 +1,6 @@
 # Template file for 'python3-peewee'
 pkgname=python3-peewee
-version=3.18.2
+version=3.18.3
 revision=1
 build_style=python3-pep517
 hostmakedepends="python3-setuptools python3-wheel python3-Cython"
@@ -12,7 +12,7 @@ license="MIT"
 homepage="https://github.com/coleifer/peewee"
 changelog="https://raw.githubusercontent.com/coleifer/peewee/master/CHANGELOG.md"
 distfiles="https://github.com/coleifer/peewee/archive/${version}.tar.gz"
-checksum=20f5ca85d46f0c251cba5ab6f734b09e89ea77af56ad66708225bc7d4331f4c7
+checksum=09a4a65346856f422e653e610f946174a70d4e26c27bfd9fc0a258555e7c5c50
 make_check=no # tests require postgres instance
 
 post_install() {


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-libc
