### PR TITLE
hackrf: update to 2026.01.2.

### DIFF
--- a/srcpkgs/hackrf/template
+++ b/srcpkgs/hackrf/template
@@ -1,6 +1,6 @@
 # Template file for 'hackrf'
 pkgname=hackrf
-version=2024.02.1
+version=2026.01.2
 revision=1
 build_wrksrc=host
 build_style=cmake
@@ -14,7 +14,7 @@ maintainer="DragonGhost7 <darkiridiumghost@gmail.com>"
 license="GPL-2.0-or-later"
 homepage="https://greatscottgadgets.com/hackrf/"
 distfiles="https://github.com/greatscottgadgets/hackrf/releases/download/v${version}/${pkgname}-${version}.tar.xz"
-checksum=d9ced67e6b801cd02c18d0c4654ed18a4bcb36c24a64330c347dfccbd859ad16
+checksum=71571bc8cfd26b3b8e1293efbd69fc8d94ce0baf802bd5af1e6d851d1c2cbc57
 
 post_install() {
 	for f in ../firmware-bin/*.{bin,dfu}; do


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)

