### PR TITLE
New packages: sstp-client-1.0.20 and network-manager-sstp-1.3.2

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -4602,3 +4602,4 @@ libfyaml.so.0 libfyaml-0.9.6_1
 libcpptrace.so.1 cpptrace-1.0.4_1
 libcgif.so.0 cgif-0.5.3_1
 libdsk.so.5 libdsk-1.5.22_1
+libsstp_api-0.so sstp-client-1.0.20_1

--- a/srcpkgs/network-manager-sstp-gnome
+++ b/srcpkgs/network-manager-sstp-gnome
@@ -1,0 +1,1 @@
+network-manager-sstp

--- a/srcpkgs/network-manager-sstp/patches/0001-remove-obsolete-spacing-in-gtk4-ui-generation.patch
+++ b/srcpkgs/network-manager-sstp/patches/0001-remove-obsolete-spacing-in-gtk4-ui-generation.patch
@@ -1,0 +1,13 @@
+diff --git a/Makefile.am b/Makefile.am
+index 770fc59..134c125 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -145,7 +145,7 @@ gtk4/resources.c: properties/gresource.xml $(shell $(GLIB_COMPILE_RESOURCES) --g
+ 
+ gtk4/%.ui: properties/%.ui
+ 	@mkdir -p $(builddir)/gtk4
+-	gtk4-builder-tool simplify --3to4 $< |grep -v can-default >$@
++	gtk4-builder-tool simplify --3to4 $< | grep -v can-default | grep -v 'name="spacing"' >$@
+ 
+ # Include a prebuilt file in tarball, to avoid hitting
+ # https://gitlab.gnome.org/GNOME/gtk/-/merge_requests/4415

--- a/srcpkgs/network-manager-sstp/template
+++ b/srcpkgs/network-manager-sstp/template
@@ -1,0 +1,37 @@
+# Template file for 'network-manager-sstp'
+pkgname=network-manager-sstp
+version=1.3.2pl1
+revision=1
+build_style=gnu-configure
+configure_args="--with-pppd-plugin-dir=/usr/lib/pppd/2.5.0
+ --with-gnome
+ --with-gtk4
+ --disable-gtk-doc
+ --disable-static"
+hostmakedepends="pkg-config intltool autoconf automake libtool gettext-devel-tools glib-devel gtk4-devel"
+makedepends="NetworkManager-devel glib-devel gnutls-devel gtk+3-devel gtk4-devel libnma-devel libsecret-devel ppp-devel sstp-client-devel"
+depends="NetworkManager"
+short_desc="NetworkManager VPN plugin for SSTP"
+maintainer="kalelidev <gxiime@gmail.com>"
+license="GPL-2.0-or-later"
+homepage="https://gitlab.gnome.org/GNOME/network-manager-sstp"
+distfiles="${homepage}/-/archive/release-${version/pl/-}/network-manager-sstp-release-${version/pl/-}.tar.bz2"
+checksum="2c7b7914224b827add0312551c575540497920f2ca3ea01c11787d38f0ae4c62"
+
+pre_configure() {
+	NOCONFIGURE=1 ./autogen.sh
+}
+
+do_install() {
+	make DESTDIR="${DESTDIR}" install
+	find "${DESTDIR}" \( -name '*.la' -o -name '*.a' \) -delete
+}
+
+network-manager-sstp-gnome_package() {
+	short_desc+=" - GNOME/GTK3/GTK4"
+	depends="network-manager-sstp>=${version}_${revision} network-manager-applet>=1.26"
+	pkg_install() {
+		vmove "usr/lib/NetworkManager/*-editor.*"
+		vmove usr/libexec/nm-sstp-auth-dialog
+	}
+}

--- a/srcpkgs/network-manager-sstp/update
+++ b/srcpkgs/network-manager-sstp/update
@@ -1,0 +1,2 @@
+site="https://gitlab.gnome.org/GNOME/network-manager-sstp/-/tags"
+pattern="release-\K[\d.]+(-\d+)?"

--- a/srcpkgs/sstp-client-devel
+++ b/srcpkgs/sstp-client-devel
@@ -1,0 +1,1 @@
+sstp-client

--- a/srcpkgs/sstp-client/template
+++ b/srcpkgs/sstp-client/template
@@ -4,9 +4,9 @@ version=1.0.20
 revision=1
 build_style=gnu-configure
 _pppver=2.5.0
-configure_args="--prefix=/usr
-	--with-runtime-dir=/var/run/sstpc
-	--with-pppd-plugin-dir=/usr/lib/pppd/${_pppver}"
+configure_args="
+ --with-runtime-dir=/var/run/sstpc
+ --with-pppd-plugin-dir=/usr/lib/pppd/${_pppver}"
 hostmakedepends="pkg-config libtool"
 makedepends="ppp-devel libevent-devel openssl-devel"
 depends="ppp ca-certificates"
@@ -17,7 +17,6 @@ homepage="https://gitlab.com/sstp-project/sstp-client"
 distfiles="https://gitlab.com/sstp-project/sstp-client/-/releases/${version}/downloads/dist-gzip/sstp-client-${version}.tar.gz"
 checksum="6c84b6cdcc21ebea6daeb8c5356dcdfd8681f4981a734f8485ed0b31fc30aadd"
 
-make_dirs="/var/run/sstpc 0755 root root"
 # No useful testsuite upstream
 make_check="no"
 

--- a/srcpkgs/sstp-client/template
+++ b/srcpkgs/sstp-client/template
@@ -1,0 +1,34 @@
+# Template file for 'sstp-client'
+pkgname=sstp-client
+version=1.0.20
+revision=1
+build_style=gnu-configure
+_pppver=2.5.0
+configure_args="--prefix=/usr
+	--with-runtime-dir=/var/run/sstpc
+	--with-pppd-plugin-dir=/usr/lib/pppd/${_pppver}"
+hostmakedepends="pkg-config libtool"
+makedepends="ppp-devel libevent-devel openssl-devel"
+depends="ppp ca-certificates"
+short_desc="Secure Socket Tunneling Protocol (SSTP) client"
+maintainer="Orphaned <orphan@voidlinux.org>"
+license="GPL-2.0-or-later"
+homepage="https://gitlab.com/sstp-project/sstp-client"
+distfiles="https://gitlab.com/sstp-project/sstp-client/-/releases/${version}/downloads/dist-gzip/sstp-client-${version}.tar.gz"
+checksum="6c84b6cdcc21ebea6daeb8c5356dcdfd8681f4981a734f8485ed0b31fc30aadd"
+
+make_dirs="/var/run/sstpc 0755 root root"
+# No useful testsuite upstream
+make_check="no"
+
+sstp-client-devel_package() {
+	depends="${sourcepkg}>=${version}_${revision}"
+	short_desc+=" - development files"
+	pkg_install() {
+		vmove usr/include
+		vmove usr/lib/pkgconfig
+		vmove usr/lib/libsstp_api.so
+		vmove "usr/lib/*.a" 2>/dev/null || :
+		vmove "usr/lib/pppd/${_pppver}/*.a"
+	}
+}


### PR DESCRIPTION
This adds the SSTP client from https://gitlab.com/sstp-project/sstp-client.

This adds support for the SSTP VPN plugin in NetworkManager from https://gitlab.gnome.org/GNOME/network-manager-sstp.

- sstp-client-1.0.20: Base SSTP VPN client.
- network-manager-sstp-1.3.2: NetworkManager plugin for SSTP, depends on sstp-client.
  Includes patch to fix obsolete GTK4 spacing in UI generation.

Combined into one PR to resolve dependency for CI/build.

**Shared library registration**  
Added to `common/shlibs`:

Testing the changes
I tested the changes in this PR: YES
New package
This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): YES
Local build testing
I built this PR locally for my native architecture, x86_64-glibc
I built this PR locally for these architectures:
aarch64 (cross)