### PR TITLE
python3-ocrmypdf: update to 17.4.2, jbig2enc: update to 0.31 + package libpdfium

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -4553,6 +4553,7 @@ libclapper-0.0.so.0 clapper-libs-0.8.0_1
 libopenxr_loader.so.1 openxr-1.1.47_1
 libppsdocument-4.0.so.6 libpapers-50.0_1
 libppsview-4.0.so.5 libpapers-50.0_1
+libpdfium.so.7778 libpdfium-7778_1
 libngtcp2.so.16 ngtcp2-1.13.0_1
 libngtcp2_crypto_ossl.so.0 ngtcp2-1.13.0_1
 libprom.so prometheus-client-c-0.1.3_1

--- a/srcpkgs/img2pdf/template
+++ b/srcpkgs/img2pdf/template
@@ -1,14 +1,22 @@
 # Template file for 'img2pdf'
 pkgname=img2pdf
-version=0.6.1
-revision=2
-build_style=python3-module
-hostmakedepends="python3-pikepdf python3-setuptools"
-depends="colord python3-pdfrw python3-pikepdf python3-Pillow python3-tkinter"
+version=0.6.3
+revision=1
+build_style=python3-pep517
+make_check_args="-k not(miff_cmyk)"
+hostmakedepends="python3-flit_core"
+depends="python3-pikepdf python3-Pillow"
+checkdepends="python3-pytest python3-numpy python3-scipy ImageMagick poppler
+ ghostscript mupdf-tools netpbm exiftool colord ${depends}"
 short_desc="Lossless conversion of raster images to PDF"
 maintainer="Orphaned <orphan@voidlinux.org>"
-license="GPL-3.0-or-later"
+license="LGPL-3.0-or-later"
 homepage="https://gitlab.mister-muffin.de/josch/img2pdf"
 distfiles="${PYPI_SITE}/i/img2pdf/img2pdf-${version}.tar.gz"
-checksum=306e279eb832bc159d7d6294b697a9fbd11b4be1f799b14b3b2174fb506af289
-make_check=no # need to patch out some bitdepth checks
+checksum=219518020f5bd242bdc46493941ea3f756f664c2e86f2454721e74353f58cd95
+
+case "$XBPS_TARGET_MACHINE" in
+	i686)
+		make_check=no # 70 errors on this arch
+		;;
+esac

--- a/srcpkgs/jbig2enc/template
+++ b/srcpkgs/jbig2enc/template
@@ -1,16 +1,16 @@
 # Template file for 'jbig2enc'
 pkgname=jbig2enc
-version=0.30
+version=0.31
 revision=1
 build_style=gnu-configure
-hostmakedepends="automake libtool"
+hostmakedepends="automake libtool pkg-config"
 makedepends="leptonica-devel zlib-devel"
 short_desc="JBIG2 Encoder"
 maintainer="Mateusz Sylwestrzak <slymattz@gmail.com>"
 license="Apache-2.0"
 homepage="https://github.com/agl/jbig2enc"
 distfiles="https://github.com/agl/jbig2enc/archive/refs/tags/${version}.tar.gz"
