### PR TITLE
easyeffects: depend on kf6-sonnet

### DIFF
--- a/srcpkgs/easyeffects/template
+++ b/srcpkgs/easyeffects/template
@@ -1,7 +1,7 @@
 # Template file for 'easyeffects'
 pkgname=easyeffects
 version=8.0.9
-revision=2
+revision=3
 build_style=cmake
 hostmakedepends="pkg-config desktop-file-utils extra-cmake-modules gettext glib-devel
  kf6-kconfig qt6-base qt6-declarative-tools qt6-declarative-private-devel"
@@ -13,7 +13,7 @@ makedepends="
  kf6-kcoreaddons-devel kf6-kconfigwidgets-devel kf6-kiconthemes-devel
  kf6-kirigami-devel kirigami-addons-devel kf6-qqc2-desktop-style-devel
  qt6-base-devel qt6-declarative-private-devel qt6-graphs-devel"
-depends="qt6-graphs kf6-kirigami kf6-qqc2-desktop-style kirigami-addons"
+depends="qt6-graphs kf6-kirigami kf6-qqc2-desktop-style kirigami-addons kf6-sonnet"
 short_desc="Sound effects for systems using PipeWire"
 maintainer="zenobit <zenobit@disroot.org>"
 license="GPL-3.0-or-later"


### PR DESCRIPTION
easyeffects won't start without it.