### PR TITLE
dex: update to 0.10.1

### DIFF
--- a/srcpkgs/dex/template
+++ b/srcpkgs/dex/template
@@ -1,6 +1,6 @@
 # Template file for 'dex'
 pkgname=dex
-version=0.9.0
+version=0.10.1
 revision=1
 build_style=gnu-makefile
 make_install_args="MANPREFIX=/usr/share/man"
@@ -11,7 +11,7 @@ maintainer="Alain Kalker <a.c.kalker@gmail.com>"
 license="GPL-3.0-or-later"
 homepage="https://github.com/jceb/dex"
 distfiles="https://github.com/jceb/dex/archive/v${version}.tar.gz"
-checksum=e49e9891089f2db1959c93c4c7b5fbeb3ffae23aaa3093caafd3dac5a4f03c3e
+checksum=661b96763b1cac062f872c78c03f150ed57d14e315720681bb1fb1e5362e29d4
 
 post_install() {
 	rm ${DESTDIR}/usr/share/doc/${pkgname}/LICENSE


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc

Current version produces python warning:

```
/usr/bin/dex:616: DeprecationWarning: glob.glob1 is deprecated and will be removed in Python 3.15. Use glob.glob and pass a directory to its root_dir argument instead.
  for _f in glob.glob1(d, '*.desktop'):
```