### PR TITLE
gitui: update to 0.28.0

### DIFF
--- a/srcpkgs/gitui/template
+++ b/srcpkgs/gitui/template
@@ -1,6 +1,6 @@
 # Template file for 'gitui'
 pkgname=gitui
-version=0.27.0
+version=0.28.0
 revision=1
 build_style=cargo
 configure_args="--no-default-features --features ghemoji,regex-onig"
@@ -12,7 +12,7 @@ license="MIT"
 homepage="https://github.com/gitui-org/gitui"
 changelog="https://raw.githubusercontent.com/gitui-org/gitui/master/CHANGELOG.md"
 distfiles="https://github.com/gitui-org/gitui/archive/v${version}.tar.gz"
-checksum=55a85f4a3ce97712b618575aa80f3c15ea4004d554e8899669910d7fb4ff6e4b
+checksum=3d7d1deef84b8cb3f59882b57b9a70d39ddd6491bd4539504d69b2b3924c044f
 
 export GITUI_RELEASE=1
 


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
