### PR TITLE
[WiP] libdisplay-info: update to 0.3.0

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -4492,7 +4492,7 @@ libdatachannel.so.0.23 libdatachannel-0.23.1_1
 libgeotiff.so.5 libgeotiff-1.7.1_1
 libdraco.so.8 draco-1.5.6_1
 libpdalcpp.so.17 libpdal-2.7.0_1
-libdisplay-info.so.2 libdisplay-info-0.2.0_1
+libdisplay-info.so.3 libdisplay-info-0.3.0_1
 libsqsh.so.1 libsqsh-1.3.0_1
 libunicode.so.0.4 libunicode-0.4.0_1
 libunicode_ucd.so.0.4 libunicode-0.4.0_1

--- a/srcpkgs/kodi/template
+++ b/srcpkgs/kodi/template
@@ -1,7 +1,7 @@
 # Template file for 'kodi'
 pkgname=kodi
 version=21.2
-revision=4
+revision=5
 _codename="Omega"
 _crossguid_ver="ca1bf4b810e2d188d04cb6286f957008ee1b7681"
 _dvdcss_ver="1.4.3-Next-Nexus-Alpha2-2"

--- a/srcpkgs/kwin-x11/template
+++ b/srcpkgs/kwin-x11/template
@@ -1,7 +1,7 @@
 # Template file for 'kwin-x11'
 pkgname=kwin-x11
 version=6.5.5
-revision=2
+revision=3
 build_style=cmake
 build_helper=qemu
 configure_args="-DBUILD_TESTING=OFF -DFORCE_CROSSCOMPILED_TOOLS=ON

--- a/srcpkgs/kwin/template
+++ b/srcpkgs/kwin/template
@@ -1,7 +1,7 @@
 # Template file for 'kwin'
 pkgname=kwin
 version=6.5.5
-revision=2
+revision=3
 build_style=cmake
 build_helper=qemu
 configure_args="-DBUILD_TESTING=OFF -DFORCE_CROSSCOMPILED_TOOLS=ON

--- a/srcpkgs/libdisplay-info/template
+++ b/srcpkgs/libdisplay-info/template
@@ -1,6 +1,6 @@
 # Template file for 'libdisplay-info'
 pkgname=libdisplay-info
-version=0.2.0
+version=0.3.0
 revision=1
 build_style=meson
 hostmakedepends="hwids"
@@ -9,7 +9,7 @@ maintainer="John <me@johnnynator.dev>"
 license="MIT"
 homepage="https://gitlab.freedesktop.org/emersion/libdisplay-info/"
 distfiles="https://gitlab.freedesktop.org/emersion/libdisplay-info/-/archive/${version}/libdisplay-info-${version}.tar.gz"
-checksum=f7331fcaf5527251b84c8fb84238d06cd2f458422ce950c80e86c72927aa8c2b
+checksum=2b467e3336aec63819d6aca28d7310d3dc7415b2b3a3c3a5aec9d3727053c078
 # tests require currently unpacakged edid-decode
 make_check=no
 

--- a/srcpkgs/mpv/template
+++ b/srcpkgs/mpv/template
@@ -1,7 +1,7 @@
 # Template file for 'mpv'
 pkgname=mpv
 version=0.41.0
-revision=1
+revision=2
 build_style=meson
 configure_args="-Dcdda=enabled -Ddvbin=enabled -Ddvdnav=enabled
  -Dlibmpv=true -Dcplugins=enabled

--- a/srcpkgs/mutter/template
+++ b/srcpkgs/mutter/template
@@ -1,7 +1,7 @@
 # Template file for 'mutter'
 pkgname=mutter
 version=48.5
-revision=1
+revision=2
 build_helper="gir"
 build_style=meson
 configure_args="-Degl_device=true -Dudev=true -Dnative_backend=true

--- a/srcpkgs/niri/template
+++ b/srcpkgs/niri/template
@@ -1,7 +1,7 @@
 # Template file for 'niri'
 pkgname=niri
 version=25.11
-revision=1
+revision=2
 build_style=cargo
 build_helper="qemu"
 configure_args="--no-default-features --features dbus,xdp-gnome-screencast"

--- a/srcpkgs/weston/template
+++ b/srcpkgs/weston/template
@@ -1,7 +1,7 @@
 # Template file for 'weston'
 pkgname=weston
 version=14.0.1
-revision=4
+revision=5
 build_style=meson
 # requires XDG_RUNTIME_DIR for most tests
 configure_args="-Dtests=false $(vopt_bool vaapi backend-drm-screencast-vaapi) "

--- a/srcpkgs/wlroots0.17/template
+++ b/srcpkgs/wlroots0.17/template
@@ -1,7 +1,7 @@
 # Template file for 'wlroots0.17'
 pkgname=wlroots0.17
 version=0.17.4
-revision=3
+revision=4
 build_style=meson
 # Follow upstream packaging recommendations:
 # https://gitlab.freedesktop.org/wlroots/wlroots/-/wikis/Packaging-recommendations

--- a/srcpkgs/wlroots0.18/template
+++ b/srcpkgs/wlroots0.18/template
@@ -1,7 +1,7 @@
 # Template file for 'wlroots0.18'
 pkgname=wlroots0.18
 version=0.18.3
-revision=1
+revision=2
 build_style=meson
 # Follow upstream packaging recommendations:
 # https://gitlab.freedesktop.org/wlroots/wlroots/-/wikis/Packaging-recommendations

--- a/srcpkgs/wlroots0.19/template
+++ b/srcpkgs/wlroots0.19/template
@@ -1,7 +1,7 @@
 # Template file for 'wlroots0.19'
 pkgname=wlroots0.19
 version=0.19.2
-revision=1
+revision=2
 build_style=meson
 # Follow upstream packaging recommendations:
 # https://gitlab.freedesktop.org/wlroots/wlroots/-/wikis/Packaging-recommendations


### PR DESCRIPTION
weston does not build with 0.3.0 yet (or does and just refuses)

- **libdisplay-info: update to 0.3.0.**
- **kwin: rebuild against libdisplay-info-0.3.0**
- **kwin-x11: rebuild against libdisplay-info-0.3.0**
- **kodi: rebuild against libdisplay-info-0.3.0**
- **mpv: rebuild against libdisplay-info-0.3.0**
- **mutter: rebuild against libdisplay-info-0.3.0**
- **niri: rebuild against libdisplay-info-0.3.0**
- **weston: rebuild against libdisplay-info-0.3.0**
- **wlroots0.17: rebuild against libdisplay-info-0.3.0**
- **wlroots0.18: rebuild against libdisplay-info-0.3.0**
- **wlroots0.19: rebuild against libdisplay-info-0.3.0**
