### PR TITLE
GoLand: update to 2025.3

### DIFF
--- a/srcpkgs/GoLand/template
+++ b/srcpkgs/GoLand/template
@@ -1,69 +1,32 @@
 # Template file for 'GoLand'
 pkgname=GoLand
-version=2021.3.3
+version=2025.3
 revision=1
-archs="x86_64 aarch64"
+archs="x86_64"
 depends="jetbrains-jdk-bin"
 short_desc="Cross-platform IDE built specially for Go developers"
 maintainer="Anton Afanasyev <anton@doubleasoftware.com>"
 license="custom:Commercial"
 homepage="https://www.jetbrains.com/go"
 distfiles="https://download.jetbrains.com/go/goland-${version}.tar.gz"
-checksum=9d2b709703516eddeb7f4d6568a7de2e268de4258c7bc7787baee806fbaee4a3
+checksum=6151856286ea546eb8af9aeb025772cee6bd57134f45494a818e8da20a8691c6
 repository=nonfree
 restricted=yes
 nopie=yes
-python_version=3
 
 post_extract() {
-	# Remove files for other OSes and/or CPU architectures
-	# Darwin (this is not packaged for macOS)
-	rm -rf plugins/cwm-plugin/quiche-native/darwin-aarch64
-	rm -rf plugins/cwm-plugin/quiche-native/darwin-x86-64
-	rm -rf plugins/go/lib/dlv/mac
-	rm -rf plugins/go/lib/dlv/macarm
-	rm -rf plugins/go/lib/dlv/windows
-	rm -rf plugins/performanceTesting/bin/libyjpagent.dylib
-	rm -rf plugins/python-ce/helpers/pydev/pydevd_attach_to_process/attach_x86.dylib
-	rm -rf plugins/python-ce/helpers/pydev/pydevd_attach_to_process/attach_x86_64.dylib
-	# Windows (this is not packaged for Windows)
-	rm -rf plugins/cwm-plugin/quiche-native/win32-x86-64
-	rm -rf plugins/performanceTesting/bin/yjpagent.dll
-	rm -rf plugins/performanceTesting/bin/yjpagent64.dll
-	rm -rf plugins/python-ce/helpers/pydev/pydevd_attach_to_process/attach_amd64.dll
-	rm -rf plugins/python-ce/helpers/pydev/pydevd_attach_to_process/attach_x86.dll
-	# x86 (unsupported after v2021.1)
-	rm -rf bin/goland.vmoptions
-	rm -rf lib/pty4j-native/linux/x86
-	rm -rf plugins/performanceTesting/bin/libyjpagent.so
-	rm -rf plugins/python-ce/helpers/pydev/pydevd_attach_to_process/attach_linux_x86.so
-	# MIPS
-	rm -rf lib/pty4j-native/linux/mips64el
-	# ARM
-	rm -rf lib/pty4j-native/linux/arm
-	# PPC
-	rm -rf lib/pty4j-native/linux/ppc64le
-
-
-	case "$XBPS_TARGET_MACHINE" in
-		x86_64)
-			rm -rf lib/pty4j-native/linux/aarch64
-			rm -rf plugins/go/lib/dlv/linuxarm
-			;;
-		aarch64)
-			rm -rf lib/pty4j-native/linux/x86-64
-			rm -rf plugins/go/lib/dlv/linux
-			rm -rf plugins/performanceTesting/bin/libyjpagent64.so
-			rm -rf plugins/python-ce/helpers/pydev/pydevd_attach_to_process/attach_linux_amd64.so
-			;;
-	esac
+	# aarch64
+	rm -rf lib/pty4j-native/linux/aarch64
+	rm -rf plugins/go/lib/dlv/linuxarm
+	rm -rf plugins/go-plugin/lib/dlv/linuxarm
+	rm -rf lib/async-profiler/aarch64
 }
 
 do_install() {
-	TARGET_PATH="usr/lib/${pkgname}"
+	_target_path="usr/lib/${pkgname}"
 
 	vmkdir usr/bin
-	vmkdir ${TARGET_PATH}
+	vmkdir ${_target_path}
 
 	local i
 	for i in license/* ; do
@@ -71,14 +34,14 @@ do_install() {
 	done
 
 	local launcher_path="bin/goland.sh"
-	sed -i '1 s/$/\nGOLAND_JDK=${GOLAND_JDK:-${IDEA_JDK}}/' "${launcher_path}"
-	vcopy bin ${TARGET_PATH}
-	vcopy help ${TARGET_PATH}
-	vcopy lib ${TARGET_PATH}
-	vcopy plugins ${TARGET_PATH}
-	vcopy product-info.json ${TARGET_PATH}
-	vcopy build.txt ${TARGET_PATH}
+	vcopy bin ${_target_path}
+	vcopy help ${_target_path}
+	vcopy lib ${_target_path}
+	vcopy jbr ${_target_path}
+	vcopy plugins ${_target_path}
+	vcopy product-info.json ${_target_path}
+	vcopy build.txt ${_target_path}
 
-	ln -sf "/${TARGET_PATH}/${launcher_path}" "${DESTDIR}/usr/bin/${pkgname}"
+	ln -sf "/${_target_path}/${launcher_path}" "${DESTDIR}/usr/bin/${pkgname}"
 	vdoc "${FILESDIR}/README.voidlinux"
 }


### PR DESCRIPTION
I removed the lines that deleted files for other OSes and architectures, since the source archive now includes only aarch64 and x86_64 files.

I also removed the aarch64 files because jetbrains-jdk-bin supports only x86_64. Like IntelliJ and PyCharm, this installs the bundled JetBrains Runtime (JBR) to avoid Java runtime version errors such as:

```
Error: LinkageError occurred while loading main class com.intellij.idea.Main
    java.lang.UnsupportedClassVersionError: com/intellij/idea/Main has been compiled by a more recent version of the Java Runtime (class file version 65.0), this version of the Java Runtime only recognizes class file versions up to 55.0
```

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-LIBC)

