### PR TITLE
swirc: update to 3.5.9.

### DIFF
--- a/srcpkgs/swirc/template
+++ b/srcpkgs/swirc/template
@@ -1,6 +1,6 @@
 # Template file for 'swirc'
 pkgname=swirc
-version=3.5.8
+version=3.5.9
 revision=1
 build_style=configure
 configure_args="$(vopt_with notify libnotify)"
@@ -17,7 +17,7 @@ license="BSD-3-Clause, ISC, MIT"
 homepage="https://www.nifty-networks.net/swirc"
 changelog="https://raw.githubusercontent.com/uhlin/swirc/master/CHANGELOG.md"
 distfiles="https://www.nifty-networks.net/swirc/releases/swirc-${version}.tgz"
-checksum=04278aa858da94d56d478404b61f670c51d8f474a210ab62a0d4090262e064c9
+checksum=3928385d20e5cc373fb1a2ed9f3fbc3bb7f41a9f9ac8eb185e5b0d7af5473382
 
 build_options="notify"
 build_options_default="notify"


### PR DESCRIPTION
Swirc 3.5.9 out!

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, **x86_64-musl**
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - armv6l-musl **cross**
