### PR TITLE
mise: update to 2026.1.6.

### DIFF
--- a/srcpkgs/mise/template
+++ b/srcpkgs/mise/template
@@ -1,6 +1,6 @@
 # Template file for 'mise'
 pkgname=mise
-version=2025.8.20
+version=2026.1.6
 revision=1
 build_style=cargo
 hostmakedepends="pkg-config"
@@ -11,7 +11,7 @@ license="MIT"
 homepage="https://github.com/jdx/mise"
 changelog="https://github.com/jdx/mise/releases"
 distfiles="https://github.com/jdx/mise/archive/v${version}.tar.gz>${pkgname}-${version}.tar.gz"
-checksum=f92d22face0128612fe27039f80beae0cd30335240cb7be1aff22b429048f485
+checksum=e6f47591e3bf3d5b8763aeb47df52687cc3308fbfb0f32d25b691efc31b3249c
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - armv6l
