### PR TITLE
gbinder-python: update to 1.3.1.

### DIFF
--- a/srcpkgs/gbinder-python/template
+++ b/srcpkgs/gbinder-python/template
@@ -1,6 +1,6 @@
 # Template file for 'gbinder-python'
 pkgname=gbinder-python
-version=1.3.0
+version=1.3.1
 revision=1
 build_style=python3-module
 hostmakedepends="python3-setuptools python3-Cython pkg-config"
@@ -9,6 +9,6 @@ depends="python3"
 short_desc="Python bindings for libgbinder"
 maintainer="Rutpiv <roger_freitas@live.com>"
 license="GPL-3.0-or-later"
-homepage="https://github.com/erfanoabdi/gbinder-python"
-distfiles="https://github.com/erfanoabdi/gbinder-python/archive/refs/tags/${version}.tar.gz"
-checksum=5a9dfabd51285950dfba5db35f98ef3b3576d4bacb95c421b09e0fdabe781acf
+homepage="https://github.com/waydroid/gbinder-python"
+distfiles="https://github.com/waydroid/gbinder-python/archive/${version}.tar.gz"
+checksum=27837fad61b741968a552d0b884e3d534b3b3cd1c92423018933972bc3aa9353


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures using specific masterdirs:
  - x86_64-musl
  - i686
- I built this PR locally for these architectures (crossbuilds):
  - aarch64
  - aarch64-musl
  - armv7l
  - armv7l-musl
  - armv6l
  - armv6l-musl