### PR TITLE
common/shlibs: add libgpiod sonames

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -4570,3 +4570,5 @@ libtomlplusplus.so.3 tomlplusplus-3.4.0_1
 libglycin-2.so.0 glycin-2.0.7_1
 libglycin-gtk4-2.so.0 glycin-gtk4-2.0.7_1
 libresvg.so.0.46 libresvg0-0.46.0_1
+libgpiod.so.3 libgpiod-2.2_4
+libgpiodcxx.so.2 libgpiod-2.2_4


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **partially** (I only have something which depends on libgpiod.so.3, not something that uses the cxx version)

#### Local build testing
- I built _with_ this PR applied locally for these architectures (if supported. mark crossbuilds):
  - aarch64 (cross from amd64)