### PR TITLE
New package: uosc-5.12.0

### DIFF
--- a/srcpkgs/uosc/files/README.voidlinux
+++ b/srcpkgs/uosc/files/README.voidlinux
@@ -1,0 +1,5 @@
+Enable the 'uosc' UI for 'mpv' by issuing:
+
+  $ mkdir -p ~/.config/mpv/scripts
+  $ ln -s /usr/share/mpv/fonts ~/.config/mpv/
+  $ ln -s /usr/share/mpv/scripts/uosc ~/.config/mpv/scripts/

--- a/srcpkgs/uosc/template
+++ b/srcpkgs/uosc/template
@@ -1,0 +1,24 @@
+# Template file for 'uosc'
+pkgname=uosc
+version=5.12.0
+revision=1
+conf_files="/etc/mpv/script-opts/uosc.conf"
+depends="mpv"
+short_desc="Feature-rich minimalist proximity-based UI for MPV player"
+maintainer="dogknowsnx <dogknowsnx@tutamail.com>"
+license="LGPL-2.1-or-later"
+homepage="https://github.com/tomasklaen/uosc"
+changelog="https://github.com/tomasklaen/uosc/releases"
+distfiles="https://github.com/tomasklaen/uosc/archive/refs/tags/${version}.tar.gz"
+checksum=a84476d6826406f1eb0815c2ce0c1318858f18de8d77c47b4387175641a13ba9
+
+do_install() {
+	vinstall src/uosc.conf 0644 etc/mpv/script-opts
+	vinstall src/uosc/main.lua 0644 usr/share/mpv/scripts/uosc
+
+	rm src/uosc/{main.lua,elements/Updater.lua}
+	vcopy src/uosc usr/share/mpv/scripts
+	vcopy src/fonts usr/share/mpv
+
+	vdoc ${FILESDIR}/README.voidlinux
+}


### PR DESCRIPTION
https://github.com/tomasklaen/uosc

#### Testing the changes
- I tested the changes in this PR: **YES**
- been using `uosc` for years

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

#### Local build testing
- I built this PR locally for my native architecture, **x86_64-glibc**
- I built this PR locally for these architectures:
  - x86_64-musl

Notes:

- <strike>In order to make this package work out-of-the-box (which I presume to be desired, when installing from a package manager), files are going to be installed into `/etc/mpv`, hence globally. Otherwise the user would have to copy everything manually from e.g. `/usr/share`, in which case I'd recommend using the installation script provided by upstream, which will copy everything needed into one's home directory.</strike>
EDIT: I reconsidered this and opted for the non-global installation, which requires additional steps (see `README.voidlinux`), but is more in line w/ Void's packaging guidelines.

- There is a utility binary called "ziggy" that can be built separately (`go` language), which is mainly used for updating `uosc` locally, but it also implements clipboard support, extra subtitle downloads and maybe some other features. I'm not interested in shipping said binary and bloating the package unnecessarily, since `lua`-`uosc` (which advertises itself as being "minimalist") does everything I need from a UI for `mpv`.
