### PR TITLE
tinyramfs: drop optional depends

### DIFF
--- a/srcpkgs/tinyramfs/template
+++ b/srcpkgs/tinyramfs/template
@@ -1,9 +1,9 @@
 # Template file for 'tinyramfs'
 pkgname=tinyramfs
 version=0.3.0
-revision=1
+revision=2
 build_style=gnu-makefile
-depends="util-linux cpio binutils kmod"
+depends="util-linux cpio kmod"
 short_desc="Tiny initramfs written in POSIX shell"
 maintainer="dkwo <npiazza@disroot.org>"
 license="GPL-3.0-only"


### PR DESCRIPTION
- I tested the changes in this PR: yes
- I built this PR locally for my native architecture, (aarch64-glibc)

it is an optional depends.