### PR TITLE
steam: add libdrm-32bit dependency

### DIFF
--- a/srcpkgs/steam/template
+++ b/srcpkgs/steam/template
@@ -1,10 +1,10 @@
 # Template file for 'steam'
 pkgname=steam
 version=1.0.0.85
-revision=1
+revision=2
 archs="i686 x86_64"
 depends="zenity xz curl dbus freetype gdk-pixbuf hicolor-icon-theme desktop-file-utils
- liberation-fonts-ttf file tar bash coreutils lsof steam-udev-rules"
+ liberation-fonts-ttf file tar bash coreutils lsof steam-udev-rules libdrm-32bit"
 short_desc="Digital distribution client bootstrap package - Valve's steam client"
 maintainer="Andrew Benson <abenson+void@gmail.com>"
 license="custom: Proprietary license"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc

### Steam client has 32-bit libdrm.so.2 runtime dependency, and fails to launch without it

Tested on two machines, and Steam client needed libdrm-32bit installed through xbps in order to run.

```
steam.sh[6625]: Error: You are missing the following 32-bit libraries, and Steam may not run:
libdrm.so.2
```

<img width="566" height="216" alt="2026-01-23-180830_566x216_scrot" src="https://github.com/user-attachments/assets/921075b4-71e2-4c56-b641-19b978f6d2fe" />