### PR TITLE
python3-audioread: update to 3.1.0, adopt.

### DIFF
--- a/srcpkgs/python3-audioread/files/README.voidlinux
+++ b/srcpkgs/python3-audioread/files/README.voidlinux
@@ -1,4 +1,3 @@
 To decode audio files the library supports different backends:
-- gstreamer via gst1-python3
-- ffmpeg via its command-line interface
-- wave, aifc, and sunau files via Python standard library
+- gstreamer via `python3-gobject`, `gstreamer1` and `gst-plugins-*1`
+- `ffmpeg` via its command-line interface

--- a/srcpkgs/python3-audioread/patches/conditional-rawread.patch
+++ b/srcpkgs/python3-audioread/patches/conditional-rawread.patch
@@ -1,0 +1,51 @@
+diff --git a/audioread/__init__.py b/audioread/__init__.py
+index 1330a40..899fb95 100644
+--- a/audioread/__init__.py
++++ b/audioread/__init__.py
+@@ -19,6 +19,16 @@ from .exceptions import DecodeError, NoBackendError
+ from .base import AudioFile  # noqa
+ 
+ 
++def _rawread_available():
++    try:
++        import aifc
++        import audioop
++        import sunau
++    except ImportError:
++        return False
++    return True
++
++
+ def _gst_available():
+     """Determine whether Gstreamer and the Python GObject bindings are
+     installed.
+@@ -75,9 +85,12 @@ def available_backends(flush_cache=False):
+     if BACKENDS and not flush_cache:
+         return BACKENDS
+ 
++    result = []
++
+     # Standard-library WAV and AIFF readers.
+-    from . import rawread
+-    result = [rawread.RawAudioFile]
++    if _rawread_available():
++        from . import rawread
++        result.append(rawread.RawAudioFile)
+ 
+     # Core Audio.
+     if _ca_available():
+diff --git a/pyproject.toml b/pyproject.toml
+index 95ce412..04578cd 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -17,10 +17,6 @@ classifiers = [
+     "Programming Language :: Python :: 3.11",
+     "License :: OSI Approved :: MIT License",
+ ]
+-dependencies = [
+-    "standard-aifc; python_version >= '3.13'",
+-    "standard-sunau; python_version >= '3.13'",
+-]
+ 
+ [project.urls]
+ Homepage = "https://github.com/beetbox/audioread"

--- a/srcpkgs/python3-audioread/template
+++ b/srcpkgs/python3-audioread/template
@@ -1,17 +1,17 @@
 # Template file for 'python3-audioread'
 pkgname=python3-audioread
-version=3.0.1
-revision=3
+version=3.1.0
+revision=1
 build_style=python3-pep517
-hostmakedepends="python3-flit_core"
+hostmakedepends="python3-poetry-core"
 depends="python3"
 checkdepends="python3-pytest-xdist ffmpeg"
-short_desc="Multi-library, cross-platform audio decoding (Python3)"
-maintainer="Orphaned <orphan@voidlinux.org>"
+short_desc="Multi-library, cross-platform audio decoding"
+maintainer="Joel Beckmeyer <joel@beckmeyer.us>"
 license="MIT"
-homepage="https://github.com/sampsyo/audioread/"
-distfiles="${PYPI_SITE}/a/audioread/audioread-${version}.tar.gz"
-checksum=ac5460a5498c48bdf2e8e767402583a4dcd13f4414d286f42ce4379e8b35066d
+homepage="https://github.com/beetbox/audioread"
+distfiles="https://github.com/beetbox/audioread/archive/refs/tags/v${version}.tar.gz"
+checksum=73a31af0d329e633d6166ff70cab31aec3e33b35c05c80d183337fcc2b417f42
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
Patched to only rawread backend if dependencies are available, fixes https://github.com/void-linux/void-packages/issues/58496

I also tried to clean up the README.voidlinux as the gst backend doesn't actually use `gst1-python3`, instead using it's dependencies `python3-gobject` and `gstreamer1` 

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