-checksum=4468442f666edc2cc4d38b11cde2123071a94edc3b403ebe60eb20ea3b2cc67b
+checksum=35c255e44a9b1c4cbe27d2c84594a43d6666645156a2d186ba60f8832566141d
 
 pre_configure() {
 	./autogen.sh

--- a/srcpkgs/libpdfium-devel
+++ b/srcpkgs/libpdfium-devel
@@ -1,0 +1,1 @@
+libpdfium

--- a/srcpkgs/libpdfium/template
+++ b/srcpkgs/libpdfium/template
@@ -1,0 +1,174 @@
+# Template file for 'libpdfium'
+# Updating libpdfium might break ABI, so make sure all dependents get rebuilt (e.g. pypdfium2)
+# Also update common/shlibs as this package produces libpdfium.so.${version}
+pkgname=libpdfium
+version=7778 # match chromium build (branch base) number
+revision=1
+_pdfium_commit="a78c62d93a8f514ea2cd98a70bd1d21226be9d93"
+_chromium_ver="148.0.7778.96"
+_fast_float_ver="8.2.5"
+hostmakedepends="python3 ninja gn pkg-config tar xz"
+makedepends="libjpeg-turbo-devel icu-devel libopenjpeg2-devel freetype-devel
+ glib-devel abseil-cpp-devel lcms2-devel libpng-devel zlib-devel harfbuzz-devel"
+short_desc="Google PDF rendering library"
+maintainer="Mateusz Sylwestrzak <slymattz@gmail.com>"
+license="Apache-2.0"
+homepage="https://pdfium.googlesource.com/pdfium"
+# use GH mirror of pdfium as https://pdfium.googlesource.com/pdfium/+archive/${_pdfium_commit}.tar.gz can be unreliable in CI
+# compute sha256sums on the original tarball by running tar xf <tarball.ext> --to-stdout | sha256sum and prepend the output with '@'
+# in checksum
+distfiles="
+ https://github.com/lukas-w/pdfium/archive/${_pdfium_commit}.tar.gz>pdfium-${version}.tar.gz
+ https://github.com/chromium-linux-tarballs/chromium-tarballs/releases/download/${_chromium_ver}/chromium-${_chromium_ver}-linux.tar.xz
+ https://github.com/fastfloat/fast_float/archive/refs/tags/v${_fast_float_ver}.tar.gz>fast_float.tar.gz
+"
+checksum="@e489b6f3b69e76f6e6a318603f45e7aca6a995e2e3f532a349d55d3860f4571e
+ 2bf85abe7341333b5347413beebb80f8e9dd02220fa690929e25816eeab8e78f
+ 17c7fb14499fcf42c3f5d143df0fbe22172e92749ec5f75ef13224005421a654"
+skip_extraction="fast_float.tar.gz chromium-${_chromium_ver}-linux.tar.xz"
+
+post_extract() {
+	mkdir -p build buildtools third_party/fast_float/src \
+		third_party/icu third_party/abseil-cpp
+
+	local _dist="${XBPS_SRCDISTDIR}/${pkgname}-${version}"
+
+	# Extract only necessary subdirs from chromium
+	tar -xf "${_dist}/chromium-${_chromium_ver}-linux.tar.xz" \
+		--strip-components=1 \
+		--wildcards \
+		'*/build/*' \
+		'*/buildtools/*'
+
+	tar -xf "${_dist}/fast_float.tar.gz" \
+		-C third_party/fast_float/src --strip-components=1
+
+	# Mock testing targets to satisfy internal dependencies
+	rm -f testing/BUILD.gn
+	for g in pdfium_test path_service embedder_test_support unit_test_support test_support pixel_diff_utils; do
+		echo "group(\"$g\") {}" >> testing/BUILD.gn
+	done
+
+	cat > build/config/gclient_args.gni <<-EOF
+		checkout_google_benchmark = false
+		checkout_nacl = false
+	EOF
+
+	cat > build_overrides/build.gni <<-EOF
+		build_with_chromium = false
+		use_system_libcxx = true
+	EOF
+
+	# System shim for ICU
+	cat > third_party/icu/BUILD.gn <<-EOF
+		import("//build/config/linux/pkg_config.gni")
+		pkg_config("icu_config") { packages = [ "icu-uc", "icu-i18n" ] }
+		group("icuuc") { public_configs = [ ":icu_config" ] }
+		group("icui18n") { public_configs = [ ":icu_config" ] }
+	EOF
+
+	# System shim for Abseil
+	cat > third_party/abseil-cpp/BUILD.gn <<-EOF
+		import("//build/config/linux/pkg_config.gni")
+		pkg_config("absl_config") {
+			packages = [
+				"absl_base", "absl_int128", "absl_strings", "absl_hash",
+				"absl_synchronization", "absl_raw_hash_set",
+				"absl_low_level_hash", "absl_raw_logging_internal"
+			]
+		}
+		group("absl") { public_configs = [ ":absl_config" ] }
+EOF
+}
+
+post_patch() {
+	# Transform internal paths to system-wide include style
+	find core -type f \( -name "*.cpp" -o -name "*.h" \) -exec sed -i \
+		-e 's|#include "third_party/abseil-cpp/\(.*\)"|#include <\1>|g' \
+		-e 's|#include "third_party/icu/source/common/\(.*\)"|#include <\1>|g' \
+		-e 's|#include "third_party/icu/source/i18n/\(.*\)"|#include <\1>|g' {} +
+
+	# Strip ARM64-specific strictness that breaks build for this arch
+	vsed -i build/config/compiler/BUILD.gn \
+		-e 's/-Wl,--fatal-warnings/-Wl,--no-fatal-warnings/g'
+
+	# Map build-system toolchain to XBPS environment
+	vsed -i build/toolchain/linux/BUILD.gn \
+		-e '/toolprefix =/d' \
+		-e "s|cc = \".*gcc\"|cc = \"${CC}\"|g" \
+		-e "s|cxx = \".*g++\"|cxx = \"${CXX}\"|g" \
+		-e "s|ar = \".*ar\"|ar = \"${AR}\"|g" \
+		-e "s|nm = \".*nm\"|nm = \"${NM}\"|g" \
+		-e "s|readelf = \".*readelf\"|readelf = \"${READELF}\"|g"
+
+	vsed -i build/config/compiler/BUILD.gn \
+		-e '1i declare_args() { extra_cflags="" extra_cppflags="" extra_ldflags="" }'
+}
+
+do_configure() {
+	case "$XBPS_TARGET_MACHINE" in
+		aarch64*) _cpu=arm64 ;;
+		arm*)     _cpu=arm ;;
+		mips64*)  _cpu=mips64 ;;
+		mips*)    _cpu=mips ;;
+		ppc*)     _cpu=ppc ;;
+		i686*)    _cpu=x86 ;;
+		x86_64*)  _cpu=x64 ;;
+	esac
+
+	# Enforce global flags for all arches
+	local _extra_cflags="${CFLAGS} -Wno-free-nonheap-object"
+	local _extra_cppflags="${CXXFLAGS} -Wno-free-nonheap-object"
+	local _extra_ldflags="${LDFLAGS} -Wl,-soname,libpdfium.so.${version} -Wl,--no-fatal-warnings"
+
+	gn gen out/Release --args="
+ target_cpu=\"${_cpu}\" is_debug=false is_component_build=true
+ pdf_is_standalone=true pdf_enable_v8=false pdf_enable_xfa=false pdf_use_skia=false
+ use_custom_libcxx=false use_sysroot=false
+ is_clang=false treat_warnings_as_errors=false symbol_level=0
+ use_system_harfbuzz=true
+ use_system_zlib=true
+ use_system_libpng=true
+ use_system_libjpeg=true
+ use_system_libopenjpeg2=true
+ use_system_lcms2=true
+ use_system_freetype=true
+ pdf_bundle_freetype=false
+ extra_cflags=\"${_extra_cflags}\"
+ extra_cppflags=\"${_extra_cppflags}\"
+ extra_ldflags=\"${_extra_ldflags}\""
+}
+
+do_build() {
+	ninja -C out/Release pdfium
+}
+
+do_install() {
+	vinstall out/Release/libpdfium.so 755 usr/lib libpdfium.so.${version}
+	ln -sf libpdfium.so.${version} ${DESTDIR}/usr/lib/libpdfium.so
+	vmkdir usr/include/pdfium
+	vcopy "public/*.h" usr/include/pdfium
+
+	vmkdir usr/lib/pkgconfig
+	cat > "${DESTDIR}/usr/lib/pkgconfig/pdfium.pc" <<-EOF
+		prefix=/usr
+		exec_prefix=\${prefix}
+		libdir=\${exec_prefix}/lib
+		includedir=\${prefix}/include/pdfium
+		Name: pdfium
+		Description: Google PDFium rendering library
+		Version: ${version}
+		Libs: -L\${libdir} -lpdfium
+		Cflags: -I\${includedir}
+EOF
+}
+
+libpdfium-devel_package() {
+	short_desc+=" - development files"
+	depends="${sourcepkg}>=${version}_${revision}"
+	pkg_install() {
+		vmove "usr/lib/*.so"
+		vmove usr/include
+		vmove usr/lib/pkgconfig
+	}
+}

--- a/srcpkgs/python3-fpdf2/template
+++ b/srcpkgs/python3-fpdf2/template
@@ -1,0 +1,13 @@
+# Template file for 'python3-fpdf2'
+pkgname=python3-fpdf2
+version=2.8.7
+revision=1
+build_style=python3-pep517
+hostmakedepends="python3-setuptools_scm python3-wheel fonttools"
+depends="python3-defusedxml python3-Pillow fonttools"
+short_desc="Simple PDF generation for Python"
+maintainer="Mateusz Sylwestrzak <slymattz@gmail.com>"
+license="LGPL-3.0-only"
+homepage="https://github.com/py-pdf/fpdf2"
+distfiles="${PYPI_SITE}/f/fpdf2/fpdf2-${version}.tar.gz"
+checksum=7060ccee5a9c7ab0a271fb765a36a23639f83ef8996c34e3d46af0a17ede57f9

--- a/srcpkgs/python3-ocrmypdf/template
+++ b/srcpkgs/python3-ocrmypdf/template
@@ -1,15 +1,22 @@
 # Template file for 'python3-ocrmypdf'
 pkgname=python3-ocrmypdf
-version=16.13.0
+version=17.4.2
 revision=1
 build_style=python3-pep517
 hostmakedepends="hatchling hatch-vcs"
 depends="python3-deprecation img2pdf python3-packaging python3-pdfminer.six
  python3-pikepdf python3-Pillow python3-pluggy python3-reportlab python3-rich
- python3-pillow_heif tesseract-ocr ghostscript unpaper pngquant jbig2enc qpdf"
+ python3-pillow_heif tesseract-ocr ghostscript unpaper pngquant jbig2enc qpdf
+ python3-fpdf2 python3-pydantic python3-pypdfium2 python3-uharfbuzz"
 short_desc="Add OCR text layer to scanned PDF files"
 maintainer="Mateusz Sylwestrzak <slymattz@gmail.com>"
 license="MPL-2.0"
 homepage="https://github.com/ocrmypdf/OCRmyPDF"
+changelog="https://raw.githubusercontent.com/ocrmypdf/OCRmyPDF/main/docs/release_notes.md"
 distfiles="${PYPI_SITE}/o/ocrmypdf/ocrmypdf-${version}.tar.gz"
-checksum=29d37e915234ce717374863a9cc5dd32d29e063dfe60c51380dda71254c88248
+checksum=b564557411c9a2695137cdc34e0a1a5084c5f33d7b3ef593f2659aa6a6a1c3cd
+
+post_install() {
+	vcompletion misc/completion/ocrmypdf.bash bash ocrmypdf
+	vcompletion misc/completion/ocrmypdf.fish fish ocrmypdf
+}

--- a/srcpkgs/python3-pikepdf/template
+++ b/srcpkgs/python3-pikepdf/template
@@ -1,6 +1,6 @@
 # Template file for 'python3-pikepdf'
 pkgname=python3-pikepdf
-version=10.1.0
+version=10.5.0
 revision=1
 build_style=python3-pep517
 hostmakedepends="python3-pybind11 python3-wheel"
@@ -16,4 +16,12 @@ license="MPL-2.0"
 homepage="https://github.com/pikepdf/pikepdf"
 changelog="https://raw.githubusercontent.com/pikepdf/pikepdf/master/docs/releasenotes/version${version%%.*}.rst"
 distfiles="${PYPI_SITE}/p/pikepdf/pikepdf-${version}.tar.gz"
-checksum=d75778283c354580a462d31bd4334f6ba92225e41ccd8bb949ec6e98a23d4eb2
+checksum=62c66fb15174bf7c13029ae67b64e04f7c5c2f9af1bd9c9aecf08f808a02acab
+
+if [ "$XBPS_BUILD_ENVIRONMENT" = "void-packages-ci" ]; then
+	case "$XBPS_TARGET_MACHINE" in
+		x86_64*|i686)
+			make_check_args="-k not((test_save_to_dev_null)or(test_repr_stream))"
+			;;
+	esac
+fi

