### PR TITLE
freecad: add python3-pyside6-network runtime dependency

### DIFF
--- a/srcpkgs/freecad/template
+++ b/srcpkgs/freecad/template
@@ -1,7 +1,7 @@
 # Template file for 'freecad'
 pkgname=freecad
 version=1.0.2
-revision=8
+revision=9
 _pycxx_ver=7.1.8
 _ondsel_ver=09d6175a2ba69e7016fcecc4f384946a2f84f92d
 build_style=cmake
@@ -23,8 +23,8 @@ makedepends="boost-devel-minimal boost-python3 libboost_filesystem
  glew-devel python3-devel yaml-cpp-devel guidelines-support-library
  qt6-base-devel qt6-svg-devel qt6-tools-devel libpyside6-devel"
 depends="python3-matplotlib python3-pivy python3-GitPython python3-Markdown
- python3-pyside6-gui python3-pyside6-printsupport python3-pyside6-ui-tools
- python3-pyside6-widgets"
+ python3-pyside6-gui python3-pyside6-network python3-pyside6-printsupport
+ python3-pyside6-ui-tools python3-pyside6-widgets"
 short_desc="General purpose 3D CAD modeler"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="LGPL-2.0-or-later"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

Checked that installing the package is fixing the error.
The addon manager now runs properly: I updated one addon with it, whereas it crashed before. 

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-musl)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - none

It seems vtk-devel cannot be cross-compiled:

    => ERROR: vtk-devel-9.5.0_2: cannot be cross compiled...
    => ERROR: vtk-devel-9.5.0_2: It seems to need vtk compile tools for the host

Already known since at least : https://github.com/void-linux/void-packages/issues/37497#issuecomment-2974236748

Fixes: https://github.com/void-linux/void-packages/issues/58368