### PR TITLE
Signal-Desktop: update to 7.85.0.

### DIFF
--- a/srcpkgs/Signal-Desktop/patches/01-no-desktop.patch
+++ b/srcpkgs/Signal-Desktop/patches/01-no-desktop.patch
@@ -1,16 +1,14 @@
-diff --git a/Signal-Desktop/package.json.orig b/Signal-Desktop/package.json
-index 832035e..e6ac14c 100644
 --- a/package.json
 +++ b/package.json
-@@ -519,11 +519,6 @@
-     },
+@@ -452,11 +452,6 @@
      "linux": {
+       "executableName": "signal-desktop",
        "category": "Network;InstantMessaging;Chat",
 -      "desktop": {
 -        "entry": {
 -          "StartupWMClass": "signal"
 -        }
 -      },
+       "artifactName": "${name}_${version}_${arch}.${ext}",
        "target": [
          "deb"
-       ],

--- a/srcpkgs/Signal-Desktop/template
+++ b/srcpkgs/Signal-Desktop/template
@@ -1,6 +1,6 @@
 # Template file for 'Signal-Desktop'
 pkgname=Signal-Desktop
-version=7.78.0
+version=7.85.0
 revision=1
 # *-musl could potentially work based on the Alpine port:
 # https://git.alpinelinux.org/aports/tree/testing/signal-desktop
@@ -13,7 +13,7 @@ maintainer="dkwo <npiazza@disroot.org>"
 license="AGPL-3.0-only"
 homepage="https://github.com/signalapp/Signal-Desktop"
 distfiles="https://github.com/signalapp/Signal-Desktop/archive/v${version}.tar.gz"
-checksum=daef31f9abc9caaf207937f0d3b257245308c365fb9d613d50c49a1048327a8c
+checksum=6a856e38ede48a6279c2d26a4b73ed2c779e47f8c608a354e5df02471e6cb850
 nostrip_files="signal-desktop"
 nocross="gyp -> aarch64-linux-gnu-gcc: error: unrecognized command-line option '-m64'"
 


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)

#### Note

The Signal Desktop application is not opening because of an incompatibility between the Signal Desktop package and Wayland.
