### PR TITLE
quickshell: enable an additional feature

### DIFF
--- a/srcpkgs/quickshell/template
+++ b/srcpkgs/quickshell/template
@@ -1,10 +1,10 @@
 # Template file for 'quickshell'
 pkgname=quickshell
 version=0.2.1
-revision=3
+revision=4
 build_style=cmake
 configure_args="-DDISTRIBUTOR=Void -DDISTRIBUTOR_DEBUGINFO_AVAILABLE=YES
- -DINSTALL_QML_PREFIX=lib/qt6/qml -DCRASH_REPORTER=OFF -DHYPRLAND=OFF"
+ -DINSTALL_QML_PREFIX=lib/qt6/qml -DCRASH_REPORTER=OFF"
 hostmakedepends="pkg-config wayland-devel qt6-base qt6-declarative-devel
  qt6-shadertools"
 makedepends="cli11 qt6-base-private-devel qt6-declarative-private-devel
@@ -17,4 +17,4 @@ license="LGPL-3.0-only"
 homepage="https://quickshell.org"
 changelog="https://quickshell.org/changelog/"
 distfiles="https://git.outfoxxed.me/quickshell/quickshell/archive/v${version}.tar.gz"
-checksum=a7e0a1029ff69d0f3b5788e042463735bacafd5fc369b1382143ffbd9d497964
+checksum=d815c5f99f4a0a28545ffaa90464420c773b7c0ab62f713d9d8735a8e7282ca7


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

I don't use Hyprland nor do I care about it. DMS, on the other hand, wants those quickshell modules to be available even when run on top of Niri. It would be nice to not have to hack imports out of DMS every time I want to install it / upgrade it.

Thoughts on this @classabbyamp ?