### PR TITLE
libconfig: update to 1.8.2.

### DIFF
--- a/srcpkgs/libconfig/template
+++ b/srcpkgs/libconfig/template
@@ -1,6 +1,6 @@
 # Template file for 'libconfig'
 pkgname=libconfig
-version=1.8.1
+version=1.8.2
 revision=1
 build_style=gnu-configure
 hostmakedepends="automake byacc flex libtool texinfo"
@@ -8,8 +8,9 @@ short_desc="C Configuration File Library"
 maintainer="skmpz <dem.procopiou@gmail.com>"
 license="LGPL-2.1-or-later"
 homepage="https://hyperrealm.com/libconfig/libconfig.html"
+changelog="https://raw.githubusercontent.com/hyperrealm/libconfig/refs/heads/master/ChangeLog"
 distfiles="https://github.com/hyperrealm/libconfig/archive/v${version}.tar.gz"
-checksum=e95798d2992a66ecd547ce3651d7e10642ff2211427c43a7238186ff4c372627
+checksum=8e71983761b08c65b15b769b3ec1d980036c461fdfd415c7183378a4b3eac8f4
 
 pre_configure() {
 	autoreconf -vi


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures:
  - [x] i686-glibc
  - [x] x86_64-musl
  - [x] aarch64-glibc (x86_64-glibc)
  - [x] aarch64-musl (x86_64-musl)
  - [x] armv7l-glibc (x86_64-glibc)
  - [x] armv6l-musl (x86_64-musl)