### PR TITLE
moon-buggy: update to 1.1.0

### DIFF
--- a/srcpkgs/moon-buggy/template
+++ b/srcpkgs/moon-buggy/template
@@ -1,18 +1,19 @@
 # Template file for 'moon-buggy'
 pkgname=moon-buggy
-version=1.0.51
-revision=5
+version=1.1.0
+revision=1
 build_style=gnu-configure
 configure_args="--sharedstatedir=/var/db"
 make_dirs="/var/db/moon-buggy 777 root root"
 makedepends="ncurses-devel"
-short_desc="A simple character graphics game"
+short_desc="Simple character graphics game"
 maintainer="Enno Boland <gottox@voidlinux.org>"
-license="GPL-2.0-only"
-homepage="http://www.seehuhn.de/pages/moon-buggy"
-distfiles="http://m.seehuhn.de/programs/$pkgname-$version.tar.gz"
-checksum=352dc16ccae4c66f1e87ab071e6a4ebeb94ff4e4f744ce1b12a769d02fe5d23f
+license="GPL-3.0-only"
+homepage="https://www.seehuhn.de/programs/moon-buggy/"
+distfiles="https://www.seehuhn.de/programs/moon-buggy/moon-buggy-${version}.tar.gz"
+checksum=259ae6e7b1838c40532af5c0f20cd7c6173cd5c552ede408114064475bcfc5b6
 
 post_extract() {
-	sed -i 's/key_name/Key_Name/g' keyboard.c
+	# don't clash with ncursesw exported symbol
+	vsed -e 's/key_name/Key_Name/g' -i keyboard.c
 }


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, **x86_64-glibc**
- I built this PR locally for these architectures:
  - x86_64-musl
  - armv6l (cross)
 
Fun fact: first stable release in ~<strike>19</strike>21 years

cc @Gottox 

