### PR TITLE
fooyin: fix missing dependency

### DIFF
--- a/srcpkgs/fooyin/template
+++ b/srcpkgs/fooyin/template
@@ -1,7 +1,7 @@
 # Template file for 'fooyin'
 pkgname=fooyin
 version=0.9.1
-revision=2
+revision=3
 _libvgm_rev="305b1bad78f7486c9e4058191abdd9195775efa0"
 build_style=cmake
 configure_args="
@@ -12,7 +12,7 @@ makedepends="qt6-base-devel qt6-svg-devel alsa-lib-devel
  ffmpeg6-devel icu-devel libarchive-devel libebur128-devel
  libgme-devel libopenmpt-devel libsndfile-devel pipewire-devel SDL2-devel
  taglib-devel KDSingleApplication"
-depends="qt6-svg"
+depends="qt6-svg qt6-plugin-sqlite"
 checkdepends="gtest-devel"
 short_desc="Customisable music player"
 maintainer="Ivan Mirić <imiric-gh@proton.me>"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)

@imiric 

I just installed the package recently and noticed it doesn't work properly without qt6-plugin-sqlite installed
