### PR TITLE
go: update to 1.25.6

### DIFF
--- a/srcpkgs/go/template
+++ b/srcpkgs/go/template
@@ -1,6 +1,6 @@
 # Template file for 'go'
 pkgname=go
-version=1.25.5
+version=1.25.6
 revision=1
 _bootstrap="1.22.6"
 create_wrksrc=yes
@@ -13,7 +13,7 @@ license="BSD-3-Clause"
 homepage="https://go.dev/"
 changelog="https://go.dev/doc/devel/release.html"
 distfiles="https://go.dev/dl/go${version}.src.tar.gz"
-checksum=22a5fd0a91efcd28a1b0537106b9959b2804b61f59c3758b51e8e5429c1a954f
+checksum=58cbf771e44d76de6f56d19e33b77d745a1e489340922875e46585b975c2b059
 nostrip=yes
 noverifyrdeps=yes
 # on CI it tries to use `git submodule`, which is not part of chroot-git


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES** (tested it against our suite of [gotosocial](https://codeberg.org/superseriousbusiness/gotosocial) tests)

#### Local build testing
- I built this PR locally for my native architecture, x86-64-glibc

cc: @the-maldridge 
