### PR TITLE
python3-peewee: update to 3.19.0.

### DIFF
--- a/srcpkgs/python3-peewee/template
+++ b/srcpkgs/python3-peewee/template
@@ -1,7 +1,7 @@
 # Template file for 'python3-peewee'
 pkgname=python3-peewee
-version=3.18.3
-revision=2
+version=3.19.0
+revision=1
 build_style=python3-pep517
 hostmakedepends="python3-setuptools python3-wheel python3-Cython"
 makedepends="python3-devel sqlite-devel"
@@ -12,7 +12,7 @@ license="MIT"
 homepage="https://github.com/coleifer/peewee"
 changelog="https://raw.githubusercontent.com/coleifer/peewee/master/CHANGELOG.md"
 distfiles="https://github.com/coleifer/peewee/archive/${version}.tar.gz"
-checksum=09a4a65346856f422e653e610f946174a70d4e26c27bfd9fc0a258555e7c5c50
+checksum=e5f587804cced3d1842ce650ced101dd96894381241aa1f1c1cdfd3490b49bd2
 make_check=no # tests require postgres instance
 
 post_install() {


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-libc
