### PR TITLE
libcap: update to 2.77.

### DIFF
--- a/srcpkgs/libcap/template
+++ b/srcpkgs/libcap/template
@@ -1,6 +1,6 @@
 # Template file for 'libcap'
 pkgname=libcap
-version=2.76
+version=2.77
 revision=1
 bootstrap=yes
 build_style=gnu-makefile
@@ -13,7 +13,7 @@ license="GPL-2.0-only, BSD-3-Clause"
 homepage="https://sites.google.com/site/fullycapable/"
 changelog="https://sites.google.com/site/fullycapable/release-notes-for-libcap"
 distfiles="${KERNEL_SITE}/libs/security/linux-privs/libcap2/libcap-${version}.tar.xz"
-checksum=629da4ab29900d0f7fcc36227073743119925fd711c99a1689bbf5c9b40c8e6f
+checksum=897bc18b44afc26c70e78cead3dbb31e154acc24bee085a5a09079a88dbf6f52
 
 subpackages="libcap-devel libcap-progs"
 


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures:
  - [x] i686-glibc
  - [x] x86_64-musl
  - [x] aarch64-glibc (x86_64-glibc)
  - [x] aarch64-musl (x86_64-musl)
  - [x] armv7l-glibc (x86_64-glibc)
  - [x] armv6l-musl (x86_64-musl)