### PR TITLE
rosegarden: update to 25.12

### DIFF
--- a/srcpkgs/rosegarden/template
+++ b/srcpkgs/rosegarden/template
@@ -1,12 +1,13 @@
 # Template file for 'rosegarden'
 pkgname=rosegarden
-version=25.06
+version=25.12
 revision=1
 build_style=cmake
-hostmakedepends="pkg-config shared-mime-info"
+configure_args="-DUSE_QT6=ON -DQT_HOST_PATH=/usr/lib"
+hostmakedepends="pkg-config qt6-base qt6-tools shared-mime-info"
 makedepends="alsa-lib-devel dssi-devel fftw-devel jack-devel ladspa-sdk liblo-devel
- liblrdf-devel libsamplerate-devel libSM-devel libsndfile-devel lilv-devel qt5-devel
- qt5-tools-devel"
+ liblrdf-devel libsamplerate-devel libSM-devel libsndfile-devel lilv-devel qt6-base-devel
+ qt6-qt5compat-devel"
 depends="shared-mime-info"
 short_desc="Music composition and editing environment"
 maintainer="newbluemoon <blaumolch@mailbox.org>"
@@ -14,8 +15,4 @@ license="GPL-2.0-or-later"
 homepage="http://rosegardenmusic.com/"
 changelog="https://raw.githubusercontent.com/tedfelix/rosegarden-official/master/CHANGELOG"
 distfiles="${SOURCEFORGE_SITE}/rosegarden/rosegarden/${version/*.*.*/${version%.*}}/rosegarden-${version}.tar.xz"
-checksum=75fe52b005899471cc4b0e4954be5d35ee1ce8f41659ab8ef48a26178aa5c36d
-
-if [ -n "${CROSS_BUILD}" ]; then
-	hostmakedepends+=" qt5-devel qt5-host-tools"
-fi
+checksum=970bcd4cc33e4a7d7b3d1cc6d8c09bffbaa5f00a487b965c12f6e8dca8cafa6d


### PR DESCRIPTION
Also switch to QT6.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64 (cross)
  - armv6l (cross)
  - armv7l-musl (cross)
  - x86_64-musl
  - i686

