### PR TITLE
slock: update to 1.6, adopt

### DIFF
--- a/srcpkgs/slock/template
+++ b/srcpkgs/slock/template
@@ -1,15 +1,16 @@
 # Template file for 'slock'
 pkgname=slock
-version=1.5
-revision=2
+version=1.6
+revision=1
 hostmakedepends="pkg-config"
 makedepends="libXrandr-devel"
 short_desc="Simple screen locker for X"
-maintainer="Orphaned <orphan@voidlinux.org>"
+maintainer="Filip Rojek <filip@filiprojek.cz>"
 license="MIT"
 homepage="http://tools.suckless.org/slock"
+changelog="https://git.suckless.org/slock/log.html"
 distfiles="http://dl.suckless.org/tools/slock-${version}.tar.gz"
-checksum=aee1e3fbf6a277fb625a3838073b979b6483e7baca4ce82f56de1ff192db0e4d
+checksum=233d22b8fa65fbdf8a05302863ee5b768ef425c57c88d12059ff15133ebc0e5c
 
 if [ "$XBPS_TARGET_LIBC" = "glibc" ]; then
 	makedepends+=" libxcrypt-devel"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
