### PR TITLE
New package: niri-float-sticky-0.0.6

### DIFF
--- a/srcpkgs/niri-float-sticky/template
+++ b/srcpkgs/niri-float-sticky/template
@@ -1,0 +1,18 @@
+# Template file for 'niri-float-sticky'
+pkgname=niri-float-sticky
+version=0.0.6
+revision=1
+build_style=go
+go_import_path="github.com/probeldev/niri-float-sticky"
+hostmakedepends="go"
+depends="niri"
+short_desc="Floating windows visible across all workspaces in niri"
+maintainer="Soulful Sailer <soulful.sailer@entropic.pro>"
+license="MIT"
+homepage="https://github.com/probeldev/niri-float-sticky/"
+distfiles="https://github.com/probeldev/niri-float-sticky/archive/refs/tags/v${version}.tar.gz"
+checksum=b829bde68f64ab5fb2a6ecf8a112a10ce96119ed76a927fd17b302bb35936ee1
+
+post_install() {
+		vlicense LICENSE
+}


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**
  - System
  - Compiled


<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64 (crossbuild)
  - aarch64-musl (crossbuild)
  - armv6l (crossbuild)
  - armv6l-musl (crossbuild)