### PR TITLE
sddm: rebuild to fix segfault

### DIFF
--- a/srcpkgs/sddm/patches/raise-cmake-minimum-version.patch
+++ b/srcpkgs/sddm/patches/raise-cmake-minimum-version.patch
@@ -1,0 +1,22 @@
+From 228778c2b4b7e26db1e1d69fe484ed75c5791c3a Mon Sep 17 00:00:00 2001
+From: Heiko Becker <heiko.becker@kde.org>
+Date: Sun, 23 Feb 2025 22:21:25 +0100
+Subject: [PATCH] CMake: Raise required version to 3.5
+
+CMake >= 4.0.0-rc1 removed compatibility with versions < 3.5 and errors
+out with such versions passed to cmake_minimum_required(). 3.5.0 has
+been released 9 years ago, so I'd assume it's available almost everywhere.
+---
+ CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 690ee7095..1b5f54af5 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,4 +1,4 @@
+-cmake_minimum_required(VERSION 3.4)
++cmake_minimum_required(VERSION 3.5)
+ 
+ project(SDDM)
+ 

--- a/srcpkgs/sddm/template
+++ b/srcpkgs/sddm/template
@@ -1,7 +1,7 @@
 # Template file for 'sddm'
 pkgname=sddm
 version=0.21.0
-revision=1
+revision=2
 build_style=cmake
 _configure_args="-DBUILD_MAN_PAGES=ON -DNO_SYSTEMD=ON -DUSE_ELOGIND=ON
  -DLOGIN_DEFS_PATH=${XBPS_SRCPKGDIR}/shadow/files/login.defs


### PR DESCRIPTION
sddm is not functional in its current state in i686 (other arches might be affected, but if x86_64 was affected too, someone would have probably noticed this sooner).

The `sddm-greeter-qt` component of SDDM segfaults, which makes SDDM unusable.

See https://github.com/sddm/sddm/issues/2139 for more info.

The solution seems to be to just rebuild SDDM. My testing showed that a rebuild of the package resolves the issue.

This would imply that it is Void's fault. It's strange.

This PR also adds a patch that raises the minimum supported CMake version. The `sddm` package fails to build without it now because we have newer CMake which dislikes v3.4.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
