### PR TITLE
toxic: update to 0.16.1

### DIFF
--- a/srcpkgs/toxic/template
+++ b/srcpkgs/toxic/template
@@ -1,6 +1,6 @@
 # Template file for 'toxic'
 pkgname=toxic
-version=0.15.1
+version=0.16.1
 revision=2
 build_style=gnu-makefile
 hostmakedepends="pkg-config"
@@ -12,7 +12,7 @@ maintainer="Piraty <mail@piraty.dev>"
 license="GPL-3.0-or-later"
 homepage="https://github.com/JFreegman/toxic/"
 distfiles="https://github.com/JFreegman/toxic/archive/v${version}.tar.gz"
-checksum=56cedc37b22a1411c68fd8b395f40f515d6a4779be02540c5cd495665caa127c
+checksum="4969f0a72e40e0ed296cfff5a5bcd58b999ace52759327c29f23866c96d64f00"
 
 do_build() {
 	make CC=$CC USER_CFLAGS="$CFLAGS" USER_LDFLAGS="$LDFLAGS" ${makejobs}


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

This package requires [toxcore-0.22.1](https://github.com/void-linux/void-packages/pull/58145) to compile, so please do not merge until the PR for toxcore-0.22.1 gets merged.
