### PR TITLE
[WIP] New package: zotero-8.0.2

### DIFF
--- a/srcpkgs/zotero/patches/change_desktop_exec_path.patch
+++ b/srcpkgs/zotero/patches/change_desktop_exec_path.patch
@@ -1,0 +1,12 @@
+The original desktop file takes the prior that it is located
+in the same directory as the binary.
+--- a/app/linux/zotero.desktop	2026-02-09 14:09:55.493483937 +0100
++++ b/app/linux/zotero.desktop	2026-02-09 14:16:09.628500071 +0100
+@@ -1,6 +1,6 @@
+ [Desktop Entry]
+ Name=Zotero
+-Exec=bash -c "$(dirname $(realpath $(echo %k | sed -e 's/^file:\\/\\///')))/zotero -url %U"
++Exec=bash -c "/bin/zotero -url %U"
+ Icon=zotero.ico
+ Type=Application
+ Terminal=false

--- a/srcpkgs/zotero/patches/pretend_release.patch
+++ b/srcpkgs/zotero/patches/pretend_release.patch
@@ -1,0 +1,26 @@
+Zotero uses tags for their releases rather than proper github releases.
+The default "source" value for $CHANNEL triggers checks on the commit hash,
+which doesn't exist since we are using the tarball and not in a git repository.
+Here, I disable the commit hash retireval which would fail, and pretend to be
+the official build to be allowed to go without it.
+
+--- a/app/scripts/dir_build	2026-02-08 19:10:42.597996579 +0100
++++ b/app/scripts/dir_build	2026-02-09 12:43:28.450260258 +0100
+@@ -84,15 +84,13 @@
+ 	fi
+ fi
+ 
+-CHANNEL="source"
+-
+-hash=$(git -C "$ROOT_DIR" rev-parse --short HEAD)
++CHANNEL="release"
+ 
+ build_dir=$(mktemp -d)
+ cleanup() { rm -rf "$build_dir"; }
+ trap cleanup EXIT
+ 
+-"$SCRIPT_DIR/prepare_build" -s "$ROOT_DIR/build" -o "$build_dir" -c "$CHANNEL" -m "$hash"
++"$SCRIPT_DIR/prepare_build" -s "$ROOT_DIR/build" -o "$build_dir" -c "$CHANNEL"
+ 
+ build_cmd=("$APP_ROOT_DIR/build.sh" -d "$build_dir" -p "$platform" -c "$CHANNEL" -s)
+ [[ -n $arch ]] && build_cmd+=( -a "$arch" )

