### PR TITLE
virtiofsd: update to 1.13.3

### DIFF
--- a/srcpkgs/virtiofsd/template
+++ b/srcpkgs/virtiofsd/template
@@ -1,6 +1,6 @@
 # Template file for 'virtiofsd'
 pkgname=virtiofsd
-version=1.13.2
+version=1.13.3
 revision=1
 build_style=cargo
 makedepends="libcap-ng-devel libseccomp-devel"
@@ -9,7 +9,7 @@ maintainer="Matthias von Faber <mvf@gmx.eu>"
 license="Apache-2.0, BSD-3-Clause"
 homepage="https://gitlab.com/virtio-fs/virtiofsd"
 distfiles="https://gitlab.com/virtio-fs/virtiofsd/-/archive/v${version}/virtiofsd-v${version}.tar.gz"
-checksum=3d611cc8c0ed9d028cd472fa6f31a491dc5623485e469af1a99f02ac6549c7c7
+checksum=9d5e67e7b19f52a8d3c411acf9beed6206e9352226cbf1e2bdaa4ed609a927ce
 
 if [ "$XBPS_TARGET_WORDSIZE" = 32 ]; then
 	broken="https://gitlab.com/virtio-fs/virtiofsd/-/issues/114"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
