### PR TITLE
ruby-erubi: update to 1.13.1

### DIFF
--- a/srcpkgs/ruby-erubi/template
+++ b/srcpkgs/ruby-erubi/template
@@ -1,13 +1,13 @@
 # Template file for 'ruby-erubi'
 pkgname=ruby-erubi
-version=1.13.0
+version=1.13.1
 revision=1
 build_style=gem
 short_desc="ERB template engine for ruby"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
 homepage="https://github.com/jeremyevans/erubi"
-checksum=fca61b47daefd865d0fb50d168634f27ad40181867445badf6427c459c33cd62
+checksum=a082103b0885dbc5ecf1172fede897f9ebdb745a4b97a5e8dc63953db1ee4ad9
 
 post_install() {
 	vlicense MIT-LICENSE


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)

This update fixes `ruby-tmuxinator` package. Seems like current `ruby-erubi` wasn't rebuilt after `ruby` update.