### PR TITLE
sysdig: remove go from deps

### DIFF
--- a/srcpkgs/sysdig/template
+++ b/srcpkgs/sysdig/template
@@ -14,7 +14,7 @@ configure_args="-DSYSDIG_VERSION=${version} -DUSE_BUNDLED_DEPS=OFF
  -DCMAKE_CXX_STANDARD=17 -DCMAKE_CXX_EXTENSIONS=OFF
  -DDRIVER_VERSION=${_falcover}"
 # bpftool needs updated
-hostmakedepends="wget pkg-config protobuf clang uthash go"
+hostmakedepends="wget pkg-config protobuf clang uthash"
 makedepends="LuaJIT-devel c-ares-devel elfutils-devel grpc-devel jsoncpp-devel
  libcurl-devel libprotoc-devel openssl-devel ncurses-devel protobuf-devel
  libb64-devel tbb-devel zlib-devel yaml-cpp-devel json-c++ jq-devel


### PR DESCRIPTION
https://github.com/void-linux/void-packages/pull/58098

@sgn accidentally left `go` in deps for sysdig, my bad
