### PR TITLE
nghttp2: update to 1.68.0.

### DIFF
--- a/srcpkgs/nghttp2/template
+++ b/srcpkgs/nghttp2/template
@@ -1,6 +1,6 @@
 # Template file for 'nghttp2'
 pkgname=nghttp2
-version=1.67.1
+version=1.68.0
 revision=1
 build_style=gnu-configure
 # build system errors out if python isn't available
@@ -14,7 +14,7 @@ maintainer="skmpz <dem.procopiou@gmail.com>"
 license="MIT"
 homepage="https://nghttp2.org"
 distfiles="https://github.com/nghttp2/nghttp2/releases/download/v${version}/nghttp2-${version}.tar.xz"
-checksum=153972aad57e7bf9d911666df7613f2390acf37ea7e1a97a0c5567e90f98e830
+checksum=5511d3128850e01b5b26ec92bf39df15381c767a63441438b25ad6235def902c
 python_version=3
 
 post_install() {


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures:
  - [x] i686-glibc
  - [x] x86_64-musl
  - [x] aarch64-glibc (x86_64-glibc)
  - [x] aarch64-musl (x86_64-musl)
  - [x] armv7l-glibc (x86_64-glibc)
  - [x] armv6l-musl (x86_64-musl)