### PR TITLE
usbutils: update to 019

### DIFF
--- a/srcpkgs/usbutils/template
+++ b/srcpkgs/usbutils/template
@@ -1,6 +1,6 @@
 # Template file for 'usbutils'
 pkgname=usbutils
-version=018
+version=019
 revision=1
 build_style=meson
 hostmakedepends="pkg-config"
@@ -12,7 +12,7 @@ license="GPL-2.0-only"
 homepage="https://github.com/gregkh/usbutils"
 changelog="https://raw.githubusercontent.com/gregkh/usbutils/master/NEWS"
 distfiles="${KERNEL_SITE}/utils/usb/usbutils/usbutils-${version}.tar.xz"
-checksum=83f68b59b58547589c00266e82671864627593ab4362d8c807f50eea923cad93
+checksum=659f40c440e31ba865c52c818a33d3ba6a97349e3353f8b1985179cb2aa71ec5
 replaces="usbhid-dump<=1.4_1"
 
 post_install() {


### PR DESCRIPTION
- I tested the changes in this PR: **briefly**
- I built this PR locally for my native architecture, **x86_64-glibc**

Notes:
- `usbhid-dump` got removed 3 years ago: [#9ee9202](https://github.com/void-linux/void-packages/commit/9ee9202339b9209a4ad80a0c67ddc5ce321db042)

cc @Gottox 
