### PR TITLE
New package: cross-riscv64-none-elf-0.1

### DIFF
--- a/srcpkgs/cross-riscv64-none-elf-binutils/template
+++ b/srcpkgs/cross-riscv64-none-elf-binutils/template
@@ -1,0 +1,37 @@
+# Template file for 'cross-riscv64-none-elf-binutils'
+_triplet=riscv64-none-elf
+_pkgname=binutils
+pkgname=cross-${_triplet}-${_pkgname}
+version=2.45.1
+revision=1
+
+short_desc="GNU binary utilities for RISC-V (bare-metal) target"
+maintainer="kuwoyuki <kuwoyuki@cock.li>"
+license="GPL-3.0-or-later"
+homepage="https://www.gnu.org/software/binutils/"
+
+distfiles="${GNU_SITE}/${_pkgname}/${_pkgname}-${version}.tar.xz"
+checksum=5fe101e6fe9d18fdec95962d81ed670fdee5f37e3f48f0bef87bddf862513aa5
+
+hostmakedepends="pkgconf"
+makedepends="zlib-devel"
+nocross=yes
+
+build_style=gnu-configure
+configure_args="--prefix=/usr
+ --target=${_triplet}
+ --with-sysroot=/usr/${_triplet}
+ --disable-nls
+ --disable-werror
+ --enable-deterministic-archives
+ --enable-interwork
+ --enable-multilib
+ --enable-plugins
+ --enable-ld=default
+ --with-system-zlib
+ --with-gnu-as
+ --with-gnu-ld"
+
+post_install() {
+	rm -fr ${DESTDIR}/usr/share/info
+}

--- a/srcpkgs/cross-riscv64-none-elf-gcc-bootstrap/template
+++ b/srcpkgs/cross-riscv64-none-elf-gcc-bootstrap/template
@@ -1,0 +1,77 @@
+# Template file for 'cross-riscv64-none-elf-gcc-bootstrap'
+pkgname=cross-riscv64-none-elf-gcc-bootstrap
+version=15.2.0
+revision=1
+_triplet=riscv64-none-elf
+build_wrksrc="build"
+build_style=gnu-configure
+configure_script="../configure"
+
+short_desc="GNU Compiler Collection - cross compiler for RISC-V target (bootstrap)"
+maintainer="kuwoyuki <kuwoyuki@cock.li>"
+license="GFDL-1.2-or-later, GPL-3.0-or-later, LGPL-2.1-or-later"
+homepage="http://gcc.gnu.org"
+distfiles="${GNU_SITE}/gcc/gcc-${version}/gcc-${version}.tar.xz"
+checksum=438fd996826b0c82485a29da03a72d71d6e3541a83ec702df4271f6fe025d24e
+
+hostmakedepends="tar flex cross-${_triplet}-binutils"
+makedepends="zlib-devel libmpc-devel"
+depends="cross-${_triplet}-binutils"
+
+nopie=yes
+lib32disabled=yes
+nocross=yes
+nostrip=yes
+bootstrap=yes
+
+configure_args="
+ --prefix=/usr
+ --libdir=/usr/lib
+ --libexecdir=/usr/lib
+ --target=${_triplet}
+ --with-sysroot=/usr/${_triplet}
+ --with-local-prefix=/usr/${_triplet}
+ --with-build-sysroot=/usr/${_triplet}
+ --with-newlib
+ --without-headers
+ --disable-shared
+ --disable-threads
+ --disable-libmudflap
+ --disable-libssp
+ --disable-libquadmath
+ --disable-libgomp
+ --disable-nls
+ --disable-werror
+ --disable-libatomic
+ --disable-gcov
+ --disable-bootstrap
+ --enable-languages=c
+ --enable-checking=release
+ --enable-multilib
+ --enable-tls
+ --with-system-zlib"
+
+post_extract() {
+	mkdir -p build
+}
+
+pre_configure() {
+	unset CFLAGS CXXFLAGS LDFLAGS
+	export CFLAGS="-O2"
+}
+
+do_build() {
+	make ${makejobs} all-gcc
+	make ${makejobs} inhibit-libc=true all-target-libgcc
+}
+
+do_install() {
+	make DESTDIR=${DESTDIR} inhibit-libc=true install-gcc
+	make DESTDIR=${DESTDIR} inhibit-libc=true install-target-libgcc
+}
+
+post_install() {
+	rm -rf ${DESTDIR}/usr/share/man/man7
+	rm -rf ${DESTDIR}/usr/share/info
+	rm -rf ${DESTDIR}/usr/lib/libcc1.*
+}

