### PR TITLE
qt6-base: not rebuild private Qt on patch update

### DIFF
--- a/common/hooks/pre-pkg/04-generate-runtime-deps.sh
+++ b/common/hooks/pre-pkg/04-generate-runtime-deps.sh
@@ -69,7 +69,7 @@ hook() {
     local _shlib_dir="${XBPS_STATEDIR}/shlib-provides"
     local _shlibtmp
 
-    local Qt_6_PRIVATE_API=6.10.2
+    local Qt_6_PRIVATE_API=6.10
 
     # Disable trap on ERR, xbps-uhelper cmd might return error... but not something
     # to be worried about because if there are broken shlibs this hook returns

--- a/srcpkgs/qt6-base/template
+++ b/srcpkgs/qt6-base/template
@@ -5,7 +5,7 @@
 # - rebuild all pkg with qt6-base-private-devel
 pkgname=qt6-base
 version=6.10.2
-revision=1
+revision=2
 build_style=cmake
 configure_args="-DINSTALL_DATADIR=share/qt6
  -DINSTALL_ARCHDATADIR=lib${XBPS_TARGET_WORDSIZE}/qt6
@@ -168,7 +168,8 @@ qt6-dbus_package() {
 }
 
 qt6-core_package() {
-	shlib_provides="libQt_6_PRIVATE_API.${version}"
+	shlib_provides="libQt_6_PRIVATE_API.${version}
+	 libQt_6_PRIVATE_API.${version%.*}"
 	short_desc+=" - Core"
 	pkg_install() {
 		vmove "usr/lib/libQt6Core.so.*"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**|**briefly**|**NO**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
