### PR TITLE
sanoid: fix runtime warnings

### DIFF
--- a/srcpkgs/sanoid/patches/file_handle_conflict.patch
+++ b/srcpkgs/sanoid/patches/file_handle_conflict.patch
@@ -1,0 +1,58 @@
+https://github.com/jimsalterjrs/sanoid/commit/393a4672e5695af5a5a8c82faed455e5689e0c69
+https://github.com/jimsalterjrs/sanoid/pull/1071
+diff --git a/sanoid b/sanoid
+index 4a71319..ce31f18 100755
+--- a/sanoid
++++ b/sanoid
+@@ -1084,11 +1084,9 @@ sub init {
+ 			@datasets = getchilddatasets($config{$section}{'path'});
+ 			DATASETS: foreach my $dataset(@datasets) {
+ 				if (! @cachedatasets) {
+-					push (@updatedatasets, $dataset);
++					push (@updatedatasets, "$dataset\n");
+ 				}
+ 
+-				chomp $dataset;
+-
+ 				if ($zfsRecursive) {
+ 					# don't try to take the snapshot ourself, recursive zfs snapshot will take care of that
+ 					$config{$dataset}{'autosnap'} = 0;
+@@ -1691,7 +1689,7 @@ sub getchilddatasets {
+ 	my $getchildrencmd = "$mysudocmd $zfs list -o name -t filesystem,volume -Hr $fs |";
+ 	 if ($args{'debug'}) { print "DEBUG: getting list of child datasets on $fs using $getchildrencmd...\n"; }
+ 	open FH, $getchildrencmd;
+-	my @children = <FH>;
++	chomp( my @children = <FH> );
+ 	close FH;
+ 
+ 	# parent dataset is the first element
+@@ -1781,25 +1779,25 @@ sub addcachedsnapshots {
+ 
+ 	copy($cache, "$cache.tmp") or die "Could not copy to $cache.tmp!\n";
+ 
+-	open FH, ">> $cache.tmp" or die "Could not write to $cache.tmp!\n";
++	open my $fh, ">> $cache.tmp" or die "Could not write to $cache.tmp!\n";
+ 	while((my $snap, my $details) = each(%taken)) {
+ 		my @parts = split("@", $snap, 2);
+ 
+ 		my $suffix = $parts[1] . "\tcreation\t" . $details->{time} . "\t-";
+ 		my $dataset = $parts[0];
+ 
+-		print FH "${dataset}\@${suffix}\n";
++		print $fh "${dataset}\@${suffix}\n";
+ 
+ 		if ($details->{recursive}) {
+ 			my @datasets = getchilddatasets($dataset);
+ 
+ 			foreach my $dataset(@datasets) {
+-				print FH "${dataset}\@${suffix}\n";
++				print $fh "${dataset}\@${suffix}\n";
+ 			}
+ 		}
+ 	}
+ 
+-	close FH;
++	close $fh;
+ 
+ 	# preserve mtime of cache for expire check
+ 	my ($dev, $ino, $mode, $nlink, $uid, $gid, $rdev, $size, $atime, $mtime, $ctime, $blksize, $blocks) = stat($cache);

--- a/srcpkgs/sanoid/template
+++ b/srcpkgs/sanoid/template
@@ -1,7 +1,7 @@
 # Template file for 'sanoid'
 pkgname=sanoid
 version=2.3.0
-revision=1
+revision=2
 depends="perl perl-Config-IniFiles perl-Capture-Tiny"
 short_desc="Policy-driven snapshot management tool for ZFS filesystems"
 maintainer="Benjamin Slade <slade@jnanam.net>"


### PR DESCRIPTION
"print() on closed filehandle FH at /usr/local/bin/sanoid line 1797"
It's harmless but annoying because it causes cron to send an email.

#### Testing the changes
- I tested the changes in this PR: **YES**