### PR TITLE
gnu-efi-libs: fix pkgconfig file pointing to the wrong directory

### DIFF
--- a/srcpkgs/gnu-efi-libs/template
+++ b/srcpkgs/gnu-efi-libs/template
@@ -2,7 +2,7 @@
 pkgname=gnu-efi-libs
 reverts="3.0w_1" # Not an actual revert, xbps considers 3.0w higher than 3.0.8
 version=3.0.18
-revision=2
+revision=3
 makedepends="pciutils-devel"
 short_desc="Library for building UEFI Applications using GNU toolchain"
 maintainer="Orphaned <orphan@voidlinux.org>"
@@ -46,7 +46,7 @@ do_build() {
 	# upstream provides LDFLAGS directly to ld: https://sourceforge.net/p/gnu-efi/bugs/33/
 	LDFLAGS="${LDFLAGS//-Wl/}"
 	LDFLAGS="${LDFLAGS//,/ }"
-	make ARCH=${TARGET_ARCH} HOSTARCH=${HOST_ARCH}
+	make ARCH=${TARGET_ARCH} HOSTARCH=${HOST_ARCH} PREFIX=/usr
 }
 
 do_install() {


### PR DESCRIPTION
By default gnu-efi uses the `/usr/local` prefix which makes the generated `gnu-efi.pc` file point to the `/usr/local/include/efi` directory for header files, which is incorrect since the actual header files are installed inside the `/usr/include/efi` folder.

Fixes #57969.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, x86_64

