### PR TITLE
cagebreak: update to 3.1.0

### DIFF
--- a/srcpkgs/cagebreak/template
+++ b/srcpkgs/cagebreak/template
@@ -1,12 +1,12 @@
 # Template file for 'cagebreak'
 pkgname=cagebreak
-version=3.0.0
+version=3.1.0
 revision=1
 build_style=meson
 configure_args="--buildtype=release -Dman-pages=true $(vopt_bool xwayland xwayland)"
 conf_files="/etc/xdg/cagebreak/config"
 hostmakedepends="pkg-config wayland-devel scdoc"
-makedepends="wlroots0.18-devel cairo-devel pango-devel libevdev-devel"
+makedepends="wlroots0.19-devel cairo-devel pango-devel libevdev-devel"
 depends="$(vopt_if xwayland xorg-server-xwayland)"
 short_desc="Tiling wayland compositor based on cage inspired by ratpoison"
 maintainer="Jose G Perez Taveras <josegpt27@gmail.com>"
@@ -14,7 +14,7 @@ license="MIT"
 homepage="https://github.com/project-repo/cagebreak"
 changelog="https://raw.githubusercontent.com/project-repo/cagebreak/master/Changelog.md"
 distfiles="https://github.com/project-repo/cagebreak/releases/download/${version}/release_${version}.tar.gz"
-checksum=fea7bc39cebaa2381758528492ce7315629e332c28a27b414948ad57d2ffb6f5
+checksum=2b62c32da739668f0d99e41144ad721c0fc02b184a9c451458644071bb335770
 
 build_options="xwayland"
 build_options_default="xwayland"


### PR DESCRIPTION
- I tested the changes in this PR: **NO**

- I built this PR locally for my native architecture, (x86_64-glibc)