### PR TITLE
kid3: update to 3.9.7.

### DIFF
--- a/srcpkgs/kid3/template
+++ b/srcpkgs/kid3/template
@@ -1,7 +1,7 @@
 # Template file for 'kid3'
 pkgname=kid3
-version=3.9.6
-revision=3
+version=3.9.7
+revision=1
 build_style=cmake
 configure_args="-DBUILD_WITH_QT6=ON -DWITH_APPS='CLI;$(vopt_if KDE KDE Qt)'
  -DWITH_DOCBOOKDIR=/usr/share/xsl/docbook -DWITH_FLAC=$(vopt_if flac ON OFF)
@@ -21,7 +21,7 @@ license="GPL-2.0-only"
 homepage="https://kid3.kde.org"
 changelog="https://invent.kde.org/multimedia/kid3/-/raw/master/ChangeLog"
 distfiles="${SOURCEFORGE_SITE}/kid3/kid3-${version}.tar.gz"
-checksum=df4a330b874cace7e84beb6d178316f681d09abb94d368c056de7e749ce4dff8
+checksum=392aafb176cc8dc9fdf08364f9bb754913725447b8f3e0e581c1d96c2fc30ae4
 
 build_options="KDE mp3 mp4 flac vorbis taglib chromaprint"
 build_options_default="mp3 mp4 flac vorbis taglib chromaprint"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture (x86_64)
- I built this PR locally for these architectures using specific masterdirs:
  - x86_64-musl
  - i686
- I built this PR locally for these architectures (crossbuilds):
  - aarch64
  - aarch64-musl
  - armv7l
  - armv7l-musl
  - armv6l
  - armv6l-musl
