### PR TITLE
pika-backup: update to 0.7.5.

### DIFF
--- a/srcpkgs/pika-backup/patches/never-type-fallback.patch
+++ b/srcpkgs/pika-backup/patches/never-type-fallback.patch
@@ -1,0 +1,25 @@
+From 842d93d65a342985bf6d7d8cacd5b38ea508df2e Mon Sep 17 00:00:00 2001
+From: Sophie Herold <sophie@hemio.de>
+Date: Mon, 23 Sep 2024 22:23:31 +0200
+Subject: [PATCH] code: Don't assume `!` getting interpreted as `()`
+
+Makes code future proof
+---
+ src/borg/functions.rs | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/borg/functions.rs b/src/borg/functions.rs
+index 28f134b3e..439516f64 100644
+--- a/src/borg/functions.rs
++++ b/src/borg/functions.rs
+@@ -102,7 +102,7 @@ impl CommandRun<task::PruneInfo> for Command<task::PruneInfo> {
+         let mut borg_call = prune_call(&self).await?;
+         borg_call.add_options(["--dry-run", "--list"]);
+ 
+-        borg_call.output(&self.communication).await?;
++        borg_call.output::<_, ()>(&self.communication).await?;
+ 
+         let messages = self
+             .communication
+-- 
+GitLab

--- a/srcpkgs/pika-backup/template
+++ b/srcpkgs/pika-backup/template
@@ -1,6 +1,6 @@
 # Template file for 'pika-backup'
 pkgname=pika-backup
-version=0.7.4
+version=0.7.5
 revision=1
 build_style=meson
 build_helper=rust
@@ -14,7 +14,7 @@ license="GPL-3.0-or-later"
 homepage="https://apps.gnome.org/en/PikaBackup/"
 changelog="https://gitlab.gnome.org/World/pika-backup/-/raw/main/CHANGELOG.md"
 distfiles="https://gitlab.gnome.org/World/pika-backup/-/archive/v${version}/pika-backup-v${version}.tar.gz"
-checksum=80952f0b297d4269ff9080919e4d08ccbc1a4f50582f41f100c1296cc1a68abf
+checksum=16891d971e399384a2f188c0cb51c40b3c03a3514f8e4482239b4669f9689bc1
 make_check_pre="xvfb-run"
 
 post_patch() {


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):

#### Note:
Includes `never-type-fallback.patch`, resolved in upstream/main.
To be removed whenever upstream backports this into 0.7.x.