### PR TITLE
mpv-mpris: update to 1.2

### DIFF
--- a/srcpkgs/mpv-mpris/template
+++ b/srcpkgs/mpv-mpris/template
@@ -1,7 +1,7 @@
 # Template file for 'mpv-mpris'
 pkgname=mpv-mpris
-version=1.1
-revision=2
+version=1.2
+revision=1
 build_style=gnu-makefile
 make_use_env=yes
 make_build_target=mpris.so
@@ -17,7 +17,7 @@ license="MIT"
 homepage="https://github.com/hoyon/mpv-mpris"
 changelog="https://github.com/hoyon/mpv-mpris/releases"
 distfiles="https://github.com/hoyon/mpv-mpris/archive/${version}.tar.gz"
-checksum=71008aa181bccf4bc7b2b5b9673e9993b1d1f5b7e2c189dc3724ab23ef1f6ebb
+checksum=ecdc66f0182a38164b8bdc79502c575df3d2c4453bae5bff225c4e5ce9dbef6c
 
 do_install() {
 	vlicense LICENSE


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, **x86_64-glibc**

[Changelog](https://github.com/hoyon/mpv-mpris/releases)
