### PR TITLE
dnscrypt-proxy: update to 2.1.15.

### DIFF
--- a/srcpkgs/dnscrypt-proxy/template
+++ b/srcpkgs/dnscrypt-proxy/template
@@ -1,6 +1,6 @@
 # Template file for 'dnscrypt-proxy'
 pkgname=dnscrypt-proxy
-version=2.1.12
+version=2.1.15
 revision=1
 build_style=go
 go_import_path=github.com/dnscrypt/dnscrypt-proxy
@@ -12,7 +12,7 @@ license="ISC"
 homepage="https://github.com/DNSCrypt/dnscrypt-proxy"
 changelog="https://raw.githubusercontent.com/DNSCrypt/dnscrypt-proxy/master/ChangeLog"
 distfiles="https://github.com/DNSCrypt/dnscrypt-proxy/archive/refs/tags/${version}.tar.gz"
-checksum=95fe29ed03dad0cdd34d47316ecb15c25f7ef5fab21d9ec52cbfc4743bcf5198
+checksum=57da91dd2a3992a1528e764bcfe9b48088c63c933c0c571a2cac3d27ac8c7546
 conf_files="/etc/dnscrypt-proxy/dnscrypt-proxy.toml"
 system_accounts="dnscrypt_proxy"
 


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)

