### PR TITLE
composer8.4: don't load phar as extension.

### DIFF
--- a/srcpkgs/composer8.4/template
+++ b/srcpkgs/composer8.4/template
@@ -1,7 +1,7 @@
 # Template file for 'composer8.4'
 pkgname=composer8.4
 version=2.8.4
-revision=1
+revision=2
 build_style=fetch
 depends="php8.4"
 short_desc="Dependency manager for PHP"
@@ -22,6 +22,6 @@ do_install() {
 	vlicense LICENSE
 
 	vmkdir /etc/php8.4/conf.d
-	printf 'extension=%s\n' phar iconv openssl zip \
+	printf 'extension=%s\n' iconv openssl zip \
 		>${DESTDIR}/etc/php8.4/conf.d/composer.ini
 }


### PR DESCRIPTION
phar is no longer dynamically linked in php8.4 so no need to include extension=phar in conf.d

fixes https://github.com/void-linux/void-packages/issues/58221

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
