### PR TITLE
glu: fix distfiles url

### DIFF
--- a/srcpkgs/glu/template
+++ b/srcpkgs/glu/template
@@ -10,7 +10,7 @@ short_desc="Mesa OpenGL utility library (GLU)"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="SGI-B-2.0"
 homepage="https://gitlab.freedesktop.org/mesa/glu"
-distfiles="https://mesa.freedesktop.org/archive/glu/glu-${version}.tar.xz"
+distfiles="https://archive.mesa3d.org/glu/glu-${version}.tar.xz"
 checksum=bd43fe12f374b1192eb15fe20e45ff456b9bc26ab57f0eee919f96ca0f8a330f
 replaces="libGLU<9.0"
 


### PR DESCRIPTION
Fixes the distfiles URL, as if you try a build with the current URL you get:
```
ERROR: xbps-fetch: failed to fetch: https://mesa.freedesktop.org/archive/glu/glu-9.0.3.tar.xz: Permanent Redirect
```

~~For a template fix that doesn't actually change anything about the package build process (including keeping the checksum the same), I wasn't sure if the revision needed bumping or not. Let me know and I can undo the revision bump!~~

#### Testing the changes
- I tested the changes in this PR: **briefly**
