### PR TITLE
New package: kile-2.9.94

### DIFF
--- a/srcpkgs/kile/template
+++ b/srcpkgs/kile/template
@@ -1,0 +1,23 @@
+# Template file for 'kile'
+pkgname=kile
+version=2.9.94
+revision=1
+build_style=cmake
+configure_args="-DKF6_HOST_TOOLING=/usr/lib/cmake
+ -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins"
+hostmakedepends="extra-cmake-modules gettext kf6-kdoctools kf6-kcoreaddons
+ kf6-kconfig qt6-base qt6-tools"
+makedepends="kf6-kcodecs-devel kf6-kcolorscheme-devel kf6-kcompletion-devel
+ kf6-kconfig-devel kf6-kconfigwidgets-devel kf6-kcoreaddons-devel
+ kf6-kcrash-devel kf6-kdbusaddons-devel kf6-kguiaddons-devel kf6-ki18n-devel
+ kf6-kiconthemes-devel kf6-kio-devel kf6-kparts-devel kf6-kservice-devel
+ kf6-ktexteditor-devel kf6-ktextwidgets-devel kf6-kwidgetsaddons-devel
+ kf6-kwindowsystem-devel kf6-kxmlgui-devel libokular-devel qt6-qt5compat-devel
+ qt6-declarative-devel poppler-qt6-devel"
+depends="texlive-core perl"
+short_desc="User friendly TeX/LaTeX frontend for KDE"
+maintainer="Nafis <mnabid.25@outlook.com>"
+license="GPL-2.0-or-later"
+homepage="https://apps.kde.org/kile/"
+distfiles="${SOURCEFORGE_SITE}/${pkgname}/${pkgname}-${version}.tar.bz2"
+checksum=53c6742bd83fb095cbdc898b03fdf8e15ab680a81693ccaf9c5076b93ad1a3ca


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Homepage: https://apps.kde.org/kile/

#15462 mentioned waiting for the `3.0` stable release, but there hasn't been one since 2012. [Most mainstream distros](https://repology.org/project/kile/versions) are packaging `2.9.94 (3.0b4)`, and even the aforementioned homepage features this one instead of the stable version. Hope an exception can be made for this one.

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture (`x86_64-glibc`)
- I built this PR locally for these architectures:
  - `x86_64-musl`
  - `aarch64` (crossbuild)
