### PR TITLE
age: fix dynamic linking on aarch64-musl

### DIFF
--- a/srcpkgs/age/template
+++ b/srcpkgs/age/template
@@ -12,7 +12,6 @@ license="BSD-3-Clause"
 homepage="https://age-encryption.org/"
 distfiles="https://github.com/FiloSottile/age/archive/v${version}.tar.gz"
 checksum=396007bc0bc53de253391493bda1252757ba63af1a19db86cfb60a35cb9d290a
-export GOFLAGS="${GOFLAGS}"
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
- Fixes #58782 

- Remove `-buildmode=pie` to fix broken dynamic linking on musl cross-builds

- Bump revision to `2`

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, `aarch64`
