### PR TITLE
wofi: update to 1.5.3.

### DIFF
--- a/srcpkgs/wofi/template
+++ b/srcpkgs/wofi/template
@@ -1,6 +1,6 @@
 # Template file for 'wofi'
 pkgname=wofi
-version=1.5.1
+version=1.5.3
 revision=1
 build_style=meson
 hostmakedepends="pkg-config"
@@ -10,4 +10,4 @@ maintainer="skmpz <dem.procopiou@gmail.com>"
 license="GPL-3.0-or-later"
 homepage="https://hg.sr.ht/~scoopta/wofi"
 distfiles="https://hg.sr.ht/~scoopta/wofi/archive/v${version}.tar.gz"
-checksum=d432d8f2c3f1d66716dc29e9fea7bb52cd319377c7faddf326491a9e92c188cb
+checksum=6216dc14d93cdb6170f89c1ca3aaacdeaa44862fbc9be947d614be266a9c49f6


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures:
  - i686-glibc
  - x86_64-musl
  - aarch64-glibc (x86_64-glibc)
  - aarch64-musl (x86_64-musl)
  - armv7l-glibc (x86_64-glibc)
  - armv6l-musl (x86_64-musl)