### PR TITLE
New package: catnip-1.8.7

### DIFF
--- a/srcpkgs/catnip/template
+++ b/srcpkgs/catnip/template
@@ -1,0 +1,22 @@
+# Template file for 'catnip'
+pkgname=catnip
+version=1.8.7
+revision=1
+archs="x86_64* aarch64*"
+build_style=go
+go_import_path="github.com/noriah/catnip"
+go_package="./cmd/catnip"
+go_build_tags="portaudio,fftw"
+hostmakedepends="pkg-config go"
+makedepends="portaudio-devel fftw-devel"
+depends="ffmpeg6"
+short_desc="Terminal audio visualizer"
+maintainer="wbohrer <willbohrer@proton.me>"
+license="MIT"
+homepage="https://github.com/noriah/catnip"
+distfiles="https://github.com/noriah/catnip/archive/v${version}.tar.gz"
+checksum=59413846f463ae8adc564b49260b1d646a2d0377928e0445790e7816e2af5369
+
+post_install() {
+	vlicense LICENSE
+}


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

#### Local build testing
- I built this PR locally for my native architecture (x86_64-musl)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64
  - armv6l (fails)
  - armv7l (fails)
  - i686 (fails)

Closes #57752.

On 32-bit architectures, the `portaudio` backend for the package doesn't build (needs a 64-bit integer). If I try to not build the backend (remove makedepend `portaudio-devel`, remove Go build tag) the tests fail. For now I will just remove 32-bit architectures, but maybe the tests can be patched.