### PR TITLE
lego: update to 4.31.0.

### DIFF
--- a/srcpkgs/lego/template
+++ b/srcpkgs/lego/template
@@ -1,6 +1,6 @@
 # Template file for 'lego'
 pkgname=lego
-version=4.26.0
+version=4.31.0
 revision=1
 build_style=go
 go_import_path="github.com/go-acme/lego/v4"
@@ -11,7 +11,7 @@ license="MIT"
 homepage="https://go-acme.github.io/lego"
 changelog="https://raw.githubusercontent.com/go-acme/lego/master/CHANGELOG.md"
 distfiles="https://github.com/go-acme/lego/archive/v${version}.tar.gz"
-checksum=31b01627ff6e40aa8a8955b68a95ee7be9c10297faed86a5528734b9a9edd981
+checksum=e3504804193be4ab72ca9a40725b3632f204f20d92920a0e886250091e3dab6e
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **NO**

#### Local build testing
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl
  - aarch64-musl (cross)