### PR TITLE
benchmark: update to 1.9.5.

### DIFF
--- a/srcpkgs/benchmark/template
+++ b/srcpkgs/benchmark/template
@@ -1,6 +1,6 @@
 # Template file for 'benchmark'
 pkgname=benchmark
-version=1.9.4
+version=1.9.5
 revision=1
 build_style=cmake
 configure_args="-DBUILD_SHARED_LIBS=ON -DBENCHMARK_ENABLE_GTEST_TESTS=OFF
@@ -10,7 +10,7 @@ maintainer="skmpz <dem.procopiou@gmail.com>"
 license="Apache-2.0"
 homepage="https://github.com/google/benchmark/"
 distfiles="https://github.com/google/benchmark/archive/v${version}.tar.gz"
-checksum=b334658edd35efcf06a99d9be21e4e93e092bd5f95074c1673d5c8705d95c104
+checksum=9631341c82bac4a288bef951f8b26b41f69021794184ece969f8473977eaa340
 
 benchmark-devel_package() {
 	depends="${sourcepkg}>=${version}_${revision}"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures:
  - [x] i686-glibc
  - [x] x86_64-musl
  - [x] aarch64-glibc (x86_64-glibc)
  - [x] aarch64-musl (x86_64-musl)
  - [x] armv7l-glibc (x86_64-glibc)
  - [x] armv6l-musl (x86_64-musl)
