### PR TITLE
chromium-widevine: update to 144.0.7559.109.

### DIFF
--- a/srcpkgs/chromium-widevine/INSTALL
+++ b/srcpkgs/chromium-widevine/INSTALL
@@ -1,6 +1,6 @@
 # INSTALL
 
-checksum=aae7efee6ee243cc97e9678d6a34db3c42c299186be061816bc5b3cbe88c1618
+checksum=3b77c509c4a0847a2bf146aabd40a7fc60ea283fbc482ad74fa1449d687d4147
 
 _baseUrl="https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable"
 _filename="google-chrome-stable_${VERSION%_*}-1_amd64.deb"

--- a/srcpkgs/chromium-widevine/template
+++ b/srcpkgs/chromium-widevine/template
@@ -2,7 +2,7 @@
 #
 # Keep in sync with 'chromium'!
 pkgname=chromium-widevine
-version=132.0.6834.83
+version=144.0.7559.109
 revision=1
 archs="x86_64"
 create_wrksrc=yes


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

Widevine Content Decryption Module in chrome://components
- Version: 4.10.2934.0, latest as of today
- Status - Up-to-date, after checking update

Visiting https://bitmovin.com/demos/drm also shows that widewine is active.

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc

This update is necessary as the old version is removed from google's server.