### PR TITLE
conduit: update to 0.10.10

### DIFF
--- a/srcpkgs/conduit/template
+++ b/srcpkgs/conduit/template
@@ -1,6 +1,6 @@
 # Template file for 'conduit'
 pkgname=conduit
-version=0.10.9
+version=0.10.10
 revision=1
 build_style=cargo
 hostmakedepends="clang pkg-config"
@@ -10,7 +10,7 @@ maintainer="Joel Beckmeyer <joel@beckmeyer.us>"
 license="Apache-2.0"
 homepage="https://conduit.rs/"
 distfiles="https://gitlab.com/famedly/conduit/-/archive/v${version}/conduit-v${version}.tar.gz"
-checksum=71aaebbb18b51a1d5f549b5eed88b80c93d6c661c214b5510d3dc3bf79b0e331
+checksum=f8153160fe2f0ecf806cea7a682788e8a2800a944d44cbd9cc45cbcfe8934087
 
 system_accounts="_conduit"
 _conduit_homedir="/var/lib/conduit"


### PR DESCRIPTION
[Release notes](https://gitlab.com/famedly/conduit/-/releases/v0.10.10):

> Fixes a critical security vulnerability, allowing for remote servers to make the Conduit instance to sign arbitrary events. It is recommended you upgrade ASAP.

#### Testing the changes
- I tested the changes in this PR: **YES**, it's up and running.

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
