### PR TITLE
nvtop: update to 3.3.1

### DIFF
--- a/srcpkgs/nvtop/template
+++ b/srcpkgs/nvtop/template
@@ -1,6 +1,6 @@
 # Template file for 'nvtop'
 pkgname=nvtop
-version=3.3.0
+version=3.3.1
 revision=1
 build_style=cmake
 hostmakedepends="pkg-config"
@@ -11,4 +11,4 @@ license="GPL-3.0-or-later"
 homepage="https://github.com/Syllo/nvtop"
 changelog="https://github.com/Syllo/nvtop/releases"
 distfiles="https://github.com/Syllo/nvtop/archive/refs/tags/${version}.tar.gz"
-checksum=bc133b3baeb620d3b859aab6238c45de64b8269579b62e544f2ff747d129337e
+checksum=8318aff973e0850bea4b9d7d313c513206cdc9b8387e8441681e84ac2bc0e980


### PR DESCRIPTION
Bugfix release -> Fix a regression that would miss-report available device memory of NVIDIA GPUs

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
