### PR TITLE
libpcap: update to 1.10.6.

### DIFF
--- a/srcpkgs/libpcap/template
+++ b/srcpkgs/libpcap/template
@@ -1,6 +1,6 @@
 # Template file for 'libpcap'
 pkgname=libpcap
-version=1.10.5
+version=1.10.6
 revision=1
 build_style=gnu-configure
 configure_args="--enable-ipv6 --with-libnl --with-pcap=linux
@@ -12,9 +12,9 @@ short_desc="System-independent interface for user-level packet capture"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="BSD-3-Clause"
 homepage="https://www.tcpdump.org/"
-changelog="https://www.tcpdump.org/libpcap-changes.txt"
+changelog="https://raw.githubusercontent.com/the-tcpdump-group/libpcap/refs/heads/master/CHANGES"
 distfiles="https://www.tcpdump.org/release/libpcap-${version}.tar.gz"
-checksum=37ced90a19a302a7f32e458224a00c365c117905c2cd35ac544b6880a81488f0
+checksum=872dd11337fe1ab02ad9d4fee047c9da244d695c6ddf34e2ebb733efd4ed8aa9
 
 build_options="bluetooth dbus usb"
 build_options_default="usb"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures:
  - [x] i686-glibc
  - [x] x86_64-musl
  - [x] aarch64-glibc (x86_64-glibc)
  - [x] aarch64-musl (x86_64-musl)
  - [x] armv7l-glibc (x86_64-glibc)
  - [x] armv6l-musl (x86_64-musl)