### PR TITLE
waydroid: update to 1.6.0.

### DIFF
--- a/srcpkgs/waydroid/template
+++ b/srcpkgs/waydroid/template
@@ -1,6 +1,6 @@
 # Template file for 'waydroid'
 pkgname=waydroid
-version=1.5.4
+version=1.6.0
 revision=1
 # https://developer.android.com/ndk/guides/abis#sa
 archs="aarch64* armv7* i686* x86_64*"
@@ -14,7 +14,7 @@ license="GPL-3.0-or-later"
 homepage="https://waydro.id"
 changelog="https://raw.githubusercontent.com/waydroid/waydroid/main/debian/changelog"
 distfiles="https://github.com/waydroid/waydroid/archive/refs/tags/${version}.tar.gz"
-checksum=b97b91673b3cc7e7f001395c08e2d2d569305216a1dd9b3c9a65f03ebc296e18
+checksum=aab88897a3a5578b4fc602a47d3357ad5d39b603e2e630ea2370a2fde3371f97
 
 python_version=3
 pycompile_dirs="usr/lib/waydroid"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture (x86_64)
- I built this PR locally for these architectures using specific masterdirs:
  - x86_64-musl
  - i686
- I built this PR locally for these architectures (crossbuilds):
  - aarch64
  - aarch64-musl
  - armv7l
  - armv7l-musl