### PR TITLE
networkmanager-dmenu: update to 2.6.3.

### DIFF
--- a/srcpkgs/networkmanager-dmenu/template
+++ b/srcpkgs/networkmanager-dmenu/template
@@ -1,6 +1,6 @@
 # Template file for 'networkmanager-dmenu'
 pkgname=networkmanager-dmenu
-version=2.6.2
+version=2.6.3
 revision=1
 depends="python3 NetworkManager python3-gobject"
 short_desc="Control NetworkManager via dmenu"
@@ -8,7 +8,7 @@ maintainer="Yushi <github@yushi.one>"
 license="MIT"
 homepage="https://github.com/firecat53/networkmanager-dmenu"
 distfiles="https://github.com/firecat53/networkmanager-dmenu/archive/refs/tags/v${version}.tar.gz"
-checksum=7a29d9d341bd093d61dc73c5a820c1788c652bcbf6481d6773188cc8ec04c9f4
+checksum=e4bc5e01551052792d5fa20f8f75dc650e475cd51160f2843c8f021aae9ee23c
 
 do_install() {
 	vbin networkmanager_dmenu


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (aarch64-glibc)
