### PR TITLE
android-studio: start with bin/studio instead of bin/studio.sh

### DIFF
--- a/srcpkgs/android-studio/template
+++ b/srcpkgs/android-studio/template
@@ -1,7 +1,7 @@
 # Template file for 'android-studio'
 pkgname=android-studio
 version=2025.2.2.8
-revision=1
+revision=2
 archs="x86_64"
 hostmakedepends="tar"
 depends="libbsd"
@@ -79,7 +79,7 @@ do_install() {
 	vcopy build.txt opt/${pkgname}/ # read as IDE version information
 	vcopy product-info.json opt/${pkgname}/
 	vmkdir usr/bin
-	ln -s /opt/android-studio/bin/studio.sh ${DESTDIR}/usr/bin/android-studio
+	ln -s /opt/android-studio/bin/studio ${DESTDIR}/usr/bin/android-studio
 
 	vinstall entry.desktop 644 usr/share/applications android-studio.desktop
 	chmod -R ugo+rX ${DESTDIR}/opt


### PR DESCRIPTION
closes: #58823

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)