### PR TITLE
vscode: disable signature verification

### DIFF
--- a/srcpkgs/vscode/patches/disable-signature-verification.patch
+++ b/srcpkgs/vscode/patches/disable-signature-verification.patch
@@ -1,0 +1,18 @@
+diff --git a/src/vs/platform/extensionManagement/node/extensionManagementService.ts b/src/vs/platform/extensionManagement/node/extensionManagementService.ts
+index 0a50a2e..5ee6782 100644
+--- a/src/vs/platform/extensionManagement/node/extensionManagementService.ts
++++ b/src/vs/platform/extensionManagement/node/extensionManagementService.ts
+@@ -36,3 +36,2 @@ import {
+ 	IAllowedExtensionsService,
+-	VerifyExtensionSignatureConfigKey,
+ 	shouldRequireRepositorySignatureFor,
+@@ -89,2 +88,3 @@ export class ExtensionManagementService extends AbstractExtensionManagementServi
+ 		@IFileService private readonly fileService: IFileService,
++		// @ts-expect-error no-unused-variable
+ 		@IConfigurationService private readonly configurationService: IConfigurationService,
+@@ -333,4 +333,3 @@ export class ExtensionManagementService extends AbstractExtensionManagementServi
+ 		if (verifySignature) {
+-			const value = this.configurationService.getValue(VerifyExtensionSignatureConfigKey);
+-			verifySignature = isBoolean(value) ? value : true;
++			verifySignature = false;
+ 		}

--- a/srcpkgs/vscode/template
+++ b/srcpkgs/vscode/template
@@ -1,7 +1,7 @@
 # Template file for 'vscode'
 pkgname=vscode
 version=1.100.3
-revision=1
+revision=2
 _electronver=35.7.2
 _npmver=10.8.3
 hostmakedepends="pkg-config python3 python3-setuptools nodejs tar git ripgrep"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture (x86_64-musl)

Closes #56359.

Patch from <https://github.com/VSCodium/vscodium/blob/master/patches/disable-signature-verification.patch>.