### PR TITLE
tlp: update to 1.9.1

### DIFF
--- a/srcpkgs/tlp/template
+++ b/srcpkgs/tlp/template
@@ -1,7 +1,7 @@
 # Template file for 'tlp'
 pkgname=tlp
 # Remember to update 'tlpui' asap.
-version=1.9.0
+version=1.9.1
 revision=1
 depends="hdparm bash iw util-linux ethtool perl"
 short_desc="Advanced power management tool for Linux"
@@ -10,7 +10,7 @@ license="GPL-2.0-or-later"
 homepage="https://linrunner.de/en/tlp/docs/tlp-linux-advanced-power-management.html"
 changelog="https://raw.githubusercontent.com/linrunner/TLP/main/changelog"
 distfiles="https://github.com/linrunner/TLP/archive/${version}.tar.gz"
-checksum=ddb40400dcba69063d8ab1d41ee55e8dea5a42a26abe27643c13040bb8ef294b
+checksum=6f7c69a8c56706f83bc3566377caf846c2ccbd8f2621fe8e56c6d1e684d15156
 
 conflicts="laptop-mode>=0 perl-Unicode-Tussle>=0"
 conf_files="/etc/tlp.conf /etc/tlp.d/*.conf"


### PR DESCRIPTION
Fixes CVE-2025-67859 (authentication bypass)
https://security.opensuse.org/2026/01/07/tlp-polkit-authentication-bypass.html

#### Testing the changes
- I tested the changes in this PR: **YES**|**briefly**|**NO**

#### Local build testing
- I built this PR locally for my native architecture, **x86_64-glibc**

cc @ahesford 
