### PR TITLE
gdm: backport dropping 61-gdm.rules

### DIFF
--- a/srcpkgs/gdm/patches/drop-wayland-udev-rules.patch
+++ b/srcpkgs/gdm/patches/drop-wayland-udev-rules.patch
@@ -1,0 +1,41 @@
+From 56bf0d707ad8d920798532f507766908d504df8f Mon Sep 17 00:00:00 2001
+From: Alessandro Astone <alessandro.astone@canonical.com>
+Date: Wed, 18 Jun 2025 12:04:10 +0200
+Subject: [PATCH] Drop udev rules
+
+The sole purpose of this set of udev rules was to conditionally disable
+Wayland. With commit 38fa8b947f8e8a34a295d581ffa975239be5d1ef dropping the
+`gdm-runtime-config` call, there is no logic left here.
+
+Part-of: <https://gitlab.gnome.org/GNOME/gdm/-/merge_requests/299>
+---
+ data/61-gdm.rules.in | 56 --------------------------------------------
+ data/meson.build     | 11 ---------
+ 2 files changed, 67 deletions(-)
+ delete mode 100644 data/61-gdm.rules.in
+
+diff --git a/data/meson.build b/data/meson.build
+index 6f0ff7861..5d0703ef7 100644
+--- a/data/meson.build
++++ b/data/meson.build
+@@ -140,17 +140,6 @@ foreach _pam_filename : pam_data_files
+   )
+ endforeach
+ 
+-if have_x11_support
+-  configure_file(
+-    input: '61-gdm.rules.in',
+-    output: '@BASENAME@',
+-    configuration: {
+-      'libexecdir': gdm_prefix / get_option('libexecdir'),
+-    },
+-    install_dir: udev_dir,
+-  )
+-endif
+-
+ # DBus service files
+ service_config = configuration_data()
+ service_config.set('sbindir', gdm_prefix / get_option('sbindir'))
+-- 
+GitLab
+

--- a/srcpkgs/gdm/template
+++ b/srcpkgs/gdm/template
@@ -1,7 +1,7 @@
 # Template file for 'gdm'
 pkgname=gdm
 version=48.0
-revision=1
+revision=2
 build_helper="gir"
 build_style=meson
 configure_args="


### PR DESCRIPTION
This file implements checks for disabling Wayland with certain setups, such as the proprietary NVIDIA driver.

While most of the NVIDIA checks were removed in gdm 48, a check still remains testing the presence of systemd user services, which always fails since it is handled by an elogind system-sleep script.

This file was removed entirely with gdm 49+.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
