### PR TITLE
scons: update to 4.10.1

### DIFF
--- a/srcpkgs/scons/template
+++ b/srcpkgs/scons/template
@@ -1,6 +1,6 @@
 # Template file for 'scons'
 pkgname=scons
-version=4.9.1
+version=4.10.1
 revision=1
 build_style="python3-module"
 make_install_args="--install-data=/usr/share/man/man1/"
@@ -11,7 +11,7 @@ maintainer="Wilson Birney <wpb@360scada.com>"
 license="MIT"
 homepage="https://www.scons.org/"
 distfiles="${SOURCEFORGE_SITE}/scons/${version}/SCons-${version}.tar.gz"
-checksum=e2d78aa56e4646e5dbaf50c0758c6d1e4b0418464d8d6d07a09beb6cf257538f
+checksum=99c0e94a42a2c1182fa6859b0be697953db07ba936ecc9817ae0d218ced20b15
 make_check=no #SCons dist tarballs do not have tests, confirmed with SCons dev
 
 post_install() {


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl

Test built all packages using scons for xbps build style:

- [x] godot  (also tested with gdextensions which use scons as well)                                                                                                                                                                                                                                 
- [x] goxel                                                                                                                                                                                                                                   
- [x] gpsd                                                                                                                                                                                                                                    
- [x] libffado                                                                                                                                                                                                                                
- [x] pingus                                                                                                                                                                                                                                  
- [x] rmlint                                                                                                                                                                                                                                  
- [x] serf                                                                                                                                                                                                                                    
- [x] vdrift                                                                                                                                                                                                                                  
- [x] xboxdrv                                                                                                                                                                                                                                 
- [x] endless-sky-gl21                                                                                                                                                                                                                        
- [x] cbang                                                                                                                                                                                                                                   
- [x] sunpinyin