### PR TITLE
runit: fix sv bash completion

### DIFF
--- a/srcpkgs/runit/files/sv
+++ b/srcpkgs/runit/files/sv
@@ -16,7 +16,7 @@ _sv()
             return
             ;;
         *)
-            COMPREPLY=( "${SVDIR%/:-/var/service}/"* )
+            COMPREPLY=( "${SVDIR:-/var/service}/"* )
             COMPREPLY=( ${COMPREPLY[@]##*/} )
             COMPREPLY=( $(compgen -W '${COMPREPLY[@]}' -- ${cur}) )
             return

--- a/srcpkgs/runit/template
+++ b/srcpkgs/runit/template
@@ -1,7 +1,7 @@
 # Template file for 'runit'
 pkgname=runit
 version=2.3.0
-revision=1
+revision=2
 build_style="gnu-makefile"
 short_desc="UNIX init scheme with service supervision"
 maintainer="Orphaned <orphan@voidlinux.org>"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->
I think there were some leftovers from toying around with bash parameter expansion, so the fallback to `/var/service` doesn't work.
@AnInternetTroll 

Fixes: 24970baebc24ad1f889871a43e0b1cb497b75b25

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
