### PR TITLE
gnome-nibbles: update to 4.5.0

### DIFF
--- a/srcpkgs/gnome-nibbles/template
+++ b/srcpkgs/gnome-nibbles/template
@@ -1,6 +1,6 @@
 # Template file for 'gnome-nibbles'
 pkgname=gnome-nibbles
-version=4.4.2
+version=4.5.0
 revision=1
 build_style=meson
 build_helper=qemu
@@ -13,4 +13,4 @@ license="GPL-3.0-or-later"
 homepage="https://gitlab.gnome.org/GNOME/gnome-nibbles"
 changelog="https://gitlab.gnome.org/GNOME/gnome-nibbles/-/raw/master/NEWS"
 distfiles="${GNOME_SITE}/${pkgname}/${version%.*}/${pkgname}-${version}.tar.xz"
-checksum=16e0602870646a6653876cbc61ee23f76340c26b12c9e89c7c30120845044155
+checksum=92f2d2ec0a33b6814c462b468cd0e83085e063d85e311e6a0c9aa69b62ffe914


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **yes**

#### Local build testing
- I built this PR locally for my native architecture, x86_64
- I crossbuilded this PR locally for these architectures:
  - armv7l
  - armv6l-musl
  - aarch64-musl