### PR TITLE
moor: update to 2.9.5.

### DIFF
--- a/srcpkgs/moor/template
+++ b/srcpkgs/moor/template
@@ -1,6 +1,6 @@
 # Template file for 'moor'
 pkgname=moor
-version=2.7.1
+version=2.9.5
 revision=1
 build_style=go
 go_import_path=github.com/walles/moor/v2
@@ -12,7 +12,7 @@ license="BSD-2-Clause"
 homepage="https://github.com/walles/moor"
 changelog="https://github.com/walles/moor/releases"
 distfiles="https://github.com/walles/moor/archive/refs/tags/v${version}.tar.gz"
-checksum=2b9a26b7000a92778802138b92bfe6134723e2c72ba1829ca7da04efd314620a
+checksum=4899e65b6251871c9376814c0bebf2c2702bfbf295dcec2ecccd8e98141288a0
 
 post_install() {
 	vman moor.1


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built and tested this PR locally for my native architecture, **x86_64**
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl
  - i686
  - armv6l
  - armv6l-musl
  - armv7l
  - armv7l-musl
  - aarch64
  - aarch64-musl

Apart from misc. improvements, fixes the mouse-copying bug (in 2.8.1)