### PR TITLE
amfora: update to 1.11.0

### DIFF
--- a/srcpkgs/amfora/template
+++ b/srcpkgs/amfora/template
@@ -1,16 +1,16 @@
 # Template file for 'amfora'
 pkgname=amfora
-version=1.10.0
-revision=2
+version=1.11.0
+revision=1
 build_style=go
 go_import_path="github.com/makeworld-the-better-one/amfora"
 short_desc="Fancy terminal browser for the Gemini protocol"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-3.0-only"
-homepage="https://github.com/makeworld-the-better-one/amfora"
-changelog="https://raw.githubusercontent.com/makeworld-the-better-one/amfora/master/CHANGELOG.md"
-distfiles="https://github.com/makeworld-the-better-one/amfora/archive/v${version}.tar.gz"
-checksum=0bc9964ccefb3ea0d66944231492f66c3b0009ab0040e19cc115d0b4cd9b8078
+homepage="https://github.com/makew0rld/amfora"
+changelog="https://raw.githubusercontent.com/makew0rld/amfora/master/CHANGELOG.md"
+distfiles="https://github.com/makew0rld/amfora/archive/refs/tags/v${version}.tar.gz"
+checksum=76ae120bdae9a1882acbb2b07a873a52e40265b3ef4c8291de0934c1e9b5982c
 
 post_install() {
 	vinstall amfora.desktop 644 usr/share/applications/


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

This fixes the build issue introduced by https://github.com/void-linux/void-packages/pull/58693, as pointed out by @the-maldridge. I'm not 100% sure sure what was causing it, but something to do with the repo access path changing (their username changed) and being out of date was probably causing some kind of confusion with the go imports. As for why this only appeared with the above update? :woman_shrugging: 