### PR TITLE
ruby-thor: update to 1.4.0

### DIFF
--- a/srcpkgs/ruby-thor/template
+++ b/srcpkgs/ruby-thor/template
@@ -1,13 +1,13 @@
 # Template file for 'ruby-thor'
 pkgname=ruby-thor
-version=1.3.1
-revision=2
+version=1.4.0
+revision=1
 build_style=gem
 short_desc="Toolkit for building powerful command-line interfaces"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
 homepage="http://whatisthor.com/"
-checksum=fa7e3471d4f6a27138e3d9c9b0d4daac9c3d7383927667ae83e9ab42ae7401ef
+checksum=8763e822ccb0f1d7bee88cde131b19a65606657b847cc7b7b4b82e772bcd8a3d
 
 post_install() {
 	vlicense LICENSE.md


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc

`ruby-tmuxinator` 3.3.5 dependency