### PR TITLE
udiskie: update to 2.6.1.

### DIFF
--- a/srcpkgs/udiskie/template
+++ b/srcpkgs/udiskie/template
@@ -1,19 +1,19 @@
 # Template file for 'udiskie'
 pkgname=udiskie
-version=2.5.8
-revision=2
-build_style=python3-module
+version=2.6.1
+revision=1
+build_style=python3-pep517
 hostmakedepends="gettext asciidoc python3-setuptools"
 depends="gtk+3 libnotify python3-docopt python3-gobject python3-keyutils
  python3-yaml udisks2"
-checkdepends="${depends} python3-pytest-xdist"
+checkdepends="${depends} python3-pytest"
 short_desc="Removable disk automounter using udisks"
 maintainer="Matthias Fulz <mfulz@olznet.de>"
 license="MIT"
 homepage="https://github.com/coldfix/udiskie"
 changelog="https://raw.githubusercontent.com/coldfix/udiskie/master/CHANGES.rst"
 distfiles="https://github.com/coldfix/udiskie/archive/refs/tags/v${version}.tar.gz"
-checksum=ade0b67392fe5cfbd3a84c502c1e76bc2edb66e3c7e1d0ccbe2e62421f699674
+checksum=225a0316d56a33d8dc67607d8b2103d1d216feb304d72724d2512fb54eeedc66
 make_check=ci-skip # privilege issue with keyring in container
 
 post_build() {


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture (x86_64)
- I built this PR locally for these architectures using specific masterdirs:
  - x86_64-musl
  - i686
- I built this PR locally for these architectures (crossbuilds):
  - aarch64
  - aarch64-musl
  - armv7l
  - armv7l-musl
  - armv6l
  - armv6l-musl