### PR TITLE
oxygen-icons5: update to 6.1.0.

### DIFF
--- a/srcpkgs/oxygen-icons5/template
+++ b/srcpkgs/oxygen-icons5/template
@@ -1,6 +1,6 @@
 # Template file for 'oxygen-icons5'
 pkgname=oxygen-icons5
-version=6.0.0
+version=6.1.0
 revision=1
 build_style=cmake
 hostmakedepends="extra-cmake-modules qt6-tools qt6-base"
@@ -11,7 +11,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later, LGPL-3.0-or-later"
 homepage="https://invent.kde.org/frameworks/oxygen-icons5"
 distfiles="${KDE_SITE}/oxygen-icons/oxygen-icons-${version}.tar.xz"
-checksum=28ec182875dcc15d9278f45ced11026aa392476f1f454871b9e2c837008e5774
+checksum=16ca971079c5067c4507cabf1b619dc87dd6b326fd5c2dd9f5d43810f2174d68
 conflicts="oxygen-icons<6.0.0"
 
 oxygen-icons_package() {


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc