### PR TITLE
keyd: update to 2.6.0

### DIFF
--- a/srcpkgs/keyd/template
+++ b/srcpkgs/keyd/template
@@ -1,6 +1,6 @@
 # Template file for 'keyd'
 pkgname=keyd
-version=2.5.0
+version=2.6.0
 revision=1
 build_style=gnu-makefile
 make_use_env=yes
@@ -10,7 +10,7 @@ license="MIT"
 homepage="https://github.com/rvaiya/keyd"
 changelog="https://raw.githubusercontent.com/rvaiya/keyd/master/docs/CHANGELOG.md"
 distfiles="https://github.com/rvaiya/keyd/archive/refs/tags/v${version}.tar.gz"
-checksum=93ec6c153ef673a7a8b4d8b686494dee11d182513f4531c71dce15a8db7f6c1c
+checksum=697089681915b89d9e98caf93d870dbd4abce768af8a647d54650a6a90744e26
 system_groups="keyd"
 
 post_install() {


### PR DESCRIPTION
#### Testing the changes
- EDIT: I may be experiencing issue similar to: https://github.com/rvaiya/keyd/issues/1181 - waiting for fix by upstream (reverted to 2.5.0 fttb)

#### Local build testing
- I built this PR locally for my native architecture, **x86_64-glibc**

[Changelog](https://raw.githubusercontent.com/rvaiya/keyd/master/docs/CHANGELOG.md)
