### PR TITLE
mutt: update to 2.3.0.

### DIFF
--- a/srcpkgs/mutt/template
+++ b/srcpkgs/mutt/template
@@ -1,6 +1,6 @@
 # Template file for 'mutt'
 pkgname=mutt
-version=2.2.16
+version=2.3.0
 revision=1
 build_style=gnu-configure
 configure_args="--enable-pop --enable-imap --enable-smtp --enable-hcache
@@ -19,7 +19,7 @@ license="GPL-2.0-or-later"
 homepage="http://www.mutt.org"
 changelog="http://mutt.org/relnotes/${version%.*}"
 distfiles="http://ftp.mutt.org/pub/mutt/${pkgname}-${version}.tar.gz"
-checksum=1d3109a743ad8b25eef97109b2bdb465db7837d0a8d211cd388be1b6faac3f32
+checksum=5d5ebc40843f7156d5ede30e50016798ac7336467f7ad347e716510516cc2130
 
 post_install() {
 	# provided by mime-types


### PR DESCRIPTION
- I tested the changes in this PR: been using this for a week, no issues.
- I built this PR locally for my native architecture, (aarch64-glibc)

cc @sgn