### PR TITLE
New package: iscan-plugin-gt-x820-2.2.1

### DIFF
--- a/srcpkgs/iscan-plugin-gt-x820/INSTALL
+++ b/srcpkgs/iscan-plugin-gt-x820/INSTALL
@@ -1,0 +1,5 @@
+if [ "$UPDATE" = "no" ] && [ "$ACTION" = "post" ]; then
+	usr/bin/iscan-registry --add interpreter usb 0x04b8 0x013a \
+		/usr/lib/iscan/libesintA1 /usr/share/iscan/esfwA1.bin
+fi
+

--- a/srcpkgs/iscan-plugin-gt-x820/REMOVE
+++ b/srcpkgs/iscan-plugin-gt-x820/REMOVE
@@ -1,0 +1,7 @@
+if [ "$UPDATE" = "no" ] && [ "$ACTION" = "pre" ]; then
+	# If we're removing sane-epkowa together with this package,
+	# there's no point (and no success) in calling iscan-registry
+	[ -x usr/bin/iscan-registry ] || exit 0
+	usr/bin/iscan-registry --remove interpreter usb 0x04b8 0x013a \
+		/usr/lib/iscan/libesintA1 /usr/share/iscan/esfwA1.bin
+fi

--- a/srcpkgs/iscan-plugin-gt-x820/template
+++ b/srcpkgs/iscan-plugin-gt-x820/template
@@ -1,0 +1,39 @@
+# Template file for 'iscan-plugin-gt-x820'
+pkgname=iscan-plugin-gt-x820
+version=2.2.1
+revision=1
+_bundlever=2.30.4
+archs="i686 x86_64"
+depends="sane-epkowa"
+short_desc="SANE/iscan plugin for Epson GT-X820/Perfection V600 Photo"
+maintainer="yosh <yosh-git@riseup.net>"
+license="custom:EPSON"
+homepage="http://download.ebz.epson.net/dsc/search/01/search/?OSC=LX"
+case "$XBPS_TARGET_MACHINE" in
+	x86_64)
+		_arch=x64
+		_plugin=x86_64
+		checksum=63647dac68e26bfee5bd75108cc6a4df0fddb8453a1e3bac2d63dea7db518bee
+		;;
+	i686)
+		_arch=x86
+		_plugin=i686
+		checksum=20f96a10e99be16a261bb1d716998dc4b041e4abb722228e2a9326db1a83901c
+		;;
+esac
+distfiles="https://download2.ebz.epson.net/iscan/plugin/gt-x820/rpm/${_arch}/iscan-gt-x820-bundle-${_bundlever}.${_arch}.rpm.tar.gz"
+repository=nonfree
+restricted=yes
+
+post_extract() {
+	cd plugins
+	bsdtar -xf iscan-plugin-gt-x820-${version}-1.${_plugin}.rpm
+}
+
+do_install() {
+	cd plugins
+	vlicense usr/share/doc/iscan-plugin-gt-x820-${version}/COPYING.EPSON.en.txt
+	vlicense usr/share/doc/iscan-plugin-gt-x820-${version}/COPYING.EPSON.ja.txt
+	vcopy usr/share/iscan usr/share
+	vcopy usr/lib*/* usr/lib
+}


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**
  - I have a Perfection V600 Photo myself and was able to scan with it using xsane and iscan. 32-bit isn't tested though.

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES** (system-wide library plugin)

#### Local build testing
- My native: `x86_64-glibc`
- `i686-glibc`

merge with/after #58312

note: the absolute paths as arguments to `iscan-registry` in the INSTALL/REMOVE scripts are read at *runtime*, not at install time. if they were relative, they would be read relative to the cwd that SANE is called from, which obviously doesn't work out