### PR TITLE
electrum: Add missing python3-pyqt6-widgets dependency

### DIFF
--- a/srcpkgs/electrum/template
+++ b/srcpkgs/electrum/template
@@ -1,7 +1,7 @@
 # Template file for 'electrum'
 pkgname=electrum
 version=4.6.2
-revision=1
+revision=2
 build_style=python3-module
 hostmakedepends="python3-setuptools python3-pyqt6-devel-tools"
 depends="python3-aiohttp python3-aiohttp_socks python3-aiorpcx
@@ -10,7 +10,7 @@ depends="python3-aiohttp python3-aiohttp_socks python3-aiorpcx
  python3-qrcode python3-socks python3-cryptography libsecp256k1
  python3-async-timeout python3-certifi python3-jsonpatch libzbar
  python3-pyqt6-declarative python3-pyqt6-gui python3-pyqt6-network
- python3-attrs electrum-ecc electrum-aionostr"
+ python3-pyqt6-widgets python3-attrs electrum-ecc electrum-aionostr"
 # Optional dependencies:
 #  btchip - BTChip hardware wallet support
 #  trezor - TREZOR hardware wallet support


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
#### Local build testing
- I built this PR locally for my native architecture, x86\_64-glibc

cc @ar-jan