### PR TITLE
New package: gpu-screen-recorder-gtk-5.7.9

### DIFF
--- a/srcpkgs/gpu-screen-recorder-gtk/files/README.voidlinux
+++ b/srcpkgs/gpu-screen-recorder-gtk/files/README.voidlinux
@@ -1,0 +1,12 @@
+GPU Screen Recorder GTK - Void Linux Notes
+
+1. Theming (KDE/Plasma users):
+  To make this application match your KDE theme, install the following packages:
+  kde-gtk-config breeze-gtk
+  Then go to System Settings -> Appearance -> Application Style ->
+  Configure GNOME/GTK Application Style and select 'Breeze'.
+
+2. Wayland Support:
+  For screen/window selection on Wayland, ensure you have a desktop portal
+  installed for your environment (e.g., xdg-desktop-portal-kde or
+  xdg-desktop-portal-wlr).

--- a/srcpkgs/gpu-screen-recorder-gtk/template
+++ b/srcpkgs/gpu-screen-recorder-gtk/template
@@ -1,0 +1,18 @@
+# Template file for 'gpu-screen-recorder-gtk'
+pkgname=gpu-screen-recorder-gtk
+version=5.7.9
+revision=1
+build_style=meson
+hostmakedepends="pkg-config meson desktop-file-utils"
+makedepends="gtk+3-devel libayatana-appindicator-devel libX11-devel"
+depends="gpu-screen-recorder"
+short_desc="GTK3 frontend for gpu-screen-recorder"
+maintainer="cherrybtw <nonopenoid123456789@gmail.com>"
+license="GPL-3.0-only"
+homepage="https://git.dec05eba.com/gpu-screen-recorder-gtk/about"
+distfiles="https://dec05eba.com/snapshot/gpu-screen-recorder-gtk.git.${version}.tar.gz"
+checksum=c369f128f1f343cef7b76ee3d80c4f132c0684ee0953ef35cc04fe6023ebf8ff
+
+post_install() {
+	vdoc ${FILESDIR}/README.voidlinux
+}

--- a/srcpkgs/gpu-screen-recorder-gtk/update
+++ b/srcpkgs/gpu-screen-recorder-gtk/update
@@ -1,0 +1,2 @@
+site="https://git.dec05eba.com/gpu-screen-recorder-gtk/refs/"
+pattern="tag/\?h=\K[\d.]+"


### PR DESCRIPTION
- I tested the changes in this PR: YES

- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

- I built this PR locally for my native architecture, (x86-64,glibc)

GTK3 frontend for gpu-screen-recorder. Provides a GUI for easier configuration and screen recording on Linux.
Depends on gpu-screen-recorder (already in repos).
Verified on KDE Plasma (Wayland)

#### GUI Screenshot
<img width="760" height="542" alt="image" src="https://github.com/user-attachments/assets/a208c24d-7157-415c-96a7-530935cce06a" />

#### Integration Demo
<details>
<summary>Video showing recording process</summary>
https://github.com/user-attachments/assets/59f7f676-eda2-4190-9a96-af5439cb86ca
</details>
