### PR TITLE
New package: peazip-10.9.0

### DIFF
--- a/srcpkgs/peazip/template
+++ b/srcpkgs/peazip/template
@@ -1,0 +1,61 @@
+# Template file for 'peazip'
+pkgname=peazip
+version=10.9.0
+revision=1
+archs="x86_64"
+build_style=gnu-makefile
+hostmakedepends="lazarus fpc git which"
+makedepends="gtk+-devel"
+depends="desktop-file-utils hicolor-icon-theme"
+short_desc="Free file archiver utility"
+maintainer="Orphaned <orphan@voidlinux.org>"
+license="LGPL-3.0-or-later"
+homepage="https://peazip.github.io"
+distfiles="https://github.com/peazip/PeaZip/releases/download/${version}/peazip-${version}.src.zip"
+checksum=dbe224ac916f9c9e5fc1afa176eb47ff3694ee7be83fc12e2337459141369906
+nostrip=yes
+nopie=yes
+
+post_extract() {
+	# Make the main and component build scripts executable
+	chmod +x build.sh components/build.sh 2>/dev/null || :
+}
+
+pre_configure() {
+	vsed -i Makefile -e 's|\(--pcp=$(tmpdir)/.lazarus\)|\1 --lazarusdir=/usr/lib/lazarus|g'
+}
+
+do_build() {
+	set -x
+	# Build components
+	lazbuild --add-package dev/metadarkstyle/metadarkstyle.lpk
+	lazbuild dev/project_peach.lpi
+	lazbuild dev/project_pea.lpi
+	lazbuild --lazarusdir=/usr/lib/lazarus --pcp=./.lazarus components/multithreadprocs/multithreadprocslaz.lpk
+	lazbuild --lazarusdir=/usr/lib/lazarus --pcp=./.lazarus components/kascrypt/kascrypt.lpk
+	lazbuild --lazarusdir=/usr/lib/lazarus --pcp=./.lazarus components/peazip/peazip_common.lpk
+	lazbuild --lazarusdir=/usr/lib/lazarus --pcp=./.lazarus components/Image32/Image32.lpk
+	lazbuild --lazarusdir=/usr/lib/lazarus --pcp=./.lazarus components/chsdet/chsdet.lpk
+	lazbuild --lazarusdir=/usr/lib/lazarus --pcp=./.lazarus components/synunihighlighter/synuni.lpk
+	lazbuild --lazarusdir=/usr/lib/lazarus --pcp=./.lazarus components/gifanim/pkg_gifanim.lpk
+	lazbuild --lazarusdir=/usr/lib/lazarus --pcp=./.lazarus components/viewer/viewerpackage.lpk
+	lazbuild --lazarusdir=/usr/lib/lazarus --pcp=./.lazarus components/virtualterminal/virtualterminal.lpk
+	lazbuild --lazarusdir=/usr/lib/lazarus --pcp=./.lazarus components/KASToolBar/kascomp.lpk
+
+	# Finally, build the main application with GTK2 widgetset in RELEASE mode
+	lazbuild --lazarusdir=/usr/lib/lazarus --pcp=./.lazarus --widgetset=gtk2 --build-mode=Release src/peazip.lpi
+	set +x
+}
+
+do_install() {
+	# Install the binary
+	vbin peazip
+
+	# Install desktop file and icons (paths from source tree)
+	vinstall install/linux/peazip.desktop 644 usr/share/applications
+	vinstall peazip.png 644 usr/share/pixmaps
+
+	# Install language files, plugins, etc.
+	vcopy language usr/share/peazip
+	vcopy plugins usr/lib/peazip
+}


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)
 

Notes:

I have been using peazip for years now, using the portable package, locally extracted. To have it integrated properly, I try & error-ed myself to this template.

As I couldn't get it to build from source as it uses lazarus and I couldn't find any other template that uses lazarus to check how to do it correctly, I opted for the approach of just repackaging a deb package that is used for vivaldi.
Also, there seem to be two outdated (?) libraries used, libgmp.so.3 and libncurses.si.5, so I added `allow_unknown_shlibs=yes` to get past the shlibs error message. Not sure if that makes problems or just makes the archivers that need those libraries not work.

It might be possible to "`if... then`" automatically integrate some of the scripts, like integrating peazip into thunar, but that's beyond my capabilities.