### PR TITLE
bind: update to 9.20.17

### DIFF
--- a/srcpkgs/bind/template
+++ b/srcpkgs/bind/template
@@ -1,24 +1,25 @@
 # Template file for 'bind'
 pkgname=bind
-version=9.16.22
-revision=4
+version=9.20.17
+revision=1
 _fullver="${version}${_patchver:+-${_patchver}}"
 build_style=gnu-configure
-configure_args="--disable-static --enable-largefile --with-libtool
- --sysconfdir=/etc/named --enable-epoll --with-openssl=${XBPS_CROSS_BASE}/usr
- --with-gssapi=/usr/bin --with-readline --with-tuning=default --without-python
- --with-libidn2 --disable-backtrace"
+configure_args="--disable-static --enable-largefile
+ --sysconfdir=/etc/named --with-openssl=${XBPS_CROSS_BASE}/usr
+ --with-gssapi=yes --with-readline --with-lmdb=yes --with-json-c
+ --with-libidn2 --with-libxml2 --with-jemalloc=yes --enable-rpath"
 hostmakedepends="automake libtool perl pkg-config"
 makedepends="openssl-devel libxml2-devel libcap-devel readline-devel mit-krb5-devel
- libidn2-devel libuv-devel $(vopt_if geoip geoip-devel)"
+ libidn2-devel libuv-devel $(vopt_if geoip geoip-devel) liburcu-devel nghttp2-devel
+ lmdb-devel json-c-devel jemalloc-devel"
 checkdepends="python3-pytest"
 short_desc="Berkeley Internet Name Domain server"
 maintainer="Randy McCaskill <randy@mccaskill.us>"
 license="MPL-2.0"
 homepage="https://www.isc.org/downloads/bind/"
-changelog="https://gitlab.isc.org/isc-projects/bind9/-/blob/v9_16/CHANGES"
+changelog="https://gitlab.isc.org/isc-projects/bind9/-/blob/v${version}/doc/changelog/changelog-${version}.rst"
 distfiles="https://ftp.isc.org/isc/bind9/${_fullver}/bind-${_fullver}.tar.xz"
-checksum=65e7b2af6479db346e2fc99bcfb6ec3240066468e09dbec575ebc7c57d994061
+checksum=5cc89a09da0917eb1ddf640cc07c172ff44fa9bbf3a34ada4b6a2f7ee70ff1c8
 # guarantee subpackage ordering
 subpackages="bind-libs bind-utils bind-devel"
 # requires special network setup
@@ -33,12 +34,21 @@ make_dirs="/var/named 0770 root named"
 build_options="geoip"
 build_options_default="geoip"
 
+pre_configure() {
+	if [ -n "$CROSS_BUILD" ]; then
+		for l in ns isccfg isccc isc dns ; do
+			LDFLAGS+=" -Wl,--rpath-link=$wrksrc/lib/${l}/.libs"
+		done
+		vsed -e "s|ac_lib_lmdb_path in /usr|ac_lib_lmdb_path in ${XBPS_CROSS_BASE} /usr|g" -i configure
+	fi
+}
+
 post_install() {
 	vsv named
 	vinstall ${FILESDIR}/named.logrotate 600 etc/logrotate.d named
 	vinstall ${FILESDIR}/named.conf 640 etc/named
 
-	vinstall bin/tests/system/common/root.hint 640 var/named
+	vinstall bin/tests/system/_common/root.hint 640 var/named
 	vinstall ${FILESDIR}/127.0.0.zone 640 var/named
 	vinstall ${FILESDIR}/localhost.zone 640 var/named
 	vlicense COPYRIGHT LICENSE


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, **x86_64**
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - **aarch64-musl**
  - **x86_64-musl**

#### Comments

Current version is ~4 years old.

Other packages do similar with `rpath-link` for cross compiling. ldd says things are all static but I don't have arm to test on.