### PR TITLE
GoLand: remove unnecessary dependency

### DIFF
--- a/srcpkgs/GoLand/template
+++ b/srcpkgs/GoLand/template
@@ -1,9 +1,9 @@
 # Template file for 'GoLand'
 pkgname=GoLand
 version=2025.3
-revision=1
+revision=2
 archs="x86_64"
-depends="jetbrains-jdk-bin"
+depends="virtual?java-environment"
 short_desc="Cross-platform IDE built specially for Go developers"
 maintainer="Anton Afanasyev <anton@doubleasoftware.com>"
 license="custom:Commercial"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**|**briefly**|**NO**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)

When copying `jbr`, this runtime is used directly, so `jetbrains-jdk-bin` isn’t needed (see #52065). I replaced it with `virtual?java-environment` as suggested in #55437.

Also, `jetbrains-jdk-bin` sets `IDEA_JDK` to Java 11, which conflicts with `intellij-idea-community-edition` since it requires Java 21 and otherwise uses its bundled `jbr`.