### PR TITLE
elogind: don't modify mem_sleep mode by default

### DIFF
--- a/srcpkgs/elogind/patches/sleep.patch
+++ b/srcpkgs/elogind/patches/sleep.patch
@@ -1,0 +1,31 @@
+Author: oreo639 <oreo6391@gmail.com>
+
+Previously systemd implemented `SuspendMode` , which elogind extended to allow configuring  mem_sleep modes such as s2idle or deep:
+https://github.com/elogind/elogind/blob/v252.9/src/shared/sleep-config.c#L145-L146
+https://github.com/elogind/elogind/blob/v252.9/src/sleep/sleep.c#L252-L287
+
+The `SuspendMode` option was removed from systemd: https://github.com/elogind/elogind/commit/4d2820778f3e0904f9fab81654d4bd3ac1df7c8c
+
+elogind re-added the option now including default mem_sleep options: https://github.com/elogind/elogind/commit/7707a30dfb2496a4c9c5939f0dd8bb39baebfecd https://github.com/elogind/elogind/commit/b409f71ac2f864f160dc872c54fa89b05a3a3bb7
+
+Previously (in elogind versions we didn't ship), s2idle would be preferred when available which causes issues on laptops where deep is the better option (and the kernel default), in 255.22 this was changed to prefer deep, which conversely causes issues on newer laptops which advertise support for deep despite s2idle being the better option (and the kernel default): https://github.com/elogind/elogind/issues/285
+
+Set the default sleep suspend mode to an empty list to skip modifying `/sys/power/mem_sleep` and preserve kernel defaults.
+
+This should be fixed with elogind 257.x which drops `SuspendMode` configuration of mem_sleep in favor of systemd's newly added `MemorySleepMode`.
+
+This is based on a similar patch in Chimera Linux (although modified to not remove the option outright): https://github.com/chimera-linux/cports/blob/9e7aff96579d41fcc1f411f88526ad7c132f8ec5/main/elogind/patches/sleep.patch
+
+diff -rup sleep-config.c.orig sleep-config.c
+--- a/src/shared/sleep-config.c
++++ b/src/shared/sleep-config.c
+@@ -45,7 +45,7 @@ static char* const* const sleep_default_
+ #if 0 /// elogind supports suspend modes (deep s2idle) so we need defaults, too
+         /* Not used by SLEEP_SUSPEND */
+ #else // 0
+-        [SLEEP_SUSPEND]      = STRV_MAKE("deep", "s2idle"),
++        [SLEEP_SUSPEND]      = STRV_MAKE_EMPTY,
+ #endif // 0
+         [SLEEP_HIBERNATE]    = STRV_MAKE("platform", "shutdown"),
+         [SLEEP_HYBRID_SLEEP] = STRV_MAKE("suspend"),
+

--- a/srcpkgs/elogind/template
+++ b/srcpkgs/elogind/template
@@ -1,7 +1,7 @@
 # Template file for 'elogind'
 pkgname=elogind
 version=255.22
-revision=1
+revision=2
 build_style=meson
 configure_args="-Dcgroup-controller=elogind -Ddefault-hierarchy=legacy
  -Ddefault-kill-user-processes=false -Dhalt-path=/usr/bin/halt
@@ -18,7 +18,8 @@ license="GPL-2.0-or-later, LGPL-2.0-or-later"
 homepage="https://github.com/elogind/elogind"
 distfiles="https://github.com/elogind/elogind/archive/refs/tags/V${version}.tar.gz"
 checksum=79b5eb96bccf3a6101b35e62d0f80b2d0a47077a1507a6edc705f8cb7bdb0619
-conf_files="/etc/elogind/*.conf"
+conf_files="/etc/elogind/*.conf /etc/elogind/logind.conf.d/*.conf
+ /etc/elogind/sleep.conf.d/*.conf"
 # tests fail differently due to containerization and kernel features
 make_check=ci-skip
 


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

Previously systemd implemented `SuspendMode` , which elogind extended to allow configuring  mem_sleep modes such as s2idle or deep:
https://github.com/elogind/elogind/blob/v252.9/src/shared/sleep-config.c#L145-L146
https://github.com/elogind/elogind/blob/v252.9/src/sleep/sleep.c#L252-L287

The `SuspendMode` option was removed from systemd: https://github.com/elogind/elogind/commit/4d2820778f3e0904f9fab81654d4bd3ac1df7c8c

elogind re-added the option now including default mem_sleep options: https://github.com/elogind/elogind/commit/7707a30dfb2496a4c9c5939f0dd8bb39baebfecd https://github.com/elogind/elogind/commit/b409f71ac2f864f160dc872c54fa89b05a3a3bb7

Previously (in elogind versions we didn't ship), s2idle would be preferred when available which causes issues on laptops where deep is the better option (and the kernel default), in 255.22 this was changed to prefer deep, which conversely causes issues on newer laptops which advertise support for deep despite s2idle being the better option (and the kernel default): https://github.com/elogind/elogind/issues/285

Set the default sleep suspend mode to an empty list to skip modifying `/sys/power/mem_sleep` and preserve kernel defaults.

This should be fixed with elogind 257.x which drops `SuspendMode` configuration of mem_sleep in favor of systemd's newly added `MemorySleepMode`.

This is based on a similar patch in Chimera Linux (although modified to not remove the option outright): https://github.com/chimera-linux/cports/blob/9e7aff96579d41fcc1f411f88526ad7c132f8ec5/main/elogind/patches/sleep.patch

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
