### PR TITLE
double-conversion: update to 3.4.0.

### DIFF
--- a/srcpkgs/double-conversion/template
+++ b/srcpkgs/double-conversion/template
@@ -1,6 +1,6 @@
 # Template file for 'double-conversion'
 pkgname=double-conversion
-version=3.3.1
+version=3.4.0
 revision=1
 build_style=cmake
 configure_args="-DBUILD_SHARED_LIBS=ON"
@@ -10,7 +10,7 @@ license="BSD-3-Clause"
 homepage="https://github.com/google/double-conversion"
 changelog="https://github.com/google/double-conversion/releases"
 distfiles="https://github.com/google/double-conversion/archive/v${version}.tar.gz"
-checksum=fe54901055c71302dcdc5c3ccbe265a6c191978f3761ce1414d0895d6b0ea90e
+checksum=42fd4d980ea86426e457b24bdfa835a6f5ad9517ddb01cdb42b99ab9c8dd5dc9
 
 if [ "$XBPS_CHECK_PKGS" ]; then
 	configure_args+=" -DBUILD_TESTING=ON"
@@ -26,6 +26,7 @@ double-conversion-devel_package() {
 	pkg_install() {
 		vmove usr/include
 		vmove usr/lib/cmake
+		vmove usr/lib/pkgconfig
 		vmove "usr/lib/*.so"
 	}
 }


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures:
  - [x] i686-glibc
  - [x] x86_64-musl
  - [x] aarch64-glibc (x86_64-glibc)
  - [x] aarch64-musl (x86_64-musl)
  - [x] armv7l-glibc (x86_64-glibc)
  - [x] armv6l-musl (x86_64-musl)