### PR TITLE
New package: xhidecursor-1.0.0

### DIFF
--- a/srcpkgs/xhidecursor/template
+++ b/srcpkgs/xhidecursor/template
@@ -1,0 +1,16 @@
+# Template file for 'xhidecursor'
+pkgname=xhidecursor
+version=1.0.0
+revision=1
+build_style=gnu-makefile
+makedepends="libX11-devel libXi-devel libXfixes-devel"
+short_desc="Minimal X-application which hides the cursor on key-press"
+maintainer="elbachir-one <bachiralfa@gmail.com>"
+license="MIT"
+homepage="https://github.com/astier/xhidecursor"
+distfiles="https://github.com/astier/xhidecursor/archive/refs/tags/${version}.tar.gz"
+checksum=fbb73860520718c9683ac96537eb6b8ca5e71da83cfd0aa7388871eedd43f255
+
+post_install() {
+	vlicense LICENSE
+}


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)