### PR TITLE
New package: uzdoom-4.14.3

### DIFF
--- a/srcpkgs/uzdoom/patches/001-uzdoom-musl-fix-build.patch
+++ b/srcpkgs/uzdoom/patches/001-uzdoom-musl-fix-build.patch
@@ -1,0 +1,14 @@
+diff --git a/libraries/lzma/C/Threads.h b/libraries/lzma/C/Threads.h
+index 4028464..86b0687 100644
+--- a/libraries/lzma/C/Threads.h
++++ b/libraries/lzma/C/Threads.h
+@@ -4,6 +4,10 @@
+ #ifndef ZIP7_INC_THREADS_H
+ #define ZIP7_INC_THREADS_H
+
++#ifndef _GNU_SOURCE
++#define _GNU_SOURCE /* Required for musl to expose cpu_set_t */
++#endif
++
+ #ifdef _WIN32
+ #include "7zWindows.h"

--- a/srcpkgs/uzdoom/patches/002-fix-build.patch
+++ b/srcpkgs/uzdoom/patches/002-fix-build.patch
@@ -1,0 +1,12 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -276,7 +276,8 @@ else()
+ 			include ( FindPkgConfig )
+ 			pkg_check_modules( MUSL_FTS musl-fts )
+ 			if ( MUSL_FTS_FOUND )
+-				set ( ALL_C_FLAGS "${ALL_C_FLAGS} ${MUSL_FTS_LDFLAGS}" )
++				list(JOIN MUSL_FTS_LDFLAGS " " MUSL_FTS_LDFLAGS_JOINED)
++				set ( ALL_C_FLAGS "${ALL_C_FLAGS} ${MUSL_FTS_LDFLAGS_JOINED}" )
+ 			else ( MUSL_FTS_FOUND )
+ 				message (ERROR "fts_* functions not found in the system" )
+ 			endif ( MUSL_FTS_FOUND )

--- a/srcpkgs/uzdoom/template
+++ b/srcpkgs/uzdoom/template
@@ -1,0 +1,37 @@
+# Template file for 'uzdoom'
+pkgname=uzdoom
+version=4.14.3
+revision=1
+# Code contains compile-time checks to ensure 64bit...
+archs="x86_64* aarch64*"
+build_style=cmake
+hostmakedepends="pkg-config"
+makedepends="bzip2-devel libgomp-devel libopenal-devel SDL2-devel libvpx-devel
+ libwebp-devel libwaylandpp-devel ZMusic-devel"
+short_desc="Feature centric port for all Doom engine games, based on GZDoom"
+maintainer="Greg Beard <gmbeard@googlemail.com>"
+license="GPL-3.0-or-later"
+homepage="https://github.com/UZDoom/UZDoom"
+changelog="https://github.com/UZDoom/UZDoom/releases"
+distfiles="https://github.com/UZDoom/UZDoom/archive/refs/tags/${version}.tar.gz"
+checksum=6ee381395e249fd02a8484e0e98330afd1cdf222b26cafece7b3d3f5188d7014
+# Cross-building seems to require a successful host-native build first, so
+# it can import a bunch of tooling built by the project itself...
+nocross=yes
+
+if [ "$XBPS_TARGET_LIBC" = musl ]; then
+	CFLAGS+=" -DZ7_AFFINITY_DISABLE"
+	CXXFLAGS+=" -DZ7_AFFINITY_DISABLE"
+	makedepends+=" musl-fts-devel libexecinfo-devel"
+fi
+
+post_extract() {
+	# Prevent configure stage from using git to extract the version info...
+	vsed -i tools/updaterevision/UpdateRevision.cmake -e 's/main()/return()/g'
+
+	sed "
+		s/@Tag@/${version}/;
+		s/@Hash@/v${version}/;
+		s/@Timestamp@/<unknown>/;
+	" tools/updaterevision/gitinfo.h.in >src/gitinfo.h
+}


### PR DESCRIPTION
UZDoom is a feature centric port for all Doom engine games, based on GZDoom, adding an advanced renderer and powerful scripting capabilities

<https://github.com/UZDoom/UZDoom>

#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
#### Local build testing
- I built this PR locally for my native architecture, x86\_64-glibc
- I built this PR locally for these architectures:
  - x86\_64-musl
  - aarch64 (using qemu/binfmt)
