### PR TITLE
waydroid: depend on kmod for modprobe

### DIFF
--- a/srcpkgs/waydroid/template
+++ b/srcpkgs/waydroid/template
@@ -1,13 +1,13 @@
 # Template file for 'waydroid'
 pkgname=waydroid
 version=1.6.0
-revision=3
+revision=4
 # https://developer.android.com/ndk/guides/abis#sa
 archs="aarch64* armv7* i686* x86_64*"
 build_style=gnu-makefile
 make_install_args="USE_NFTABLES=1 USE_DBUS_ACTIVATION=0"
 depends="gbinder-python python3-gobject python3-dbus gtk+3 polkit dnsmasq
- nftables lxc"
+ nftables lxc kmod"
 short_desc="Container-based approach to boot a full Android system"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-3.0-or-later"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture (x86_64)
- I built this PR locally for these architectures using specific masterdirs:
  - x86_64-musl
  - i686
- I built this PR locally for these architectures (crossbuilds):
  - aarch64
  - aarch64-musl
  - armv7l
  - armv7l-musl

---

Fixes #58226: add missing kmod runtime dependency for modprobe.