### PR TITLE
nanomsg: update to 1.2.2.

### DIFF
--- a/srcpkgs/nanomsg/template
+++ b/srcpkgs/nanomsg/template
@@ -1,6 +1,6 @@
 # Template file for 'nanomsg'
 pkgname=nanomsg
-version=1.2
+version=1.2.2
 revision=1
 build_style=cmake
 short_desc='Simple, high-performance implementation of scalability protocols'
@@ -9,7 +9,7 @@ license="MIT"
 homepage='http://nanomsg.org/'
 changelog="https://github.com/nanomsg/nanomsg/releases"
 distfiles="https://github.com/nanomsg/nanomsg/archive/$version.tar.gz>nanomsg-${version}.tar.gz"
-checksum=6ef7282e833df6a364f3617692ef21e59d5c4878acea4f2d7d36e21c8858de67
+checksum=3ffeafa9335245a23a99827e8d389bfce5100610f44ebbe4bfaf47e8192d5939
 
 post_install() {
 	vlicense COPYING


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture (x86_64)
- I built this PR locally for these architectures using specific masterdirs:
  - x86_64-musl
  - i686
- I built this PR locally for these architectures (crossbuilds):
  - aarch64
  - aarch64-musl
  - armv7l
  - armv7l-musl
  - armv6l
  - armv6l-musl
 
---

The latest `Criterion` release (2.4.3) now depends on `nanomsg` 1.2.2 in its Meson wrap, as tracked in void-linux/void-packages#50109.
