### PR TITLE
mise: update to 2026.3.2.

### DIFF
--- a/srcpkgs/mise/template
+++ b/srcpkgs/mise/template
@@ -1,6 +1,6 @@
 # Template file for 'mise'
 pkgname=mise
-version=2026.1.6
+version=2026.3.2
 revision=1
 build_style=cargo
 hostmakedepends="pkg-config"
@@ -11,7 +11,7 @@ license="MIT"
 homepage="https://github.com/jdx/mise"
 changelog="https://github.com/jdx/mise/releases"
 distfiles="https://github.com/jdx/mise/archive/v${version}.tar.gz>${pkgname}-${version}.tar.gz"
-checksum=e6f47591e3bf3d5b8763aeb47df52687cc3308fbfb0f32d25b691efc31b3249c
+checksum=e8ddea54c706eeae68f36f8d69b3bc6481d1368df30bee11f247d8427fb74d37
 
 case "$XBPS_TARGET_MACHINE" in
 	i686*) broken="runs out of memory" ;;


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - armv6l

