### PR TITLE
asahi-uboot: update to 2025.10+2

### DIFF
--- a/srcpkgs/asahi-uboot/template
+++ b/srcpkgs/asahi-uboot/template
@@ -1,6 +1,6 @@
 # Template file for 'asahi-uboot'
 pkgname=asahi-uboot
-version=2025.10+1
+version=2025.10+2
 revision=1
 archs="aarch64*"
 hostmakedepends="bison flex which python3 swig python3-devel
@@ -13,10 +13,10 @@ maintainer="dkwo <npiazza@disroot.org>, Will Springer <skirmisher@protonmail.com
 license="GPL-2.0-or-later, MIT"
 homepage="https://asahilinux.org"
 distfiles="https://github.com/AsahiLinux/u-boot/archive/refs/tags/asahi-v${version/+/-}.tar.gz"
-checksum=8c763e0f8912a4e991da73100f9d9d9c1c723a733e4004d9435b0a1681c0560a
+checksum=899895de62aeef3d6c7360133396089bdf85ac09490429b2b3f69a4dfdfcb415
 make_check=no # missing python3-libfdt ?
 
-if [ "$CROSS_BUILD" ]; then
+if [ "${CROSS_BUILD}" ]; then
 	export CROSS_COMPILE=${XBPS_CROSS_TRIPLET}-
 fi
 


### PR DESCRIPTION
- I tested the changes in this PR: yes
- I built this PR locally for my native architecture, (aarch64-glibc)