### PR TITLE
remmina: update to 1.4.42

### DIFF
--- a/srcpkgs/remmina/template
+++ b/srcpkgs/remmina/template
@@ -1,12 +1,12 @@
 # Template file for 'remmina'
 pkgname=remmina
-version=1.4.39
-revision=4
+version=1.4.42
+revision=1
 build_style=cmake
-configure_args="-DCMAKE_USE_PTHREADS_INIT=ON -DWITH_KF6WALLET=on"
-hostmakedepends="glib-devel intltool pkg-config shared-mime-info freerdp
- qt6-base"
-makedepends="avahi-glib-libs-devel avahi-ui-libs-devel freerdp-devel
+configure_args="-DCMAKE_USE_PTHREADS_INIT=ON -DWITH_KF6WALLET=ON -DWITH_FREERDP3=ON"
+hostmakedepends="glib-devel intltool pkg-config shared-mime-info freerdp3
+ qt6-base xdg-utils"
+makedepends="avahi-glib-libs-devel avahi-ui-libs-devel freerdp3-devel fuse3-devel
  gobject-introspection gstreamermm-devel json-glib-devel kf6-kwallet-devel
  libgcrypt-devel liblz4-devel libsasl-devel
  libsecret-devel libsodium-devel libsoup3-devel libssh-devel libva-devel
@@ -20,7 +20,7 @@ license="GPL-2.0-or-later"
 homepage="https://remmina.org"
 changelog="https://gitlab.com/Remmina/Remmina/-/raw/master/CHANGELOG.md"
 distfiles="https://gitlab.com/Remmina/Remmina/-/archive/v${version}/Remmina-v${version}.tar.bz2"
-checksum=2c26b24a52ff3a6f895041d2ded5d8154cad631874e31e0a4bffe5697c815c77
+checksum=9467e696534d388797026845b3a10b6206b88542769249d9cd7299a5dfaac746
 
 if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
 	makedepends+=" libexecinfo-devel"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)
 

Note:

The freerdp dependency has been switched to freerdp3 because with freerdp (2) there's a build error I don't know how to fix.
If there is a reason to stay on freerdp (2) as a dependency, please let me know - and maybe help me to fix the build issue.