--- a/srcpkgs/cross-riscv64-none-elf-gcc/template
+++ b/srcpkgs/cross-riscv64-none-elf-gcc/template
@@ -1,0 +1,80 @@
+# Template file for 'cross-riscv64-none-elf-gcc'
+_triplet=riscv64-none-elf
+_pkgname=gcc
+pkgname=cross-${_triplet}-${_pkgname}
+version=15.2.0
+revision=1
+short_desc="GNU Compiler Collection - cross compiler for RISC-V (bare-metal) target"
+maintainer="kuwoyuki <kuwoyuki@cock.li>"
+license="GFDL-1.2-or-later, GPL-3.0-or-later, LGPL-2.1-or-later"
+homepage="http://gcc.gnu.org"
+
+distfiles="${GNU_SITE}/gcc/gcc-${version}/gcc-${version}.tar.xz"
+checksum=438fd996826b0c82485a29da03a72d71d6e3541a83ec702df4271f6fe025d24e
+
+build_wrksrc=build
+build_style=gnu-configure
+
+hostmakedepends="tar texinfo gmp-devel mpfr-devel libmpc-devel isl-devel zlib-devel libzstd-devel"
+makedepends="cross-${_triplet}-binutils cross-${_triplet}-newlib"
+depends="cross-${_triplet}-binutils"
+conflicts="cross-${_triplet}-gcc-bootstrap"
+
+nocross=yes
+nopie=yes
+nostrip_files="libgcc.a libgcov.a libgcc_eh.a libc.a libm.a libstdc++.a libsupc++.a libnosys.a crt0.o crti.o crtn.o"
+
+post_extract() {
+	mkdir -p build
+}
+
+pre_configure() {
+	export CFLAGS_FOR_TARGET="-g -Os -ffunction-sections -fdata-sections"
+	export CXXFLAGS_FOR_TARGET="-g -Os -ffunction-sections -fdata-sections"
+}
+
+do_configure() {
+	../configure \
+		--target=${_triplet} \
+		--prefix=/usr \
+		--libexecdir=/usr/lib \
+		--with-sysroot=/usr/${_triplet} \
+		--with-native-system-header-dir=/include \
+		--with-python-dir=share/gcc-${_triplet} \
+		--enable-languages=c,c++ \
+		--enable-threads=single \
+		--enable-plugins \
+		--enable-multilib \
+		--enable-libgcc \
+		--enable-gnu-indirect-function \
+		--with-newlib \
+		--with-gnu-as \
+		--with-gnu-ld \
+		--with-system-zlib \
+		--with-gmp \
+		--with-mpfr \
+		--with-mpc \
+		--with-isl \
+		--with-libelf \
+		--disable-shared \
+		--disable-tls \
+		--disable-libmudflap \
+		--disable-libssp \
+		--disable-libquadmath \
+		--disable-libgomp \
+		--disable-nls \
+		--disable-libffi \
+		--disable-decimal-float \
+		--disable-libstdcxx-pch \
+		--disable-werror \
+		--disable-gcov
+}
+
+pre_build() {
+	pre_configure
+}
+
+post_install() {
+	rm -fr ${DESTDIR}/usr/share/{info,man/man7}
+	rm -fr ${DESTDIR}/usr/lib/libcc1.*
+}

