### PR TITLE
asio: update to 1.36.0.

### DIFF
--- a/srcpkgs/asio/template
+++ b/srcpkgs/asio/template
@@ -1,14 +1,14 @@
 # Template file for 'asio'
 pkgname=asio
-version=1.24.0
+version=1.36.0
 revision=1
 build_style=gnu-configure
 short_desc="Cross-platform C++ library for ASynchronous network I/O"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="BSL-1.0"
-homepage="http://think-async.com/Asio/"
+homepage="https://think-async.com/Asio/"
 distfiles="${SOURCEFORGE_SITE}/asio/asio-${version}.tar.bz2"
-checksum=8976812c24a118600f6fcf071a20606630a69afe4c0abee3b0dea528e682c585
+checksum=7bf4dbe3c1ccd9cc4c94e6e6be026dcc2110f9201d286bb9500dc85d69825524
 
 post_install() {
 	vlicense LICENSE_1_0.txt


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**
  - compiled and ran a primitive UDP client: sent and recieved packages to/from a netcat client 
  - compiled and ran a TCP server: connected to this server with netcat, server was able to recieve and send acknowledgement message
  
#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - armv6l
