### PR TITLE
[RFC] track which files linked which libs in rdep hook

### DIFF
--- a/common/hooks/pre-pkg/04-generate-runtime-deps.sh
+++ b/common/hooks/pre-pkg/04-generate-runtime-deps.sh
@@ -46,6 +46,8 @@ store_pkgdestdir_rundeps() {
 }
 
 parse_shlib_needed() {
+	local -A dependents
+
     while read -r f; do
         lf=${f#${PKGDESTDIR}}
 	    if [ "${skiprdeps/${lf}/}" != "${skiprdeps}" ]; then
@@ -54,14 +56,21 @@ parse_shlib_needed() {
 	    fi
         read -n4 elfmagic < "$f"
         if [ "$elfmagic" = $'\177ELF' ]; then
-            $OBJDUMP -p "$f" |
-            awk '
-                /NEEDED/{print $2;}
-                /Qt_5_PRIVATE_API/{next;}
-                /Qt_[0-9]*_PRIVATE_API/{print $NF;}
-            '
+			while read -r shlib; do
+				dependents[$shlib]+="$lf"
+			done < \
+				<($OBJDUMP -p "$f" |
+            	awk '
+                	/NEEDED/{print $2;}
+                	/Qt_5_PRIVATE_API/{next;}
+                	/Qt_[0-9]*_PRIVATE_API/{print $NF;}
+            	')
         fi
     done
+
+	for shlib in "${!dependents[@]}"; do
+		echo "$shlib ${dependents[$shlib]}"
+	done | sort
 }
 
 hook() {
@@ -86,22 +95,22 @@ hook() {
     depsftmp=$(mktemp) || exit 1
     find ${PKGDESTDIR} -type f -perm -u+w > $depsftmp 2>/dev/null
 
-    for f in ${shlib_requires}; do
-        verify_deps+=" ${f}"
-    done
-
-    _shlibtmp=$(mktemp) || exit 1
-    parse_shlib_needed 3>&1 >"$_shlibtmp" <"$depsftmp"
+    verify_deps=$(parse_shlib_needed <"$depsftmp")
     rm -f "$depsftmp"
-    verify_deps=$(sort <"$_shlibtmp" | uniq)
-    rm -f "$_shlibtmp"
+
+    for f in ${shlib_requires}; do
+        verify_deps+="\n${f}"
+    done
 
     #
     # Add required run time packages by using required shlibs resolved
     # above, the mapping is done thru the common/shlibs file.
     #
-    for f in ${verify_deps}; do
+	while read -r f; do
         unset _rdep _pkgname _rdepver
+
+		linked_by="$(echo "$f" | cut -f2- -d ' ')"
+		f="$(echo "$f" | cut -f1 -d ' ')"
 
         case "$f" in
         Qt_*_PRIVATE_API)
@@ -137,14 +146,14 @@ hook() {
             _rdep="$(awk -v sl="$f" -v arch="$XBPS_TARGET_MACHINE" '$1 == sl && ($3 == "" || $3 == "ignore" || $3 == arch) { print $2; exit; }' "$mapshlibs")"
 
             if [ -z "$_rdep" ]; then
-                msg_red_nochroot "   SONAME: $f <-> UNKNOWN PKG PLEASE FIX!\n"
+                msg_red_nochroot "   SONAME: $f <-> UNKNOWN PKG PLEASE FIX! linked by $linked_by\n"
                 broken_shlibs=1
                 continue
             fi
             _pkgname=$($XBPS_UHELPER_CMD getpkgname "${_rdep}" 2>/dev/null)
             _rdepver=$($XBPS_UHELPER_CMD getpkgversion "${_rdep}" 2>/dev/null)
             if [ -z "${_pkgname}" -o -z "${_rdepver}" ]; then
-                msg_red_nochroot "   SONAME: $f <-> UNKNOWN PKG PLEASE FIX!\n"
+                msg_red_nochroot "   SONAME: $f <-> UNKNOWN PKG PLEASE FIX! linked by $linked_by\n"
                 broken_shlibs=1
                 continue
             fi
@@ -153,9 +162,9 @@ hook() {
             # By this point, SONAME can't be found in current pkg
             sorequires+="${f} "
         fi
-        echo "   SONAME: $f <-> ${_sdep}"
+        echo "   SONAME: $f <-> ${_sdep} linked by $linked_by"
         add_rundep "${_sdep}"
-    done
+	done < <(echo "$verify_deps")
     #
     # If pkg uses any unknown SONAME error out.
     #


### PR DESCRIPTION
I came across an issue where packaging a binary redistributable can fail if there are contained files which link shlibs not present in Void. This is very annoying to debug, especially since the `generate-runtime-deps` hook *does* know which files link which shlibs, it juts forgets by the time the error messages are generated.

My proposed solution is to keep track of which files depend on which shlibs, so this can be reported to the user and make resolving the issue described above easier.

This is not a complete implementation of this feature, but I want feedback before spending more time on it.

When I brought this up on IRC it was mentioned the extra error messaging should only show up when the user calls `xbps-src` with `-v`. It wasn't immediately obvious to me how best to implement this, so I left it out for now.
I also didn't give much thought to the changes to the error messages.

The substantive changes are to the `parse_shlib_needed()` function.