### PR TITLE
expat: update to 2.7.4.

### DIFF
--- a/srcpkgs/expat/template
+++ b/srcpkgs/expat/template
@@ -1,6 +1,6 @@
 # Template file for 'expat'
 pkgname=expat
-version=2.7.3
+version=2.7.4
 revision=1
 build_style=gnu-configure
 short_desc="XML parser library written in C"
@@ -9,7 +9,7 @@ license="MIT"
 homepage="https://libexpat.github.io/"
 changelog="https://raw.githubusercontent.com/libexpat/libexpat/master/expat/Changes"
 distfiles="https://github.com/libexpat/libexpat/releases/download/R_${version//./_}/expat-${version}.tar.xz"
-checksum=71df8f40706a7bb0a80a5367079ea75d91da4f8c65c58ec59bcdfbf7decdab9f
+checksum=9e9cabb457c1e09de91db2706d8365645792638eb3be1f94dbb2149301086ac0
 
 post_install() {
 	vlicense COPYING


### PR DESCRIPTION
@leahneukirchen 
- I tested the changes in this PR: briefly
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-glibc
  - aarch64-musl
  - i686-glibc
  - mipsel-musl