### PR TITLE
google-authenticator-libpam: update to 1.11.

### DIFF
--- a/srcpkgs/google-authenticator-libpam/template
+++ b/srcpkgs/google-authenticator-libpam/template
@@ -1,6 +1,6 @@
 # Template file for 'google-authenticator-libpam'
 pkgname=google-authenticator-libpam
-version=1.09
+version=1.11
 revision=1
 build_style=gnu-configure
 hostmakedepends="automake libtool"
@@ -10,7 +10,7 @@ maintainer="Enno Boland <gottox@voidlinux.org>"
 license="Apache-2.0"
 homepage="https://github.com/google/google-authenticator-libpam"
 distfiles="https://github.com/google/google-authenticator-libpam/archive/$version.tar.gz"
-checksum=ab1d7983413dc2f11de2efa903e5c326af8cb9ea37765dacb39949417f7cd037
+checksum=3ee08a6dd46aace7dba1c88cf47e9cd267447ccd1cd8be1d5a05fd0e6816062d
 replaces="libpam-google-authenticator>=0"
 # Tries to change user to nobody and fails due to being in a user namespace
 make_check=no


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)

