### PR TITLE
hydroxide: update to 0.2.31.

### DIFF
--- a/srcpkgs/hydroxide/template
+++ b/srcpkgs/hydroxide/template
@@ -1,6 +1,6 @@
 # Template file for 'hydroxide'
 pkgname=hydroxide
-version=0.2.30
+version=0.2.31
 revision=1
 build_style=go
 go_import_path=github.com/emersion/hydroxide
@@ -10,7 +10,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
 homepage="https://github.com/emersion/hydroxide"
 distfiles="${homepage}/archive/v${version}.tar.gz"
-checksum=752c88bdedd1d35a66f7dccb37ba7a392469f6570788d4ef70ecf7ca87a6bbd2
+checksum=b4948ba32a3bebca1857b78aabd356a261d1f34b72ab0b36b11e2ce03a748184
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures (as crossbuilds):
  - aarch64-musl

