### PR TITLE
swirc: update to 3.5.7.

### DIFF
--- a/srcpkgs/swirc/template
+++ b/srcpkgs/swirc/template
@@ -1,6 +1,6 @@
 # Template file for 'swirc'
 pkgname=swirc
-version=3.5.6
+version=3.5.7
 revision=1
 build_style=configure
 configure_args="$(vopt_with notify libnotify)"
@@ -17,7 +17,7 @@ license="BSD-3-Clause, ISC, MIT"
 homepage="https://www.nifty-networks.net/swirc"
 changelog="https://raw.githubusercontent.com/uhlin/swirc/master/CHANGELOG.md"
 distfiles="https://www.nifty-networks.net/swirc/releases/swirc-${version}.tgz"
-checksum=27b978fb88e807e4c8581b7f8a65d1da57c0c98eac3f3e93b17807deb06d88d8
+checksum=050b12815bc63b6c90b88bf73089614ee552ca7de8ccfa70a9092c961c37b245
 
 build_options="notify"
 build_options_default="notify"


### PR DESCRIPTION
New year, new Swirc release. 3.5.7 out!

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, **x86_64-musl**
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - armv6l-musl **cross**
