### PR TITLE
remote-touchpad: update to 1.5.3

### DIFF
--- a/srcpkgs/remote-touchpad/template
+++ b/srcpkgs/remote-touchpad/template
@@ -1,6 +1,6 @@
 # Template file for 'remote-touchpad'
 pkgname=remote-touchpad
-version=1.5.0
+version=1.5.3
 revision=1
 build_style=go
 go_import_path="github.com/unrud/remote-touchpad"
@@ -12,7 +12,7 @@ license="GPL-3.0-or-later"
 homepage="https://github.com/Unrud/remote-touchpad"
 changelog="https://github.com/Unrud/remote-touchpad/blob/master/CHANGELOG.md"
 distfiles="https://github.com/Unrud/remote-touchpad/archive/refs/tags/v${version}.tar.gz"
-checksum="e715ca1d1c1fc95a80d75e21b9c180868d979cc223a971c7fcd0f843d05e6113"
+checksum="be38e40a4bff32b009a105ef9901f1c2208658a63aaf9d2cc47338c6f91043cc"
 
 post_install() {
 	vbin desktop/remote-touchpad-wait-on-error


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR:**briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - armv6l-musl (crossbuild)