### PR TITLE
libseccomp: update to 2.5.6.

### DIFF
--- a/srcpkgs/libseccomp/template
+++ b/srcpkgs/libseccomp/template
@@ -1,6 +1,6 @@
 # Template file for 'libseccomp'
 pkgname=libseccomp
-version=2.5.5
+version=2.5.6
 revision=1
 build_style=gnu-configure
 hostmakedepends="automake libtool gperf"
@@ -11,7 +11,7 @@ license="LGPL-2.1-or-later"
 homepage="https://github.com/seccomp/libseccomp/"
 changelog="https://raw.githubusercontent.com/seccomp/libseccomp/main/CHANGELOG"
 distfiles="https://github.com/seccomp/${pkgname}/archive/v${version}.tar.gz"
-checksum=7082b016d3cbda3e15c0e71ebd018023d693bb7507389b32f943db13f935e01d
+checksum=e7efb42e22c7d59eff39b6ff6722696614744d23ac422b17e85a3d404e3e1d6d
 
 pre_configure() {
 	NOCONFIGURE=1 ./autogen.sh


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures:
  - x86_64-musl
  - aarch64-glibc (crossbuild)

#### Notes
- current 2.5.5 is [no longer supported](https://github.com/seccomp/libseccomp/releases/tag/v2.5.5)
- 2.6.0 doesn't compile on musl according to #56163