### PR TITLE
zutty: update to 0.16.0

### DIFF
--- a/srcpkgs/zutty/template
+++ b/srcpkgs/zutty/template
@@ -1,6 +1,6 @@
 # Template file for 'zutty'
 pkgname=zutty
-version=0.14
+version=0.16
 revision=1
 build_style=waf3
 hostmakedepends="pkg-config"
@@ -10,8 +10,8 @@ short_desc="X terminal emulator rendering through OpenGL ES Compute Shaders"
 maintainer="Javier Caballero <jacallo@protonmail.com>"
 license="GPL-3.0-or-later"
 homepage="https://tomscii.sig7.se/zutty"
-distfiles="https://github.com/tomscii/zutty/archive/refs/tags/${version}.tar.gz"
-checksum=6de17d6b7a3fe6991df30ba1ca7d6a08e605369cf92247deeb19758379b5af2f
+distfiles="https://git.hq.sig7.se/zutty.git/snapshot/${version}.tar.gz"
+checksum=c794ba769f4bd973d0b836c7c138dd2f827ace8359f772d3a136eee671adaa40
 
 post_install() {
 	# Copy icons


### PR DESCRIPTION
Also updates the distfiles location to the new as linked on https://github.com/tomscii/zutty

#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, x86-64
