### PR TITLE
New package: envision-3.2.0

### DIFF
--- a/srcpkgs/envision/patches/libclang.patch
+++ b/srcpkgs/envision/patches/libclang.patch
@@ -1,0 +1,12 @@
+--- a/src/depcheck/mod.rs
++++ b/src/depcheck/mod.rs
+@@ -154,6 +154,9 @@ fn shared_obj_paths() -> Vec<String> {
+         "/usr/lib/llvm/18/lib64".into(),
+         "/usr/lib/llvm/19/lib64".into(),
+         "/usr/lib/llvm/20/lib64".into(),
++        // Void puts libclang >= 19 in /usr/lib/llvm/[llvm major version]/lib.
++        "/usr/lib/llvm/19/lib".into(),
++        "/usr/lib/llvm/21/lib".into(),
+         "/lib/x86_64-linux-gnu".into(),
+         "/lib/aarch64-linux-gnu".into(),
+         "/app/lib".into(),

--- a/srcpkgs/envision/template
+++ b/srcpkgs/envision/template
@@ -1,0 +1,20 @@
+# Template file for 'envision'
+pkgname=envision
+version=3.2.0
+revision=1
+build_style=meson
+build_helper="rust"
+configure_args="-Dprofile=release"
+hostmakedepends="rust cargo pkg-config gettext desktop-file-utils"
+makedepends="libgit2-1.8-devel gtk4-devel libadwaita-devel libdrm-devel vte3-gtk4-devel openxr-devel"
+depends="polkit"
+short_desc="Orchestrator for the free XR stack"
+maintainer="Lennart Kroll <void@lennyboy.anonaddy.com>"
+license="AGPL-3.0-or-later"
+homepage="https://gitlab.com/gabmus/envision"
+distfiles="https://gitlab.com/gabmus/envision/-/archive/${version}/envision-${version}.tar.gz"
+checksum="8a03113487e19e3b1d7c6d99cd2e73d2580b5550957e64dcf9260c45453fdd3f"
+
+post_install() {
+	vlicense LICENSE
+}


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc

This PR adds a package for Envision (https://gitlab.com/gabmus/envision) which is otherwise only available as an Appimage. This native package has a couple of benefits like better desktop integration (correct scaling) and working "open folder" buttons which won't be fixed in the Appimage (see https://gitlab.com/gabmus/envision/-/issues/96).

The libclang patch is necessary for the included dependency checker to work in the current release, but is already merged and will therefore not be necessary in the next tagged release, see [MR](https://gitlab.com/gabmus/envision/-/merge_requests/140).