### PR TITLE
rio: update to 0.2.37.

### DIFF
--- a/srcpkgs/rio/template
+++ b/srcpkgs/rio/template
@@ -1,11 +1,11 @@
 # Template file for 'rio'
 pkgname=rio
-version=0.2.28
+version=0.2.37
 revision=1
 build_style=cargo
 build_wrksrc="frontends/rioterm"
 hostmakedepends="pkg-config scdoc"
-makedepends="libglvnd-devel libxcb-devel libxkbcommon-devel wayland-devel"
+makedepends="libglvnd-devel libxcb-devel libxkbcommon-devel wayland-devel fontconfig-devel"
 depends="rio-terminfo-${version}_${revision}"
 short_desc="Hardware-accelerated GPU terminal emulator powered by WebGPU"
 maintainer="Orphaned <orphan@voidlinux.org>"
@@ -13,7 +13,7 @@ license="MIT"
 homepage="https://raphamorim.io/rio/"
 changelog="https://raw.githubusercontent.com/raphamorim/rio/main/CHANGELOG.md"
 distfiles="https://github.com/raphamorim/rio/archive/refs/tags/v${version}.tar.gz"
-checksum=cd0a72997a1dfb3d2d05b22a6cf6d22d512dfa8a2946f2fefcdcf6fbebbb485c
+checksum=f52bcd0fb3c669cae016c614a77a95547c2769e6a98a17d7bbc703b6e72af169
 
 case "${XBPS_TARGET_MACHINE}" in
 	i686*)


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86-libc)
- I built this PR locally for these architectures:
  - armv6l
