### PR TITLE
[WIP] gimp: update to 3.0.6.

### DIFF
--- a/srcpkgs/gimp/template
+++ b/srcpkgs/gimp/template
@@ -1,6 +1,6 @@
 # Template file for 'gimp'
 pkgname=gimp
-version=3.0.4
+version=3.0.6
 revision=1
 build_style=meson
 build_helper="gir qemu"
@@ -13,7 +13,7 @@ makedepends="babl-devel gtk+3-devel gegl-devel libgexiv2-devel libgirepository-d
  libXmu-devel ghostscript-devel libmng-devel aalib-devel libXpm-devel libopenexr-devel
  libwebp-devel libheif-devel poppler-glib-devel libwmf-devel libopenjpeg2-devel
  libjxl-devel alsa-lib-devel cfitsio-devel python3-gobject-devel libgomp-devel
- libunwind-devel lua51-lgi"
+ libunwind-devel lua51-lgi AppStream-devel cmake"
 depends="desktop-file-utils hicolor-icon-theme iso-codes mypaint-brushes python3-gobject gjs"
 checkdepends="xvfb-run dbus"
 short_desc="GNU image manipulation program"
@@ -22,7 +22,7 @@ maintainer="fosslinux <fosslinux@aussies.space>"
 license="GPL-3.0-only"
 homepage="https://www.gimp.org"
 distfiles="https://download.gimp.org/gimp/v${version%.*}/gimp-${version/+rc/-RC}.tar.xz"
-checksum=8caa2ec275bf09326575654ac276afc083f8491e7cca45d19cf29e696aecab25
+checksum=246c225383c72ef9f0dc7703b7d707084bbf177bd2900e94ce466a62862e296b
 lib32disabled=yes
 
 if [ "$CROSS_BUILD" ]; then


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture (x86_64-musl)

Aims to close #58080.

Successfully builds locally and starts normally with no significant errors during my testing. Tested the issue described in #58080 and appears fixed.
Unfortunately, 3 local tests with the `-Q` option fail:
```
 3/21 gimp:app / save-and-export             FAIL
 4/21 gimp:app / single-window-mode          FAIL
 5/21 gimp:app / ui                          FAIL
```

Full logs:
[builddir/gimp-3.0.6/build/meson-logs/testlog.txt](https://github.com/user-attachments/files/23980775/testlog.txt)

Additionally, meson refused to build without AppStream development files and CMake. I hastily added the required packages to `makedepends`. I haven't a clue whether or not I'm somehow supposed to embed both meson and CMake into `build_style`.

 I confirmed multiple times that 3.0.4 (currently packaged GIMP version) built and tested successfully without any additions. It is odd that a patch version release is being difficult.

I'll continue investigating and sharing results in comments, but I'll happily take advice or contributions.