### PR TITLE
btop: update to 1.4.6.

### DIFF
--- a/srcpkgs/btop/template
+++ b/srcpkgs/btop/template
@@ -1,6 +1,6 @@
 # Template file for 'btop'
 pkgname=btop
-version=1.4.5
+version=1.4.6
 revision=1
 build_style=gnu-makefile
 hostmakedepends="lowdown"
@@ -10,4 +10,4 @@ license="Apache-2.0"
 homepage="https://github.com/aristocratos/btop"
 changelog="https://raw.githubusercontent.com/aristocratos/btop/main/CHANGELOG.md"
 distfiles="https://github.com/aristocratos/btop/archive/refs/tags/v${version}.tar.gz"
-checksum=0ffe03d3e26a3e9bbfd5375adf34934137757994f297d6b699a46edd43c3fc02
+checksum=4beb90172c6acaac08c1b4a5112fb616772e214a7ef992bcbd461453295a58be


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture (x86_64)
- I built this PR locally for these architectures using specific masterdirs:
  - x86_64-musl
  - i686
- I built this PR locally for these architectures (crossbuilds):
  - aarch64
  - aarch64-musl
  - armv7l
  - armv7l-musl
  - armv6l
  - armv6l-musl