### PR TITLE
gnome-mahjongg: update to 49.1.1

### DIFF
--- a/srcpkgs/gnome-mahjongg/template
+++ b/srcpkgs/gnome-mahjongg/template
@@ -1,6 +1,6 @@
 # Template file for 'gnome-mahjongg'
 pkgname=gnome-mahjongg
-version=49.0.1
+version=49.1.1
 revision=1
 build_style=meson
 hostmakedepends="gettext glib-devel itstool pkg-config vala
@@ -12,4 +12,4 @@ license="GPL-2.0-or-later"
 homepage="https://gitlab.gnome.org/GNOME/gnome-mahjongg"
 changelog="https://gitlab.gnome.org/GNOME/gnome-mahjongg/-/raw/master/NEWS"
 distfiles="${GNOME_SITE}/${pkgname}/${version%%.*}/${pkgname}-${version}.tar.xz"
-checksum=45b3a48dcb1ed6189a63b6bf55508e8b38eb5a956657a7fe2a5225cc2f8bc132
+checksum=e9edd31ac2698b8d9a5be1d11c60d43450a889f8769cca0bef3395a11a5d5fd1


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **yes**

#### Local build testing
- I built this PR locally for my native architecture, x86_64
- I crossbuilded this PR locally for these architectures:
  - armv7l
  - armv6l-musl
  - aarch64-musl