### PR TITLE
python3-parse: update to 1.21.0, orphan.

### DIFF
--- a/srcpkgs/python3-parse/template
+++ b/srcpkgs/python3-parse/template
@@ -1,17 +1,17 @@
 # Template file for 'python3-parse'
 pkgname=python3-parse
-version=1.20.2
-revision=3
+version=1.21.0
+revision=1
 build_style=python3-pep517
 hostmakedepends="python3-setuptools python3-wheel"
 depends="python3"
 checkdepends="python3-pytest"
 short_desc="Parse strings using the format() syntax (Python3)"
-maintainer="skmpz <dem.procopiou@gmail.com>"
+maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
 homepage="https://github.com/r1chardj0n3s/parse"
 distfiles="${PYPI_SITE}/p/parse/parse-${version}.tar.gz"
-checksum=b41d604d16503c79d81af5165155c0b20f6c8d6c559efa66b4b695c3e5a0a0ce
+checksum=937725d51330ffec9c7a26fdb5623baa135d8ba8ed78817ea9523538844e3ce4
 
 post_install() {
 	sed -n '/Copyright/,/SOFTWARE\./p' parse.py >LICENSE


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures:
  - [x] i686-glibc
  - [x] x86_64-musl
  - [x] aarch64-glibc (x86_64-glibc)
  - [x] aarch64-musl (x86_64-musl)
  - [x] armv7l-glibc (x86_64-glibc)
  - [x] armv6l-musl (x86_64-musl)
