### PR TITLE
ruby-asciidoctor: update to 2.0.26

### DIFF
--- a/srcpkgs/ruby-asciidoctor/template
+++ b/srcpkgs/ruby-asciidoctor/template
@@ -1,13 +1,13 @@
 # Template file for 'ruby-asciidoctor'
 pkgname=ruby-asciidoctor
-version=2.0.15
-revision=6
+version=2.0.26
+revision=1
 build_style=gem
 short_desc="Ruby implementation of AsciiDoc"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
 homepage="https://asciidoctor.org"
-checksum=c4120b16f7c054ee39e755b5b8cee6b248facaa4ec56b7ce493fd646aa8c744c
+checksum=16e3accf1fc206bbd6335848649d7fd65f31d2daa60d85af13d47a8ee4b071c1
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc