### PR TITLE
libssh: update to 0.12.0.

### DIFF
--- a/srcpkgs/libssh/template
+++ b/srcpkgs/libssh/template
@@ -1,6 +1,6 @@
 # Template file for 'libssh'
 pkgname=libssh
-version=0.11.3
+version=0.12.0
 revision=1
 build_style=cmake
 hostmakedepends="pkg-config python3"
@@ -12,7 +12,7 @@ license="LGPL-2.1-or-later"
 homepage="https://www.libssh.org/"
 changelog="https://git.libssh.org/projects/libssh.git/plain/CHANGELOG"
 distfiles="https://git.libssh.org/projects/libssh.git/snapshot/libssh-${version}.tar.gz"
-checksum=aac65c6ee8cfd93a54ac93a198f4c12e6a5e988954f5603ffe00b7f01caab7eb
+checksum=a93c97f539f23a213734fa4a1807c7da577ad155d78145d44fd2af26bfb0e2ea
 
 case "$XBPS_TARGET_MACHINE" in
 	*-musl) configure_args="-DHAVE_GLOB=0" ;;


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures:
  - [x] i686-glibc
  - [x] x86_64-musl
  - [x] aarch64-glibc (x86_64-glibc)
  - [x] aarch64-musl (x86_64-musl)
  - [x] armv7l-glibc (x86_64-glibc)
  - [x] armv6l-musl (x86_64-musl)