### PR TITLE
ripgrep-all: update to 0.10.10.

### DIFF
--- a/srcpkgs/ripgrep-all/template
+++ b/srcpkgs/ripgrep-all/template
@@ -1,6 +1,6 @@
 # Template file for 'ripgrep-all'
 pkgname=ripgrep-all
-version=0.10.9
+version=0.10.10
 revision=1
 build_style=cargo
 hostmakedepends="pkg-config"
@@ -13,7 +13,7 @@ license="AGPL-3.0-or-later"
 homepage="https://github.com/phiresky/ripgrep-all"
 changelog="https://raw.githubusercontent.com/phiresky/ripgrep-all/master/CHANGELOG.md"
 distfiles="https://github.com/phiresky/ripgrep-all/archive/refs/tags/v${version}.tar.gz"
-checksum=a5b3150940dcddd35a26e9de398f11a563d0466a335e5450ceb7ff369e9fef45
+checksum=17fadc7b73a51608d57f82b4a11f3edc0da87716cc4b302103eed9d4b9010fe5
 
 post_install() {
 	vlicense LICENSE.md


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

This update fixes a vulnerability potentially allowing  arbitrary file write,
see https://github.com/phiresky/ripgrep-all/issues/307

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
