### PR TITLE
biber: update to 2.21

### DIFF
--- a/srcpkgs/biber/template
+++ b/srcpkgs/biber/template
@@ -1,6 +1,6 @@
 # Template file for 'biber'
 pkgname=biber
-version=2.20
+version=2.21
 revision=1
 build_style=perl-ModuleBuild
 hostmakedepends="perl-Module-Build"
@@ -53,4 +53,11 @@ license="Artistic-2.0"
 homepage="http://biblatex-biber.sourceforge.net"
 changelog="https://raw.githubusercontent.com/plk/biber/dev/Changes"
 distfiles="https://github.com/plk/biber/archive/refs/tags/v${version}.tar.gz"
-checksum=19f0312e59bf2f5711b8d69b3585a0ca894c36574f086fbb8d53ccd5c0a45ff9
+checksum=2652cf3ae0abff5fb233aa77f18e70014cc2c70b94a8693c099a3cad9bbb4b20
+
+pre_check() {
+	# failure is harmless since reference data for tests assume 64-bit
+	if [ "${XBPS_TARGET_WORDSIZE}" == 32 ]; then
+		rm t/dateformats.t
+	fi
+}


### PR DESCRIPTION
- I tested the changes in this PR: yes
- I built this PR locally for my native architecture, (aarch64-glibc)

The test on i686 has always been failing, harmless according to upstream.