### PR TITLE
qmidiarp: update to 0.7.2, switch to Qt6

### DIFF
--- a/srcpkgs/qmidiarp/patches/cross.patch
+++ b/srcpkgs/qmidiarp/patches/cross.patch
@@ -1,15 +1,15 @@
 --- a/configure.ac
 +++ b/configure.ac
-@@ -136,12 +136,6 @@ if test "x$ac_buildapp" = "xyes" -o ["x$ac_lv2pluginuis" = "xyes"  -a "x$ac_lv2w
-           QT_INCLUDE_DIR=`$PKG_CONFIG --variable=includedir Qt5Gui`
-           QT_CXXFLAGS=`$PKG_CONFIG --cflags Qt5Core Qt5Gui Qt5Widgets`
+@@ -144,12 +144,6 @@ if test "x$ac_buildapp" = "xyes" -o ["x$ac_lv2pluginuis" = "xyes"  -a "x$ac_lv2w
+           QT_INCLUDE_DIR=`$PKG_CONFIG --variable=includedir Qt6Widgets`
+           QT_CXXFLAGS=`$PKG_CONFIG --cflags Qt6Core Qt6Gui Qt6Widgets`
            QT_CXXFLAGS="$QT_CXXFLAGS -fPIC"
 -          EXTRA_QT_INCLUDE_DIR="$QT_INCLUDE_DIR/Qt"
--          AS_IF([test -e $QT_INCLUDE_DIR/QtWidgets/QWidget],
+-          AS_IF([test -e $QT_INCLUDE_DIR/QWidget],
 -            AC_MSG_NOTICE([No extra QT_INCLUDE_DIR needed]),
--              AS_IF([test -e $EXTRA_QT_INCLUDE_DIR/QtWidgets/QWidget],
+-              AS_IF([test -e $EXTRA_QT_INCLUDE_DIR/QWidget],
 -                QT_CPPFLAGS="$QT_CPPFLAGS -I$EXTRA_QT_INCLUDE_DIR",
 -                  AC_MSG_WARN([QWidget not found])))
-         
+ 
+           AC_MSG_NOTICE([Set QT_CXXFLAGS... $QT_CXXFLAGS])        
            AC_SUBST(QT_CXXFLAGS)
-           AC_SUBST(Qt5_LIBS)

--- a/srcpkgs/qmidiarp/template
+++ b/srcpkgs/qmidiarp/template
@@ -1,17 +1,17 @@
 # Template file for 'qmidiarp'
 pkgname=qmidiarp
-version=0.7.1
+version=0.7.2
 revision=1
 build_style=gnu-configure
-hostmakedepends="automake libtool pkg-config qt5-host-tools"
-makedepends="alsa-lib-devel jack-devel lv2 qt5-devel"
+hostmakedepends="automake libtool pkg-config qt6-base qt6-tools"
+makedepends="alsa-lib-devel jack-devel lv2 qt6-base-devel"
 short_desc="MIDI arpeggiator and LFO"
 maintainer="Matthias von Faber <mvf@gmx.eu>"
 license="GPL-2.0-or-later"
 homepage="http://qmidiarp.sourceforge.net"
 distfiles="${SOURCEFORGE_SITE}/project/qmidiarp/qmidiarp/${version}/qmidiarp-${version}.tar.bz2"
-checksum=40d3bdbebbb6dd0a39f05c793446e4a33295692d9840e0627f8cb744d6f0e114
-CXXFLAGS="-D_GNU_SOURCE"
+checksum=493dc86542bb580b330b206ac9d6dfeb1d926c23c6129604a302e9a62967139a
+export PATH="$PATH:/usr/lib/qt6/bin:/usr/lib/qt6/libexec"
 
 pre_configure() {
 	autoreconf -if


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
