### PR TITLE
runit-void: register vlogger as an alternative for logger(1)

### DIFF
--- a/srcpkgs/runit-void/template
+++ b/srcpkgs/runit-void/template
@@ -1,7 +1,7 @@
 # Template file for 'runit-void'
 pkgname=runit-void
 version=20250212
-revision=2
+revision=3
 build_style=gnu-makefile
 short_desc="Void Linux runit scripts"
 maintainer="Enno Boland <gottox@voidlinux.org>"
@@ -26,6 +26,11 @@ conf_files="
 make_dirs="
  /etc/zzz.d/suspend 0755 root root
  /etc/zzz.d/resume 0755 root root"
+
+alternatives="
+ logger:logger:/usr/bin/vlogger
+ logger:/usr/share/man/man1/logger.1:/usr/share/man/man8/vlogger.8
+"
 
 post_install() {
 	vmkdir usr/bin


### PR DESCRIPTION
vlogger supports acting like a POSIX-compatible (POSIX is not very demanding here) logger(1) since `288f526`.
This change exposes it as such.
One of the reasons that you might want it is support for setting facility only (i.e. `-p user` to mean `-p user.notice`), which is unavailable via util-linux or busybox.

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64 musl)