### PR TITLE
protonmail-bridge: update to 3.21.2.

### DIFF
--- a/srcpkgs/protonmail-bridge/patches/no-gui-tester.patch
+++ b/srcpkgs/protonmail-bridge/patches/no-gui-tester.patch
@@ -1,7 +1,0 @@
---- a/internal/frontend/bridge-gui/CMakeLists.txt.orig
-+++ b/internal/frontend/bridge-gui/CMakeLists.txt
-@@ -29,4 +29,3 @@
- 
- add_subdirectory(bridgepp)
- add_subdirectory(bridge-gui)
--add_subdirectory(bridge-gui-tester)

--- a/srcpkgs/protonmail-bridge/patches/qt610-deploy-script.patch
+++ b/srcpkgs/protonmail-bridge/patches/qt610-deploy-script.patch
@@ -1,0 +1,10 @@
+--- a/internal/frontend/bridge-gui/bridge-gui/CMakeLists.txt
++++ b/internal/frontend/bridge-gui/bridge-gui/CMakeLists.txt
+@@ -172,7 +172,7 @@ install(TARGETS bridge-gui
+         )
+ qt_generate_deploy_app_script(
+         TARGET bridge-gui
+-        FILENAME_VARIABLE deploy_script
++        OUTPUT_SCRIPT deploy_script
+         NO_UNSUPPORTED_PLATFORM_ERROR)
+ if(UNIX AND NOT APPLE)

--- a/srcpkgs/protonmail-bridge/patches/system-icu.patch
+++ b/srcpkgs/protonmail-bridge/patches/system-icu.patch
@@ -1,12 +1,11 @@
---- a/internal/frontend/bridge-gui/bridge-gui/DeployLinux.cmake.orig
+--- a/internal/frontend/bridge-gui/bridge-gui/DeployLinux.cmake
 +++ b/internal/frontend/bridge-gui/bridge-gui/DeployLinux.cmake
-@@ -54,9 +54,9 @@
- AppendQt6Lib("libQt6Core.so.6")
+@@ -54,9 +54,9 @@ AppendQt6Lib("libQt6Core.so.6")
  AppendQt6Lib("libQt6QuickTemplates2.so.6")
  AppendQt6Lib("libQt6DBus.so.6")
--AppendQt6Lib("libicui18n.so.56")
--AppendQt6Lib("libicuuc.so.56")
--AppendQt6Lib("libicudata.so.56")
+-AppendQt6Lib("libicui18n.so.73")
+-AppendQt6Lib("libicuuc.so.73")
+-AppendQt6Lib("libicudata.so.73")
 +AppendQt6Lib("libicui18n.so")
 +AppendQt6Lib("libicuuc.so")
 +AppendQt6Lib("libicudata.so")

--- a/srcpkgs/protonmail-bridge/template
+++ b/srcpkgs/protonmail-bridge/template
@@ -1,7 +1,7 @@
 # Template file for 'protonmail-bridge'
 pkgname=protonmail-bridge
-version=3.12.0
-revision=3
+version=3.21.2
+revision=1
 archs="x86_64* aarch64* riscv64*"
 build_style=cmake
 build_helper=qmake6
@@ -25,12 +25,13 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-3.0-or-later"
 homepage="https://proton.me/mail/bridge"
 distfiles="https://github.com/ProtonMail/proton-bridge/archive/refs/tags/v${version}.tar.gz"
-checksum=4215fd1848fff262da55194270f495e19722cdf8bbf98dbe3ca4ff5ca5aa4a1f
+checksum=d6c373f219d7351b18277061faab24cd677c28ea4398de5c48f752e7a14f1c2a
 nopie_files="/usr/libexec/protonmail/bridge"
 nocross="protobuf generation fails"
 
 post_patch() {
 	vsed -i -e 's/^Exec=.*$/Exec=protonmail-bridge-gui/' "$wrksrc"/dist/proton-bridge.desktop
+	vsed -i -e '/include(Deploy.*\.cmake)/d' "$wrksrc"/internal/frontend/bridge-gui/bridge-gui/CMakeLists.txt
 }
 
 pre_build() {


### PR DESCRIPTION
- Remove obsolete patches (system-icu, no-gui-tester)
- Add Qt 6.10 compatibility patch (FILENAME_VARIABLE -> OUTPUT_SCRIPT)
- Skip DeployLinux.cmake via post_patch (uses system Qt)

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc