### PR TITLE
New package: openpgp-card-tool-git-0.1.6

### DIFF
--- a/srcpkgs/openpgp-card-tool-git/template
+++ b/srcpkgs/openpgp-card-tool-git/template
@@ -1,0 +1,19 @@
+# Template file for 'openpgp-card-tool-git'
+pkgname=openpgp-card-tool-git
+version=0.1.6
+revision=1
+build_style=cargo
+hostmakedepends="pkg-config llvm clang"
+makedepends="dbus-devel sqlite-devel openssl-devel pcsclite-devel"
+depends="pcsclite pcsc-ccid"
+short_desc="OpenPGP card tool for Git signing and verification"
+maintainer="Alex March <alex@hosaka.cc>"
+license="MIT OR Apache-2.0"
+homepage="https://codeberg.org/openpgp-card/oct-git"
+distfiles="https://codeberg.org/openpgp-card/oct-git/archive/v${version}.tar.gz"
+checksum=fc0f3ba974a5020f844580781cc52c342a9ff93ab877a3a7e2a281d0d2899737
+
+post_install() {
+	vlicense LICENSES/MIT.txt
+	vdoc README.md
+}


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv6l

From the author of the [openpgp-card-tools](https://codeberg.org/openpgp-card/openpgp-card-tools) package mentioned in the void documentation. I wasn't sure if the package name should be `oct-git` instead, please let me know if that is more appropriate than `openpgp-card-tools-git`