### PR TITLE
fish-shell: register /usr/sbin/fish in /etc/shells

### DIFF
--- a/srcpkgs/fish-shell/template
+++ b/srcpkgs/fish-shell/template
@@ -16,7 +16,7 @@ homepage="https://fishshell.com/"
 changelog="https://raw.githubusercontent.com/fish-shell/fish-shell/refs/heads/master/CHANGELOG.rst"
 distfiles="https://github.com/fish-shell/fish-shell/releases/download/${version}/fish-${version}.tar.xz"
 checksum=eba0e7d325c1d46046bb9d29434e7e0dabf7f584eb156845005d688e10b86e57
-register_shell="/bin/fish /usr/bin/fish"
+register_shell="/bin/fish /usr/bin/fish /usr/sbin/fish"
 # some tests fail in ci, cba to hardcode skipping
 make_check=ci-skip
 


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-musl)