### PR TITLE
containerd: update to 2.2.0.

### DIFF
--- a/srcpkgs/containerd/template
+++ b/srcpkgs/containerd/template
@@ -1,7 +1,7 @@
 # Template file for 'containerd'
 pkgname=containerd
-version=2.0.1
-revision=2
+version=2.2.0
+revision=1
 build_style=go
 build_helper="qemu"
 go_import_path=github.com/containerd/containerd/v2
@@ -11,7 +11,7 @@ go_package="${go_import_path}/cmd/containerd
 go_ldflags="-X ${go_import_path}/version.Version=${version}
  -X ${go_import_path}/version.Revision=UNSET"
 go_build_tags="seccomp apparmor"
-make_check_args="-skip (^TestSetNegativeOomScoreAdjustmentWhenPrivileged$|^TestEnsureRemoveAllWithMount$|^TestBinDirVerifyImage$)"
+make_check_args="-skip (^TestSetNegativeOomScoreAdjustmentWhenPrivileged$|^TestEnsureRemoveAllWithMount$|^TestBinDirVerifyImage$|^TestSetPositiveOomScoreAdjustment$|^TestSetOOMScoreBoundaries$)"
 hostmakedepends="pkg-config go-md2man"
 makedepends="libbtrfs-devel libseccomp-devel"
 depends="runc"
@@ -21,7 +21,7 @@ maintainer="Orphan <orphan@voidlinux.org>"
 license="Apache-2.0"
 homepage="https://github.com/containerd/containerd"
 distfiles="https://github.com/containerd/containerd/archive/v${version}.tar.gz"
-checksum=a2958e6c97dcc44d2b3fc5f1e0c5cfb267d4620b26b51ff52cbe7bd07678707d
+checksum=86e7a268fc73f5332522baef86082c1d6c17986e2957a9ad842ead35d1080fca
 make_dirs="/var/lib/containerd 0755 root root"
 
 # Cross builds fail with -fuse-ld=gold

--- a/srcpkgs/runc/template
+++ b/srcpkgs/runc/template
@@ -1,12 +1,12 @@
 # Template file for 'runc'
 pkgname=runc
-version=1.2.8
+version=1.3.3
 revision=1
 build_style=go
 go_import_path=github.com/opencontainers/runc
 go_build_tags="seccomp apparmor"
 go_ldflags="-X main.version=${version}"
-make_check_args="-skip=(^TestValidateSysctlWithBindHostNetNS$|^TestNsenterValidPaths$|^TestNsenterChildLogging$)"
+make_check_args="-skip=(^TestValidateSysctlWithBindHostNetNS$|^TestNsenterValidPaths$|^TestNsenterChildLogging$|^TestFactoryLoadContainer$)"
 hostmakedepends="pkg-config go-md2man"
 makedepends="libseccomp-devel"
 checkdepends="curl tar xz"
@@ -16,7 +16,7 @@ license="Apache-2.0"
 homepage="https://github.com/opencontainers/runc"
 changelog="https://github.com/opencontainers/runc/raw/main/CHANGELOG.md"
 distfiles="https://github.com/opencontainers/runc/releases/download/v${version}/runc.tar.xz"
-checksum=add42d467087ac18e43d18de7061e145d4d2b2aa3608e684c907ffd6c816d007
+checksum=3488f287ec8dd88a7599647a5d119c628b86bfffd176786871e1ffd98d8049cc
 
 post_build() {
 	make man


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures:
  - x86_64-musl
  - aarch64-glibc (crossbuild)

#### Notes
- deprecates #57808
- containerd 2.0 branch support ended on November 7, 2025
- also updates runc to 1.3.3
