### PR TITLE
spotify-player: update to 0.21.2.

### DIFF
--- a/srcpkgs/spotify-player/template
+++ b/srcpkgs/spotify-player/template
@@ -1,6 +1,6 @@
 # Template file for 'spotify-player'
 pkgname=spotify-player
-version=0.20.7
+version=0.21.2
 revision=1
 build_style=cargo
 make_install_args="--path spotify_player"
@@ -11,7 +11,7 @@ maintainer="Rodrigo Oliveira <mdkcore@qtrnn.io>"
 license="MIT"
 homepage="https://github.com/aome510/spotify-player"
 distfiles="https://github.com/aome510/spotify-player/archive/refs/tags/v${version}.tar.gz"
-checksum=8b4c7ec7855fb2af8862a1ca8818307f2befcb00c02e9e5da570b1a5b3b908c1
+checksum=63fce17376105ba57a3a20d9e237141dfe655a4df606d6cd666a6cdd485f2f24
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
Ping maintainer @mdkcore0. Closes #56927.

#### Testing the changes
- I tested the changes in this PR: **briefly**

Unable to authenticate due to https://github.com/aome510/spotify-player/issues/898, so I was not able to test all functionality.

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - armv6l (**cross**) (as suggested by Contributing.md; hadn't done this before, but it went without a hitch)

