### PR TITLE
fuse-sshfs: update to 3.7.5.

### DIFF
--- a/srcpkgs/fuse-sshfs/template
+++ b/srcpkgs/fuse-sshfs/template
@@ -1,7 +1,7 @@
 # Template file for 'fuse-sshfs'
 pkgname=fuse-sshfs
-version=3.7.3
-revision=2
+version=3.7.5
+revision=1
 build_style=meson
 configure_args="--sbindir=bin"
 hostmakedepends="pkg-config python3-docutils"
@@ -13,7 +13,7 @@ maintainer="skmpz <dem.procopiou@gmail.com>"
 license="GPL-2.0-or-later"
 homepage="https://github.com/libfuse/sshfs"
 distfiles="https://github.com/libfuse/sshfs/releases/download/sshfs-${version}/sshfs-${version}.tar.xz"
-checksum=5218ce7bdd2ce0a34137a0d7798e0f6d09f0e6d21b1e98ee730a18b0699c2e99
+checksum=0e45db63c2d00919db3174134fa234c6e0682d6fe573c46312d1d53d1d61a8bb
 
 case "${XBPS_TARGET_MACHINE}" in
 	i686|armv6l|armv7l)


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures:
  - [x] i686-glibc
  - [x] x86_64-musl
  - [x] aarch64-glibc (x86_64-glibc)
  - [x] aarch64-musl (x86_64-musl)
  - [x] armv7l-glibc (x86_64-glibc)
  - [x] armv6l-musl (x86_64-musl)
