### PR TITLE
New package: gpu-screen-recorder-5.12.3

### DIFF
--- a/srcpkgs/gpu-screen-recorder/files/README.voidlinux
+++ b/srcpkgs/gpu-screen-recorder/files/README.voidlinux
@@ -1,0 +1,35 @@
+gpu-screen-recorder supports multiple modes of operation.
+
+By default, gpu-screen-recorder runs without elevated privileges.
+This mode is sufficient for most use cases, but may have limitations
+when recording using KMS (Wayland/X11).
+
+For high-performance KMS recording, elevated privileges are required.
+Upstream provides several possible approaches:
+
+1) Linux capabilities (prefered by upstream):
+
+   # setcap cap_sys_admin+ep /usr/bin/gsr-kms-server
+
+   Note: cap_sys_admin is a very powerful capability and should be
+   granted with care.
+
+2) setuid root (NOT recommended):
+
+   # chmod 4755 /usr/bin/gsr-kms-server
+
+   WARNING: This allows the binary to run with full root privileges.
+   This approach significantly increases the attack surface and
+   should only be used if you fully understand the risks.
+
+3) pkexec (if XDG portals are properly configured):
+
+   gpu-screen-recorder can invoke privileged operations via pkexec
+   when portals are available.
+
+On Wayland systems, using portal-based capture (-w portal) is recommended
+and does not require any elevated privileges.
+
+No privilege escalation is performed automatically by the package.
+It is up to the system administrator to choose the appropriate
+configuration.

--- a/srcpkgs/gpu-screen-recorder/template
+++ b/srcpkgs/gpu-screen-recorder/template
@@ -1,0 +1,24 @@
+# Template file for 'gpu-screen-recorder'
+pkgname=gpu-screen-recorder
+version=5.12.3
+revision=1
+build_style=meson
+hostmakedepends="meson ninja pkg-config wayland-devel"
+makedepends="ffmpeg-devel libcap-devel libdrm-devel libglvnd-devel
+ libva-devel libX11-devel libXcomposite-devel libXcursor-devel
+ libXdamage-devel libXext-devel libXfixes-devel libXi-devel
+ libXinerama-devel libXrandr-devel pipewire-devel pulseaudio-devel"
+short_desc="Extremely fast screen recorder for Linux"
+maintainer="cherrybtw <nonopenoid123456789@gmail.com>"
+license="GPL-3.0-only"
+homepage="https://git.dec05eba.com/gpu-screen-recorder/about"
+distfiles="https://dec05eba.com/snapshot/gpu-screen-recorder.git.${version}.tar.gz"
+checksum=66b483f910a71d0b3320ca9a87cf8b16f97ca0db1dab324184c7c5a876203bdd
+
+post_patch() {
+	vsed -i "/meson_post_install.sh/d" meson.build
+}
+
+post_install() {
+	vdoc ${FILESDIR}/README.voidlinux
+}

--- a/srcpkgs/gpu-screen-recorder/update
+++ b/srcpkgs/gpu-screen-recorder/update
@@ -1,0 +1,3 @@
+site="https://git.dec05eba.com/gpu-screen-recorder/refs/"
+pattern="tag/\?h=\K[\d.]+"
+


### PR DESCRIPTION
- I tested the changes in this PR: **YES**

- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

- I built this PR locally for my native architecture, **x86_64** (glibc)

Extremely fast screen recorder for Linux. 
- Added `INSTALL.msg` regarding the `gsr-kms-server` setuid bit. 
- I did NOT set setuid in the template to follow Void security policies.
