### PR TITLE
astroid: rebuild for abseil update

### DIFF
--- a/srcpkgs/astroid/template
+++ b/srcpkgs/astroid/template
@@ -1,7 +1,7 @@
 # Template file for 'astroid'
 pkgname=astroid
 version=0.17
-revision=4
+revision=5
 build_style=cmake
 build_helper=gir
 hostmakedepends="pkg-config scdoc protobuf gobject-introspection"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->

The recent protobuf rebuild for the abseil update resulted in an ABI mismatch.

`astroid: symbol lookup error: astroid: undefined symbol: _ZN6google8protobuf8internal17AssignDescriptorsEPFPKNS1_15DescriptorTableEvEPN4absl12lts_202401169once_flagERKNS0_8MetadataE`