### PR TITLE
poedit: add runtime gettext dependency

### DIFF
--- a/srcpkgs/poedit/template
+++ b/srcpkgs/poedit/template
@@ -1,14 +1,14 @@
 # Template file for 'poedit'
 pkgname=poedit
 version=3.7
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--with-wx-config=wx-config-gtk3 --with-boost-system=c"
 hostmakedepends="pkg-config"
 makedepends="boost-devel-minimal libboost_thread
  cld2-devel db-devel enchant2-devel gtk+3-devel
  gtkspell3-devel Lucene++-devel wxWidgets-gtk3-devel pugixml-devel"
-depends="desktop-file-utils hicolor-icon-theme"
+depends="desktop-file-utils hicolor-icon-theme gettext"
 short_desc="Cross-platform gettext catalogs (.po files) editor"
 maintainer="Eloi Torrents <eloitor@disroot.org>"
 license="MIT"


### PR DESCRIPTION
Without this, when opening a .po file, I get "Unhandled exception
occurred: Cannot execute program: [msgcat, --version]" and the file
won't open.

Cc: @Eloitor

---

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
#### Local build testing
- I built this PR locally for my native architecture, (x86_64-musl)
<!--
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
