### PR TITLE
New package: git-credential-oauth

### DIFF
--- a/srcpkgs/git-credential-oauth/template
+++ b/srcpkgs/git-credential-oauth/template
@@ -1,0 +1,12 @@
+# Template file for 'git-credential-oauth'
+pkgname=git-credential-oauth
+version=0.17.2
+revision=1
+build_style=go
+go_import_path=github.com/hickford/git-credential-oauth
+short_desc="Git credential helper that authenticate using OAuth"
+maintainer="SkinChangerDev <cjt07sfmj@mozmail.com>"
+license="Apache-2.0"
+homepage="https://github.com/hickford/git-credential-oauth"
+distfiles="https://github.com/hickford/git-credential-oauth/archive/refs/tags/v${version}.tar.gz"
+checksum=23769afc87f82fe21b5519d059bb5ce56b2fad2c4abc7ecde9bff49a4e065ab6


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**
- `git-credential-oauth` was picked up by git, and successfully authenticated to both Github and Gitlab
- I have not tested other supported platforms such as BitBucket, but I except them to work as well.

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

A PR for this package (#44237) was originally opened in 2023, but it was later closed automatically due to inactivity. This was in part because the PR author was not a Void Linux user, but the upstream developer. I've opened this PR as:
- I am a user of `git-credential-oauth` since before I switched to Void
- I am willing to maintain this package