### PR TITLE
puddletag: update to 2.5.0.

### DIFF
--- a/srcpkgs/puddletag/template
+++ b/srcpkgs/puddletag/template
@@ -1,7 +1,7 @@
 # Template file for 'puddletag'
 pkgname=puddletag
-version=2.4.0
-revision=2
+version=2.5.0
+revision=1
 build_style=python3-pep517
 hostmakedepends="python3-setuptools python3-wheel"
 depends="python3 python3-configobj python3-mutagen python3-parsing
@@ -14,7 +14,7 @@ maintainer="JkktBkkt <apkabikov+void@gmail.com>"
 license="GPL-3.0-or-later"
 homepage="https://github.com/puddletag/puddletag"
 distfiles="https://github.com/puddletag/puddletag/archive/${version}.tar.gz"
-checksum=892864eabdb9bea627087e6b342a861ec6b8400d7f8e706a85565d71a1fb1be3
+checksum=aa04bd796a78ca726c91c28ade0b64a9d693cac307713728359dfc551d250815
 
 post_patch() {
 	vsed -i '/^pyqt.-qt/d' requirements.txt


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, x86-64
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl
  - i686 
  - armv6l *
  - armv6l-musl *
  - armv7l *
  - armv7l-musl *
  - aarch64 *
  - aarch64-musl *

Right after the release of 2.5.0 author commited switch to Qt6, but almost 5 months later and there's still not a new tag, so keeping Qt5 version still.
