### PR TITLE
persepolis: add missing runtime dependency python3-pyside6-network

### DIFF
--- a/srcpkgs/persepolis/template
+++ b/srcpkgs/persepolis/template
@@ -1,13 +1,13 @@
 # Template file for 'persepolis'
 pkgname=persepolis
 version=5.2.0
-revision=2
+revision=3
 build_style=meson
 build_helper=python3
 hostmakedepends="python3-packaging-bootstrap"
 depends="python3-pysocks python3-requests qt6-svg python3-urllib3
- python3-pyside6-gui python3-pyside6-multimedia python3-pyside6-widgets
- python3-setproctitle python3-psutil"
+ python3-pyside6-gui python3-pyside6-network python3-pyside6-multimedia
+ python3-pyside6-widgets python3-setproctitle python3-psutil"
 short_desc="QT Download Manager"
 maintainer="Komeil Parseh <komeilparseh@disroot.org>"
 license="GPL-3.0-or-later"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
- I built this PR locally for my native architecture, (x86-64-glibc)

Tried to download something in Persepolis this morning and it didn't launch. This was the error.
```Traceback (most recent call last):
  File "/usr/lib/python3.13/site-packages/persepolis/scripts/play.py", line 17, in <module>
    from PySide6.QtMultimedia import QSoundEffect
ImportError: could not import module 'PySide6.QtNetwork'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/bin/persepolis", line 26, in <module>
    from persepolis.scripts import persepolis
  File "/usr/lib/python3.13/site-packages/persepolis/scripts/persepolis.py", line 101, in <module>
    from persepolis.scripts.mainwindow import MainWindow
  File "/usr/lib/python3.13/site-packages/persepolis/scripts/mainwindow.py", line 50, in <module>
    from persepolis.scripts.bubble import notifySend, checkNotificationSounds, createNotificationSounds
  File "/usr/lib/python3.13/site-packages/persepolis/scripts/bubble.py", line 16, in <module>
    from persepolis.scripts.play import playNotification
  File "/usr/lib/python3.13/site-packages/persepolis/scripts/play.py", line 19, in <module>
    from PyQt5.QtCore import QUrl, QSettings
ModuleNotFoundError: No module named 'PyQt5'
```
Installing python3-pyside6-network fixed it.