### PR TITLE
python3-s-tui: fix urwid curses_display import.

### DIFF
--- a/srcpkgs/python3-s-tui/patches/fix-urwid-curses_display.patch
+++ b/srcpkgs/python3-s-tui/patches/fix-urwid-curses_display.patch
@@ -1,0 +1,22 @@
+From 7db32d9c8588305e17542aa696b9a1fee2fcbc0a Mon Sep 17 00:00:00 2001
+From: amanusk <amanusk@pm.me>
+Date: Sun, 14 Dec 2025 09:56:28 +0200
+Subject: [PATCH] Fix unsucceful import of curses_display (#247)
+
+Fixes issues #246
+---
+ s_tui/s_tui.py | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/s_tui/s_tui.py b/s_tui/s_tui.py
+index 1245e97..4c1900c 100755
+--- a/s_tui/s_tui.py
++++ b/s_tui/s_tui.py
+@@ -36,7 +36,6 @@
+ 
+ import psutil
+ import urwid
+-import urwid.curses_display
+ 
+ try:
+     import configparser

--- a/srcpkgs/python3-s-tui/template
+++ b/srcpkgs/python3-s-tui/template
@@ -1,7 +1,7 @@
 # Template file for 'python3-s-tui'
 pkgname=python3-s-tui
 version=1.2.0
-revision=2
+revision=3
 build_style=python3-module
 hostmakedepends="python3-setuptools"
 depends="stress-ng python3-urwid python3-psutil"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures using specific masterdirs:
  - x86_64-musl
  - i686
- I built this PR locally for these architectures (crossbuilds):
  - aarch64
  - aarch64-musl
  - armv7l
  - armv7l-musl
  - armv6l
  - armv6l-musl