### PR TITLE
xdg-desktop-portal-termfilechooser: update to 1.2.1

### DIFF
--- a/srcpkgs/xdg-desktop-portal-termfilechooser/template
+++ b/srcpkgs/xdg-desktop-portal-termfilechooser/template
@@ -1,6 +1,6 @@
 # Template file for 'xdg-desktop-portal-termfilechooser'
 pkgname=xdg-desktop-portal-termfilechooser
-version=1.1.1
+version=1.2.1
 revision=1
 build_style=meson
 hostmakedepends="pkg-config gettext glib-devel xdg-desktop-portal cmake scdoc"
@@ -11,7 +11,7 @@ maintainer="zlice <zlice555@gmail.com>"
 license="MIT"
 homepage="https://github.com/hunkyburrito/xdg-desktop-portal-termfilechooser"
 distfiles="https://github.com/hunkyburrito/xdg-desktop-portal-termfilechooser/archive/refs/tags/v${version}.tar.gz"
-checksum=136824dbbbcefbc86c65fa83309104aadfdbeb8e0b84c16b1274d83465ed28a4
+checksum=49b9425631b2ecf830e12d55e281190dfe6558fa8225fe112b00ab879925cfdd
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture: **x86_64**