### PR TITLE
audacity: update to 3.7.7, adopt.

### DIFF
--- a/srcpkgs/audacity/template
+++ b/srcpkgs/audacity/template
@@ -1,7 +1,7 @@
 # Template file for 'audacity'
 pkgname=audacity
-version=3.7.3
-revision=3
+version=3.7.7
+revision=1
 build_style=cmake
 build_helper="cmake-wxWidgets-gtk3 qemu"
 configure_args="-Daudacity_use_ffmpeg=loaded -Daudacity_lib_preference=system
@@ -20,12 +20,12 @@ makedepends="wxWidgets-gtk3-devel gtk+3-devel expat-devel lame-devel
  opusfile-devel rapidjson"
 depends="desktop-file-utils hicolor-icon-theme"
 short_desc="Graphical cross-platform audio editor"
-maintainer="Orphaned <orphan@voidlinux.org>"
+maintainer="Eren Öztürk <erenozturkhde@gmail.com>"
 license="GPL-2.0-or-later, GPL-3.0-or-later, CC-BY-3.0"
 homepage="https://www.audacityteam.org"
 changelog="https://github.com/audacity/audacity/raw/master/CHANGELOG.txt"
 distfiles="https://github.com/audacity/audacity/releases/download/Audacity-${version}/audacity-sources-${version}.tar.gz"
-checksum=5dbe4f494f9fa51e47bfe6dc2c3bf62e1eaedbf087bad79cce51e461c1db3e92
+checksum=1574688e54009b40faeffe5752b5f822ff251e2d4228e8ec60ec0f99f3423cda
 
 case "$XBPS_TARGET_MACHINE" in
 	i686*) CFLAGS="-msse2";;


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc

I'd like to adopt this package as it was orphaned. I'm an active Void Linux user and I've updated the package to the latest stable version (3.7.7). I've verified the build on x86_64-glibc.