### PR TITLE
wiremix: update to 0.9.0.

### DIFF
--- a/srcpkgs/wiremix/template
+++ b/srcpkgs/wiremix/template
@@ -1,6 +1,6 @@
 # Template file for 'wiremix'
 pkgname=wiremix
-version=0.8.0
+version=0.9.0
 revision=1
 build_style=cargo
 hostmakedepends="pkg-config clang"
@@ -11,7 +11,7 @@ license="MIT OR Apache-2.0"
 homepage="https://github.com/tsowell/wiremix/"
 changelog="https://github.com/tsowell/wiremix/raw/main/CHANGELOG.md"
 distfiles="https://github.com/tsowell/wiremix/archive/refs/tags/v${version}.tar.gz"
-checksum=db357d21c76809d674024f1094c2ac6ddd2d6866d4b8ae53cbb0620599006e31
+checksum=9fd8979fa3bc260a80d170c30041ab2aeea26273439bac8ce928a9405ce1d0f5
 export VERGEN_GIT_DESCRIBE="v${version}"
 
 post_patch() {


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
