### PR TITLE
swww: update to 0.11.2

### DIFF
--- a/srcpkgs/swww/template
+++ b/srcpkgs/swww/template
@@ -1,6 +1,6 @@
 # Template file for 'swww'
 pkgname=swww
-version=0.10.3
+version=0.11.2
 revision=1
 build_style=cargo
 hostmakedepends="scdoc pkg-config"
@@ -8,10 +8,10 @@ makedepends="liblz4-devel wayland-devel wayland-protocols"
 short_desc="Solution to your Wayland Wallpaper Woes"
 maintainer="Daniel Martinez <danielmartinez@cock.li>"
 license="GPL-3.0-only"
-homepage="https://github.com/LGFae/swww"
-changelog="https://raw.githubusercontent.com/LGFae/swww/main/CHANGELOG.md"
-distfiles="https://github.com/LGFae/swww/archive/refs/tags/v${version}.tar.gz"
-checksum=8a86fe633c54e1d4278644cb728deea5decd0d4b1630506f4925a65ccf8a67e5
+homepage="https://codeberg.org/LGFae/awww"
+changelog="https://codeberg.org/LGFae/awww/src/branch/main/CHANGELOG.md"
+distfiles="https://codeberg.org/LGFae/awww/archive/v${version}.tar.gz"
+checksum=0bd1d3a7461b1bc0b99f49aa64ce01d3e84412c5afd6534a1221c4aa3341ccd6
 
 post_build() {
 	./doc/gen.sh


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
- I built this PR locally for my native architecture, (x86_64-glibc)

The upstream project has renamed to awww and moved to codeberg(even thought the v0.11.2 is still in github repo) but I am not maintainer, and the maintainer is still active here. +the built binaries still uses the name swww. So I just did the version update since rust >= 1.89(a requirement in new version's build process) is in void repos now.