### PR TITLE
spotify: update to 1.2.82.

### DIFF
--- a/srcpkgs/spotify/template
+++ b/srcpkgs/spotify/template
@@ -1,8 +1,8 @@
 # Template file for 'spotify'
 pkgname=spotify
-version=1.2.79
+version=1.2.82
 revision=1
-_subver=427.g80eb4a07
+_subver=428.g0ac8be2b
 archs="x86_64"
 create_wrksrc=yes
 hostmakedepends="libcurl"
@@ -12,7 +12,7 @@ maintainer="Stefan Mühlinghaus <jazzman@alphabreed.com>"
 license="custom:Proprietary"
 homepage="https://www.spotify.com"
 distfiles="http://repository.spotify.com/pool/non-free/s/spotify-client/spotify-client_${version}.${_subver}_amd64.deb"
-checksum=456d2699a1affd8fa22e5a46e2cf7560b0d91b1d5cd29c74b70682fbfb064b0a
+checksum=d7cae04d3ace58703907b07d947b39006d51eda5b1a5ccd7bc59fecb51b2dc10
 repository=nonfree
 restricted=yes
 nostrip=yes

--- a/srcpkgs/spotify/update
+++ b/srcpkgs/spotify/update
@@ -1,3 +1,3 @@
-site="http://repository.spotify.com/pool/non-free/s/spotify-client/"
+site="http://repository.spotify.com/pool/non-free/s/spotify-client"
 version="${version}.${_subver}.amd64"
 pattern='>spotify-client_\K.+(?=\.deb<)'


### PR DESCRIPTION
Also fix update-check not showing the latest version.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture (`x86_64-glibc`)
<!--
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
