### PR TITLE
python3-zope.interface: update to 8.2.

### DIFF
--- a/srcpkgs/python3-zope.interface/template
+++ b/srcpkgs/python3-zope.interface/template
@@ -1,22 +1,20 @@
 # Template file for 'python3-zope.interface'
 pkgname=python3-zope.interface
-version=7.2
-revision=2
+version=8.2
+revision=1
 build_style=python3-module
 hostmakedepends="python3-setuptools"
 makedepends="python3-devel"
-depends="python3-setuptools"
-short_desc="Zope interfaces for Python3"
+depends="python3"
+checkdepends="python3-pytest python3-zope.testing"
+short_desc="Zope interfaces for Python"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="ZPL-2.1"
 homepage="https://github.com/zopefoundation/zope.interface"
 changelog="https://raw.githubusercontent.com/zopefoundation/zope.interface/master/CHANGES.rst"
-distfiles="${PYPI_SITE}/z/zope.interface/zope.interface-${version}.tar.gz"
-checksum=8b49f1a3d1ee4cdaf5b32d2e738362c7f5e40ac8b46dd7d1a65e82a4872728fe
-# Tests can't find the package they test
-make_check=no
+distfiles="${PYPI_SITE}/z/zope_interface/zope_interface-${version}.tar.gz"
+checksum=afb20c371a601d261b4f6edb53c3c418c249db1a9717b0baafc9a9bb39ba1224
 
 post_install() {
-	vinstall src/zope/__init__.py 644 ${py3_sitelib}/zope
 	vlicense LICENSE.txt LICENSE
 }


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

Needs testing:
- [x] certbot-5.1.0_2
- [x] certbot-apache-5.1.0_2
- [x] certbot-nginx-5.1.0_2
- [x] deluge-2.2.0_2
- [x] python3-Twisted-24.11.0_3
- [x] python3-gevent-24.11.1_2
- [x] python3-repoze.sphinx.autointerface-0.8_9
- [x] python3-txtorcon-23.11.0_3
- [x] python3-zope.component-5.0.0_6
- [x] python3-zope.configuration-4.4.0_7
- [x] python3-zope.exceptions-4.4_7
- [x] python3-zope.proxy-4.4.0_6
- [x] python3-zope.schema-6.0.0_7
- [ ] python3-zope.testrunner-5.2_6 - seems to be broken due to expecting import from `unittests` that no longer exists
- [x] synapse-1.146.0_1

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
