### PR TITLE
hex2hcd: simply pull bluez

### DIFF
--- a/srcpkgs/hex2hcd/template
+++ b/srcpkgs/hex2hcd/template
@@ -1,16 +1,10 @@
 # Template file for 'hex2hcd'
 pkgname=hex2hcd
 version=2016.02.21
-revision=3
-build_style=gnu-makefile
+revision=4
+metapackage=yes
+depends="bluez"
 short_desc="Convert *.hex firmware files to *.hcd format"
 maintainer="Antonio Malcolm <antonio@antoniomalcolm.com>"
-license="GPL-2.0-or-later"
-homepage="https://github.com/antonio-malcolm/hex2hcd"
-distfiles="${homepage}/archive/${version}.tar.gz"
-checksum=45cab33daa404c6e66979abea975f11cb5705152c7723a2a16391f5fd1ba847b
-conflicts="bluez" # /usr/bin/hex2hcd
-
-do_install() {
-	vbin ${pkgname}
-}
+license="0BSD"
+homepage="https://github.com/jessesung/hex2hcd"


### PR DESCRIPTION
hex2hcd simply decode Broadcom hex format to hcd format, which is exactly what bluez's hex2hcd is doing

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**|**briefly**|**NO**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
