### PR TITLE
opera: update to 126.0.5750.59.

### DIFF
--- a/srcpkgs/opera/template
+++ b/srcpkgs/opera/template
@@ -1,6 +1,6 @@
 # Template file for 'opera'
 pkgname=opera
-version=122.0.5643.142
+version=126.0.5750.59
 revision=1
 archs="x86_64"
 create_wrksrc=yes
@@ -10,7 +10,7 @@ maintainer="mobinmob <mobinmob@disroot.org>"
 license="custom:Proprietary"
 homepage="https://www.opera.com/computer"
 distfiles="https://get.geo.opera.com/pub/opera/desktop/${version}/linux/opera-stable_${version}_amd64.rpm"
-checksum=06030914b0da3d61e40b47b3d398b78377152e31d2e36cd2c492d68789f58995
+checksum=c83e0b4b84c16b06a6cb6b1b2f17962569767a9d8df522bee40eea35f4b352f5
 repository="nonfree"
 nostrip=yes
 
@@ -20,12 +20,12 @@ do_install() {
 	vmkdir usr/lib
 
 	# Copy files
-	vcopy usr/lib64/opera usr/lib/
+	vcopy usr/lib64/opera-stable usr/lib/
 	vcopy usr/share usr/share/
 
 	# Link executable in path
-	ln -s ../lib/opera/opera "${DESTDIR}/usr/bin/opera"
+	ln -s ../lib/opera-stable/opera "${DESTDIR}/usr/bin/opera"
 
 	# Install 3rd-party licenses
-	vlicense usr/lib64/opera/opera_autoupdate.licenses
+	vlicense usr/lib64/opera-stable/opera_autoupdate.licenses
 }


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture (x86_64-glibc)
<!--
  - I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
