### PR TITLE
nvidia: added open build option

### DIFF
--- a/srcpkgs/nvidia/patches/nvidia-tegra-bpmp.patch
+++ b/srcpkgs/nvidia/patches/nvidia-tegra-bpmp.patch
@@ -11,3 +11,17 @@
  
  // Use the CCF APIs if enabled in Kernel config and RM build
  // has Dual license define enabled.
+
+--- a/kernel-open/nvidia/nv-clk.c
++++ b/kernel-open/nvidia/nv-clk.c
+@@ -27,8 +27,10 @@
+ #include "nv-linux.h"
+ #include "nv-platform.h"
+ 
++#if IS_ENABLED(CONFIG_TEGRA_BPMP)
+ #include <soc/tegra/bpmp-abi.h>
+ #include <soc/tegra/bpmp.h>
++#endif // IS_ENABLED(CONFIG_TEGRA_BPMP)
+ 
+ // Use the CCF APIs if enabled in Kernel config and RM build
+ // has Dual license define enabled.

--- a/srcpkgs/nvidia/template
+++ b/srcpkgs/nvidia/template
@@ -28,6 +28,11 @@ depends="nvidia-libs-${version}_${revision}
  nvidia-firmware-${version}_${revision}"
 patch_args="-Np1 --directory=${XBPS_BUILDDIR}/${pkgname}-${version}/${_pkg}"
 
+build_options="open"
+desc_option_open="Use open kernel module sources"
+build_options_default="open"
+
+
 _install_libs() {
 	local libdir=$1
 
@@ -254,7 +259,11 @@ do_install() {
 
 	# dkms pkg
 	vmkdir usr/src/nvidia-${version}
-	vcopy "kernel/*" usr/src/nvidia-${version}
+	if [ "$build_option_open" ]; then
+		vcopy "kernel-open/*" usr/src/nvidia-${version}
+	else
+		vcopy "kernel/*" usr/src/nvidia-${version}
+	fi
 	vcopy ${FILESDIR}/dkms.conf usr/src/nvidia-${version}
 	sed -e "s/__PKGVER/${version}/g" \
 		-e 's/__MAKEJOBS/-j$(nproc)/g' \


### PR DESCRIPTION
This pull requests adds the build option `open` to nvidia package (notable nvidia-dkms) which has a similar result to `nvidia-open` on different distros. (e.g. usable through `./xbps-src pkg nvidia -o open`)
As this is currently disabled by default it shouldn't affect anyone, but it should help with adding the ground work so a potential alternative `nvidia-open`/`nvidia-dkms-open` package can be added in the future.

#### Testing the changes
- I tested the changes in this PR: briefly (1-2 months)

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc) 

Note: that nvidia relies on glibc for it's precompiled libraries 
