### PR TITLE
libarchive: update to 3.8.4

### DIFF
--- a/srcpkgs/libarchive/template
+++ b/srcpkgs/libarchive/template
@@ -1,6 +1,6 @@
 # Template file for 'libarchive'
 pkgname=libarchive
-version=3.8.3
+version=3.8.4
 revision=1
 bootstrap=yes
 build_style=gnu-configure
@@ -18,7 +18,7 @@ license="BSD-2-Clause"
 homepage="https://www.libarchive.org/"
 changelog="https://github.com/libarchive/libarchive/releases"
 distfiles="https://github.com/libarchive/libarchive/releases/download/v${version}/libarchive-${version}.tar.xz"
-checksum=90e21f2b89f19391ce7b90f6e48ed9fde5394d23ad30ae256fb8236b38b99788
+checksum=c7b847b57feacf5e182f4d14dd6cae545ac6843d55cb725f58e107cdf1c9ad73
 
 build_options="acl expat lzo lz4 ssl zstd"
 build_options_default="acl ssl lz4 zstd"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**|**briefly**|**NO**
- briefly tested `bsdtar`

#### Local build testing
- I built this PR locally for my native architecture, **x86_64-glibc**

[Bugfix release](https://github.com/libarchive/libarchive/releases)

cc @leahneukirchen 