### PR TITLE
libcap-ng: update pkg urls from http -> https

### DIFF
--- a/srcpkgs/libcap-ng/template
+++ b/srcpkgs/libcap-ng/template
@@ -1,14 +1,14 @@
 # Template file for 'libcap-ng'
 pkgname=libcap-ng
 version=0.8.5
-revision=3
+revision=4
 build_style=gnu-configure
 configure_args="--without-python --without-python3"
 short_desc="Alternate POSIX capabilities library"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later, LGPL-2.1-or-later"
-homepage="http://people.redhat.com/sgrubb/libcap-ng/"
-distfiles="http://people.redhat.com/sgrubb/$pkgname/$pkgname-$version.tar.gz"
+homepage="https://people.redhat.com/sgrubb/libcap-ng/"
+distfiles="https://people.redhat.com/sgrubb/libcap-ng/libcap-ng-${version}.tar.gz"
 checksum=3ba5294d1cbdfa98afaacfbc00b6af9ed2b83e8a21817185dfd844cc8c7ac6ff
 
 subpackages="libcap-ng-devel libcap-ng-progs"


### PR DESCRIPTION
Previously, build was broken with "no route to host" errors, which can be fixed by switching url protos from http -> https.

#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
