### PR TITLE
New package: cortile-2.5.2

### DIFF
--- a/srcpkgs/cortile/template
+++ b/srcpkgs/cortile/template
@@ -1,0 +1,17 @@
+# Template file for 'cortile'
+pkgname=cortile
+version=2.5.2
+revision=1
+build_style=go
+go_import_path="github.com/leukipp/cortile/v2"
+short_desc="Linux auto tiling manager with hot corner support for EWMH compliant WMs"
+maintainer="zenobit <zenobit@disroot.org>"
+license="MIT"
+homepage="https://github.com/leukipp/cortile"
+changelog="https://github.com/leukipp/cortile/compare/v1.0.0-rc.1...v${version}"
+distfiles="https://github.com/leukipp/cortile/archive/refs/tags/v${version}.tar.gz"
+checksum=6d5ea7c542093c109cbf0b23866aa154f49b7637d2f02d7d0467c38a4f114b01
+
+post_install() {
+	vlicense LICENSE
+}


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

#### Local build testing
- I built this PR locally for my native architecture, x64 glibc