### PR TITLE
melonDS: update to 1.1, switch to Qt6, adopt

### DIFF
--- a/srcpkgs/melonDS/template
+++ b/srcpkgs/melonDS/template
@@ -1,14 +1,17 @@
 # Template file for 'melonDS'
 pkgname=melonDS
-version=0.9.5
+version=1.1
 revision=1
 build_style=cmake
-hostmakedepends="pkg-config qt5-host-tools qt5-qmake extra-cmake-modules"
-makedepends="qt5-devel libslirp-devel SDL2-devel libepoxy-devel
- libarchive-devel qt5-multimedia-devel"
-short_desc="Fast and accurate Nintendo DS emulator"
-maintainer="Francesco Circhetta <francesco.circhetta@gmail.com>"
+hostmakedepends="extra-cmake-modules pkg-config qt6-base"
+makedepends="SDL2-devel faad2-devel libarchive-devel libenet-devel
+ libepoxy-devel libslirp-devel qt6-base-devel qt6-multimedia-devel
+ qt6-svg-devel wayland-devel"
+depends="qt6-svg"
+short_desc="Nintendo DS emulator"
+maintainer="Matthias von Faber <mvf@gmx.eu>"
 license="GPL-3.0-or-later"
-homepage="http://melonds.kuribo64.net/"
-distfiles="https://github.com/Arisotura/melonDS/archive/${version}.tar.gz"
-checksum=52c6b99340b8bba8c52b11a2242591f05e838c34ddd9ec20dcf1a6039405434a
+homepage="https://melonds.kuribo64.net/"
+changelog="https://github.com/melonDS-emu/melonDS/releases"
+distfiles="https://github.com/melonDS-emu/melonDS/archive/refs/tags/${version}.tar.gz"
+checksum=61e339bcb18a68a17485973637d972ea628c5624d7e6b8adf6870f895d5e26fd


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->

Hope this is fine to adopt. Maintainer's last `void-packages` commit was almost 5 years ago, and all updates to this package have been by others.