### PR TITLE
rpi-imager: update to 2.0.4

### DIFF
--- a/srcpkgs/rpi-imager/template
+++ b/srcpkgs/rpi-imager/template
@@ -1,20 +1,20 @@
 # Template file for 'rpi-imager'
 pkgname=rpi-imager
-version=1.8.5
+version=2.0.4
 revision=1
 build_wrksrc=src
 build_style=cmake
 configure_args="-DENABLE_TELEMETRY=OFF -DENABLE_CHECK_VERSION=OFF"
-hostmakedepends="qt5-host-tools qt5-qmake"
-makedepends="qt5-devel qt5-declarative-devel qt5-svg-devel qt5-tools-devel
+hostmakedepends="git cmake qt6-tools qt6-svg pkg-config"
+makedepends="qt6-declarative-devel qt6-svg-devel qt6-tools-devel
  libcurl-devel libarchive-devel gnutls-devel"
-depends="qt5-quickcontrols2 qt5-svg util-linux"
+depends="curl libgcc gnutls hicolor-icon-theme libarchive polkit qt6-base qt6-declarative xz zstd"
 short_desc="Raspberry Pi Imaging Utility"
 maintainer="Adam Gausmann <adam@gaussian.dev>"
 license="Apache-2.0"
 homepage="https://github.com/raspberrypi/rpi-imager"
 distfiles="https://github.com/raspberrypi/rpi-imager/archive/v${version}.tar.gz"
-checksum=443e2ca2132067cc67038c82d890f70fd744da2503588852f014435dd11fb786
+checksum=51a8110bbc885cdfbd3541ed81091c708e7b8dc6f43717cadfd88faffccdda97
 
 pre_configure() {
 	ln -sf /bin/true $XBPS_WRAPPERDIR/lsblk


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)

The rpi-imager application no longer writes data to the SD card because its version is outdated.

