### PR TITLE
oversteer: rebuild for python3.14

### DIFF
--- a/srcpkgs/oversteer/template
+++ b/srcpkgs/oversteer/template
@@ -1,7 +1,7 @@
 # Template file for 'oversteer'
 pkgname=oversteer
 version=0.8.3
-revision=2
+revision=3
 build_style=meson
 hostmakedepends="pkg-config gettext desktop-file-utils"
 makedepends="eudev-libudev-devel"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
