### PR TITLE
epy: add python3-magic as dependency

### DIFF
--- a/srcpkgs/epy/patches/no-imghdr.patch
+++ b/srcpkgs/epy/patches/no-imghdr.patch
@@ -4,7 +4,7 @@
  [tool.poetry.dependencies]
  python = "^3.8"
  windows-curses = { version = "*", markers = "platform_system == 'Windows'" }
-+magic = { version = "*" }
++python-magic = { version = "*" }
  
  [tool.poetry.dev-dependencies]
  pynvim = "^0.4.3"

--- a/srcpkgs/epy/template
+++ b/srcpkgs/epy/template
@@ -1,10 +1,10 @@
 # Template file for 'epy'
 pkgname=epy
 version=2023.6.11
-revision=5
+revision=6
 build_style=python3-pep517
 hostmakedepends="python3-poetry-core"
-depends="python3"
+depends="python3-magic"
 checkdepends="python3-pytest"
 short_desc="CLI ebook reader"
 maintainer="Orphaned <orphan@voidlinux.org>"


### PR DESCRIPTION
It is mentioned in #54741 that a patch is added in [b21778d](https://github.com/void-linux/void-packages/commit/b21778df877397616bea031835a4b00394118967) to replace `imghdr` with `magic` but then `python3-magic` is missing from `epy` dependency.


<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**
<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (aarch64-glibc)
