### PR TITLE
lazydocker: update to 0.24.2.

### DIFF
--- a/srcpkgs/lazydocker/template
+++ b/srcpkgs/lazydocker/template
@@ -1,6 +1,6 @@
 # Template file for 'lazydocker'
 pkgname=lazydocker
-version=0.24.1
+version=0.24.2
 revision=1
 build_style=go
 go_import_path=github.com/jesseduffield/lazydocker
@@ -11,7 +11,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
 homepage="https://github.com/jesseduffield/lazydocker"
 distfiles="https://github.com/jesseduffield/lazydocker/archive/v${version}.tar.gz"
-checksum=f54197d333a28e658d2eb4d9b22461ae73721ec9e4106ba23ed177fc530c21f4
+checksum=2a8421f7c72b0a08b50f95af0994cef8c21cc16173fef23011849e50831ae33c
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture (x86_64)
- I built this PR locally for these architectures using specific masterdirs:
  - x86_64-musl
  - i686
- I built this PR locally for these architectures (crossbuilds):
  - aarch64
  - aarch64-musl
  - armv7l
  - armv7l-musl
  - armv6l
  - armv6l-musl