### PR TITLE
os-prober: update to 1.84

### DIFF
--- a/srcpkgs/os-prober/template
+++ b/srcpkgs/os-prober/template
@@ -1,6 +1,6 @@
 # Template file for 'os-prober'
 pkgname=os-prober
-version=1.83
+version=1.84
 revision=1
 build_style=gnu-makefile
 make_dirs="/var/lib/os-prober 0755 root root"
@@ -10,7 +10,7 @@ license="GPL-2.0-or-later"
 homepage="https://packages.debian.org/sid/os-prober"
 changelog="https://metadata.ftp-master.debian.org/changelogs/main/o/os-prober/unstable_changelog"
 distfiles="${DEBIAN_SITE}/main/o/${pkgname}/${pkgname}_${version}.tar.xz"
-checksum=8c82d5084c2b6f8935f6633612f18d16d04a0deffd6b99c264985fb7204140a6
+checksum=42e48245986d8ec9491a07a74522c7b78e685ddc9b4f801045c62cd03dd7b067
 
 case "$XBPS_TARGET_MACHINE" in
 	i686*|x86_64*) _ARCH="x86";;


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, x86_64
- I crossbuilded this PR locally for these architectures:
  - armv7l
  - armv6l-musl
  - aarch64-musl