### PR TITLE
x13s-base: fix mkinitcpio configuration

### DIFF
--- a/srcpkgs/x13s-base/files/mkinitcpio.conf
+++ b/srcpkgs/x13s-base/files/mkinitcpio.conf
@@ -1,6 +1,17 @@
-MODULES+=(nvme phy_qcom_qmp_pcie)
+MODULES+=( nvme phy_qcom_qmp_pcie )
+
 # keyboard
-MODULES+=(i2c_hid_of i2c_qcom_geni)
+MODULES+=( i2c_hid_of i2c_qcom_geni )
+
 # display
-MODULES+=(leds_qcom_lpg pwm_bl qrtr pmic_glink_altmode gpio_sbu_mux panel_edp msm
- phy_qcom_qmp_combo pinctrl_sc8280xp gpucc_sc8280xp dispcc_sc8280xp phy_qcom_edp)
+MODULES+=(
+	leds_qcom_lpg pwm_bl qrtr spmi_pmic_arb pmic_glink_altmode gpio_sbu_mux
+	panel_edp msm phy_qcom_qmp_combo pinctrl_sc8280xp gpucc_sc8280xp
+	dispcc_sc8280xp phy_qcom_edp
+)
+
+FILES+=(
+	/usr/lib/firmware/qcom/sc8280xp/LENOVO/21BX/qcdxkmsuc8280.mbn
+	/usr/lib/firmware/qcom/a660_sqe.fw
+	/usr/lib/firmware/qcom/a660_gmu.bin
+)

--- a/srcpkgs/x13s-base/template
+++ b/srcpkgs/x13s-base/template
@@ -1,14 +1,14 @@
 # Template file for 'x13s-base'
 pkgname=x13s-base
 version=4
-revision=1
+revision=2
 archs="aarch64*"
 depends="linux linux-firmware-qualcomm alsa-ucm-conf"
 short_desc="Void Linux Thinkpad X13s platform package"
 maintainer="classabbyamp <void@placeviolette.net>"
 license="Public Domain"
 homepage="https://www.voidlinux.org"
-conf_files="/etc/default/x13s"
+conf_files="/etc/default/x13s /etc/mkinitcpio.conf.d/x13s.conf"
 
 do_install() {
 	vinstall "${FILESDIR}"/72-touchscreen.rules 644 usr/lib/udev/rules.d 72-x13s-touchscreen.rules
@@ -18,6 +18,5 @@ do_install() {
 	vinstall "${FILESDIR}"/dracut.conf 644 usr/lib/dracut/dracut.conf.d x13s.conf
 	vinstall "${FILESDIR}"/x13s-setup 755 usr/libexec
 	vinstall "${FILESDIR}"/x13s.default 644 etc/default x13s
-	# not currently working
-	# vinstall "${FILESDIR}"/mkinitcpio.conf 644 etc/mkinitcpio.conf.d x13s.conf
+	vinstall "${FILESDIR}"/mkinitcpio.conf 644 etc/mkinitcpio.conf.d x13s.conf
 }


### PR DESCRIPTION
A `mkinitcpio` initramfs image boots 6.16.9 with these changes. It seems like this was only missing the firmware images.

cc: @classabbyamp 