### PR TITLE
opus: update to 1.6.

### DIFF
--- a/srcpkgs/opus/template
+++ b/srcpkgs/opus/template
@@ -1,15 +1,19 @@
 # Template file for 'opus'
 pkgname=opus
-version=1.5.2
+version=1.6
 revision=1
 build_style=gnu-configure
-configure_args="--enable-dred --enable-osce --enable-custom-modes"
+configure_args="--enable-dred --enable-osce --enable-custom-modes
+	--enable-opus-custom-api $(vopt_enable qext qext)"
 short_desc="Totally open, royalty-free, highly versatile audio codec"
 maintainer="Rutpiv <roger_freitas@live.com>"
 license="BSD-3-Clause"
 homepage="https://www.opus-codec.org/"
 distfiles="https://downloads.xiph.org/releases/opus/opus-${version}.tar.gz"
-checksum=65c1d2f78b9f2fb20082c38cbe47c951ad5839345876e46941612ee87f9a7ce1
+checksum=b7637334527201fdfd6dd6a02e67aceffb0e5e60155bbd89175647a80301c92c
+
+build_options="qext"
+desc_option_qext="Enable scalable quality extension (Opus HD)"
 
 post_install() {
 	vlicense COPYING


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture (x86_64)
- I built this PR locally for these architectures using specific masterdirs:
  - x86_64-musl
  - i686
- I built this PR locally for these architectures (crossbuilds):
  - aarch64
  - aarch64-musl
  - armv7l
  - armv7l-musl
  - armv6l
  - armv6l-musl

---

Expose optional Opus features as build options in the template.

Features such as DRED, OSCE, custom modes, and the Opus custom API are enabled by default to align with the existing build configuration.

The scalable quality extension (Opus HD / qext) is kept disabled by default, as it is still experimental. It remains available as an opt-in build option for users who want to enable it explicitly.