### PR TITLE
New package: gpu-screen-recorder-ui-1.10.7

### DIFF
--- a/srcpkgs/gpu-screen-recorder-ui/files/README.voidlinux
+++ b/srcpkgs/gpu-screen-recorder-ui/files/README.voidlinux
@@ -1,0 +1,48 @@
+GPU Screen Recorder UI (MGL++) - Void Linux Notes
+====================================
+1: High-performance (KMS) recording:
+  KMS recording may require additional privileges.
+  See /usr/share/doc/gpu-screen-recorder/README.voidlinux for details.
+
+2. Global Hotkeys and Virtual Input:
+  To use global hotkeys and virtual keyboard features, your user must 
+  have permission to access input devices and uinput.
+
+  Step A: Add your user to the 'input' group:
+   # usermod -aG input <your_username>
+
+  Step B:
+  (Recommended) Create a udev rule for uinput:
+  Create a file /etc/udev/rules.d/99-uinput.rules with:
+   KERNEL=="uinput", GROUP="input", MODE="0660", OPTIONS+="static_node=uinput"
+
+  After these steps, REBOOT or reload rules and re-login:
+   # udevadm control --reload-rules && udevadm trigger
+  NOTE: Adding a user to the 'input' group allows any application running under that user
+  to read all keystrokes. This is a trade-off for global hotkey support.
+
+   or
+
+   Set SUID bit to gsr-global-hotkeys library:
+   # chmod 4755 /usr/bin/gsr-global-hotkeys
+   WARNING: This allows the binary to run with full root privileges.
+      This approach significantly increases the attack surface and
+      should only be used if you fully understand the risks.
+
+No privilege escalation is performed automatically by the package.
+It is up to the system administrator to choose the appropriate
+configuration.
+
+3. Wayland Support:
+    - For Hyprland: Ensure 'gsr-hyprland-helper' is in your PATH.
+    - For KDE Plasma: Ensure 'gsr-kwin-helper' is in your PATH.
+
+4. Autostart:
+    - The "Autostart" button in the UI is hardcoded for systemd and will not work.
+    To enable daemon on startup, manually add "gsr-ui launch-daemon"
+    to your desktop environment's autostart settings or copy the provided
+    desktop file:
+    # cp /usr/share/applications/gsr-ui-daemon.desktop ~/.config/autostart/
+    or
+    # cp /usr/share/applications/gsr-ui-daemon.desktop /etc/xdg/autostart/
+

--- a/srcpkgs/gpu-screen-recorder-ui/files/gsr-ui-daemon.desktop
+++ b/srcpkgs/gpu-screen-recorder-ui/files/gsr-ui-daemon.desktop
@@ -1,0 +1,6 @@
+[Desktop Entry]
+Name=GPU Screen Recorder UI (Autostart)
+Comment=Comment=Start the hotkey and overlay daemon for GSR
+Exec=gsr-ui launch-daemon
+Icon=gpu-screen-recorder
+Type=Application

--- a/srcpkgs/gpu-screen-recorder-ui/template
+++ b/srcpkgs/gpu-screen-recorder-ui/template
@@ -1,0 +1,25 @@
+# Template file for 'gpu-screen-recorder-ui'
+pkgname=gpu-screen-recorder-ui
+version=1.10.7
+revision=1
+build_style=meson
+hostmakedepends="pkg-config meson desktop-file-utils wayland-devel"
+makedepends="libX11-devel libXrandr-devel libXrender-devel libXcomposite-devel
+	libXfixes-devel libXext-devel libXi-devel libXcursor-devel libglvnd-devel
+	pulseaudio-devel libdrm-devel dbus-devel libcap-devel wayland-devel"
+depends="gpu-screen-recorder gpu-screen-recorder-notification"
+short_desc="ShadowPlay-like UI for gpu-screen-recorder"
+maintainer="cherrybtw <nonopenoid123456789@gmail.com>"
+license="GPL-3.0-only, OFL-1.1, CC-BY-SA-3.0, CC0-1.0, CC-BY-4.0"
+homepage="https://git.dec05eba.com/gpu-screen-recorder-ui/about"
+distfiles="https://dec05eba.com/snapshot/gpu-screen-recorder-ui.git.${version}.tar.gz"
+checksum=8644045c0e5786552aaa747dde8c0441dc01d16783971fb2c22aa47f08a9470e
+
+post_patch() {
+	vsed -i "s/meson.add_install_script/# meson.add_install_script/" meson.build
+}
+
+post_install() {
+	vdoc ${FILESDIR}/README.voidlinux
+	vinstall ${FILESDIR}/gsr-ui-daemon.desktop 644 /usr/share/applications/
+}

--- a/srcpkgs/gpu-screen-recorder-ui/update
+++ b/srcpkgs/gpu-screen-recorder-ui/update
@@ -1,0 +1,2 @@
+site="https://git.dec05eba.com/gpu-screen-recorder-ui/refs/"
+pattern="tag/\?h=\K[\d.]+"


### PR DESCRIPTION
- I tested the changes in this PR: **YES**

- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

- I built this PR locally for these architectures 
  - aarch64-glibc
  - x86-64-glibc

A ShadowPlay-like UI for gpu-screen-recorder
This package depends on [PR #58868](https://github.com/void-linux/void-packages/pull/58868).

Screenshot with UI:

<img width="426" height="240" alt="image" src="https://github.com/user-attachments/assets/f6abb16e-6da3-496b-80c7-fc172e388671" />
