### PR TITLE
VeraCrypt: update to 1.26.24.

### DIFF
--- a/srcpkgs/VeraCrypt/template
+++ b/srcpkgs/VeraCrypt/template
@@ -1,6 +1,6 @@
 # Template file for 'VeraCrypt'
 pkgname=VeraCrypt
-version=1.26.15
+version=1.26.24
 revision=1
 build_wrksrc=src
 build_style=gnu-makefile
@@ -13,7 +13,7 @@ maintainer="Gustavo Heinz <gustavoheinz95@gmail.com>"
 license="Apache-2.0, custom:TrueCrypt-3.0"
 homepage="https://www.veracrypt.fr"
 distfiles="https://launchpad.net/veracrypt/trunk/${version}/+download/VeraCrypt_${version}_Source.tar.bz2"
-checksum=ba97025030e21b9b2331b7eb089701163c32af4b7e04535f335baf8d74a74916
+checksum=7f5c20af429377ab56f7b52ca868936b9923d784f4606da9886c362978903e78
 
 # license is Apache-2.0 AND TrueCrypt-3.0
 # TrueCrypt-3.0 is non-free, VI.4 disallow distributing


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)