### PR TITLE
sway: make xorg-server-xwayland an optional dependency

### DIFF
--- a/srcpkgs/sway/template
+++ b/srcpkgs/sway/template
@@ -8,7 +8,7 @@ conf_files="/etc/sway/config"
 hostmakedepends="pkg-config wayland-devel scdoc"
 makedepends="wlroots0.19-devel pcre2-devel json-c-devel pango-devel cairo-devel
  gdk-pixbuf-devel libevdev-devel"
-depends="libcap-progs swaybg xorg-server-xwayland libxkbcommon>=1.5.0_1"
+depends="libcap-progs swaybg libxkbcommon>=1.5.0_1"
 short_desc="Tiling Wayland compositor compatible with i3"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

sway does not require xorg-server-xwayland to run.
It is only needed for X11 applications.

Making it a hard dependency forces an unnecessary X component into Wayland-only systems

This change moves xorg-server-xwayland out of required dependencies so users can install it only when needed