### PR TITLE
osinfo-db: update to 20251212, orphan.

### DIFF
--- a/srcpkgs/osinfo-db/template
+++ b/srcpkgs/osinfo-db/template
@@ -1,15 +1,15 @@
 # Template file for 'osinfo-db'
 pkgname=osinfo-db
-version=20250606
+version=20251212
 revision=1
 build_style=fetch
 hostmakedepends="osinfo-db-tools"
 short_desc="Osinfo database about operating systems"
-maintainer="skmpz <dem.procopiou@gmail.com>"
+maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="https://libosinfo.org"
 distfiles="https://releases.pagure.org/libosinfo/osinfo-db-${version}.tar.xz"
-checksum=9940aa47df298073c51dcf8a4dcc855f494ab864c24cdbda46bd897957357fe1
+checksum=06379250c91306c98cb9726af44eae5909dfdd5449f90331e904ae1221d8d5e7
 skip_extraction="${pkgname}-${version}.tar.xz"
 
 do_install() {


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures:
  - [x] i686-glibc
  - [x] x86_64-musl
  - [x] aarch64-glibc (x86_64-glibc)
  - [x] aarch64-musl (x86_64-musl)
  - [x] armv7l-glibc (x86_64-glibc)
  - [x] armv6l-musl (x86_64-musl)