### PR TITLE
rofi-calc: update to 2.5.0.

### DIFF
--- a/srcpkgs/rofi-calc/template
+++ b/srcpkgs/rofi-calc/template
@@ -1,6 +1,6 @@
 # Template file for 'rofi-calc'
 pkgname=rofi-calc
-version=2.4.0
+version=2.5.0
 revision=1
 build_style=meson
 hostmakedepends="pkg-config"
@@ -10,8 +10,9 @@ short_desc="Do live calcualtions in rofi"
 maintainer="Alexander Gehrke <void@qwertyuiop.de>"
 license="MIT"
 homepage="https://github.com/svenstaro/rofi-calc"
+changelog="https://raw.githubusercontent.com/svenstaro/rofi-calc/refs/heads/master/CHANGELOG.md"
 distfiles="${homepage}/archive/v${version}.tar.gz"
-checksum=ed00fb98376c4e36830a890f1c40fac725cfe2b1ce13cab9edfa9f7c8417730b
+checksum=92cf4a1b2a42067d162cc7e87556644dab5db335cb3a65bc30e97467d7347b75
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**
  - Simple bump, works perfectly fine. (Additionally added the missing changelog section)

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64
