### PR TITLE
qmk: update to 1.2.0

### DIFF
--- a/srcpkgs/qmk/template
+++ b/srcpkgs/qmk/template
@@ -1,7 +1,7 @@
 # Template file for 'qmk'
 pkgname=qmk
-version=1.1.6
-revision=2
+version=1.2.0
+revision=1
 build_style=python3-pep517
 hostmakedepends="python3-wheel"
 # This includes the requirements from requirements.txt in the qmk_firmware
@@ -15,7 +15,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
 homepage="https://github.com/qmk/qmk_cli"
 distfiles="${PYPI_SITE}/q/qmk/qmk-${version}.tar.gz"
-checksum=dc436cdbabf2f8cec6dbad453de3832be01bac8e7e9c19075c29866ee22a8b50
+checksum=164bd16c4c401b2b765ee4f017bcfa8141942ddf362961c4cba1975d8cb28a48
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

Tried building firmware for my keyboard, then was able to flash it successfully.

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
