### PR TITLE
libdrm: update to 2.4.131

### DIFF
--- a/srcpkgs/libdrm/template
+++ b/srcpkgs/libdrm/template
@@ -1,6 +1,6 @@
 # Template file for 'libdrm'
 pkgname=libdrm
-version=2.4.124
+version=2.4.131
 revision=1
 build_style=meson
 configure_args="-Dudev=true -Dvalgrind=disabled -Dinstall-test-programs=true"
@@ -10,8 +10,8 @@ short_desc="Userspace interface to kernel DRM services"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
 homepage="https://dri.freedesktop.org/"
-distfiles="https://gitlab.freedesktop.org/mesa/drm/-/archive/libdrm-${version}/drm-libdrm-${version}.tar.gz"
-checksum=49c077f3938147e7c321fe89255eb189c1be68f6ed0aa36e29d38e3db0e84e08
+distfiles="https://gitlab.freedesktop.org/mesa/libdrm/-/archive/libdrm-${version}/libdrm-libdrm-${version}.tar.gz"
+checksum=94fed0e93809d239fcbcf1d652753454e728ba887fb2175534219d0e67a81814
 
 case "$XBPS_TARGET_MACHINE" in
 	aarch64*) configure_args+=" -Dvc4=enabled";;


### PR DESCRIPTION
this also updates the gitlab project url to the latest, as per the header message if you visit https://gitlab.freedesktop.org/mesa/drm

#### Testing the changes
- I tested the changes in this PR: **briefly**
