### PR TITLE
nomacs: update to 3.22.0

### DIFF
--- a/srcpkgs/nomacs/template
+++ b/srcpkgs/nomacs/template
@@ -1,31 +1,17 @@
 # Template file for 'nomacs'
 pkgname=nomacs
-version=3.17.2287
-revision=5
-_plugins_ver=3.17.2285
+version=3.22.0
+revision=1
 build_wrksrc=ImageLounge
 build_style=cmake
 configure_args="-DCMAKE_BUILD_TYPE=None -DENABLE_TRANSLATIONS=1
- -DUSE_SYSTEM_QUAZIP=1"
-hostmakedepends="pkg-config qt5-qmake qt5-host-tools quazip-devel"
-makedepends="qt5-tools-devel qt5-svg-devel exiv2-devel libopencv-devel
+ -DENABLE_QUAZIP=1 -DUSE_SYSTEM_QUAZIP=1"
+hostmakedepends="pkg-config qt6-base qt6-declarative-host-tools quazip-qt6-devel"
+makedepends="qt6-tools-devel qt6-svg-devel qt6-qt5compat-devel exiv2-devel libopencv-devel
  libraw-devel quazip-devel"
 short_desc="Simple yet powerful Qt imageviewer"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-3.0-or-later"
 homepage="https://github.com/nomacs/nomacs"
-distfiles="https://github.com/nomacs/nomacs/archive/${version}.tar.gz
- https://github.com/novomesk/nomacs-plugins/archive/refs/tags/${_plugins_ver}.tar.gz>plugins.tar.gz"
-checksum="6905ea615358f84a0c83d5b1b7077871dea0526ec667500a1951448cb845a92c
- 946b2d754be9ecca5cb155f7ecc5dcafb164f6c3dcc7bf5c3c0610d3b47774aa"
-skip_extraction="plugins.tar.gz"
-
-post_extract() {
-	cd ${build_wrksrc}
-	vsrcextract -C plugins "plugins.tar.gz"
-}
-
-post_patch() {
-	# XXX: remove this when updating, it no longer requires git as of 3.17.2295
-	vsed -i -e "s/import subprocess/return '${version}'/" ../scripts/versionupdate.py
-}
+distfiles="https://github.com/nomacs/nomacs/archive/${version}.tar.gz"
+checksum="0842ce44999fe6a315069ca06b1b3d189dcb34308c8b359b83c453eb76366c0f"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)

Note: The package builds, installs and runs fine with the template as proposed, but the [readme](https://github.com/nomacs/nomacs#build-options-and-their-dependencies) states the following:

"Build options and their dependencies

This is the list of configurable packages and what they provide in nomacs. To ensure a feature is included/excluded set the cmake option for that feature. By default, all features are enabled if the dependencies are found when running cmake**.

The following Qt components are necessary: `Core, Concurrent, Network, PrintSupport, SVG, Widgets, Core5Compat.`"

Of these dependencies only `qt6-svg-devel` was already present from previous versions. I added `qt6-qt5compat-devel` because the build would otherwise fail.

The packages `qt6-core qt6-concurrent qt6-network qt6-printsupport qt6-widgets` aren't necessary for building without error messages.
But as they are explicitly mentioned, I wonder if I should still add them. I wouldn't know, though, where to add them - to `makedepends`, `hostmakedepends` or even `depends`?

Another question would be the added `-DENABLE_QUAZIP=1`.
I did a build test with the previous version and during checks it said that quazip was enabled. Without any changes to the template in that regard for the new version, it would say that quazip was not included. So, I added the argument. I also did a test install with both options. With the added argument, the install would also install quazip-qt6, without the argument, it would not. I'm not sure if nomacs would be able to use the qt5 version of quazip that the previous version depended on. The qt5compat dependency might allow for that - or not, I don't know. So, the question would be if the added argument is needed or if it would be incompatible with the pre-existing argument `-DUSE_SYSTEM_QUAZIP=1`.