### PR TITLE
New package: nouveau-reclocking-1.1

### DIFF
--- a/srcpkgs/nouveau-reclocking/template
+++ b/srcpkgs/nouveau-reclocking/template
@@ -1,0 +1,15 @@
+# Template file for 'nouveau-reclocking'
+pkgname=nouveau-reclocking
+version=1.1
+revision=1
+depends="lua"
+short_desc="Utility for reclocking your GPU with Nouveau"
+maintainer="wbohrer <willbohrer@proton.me>"
+license="GPL-3.0-or-later"
+homepage="https://github.com/ventureoo/nouveau-reclocking"
+distfiles="https://github.com/ventureoo/nouveau-reclocking/archive/v${version}.tar.gz"
+checksum=33940af8f51f22761acdf2425db064cb72a84a27ff72e20e521689851da44a0c
+
+do_install() {
+	vbin src/nouveau-reclocking.lua nouveau-reclocking
+}


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

#### Local build testing
- I built this PR locally for my native architecture (x86_64-musl)

I plan to reference this package in the `nouveau` section of the [NVIDIA driver page](https://github.com/void-linux/void-docs/blob/master/src/config/graphical-session/graphics-drivers/nvidia.md) in the handbook (see [comment in my PR](https://github.com/void-linux/void-docs/pull/875#discussion_r2649330166).

The single source code file shebangs the Lua system binary so the package installs it directly (only 8kb). If anyone knows of a standard directory to store Lua bytecode files please follow-up.