### PR TITLE
fastfetch: update to 2.55.0.

### DIFF
--- a/srcpkgs/fastfetch/template
+++ b/srcpkgs/fastfetch/template
@@ -1,6 +1,6 @@
 # Template file for 'fastfetch'
 pkgname=fastfetch
-version=2.54.0
+version=2.55.0
 revision=1
 build_style=cmake
 configure_args="-DENABLE_SYSTEM_YYJSON=ON -DBUILD_FLASHFETCH=OFF"
@@ -14,7 +14,7 @@ license="MIT"
 homepage="https://github.com/fastfetch-cli/fastfetch"
 changelog="https://github.com/fastfetch-cli/fastfetch/raw/dev/CHANGELOG.md"
 distfiles="https://github.com/fastfetch-cli/fastfetch/archive/refs/tags/${version}.tar.gz"
-checksum=e6a0516364bc0a4991a588537ee2abb538b86db41f7d9dff795d49baec990529
+checksum=d99ea4f5398ef05059771aa0b1aeda4bc1d01d951ae91d93c5b6dfb550649dbe
 
 case "$XBPS_TARGET_MACHINE" in
 	x86_64|aarch64) makedepends+=" DirectX-Headers" ;;


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures using specific masterdirs:
  - x86_64-musl
  - i686
- I built this PR locally for these architectures (crossbuilds):
  - aarch64
  - aarch64-musl
  - armv7l
  - armv7l-musl
  - armv6l
  - armv6l-musl
  
maintainer ping @classabbyamp 