### PR TITLE
common/shlibs: add glycin 2.0.7 sonames

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -4562,3 +4562,5 @@ libcmark-gfm-extensions.so.0 cmark-gfm-0.29.0.gfm.13_1
 libpisp.so.1 libpisp-1.3.0_1
 libMpvQt.so.2 mpvqt-1.1.1_1
 libtomlplusplus.so.3 tomlplusplus-3.4.0_1
+libglycin-2.so.0 glycin-2.0.7_1
+libglycin-gtk4-2.so.0 glycin-gtk4-2.0.7_1


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)

This fixes a shlib issue I have with packages dependent on this package:

```
=> bazaar-0.7.5_1: running pre-pkg hook: 04-generate-runtime-deps ...
   SONAME: libadwaita-1.so.0 <-> libadwaita>=1.4.0_1
   SONAME: libappstream.so.5 <-> AppStream>=1.0.2_1
   SONAME: libc.so.6 <-> glibc>=2.41_1
   SONAME: libcairo.so.2 <-> cairo>=1.8.6_1
   SONAME: libdex-1.so.1 <-> libdex>=0.2.0_1
   SONAME: libflatpak.so.0 <-> flatpak>=0.9.3_2
   SONAME: libgio-2.0.so.0 <-> glib>=2.86.0_1
   SONAME: libglib-2.0.so.0 <-> glib>=2.86.0_1
   SONAME: libglycin-2.so.0 <-> UNKNOWN PKG PLEASE FIX!
   SONAME: libglycin-gtk4-2.so.0 <-> glycin-gtk4>=2.0.7_1
   SONAME: libgobject-2.0.so.0 <-> glib>=2.86.0_1
   SONAME: libgraphene-1.0.so.0 <-> graphene>=1.8.2_1
   SONAME: libgtk-4.so.1 <-> gtk4>=4.12.0_1
   SONAME: libjson-glib-1.0.so.0 <-> json-glib>=0.12.2_1
   SONAME: libm.so.6 <-> glibc>=2.41_1
   SONAME: libmd4c.so.0 <-> libmd4c>=0.4.8_1
   SONAME: libpango-1.0.so.0 <-> pango>=1.24.0_1
   SONAME: libsecret-1.so.0 <-> libsecret>=0.10_1
   SONAME: libsoup-3.0.so.0 <-> libsoup3>=3.0.0_1
   SONAME: libwebkitgtk-6.0.so.4 <-> libwebkitgtk60>=2.40.0_1
   SONAME: libxmlb.so.2 <-> libxmlb>=0.2.1_1
   SONAME: libyaml-0.so.2 <-> libyaml>=0.1.4_1
=> ERROR: bazaar-0.7.5_1: cannot guess required shlibs, aborting!
Do you want to import this public key? [Y/n] 

Error: Process completed with exit code 1.
```