### PR TITLE
nfs-utils: remove automatic statd check and defer control to user

### DIFF
--- a/srcpkgs/nfs-utils/files/nfs-server/run
+++ b/srcpkgs/nfs-utils/files/nfs-server/run
@@ -7,11 +7,6 @@ exec 2>&1
 # Settings in ./conf should be preferred over /etc/conf.d/nfs-server.conf
 [ -r ./conf ] && . ./conf
 
-# If this var is set, there's no need to enable statd and rpcbind services as they pertain to NFSv3
-if [ -z "$NFSV4_ONLY" ]; then
-	sv check statd >/dev/null || exit 1
-fi
-
 # Check/mount rpc_pipefs (loads sunrpc kernel module)
 if ! mountpoint -q /var/lib/nfs/rpc_pipefs; then
 	mount -t rpc_pipefs rpc_pipefs /var/lib/nfs/rpc_pipefs -o defaults || exit 1

--- a/srcpkgs/nfs-utils/template
+++ b/srcpkgs/nfs-utils/template
@@ -1,7 +1,7 @@
 # Template file for 'nfs-utils'
 pkgname=nfs-utils
 version=2.8.4
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--with-statduser=nobody --enable-gss --enable-nfsv4
  --with-statedir=/var/lib/nfs --enable-libmount-mount --enable-svcgss


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Motivation for the change
Currently, the NFSV4_ONLY variable is only checked for a non-empty string meaning assigning any value including n/no/false etc. would make it pass the test.

The proposed change normalizes the check.

Please advise whether this should be revbumped or left as is.

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture: x86_64-glibc
