### PR TITLE
p11-kit: update to 0.26.2

### DIFF
--- a/srcpkgs/p11-kit/template
+++ b/srcpkgs/p11-kit/template
@@ -1,6 +1,6 @@
 # Template file for 'p11-kit'
 pkgname=p11-kit
-version=0.25.10
+version=0.26.2
 revision=1
 build_style=meson
 build_helper="qemu"
@@ -16,7 +16,7 @@ license="BSD-3-Clause"
 homepage="https://github.com/p11-glue/p11-kit"
 changelog="https://raw.githubusercontent.com/p11-glue/p11-kit/master/NEWS"
 distfiles="https://github.com/p11-glue/p11-kit/releases/download/${version}/p11-kit-${version}.tar.xz"
-checksum=a62a137a966fb3a9bbfa670b4422161e369ddea216be51425e3be0ab2096e408
+checksum=09fd9f44da4813a3141e73d5e7cf7008e5660d0405f13d56c15e1da9dcecf828
 conf_files="/etc/pkcs11/pkcs11.conf"
 
 if [ "$XBPS_CHECK_PKGS" ]; then


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, **x86_64-glibc**

Notes
- Contains a CVE fix: [Changelog](https://raw.githubusercontent.com/p11-glue/p11-kit/master/NEWS)
