### PR TITLE
iso-codes: update to 4.20.1.

### DIFF
--- a/srcpkgs/iso-codes/template
+++ b/srcpkgs/iso-codes/template
@@ -1,8 +1,8 @@
 # Template file for 'iso-codes'
 pkgname=iso-codes
-version=4.18.0
+version=4.20.1
 revision=1
-build_style=gnu-configure
+build_style=meson
 hostmakedepends="gettext python3"
 short_desc="List of country, language and currency names"
 maintainer="skmpz <dem.procopiou@gmail.com>"
@@ -10,4 +10,4 @@ license="LGPL-2.1-or-later"
 homepage="https://salsa.debian.org/iso-codes-team/iso-codes"
 changelog="https://salsa.debian.org/iso-codes-team/iso-codes/-/raw/main/CHANGELOG.md"
 distfiles="${DEBIAN_SITE}/main/i/iso-codes/iso-codes_${version}.orig.tar.xz"
-checksum=066bc4df7bf299561856a07119cde01d563c8c4c39906537a39363bb833d466c
+checksum=5d551f3ddb32548c4321e9011720fd97751af0107592f79ebffc939bd32f2268


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures:
  - i686-glibc
  - x86_64-musl
  - aarch64-glibc (x86_64-glibc)
  - aarch64-musl (x86_64-musl)
  - armv7l-glibc (x86_64-glibc)
  - armv6l-musl (x86_64-musl)