### PR TITLE
xorg-server-xwayland: update to 24.1.9.

### DIFF
--- a/srcpkgs/xorg-server-xwayland/template
+++ b/srcpkgs/xorg-server-xwayland/template
@@ -1,6 +1,6 @@
 # Template file for 'xorg-server-xwayland'
 pkgname=xorg-server-xwayland
-version=24.1.8
+version=24.1.9
 revision=1
 build_style=meson
 configure_args="-Dipv6=true -Dxvfb=false -Dxdmcp=false -Dxcsecurity=true
@@ -16,7 +16,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
 homepage="https://xorg.freedesktop.org"
 distfiles="https://gitlab.freedesktop.org/xorg/xserver/-/archive/xwayland-${version}/xserver-xwayland-${version}.tar.gz"
-checksum=74cabefc337e2e4a50f3bea88d35867b089fa21ecb176f0e11022556e176a85c
+checksum=27b2c92659eaf3fc3705998bcdc6a8a3953c990f83023069425343ac9a85ebe2
 make_check=no # needs xtest repository
 
 post_install() {


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures:
  - [x] i686-glibc
  - [x] x86_64-musl
  - [x] aarch64-glibc (x86_64-glibc)
  - [x] aarch64-musl (x86_64-musl)
  - [x] armv7l-glibc (x86_64-glibc)
  - [x] armv6l-musl (x86_64-musl)