### PR TITLE
New package: localsend-bin-1.17.0

### DIFF
--- a/srcpkgs/localsend-bin/files/localsend_app.desktop
+++ b/srcpkgs/localsend-bin/files/localsend_app.desktop
@@ -1,0 +1,10 @@
+[Desktop Entry]
+Type=Application
+Version=1.0
+Name=LocalSend
+GenericName=An open source cross-platform alternative to AirDrop
+Icon=localsend_app
+Exec=localsend_app %U
+Categories=GTK;FileTransfer;Utility;
+Keywords=Sharing;LAN;Files;
+StartupNotify=true

--- a/srcpkgs/localsend-bin/template
+++ b/srcpkgs/localsend-bin/template
@@ -1,0 +1,29 @@
+# Template file for 'localsend-bin'
+pkgname=localsend-bin
+version=1.17.0
+revision=1
+archs="x86_64"
+ignore_elf_dirs="/usr/share/localsend_app"
+
+short_desc="Open-source cross-platform alternative to AirDrop."
+maintainer="Orphaned <orphan@voidlinux.org>"
+license="Apache-2.0"
+homepage="https://localsend.org/"
+nocross=yes
+nostrip=yes
+
+distfiles="https://github.com/localsend/localsend/releases/download/v${version}/LocalSend-${version}-linux-x86-64.tar.gz"
+checksum=6f05e851b72dbeaac764d3446b5a61c34db22f6278baa92607d5b080997f8c81
+
+do_install() {
+	vmkdir "usr/share/localsend_app"
+	cp -r {data,lib,localsend_app} "${DESTDIR}/usr/share/localsend_app/"
+
+	vmkdir "usr/bin"
+	ln -s ../share/localsend_app/localsend_app "${DESTDIR}/usr/bin/"
+
+	vinstall data/flutter_assets/assets/img/logo-128.png 644 "usr/share/icons/hicolor/128x128/apps/" localsend_app.png
+	vinstall data/flutter_assets/assets/img/logo-256.png 644 "usr/share/icons/hicolor/256x256/apps/" localsend_app.png
+
+	vinstall "${FILESDIR}/localsend_app.desktop" 644 "usr/share/applications/"
+}


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)

Localsend is a Flutter software for local area network file transfer. Its source code build is blocked due to #12749, but it provides a prebuilt binary for Linux, and this version repackages that binary.