### PR TITLE
fftw: fix build under current cmake version

### DIFF
--- a/srcpkgs/fftw/template
+++ b/srcpkgs/fftw/template
@@ -1,7 +1,7 @@
 # Template file for 'fftw'
 pkgname=fftw
 version=3.3.10
-revision=3
+revision=4
 hostmakedepends="libtool automake cmake-bootstrap"
 makedepends="libgomp-devel"
 short_desc="Library for computing the discrete Fourier transform (DFT)"
@@ -42,6 +42,10 @@ do_configure() {
 	cd ${wrksrc}
 	# fix wrong soname in FFTW3LibraryDepends.cmake
 	vsed -e 's/3.6.9/3.6.10/' -i CMakeLists.txt
+
+    # fix erroring minimum cmake requirement, (for cmake >= 4.0 minimum should be >= 3.5)
+    vsed -e 's/cmake_minimum_required (VERSION 3.0)/cmake_minimum_required (VERSION 3.5)/' \
+         -i CMakeLists.txt
 
 	# create missing FFTW3LibraryDepends.cmake
 	cmake -B build -D CMAKE_INSTALL_PREFIX=/usr -D CMAKE_BUILD_TYPE=None \


### PR DESCRIPTION
Adds a fix for the fftw build which is failing under the current cmake version, by bumping the minimum required cmake in CMakeLists.txt to 3.5 as required by versions >= 4.0

#### Testing the changes
- I tested the changes in this PR: **NO** (working on it, will update when tested)

#### Local build testing
- I built this PR locally for my native architecture, x86-64-glibc
