### PR TITLE
spotify: update template to 1.2.79.427.g80eb4a07

### DIFF
--- a/srcpkgs/spotify/template
+++ b/srcpkgs/spotify/template
@@ -2,7 +2,7 @@
 pkgname=spotify
 version=1.2.79
 revision=1
-_subver=425.g1d0fcf61
+_subver=427.g80eb4a07
 archs="x86_64"
 create_wrksrc=yes
 hostmakedepends="libcurl"
@@ -12,7 +12,7 @@ maintainer="Stefan Mühlinghaus <jazzman@alphabreed.com>"
 license="custom:Proprietary"
 homepage="https://www.spotify.com"
 distfiles="http://repository.spotify.com/pool/non-free/s/spotify-client/spotify-client_${version}.${_subver}_amd64.deb"
-checksum=9843c7aeddffbd02ea7b0212231bda1f85904995e57bed612d3a38de6e13efe8
+checksum=456d2699a1affd8fa22e5a46e2cf7560b0d91b1d5cd29c74b70682fbfb064b0a
 repository=nonfree
 restricted=yes
 nostrip=yes


### PR DESCRIPTION
Updated version and checksum to match new Spotify 1.2.79.427.g80eb4a07 release. Checksum updated due to Spotify reuploading the binary.

- I tested the changes in this PR: **YES**
- - I built this PR locally for my native architecture, x86_64, glibc