### PR TITLE
dav1d: update to 1.5.3

### DIFF
--- a/srcpkgs/dav1d/template
+++ b/srcpkgs/dav1d/template
@@ -1,6 +1,6 @@
 # Template file for 'dav1d'
 pkgname=dav1d
-version=1.5.2
+version=1.5.3
 revision=1
 build_style=meson
 configure_args="-Denable_asm=true -Denable_tools=true -Dfuzzing_engine=none
@@ -11,7 +11,7 @@ license="BSD-2-Clause"
 homepage="https://code.videolan.org/videolan/dav1d"
 changelog="https://code.videolan.org/videolan/dav1d/raw/master/NEWS"
 distfiles="https://code.videolan.org/videolan/dav1d/-/archive/${version}/dav1d-${version}.tar.bz2"
-checksum=c748a3214cf02a6d23bc179a0e8caea9d6ece1e46314ef21f5508ca6b5de6262
+checksum=e099f53253f6c247580c554d53a13f1040638f2066edc3c740e4c2f15174ce22
 
 if [ "$XBPS_CHECK_PKGS" ]; then
 	configure_args+=" -Denable_tests=true"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**
- Opening `.avif` files with `swayimg`
- Rendering `.avif` files with `chafa` inside `foot` terminal

#### Local build testing
- I built this PR locally for my native architecture, **x86_64-glibc**

[Changelog](https://code.videolan.org/videolan/dav1d/raw/master/NEWS)
