### PR TITLE
swayimg: remove redundant config file

### DIFF
--- a/srcpkgs/swayimg/template
+++ b/srcpkgs/swayimg/template
@@ -1,7 +1,7 @@
 # Template file for 'swayimg'
 pkgname=swayimg
 version=4.7
-revision=1
+revision=2
 build_style=meson
 configure_args="-D version=${version}"
 hostmakedepends="pkg-config wayland-devel"
@@ -19,6 +19,10 @@ checksum=342952aa30f62f163dfcb36448d7f2a860abf972bb24690d2e49b28b6f2ba7cc
 post_install() {
 	vcompletion extra/bash.completion bash
 	vcompletion extra/zsh.completion zsh
+
+	# upstream installs the config file into 'datadir'
+	rm ${DESTDIR}/usr/share/swayimg/swayimgrc
 	vsconf extra/swayimgrc
+
 	vlicense LICENSE
 }


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, **x86_64-glibc**

Right now we install the config file twice:

```
/usr/share/examples/swayimg/swayimgrc
/usr/share/swayimg/swayimgrc
```
The latter is being parsed regardless, which is bad (see e.g.: https://github.com/artemsen/swayimg/issues/375)

cc @voidbert 

