### PR TITLE
libutf8proc: update to 2.11.3

### DIFF
--- a/srcpkgs/libutf8proc/template
+++ b/srcpkgs/libutf8proc/template
@@ -1,6 +1,6 @@
 # Template file for 'libutf8proc'
 pkgname=libutf8proc
-version=2.11.2
+version=2.11.3
 revision=1
 build_style=cmake
 configure_args="-DBUILD_SHARED_LIBS=ON"
@@ -10,7 +10,7 @@ license="MIT"
 homepage="http://juliastrings.github.io/utf8proc/"
 changelog="https://raw.githubusercontent.com/JuliaStrings/utf8proc/master/NEWS.md"
 distfiles="https://github.com/JuliaStrings/utf8proc/archive/refs/tags/v${version}.tar.gz"
-checksum=a9b8d8fd57fb3aeca2aede62fd58958036d3bd29871afc1b871e3916c48420a7
+checksum=abfed50b6d4da51345713661370290f4f4747263ee73dc90356299dfc7990c78
 
 if [ -n "$XBPS_CHECK_PKGS" ]; then
 	configure_args+=" -DUTF8PROC_ENABLE_TESTING=ON"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, **x86_64-glibc**

[Changelog](https://raw.githubusercontent.com/JuliaStrings/utf8proc/master/NEWS.md)
