### PR TITLE
base-files: change default root shell to bash

### DIFF
--- a/srcpkgs/base-files/files/passwd
+++ b/srcpkgs/base-files/files/passwd
@@ -1,2 +1,2 @@
-root:x:0:0:root:/root:/bin/sh
+root:x:0:0:root:/root:/bin/bash
 nobody:x:99:99:Unprivileged User:/dev/null:/bin/false

--- a/srcpkgs/base-files/template
+++ b/srcpkgs/base-files/template
@@ -1,6 +1,6 @@
 # Template file for 'base-files'
 pkgname=base-files
-version=0.145
+version=0.146
 revision=1
 bootstrap=yes
 depends="xbps-triggers"


### PR DESCRIPTION
as bash is no longer dynmaically linked against readline, there shouldn't be any issue with making the default shell for the root user to bash.

this should have no automatic effect on most existing systems, as `/etc/passwd` is a conf file and almost everyone one will have edited it at some point. users can resolve the `.new` and add it if they wish.

this does **NOT** change the default `/bin/sh` to bash. that is still dash.

#### Testing the changes
- I tested the changes in this PR: **YES**
