### PR TITLE
gopass: update to 1.16.1

### DIFF
--- a/srcpkgs/gopass/template
+++ b/srcpkgs/gopass/template
@@ -1,6 +1,6 @@
 # Template file for 'gopass'
 pkgname=gopass
-version=1.15.15
+version=1.16.1
 revision=1
 build_style=go
 go_import_path=github.com/gopasspw/gopass
@@ -14,7 +14,7 @@ license="MIT"
 homepage="https://www.gopass.pw/"
 changelog="https://raw.githubusercontent.com/gopasspw/gopass/master/CHANGELOG.md"
 distfiles="https://github.com/gopasspw/gopass/archive/refs/tags/v${version}.tar.gz"
-checksum=00ad6a32f89fe64760b70b9424af19b88d671673a66424d59d80cfa97deb75d3
+checksum=33451a782b66266c59560a5ec7f4e34c104c501a36b445fc574fad71e3b3d884
 make_check_pre="env GOPASS_BINARY=${GOPATH}/bin/gopass"
 
 export GOFLAGS="-buildmode=pie"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
