### PR TITLE
lcms2: update to 2.18.

### DIFF
--- a/srcpkgs/lcms2/template
+++ b/srcpkgs/lcms2/template
@@ -1,6 +1,6 @@
 # Template file for 'lcms2'
 pkgname=lcms2
-version=2.17
+version=2.18
 revision=1
 build_style=meson
 configure_args="-Dutils=true $(vopt_bool plugins fastfloat) $(vopt_bool plugins threaded)"
@@ -10,8 +10,9 @@ short_desc="Small-footprint color management engine, version 2"
 maintainer="skmpz <dem.procopiou@gmail.com>"
 license="MIT $(vopt_if plugins GPL-3.0-or-later)"
 homepage="https://littlecms.com"
+changelog="https://raw.githubusercontent.com/mm2/Little-CMS/refs/heads/master/ChangeLog"
 distfiles="${SOURCEFORGE_SITE}/lcms/lcms2-${version}.tar.gz"
-checksum=d11af569e42a1baa1650d20ad61d12e41af4fead4aa7964a01f93b08b53ab074
+checksum=ee67be3566f459362c1ee094fde2c159d33fa0390aa4ed5f5af676f9e5004347
 build_options="plugins"
 build_options_default=" "
 desc_option_plugins="Build with threaded and fast float plugins (GPL-3.0-or-later)"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures:
  - [x] i686-glibc
  - [x] x86_64-musl
  - [x] aarch64-glibc (x86_64-glibc)
  - [x] aarch64-musl (x86_64-musl)
  - [x] armv7l-glibc (x86_64-glibc)
  - [x] armv6l-musl (x86_64-musl)