--- a/srcpkgs/python3-pypdfium2/template
+++ b/srcpkgs/python3-pypdfium2/template
@@ -1,0 +1,69 @@
+# Template file for 'python3-pypdfium2'
+pkgname=python3-pypdfium2
+version=5.8.0
+revision=1
+build_style=python3-pep517
+build_wrksrc="pypdfium2-${version}"
+hostmakedepends="python3-setuptools_scm python3-wheel python3-packaging tar pkg-config gcc"
+makedepends="python3-devel libpdfium-devel"
+depends="python3 libpdfium"
+checkdepends="python3-pytest python3-Pillow python3-numpy"
+short_desc="Python bindings to PDFium"
+maintainer="Mateusz Sylwestrzak <slymattz@gmail.com>"
+license="Apache-2.0 OR BSD-3-Clause OR CC-BY-4.0 OR LGPL-3.0-or-later OR MIT OR MPL-2.0"
+homepage="https://github.com/pypdfium2-team/pypdfium2"
+_ctypesgen_commit="b561360fad763b4a64e2d8ef8f7ddf354670dbb7" # use pypdfium2's own fork of ctypesgen
+distfiles="https://github.com/pypdfium2-team/pypdfium2/archive/refs/tags/${version}.tar.gz
+ https://github.com/pypdfium2-team/ctypesgen/archive/${_ctypesgen_commit}.tar.gz>ctypesgen-${_ctypesgen_commit}.tar.gz"
+checksum="227c5832407e6a56219b0671cc12b5dcfab07165bebad33dc13bf7f40a9a6626
+ 5ae14b36da396d3bea23e41f615c12349697be63144fc840f29336e50ab94406"
+create_wrksrc=yes
+
+post_extract() {
+	mv "ctypesgen-${_ctypesgen_commit}" "ctypesgen_fork"
+}
+
+pre_build() {
+	export SETUPTOOLS_SCM_PRETEND_VERSION="${version}"
+	export PDFIUM_PLATFORM="sourcebuild"
+
+	_data_dir="data/sourcebuild"
+	mkdir -p "${_data_dir}"
+
+	_prefix="${XBPS_CROSS_BASE}/usr"
+	_header_dir="${_prefix}/include/pdfium"
+
+	_headers=$(find "${_header_dir}" -maxdepth 1 -name "*.h" | sort)
+
+	_pdfium_ver=$(pkg-config --modversion pdfium)
+
+	cat > "${_data_dir}/version.json" <<-EOF
+		{"major":0,"minor":0,"build":${_pdfium_ver},"patch":0,"origin":"sourcebuild","flags":[],"n_commits":0,"hash":"","is_reproducible":true}
+	EOF
+
+	PYTHONPATH="../ctypesgen_fork/src" python3 -m ctypesgen \
+		--library pdfium --no-srcinfo \
+		--headers ${_headers} \
+		--cpp "${CC} -E ${CFLAGS} ${CPPFLAGS}" \
+		-I "${_header_dir}" \
+		-I "${_prefix}/include" \
+		-I "$(${CC} -print-file-name=include)" \
+		-D "FPDF_EXPORT=" -D "FPDF_CALLCONV=" -D "__linux__" \
+		-o "${_data_dir}/bindings.py"
+
+	# Resolve the path to libpdfium.so.VER
+	local _real_path=$(readlink -f "${XBPS_CROSS_BASE}/usr/lib/libpdfium.so")
+	local _real_name="${_real_path##*/}"
+
+	# Runtime fix: ensure it loads the specific SO version
+	vsed -i "${_data_dir}/bindings.py" \
+		-e "s|name = 'pdfium'|name = '${_real_name}'|g"
+
+	vsed -i pyproject.toml \
+		-e '/ctypesgen/d'
+}
+
+post_install() {
+	vlicense LICENSES/BSD-3-Clause.txt
+	vlicense LICENSES/MIT.txt
+}

--- a/srcpkgs/python3-uharfbuzz/template
+++ b/srcpkgs/python3-uharfbuzz/template
@@ -1,0 +1,14 @@
+# Template file for 'python3-uharfbuzz'
+pkgname=python3-uharfbuzz
+version=0.54.1
+revision=1
+build_style=python3-pep517
+hostmakedepends="python3-setuptools_scm python3-wheel python3-Cython python3-pkgconfig"
+makedepends="python3-devel"
+depends="python3"
+short_desc="Streamlined Cython bindings for the harfbuzz shaping engine"
+maintainer="Mateusz Sylwestrzak <slymattz@gmail.com>"
+license="Apache-2.0"
+homepage="https://github.com/harfbuzz/uharfbuzz"
+distfiles="${PYPI_SITE}/u/uharfbuzz/uharfbuzz-${version}.tar.gz"
+checksum=ded760c284c686f1f17f5c4bf44527857ef488b7f0aebceae4c1ef1903ddddb3


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

Version 17 [depends](https://github.com/ocrmypdf/OCRmyPDF/blob/9dcd882c83923dd0c1a83e84a0793d678cd99fa1/pyproject.toml#L25) on pypdfium2 as 
> an alternative to Ghostscript for page rendering

 https://raw.githubusercontent.com/ocrmypdf/OCRmyPDF/refs/heads/main/docs/release_notes.md

Despite being an alternative, it is listed as a hard dependency. That's why I put some effort into packaging libpdfium (other distros typically package pdfium-binaries.)

EDIT 4/16/26: libpdfium updated to 7727
EDIT 4/21/26: ocrmypdf updated to 17.4.2, jbig2enc updated to 0.31
EDIT 5/11/26: libpdfium updated to 7778
EDIT 5/16/26: pypdfium2 updated to 5.8.0, uharfbuzz updated to 0.54.1

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture: x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl (crossbuild)
  - armv6l-musl (crossbuild)

