### PR TITLE
[ci skip] New package: electron39. Switch electron rev. deps. to v39.

### DIFF
--- a/srcpkgs/electron39-devel
+++ b/srcpkgs/electron39-devel
@@ -1,0 +1,1 @@
+electron39

--- a/srcpkgs/electron39/files/musl-patches/chromium-libc++-musl.patch
+++ b/srcpkgs/electron39/files/musl-patches/chromium-libc++-musl.patch
@@ -1,0 +1,11 @@
+--- a/buildtools/third_party/libc++/__config_site
++++ b/buildtools/third_party/libc++/__config_site
+@@ -25,7 +25,7 @@
+ #define _LIBCPP_HAS_THREADS 1
+ #define _LIBCPP_HAS_MONOTONIC_CLOCK 1
+ #define _LIBCPP_HAS_TERMINAL 1
+-#define _LIBCPP_HAS_MUSL_LIBC 0
++#define _LIBCPP_HAS_MUSL_LIBC 1
+ 
+ #ifdef _WIN32
+ #define _LIBCPP_HAS_THREAD_API_PTHREAD 0

--- a/srcpkgs/electron39/files/musl-patches/chromium-musl-sandbox.patch
+++ b/srcpkgs/electron39/files/musl-patches/chromium-musl-sandbox.patch
@@ -1,0 +1,125 @@
+Source: https://git.alpinelinux.org/aports/tree/community/chromium/musl-sandbox.patch
+musl uses different syscalls from glibc for some functions, so the sandbox has
+to account for that
+--
+diff --git a/sandbox/linux/seccomp-bpf-helpers/syscall_parameters_restrictions.cc ./sandbox/linux/seccomp-bpf-helpers/syscall_parameters_restrictions.cc
+index ff5a1c0..da56b9b 100644
+--- a/sandbox/linux/seccomp-bpf-helpers/syscall_parameters_restrictions.cc
++++ ./sandbox/linux/seccomp-bpf-helpers/syscall_parameters_restrictions.cc
+@@ -139,21 +139,11 @@ namespace sandbox {
+ // present (as in newer versions of posix_spawn).
+ ResultExpr RestrictCloneToThreadsAndEPERMFork() {
+   const Arg<unsigned long> flags(0);
+-
+-  // TODO(mdempsky): Extend DSL to support (flags & ~mask1) == mask2.
+-  const uint64_t kAndroidCloneMask = CLONE_VM | CLONE_FS | CLONE_FILES |
+-                                     CLONE_SIGHAND | CLONE_THREAD |
+-                                     CLONE_SYSVSEM;
+-  const uint64_t kObsoleteAndroidCloneMask = kAndroidCloneMask | CLONE_DETACHED;
+-
+-  const uint64_t kGlibcPthreadFlags =
+-      CLONE_VM | CLONE_FS | CLONE_FILES | CLONE_SIGHAND | CLONE_THREAD |
+-      CLONE_SYSVSEM | CLONE_SETTLS | CLONE_PARENT_SETTID | CLONE_CHILD_CLEARTID;
+-  const BoolExpr glibc_test = flags == kGlibcPthreadFlags;
+-
+-  const BoolExpr android_test =
+-      AnyOf(flags == kAndroidCloneMask, flags == kObsoleteAndroidCloneMask,
+-            flags == kGlibcPthreadFlags);
++  const int required = CLONE_VM | CLONE_FS | CLONE_FILES | CLONE_SIGHAND |
++                       CLONE_THREAD | CLONE_SYSVSEM;
++  const int safe = CLONE_SETTLS | CLONE_PARENT_SETTID | CLONE_CHILD_CLEARTID |
++                   CLONE_DETACHED;
++  const BoolExpr thread_clone_ok = (flags&~safe)==required;
+ 
+   // The following two flags are the two important flags in any vfork-emulating
+   // clone call. EPERM any clone call that contains both of them.
+@@ -163,7 +153,7 @@ ResultExpr RestrictCloneToThreadsAndEPERMFork() {
+       AnyOf((flags & (CLONE_VM | CLONE_THREAD)) == 0,
+             (flags & kImportantCloneVforkFlags) == kImportantCloneVforkFlags);
+ 
+-  return If(IsAndroid() ? android_test : glibc_test, Allow())
++  return If(thread_clone_ok, Allow())
+       .ElseIf(is_fork_or_clone_vfork, Error(EPERM))
+       .Else(CrashSIGSYSClone());
+ }
+diff --git a/sandbox/linux/seccomp-bpf-helpers/syscall_sets.cc ./sandbox/linux/seccomp-bpf-helpers/syscall_sets.cc
+index d9d1882..0567557 100644
+--- a/sandbox/linux/seccomp-bpf-helpers/syscall_sets.cc
++++ ./sandbox/linux/seccomp-bpf-helpers/syscall_sets.cc
+@@ -392,6 +392,7 @@ bool SyscallSets::IsAllowedProcessStartOrDeath(int sysno) {
+ #if defined(__i386__)
+     case __NR_waitpid:
+ #endif
++    case __NR_set_tid_address:
+       return true;
+     case __NR_clone:  // Should be parameter-restricted.
+     case __NR_setns:  // Privileged.
+@@ -404,7 +405,6 @@ bool SyscallSets::IsAllowedProcessStartOrDeath(int sysno) {
+ #if defined(__i386__) || defined(__x86_64__) || defined(__mips__)
+     case __NR_set_thread_area:
+ #endif
+-    case __NR_set_tid_address:
+     case __NR_unshare:
+ #if !defined(__mips__) && !defined(__aarch64__)
+     case __NR_vfork:
+@@ -514,6 +514,8 @@ bool SyscallSets::IsAllowedAddressSpaceAccess(int sysno) {
+     case __NR_munlock:
+     case __NR_munmap:
+     case __NR_mseal:
++    case __NR_mremap:
++    case __NR_membarrier:
+       return true;
+     case __NR_madvise:
+     case __NR_mincore:
+@@ -531,7 +533,6 @@ bool SyscallSets::IsAllowedAddressSpaceAccess(int sysno) {
+     case __NR_modify_ldt:
+ #endif
+     case __NR_mprotect:
+-    case __NR_mremap:
+     case __NR_msync:
+     case __NR_munlockall:
+     case __NR_readahead:
+diff --git a/sandbox/linux/system_headers/linux_syscalls.h ./sandbox/linux/system_headers/linux_syscalls.h
+index 2b78a0c..b6fedb5 100644
+--- a/sandbox/linux/system_headers/linux_syscalls.h
++++ b/sandbox/linux/system_headers/linux_syscalls.h
+@@ -10,6 +10,7 @@
+ #define SANDBOX_LINUX_SYSTEM_HEADERS_LINUX_SYSCALLS_H_
+ 
+ #include "build/build_config.h"
++#include <sys/syscall.h>
+ 
+ #if defined(__x86_64__)
+ #include "sandbox/linux/system_headers/x86_64_linux_syscalls.h"
+--- a/sandbox/policy/linux/bpf_renderer_policy_linux.cc
++++ b/sandbox/policy/linux/bpf_renderer_policy_linux.cc
+@@ -94,6 +94,9 @@
+     case __NR_pwrite64:
+     case __NR_sched_get_priority_max:
+     case __NR_sched_get_priority_min:
++    case __NR_sched_getparam:
++    case __NR_sched_getscheduler:
++    case __NR_sched_setscheduler:
+     case __NR_sysinfo:
+     case __NR_times:
+     case __NR_uname:
+--- a/sandbox/linux/seccomp-bpf-helpers/baseline_policy.cc
++++ b/sandbox/linux/seccomp-bpf-helpers/baseline_policy.cc
+@@ -225,10 +225,15 @@
+   if (sysno == __NR_getpriority || sysno ==__NR_setpriority)
+     return RestrictGetSetpriority(current_pid);
+ 
++  // XXX: hacks for musl sandbox, calls needed?
++  if (sysno == __NR_sched_getparam || sysno == __NR_sched_getscheduler ||
++      sysno == __NR_sched_setscheduler) {
++    return Allow();
++  }
++
+   // The scheduling syscalls are used in threading libraries and also heavily in
+   // abseil. See for example https://crbug.com/1370394.
+-  if (sysno == __NR_sched_getaffinity || sysno == __NR_sched_getparam ||
+-      sysno == __NR_sched_getscheduler || sysno == __NR_sched_setscheduler) {
++  if (sysno == __NR_sched_getaffinity) {
+     return RestrictSchedTarget(current_pid, sysno);
+   }
+ 

--- a/srcpkgs/electron39/files/musl-patches/chromium-musl-tid-caching.patch
+++ b/srcpkgs/electron39/files/musl-patches/chromium-musl-tid-caching.patch
@@ -1,0 +1,90 @@
+Source: https://git.alpinelinux.org/aports/plain/community/chromium/musl-tid-caching.patch
+the sandbox caching of thread id's only works with glibc
+see: https://gitlab.alpinelinux.org/alpine/aports/-/merge_requests/32356
+see: https://gitlab.alpinelinux.org/alpine/aports/-/issues/13579
+--
+--- a/sandbox/linux/services/namespace_sandbox.cc
++++ b/sandbox/linux/services/namespace_sandbox.cc
+@@ -209,6 +209,72 @@
+   return base::LaunchProcess(argv, launch_options_copy);
+ }
+ 
++#if !defined(LIBC_GLIBC)
++#if defined(__aarch64__)
++#define TLS_ABOVE_TP
++#endif
++
++struct musl_pthread
++{
++  /* Part 1 -- these fields may be external or
++  * internal (accessed via asm) ABI. Do not change. */
++  struct pthread *self;
++#ifndef TLS_ABOVE_TP
++  uintptr_t *dtv;
++#endif
++  struct pthread *prev, *next; /* non-ABI */
++  uintptr_t sysinfo;
++#ifndef TLS_ABOVE_TP
++#ifdef CANARY_PAD
++  uintptr_t canary_pad;
++#endif
++  uintptr_t canary;
++#endif
++
++/* Part 2 -- implementation details, non-ABI. */
++  int tid;
++  int errno_val;
++  volatile int detach_state;
++  volatile int cancel;
++  volatile unsigned char canceldisable, cancelasync;
++  unsigned char tsd_used:1;
++  unsigned char dlerror_flag:1;
++  unsigned char *map_base;
++  size_t map_size;
++  void *stack;
++  size_t stack_size;
++  size_t guard_size;
++  void *result;
++  struct __ptcb *cancelbuf;
++  void **tsd;
++  struct {
++    volatile void *volatile head;
++    long off;
++    volatile void *volatile pending;
++  } robust_list;
++  int h_errno_val;
++  volatile int timer_id;
++  locale_t locale;
++  volatile int killlock[1];
++  char *dlerror_buf;
++  void *stdio_locks;
++
++  /* Part 3 -- the positions of these fields relative to
++  * the end of the structure is external and internal ABI. */
++#ifdef TLS_ABOVE_TP
++  uintptr_t canary;
++  uintptr_t *dtv;
++#endif
++};
++
++void MaybeUpdateMuslTidCache()
++{
++  pid_t real_tid = sys_gettid();
++  pid_t* cached_tid_location = &reinterpret_cast<struct musl_pthread*>(pthread_self())->tid;
++  *cached_tid_location = real_tid;
++}
++#endif
++
+ // static
+ pid_t NamespaceSandbox::ForkInNewPidNamespace(bool drop_capabilities_in_child) {
+   const pid_t pid =
+@@ -226,6 +292,8 @@
+ #if defined(LIBC_GLIBC)
+     MaybeUpdateGlibcTidCache();
+-#endif
++#else
++    MaybeUpdateMuslTidCache();
++#endif
+     return 0;
+   }
+ 

--- a/srcpkgs/electron39/files/musl-patches/chromium-no-res-ninit-nclose.patch
+++ b/srcpkgs/electron39/files/musl-patches/chromium-no-res-ninit-nclose.patch
@@ -1,0 +1,33 @@
+Source: https://git.alpinelinux.org/aports/plain/community/chromium/no-res-ninit-nclose.patch
+similar to dns-resolver.patch, musl doesn't have res_ninit and so on
+--
+--- a/net/dns/public/scoped_res_state.cc
++++ b/net/dns/public/scoped_res_state.cc
+@@ -13,7 +13,7 @@
+ namespace net {
+ 
+ ScopedResState::ScopedResState() {
+-#if BUILDFLAG(IS_OPENBSD) || BUILDFLAG(IS_FUCHSIA)
++#if BUILDFLAG(IS_OPENBSD) || BUILDFLAG(IS_FUCHSIA) || defined(_GNU_SOURCE)
+   // Note: res_ninit in glibc always returns 0 and sets RES_INIT.
+   // res_init behaves the same way.
+   memset(&_res, 0, sizeof(_res));
+@@ -25,16 +25,8 @@
+ }
+ 
+ ScopedResState::~ScopedResState() {
+-#if !BUILDFLAG(IS_OPENBSD) && !BUILDFLAG(IS_FUCHSIA)
+-
+-  // Prefer res_ndestroy where available.
+-#if BUILDFLAG(IS_APPLE) || BUILDFLAG(IS_FREEBSD)
+-  res_ndestroy(&res_);
+-#else
+-  res_nclose(&res_);
+-#endif  // BUILDFLAG(IS_APPLE) || BUILDFLAG(IS_FREEBSD)
+-
+-#endif  // !BUILDFLAG(IS_OPENBSD) && !BUILDFLAG(IS_FUCHSIA)
++  // musl res_init() doesn't actually do anything
++  // no destruction is necessary as no memory has been allocated
+ }
+ 
+ bool ScopedResState::IsValid() const {

--- a/srcpkgs/electron39/files/musl-patches/electron_shell-file-dialog-drop-glibc.patch
+++ b/srcpkgs/electron39/files/musl-patches/electron_shell-file-dialog-drop-glibc.patch
@@ -1,0 +1,15 @@
+diff --git a/./electron/shell/browser/ui/file_dialog.h b/./electron/shell/browser/ui/file_dialog.h
+index 6cdfc7b..f7757da 100644
+--- a/shell/browser/ui/file_dialog.h
++++ b/shell/browser/ui/file_dialog.h
+@@ -13,10 +13,6 @@
+ #include "base/files/file_path.h"
+ #include "base/memory/raw_ptr_exclusion.h"
+ 
+-#if BUILDFLAG(IS_LINUX)
+-#include <bits/stdint-uintn.h>
+-#endif
+-
+ namespace electron {
+ class NativeWindow;
+ }

--- a/srcpkgs/electron39/files/patches/chromium-138-rust-musl-targets.patch
+++ b/srcpkgs/electron39/files/patches/chromium-138-rust-musl-targets.patch
@@ -1,0 +1,47 @@
+--- a/build/config/rust.gni
++++ b/build/config/rust.gni
+@@ -196,7 +196,18 @@
+ # a cargo project that dumps the `CARGO_CFG_TARGET_ABI` from its build.rs. See
+ # https://issues.chromium.org/u/1/issues/372512092#comment5 for an example.
+ rust_abi_target = ""
+-if (is_linux || is_chromeos) {
++if (is_musl) {
++  if (current_cpu == "arm64") {
++    rust_abi_target = "aarch64-unknown-linux-musl"
++    cargo_target_abi = ""
++  } else if (current_cpu == "x86") {
++    rust_abi_target = "i686-unknown-linux-musl"
++    cargo_target_abi = ""
++  } else if (current_cpu == "x64") {
++    rust_abi_target = "x86_64-unknown-linux-musl"
++    cargo_target_abi = ""
++  }
++} else if (is_linux || is_chromeos) {
+   if (current_cpu == "arm64") {
+     rust_abi_target = "aarch64-unknown-linux-gnu"
+     cargo_target_abi = ""
+--- a/build/rust/known-target-triples.txt
++++ b/build/rust/known-target-triples.txt
+@@ -17,6 +17,7 @@
+ aarch64-pc-windows-msvc
+ aarch64-unknown-fuchsia
+ aarch64-unknown-linux-gnu
++aarch64-unknown-linux-musl
+ arm64e-apple-ios
+ arm-unknown-linux-gnueabi
+ arm-unknown-linux-gnueabihf
+@@ -28,6 +29,7 @@
+ i686-linux-android
+ i686-pc-windows-msvc
+ i686-unknown-linux-gnu
++i686-unknown-linux-musl
+ loongarch64-unknown-linux-gnu
+ riscv64-linux-android
+ riscv64gc-unknown-linux-gnu
+@@ -41,5 +43,6 @@
+ x86_64-pc-windows-msvc
+ x86_64-unknown-fuchsia
+ x86_64-unknown-linux-gnu
++x86_64-unknown-linux-musl
+ powerpc64le-unknown-linux-gnu
+ s390x-unknown-linux-gnu

--- a/srcpkgs/electron39/files/patches/chromium-140-musl-prctl.patch
+++ b/srcpkgs/electron39/files/patches/chromium-140-musl-prctl.patch
@@ -1,0 +1,25 @@
+From 98338d64fff786f366b209c14735ff73b2c353bd Mon Sep 17 00:00:00 2001
+From: LN Liberda <lauren@selfisekai.rocks>
+Date: Tue, 2 Sep 2025 23:49:49 +0200
+Subject: [PATCH] musl/linux: Don't import conflicting libc and kernel headers
+
+/usr/include/sys/prctl.h:88:8: error: redefinition of 'prctl_mm_map'
+/usr/include/linux/prctl.h:134:8: note: previous definition is here
+---
+ rtc_base/platform_thread_types.cc | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/third_party/webrtc/rtc_base/platform_thread_types.cc b/third_party/webrtcrtc_base/platform_thread_types.cc
+index 20bf4afc44..5b26c120e4 100644
+--- a/third_party/webrtc/rtc_base/platform_thread_types.cc
++++ b/third_party/webrtcrtc_base/platform_thread_types.cc
+@@ -12,7 +12,9 @@
+ 
+ // IWYU pragma: begin_keep
+ #if defined(WEBRTC_LINUX)
++#if defined(__GLIBC__)
+ #include <linux/prctl.h>
++#endif
+ #include <sys/prctl.h>
+ #include <sys/syscall.h>
+ 

--- a/srcpkgs/electron39/files/patches/chromium-140-musl-toolchain.patch
+++ b/srcpkgs/electron39/files/patches/chromium-140-musl-toolchain.patch
@@ -1,0 +1,63 @@
+--- a/build/toolchain/toolchain.gni
++++ b/build/toolchain/toolchain.gni
+@@ -51,6 +51,10 @@
+   }
+ }
+ 
++declare_args() {
++  is_musl = false
++}
++
+ # Extension for shared library files (including leading dot).
+ if (is_apple) {
+   shlib_extension = ".dylib"
+--- a/build/config/compiler/BUILD.gn
++++ b/build/config/compiler/BUILD.gn
+@@ -1282,8 +1282,13 @@
+     # simplicity we always explicitly set the architecture.
+     if (current_cpu == "x64") {
+       if (is_clang && !is_android && !is_fuchsia && !is_chromeos_device) {
+-        cflags += [ "--target=x86_64-unknown-linux-gnu" ]
+-        ldflags += [ "--target=x86_64-unknown-linux-gnu" ]
++        if (is_musl) {
++          cflags += [ "--target=x86_64-unknown-linux-musl" ]
++          ldflags += [ "--target=x86_64-unknown-linux-musl" ]
++        } else {
++          cflags += [ "--target=x86_64-unknown-linux-gnu" ]
++          ldflags += [ "--target=x86_64-unknown-linux-gnu" ]
++        }
+       } else {
+         cflags += [ "-m64" ]
+         ldflags += [ "-m64" ]
+@@ -1291,8 +1296,13 @@
+       cflags += [ "-msse3" ]
+     } else if (current_cpu == "x86") {
+       if (is_clang && !is_android && !is_chromeos_device) {
+-        cflags += [ "--target=i386-unknown-linux-gnu" ]
+-        ldflags += [ "--target=i386-unknown-linux-gnu" ]
++        if (is_musl) {
++          cflags += [ "--target=i386-unknown-linux-musl" ]
++          ldflags += [ "--target=i386-unknown-linux-musl" ]
++        } else {
++          cflags += [ "--target=i386-unknown-linux-gnu" ]
++          ldflags += [ "--target=i386-unknown-linux-gnu" ]
++        }
+       } else {
+         cflags += [ "-m32" ]
+         ldflags += [ "-m32" ]
+@@ -1315,8 +1325,13 @@
+       }
+     } else if (current_cpu == "arm64") {
+       if (is_clang && !is_android && !is_fuchsia && !is_chromeos_device) {
+-        cflags += [ "--target=aarch64-linux-gnu" ]
+-        ldflags += [ "--target=aarch64-linux-gnu" ]
++        if (is_musl) {
++          cflags += [ "--target=aarch64-linux-musl" ]
++          ldflags += [ "--target=aarch64-linux-musl" ]
++        } else {
++          cflags += [ "--target=aarch64-linux-gnu" ]
++          ldflags += [ "--target=aarch64-linux-gnu" ]
++        }
+       }
+     } else if (current_cpu == "mipsel") {
+       ldflags += [ "-Wl,--hash-style=sysv" ]

--- a/srcpkgs/electron39/files/patches/chromium-141-cross-toolchain.patch
+++ b/srcpkgs/electron39/files/patches/chromium-141-cross-toolchain.patch
@@ -1,0 +1,112 @@
+--- a/build/toolchain/linux/unbundle/BUILD.gn.orig
++++ b/build/toolchain/linux/unbundle/BUILD.gn
+@@ -39,3 +39,22 @@
+     current_os = host_os
+   }
+ }
++
++gcc_toolchain("v8_snapshot_cross") {
++  cc = getenv("BUILD_CC")
++  cxx = getenv("BUILD_CXX")
++  ar = getenv("BUILD_AR")
++  nm = getenv("BUILD_NM")
++  ld = cxx
++
++  extra_cflags = getenv("BUILD_CFLAGS")
++  extra_cppflags = getenv("BUILD_CPPFLAGS")
++  extra_cxxflags = getenv("BUILD_CXXFLAGS")
++  extra_ldflags = getenv("BUILD_LDFLAGS")
++
++  toolchain_args = {
++    current_cpu = host_cpu
++    current_os = host_os
++    v8_current_cpu = target_cpu
++  }
++}
+--- a/build/config/clang/BUILD.gn
++++ b/build/config/clang/BUILD.gn
+@@ -215,7 +215,11 @@
+         assert(false)  # Unhandled target platform
+       }
+ 
+-      _clang_lib_dir = "$clang_base_path/lib/clang/$clang_version/lib"
++      if (current_cpu != target_cpu) {
++        _clang_lib_dir = "$clang_base_path/lib/clang/$clang_version/lib"
++      } else {
++        _clang_lib_dir = "$clang_cross_path/lib/clang/$clang_version/lib"
++      }
+       _lib_file = "${_prefix}clang_rt.${_libname}${_suffix}.${_ext}"
+       libs = [ "$_clang_lib_dir/$_dir/$_lib_file" ]
+     }
+--- a/build/config/clang/clang.gni
++++ b/build/config/clang/clang.gni
+@@ -36,6 +36,7 @@
+        is_mac || is_ios || is_chromeos)
+ 
+   clang_base_path = default_clang_base_path
++  clang_cross_path = default_clang_base_path
+ 
+   # Specifies whether or not bitcode should be embedded during compilation.
+   # This is used for creating a MLGO corpus from Chromium in the non-ThinLTO case.
+--- a/build/rust/std/find_std_rlibs.py
++++ b/build/rust/std/find_std_rlibs.py
+@@ -26,6 +26,7 @@
+                       help="Path to Rust binaries",
+                       required=True),
+   parser.add_argument("--target", help="Rust target triple", required=False),
++  parser.add_argument("--sysroot", help="Rust sysroot", required=False),
+   parser.add_argument("--output",
+                       help="Path to rlibs without suffixes",
+                       required=True)
+@@ -50,6 +51,8 @@
+   rustc_args = [rustc, "--print", "target-libdir"]
+   if args.target:
+     rustc_args.extend(["--target", args.target])
++  if args.sysroot:
++    rustc_args.extend(["--sysroot", args.sysroot])
+   rustlib_dir = subprocess.check_output(rustc_args).rstrip().decode()
+ 
+   # Copy the rlibs to a predictable location. Whilst we're doing so,
+--- a/build/config/rust.gni
++++ b/build/config/rust.gni
+@@ -60,6 +60,7 @@
+   # a Rust sysroot, which will have a 'bin' directory and others. Commonly
+   # <home dir>/.rustup/toolchains/nightly-<something>-<something>
+   rust_sysroot_absolute = ""
++  rust_cross_sysroot_absolute = ""
+ 
+   # Directory under which to find `bin/bindgen` (a `bin` directory containing
+   # the bindgen exectuable).
+--- a/build/rust/std/BUILD.gn
++++ b/build/rust/std/BUILD.gn
+@@ -62,7 +62,7 @@
+     # When building proc macros, include the proc_macro crate in what should be
+     # copied with find_stdlib. Otherwise it is not copied since it will be
+     # unused.
+-    stdlib_files += [ "proc_macro" ]
++    stdlib_files += [ "proc_macro", "rustc_literal_escaper" ]
+   }
+ 
+   # Different Rust toolchains may add or remove files relative to the above
+@@ -294,6 +294,13 @@
+         rust_abi_target,
+       ]
+ 
++      if (current_cpu == target_cpu && rust_cross_sysroot_absolute != "") {
++        args += [
++          "--sysroot",
++          rust_cross_sysroot_absolute,
++        ]
++      }
++
+       outputs = []
+       foreach(lib, all_stdlibs_to_copy) {
+         outputs += [ "$target_out_dir/lib$lib.rlib" ]
+@@ -351,6 +358,7 @@
+     group("std") {
+       all_dependent_configs = [
+         ":prebuilt_stdlib_libs",
++        ":prebuilt_stdlib_sysroot",
+         ":stdlib_public_dependent_libs",
+       ]
+       deps = [ ":prebuilt_rustc_copy_to_sysroot" ]

--- a/srcpkgs/electron39/files/patches/chromium-aarch64-musl-no-memory-tagging.patch
+++ b/srcpkgs/electron39/files/patches/chromium-aarch64-musl-no-memory-tagging.patch
@@ -1,0 +1,22 @@
+--- a/base/allocator/partition_allocator/partition_alloc.gni
++++ b/base/allocator/partition_allocator/partition_alloc.gni
+@@ -90,7 +90,7 @@
+ use_large_empty_slot_span_ring = true
+ 
+ has_memory_tagging = current_cpu == "arm64" && is_clang && !is_asan &&
+-                     !is_hwasan && (is_linux || is_android)
++                     !is_hwasan && (is_linux || is_android) && !is_musl
+ 
+ declare_args() {
+   # Debug configuration.
+--- a/base/allocator/partition_allocator/src/partition_alloc/aarch64_support.h
++++ b/base/allocator/partition_allocator/src/partition_alloc/aarch64_support.h
+@@ -10,7 +10,7 @@
+ #include "partition_alloc/build_config.h"
+ #include "partition_alloc/buildflags.h"
+ 
+-#if PA_BUILDFLAG(IS_ANDROID) || PA_BUILDFLAG(IS_LINUX)
++#if PA_BUILDFLAG(IS_ANDROID) || (PA_BUILDFLAG(IS_LINUX) && defined(__GLIBC__))
+ #define HAS_HW_CAPS
+ #endif
+ 

--- a/srcpkgs/electron39/files/patches/chromium-angle-wayland-include.patch
+++ b/srcpkgs/electron39/files/patches/chromium-angle-wayland-include.patch
@@ -1,0 +1,39 @@
+Patch-Source: https://github.com/archlinux/svntogit-packages/blob/a353833a5a731abfaa465b658f61894a516aa49b/trunk/angle-wayland-include-protocol.patch
+diff -upr third_party/angle.orig/BUILD.gn third_party/angle/BUILD.gn
+--- a/third_party/angle.orig/BUILD.gn	2022-08-17 19:38:11.000000000 +0000
++++ b/third_party/angle/BUILD.gn	2022-08-18 11:04:09.061751111 +0000
+@@ -489,6 +489,12 @@ config("angle_vulkan_wayland_config") {
+   if (angle_enable_vulkan && angle_use_wayland &&
+       defined(vulkan_wayland_include_dirs)) {
+     include_dirs = vulkan_wayland_include_dirs
++  } else if (angle_enable_vulkan && angle_use_wayland) {
++    include_dirs = [
++      "$wayland_gn_dir/src/src",
++      "$wayland_gn_dir/include/src",
++      "$wayland_gn_dir/include/protocol",
++    ]
+   }
+ }
+ 
+@@ -1073,6 +1079,7 @@ if (angle_use_wayland) {
+     include_dirs = [
+       "$wayland_dir/egl",
+       "$wayland_dir/src",
++      "$wayland_gn_dir/include/protocol",
+     ]
+   }
+ 
+diff -upr third_party/angle.orig/src/third_party/volk/BUILD.gn third_party/angle/src/third_party/volk/BUILD.gn
+--- a/third_party/angle.orig/src/third_party/volk/BUILD.gn	2022-08-17 19:38:12.000000000 +0000
++++ b/third_party/angle/src/third_party/volk/BUILD.gn	2022-08-18 11:04:36.499828006 +0000
+@@ -21,6 +21,9 @@ source_set("volk") {
+   configs += [ "$angle_root:angle_no_cfi_icall" ]
+   public_deps = [ "$angle_vulkan_headers_dir:vulkan_headers" ]
+   if (angle_use_wayland) {
+-    include_dirs = [ "$wayland_dir/src" ]
++    include_dirs = [
++      "$wayland_dir/src",
++      "$wayland_gn_dir/include/protocol",
++    ]
+   }
+ }

--- a/srcpkgs/electron39/files/patches/chromium-chromium-117-string-convert.patch
+++ b/srcpkgs/electron39/files/patches/chromium-chromium-117-string-convert.patch
@@ -1,0 +1,21 @@
+diff -up chromium-117.0.5938.62/net/dns/host_resolver_cache.cc.me chromium-117.0.5938.62/net/dns/host_resolver_cache.cc
+diff -up chromium-117.0.5938.62/net/dns/host_resolver_cache.h.me chromium-117.0.5938.62/net/dns/host_resolver_cache.h
+--- chromium-117.0.5938.62/net/dns/host_resolver_cache.h.me	2023-09-14 15:21:24.632965004 +0200
++++ chromium-117.0.5938.62/net/dns/host_resolver_cache.h	2023-09-15 09:15:48.511300845 +0200
+@@ -143,12 +143,14 @@ class NET_EXPORT HostResolverCache final
+     }
+ 
+     bool operator()(const Key& lhs, const KeyRef& rhs) const {
++      const std::string rhs_domain_name{rhs.domain_name};
+       return std::tie(lhs.domain_name, lhs.network_anonymization_key) <
+-             std::tie(rhs.domain_name, *rhs.network_anonymization_key);
++             std::tie(rhs_domain_name, *rhs.network_anonymization_key);
+     }
+ 
+     bool operator()(const KeyRef& lhs, const Key& rhs) const {
+-      return std::tie(lhs.domain_name, *lhs.network_anonymization_key) <
++      const std::string lhs_domain_name{lhs.domain_name};
++      return std::tie(lhs_domain_name, *lhs.network_anonymization_key) <
+              std::tie(rhs.domain_name, rhs.network_anonymization_key);
+     }
+   };

--- a/srcpkgs/electron39/files/patches/chromium-chromium-121-rust-without-profiler_builtins.patch
+++ b/srcpkgs/electron39/files/patches/chromium-chromium-121-rust-without-profiler_builtins.patch
@@ -1,0 +1,10 @@
+--- a/build/rust/std/BUILD.gn
++++ b/build/rust/std/BUILD.gn
+@@ -100,7 +100,6 @@
+   # don't need to pass to the C++ linker because they're used for specialized
+   # purposes.
+   skip_stdlib_files = [
+-    "profiler_builtins",
+     "rustc_std_workspace_alloc",
+     "rustc_std_workspace_core",
+     "rustc_std_workspace_std",

--- a/srcpkgs/electron39/files/patches/chromium-chromium-124-iwyu-sys-select-dawn-terminal.patch
+++ b/srcpkgs/electron39/files/patches/chromium-chromium-124-iwyu-sys-select-dawn-terminal.patch
@@ -1,0 +1,24 @@
+From cf993f56ce699ca0ed66ca5a6b88fe7b31c03a75 Mon Sep 17 00:00:00 2001
+From: "lauren n. liberda" <lauren@selfisekai.rocks>
+Date: Fri, 5 Apr 2024 06:08:21 +0200
+Subject: [PATCH] iwyu: sys/select.h in terminal utils
+
+required for fd_set. fixes building on musl libc
+
+Change-Id: I5c03d58c8337c1af871024a436b09117ad9206d4
+---
+ src/tint/utils/system/terminal_posix.cc | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/third_party/dawn/src/tint/utils/system/terminal_posix.cc b/third_party/dawn/src/tint/utils/system/terminal_posix.cc
+index e820774244..a97eab7db8 100644
+--- a/third_party/dawn/src/tint/utils/system/terminal_posix.cc
++++ b/third_party/dawn/src/tint/utils/system/terminal_posix.cc
+@@ -27,6 +27,7 @@
+ 
+ // GEN_BUILD:CONDITION(tint_build_is_linux || tint_build_is_mac)
+ 
++#include <sys/select.h>
+ #include <unistd.h>
+ 
+ #include <termios.h>

--- a/srcpkgs/electron39/files/patches/chromium-chromium-138-rust-clang_lib.patch
+++ b/srcpkgs/electron39/files/patches/chromium-chromium-138-rust-clang_lib.patch
@@ -1,0 +1,22 @@
+--- a/build/config/clang/BUILD.gn
++++ b/build/config/clang/BUILD.gn
+@@ -208,14 +208,15 @@
+           assert(false)  # Unhandled cpu type
+         }
+       } else if (is_linux || is_chromeos) {
++        _dir = "linux"
+         if (current_cpu == "x64") {
+-          _dir = "x86_64-unknown-linux-gnu"
++          _suffix = "-x86_64"
+         } else if (current_cpu == "x86") {
+-          _dir = "i386-unknown-linux-gnu"
++          _suffix = "-i386"
+         } else if (current_cpu == "arm") {
+-          _dir = "armv7-unknown-linux-gnueabihf"
++          _suffix = "-armhf"
+         } else if (current_cpu == "arm64") {
+-          _dir = "aarch64-unknown-linux-gnu"
++          _suffix = "-aarch64"
+         } else if (current_cpu == "loong64") {
+           _dir = "loongarch64-unknown-linux-gnu"
+         } else {

--- a/srcpkgs/electron39/files/patches/chromium-chromium-revert-drop-of-system-java.patch
+++ b/srcpkgs/electron39/files/patches/chromium-chromium-revert-drop-of-system-java.patch
@@ -1,0 +1,15 @@
+This was dropped for some reason in 6951c37cecd05979b232a39e5c10e6346a0f74ef
+--- a/third_party/closure_compiler/compiler.py	2021-05-20 04:17:53.000000000 +0200
++++ b/third_party/closure_compiler/compiler.py	2021-05-20 04:17:53.000000000 +0200
+@@ -13,8 +13,9 @@
+ 
+ 
+ _CURRENT_DIR = os.path.join(os.path.dirname(__file__))
+-_JAVA_PATH = os.path.join(_CURRENT_DIR, "..", "jdk", "current", "bin", "java")
+-assert os.path.isfile(_JAVA_PATH), "java only allowed in android builds"
++_JAVA_BIN = "java"
++_JDK_PATH = os.path.join(_CURRENT_DIR, "..", "jdk", "current", "bin", "java")
++_JAVA_PATH = _JDK_PATH if os.path.isfile(_JDK_PATH) else _JAVA_BIN
+ 
+ class Compiler(object):
+   """Runs the Closure compiler on given source files to typecheck them

--- a/srcpkgs/electron39/files/patches/chromium-chromium-system-nodejs.patch
+++ b/srcpkgs/electron39/files/patches/chromium-chromium-system-nodejs.patch
@@ -1,0 +1,21 @@
+--- a/third_party/node/node.py
++++ b/third_party/node/node.py
+@@ -11,17 +11,7 @@
+ 
+ 
+ def GetBinaryPath():
+-  if platform.machine() == 'arm64':
+-    darwin_path = 'mac_arm64'
+-    darwin_name = 'node-darwin-arm64'
+-  else:
+-    darwin_path = 'mac'
+-    darwin_name = 'node-darwin-x64'
+-  return os_path.join(os_path.dirname(__file__), *{
+-    'Darwin': (darwin_path, darwin_name, 'bin', 'node'),
+-    'Linux': ('linux', 'node-linux-x64', 'bin', 'node'),
+-    'Windows': ('win', 'node.exe'),
+-  }[platform.system()])
++    return "/usr/bin/node"
+ 
+ 
+ def RunNode(cmd_parts, stdout=None):

--- a/srcpkgs/electron39/files/patches/chromium-compiler.patch
+++ b/srcpkgs/electron39/files/patches/chromium-compiler.patch
@@ -1,0 +1,25 @@
+--- a/build/config/compiler/BUILD.gn.orig
++++ b/build/config/compiler/BUILD.gn
+@@ -658,22 +658,6 @@
+       }
+     }
+ 
+-    # TODO(crbug.com/40283598): This causes binary size growth and potentially
+-    # other problems.
+-    if (default_toolchain != "//build/toolchain/cros:target") {
+-      cflags += [
+-        "-mllvm",
+-        "-split-threshold-for-reg-with-hint=0",
+-      ]
+-      if (use_thin_lto && is_a_target_toolchain) {
+-        if (is_win) {
+-          ldflags += [ "-mllvm:-split-threshold-for-reg-with-hint=0" ]
+-        } else {
+-          ldflags += [ "-Wl,-mllvm,-split-threshold-for-reg-with-hint=0" ]
+-        }
+-      }
+-    }
+-
+     # TODO(crbug.com/40192287): Investigate why/if this should be needed.
+     if (is_win) {
+       cflags += [ "/clang:-ffp-contract=off" ]

--- a/srcpkgs/electron39/files/patches/chromium-cr138-node-version-check.patch
+++ b/srcpkgs/electron39/files/patches/chromium-cr138-node-version-check.patch
@@ -1,0 +1,67 @@
+From 41bd9e8e46a97cfe8a0dfd2c2626aa7d4809ed4d Mon Sep 17 00:00:00 2001
+From: LN Liberda <lauren@selfisekai.rocks>
+Date: Wed, 28 May 2025 12:10:07 +0200
+Subject: [PATCH] Allow to disable the Node.js version check with a build arg
+
+For distributions building Chromium with their own Node.js binaries,
+version mismatches are expected. Keep the check on by default,
+but allow to opt-out of it.
+
+Bug: 401522564
+Change-Id: I211279a607b5b5fefd13614b177e55e57ba804c1
+---
+ third_party/node/BUILD.gn | 40 ++++++++++++++++++++++++---------------
+ 1 file changed, 25 insertions(+), 15 deletions(-)
+
+diff --git a/third_party/node/BUILD.gn b/third_party/node/BUILD.gn
+index 1741e14401c8c..75631fac8b462 100644
+--- a/third_party/node/BUILD.gn
++++ b/third_party/node/BUILD.gn
+@@ -4,22 +4,32 @@
+ 
+ import("//third_party/node/node.gni")
+ 
+-node("check_version") {
+-  script = "check_version.py"
++declare_args() {
++  # Check the version of the Node.js binary.
++  node_version_check = true
++}
++
++if (node_version_check) {
++  node("check_version") {
++    script = "check_version.py"
+ 
+-  expected_version_file = "update_node_binaries"
+-  inputs = [
+-    expected_version_file,
+-    "check_version.js",
+-  ]
++    expected_version_file = "update_node_binaries"
++    inputs = [
++      expected_version_file,
++      "check_version.js",
++    ]
+ 
+-  out_file = "${target_gen_dir}/check_version_result.txt"
+-  outputs = [ out_file ]
++    out_file = "${target_gen_dir}/check_version_result.txt"
++    outputs = [ out_file ]
+ 
+-  args = [
+-    "--expected_version_file",
+-    rebase_path(expected_version_file, root_build_dir),
+-    "--out_file",
+-    rebase_path(out_file, root_build_dir),
+-  ]
++    args = [
++      "--expected_version_file",
++      rebase_path(expected_version_file, root_build_dir),
++      "--out_file",
++      rebase_path(out_file, root_build_dir),
++    ]
++  }
++} else {
++  group("check_version") {
++  }
+ }

--- a/srcpkgs/electron39/files/patches/chromium-fc-cache-version.patch
+++ b/srcpkgs/electron39/files/patches/chromium-fc-cache-version.patch
@@ -1,0 +1,13 @@
+instead of hardcoding the version, use the defined macro.
+--
+--- a/third_party/test_fonts/fontconfig/generate_fontconfig_caches.cc
++++ b/third_party/test_fonts/fontconfig/generate_fontconfig_caches.cc
+@@ -59,7 +59,7 @@
+   FcFini();
+ 
+   // Check existence of intended fontconfig cache file.
+-  auto cache = fontconfig_caches + "/" + kCacheKey + "-le64.cache-11";
++  auto cache = fontconfig_caches + "/" + kCacheKey + "-le64.cache-" + FC_CACHE_VERSION;
+   bool cache_exists = access(cache.c_str(), F_OK) == 0;
+   return !cache_exists;
+ }

--- a/srcpkgs/electron39/files/patches/chromium-fix-aarch64-musl-memory-tagging-macros.patch
+++ b/srcpkgs/electron39/files/patches/chromium-fix-aarch64-musl-memory-tagging-macros.patch
@@ -1,0 +1,29 @@
+--- a/base/allocator/partition_allocator/src/partition_alloc/tagging.cc
++++ b/base/allocator/partition_allocator/src/partition_alloc/tagging.cc
+@@ -28,13 +28,25 @@
+ #endif
+ #endif
+ 
+-#ifndef HAS_PR_MTE_MACROS
++#ifndef PR_MTE_TCF_SHIFT
+ #define PR_MTE_TCF_SHIFT 1
++#endif
++#ifndef PR_MTE_TCF_NONE
+ #define PR_MTE_TCF_NONE (0UL << PR_MTE_TCF_SHIFT)
++#endif
++#ifndef PR_MTE_TCF_SYNC
+ #define PR_MTE_TCF_SYNC (1UL << PR_MTE_TCF_SHIFT)
++#endif
++#ifndef PR_MTE_TCF_ASYNC
+ #define PR_MTE_TCF_ASYNC (2UL << PR_MTE_TCF_SHIFT)
++#endif
++#ifndef PR_MTE_TCF_MASK
+ #define PR_MTE_TCF_MASK (3UL << PR_MTE_TCF_SHIFT)
++#endif
++#ifndef PR_MTE_TAG_SHIFT
+ #define PR_MTE_TAG_SHIFT 3
++#endif
++#ifndef PR_MTE_TAG_MASK
+ #define PR_MTE_TAG_MASK (0xffffUL << PR_MTE_TAG_SHIFT)
+ #endif
+ #endif

--- a/srcpkgs/electron39/files/patches/chromium-fix-argument_spec-isnan-isinf.patch
+++ b/srcpkgs/electron39/files/patches/chromium-fix-argument_spec-isnan-isinf.patch
@@ -1,0 +1,11 @@
+--- a/extensions/renderer/bindings/argument_spec.cc
++++ b/extensions/renderer/bindings/argument_spec.cc
+@@ -2,6 +2,8 @@
+ // Use of this source code is governed by a BSD-style license that can be
+ // found in the LICENSE file.
+ 
++#include <cmath>
++
+ #include "extensions/renderer/bindings/argument_spec.h"
+ 
+ #include "base/check.h"

--- a/srcpkgs/electron39/files/patches/chromium-fix-missing-TEMP_FAILURE_RETRY-macro.patch
+++ b/srcpkgs/electron39/files/patches/chromium-fix-missing-TEMP_FAILURE_RETRY-macro.patch
@@ -1,0 +1,21 @@
+This macro is defined in glibc, but not musl.
+
+--- a/sandbox/linux/suid/process_util.h.orig
++++ b/sandbox/linux/suid/process_util.h
+@@ -11,6 +11,16 @@
+ #include <stdint.h>
+ #include <sys/types.h>
+ 
++// Some additional functions
++#if !defined(TEMP_FAILURE_RETRY)
++# define TEMP_FAILURE_RETRY(expression) \
++	(__extension__			\
++	 ({ long int __result;		\
++	  do __result = (long int) (expression); \
++	  while (__result == -1L && errno == EINTR); \
++	  __result; }))
++#endif
++
+ // This adjusts /proc/process/oom_score_adj so the Linux OOM killer
+ // will prefer certain process types over others. The range for the
+ // adjustment is [-1000, 1000], with [0, 1000] being user accessible.

--- a/srcpkgs/electron39/files/patches/chromium-fix-missing-cstdint-include-musl.patch
+++ b/srcpkgs/electron39/files/patches/chromium-fix-missing-cstdint-include-musl.patch
@@ -1,0 +1,10 @@
+--- a/net/third_party/quiche/src/quiche/http2/adapter/window_manager.h
++++ b/net/third_party/quiche/src/quiche/http2/adapter/window_manager.h
+@@ -3,6 +3,7 @@
+ 
+ #include <stddef.h>
+ 
++#include <cstdint>
+ #include <functional>
+ 
+ #include "quiche/common/platform/api/quiche_export.h"

--- a/srcpkgs/electron39/files/patches/chromium-fix-musl-missing-unistd_h-include.patch
+++ b/srcpkgs/electron39/files/patches/chromium-fix-musl-missing-unistd_h-include.patch
@@ -1,0 +1,10 @@
+--- a/sandbox/linux/services/credentials.h
++++ b/sandbox/linux/services/credentials.h
+@@ -13,6 +13,7 @@
+ 
+ #include <string>
+ #include <vector>
++#include <unistd.h>
+ 
+ #include "sandbox/linux/system_headers/capability.h"
+ #include "sandbox/sandbox_export.h"

--- a/srcpkgs/electron39/files/patches/chromium-fix-perfetto-GetThreadName-musl.patch
+++ b/srcpkgs/electron39/files/patches/chromium-fix-perfetto-GetThreadName-musl.patch
@@ -1,0 +1,22 @@
+--- a/third_party/perfetto/include/perfetto/ext/base/thread_utils.h
++++ b/third_party/perfetto/include/perfetto/ext/base/thread_utils.h
+@@ -30,7 +30,8 @@
+ #include <algorithm>
+ #endif
+ 
+-#if PERFETTO_BUILDFLAG(PERFETTO_OS_ANDROID)
++#if PERFETTO_BUILDFLAG(PERFETTO_OS_ANDROID) || \
++    (PERFETTO_BUILDFLAG(PERFETTO_OS_LINUX) && !defined(__GLIBC__))
+ #include <sys/prctl.h>
+ #endif
+ 
+@@ -58,7 +59,8 @@
+ 
+ inline bool GetThreadName(std::string& out_result) {
+   char buf[16] = {};
+-#if PERFETTO_BUILDFLAG(PERFETTO_OS_ANDROID)
++#if PERFETTO_BUILDFLAG(PERFETTO_OS_ANDROID) || \
++    (PERFETTO_BUILDFLAG(PERFETTO_OS_LINUX) && !defined(__GLIBC__))
+   if (prctl(PR_GET_NAME, buf) != 0)
+     return false;
+ #else

--- a/srcpkgs/electron39/files/patches/chromium-libc_malloc.patch
+++ b/srcpkgs/electron39/files/patches/chromium-libc_malloc.patch
@@ -1,0 +1,34 @@
+--- a/base/process/memory_linux.cc
++++ b/base/process/memory_linux.cc
+@@ -18,6 +18,13 @@
+ #include "base/threading/thread_restrictions.h"
+ #include "build/build_config.h"
+ 
++#if defined(LIBC_GLIBC)
++extern "C" {
++extern void *__libc_malloc(size_t size);
++extern void *__libc_free(void *ptr);
++}
++#endif
++
+ namespace base {
+ 
+ namespace {
+@@ -111,7 +118,7 @@
+ #elif defined(MEMORY_TOOL_REPLACES_ALLOCATOR) || !defined(LIBC_GLIBC)
+   *result = malloc(size);
+ #elif defined(LIBC_GLIBC)
+-  *result = __libc_malloc(size);
++  *result = ::__libc_malloc(size);
+ #endif
+   return *result != nullptr;
+ }
+@@ -122,7 +129,7 @@
+ #elif defined(MEMORY_TOOL_REPLACES_ALLOCATOR) || !defined(LIBC_GLIBC)
+   free(ptr);
+ #elif defined(LIBC_GLIBC)
+-  __libc_free(ptr);
++  ::__libc_free(ptr);
+ #endif
+ }
+ 

--- a/srcpkgs/electron39/files/patches/chromium-musl-no-execinfo.patch
+++ b/srcpkgs/electron39/files/patches/chromium-musl-no-execinfo.patch
@@ -1,0 +1,68 @@
+musl does not have execinfo.h, and hence no implementation of
+. backtrace()
+. backtrace_symbols()
+for discussion about this, see https://www.openwall.com/lists/musl/2021/07/16/1
+--
+--- a/v8/src/codegen/external-reference-table.cc
++++ b/v8/src/codegen/external-reference-table.cc
+@@ -11,7 +11,9 @@
+
+ #if defined(DEBUG) && defined(V8_OS_LINUX) && !defined(V8_OS_ANDROID)
+ #define SYMBOLIZE_FUNCTION
++#if defined(__GLIBC__)
+ #include <execinfo.h>
++#endif
+
+ #include <vector>
+
+@@ -96,7 +98,7 @@
+ }
+
+ const char* ExternalReferenceTable::ResolveSymbol(void* address) {
+-#ifdef SYMBOLIZE_FUNCTION
++#if defined(SYMBOLIZE_FUNCTION) && defined(__GLIBC__)
+   char** names = backtrace_symbols(&address, 1);
+   const char* name = names[0];
+   // The array of names is malloc'ed. However, each name string is static
+--- a/third_party/swiftshader/third_party/llvm-subzero/build/Linux/include/llvm/Config/config.h
++++ b/third_party/swiftshader/third_party/llvm-subzero/build/Linux/include/llvm/Config/config.h
+@@ -58,7 +58,7 @@
+ #define HAVE_ERRNO_H 1
+ 
+ /* Define to 1 if you have the <execinfo.h> header file. */
+-#define HAVE_EXECINFO_H 1
++/* #define HAVE_EXECINFO_H 1 */
+ 
+ /* Define to 1 if you have the <fcntl.h> header file. */
+ #define HAVE_FCNTL_H 1
+--- a/base/debug/stack_trace.cc
++++ b/base/debug/stack_trace.cc
+@@ -311,7 +311,7 @@
+ 
+ std::string StackTrace::ToStringWithPrefix(cstring_view prefix_string) const {
+   std::stringstream stream;
+-#if !defined(__UCLIBC__) && !defined(_AIX)
++#if defined(__GLIBC__) && !defined(_AIX)
+   OutputToStreamWithPrefix(&stream, prefix_string);
+ #endif
+   return stream.str();
+@@ -335,7 +335,7 @@
+ }
+ 
+ std::ostream& operator<<(std::ostream& os, const StackTrace& s) {
+-#if !defined(__UCLIBC__) && !defined(_AIX)
++#if defined(__GLIBC__) && !defined(_AIX)
+   s.OutputToStream(&os);
+ #else
+   os << "StackTrace::OutputToStream not implemented.";
+--- a/base/debug/stack_trace_unittest.cc
++++ b/base/debug/stack_trace_unittest.cc
+@@ -33,7 +33,7 @@
+ typedef testing::Test StackTraceTest;
+ #endif
+ 
+-#if !defined(__UCLIBC__) && !defined(_AIX)
++#if !defined(__UCLIBC__) && !defined(_AIX) && defined(__GLIBC__)
+ // StackTrace::OutputToStream() is not implemented under uclibc, nor AIX.
+ // See https://crbug.com/706728
+ 

--- a/srcpkgs/electron39/files/patches/chromium-musl-no-mallinfo.patch
+++ b/srcpkgs/electron39/files/patches/chromium-musl-no-mallinfo.patch
@@ -1,0 +1,125 @@
+Source: https://git.alpinelinux.org/aports/plain/community/chromium/no-mallinfo.patch
+musl does not implement mallinfo()/mallinfo2()
+(or rather, malloc-ng, musl's allocator, doesn't)
+--
+--- a/base/trace_event/malloc_dump_provider.cc
++++ b/base/trace_event/malloc_dump_provider.cc
+@@ -185,7 +185,6 @@
+ #define MALLINFO2_FOUND_IN_LIBC
+   struct mallinfo2 info = mallinfo2();
+ #endif
+-#endif  // defined(__GLIBC__) && defined(__GLIBC_PREREQ)
+ #if !defined(MALLINFO2_FOUND_IN_LIBC)
+   struct mallinfo info = mallinfo();
+ #endif
+@@ -205,6 +204,7 @@
+     sys_alloc_dump->AddScalar(MemoryAllocatorDump::kNameSize,
+                               MemoryAllocatorDump::kUnitsBytes, info.uordblks);
+   }
++#endif  // defined(__GLIBC__) && defined(__GLIBC_PREREQ)
+ }
+ #endif
+ 
+@@ -339,7 +340,7 @@
+                      &allocated_objects_count);
+ #elif BUILDFLAG(IS_FUCHSIA)
+ // TODO(fuchsia): Port, see https://crbug.com/706592.
+-#else
++#elif defined(__GLIBC__)
+   ReportMallinfoStats(/*pmd=*/nullptr, &total_virtual_size, &resident_size,
+                       &allocated_objects_size, &allocated_objects_count);
+ #endif
+--- a/base/process/process_metrics_posix.cc
++++ b/base/process/process_metrics_posix.cc
+@@ -105,7 +105,7 @@
+ 
+ #endif  // !BUILDFLAG(IS_FUCHSIA)
+ 
+-#if BUILDFLAG(IS_LINUX) || BUILDFLAG(IS_CHROMEOS) || BUILDFLAG(IS_ANDROID)
++#if (BUILDFLAG(IS_LINUX) && defined(__GLIBC__)) || BUILDFLAG(IS_CHROMEOS) || BUILDFLAG(IS_ANDROID)
+ namespace {
+ 
+ size_t GetMallocUsageMallinfo() {
+@@ -123,7 +123,7 @@
+ }
+ 
+ }  // namespace
+-#endif  // BUILDFLAG(IS_LINUX) || BUILDFLAG(IS_CHROMEOS) ||
++#endif  // (BUILDFLAG(IS_LINUX) && defined(__GLIBC__)) || BUILDFLAG(IS_CHROMEOS) ||
+         // BUILDFLAG(IS_ANDROID)
+ 
+ size_t ProcessMetrics::GetMallocUsage() {
+@@ -131,9 +131,9 @@
+   malloc_statistics_t stats = {0};
+   malloc_zone_statistics(nullptr, &stats);
+   return stats.size_in_use;
+-#elif BUILDFLAG(IS_LINUX) || BUILDFLAG(IS_CHROMEOS) || BUILDFLAG(IS_ANDROID)
++#elif (BUILDFLAG(IS_LINUX) && defined(__GLIBC__)) || BUILDFLAG(IS_CHROMEOS) || BUILDFLAG(IS_ANDROID)
+   return GetMallocUsageMallinfo();
+-#elif BUILDFLAG(IS_FUCHSIA)
++#else
+   // TODO(fuchsia): Not currently exposed. https://crbug.com/735087.
+   return 0;
+ #endif
+--- ./third_party/tflite/src/tensorflow/lite/profiling/memory_info.cc.orig
++++ ./third_party/tflite/src/tensorflow/lite/profiling/memory_info.cc
+@@ -35,7 +35,7 @@
+ 
+ MemoryUsage GetMemoryUsage() {
+   MemoryUsage result;
+-#ifdef __linux__
++#if defined(__linux__) && defined(__GLIBC__)
+   rusage res;
+   if (getrusage(RUSAGE_SELF, &res) == 0) {
+     result.max_rss_kb = res.ru_maxrss;
+--- ./third_party/swiftshader/third_party/llvm-subzero/lib/Support/Unix/Process.inc
++++ ./third_party/swiftshader/third_party/llvm-subzero/lib/Support/Unix/Process.inc.orig
+@@ -86,11 +86,11 @@
+ }
+
+ size_t Process::GetMallocUsage() {
+-#if defined(HAVE_MALLINFO2)
++#if defined(HAVE_MALLINFO2) && defined(__GLIBC__)
+   struct mallinfo2 mi;
+   mi = ::mallinfo2();
+   return mi.uordblks;
+-#elif defined(HAVE_MALLINFO)
++#elif defined(HAVE_MALLINFO) && defined(__GLIBC__)
+   struct mallinfo mi;
+   mi = ::mallinfo();
+   return mi.uordblks;
+
+--- ./third_party/swiftshader/third_party/llvm-10.0/configs/linux/include/llvm/Config/config.h.orig	2019-09-30 13:03:42.556880537 -0400
++++ ./third_party/swiftshader/third_party/llvm-10.0/configs/linux/include/llvm/Config/config.h	2019-09-30 13:07:27.989821227 -0400
+@@ -122,7 +122,9 @@
+ /* #undef HAVE_MALLCTL */
+ 
+ /* Define to 1 if you have the `mallinfo' function. */
++#if defined(__GLIBC__)
+ #define HAVE_MALLINFO 1
++#endif
+ 
+ /* Define to 1 if you have the <malloc.h> header file. */
+ #define HAVE_MALLOC_H 1
+--- a/base/allocator/partition_allocator/src/partition_alloc/shim/allocator_shim_default_dispatch_to_partition_alloc.cc
++++ b/base/allocator/partition_allocator/src/partition_alloc/shim/allocator_shim_default_dispatch_to_partition_alloc.cc
+@@ -660,7 +660,7 @@
+ 
+ #endif  // !PA_BUILDFLAG(IS_APPLE) && !PA_BUILDFLAG(IS_ANDROID)
+ 
+-#if PA_BUILDFLAG(IS_LINUX) || PA_BUILDFLAG(IS_CHROMEOS)
++#if (PA_BUILDFLAG(IS_LINUX) && defined(__GLIBC__)) || PA_BUILDFLAG(IS_CHROMEOS)
+ SHIM_ALWAYS_EXPORT struct mallinfo mallinfo(void) __THROW {
+   partition_alloc::SimplePartitionStatsDumper allocator_dumper;
+   Allocator()->DumpStats("malloc", true, &allocator_dumper);
+--- a/base/allocator/partition_allocator/src/partition_alloc/shim/allocator_shim_default_dispatch_to_partition_alloc_unittest.cc
++++ b/base/allocator/partition_allocator/src/partition_alloc/shim/allocator_shim_default_dispatch_to_partition_alloc_unittest.cc
+@@ -29,7 +29,7 @@
+ #if PA_BUILDFLAG(USE_PARTITION_ALLOC_AS_MALLOC)
+ 
+ // Platforms on which we override weak libc symbols.
+-#if PA_BUILDFLAG(IS_LINUX) || PA_BUILDFLAG(IS_CHROMEOS)
++#if (PA_BUILDFLAG(IS_LINUX) && defined(__GLIBC__)) || PA_BUILDFLAG(IS_CHROMEOS)
+ 
+ PA_NOINLINE void FreeForTest(void* data) {
+   free(data);

--- a/srcpkgs/electron39/files/patches/chromium-musl-no-sandbox-settls.patch
+++ b/srcpkgs/electron39/files/patches/chromium-musl-no-sandbox-settls.patch
@@ -1,0 +1,15 @@
+Source: https://gitlab.alpinelinux.org/alpine/aports/-/blob/master/community/chromium/no-sandbox-settls.patch
+this optimisation of CLONE_SETTLS is not valid used like this, and future musl
+clone(3) will EINVAL on this use
+--
+--- a/sandbox/linux/services/credentials.cc
++++ b/sandbox/linux/services/credentials.cc
+@@ -89,7 +89,7 @@
+ 
+   int clone_flags = CLONE_FS | LINUX_SIGCHLD;
+   void* tls = nullptr;
+-#if (defined(ARCH_CPU_X86_64) || defined(ARCH_CPU_ARM_FAMILY)) && \
++#if defined(__GLIBC__) && (defined(ARCH_CPU_X86_64) || defined(ARCH_CPU_ARM_FAMILY)) && \
+     !defined(MEMORY_SANITIZER)
+   // Use CLONE_VM | CLONE_VFORK as an optimization to avoid copying page tables.
+   // Since clone writes to the new child's TLS before returning, we must set a

--- a/srcpkgs/electron39/files/patches/chromium-musl-partition-atfork.patch
+++ b/srcpkgs/electron39/files/patches/chromium-musl-partition-atfork.patch
@@ -1,0 +1,11 @@
+--- a/base/allocator/partition_allocator/src/partition_alloc/partition_root.cc
++++ b/base/allocator/partition_allocator/src/partition_alloc/partition_root.cc
+@@ -239,7 +239,7 @@
+   if (!g_global_init_called.compare_exchange_strong(expected, true))
+     return;
+ 
+-#if PA_BUILDFLAG(IS_LINUX) || PA_BUILDFLAG(IS_CHROMEOS)
++#if (PA_BUILDFLAG(IS_LINUX) && defined(__GLIBC__)) || PA_BUILDFLAG(IS_CHROMEOS)
+   // When fork() is called, only the current thread continues to execute in the
+   // child process. If the lock is held, but *not* by this thread when fork() is
+   // called, we have a deadlock.

--- a/srcpkgs/electron39/files/patches/chromium-no-getcontext.patch
+++ b/srcpkgs/electron39/files/patches/chromium-no-getcontext.patch
@@ -1,0 +1,27 @@
+--- a/third_party/breakpad/breakpad/src/client/linux/handler/exception_handler.cc	2015-12-06 09:59:55.554536646 +0100
++++ b/third_party/breakpad/breakpad/src/client/linux/handler/exception_handler.cc	2015-12-06 10:01:16.818238035 +0100
+@@ -477,7 +477,9 @@ bool ExceptionHandler::SimulateSignalDel
+   siginfo.si_code = SI_USER;
+   siginfo.si_pid = getpid();
+   ucontext_t context;
++#if defined(__GLIBC__)
+   getcontext(&context);
++#endif
+   return HandleSignal(sig, &siginfo, &context);
+ }
+ 
+@@ -647,9 +649,14 @@ bool ExceptionHandler::WriteMinidump() {
+   sys_prctl(PR_SET_DUMPABLE, 1, 0, 0, 0);
+ 
+   CrashContext context;
++
++#if defined(__GLIBC__)
+   int getcontext_result = getcontext(&context.context);
+   if (getcontext_result)
+     return false;
++#else
++  return false;
++#endif
+ 
+ #if defined(__i386__)
+   // In CPUFillFromUContext in minidumpwriter.cc the stack pointer is retrieved

--- a/srcpkgs/electron39/files/patches/chromium-node-do-not-check-version.patch
+++ b/srcpkgs/electron39/files/patches/chromium-node-do-not-check-version.patch
@@ -1,0 +1,19 @@
+--- a/third_party/node/node.gni
++++ b/third_party/node/node.gni
+@@ -35,16 +35,5 @@
+         inputs += [ "//third_party/node/mac/node-darwin-x64/bin/node" ]
+       }
+     }
+-
+-    # Automatically add a dependency to ":check_version" to ensure NodeJS is
+-    # always running the expected version, except when the ':check_version'
+-    # target itself is running in which case it shouldn't depend on itself.
+-    if (get_label_info(":" + target_name, "label_no_toolchain") !=
+-        "//third_party/node:check_version") {
+-      if (!defined(deps)) {
+-        deps = []
+-      }
+-      deps += [ "//third_party/node:check_version" ]
+-    }
+   }
+ }

--- a/srcpkgs/electron39/files/patches/chromium-node-python3.14.patch
+++ b/srcpkgs/electron39/files/patches/chromium-node-python3.14.patch
@@ -1,0 +1,37 @@
+Adapted from:
+From 8bc7dfd16fb95d5585eaaf0cea678ba1f9f4a755 Mon Sep 17 00:00:00 2001
+From: Christian Clauss <cclauss@me.com>
+Date: Mon, 13 Oct 2025 16:56:33 +0200
+Subject: [PATCH] build: test on Python 3.14 release candidate 3
+
+Python v3.14 -- October 7th
+* https://www.python.org/download/pre-releases
+* https://www.python.org/downloads/release/python-3140rc3
+
+PR-URL: https://github.com/nodejs/node/pull/59983
+Reviewed-By: Marco Ippolito <marcoippolito54@gmail.com>
+Reviewed-By: Stefan Stojanovic <stefan.stojanovic@janeasystems.com>
+Reviewed-By: Stewart X Addison <sxa@redhat.com>
+---
+
+diff --git a/configure b/configure
+index 412f0b416e79c3..0d8f79ba9ab396 100755
+--- a/third_party/electron_node/configure
++++ a/third_party/electron_node/configure
+@@ -4,6 +4,7 @@
+ # Note that the mix of single and double quotes is intentional,
+ # as is the fact that the ] goes on a new line.
+ _=[ 'exec' '/bin/sh' '-c' '''
++command -v python3.14 >/dev/null && exec python3.14 "$0" "$@"
+ command -v python3.13 >/dev/null && exec python3.13 "$0" "$@"
+ command -v python3.12 >/dev/null && exec python3.12 "$0" "$@"
+ command -v python3.11 >/dev/null && exec python3.11 "$0" "$@"
+@@ -22,7 +23,7 @@ except ImportError:
+   from distutils.spawn import find_executable as which
+ 
+ print('Node.js configure: Found Python {}.{}.{}...'.format(*sys.version_info))
+-acceptable_pythons = ((3, 13), (3, 12), (3, 11), (3, 10), (3, 9), (3, 8))
++acceptable_pythons = ((3, 14), (3, 13), (3, 12), (3, 11), (3, 10), (3, 9), (3, 8))
+ if sys.version_info[:2] in acceptable_pythons:
+   import configure
+ else:

--- a/srcpkgs/electron39/files/patches/chromium-sandbox-membarrier.patch
+++ b/srcpkgs/electron39/files/patches/chromium-sandbox-membarrier.patch
@@ -1,0 +1,10 @@
+--- a/sandbox/linux/seccomp-bpf-helpers/syscall_sets.cc
++++ b/sandbox/linux/seccomp-bpf-helpers/syscall_sets.cc
+@@ -370,6 +370,7 @@
+   switch (sysno) {
+     case __NR_exit:
+     case __NR_exit_group:
++    case __NR_membarrier:
+     case __NR_wait4:
+     case __NR_waitid:
+ #if defined(__i386__)

--- a/srcpkgs/electron39/files/patches/chromium-systypes.patch
+++ b/srcpkgs/electron39/files/patches/chromium-systypes.patch
@@ -1,0 +1,11 @@
+--- a/base/third_party/symbolize/symbolize.h
++++ b/base/third_party/symbolize/symbolize.h
+@@ -58,6 +58,8 @@
+ #include "config.h"
+ #include "glog/logging.h"
+ 
++#include <sys/types.h>
++
+ #ifdef HAVE_SYMBOLIZE
+ 
+ #if defined(__ELF__)  // defined by gcc

--- a/srcpkgs/electron39/files/patches/chromium-unbundled-cross-toolchain.patch
+++ b/srcpkgs/electron39/files/patches/chromium-unbundled-cross-toolchain.patch
@@ -1,0 +1,12 @@
+--- a/build/toolchain/linux/unbundle/BUILD.gn.orig
++++ b/build/toolchain/linux/unbundle/BUILD.gn
+@@ -35,7 +35,7 @@
+   extra_ldflags = getenv("BUILD_LDFLAGS")
+ 
+   toolchain_args = {
+-    current_cpu = current_cpu
+-    current_os = current_os
++    current_cpu = host_cpu
++    current_os = host_os
+   }
+ }

--- a/srcpkgs/electron39/files/patches/chromium-webrtc-size_t.patch
+++ b/srcpkgs/electron39/files/patches/chromium-webrtc-size_t.patch
@@ -1,0 +1,10 @@
+--- a/third_party/webrtc/modules/audio_processing/aec3/clockdrift_detector.h	2020-08-10 20:42:29.000000000 +0200
++++ b/third_party/webrtc/modules/audio_processing/aec3/clockdrift_detector.h	2020-09-04 12:47:07.014833633 +0200
+@@ -12,6 +12,7 @@
+ #define MODULES_AUDIO_PROCESSING_AEC3_CLOCKDRIFT_DETECTOR_H_
+ 
+ #include <array>
++#include <cstddef>
+ 
+ namespace webrtc {
+ 

--- a/srcpkgs/electron39/files/patches/electron-Build-fixes.patch.patch
+++ b/srcpkgs/electron39/files/patches/electron-Build-fixes.patch.patch
@@ -1,0 +1,12 @@
+diff --git a/build/npm.gni b/build/npm.gni
+index a1987d095..fb33a14c3 100644
+--- a/build/npm.gni
++++ b/build/npm.gni
+@@ -35,7 +35,6 @@ template("npm_action") {
+     if (!defined(deps)) {
+       deps = []
+     }
+-    deps += [ ":npm_pre_flight_" + target_name ]
+ 
+     script = "//electron/build/npm-run.py"
+     args = [

--- a/srcpkgs/electron39/files/patches/electron-exclude-content-test-patches.patch
+++ b/srcpkgs/electron39/files/patches/electron-exclude-content-test-patches.patch
@@ -1,0 +1,10 @@
+--- electron/script/apply_all_patches.py	2024-02-14 19:35:26.000000000 +0100
++++ -	2024-02-19 12:58:37.818075522 +0100
+@@ -22,6 +22,7 @@
+     patch_data=patch_from_dir(patch_dir),
+     repo=repo,
+     threeway=THREEWAY,
++    exclude=['third_party/blink/tools/**', 'test/mjsunit/**', 'content/test/**', 'test/cctest/**', 'test/unit  tests/**', 'third_party/blink/web_tests/**', '.gitignore'],
+   )
+ 
+ def apply_config(config):

--- a/srcpkgs/electron39/files/patches/electron-no-need-for-husky.patch
+++ b/srcpkgs/electron39/files/patches/electron-no-need-for-husky.patch
@@ -1,0 +1,10 @@
+--- a/package.json	2022-07-06 17:31:50.000000000 +0200
++++ -	2022-07-08 23:04:43.654812957 +0200
+@@ -98,7 +98,6 @@
+     "precommit": "node -e 'process.exit(0)'",
+     "preinstall": "npm run create-typescript-definitions",
+     "prepack": "check-for-leaks",
+-    "prepare": "husky",
+     "repl": "node ./script/start.js --interactive",
+     "start": "node ./script/start.js",
+     "test": "node ./script/spec-runner.js",

--- a/srcpkgs/electron39/files/patches/unbundled-cross-toolchain.patch
+++ b/srcpkgs/electron39/files/patches/unbundled-cross-toolchain.patch
@@ -1,0 +1,12 @@
+--- a/build/toolchain/linux/unbundle/BUILD.gn.orig
++++ b/build/toolchain/linux/unbundle/BUILD.gn
+@@ -35,7 +35,7 @@
+   extra_ldflags = getenv("BUILD_LDFLAGS")
+ 
+   toolchain_args = {
+-    current_cpu = current_cpu
+-    current_os = current_os
++    current_cpu = host_cpu
++    current_os = host_os
+   }
+ }

--- a/srcpkgs/electron39/template
+++ b/srcpkgs/electron39/template
@@ -1,0 +1,480 @@
+# Template file for 'electron39'
+pkgname=electron39
+version=39.2.3
+revision=1
+_nodever=22.21.1
+_chromiumver=142.0.7444.175
+archs="x86_64* aarch64*"
+create_wrksrc=yes
+build_wrksrc="src"
+_llvmver=21
+hostmakedepends="
+ $(vopt_if clang "clang${_llvmver} lld${_llvmver} llvm${_llvmver} compiler-rt${_llvmver}")
+ pkg-config perl gperf bison ninja nodejs hwids which git yarn jq
+ python3 libepoxy-devel libevent-devel libglib-devel rust rust-bindgen
+ gn"
+makedepends="libpng-devel gtk+3-devel nss-devel pciutils-devel
+ libXi-devel libgcrypt-devel cups-devel elfutils-devel
+ libXcomposite-devel speech-dispatcher-devel libXrandr-devel mit-krb5-devel
+ libXScrnSaver-devel alsa-lib-devel libdrm-devel
+ libxml2-devel libxslt-devel $(vopt_if pulseaudio pulseaudio-devel) libexif-devel
+ libXcursor-devel libflac-devel speex-devel libmtp-devel libwebp-devel
+ libjpeg-turbo-devel libevent-devel json-c-devel minizip-devel jsoncpp-devel
+ zlib-devel libcap-devel libXdamage-devel fontconfig-devel freetype-devel opus-devel libffi-devel
+ libva-devel libuv-devel c-ares-devel libnotify-devel
+ $(vopt_if pipewire pipewire-devel) wayland-devel libcurl-devel libxshmfence-devel
+ compiler-rt${_llvmver} rust-std"
+short_desc="Cross platform application framework based on web technologies"
+maintainer="Duncaen <duncaen@voidlinux.org>"
+license="BSD-3-Clause"
+homepage="https://electronjs.org"
+distfiles=" https://ayakael.net/api/packages/mirrors/generic/electron/v${version}/electron-v${version}-${_chromiumver}.tar.zst
+ https://github.com/nodejs/node/archive/v${_nodever}.tar.gz>node-${_nodever}.tar.gz"
+checksum="eb5e9d1a5dbc9b724da8ce481bdc0472cd6ae202db4e57a94f316bbef6584ebf
+ 4b5ad1795fb6adfb1862df9a626bdca85185866fcd7d0313e87a347eec293fd8"
+
+if [ "$XBPS_LIBC" = musl ]; then
+	hostmakedepends+=" musl-legacy-compat"
+fi
+
+if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
+	makedepends+=" musl-legacy-compat"
+fi
+
+no_generic_pkgconfig_link=yes
+lib32disabled=yes
+
+build_options="clang libcxx debug vaapi pulseaudio sndio pipewire lto drumbrake"
+build_options_default="clang libcxx vaapi pulseaudio pipewire"
+desc_option_clang="Use clang to build"
+desc_option_libcxx="Use bundled libc++"
+desc_option_debug="Build with debug symbols"
+desc_option_pipewire="Enable support for screen sharing for WebRTC via PipeWire"
+desc_option_drumbrake="WebAssembly Interpreter"
+
+if [ "$CROSS_BUILD" ]; then
+	hostmakedepends+=" libX11-devel libxcb-devel pciutils-devel libXext-devel libglvnd-devel
+	 libjpeg-turbo-devel libXi-devel nss-devel libpng-devel libwebp-devel
+	 libxml2-devel $(vopt_if pulseaudio pulseaudio-devel) libxslt-devel libxkbcommon-devel
+	 $(vopt_if pipewire pipewire-devel) opus-devel pango-devel libva-devel
+	 libcurl-devel libXrandr-devel libXcomposite-devel cups-devel
+	 mit-krb5-devel alsa-lib-devel libXdamage-devel libepoxy-devel libevdev-devel
+	 libavif-devel libaom-devel libdav1d-devel libflac-devel
+	 libdrm-devel libgbm-devel"
+fi
+
+if [ ! "$XBPS_WORDSIZE" = "$XBPS_TARGET_WORDSIZE" ]; then
+	broken="chromium (v8) can only be cross compiled if word size matches"
+fi
+
+if [ "$CROSS_BUILD" ]; then
+	case "${XBPS_TARGET_MACHINE}" in
+		#aarch64*) ;;
+		*) nocross="chromium can not be cross compiled for this architecture" ;;
+	esac
+fi
+
+_buildtype=Release
+
+_setup_clang() {
+	export CC=clang
+	export CXX=clang++
+	export AR=llvm-ar
+	export NM=llvm-nm
+	export CFLAGS="-Wno-unknown-warning-option -fdebug-prefix-map=$wrksrc=."
+	export CXXFLAGS="-Wno-unknown-warning-option -fdebug-prefix-map=$wrksrc=."
+	export LDFLAGS=""
+	export BUILD_CC=clang
+	export BUILD_CXX=clang++
+	export BUILD_AR=llvm-ar
+	export BUILD_NM=llvm-nm
+	export BUILD_CFLAGS="-Wno-unknown-warning-option"
+	export BUILD_CXXFLAGS="-Wno-unknown-warning-option"
+	if [[ -n "$CROSS_BUILD" ]]; then
+		CFLAGS+=" --sysroot=${XBPS_CROSS_BASE}"
+		CXXFLAGS+=" --sysroot=${XBPS_CROSS_BASE}"
+		LDFLAGS+=" --sysroot=${XBPS_CROSS_BASE}"
+		if [[ -z "$build_option_libcxx" ]]; then
+			local gcc_version=$(gcc -dumpversion)
+			local clang_version=$(clang -dumpversion)
+			CFLAGS+=" --gcc-toolchain=/usr"
+			CFLAGS+=" -nostdinc"
+			CFLAGS+=" -isystem ${XBPS_CROSS_BASE}/usr/include"
+			CFLAGS+=" -isystem /usr/lib/clang/${clang_version}/include"
+			CXXFLAGS+=" --gcc-toolchain=/usr"
+			CXXFLAGS+=" -nostdinc++"
+			CXXFLAGS+=" -isystem ${XBPS_CROSS_BASE}/usr/include/c++/${gcc_version%.*}"
+			CXXFLAGS+=" -isystem ${XBPS_CROSS_BASE}/usr/include/c++/${gcc_version%.*}/${XBPS_CROSS_TRIPLET}"
+			CXXFLAGS+=" -isystem ${XBPS_CROSS_BASE}/usr/include/c++/${gcc_version%.*}/backward"
+			CXXFLAGS+=" -nostdinc"
+			CXXFLAGS+=" -isystem ${XBPS_CROSS_BASE}/usr/include"
+			CXXFLAGS+=" -isystem /usr/lib/clang/${clang_version}/include"
+			LDFLAGS+=" --gcc-toolchain=/usr"
+		fi
+	fi
+}
+
+_setup_toolchain() {
+	if [ "$build_option_clang" ]; then
+		_setup_clang
+	fi
+}
+
+_apply_patch() {
+	local args="$1" pname="$(basename $2)"
+
+	if [ ! -f ".${pname}_done" ]; then
+		if [ -f "${2}.args" ]; then
+			args=$(<"${2}.args")
+		fi
+		msg_normal "$pkgver: patching: ${pname}.\n"
+		patch -N $args -i $2
+		touch .${pname}_done
+	fi
+}
+
+_git_am() {
+	local pname="$(basename $1)"
+
+	if [ ! -f ".${pname}_done" ]; then
+		msg_normal "$pkgver: patching: ${pname}.\n"
+		git -c 'user.name=Electron build' -c 'user.email=electron@ebuild' \
+			am --exclude "third_party/blink/tools/**" \
+			--exclude "test/mjsunit/**" --exclude "content/test/**" \
+			--exclude "test/cctest/**" --exclude "test/unittests/**" \
+			--exclude "third_party/blink/web_tests/**" \
+			--exclude "chrome/test/**" \
+			$1
+		touch .${pname}_done
+	fi
+}
+
+
+_get_chromium_arch() {
+	case "$1" in
+		x86_64*) echo x64 ;;
+		i686*) echo x86 ;;
+		arm*) echo arm ;;
+		aarch64*) echo arm64 ;;
+		ppc64*) echo ppc64 ;;
+		ppc*) echo ppc ;;
+		mipsel*) echo mipsel ;;
+		mips*) echo mips ;;
+		*) msg_error "$pkgver: cannot be compiled for ${XBPS_TARGET_MACHINE}.\n" ;;
+	esac
+}
+
+post_extract() {
+	mv "electron-v${version}-${_chromiumver}" src
+	mv "node-${_nodever}" src/third_party/electron_node
+}
+
+_git_init() {
+	repopath="$1"
+	cd "${wrksrc}/${repopath}"
+	rm -rf ".git"
+	git init -q
+	git config "gc.auto" 0
+	if [ "$repopath" != "src" ]; then
+		echo "/${repopath#src/}" >> "$wrksrc/$build_wrksrc/.gitignore"
+	fi
+	pwd
+	ls
+	git add .
+	git -c 'user.name=Electron build' \
+		-c 'user.email=electron@ebuild' \
+		commit --allow-empty -q -m "init"
+
+}
+
+post_patch() {
+	cd "$wrksrc"
+	for x in $FILESDIR/patches/*.patch; do
+		case "${x##*/}" in
+			electron*.patch)
+				_apply_patch "-d src/electron -p1" "$x"
+		esac
+	done
+
+	for x in $FILESDIR/patches/*; do
+		case "${x##*/}" in
+			chromium*.patch)
+				cd src
+				_apply_patch -p1 "$x"
+				cd "$wrksrc"
+				;;
+		esac
+	done
+
+	if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
+		for x in $FILESDIR/musl-patches/*; do
+			case "${x##*/}" in
+				chromium*.patch)
+					cd src
+					_apply_patch -p1 "$x"
+					cd "$wrksrc"
+					;;
+				electron*.patch)
+					cd src/electron
+					_apply_patch -p1 "$x"
+					cd "$wrksrc"
+					;;
+			esac
+		done
+	fi
+
+	vsed -i 's/OFFICIAL_BUILD/GOOGLE_CHROME_BUILD/' \
+		src/tools/generate_shim_headers/generate_shim_headers.py
+}
+
+pre_configure() {
+	local system=()
+
+	# https://groups.google.com/a/chromium.org/d/topic/chromium-packagers/9JX1N2nf4PU/discussion
+	touch chrome/test/data/webui/i18n_process_css_test.html
+	# Use the file at run time instead of effectively compiling it in
+	sed 's|//third_party/usb_ids/usb.ids|/usr/share/hwdata/usb.ids|g' \
+		-i services/device/public/cpp/usb/BUILD.gn
+
+	mkdir -p third_party/node/linux/node-linux-x64/bin
+	ln -sf /usr/bin/node third_party/node/linux/node-linux-x64/bin/
+	rm -f third_party/devtools-frontend/src/third_party/esbuild/esbuild
+
+	if false; then
+		# compile gn early, so it can be used to generate gni stuff
+		AR="ar" CC=$CC_FOR_BUILD CXX=$CXX_FOR_BUILD LD=$CXX_FOR_BUILD \
+			CFLAGS=$CFLAGS_FOR_BUILD CXXFLAGS=$CXXFLAGS_FOR_BUILD LDFLAGS=$LDFLAGS_FOR_BUILD \
+			tools/gn/bootstrap/bootstrap.py ${makejobs} --skip-generate-buildfiles
+	fi
+
+	# reusable system library settings
+	# libcxx
+	# snappy System snappy is linked against libstdc++ and not CR libcxx
+	# ffmpeg
+	system=(
+		flac
+		fontconfig
+		freetype
+		libdrm
+		libjpeg
+		libpng
+		libwebp
+		libxml
+		libxslt
+		opus
+	)
+
+	# remove build scripts for system provided dependencies - basically does the
+	# same as the bundeled script to remove bundeled libs, but this way we don't
+	# have to list the remaining libs
+	for LIB in "${system[@]}" libjpeg_turbo; do
+		msg_normal "Removing buildscripts for system provided $LIB\n"
+		find "third_party/$LIB" -type f \
+			\! -path "third_party/$LIB/chromium/*" \
+			\! -path "third_party/$LIB/google/*" \
+			\! -path './base/third_party/icu/*' \
+			\! -path './third_party/harfbuzz-ng/utils/hb_scoped.h' \
+			\! -regex '.*\.\(gn\|gni\|isolate\)' \
+			-delete || :
+	done
+
+
+	# switch to system provided dependencies
+	build/linux/unbundle/replace_gn_files.py --system-libraries "${system[@]}"
+
+	third_party/libaddressinput/chromium/tools/update-strings.py
+
+	# Satisfy some scripts that use git describe to figure out the electron version
+	# cd ${wrksrc}/src/electron
+	# git tag -f "v${version}"
+}
+
+do_configure() {
+	local target_arch="$(_get_chromium_arch ${XBPS_TARGET_MACHINE})"
+	local host_arch="$(_get_chromium_arch ${XBPS_MACHINE})"
+	local conf=()
+
+	cd third_party/electron_node
+	if [ "$CROSS_BUILD" ]; then
+		conf_args=" --dest-cpu=${target_arch} --cross-compiling"
+	fi
+	./configure --prefix=/usr \
+		--shared-zlib \
+		--shared-libuv \
+		--shared-openssl \
+		--shared-cares \
+		--openssl-use-def-ca-store \
+		--without-npm \
+		--without-bundled-v8 \
+		${conf_args}
+
+	cd "$wrksrc/$build_wrksrc"/electron
+	yarn install --frozen-lockfile
+	cd "$wrksrc/$build_wrksrc"
+
+	local clang_version="$(clang -dumpversion)"
+	conf+=(
+		'import("//electron/build/args/release.gn")'
+		"override_electron_version=\"${version}\""
+	)
+	conf+=(
+		'enable_nacl=false'
+
+		'use_sysroot=false'
+
+		'host_pkg_config="/usr/bin/pkg-config"'
+
+		"is_clang=$(vopt_if clang true false)"
+		"use_lld=$(vopt_if clang true false)"
+		'clang_use_chrome_plugins=false'
+		'clang_base_path="/usr"'
+		"clang_cross_path=\"${XBPS_CROSS_BASE}\""
+		"clang_version=\"${clang_version%%.*}\""
+		'use_clang_modules=false' # not yet supported with void's libcxx
+
+		"use_custom_libcxx=$(vopt_if libcxx true false)" # https://github.com/llvm/llvm-project/issues/61705
+
+		'enable_rust=true'
+		'rust_sysroot_absolute="/usr"'
+		"rust_cross_sysroot_absolute=\"${XBPS_CROSS_BASE}\""
+		'rust_bindgen_root="/usr"'
+		"rustc_version=\"$(rustc --version)\""
+
+		'node_version_check=false'
+
+		# is_debug makes the build a debug build, changes some things.
+		# might be useful for real debugging vs just debug symbols.
+		"is_debug=false"
+		"blink_symbol_level=$(vopt_if debug 1 0)"
+		"symbol_level=$(vopt_if debug 1 0)"
+
+		'icu_use_data_file=true'
+
+		'enable_widevine=false'
+		'enable_hangout_services_extension=true'
+
+		'use_system_harfbuzz=false'
+		'use_system_libffi=true'
+
+		'use_qt5=false'
+		'use_qt6=false'
+
+		'use_cups=true'
+
+		"use_vaapi=$(vopt_if vaapi true false)"
+
+		"use_pulseaudio=$(vopt_if pulseaudio true false)"
+		"link_pulseaudio=$(vopt_if pulseaudio true false)"
+
+		"rtc_use_pipewire=$(vopt_if pipewire true false)"
+
+		"v8_enable_drumbrake=$(vopt_if drumbrake true false)"
+
+		# Always support proprietary codecs.
+		# Enable H.264 support in bundled ffmpeg.
+		'proprietary_codecs=true'
+		'ffmpeg_branding="Chrome"'
+
+		# Make sure that -Werror doesn't get added to CFLAGS by the build system.
+		# Depending on GCC version the warnings are different and we don't want
+		# the build to fail because of that.
+		'treat_warnings_as_errors=false'
+		'fatal_linker_warnings=false'
+
+		# Save space by removing DLOG and DCHECK messages (about 6% reduction).
+		# 'logging_like_official_build=true'
+		'disable_fieldtrial_testing_config=true'
+
+		'is_official_build=true'
+
+		# segfaults with llvm-12.0.1
+		'is_cfi=false'
+		'use_cfi_icall=false'
+
+		"use_thin_lto=$(vopt_if lto true false)"
+		'chrome_pgo_phase=0'
+	)
+
+	if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
+		conf+=( 'is_musl=true' )
+	fi
+
+	if [ "$CROSS_BUILD" ]; then
+		conf+=(
+			'custom_toolchain="//build/toolchain/linux/unbundle:default"'
+			'host_toolchain="//build/toolchain/linux/unbundle:host"'
+			'v8_snapshot_toolchain="//build/toolchain/linux/unbundle:v8_snapshot_cross"'
+		)
+	else
+		conf+=(
+			'custom_toolchain="//build/toolchain/linux/unbundle:default"'
+			'host_toolchain="//build/toolchain/linux/unbundle:default"'
+		)
+	fi
+
+	conf+=(
+		"target_cpu=\"$target_arch\""
+		"host_cpu=\"$host_arch\""
+	)
+
+	_setup_toolchain
+	if false; then
+		out/Release/gn gen out/Release --args="${conf[*]}"
+	else
+		gn gen out/Release --args="${conf[*]}"
+	fi
+}
+
+do_build() {
+	# XXX: need for error: the option `Z` is only accepted on the nightly compiler
+	export RUSTC_BOOTSTRAP=1
+	export ELECTRON_OUT_DIR="${wrksrc}/${build_wrksrc}/out/${_buildtype}/"
+
+	_setup_toolchain
+	msg_normal "Ninja turtles GO!\n"
+	CCACHE_SLOPPINESS=include_file_mtime ninja ${makejobs} -C out/$_buildtype \
+		copy_node_headers version electron chromium_licenses
+}
+
+do_install() {
+	vmkdir /usr/lib/$pkgname
+	vmkdir /usr/include/$pkgname
+
+	for f in out/$_buildtype/*.bin out/$_buildtype/*.pak out/$_buildtype/icudtl.dat; do
+		vinstall $f 0644 usr/lib/$pkgname
+	done
+	vinstall out/$_buildtype/resources/default_app.asar 0644 usr/lib/$pkgname/resources
+
+
+	vcopy out/$_buildtype/locales usr/lib/$pkgname
+	rm -v ${DESTDIR}/usr/lib/$pkgname/locales/*.pak.info
+
+	vinstall out/$_buildtype/electron 0755 usr/lib/$pkgname
+	vinstall out/$_buildtype/chrome_crashpad_handler 0755 usr/lib/$pkgname
+	vinstall out/$_buildtype/libEGL.so 0755 usr/lib/$pkgname
+	vinstall out/$_buildtype/libGLESv2.so 0755 usr/lib/$pkgname
+	vinstall out/$_buildtype/libvulkan.so.1 0755 usr/lib/$pkgname
+	vinstall out/$_buildtype/libffmpeg.so 0755 usr/lib/$pkgname
+	vinstall out/$_buildtype/libvk_swiftshader.so 0755 usr/lib/$pkgname
+	vinstall out/$_buildtype/vk_swiftshader_icd.json 0644 usr/lib/$pkgname
+	vinstall out/$_buildtype/version 0644 usr/lib/$pkgname
+	vinstall out/$_buildtype/LICENSES.chromium.html 0644 usr/lib/$pkgname
+
+	vcopy out/$_buildtype/gen/node_headers usr/include/$pkgname
+	ln -sv /usr/include/$pkgname/node_headers/include/node ${DESTDIR}/usr/include/$pkgname/node
+
+	vlicense ${wrksrc}/src/LICENSE chromium.LICENSE
+	vlicense ${wrksrc}/src/electron/LICENSE electron.LICENSE
+	vlicense ${wrksrc}/src/third_party/electron_node/LICENSE node.LICENSE
+
+	vmkdir /usr/bin
+	ln -s ../lib/$pkgname/electron "$DESTDIR"/usr/bin/$pkgname
+}
+
+electron39-devel_package() {
+	depends="${sourcepkg}>=${version}_${revision}"
+	short_desc+=" - development files"
+	pkg_install() {
+		vmove usr/include
+	}
+}

--- a/srcpkgs/electron39/update
+++ b/srcpkgs/electron39/update
@@ -1,0 +1,2 @@
+site=https://www.electronjs.org/releases/stable?version=${version%%.*}
+pattern='tag/v\K[\d\.]+(?=")'

--- a/srcpkgs/element-desktop/template
+++ b/srcpkgs/element-desktop/template
@@ -1,8 +1,8 @@
 # Template file for 'element-desktop'
 pkgname=element-desktop
 version=1.12.1
-revision=1
-_electronver=35
+revision=2
+_electronver=39
 create_wrksrc=yes
 build_helper="rust"
 conf_files="/etc/element-desktop/config.json"
@@ -86,7 +86,7 @@ do_build() {
 	ELECTRON_RUN_AS_NODE=1 IS_TASJE=1 node -e 'console.log(JSON.stringify(require("./electron-builder.js").default))' | awk '/^{/{x=1} x' >electron-builder.json
 
 	yarn install --frozen-lockfile --ignore-scripts --production
-	npm rebuild keytar-forked --nodedir=/usr/include/electron35/node_headers --build-from-source
+	npm rebuild keytar-forked --nodedir=/usr/include/electron${_electronver}/node_headers --build-from-source
 
 	# stripping in build because it gets into asar
 	/usr/bin/$STRIP node_modules/keytar-forked/build/Release/keytar.node

--- a/srcpkgs/vscode/template
+++ b/srcpkgs/vscode/template
@@ -1,8 +1,8 @@
 # Template file for 'vscode'
 pkgname=vscode
 version=1.100.3
-revision=1
-_electronver=35.7.2
+revision=2
+_electronver=39.2.3
 _npmver=10.8.3
 hostmakedepends="pkg-config python3 python3-setuptools nodejs tar git ripgrep"
 makedepends="libxkbfile-devel libsecret-devel libxml2-devel mit-krb5-devel nodejs-devel ncurses-devel electron${_electronver%%.*}-devel"

--- a/srcpkgs/wire-desktop/template
+++ b/srcpkgs/wire-desktop/template
@@ -1,8 +1,8 @@
 # Template file for 'wire-desktop'
 pkgname=wire-desktop
 version=3.40.3718
-revision=1
-_electronver=35
+revision=2
+_electronver=39
 hostmakedepends="nodejs yarn git"
 makedepends="electron${_electronver}-devel"
 depends="electron${_electronver}"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES** — vscode, element-desktop
- **briefly** — wire-desktop (opens, loads the default page, but I don't really have a means of using it the intended way)

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl (not used the packages with it)

Keeps v35 in current state, though it FTBFS and would probably make sense to remove if this is merged.

cc: @Duncaen as maintainer of electron35 and chromium (which are what I based off of and where I honestly lifted most, if not all, patches from, respectively)