### PR TITLE
libpng: update to 1.6.54.

### DIFF
--- a/srcpkgs/libpng/template
+++ b/srcpkgs/libpng/template
@@ -1,6 +1,6 @@
 # Template file for 'libpng'
 pkgname=libpng
-version=1.6.53
+version=1.6.54
 revision=1
 build_style=gnu-configure
 makedepends="zlib-devel"
@@ -10,7 +10,7 @@ license="Libpng"
 homepage="http://www.libpng.org/pub/png/libpng.html"
 changelog="https://github.com/pnggroup/libpng/blob/master/CHANGES"
 distfiles="${SOURCEFORGE_SITE}/libpng/libpng-${version}.tar.xz"
-checksum=1d3fb8ccc2932d04aa3663e22ef5ef490244370f4e568d7850165068778d98d4
+checksum=01c9d8a303c941ec2c511c14312a3b1d36cedb41e2f5168ccdaa85d53b887805
 
 case "$XBPS_TARGET_MACHINE" in
 	arm*) configure_args="--enable-arm-neon=no";;


### PR DESCRIPTION
@leahneukirchen
- I tested the changes in this PR: briefly
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
    armv6l-musl
    i686
    i686-musl