### PR TITLE
New package: bcompare-5.1.7.31736

### DIFF
--- a/srcpkgs/bcompare-ext-nautilus
+++ b/srcpkgs/bcompare-ext-nautilus
@@ -1,0 +1,1 @@
+bcompare

--- a/srcpkgs/bcompare/template
+++ b/srcpkgs/bcompare/template
@@ -1,0 +1,56 @@
+# Template file for 'bcompare'
+pkgname=bcompare
+version=5.1.7.31736
+revision=1
+archs="x86_64"
+
+# Bcompare linked with libbz2.so.1.0 from bzip2 not exist in void
+# add it as a link to libbz2.so.1
+depends="bzip2"
+
+short_desc="GUI tools to compare, merge files and folders."
+maintainer="Orphaned <orphan@voidlinux.org>"
+license="custom:EULA"
+homepage="https://www.scootersoftware.com"
+nocross=yes
+nostrip=yes
+repository=nonfree
+
+distfiles="https://www.scootersoftware.com/files/${pkgname}-${version}.x86_64.tar.gz"
+checksum=aeaa895e3e8d53e1b1f2646716eed6ec3b7127421d10a632351fb64702c9d305
+
+do_install() {
+	vmkdir "usr/lib/beyondcompare"
+	cp {BCompare,BCompare.mad,lib7z.so,libQt5Pas.so.1,libcloudstorage.so.22.0,libunrar.so} "${DESTDIR}/usr/lib/beyondcompare/"
+
+	ln -sf /usr/lib/libbz2.so.1 "${DESTDIR}/usr/lib/beyondcompare/libbz2.so.1.0"
+
+	cat <<-EOF >"bcompare" || die
+		#!/bin/sh
+		LD_LIBRARY_PATH="/usr/lib/beyondcompare" \\
+		exec /usr/lib/beyondcompare/BCompare "\$@"
+	EOF
+	vbin bcompare
+
+	vinstall ext/bcompare-ext-nautilus.amd64.so.ext4 755 "usr/lib/nautilus/extensions-4/" bcompare-ext-nautilus.so
+
+	vinstall "bcompare.desktop" 644 "usr/share/applications/"
+
+	vmkdir "usr/share/doc/${pkgname}"
+	cp -r "help" "${DESTDIR}/usr/share/doc/${pkgname}/"
+
+	vinstall bcompare.xml 644 "usr/share/mime/packages/"
+
+	vmkdir "usr/share/pixmaps"
+	cp {bcompare.png,bcomparefull32.png,bcomparehalf32.png} "${DESTDIR}/usr/share/pixmaps/"
+
+	vlicense copyright
+}
+
+bcompare-ext-nautilus_package() {
+	depends="${sourcepkg}>=${version}_${revision} nautilus"
+	short_desc+=" - Nautilus Extension"
+	pkg_install() {
+		vmove usr/lib/nautilus/extensions-4/bcompare-ext-nautilus.so
+	}
+}


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)

This is a handy file and folder comparison and merging tool from https://www.scootersoftware.com.

It supports adding extra menu items to the right-click menu of file managers in GNOME, KDE, and some other desktop environments. Since I'm only familiar with GNOME, I only included the Nautilus subpackage.