--- a/srcpkgs/zotero/patches/skip_git_submodules_pull.patch
+++ b/srcpkgs/zotero/patches/skip_git_submodules_pull.patch
@@ -1,0 +1,132 @@
+The build usually pulls its git submodules by itself.
+We do not want that since we are already getting them through distfiles,
+and it would fail anyway since we are not in a git repo.
+
+--- a/js-build/note-editor.js	2026-02-08 18:15:06.223082132 +0100
++++ b/js-build/note-editor.js	2026-02-08 19:00:33.377012201 +0100
+@@ -10,40 +10,6 @@
+ async function getZoteroNoteEditor(signatures) {
+ 	const t1 = Date.now();
+ 
+-	const modulePath = path.join(__dirname, '..', 'note-editor');
+-
+-	const { stdout } = await exec('git rev-parse HEAD', { cwd: modulePath });
+-	const hash = stdout.trim();
+-
+-	if (!('note-editor' in signatures) || signatures['note-editor'].hash !== hash) {
+-		const targetDir = path.join(__dirname, '..', 'build', 'resource', 'note-editor');
+-		try {
+-			const filename = hash + '.zip';
+-			const tmpDir = path.join(__dirname, '..', 'tmp', 'builds', 'note-editor');
+-			const url = buildsURL + 'note-editor/' + filename;
+-
+-			await fs.remove(targetDir);
+-			await fs.ensureDir(targetDir);
+-			await fs.ensureDir(tmpDir);
+-
+-			await exec(
+-				`cd ${tmpDir}`
+-				+ ` && (test -f ${filename} || curl -f ${url} -o ${filename})`
+-				+ ` && unzip ${filename} zotero/* -d ${targetDir}`
+-				+ ` && mv ${path.join(targetDir, 'zotero', '*')} ${targetDir}`
+-			);
+-
+-			await fs.remove(path.join(targetDir, 'zotero'));
+-		}
+-		catch (e) {
+-			console.error(e);
+-			await exec('npm ci', { cwd: modulePath });
+-			await exec('npm run build', { cwd: modulePath });
+-			await fs.copy(path.join(modulePath, 'build', 'zotero'), targetDir);
+-		}
+-		signatures['note-editor'] = { hash };
+-	}
+-	
+ 	const t2 = Date.now();
+ 
+ 	return {
+diff -ur a/js-build/pdf-worker.js b/js-build/pdf-worker.js
+--- a/js-build/pdf-worker.js	2026-02-08 18:42:29.759039988 +0100
++++ b/js-build/pdf-worker.js	2026-02-08 19:00:42.188011975 +0100
+@@ -10,37 +10,6 @@
+ async function getPDFWorker(signatures) {
+ 	const t1 = Date.now();
+ 
+-	const modulePath = path.join(__dirname, '..', 'pdf-worker');
+-
+-	const { stdout } = await exec('git rev-parse HEAD', { cwd: modulePath });
+-	const hash = stdout.trim();
+-
+-	if (!('pdf-worker' in signatures) || signatures['pdf-worker'].hash !== hash) {
+-		const targetDir = path.join(__dirname, '..', 'build', 'chrome', 'content', 'zotero', 'xpcom', 'pdfWorker');
+-		try {
+-			const filename = hash + '.zip';
+-			const tmpDir = path.join(__dirname, '..', 'tmp', 'builds', 'pdf-worker');
+-			const url = buildsURL + 'document-worker/' + filename;
+-
+-			await fs.remove(targetDir);
+-			await fs.ensureDir(targetDir);
+-			await fs.ensureDir(tmpDir);
+-
+-			await exec(
+-				`cd ${tmpDir}`
+-				+ ` && (test -f ${filename} || curl -f ${url} -o ${filename})`
+-				+ ` && unzip -o ${filename} worker.js -d ${targetDir}`
+-			);
+-		}
+-		catch (e) {
+-			console.error(e);
+-			await exec('npm ci', { cwd: modulePath });
+-			await exec('npm run build', { cwd: modulePath });
+-			await fs.copy(path.join(modulePath, 'build', 'worker.js'), path.join(targetDir, 'worker.js'));
+-		}
+-		signatures['pdf-worker'] = { hash };
+-	}
+-
+ 	const t2 = Date.now();
+ 
+ 	return {
+diff -ur a/js-build/reader.js b/js-build/reader.js
+--- a/js-build/reader.js	2026-02-08 18:42:29.759039988 +0100
++++ b/js-build/reader.js	2026-02-08 19:00:51.609011734 +0100
+@@ -10,40 +10,6 @@
+ async function getReader(signatures) {
+ 	const t1 = Date.now();
+ 
+-	const modulePath = path.join(__dirname, '..', 'reader');
+-	
+-	const { stdout } = await exec('git rev-parse HEAD', { cwd: modulePath });
+-	const hash = stdout.trim();
+-	
+-	if (!('reader' in signatures) || signatures['reader'].hash !== hash) {
+-		const targetDir = path.join(__dirname, '..', 'build', 'resource', 'reader');
+-		try {
+-			const filename = hash + '.zip';
+-			const tmpDir = path.join(__dirname, '..', 'tmp', 'builds', 'reader');
+-			const url = buildsURL + 'reader/' + filename;
+-
+-			await fs.remove(targetDir);
+-			await fs.ensureDir(targetDir);
+-			await fs.ensureDir(tmpDir);
+-
+-			await exec(
+-				`cd ${tmpDir}`
+-				+ ` && (test -f ${filename} || curl -f ${url} -o ${filename})`
+-				+ ` && unzip ${filename} zotero/* -d ${targetDir}`
+-				+ ` && mv ${path.join(targetDir, 'zotero', '*')} ${targetDir}`
+-			);
+-
+-			await fs.remove(path.join(targetDir, 'zotero'));
+-		}
+-		catch (e) {
+-			console.error(e);
+-			await exec('npm ci', { cwd: modulePath });
+-			await exec('npm run build', { cwd: modulePath });
+-			await fs.copy(path.join(modulePath, 'build', 'zotero'), targetDir);
+-		}
+-		signatures['reader'] = { hash };
+-	}
+-	
+ 	const t2 = Date.now();
+ 
+ 	return {

--- a/srcpkgs/zotero/patches/skip_updater.patch
+++ b/srcpkgs/zotero/patches/skip_updater.patch
@@ -1,0 +1,19 @@
+Zotero pulls that `updater.tar.gz` through git LFS, which we don't want as dependency
+and would not work since we are not in a git repo.
+Getting a direct link for distfiles is not obvious to me.
+Updates should be managed by XBPS anyway.
+
+--- a/app/build.sh	2026-02-08 20:28:31.050876868 +0100
++++ b/app/build.sh	2026-02-09 13:00:28.820304259 +0100
+@@ -1027,11 +1027,6 @@
+ 		# Copy Ubuntu launcher files
+ 		cp "$CALLDIR/linux/zotero.desktop" "$APPDIR"
+ 		cp "$CALLDIR/linux/set_launcher_icon" "$APPDIR"
+-		
+-		# Use our own updater, because Mozilla's requires updates signed by Mozilla
+-		check_lfs_file "$CALLDIR/linux/updater.tar.xz"
+-		tar xf "$CALLDIR/linux/updater.tar.xz" --to-stdout updater-$arch > "$APPDIR/updater"
+-		chmod 755 "$APPDIR/updater"
+ 
+ 		# Copy app files
+ 		rsync -a "$base_dir/" "$APPDIR/"

--- a/srcpkgs/zotero/template
+++ b/srcpkgs/zotero/template
@@ -1,0 +1,163 @@
+# Template file for 'zotero'
+pkgname=zotero
+version=8.0.2
+revision=1
+archs="x86_64 aarch64 i686"
+short_desc="Tool to collect, organize, annotate, cite, and share research sources"
+maintainer="Trong-Lanh, Rémi Nɢᴜʏᴇɴ <tl.remi.nguyen@gmail.com>"
+license="AGPL-3.0-or-later"
+homepage="https://www.zotero.org/"
+changelog="https://www.zotero.org/support/changelog"
+
+# TODO: add test phase
+# TODO: use xbps pdf.js? how?
+# TODO: use xbps Firefox? how?
+# TODO: check libreoffice plugin: source -> release, install path
+# TODO: patch to replace rsync with cp and chmod?
+# TODO: patch xz -> gz?
+
+# GIT submodules; what a mess.
+_noteeditor_version=5d8573ba7842c6f7fe6e221b8eb4fdf76de2dc71                  # note-editor
+_bundledstyles_version=86e08aba49b2cac652720503b09d207f6cea5f9a               # styles
+_translators_version=92d17b12100988320c0b1fe088860956d092e808                 # translators
+_pdfworker_version=fd642b38287f1e59aaf8e02c3132da6d3daa39c1                   # pdf-worker
+_pdfworker_pdfjs_version=7cb304b6707d2c861f992612e9aced228555a7f3             # pdf-worker/pdf.js
+_reader_version=584c698eadb4df8049047076f5fa51c32b3b06d7                      # reader
+_reader_epubjs_version=a6139d586b66d404f3da2b846598960c0394afc5               # reader/epubjs/epub.js
+_reader_pdfjs_version=2334200130e8da8fad0e52714bb49f00aae83377                # reader/pdfjs/pdf.js
+_singlefile_version=0bca0227851348ef9bbaec780e88deb32b1cc03d                  # resource/SingleFile
+_schema_version=5eedf4402ea6e7393eaf16902b63f572f48707a7                      # resource/schema/global
+_libreofficeintegration_version=692759ba43d77a2448b37e6d1dd7992a2ba59007      # app/modules/zotero-libreoffice-integration
+_locales_version=99724467e5e435b71249eaa079bed49915ee278e                     # chrome/content/zotero/locale/csl
+_translate_version=017253c17c94f722057a652e8741d68515656a8b                   # chrome/content/zotero/xpcom/translate
+_translate_utilities_version=cccf1235a318c259345fc623d5e9d6770ba19df7         # chrome/content/zotero/xpcom/translate -> modules/utilities
+_translate_utilities_schema_version=1b12272d44134a652519e9192e5a936ac9fcd707  # chrome/content/zotero/xpcom/translate -> modules/utilities -> resource/schema/global
+_utilities_version=6b4d04f943d3dbd1c3d5a356ec2b81e952b46c3c                   # chrome/content/zotero/xpcom/utilities
+_utilities_schema_version=7f04bb5a6c0c8acfb070849cec81775d1ac25947            # chrome/content/zotero/xpcom/utilities -> resource/schema/global
+# The `test/resource/chai` and `test/resource/mocha` submodules listed in .gitattributes
+# do not seem to bee pulled, there is no link in the directories, just symlinks
+# that point to `node_modules/`, where those two packages are installed via npm instead.
+
+# They use an ESR of Firefox that they modify inplace.
+# The version is set in app/config.sh as $GECKO_VERSION_LINUX
+# That version is newer than the one in XBPS (140.2.0)
+_firefox_version=140.7.0esr
+
+# tar, xz, unzip, zip and perl are needed for the shenanigans
+# they operate on Firefox,
+# in app/scripts/fetch_xulrunner, function modify_omni().
+hostmakedepends="nodejs python3 rsync tar xz unzip zip perl"
+distfiles="
+ https://github.com/zotero/${pkgname}/archive/refs/tags/${version}.tar.gz
+ https://github.com/zotero/bundled-styles/archive/${_bundledstyles_version}.tar.gz>bundled-styles.tar.gz
+ https://github.com/zotero/epub.js/archive/${_reader_epubjs_version}.tar.gz>epubjs.tar.gz
+ https://github.com/zotero/note-editor/archive/${_noteeditor_version}.tar.gz>note-editor.tar.gz
+ https://github.com/zotero/pdf-worker/archive/${_pdfworker_version}.tar.gz>pdf-worker.tar.gz
+ https://github.com/zotero/pdf.js/archive/${_pdfworker_pdfjs_version}.tar.gz>pdf-worker_pdfjs.tar.gz
+ https://github.com/zotero/pdf.js/archive/${_reader_pdfjs_version}.tar.gz>reader_pdfjs.tar.gz
+ https://github.com/zotero/reader/archive/${_reader_version}.tar.gz>reader.tar.gz
+ https://github.com/zotero/translate/archive/${_translate_version}.tar.gz>translate.tar.gz
+ https://github.com/zotero/translators/archive/${_translators_version}.tar.gz>translators.tar.gz
+ https://github.com/zotero/utilities/archive/${_translate_utilities_version}.tar.gz>translate_utilities.tar.gz
+ https://github.com/zotero/utilities/archive/${_utilities_version}.tar.gz>utilities.tar.gz
+ https://github.com/zotero/zotero-libreoffice-integration/archive/${_libreofficeintegration_version}.tar.gz>libreoffice-integration.tar.gz
+ https://github.com/zotero/zotero-schema/archive/${_schema_version}.tar.gz>schema.tar.gz
+ https://github.com/zotero/zotero-schema/archive/${_translate_utilities_schema_version}.tar.gz>translate_utilities_schema.tar.gz
+ https://github.com/zotero/zotero-schema/archive/${_utilities_schema_version}.tar.gz>utilities_schema.tar.gz
+ https://github.com/citation-style-language/locales/archive/${_locales_version}.tar.gz>locales.tar.gz
+ https://github.com/gildas-lormeau/SingleFile/archive/${_singlefile_version}.tar.gz>singlefile.tar.gz
+ https://ftp.mozilla.org/pub/firefox/releases/${_firefox_version}/linux-x86_64/en-US/firefox-${_firefox_version}.tar.xz>firefox-${_firefox_version}-x86_64.tar.xz
+ "  # TODO: firefox alt archs
+checksum="b823794304e41db2b069ae6344e02a7d8398a1b52ab7a7ebcfc22152e3da2f3f
+ b8a9fb24b4839ba801a080aa261c6f27c7d782431a2aa309a6c4dea76deb2158
+ 219c9ab70af2222e4d21aeb0923670f36cc4e3fbd9326a3af3ba60ee14cbe815
+ 31d66e319fab2232a1351aa10cc13393687cf0f0433a680e3d8b3e0e7332fde4
+ 0a089056fb6145196138590d3583ed5e811a7f8342bbd72cec6a3b5e31cb7094
+ 74612b20c925d85c3bbe9f1c4b661ca0f771a92d4be66de42ec49ae5016137cb
+ c1fbf5b9d266c1626ebcc4da79b7e08fc1527ac2e69aad306cb3f8865e3d1044
+ 93153ce62ed992168a3fe0d18e0b6ab02a011c43667b8603ce9c08e10f949f54
+ be29dcf4cd2916ee322b78634df1d66117b5d7dff9cdb2c4dd9f629705054ed9
+ 856ec209664b985943c075b9f8383323e6bc95155ae27ee884063ae64bf98f71
+ 7b2d41f08ecbcd978cb82a10df0f9859f4eeb8812d61e29e7636dfab9d235967
+ 3cbb658cc448ea82b74ced72312442baf4a1bcccb6654c2076cccff24df48431
+ ed0bd0c7e63028ad620eed5779219a4200997f8d78799fabf3f42d86a9f1d2e2
+ 6e41510528b763c1a137ef968ad8efc674b2f8645543ba23943a6424fb757060
+ 1aedf798ef987df1d3e6cd6fab9aacb56c88603f1094025420ed4ea7a96343ed
+ ee0c526620a23f2e0180dc280cd85e215a21dd742953c29fd7cd29046180a788
+ d04aacc3e5239728975b526c4416ed6cfa73f991c0d53aa9105b1b77df1c5c17
+ e41cb8dd837a4ce1d1a4adc69988ed3cbc73c4fd2c8147f9ce8f3b5665b94612
+ 5e23761cf9b2f78ab5a549732d48b4e52b2f20fb670a111f9265069d18181d38"
+skip_extraction="
+ bundled-styles.tar.gz
+ epubjs.tar.gz
+ libreoffice-integration.tar.gz
+ locales.tar.gz
+ note-editor.tar.gz
+ pdf-worker.tar.gz
+ pdf-worker_pdfjs.tar.gz
+ reader.tar.gz
+ reader_pdfjs.tar.gz
+ schema.tar.gz
+ singlefile.tar.gz
+ translate.tar.gz
+ translate_utilities.tar.gz
+ translate_utilities_schema.tar.gz
+ translators.tar.gz
+ utilities.tar.gz
+ utilities_schema.tar.gz
+ firefox-${_firefox_version}-x86_64.tar.xz
+ "  # TODO: firefox alt archs
+
+post_extract() {
+	vsrcextract -C note-editor "note-editor.tar.gz"
+	vsrcextract -C styles "bundled-styles.tar.gz"
+	vsrcextract -C translators "translators.tar.gz"
+	vsrcextract -C pdf-worker "pdf-worker.tar.gz"
+	vsrcextract -C pdf-worker/pdf.js "pdf-worker_pdfjs.tar.gz"
+	vsrcextract -C reader "reader.tar.gz"
+	vsrcextract -C reader/epubjs/epub.js "epubjs.tar.gz"
+	vsrcextract -C reader/pdfjs/pdf.js "reader_pdfjs.tar.gz"
+	vsrcextract -C resource/SingleFile "singlefile.tar.gz"
+	vsrcextract -C resource/schema/global "schema.tar.gz"
+	vsrcextract -C app/modules/zotero-libreoffice-integration "libreoffice-integration.tar.gz"
+	vsrcextract -C chrome/content/zotero/locale/csl "locales.tar.gz"
+	vsrcextract -C chrome/content/zotero/xpcom/translate "translate.tar.gz"
+	vsrcextract -C chrome/content/zotero/xpcom/translate/modules/utilities "translate_utilities.tar.gz"
+	vsrcextract -C chrome/content/zotero/xpcom/translate/modules/utilities/resource/schema/global "translate_utilities_schema.tar.gz"
+	vsrcextract -C chrome/content/zotero/xpcom/utilities "utilities.tar.gz"
+	vsrcextract -C chrome/content/zotero/xpcom/utilities/resource/schema/global "utilities_schema.tar.gz"
+	# WARN: This is Firefox's **binaries** release, not the source.
+	vsrccopy "firefox-${_firefox_version}-x86_64.tar.xz" app/xulrunner/  # TODO: firefox alt archs
+}
+
+pre_build() {
+	npm install
+}
+
+do_build() {
+	npm run build
+	case "${XBPS_TARGET_MACHINE}" in
+		"x86_64")
+			app/scripts/dir_build -pl -ax64
+			;;
+		"aarch64")
+			app/scripts/dir_build -pl -aarm64
+			;;
+		"i686")
+			app/scripts/dir_build -pl -ai686
+			;;
+		*)
+			exit -1
+			;;
+	esac
+	# exit -1
+}
+
+do_install() {
+	vmkdir usr/lib/zotero
+	vmkdir usr/bin
+	vcopy app/staging/Zotero_linux-${XBPS_TARGET_MACHINE}/* usr/lib/zotero  # TODO: check arch
+	ln -s /usr/lib/zotero/zotero ${DESTDIR}/usr/bin/zotero
+	vinstall "app/linux/zotero.desktop" 644 usr/share/applications
+	vlicense COPYING
+}


### PR DESCRIPTION
related issues: #21434, #25508

#### Testing the changes
- I tested the changes in this PR: **NO**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **compiled**

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-GLIBC)

### Status
This currently builds and seems to run,
**but**,
- their build process involves modifying a binary release of Firefox-ESR
  - I moved that to the `distfiles` but I doubt this is satisfactory enough
  - I am currently messing around to use the xbps version of `firefox-esr` (which is behind schedule, currently at 140.2.0 while zotero uses 140.7.0)
    - either this is possible, or we'll need to recompile Firefox on the spot ? (seems overkill)
- different architecture support need some flags which _don't always_ match `XBPS_TARGET_MACHINE`, there will have to be some switch case sprinkling
