### PR TITLE
qbittorrent: don't build with -DWEBUI=OFF

### DIFF
--- a/srcpkgs/qbittorrent/template
+++ b/srcpkgs/qbittorrent/template
@@ -1,9 +1,9 @@
 # Template file for 'qbittorrent'
 pkgname=qbittorrent
 version=5.1.2
-revision=3
+revision=4
 build_style=cmake
-configure_args="-DSYSTEMD=OFF -DGUI=ON -DWEBUI=OFF"
+configure_args="-DSYSTEMD=OFF -DGUI=ON"
 hostmakedepends="pkg-config qt6-tools qt6-declarative-host-tools"
 makedepends="libtorrent-rasterbar-devel qt6-base-private-devel qt6-declarative-devel qt6-svg-devel"
 depends="qt6-svg"
@@ -18,7 +18,6 @@ CXXFLAGS=-std=gnu++17
 
 post_configure() { # qbittorrent-nox
 	configure_args="${configure_args//DGUI=ON/DGUI=OFF}"
-	configure_args="${configure_args//DWEBUI=OFF/DWEBUI=ON}"
 	(
 		cmake_builddir="nox-build"
 		do_configure


### PR DESCRIPTION
This is useful if you want to run the qBittorrent GUI and also have the WebUI/API for scripting (the name "WebUI" is a bit of a misnomer, as it's useful for all kinds of scripting). Right now this is impossible, because you can either have the GUI via qbittorrent or WebUI/API via qbittorrent-nox, but not both.

As near as I can tell there is no downside to doing this: it adds no dependencies and it's disabled by default and you need to explicitly enable it in the settings.

#### Testing the changes
- I tested the changes in this PR: **YES**