### PR TITLE
New package: yacy-1.941

### DIFF
--- a/srcpkgs/yacy/INSTALL
+++ b/srcpkgs/yacy/INSTALL
@@ -1,0 +1,6 @@
+# INSTALL
+case "$ACTION" in
+post)
+	chown -R _yacy:_yacy /var/lib/yacy
+	;;
+esac

--- a/srcpkgs/yacy/files/yacy/run
+++ b/srcpkgs/yacy/files/yacy/run
@@ -1,0 +1,3 @@
+#!/bin/sh
+exec 2>&1
+exec chpst -u _yacy:_yacy /var/lib/yacy/startYACY.sh -f

--- a/srcpkgs/yacy/template
+++ b/srcpkgs/yacy/template
@@ -1,0 +1,29 @@
+# Template file for 'yacy'
+pkgname=yacy
+version=1.941
+revision=1
+hostmakedepends="apache-ant openjdk21 git"
+depends="openjdk21"
+short_desc="Distributed Peer-to-Peer Web Search Engine and Intranet Search Appliance"
+maintainer="Jason Elswick <jason@jasondavid.us>"
+license="GPL-2.0-or-later"
+homepage="https://yacy.net"
+distfiles="https://github.com/yacy/yacy_search_server/archive/refs/tags/Release_${version}.tar.gz"
+checksum=90e0bdef16893cdc5f0e812add1b977ee5fee34fa18ac56d4f6deba6fe521050
+system_accounts="_yacy"
+_yacy_homedir="/var/lib/yacy"
+make_dirs="/var/lib/yacy 0755 _yacy _yacy"
+
+do_build() {
+	export JAVA_HOME="/usr/lib/jvm/openjdk21"
+	ant all
+}
+
+do_install() {
+	vmkdir var/lib/yacy
+	vcopy ${wrksrc}/* var/lib/yacy
+}
+
+post_install() {
+	vsv yacy
+}


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-libc

Some backstory. Originally the tagged source releases on github stopped after 2016, though yacy was still being developed, and had already compiled downloads on their main page yacy.net. I and others created github issues on the yacy_search_server project asking for tagged source releases, and finally they delivered. I had old defunct templates (that never got merged) that didn't technically compile the program the way this template does but installed yacy, but this approach is better.
