### PR TITLE
lutris: update to 0.5.19.

### DIFF
--- a/srcpkgs/lutris/template
+++ b/srcpkgs/lutris/template
@@ -1,7 +1,7 @@
 # Template file for 'lutris'
 pkgname=lutris
-version=0.5.18
-revision=2
+version=0.5.19
+revision=1
 build_style=meson
 hostmakedepends="gettext python3-setuptools python3-gobject gtk+3-devel"
 depends="python3-dbus python3-gobject python3-yaml python3-evdev python3-Pillow
@@ -13,4 +13,4 @@ license="GPL-3.0-or-later"
 homepage="https://lutris.net"
 changelog="https://raw.githubusercontent.com/lutris/lutris/master/debian/changelog"
 distfiles="https://github.com/lutris/lutris/archive/v${version}.tar.gz"
-checksum=b9d4ad052d1c750910940d5cc7c583967c0c65c1584b7f4a1abaf46e40c3d8d1
+checksum=54edba892517473920b04423037dd480afb5e3b5e197040db33d15b1535d5096


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture (x86_64)
- I built this PR locally for these architectures using specific masterdirs:
  - x86_64-musl
  - i686
- I built this PR locally for these architectures (crossbuilds):
  - aarch64
  - aarch64-musl
  - armv7l
  - armv7l-musl
  - armv6l
  - armv6l-musl