### PR TITLE
New package: adw-bluetooth-1.0.0.

### DIFF
--- a/srcpkgs/adw-bluetooth/template
+++ b/srcpkgs/adw-bluetooth/template
@@ -1,0 +1,29 @@
+# Template file for 'adw-bluetooth'
+pkgname=adw-bluetooth
+version=1.0.0
+revision=1
+build_style=meson
+hostmakedepends="pkg-config nodejs blueprint-compiler glib-devel desktop-file-utils"
+makedepends="gjs-devel gtk4 libadwaita"
+depends="gjs libadwaita"
+short_desc="Bluetooth device manager built with GTK4 and Libadwaita"
+maintainer="xJayMorex <github@johntaylor.hu>"
+license="GPL-3.0-or-later"
+homepage="https://github.com/ezratweaver/adw-bluetooth"
+distfiles="https://github.com/ezratweaver/adw-bluetooth/archive/refs/tags/${version}.tar.gz"
+checksum=a2815400f4090fa375b06fbe5fbc6df4926701cc84498d1f50a8648b9d489d99
+
+if [ "$CROSS_BUILD" ]; then
+	hostmakedepends+=" gjs-devel"
+fi
+
+pre_configure() {
+	npm i typescript
+	export PATH="$PATH:$(pwd)/node_modules/.bin"
+}
+
+pre_build() {
+	if [ "$CROSS_BUILD" ]; then
+		export GI_TYPELIB_PATH="${XBPS_CROSS_BASE}/usr/lib/girepository-1.0"
+	fi
+}


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures:
  - x86_64-musl
  - aarch64-glibc (crossbuild)
