### PR TITLE
mutt: update to 2.2.16

### DIFF
--- a/srcpkgs/mutt/template
+++ b/srcpkgs/mutt/template
@@ -1,6 +1,6 @@
 # Template file for 'mutt'
 pkgname=mutt
-version=2.2.15
+version=2.2.16
 revision=1
 build_style=gnu-configure
 configure_args="--enable-pop --enable-imap --enable-smtp --enable-hcache
@@ -19,7 +19,7 @@ license="GPL-2.0-or-later"
 homepage="http://www.mutt.org"
 changelog="http://mutt.org/relnotes/${version%.*}"
 distfiles="http://ftp.mutt.org/pub/mutt/${pkgname}-${version}.tar.gz"
-checksum=a51686104e4203f4c2a3b176527be3b95d08e808e94fd2dcadb7c30566bf894d
+checksum=1d3109a743ad8b25eef97109b2bdb465db7837d0a8d211cd388be1b6faac3f32
 
 post_install() {
 	# provided by mime-types


### PR DESCRIPTION
- I tested the changes in this PR: yes
- I built this PR locally for my native architecture, (aarch64-glibc)

cc @sgn 