### PR TITLE
borgmatic: update to 2.1.1.

### DIFF
--- a/srcpkgs/borgmatic/template
+++ b/srcpkgs/borgmatic/template
@@ -1,12 +1,12 @@
 # Template file for 'borgmatic'
 pkgname=borgmatic
-version=2.1.0
+version=2.1.1
 revision=1
 build_style=python3-pep517
 make_check_args="--deselect=tests/integration/commands/test_borgmatic.py::test_borgmatic_version_matches_news_version"
 hostmakedepends="python3-setuptools python3-wheel"
-depends="borg python3-setuptools python3-ruamel.yaml python3-jsonschema
- python3-requests python3-packaging"
+depends="borg python3-ruamel.yaml python3-jsonschema python3-requests
+ python3-packaging"
 checkdepends="${depends} python3-pytest python3-flexmock python3-apprise"
 short_desc="Wrapper script for the Borg backup software"
 maintainer="Joel Beckmeyer <joel@beckmeyer.us>"
@@ -14,7 +14,7 @@ license="GPL-3.0-or-later"
 homepage="https://torsion.org/borgmatic/"
 changelog="https://projects.torsion.org/borgmatic-collective/borgmatic/raw/branch/master/NEWS"
 distfiles="${PYPI_SITE}/b/borgmatic/borgmatic-${version}.tar.gz"
-checksum=495f21fbfa34130706862d44710921cfff6e0a07844464012995548046865e64
+checksum=3c23cacf9e88a9712f4ec5cf4fa595e69c6d600eba5477f80fe2ca396067b109
 
 post_patch() {
 	vsed -i pyproject.toml -e 's/--cov-report.*--cov-fail-under=100//'


### PR DESCRIPTION
`python3-setuptools` not needed since 1.9.0

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
