### PR TITLE
Add application/json

### DIFF
--- a/common/xbps-src/shutils/update_check.sh
+++ b/common/xbps-src/shutils/update_check.sh
@@ -222,7 +222,7 @@ update_check() {
         fi
 
         msg_verbose "fetching $url and scanning with $rx\n"
-        curl "${curlargs[@]}" -H 'Accept: text/html,application/xhtml+xml,application/xml,text/plain,application/rss+xml' "$url" |
+        curl "${curlargs[@]}" -H 'Accept: text/html,application/xhtml+xml,application/xml,text/plain,application/rss+xml,application/json' "$url" |
             grep -Po -i "$rx"
         fetchedurls[$url]=yes
     done |


### PR DESCRIPTION
Added support for application/json content type.
Enabling interaction with APIs like `https://api.github.com/repos/<user>/<repo>/releases/latest`.

#### Testing the changes
- I tested the changes in this PR: **briefly**