### PR TITLE
gparted: update to 1.8.0.

### DIFF
--- a/srcpkgs/gparted/template
+++ b/srcpkgs/gparted/template
@@ -1,6 +1,6 @@
 # Template file for 'gparted'
 pkgname=gparted
-version=1.7.0
+version=1.8.0
 revision=1
 build_style=gnu-configure
 configure_args="--enable-libparted-dmraid"
@@ -13,7 +13,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="https://gparted.sourceforge.io"
 distfiles="${SOURCEFORGE_SITE}/gparted/gparted/gparted-${version}/gparted-${version}.tar.gz"
-checksum=84ae3b9973e443a2175f07aa0dc2aceeadb1501e0f8953cec83b0ec3347b7d52
+checksum=f584ed4be7fd09c2cf6a784778a8540970d985f0ac8e5a7bd0628528a3ab5609
 disable_parallel_check=true
 
 # Some tests are known to fail in CI since 1.1.0


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures:
  - [x] i686-glibc
  - [x] x86_64-musl
  - [x] aarch64-glibc (x86_64-glibc)
  - [x] aarch64-musl (x86_64-musl)
  - [x] armv7l-glibc (x86_64-glibc)
  - [x] armv6l-musl (x86_64-musl)