### PR TITLE
mc: fix distfiles URL and remove missing changelog URL

### DIFF
--- a/srcpkgs/mc/template
+++ b/srcpkgs/mc/template
@@ -10,8 +10,7 @@ short_desc="User-friendly file manager and visual shell"
 maintainer="0x5c <dev@0x5c.io>"
 license="GPL-3.0-or-later"
 homepage="https://midnight-commander.org/"
-changelog="https://midnight-commander.org/wiki/NEWS-${version}"
-distfiles="https://www.midnight-commander.org/downloads/mc-${version}.tar.xz"
+distfiles="https://ftp.osuosl.org/pub/midnightcommander/mc-${version}.tar.xz"
 checksum=cae149d42f844e5185d8c81d7db3913a8fa214c65f852200a9d896b468af164c
 
 conf_files="


### PR DESCRIPTION
Upstream decomissioned their ftp server and moved to OSU OSL. Also nuked their wiki which had the changelogs.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