--- a/srcpkgs/cross-riscv64-none-elf-newlib/template
+++ b/srcpkgs/cross-riscv64-none-elf-newlib/template
@@ -1,0 +1,85 @@
+# Template file for 'cross-riscv64-none-elf-newlib'
+_triplet=riscv64-none-elf
+_pkgname=newlib
+
+pkgname=cross-${_triplet}-${_pkgname}
+version=4.5.0.20241231
+revision=1
+short_desc="C library intended for use on embedded systems (RISC-V)"
+maintainer="kuwoyuki <kuwoyuki@cock.li>"
+license="BSD-3-Clause"
+homepage="https://www.sourceware.org/newlib/"
+
+hostmakedepends="texinfo cross-${_triplet}-binutils cross-${_triplet}-gcc-bootstrap"
+nocross=yes
+nostrip=yes
+
+distfiles="https://sourceware.org/pub/newlib/newlib-${version}.tar.gz"
+checksum=33f12605e0054965996c25c1382b3e463b0af91799001f5bb8c0630f2ec8c852
+
+build_style=gnu-configure
+configure_args="
+ --prefix=/usr
+ --target=${_triplet}
+ --enable-newlib-io-long-long
+ --enable-newlib-io-c99-formats
+ --enable-newlib-register-fini
+ --enable-newlib-retargetable-locking
+ --disable-newlib-supplied-syscalls
+ --disable-nls"
+
+post_extract() {
+	mkdir -p build-{newlib,nano}
+}
+
+pre_configure() {
+	:
+}
+
+do_configure() {
+	# regular newlib build
+	cd build-newlib
+	export CFLAGS_FOR_TARGET="-g -O2 -ffunction-sections -fdata-sections"
+	../configure ${configure_args}
+
+	# nano variant build
+	cd ../build-nano
+	export CFLAGS_FOR_TARGET="-g -Os -ffunction-sections -fdata-sections"
+	../configure ${configure_args} \
+		--disable-newlib-supplied-syscalls \
+		--enable-newlib-reent-small \
+		--enable-newlib-retargetable-locking \
+		--disable-newlib-fvwrite-in-streamio \
+		--disable-newlib-fseek-optimization \
+		--disable-newlib-wide-orient \
+		--enable-newlib-nano-malloc \
+		--disable-newlib-unbuf-stream-opt \
+		--enable-lite-exit \
+		--enable-newlib-global-atexit \
+		--enable-newlib-nano-formatted-io
+}
+
+do_build() {
+	cd build-newlib
+	make ${makejobs}
+
+	cd ../build-nano
+	make ${makejobs}
+}
+
+do_install() {
+	cd build-nano
+	make DESTDIR=${DESTDIR} install
+
+	find ${DESTDIR} -regex ".*/lib\(c\|g\|m\|rdimon\|gloss\)\.a" \
+		-exec rename .a _nano.a '{}' \;
+
+	vmkdir usr/${_triplet}/include/newlib-nano
+	vinstall ${DESTDIR}/usr/${_triplet}/include/newlib.h 644 \
+		usr/${_triplet}/include/newlib-nano
+
+	cd ../build-newlib
+	make DESTDIR=${DESTDIR} install
+
+	vlicense ../COPYING
+}

--- a/srcpkgs/cross-riscv64-none-elf/template
+++ b/srcpkgs/cross-riscv64-none-elf/template
@@ -1,0 +1,14 @@
+# Template file for 'cross-riscv64-none-elf'
+_triplet=riscv64-none-elf
+
+pkgname=cross-${_triplet}
+version=0.1
+revision=1
+metapackage=yes
+depends="cross-${_triplet}-binutils cross-${_triplet}-gcc cross-${_triplet}-newlib"
+short_desc="GNU Cross toolchain for the RISC-V architecture (bare-metal)"
+maintainer="kuwoyuki <kuwoyuki@cock.li>"
+license="GPL-3.0-or-later, GPL-2.0-or-later, LGPL-2.1-or-later"
+homepage="https://gcc.gnu.org"
+
+short_desc+=" (metapackage)"


### PR DESCRIPTION
GCC toolchain targeting bare-metal RISC-V systems (`riscv64-none-elf`)

#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)