### PR TITLE
nghttp3: include static libs in build

### DIFF
--- a/srcpkgs/nghttp3/template
+++ b/srcpkgs/nghttp3/template
@@ -1,15 +1,29 @@
 # Template file for 'nghttp3'
 pkgname=nghttp3
 version=1.12.0
-revision=1
+revision=2
 build_style=cmake
-configure_args="-DENABLE_STATIC_LIB=OFF -DBUILD_TESTING=ON"
 short_desc="HTTP/3 library written in C"
 maintainer="Đoàn Trần Công Danh <congdanhqx@gmail.com>"
 license="MIT"
 homepage="https://nghttp2.org/nghttp3/"
 distfiles="https://github.com/ngtcp2/nghttp3/releases/download/v${version}/nghttp3-${version}.tar.xz"
 checksum=6ca1e523b7edd75c02502f2bcf961125c25577e29405479016589c5da48fc43d
+
+if [ "$XBPS_CHECK_PKGS" ]; then
+	# see: https://github.com/ngtcp2/nghttp3/blob/78f27c1a4367c33764b36afd4575ef31bd8dde4f/CMakeOptions.txt#L9
+	configure_args="-DBUILD_TESTING=ON -DENABLE_STATIC_LIB=OFF"
+fi
+
+post_check() {
+	# -DBUILD_TESTING required for do_check is incompatible with -DENABLE_STATIC_LIB,
+	# so after running checks perform a reconfigure and rebuild with flags inversed
+	rm -r build/
+	mkdir build/
+	configure_args="-DBUILD_TESTING=OFF -DENABLE_STATIC_LIB=ON"
+	(do_configure)
+	(do_build)
+}
 
 post_install() {
 	vlicense COPYING
@@ -24,5 +38,6 @@ nghttp3-devel_package() {
 		vmove usr/lib/cmake
 		vmove usr/lib/pkgconfig
 		vmove "usr/lib/*.so"
+		vmove "usr/lib/*.a"
 	}
 }


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

Updates the nghttp3 template to build and include static library files in devel package.

cc: @sgn 