### PR TITLE
goldendict-ng: update to 26.1.1

### DIFF
--- a/srcpkgs/goldendict-ng/template
+++ b/srcpkgs/goldendict-ng/template
@@ -1,8 +1,8 @@
 # Template file for 'goldendict-ng'
 pkgname=goldendict-ng
-version=25.10.2
+version=26.1.1
 revision=1
-_version_tag=Release.673d1b90
+_version_tag=Release.5491ffca
 build_style=cmake
 configure_args="-DUSE_ALTERNATIVE_NAME=ON -DUSE_SYSTEM_FMT=ON -DWITH_TTS=OFF"
 hostmakedepends="pkg-config qt6-declarative-host-tools qt6-tools"
@@ -16,7 +16,7 @@ maintainer="Mateusz Sylwestrzak <slymattz@gmail.com>"
 license="GPL-3.0-or-later"
 homepage="https://xiaoyifang.github.io/goldendict-ng/"
 distfiles="https://github.com/xiaoyifang/goldendict-ng/archive/refs/tags/v${version}-${_version_tag}.tar.gz"
-checksum=0cdfacec1a8fbe9ed84dec88a9bc92d5c152172c9e5af264ded26fbfd5f1be0e
+checksum=e59b343b4ecd2b34c110797119e700a25628d0ef6c7f589511e411bcf85adf7d
 
 if [ "$XBPS_WORDSIZE$XBPS_WORDSIZE" != "64$XBPS_TARGET_WORDSIZE" ]; then
 	broken="Qt6 WebEngine"


### PR DESCRIPTION

#### Testing the changes
- I tested the changes in this PR: **YES**

With this new version, the popup feature finally works as expected on my setup: wayland + wl-paste --primary

#### Local build testing
- I built this PR locally for my native architecture: x86_64-glibc
- I also built it for x86_64-musl
