### PR TITLE
cmake-language-server: Add missing runtime requirement of python3-typ…

### DIFF
--- a/srcpkgs/cmake-language-server/template
+++ b/srcpkgs/cmake-language-server/template
@@ -1,10 +1,10 @@
 # Template file for 'cmake-language-server'
 pkgname=cmake-language-server
 version=0.1.11
-revision=1
+revision=2
 build_style=python3-pep517
 hostmakedepends="python3-pdm-backend"
-depends="python3-pygls"
+depends="python3-pygls python3-typing_extensions"
 short_desc="CMake LSP Implementation"
 maintainer="Mihail Ivanchev <contact@ivanchev.net>"
 license="MIT"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)

The error was:
```
$ cmake-language-server 
Traceback (most recent call last):
  File "/usr/bin/cmake-language-server", line 5, in <module>
    from cmake_language_server.server import main
  File "/usr/lib/python3.13/site-packages/cmake_language_server/server.py", line 34, in <module>
    from pygls.server import LanguageServer
  File "/usr/lib/python3.13/site-packages/pygls/server.py", line 35, in <module>
    import cattrs
  File "/usr/lib/python3.13/site-packages/cattrs/__init__.py", line 3, in <module>
    from .converters import BaseConverter, Converter, GenConverter, UnstructureStrategy
  File "/usr/lib/python3.13/site-packages/cattrs/converters.py", line 16, in <module>
    from typing_extensions import Self
ModuleNotFoundError: No module named 'typing_extensions'
$ 
```