### PR TITLE
R: update to 4.5.2

### DIFF
--- a/srcpkgs/R/template
+++ b/srcpkgs/R/template
@@ -1,6 +1,6 @@
 # Template file for 'R'
 pkgname=R
-version=4.3.1
+version=4.5.2
 revision=1
 build_style=gnu-configure
 configure_args="--docdir=/usr/share/doc/R rdocdir=/usr/share/doc/R
@@ -23,7 +23,7 @@ license="GPL-2.0-or-later"
 homepage="https://www.r-project.org/"
 changelog="https://cran.r-project.org/doc/manuals/r-release/NEWS.html"
 distfiles="https://cran.r-project.org/src/base/R-4/${pkgname}-${version}.tar.gz"
-checksum=8dd0bf24f1023c6f618c3b317383d291b4a494f40d73b983ac22ffea99e4ba99
+checksum=0d71ff7106ec69cd7c67e1e95ed1a3cee355880931f2eb78c530014a9e379f20
 nocross=yes
 shlib_provides="libR.so"
 # tests require texlive distribution


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)

Following previous discussions in currently open PRs for 4.5.1 and 4.4.2, it seems like the suggestion in [this comment](https://github.com/void-linux/void-packages/pull/53758#issuecomment-3194277594) is a good idea. Given that R and all R-* packages except one are currently almost 2.5 years out of date, requiring users to set and manage their own `.libPaths` or whatever, which still works, seems like a better alternative.