### PR TITLE
zix: update to 0.8.0.

### DIFF
--- a/srcpkgs/zix/template
+++ b/srcpkgs/zix/template
@@ -1,6 +1,6 @@
 # Template file for 'zix'
 pkgname=zix
-version=0.6.2
+version=0.8.0
 revision=1
 build_style=meson
 short_desc="C library of portability wrappers and data structures"
@@ -9,7 +9,7 @@ license="ISC"
 homepage="https://gitlab.com/drobilla/zix/"
 changelog="https://gitlab.com/drobilla/zix/-/raw/main/NEWS"
 distfiles="https://download.drobilla.net/zix-${version}.tar.xz"
-checksum=4bc771abf4fcf399ea969a1da6b375f0117784f8fd0e2db356a859f635f616a7
+checksum=e9b6fe3ede984fa53f2edcebdabb35fb99ace807722772156aea49c079cad191
 
 post_install() {
 	vlicense COPYING


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
