### PR TITLE
biblioteq: update to 2026.01.07.

### DIFF
--- a/srcpkgs/biblioteq/template
+++ b/srcpkgs/biblioteq/template
@@ -1,6 +1,6 @@
 # Template file for 'biblioteq'
 pkgname=biblioteq
-version=2026.01.05
+version=2026.01.07
 revision=1
 build_style=qmake
 build_helper=qmake6
@@ -13,7 +13,7 @@ maintainer="Rutpiv <roger_freitas@live.com>"
 license="BSD-3-Clause"
 homepage="https://textbrowser.github.io/biblioteq/"
 distfiles="https://github.com/textbrowser/biblioteq/archive/${version}.tar.gz"
-checksum=d1aa1e6cd5f47ef2ba274efdfda42f8b956aab6548c47b74f5cc6871b0165396
+checksum=535b6a468011554285f003f52e703901434e34a8c3c726bf856bcaa0394c3662
 conf_files="/etc/biblioteq.conf"
 
 # Set the appropriate build helper and dependencies based on architecture


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures using specific masterdirs:
  - x86_64-musl
  - i686
- I built this PR locally for these architectures (crossbuilds):
  - aarch64
  - aarch64-musl
  - armv7l
  - armv7l-musl
  - armv6l
  - armv6l-musl