### PR TITLE
libarchive: update to 3.8.5

### DIFF
--- a/srcpkgs/libarchive/template
+++ b/srcpkgs/libarchive/template
@@ -1,6 +1,6 @@
 # Template file for 'libarchive'
 pkgname=libarchive
-version=3.8.4
+version=3.8.5
 revision=1
 bootstrap=yes
 build_style=gnu-configure
@@ -18,7 +18,7 @@ license="BSD-2-Clause"
 homepage="https://www.libarchive.org/"
 changelog="https://github.com/libarchive/libarchive/releases"
 distfiles="https://github.com/libarchive/libarchive/releases/download/v${version}/libarchive-${version}.tar.xz"
-checksum=c7b847b57feacf5e182f4d14dd6cae545ac6843d55cb725f58e107cdf1c9ad73
+checksum=d68068e74beee3a0ec0dd04aee9037d5757fcc651591a6dcf1b6d542fb15a703
 
 build_options="acl expat lzo lz4 ssl zstd"
 build_options_default="acl ssl lz4 zstd"


### PR DESCRIPTION
#### Testing the changes
- briefly tested `bsdtar`

#### Local build testing
- I built this PR locally for my native architecture, **x86_64-glibc**

[Bugfix release](https://github.com/libarchive/libarchive/releases)
