### PR TITLE
cava: update to 0.10.7.

### DIFF
--- a/srcpkgs/cava/template
+++ b/srcpkgs/cava/template
@@ -1,6 +1,6 @@
 # Template file for 'cava'
 pkgname=cava
-version=0.10.6
+version=0.10.7
 revision=1
 build_style=gnu-configure
 hostmakedepends="autoconf-archive automake libtool pkg-config"
@@ -13,7 +13,7 @@ license="MIT"
 homepage="https://github.com/karlstav/cava"
 changelog="https://github.com/karlstav/cava/releases"
 distfiles="https://github.com/karlstav/cava/archive/refs/tags/${version}.tar.gz"
-checksum=b1ce6653659a138cbaebf0ef2643a1569525559c597162e90bf9304ac8781398
+checksum=43f994f7e609fab843af868d8a7bc21471ac62c5a4724ef97693201eac42e70a
 build_options="alsa jack pipewire pulseaudio sndio"
 build_options_default="alsa jack pipewire pulseaudio sndio"
 


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures:
  - [x] i686-glibc
  - [x] x86_64-musl
  - [x] aarch64-glibc (x86_64-glibc)
  - [x] aarch64-musl (x86_64-musl)
  - [x] armv7l-glibc (x86_64-glibc)
  - [x] armv6l-musl (x86_64-musl)