### PR TITLE
lutris: update to 0.5.20.

### DIFF
--- a/srcpkgs/lutris/template
+++ b/srcpkgs/lutris/template
@@ -1,8 +1,7 @@
 # Template file for 'lutris'
 pkgname=lutris
-reverts="0.5.19_1"
-version=0.5.18
-revision=3
+version=0.5.20
+revision=1
 build_style=meson
 hostmakedepends="gettext python3-setuptools python3-gobject gtk+3-devel"
 depends="python3-dbus python3-gobject python3-yaml python3-evdev python3-Pillow
@@ -14,4 +13,4 @@ license="GPL-3.0-or-later"
 homepage="https://lutris.net"
 changelog="https://raw.githubusercontent.com/lutris/lutris/master/debian/changelog"
 distfiles="https://github.com/lutris/lutris/archive/v${version}.tar.gz"
-checksum=b9d4ad052d1c750910940d5cc7c583967c0c65c1584b7f4a1abaf46e40c3d8d1
+checksum=140165a1a05c6bed57094e75d3c4e810eed81a79e95539a767b96397ec9105cb


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture (x86_64)
- I built this PR locally for these architectures using specific masterdirs:
  - x86_64-musl
  - i686
- I built this PR locally for these architectures (crossbuilds):
  - aarch64
  - aarch64-musl
  - armv7l
  - armv7l-musl
  - armv6l
  - armv6l-musl
  
---
Unlike #58340, this tag is properly associated with a published release.

Tested locally, works as expected.