### PR TITLE
spotify: update to 1.2.79

### DIFF
--- a/srcpkgs/spotify/template
+++ b/srcpkgs/spotify/template
@@ -1,8 +1,8 @@
 # Template file for 'spotify'
 pkgname=spotify
-version=1.2.63
+version=1.2.79
 revision=1
-_subver=394.g126b0d89
+_subver=425.g1d0fcf61
 archs="x86_64"
 create_wrksrc=yes
 hostmakedepends="libcurl"
@@ -12,7 +12,7 @@ maintainer="Stefan Mühlinghaus <jazzman@alphabreed.com>"
 license="custom:Proprietary"
 homepage="https://www.spotify.com"
 distfiles="http://repository.spotify.com/pool/non-free/s/spotify-client/spotify-client_${version}.${_subver}_amd64.deb"
-checksum=99c229f829ccb9c2a188be80d1241d2b8c8fd35f1e8d773438c0f612d68e940e
+checksum=9843c7aeddffbd02ea7b0212231bda1f85904995e57bed612d3a38de6e13efe8
 repository=nonfree
 restricted=yes
 nostrip=yes


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)

Lossless audio works which I think is the only major change since the last update.

*EDIT*: Pinging maintainer @teh-jazzman 