### PR TITLE
wine: update to 11.0

### DIFF
--- a/srcpkgs/wine/template
+++ b/srcpkgs/wine/template
@@ -1,6 +1,6 @@
 # Template file for 'wine'
 pkgname=wine
-version=10.20
+version=11.0
 revision=1
 _pkgver=${version/r/-r}
 create_wrksrc=yes
@@ -11,10 +11,13 @@ short_desc="Run Microsoft Windows applications"
 maintainer="Helmut Pozimski <helmut@pozimski.eu>"
 license="LGPL-2.1-or-later"
 homepage="http://www.winehq.org/"
-distfiles="https://dl.winehq.org/wine/source/${version%.*}.x/wine-${_pkgver}.tar.xz
+# For non-zero subversions
+# distfiles="https://dl.winehq.org/wine/source/${version%.*}.x/wine-${_pkgver}.tar.xz
+# For zero subversions
+distfiles="https://dl.winehq.org/wine/source/${version%.*}.0/wine-${_pkgver}.tar.xz
  https://github.com/wine-staging/wine-staging/archive/v${_pkgver}.tar.gz"
-checksum="81b4a153958f6247fe5041d5df65eadcbbeea1b6ba8cda24eb7e3d7ce2d1fe3c
- 83d0d97b1f4b7ee9d61b58c7a87657b768a635d2f3bd5c6435fe337419be0c7a"
+checksum="c07a6857933c1fc60dff5448d79f39c92481c1e9db5aa628db9d0358446e0701
+ ae4f711922c45252252a565e85b7f011c85387be1deb5acddca587364d5a2620"
 
 # NOTE: wine depends on specific versions of wine-mono and wine-gecko,
 # check for updates to these packages when updating wine
@@ -47,7 +50,7 @@ fi
 hostmakedepends="pkg-config flex gettext
  $(vopt_if mingw "cross-${XBPS_TARGET_MACHINE%-musl}-w64-mingw32")
  $(vopt_if staging 'autoconf')"
-makedepends="gettext-devel ncurses-devel glu-devel libSM-devel
+makedepends="gettext-devel glu-devel libSM-devel
  libXext-devel libX11-devel libXpm-devel libXinerama-devel
  libXcomposite-devel libXmu-devel libXxf86vm-devel
  libXcursor-devel libXrandr-devel libXdamage-devel libXi-devel


### PR DESCRIPTION
@Hoshpak 

Also remove ncurses dependency as it's not needed as of wine 5.18, relevant links:

[1] https://www.winehq.org//announce/5.18
[2] https://source.winehq.org/git/wine.git/commit/26c715f85b490eda36fa06473a24218bda40a56e

Haven't tested anything other than x86_64.