### PR TITLE
python3-Sphinx: fix license

### DIFF
--- a/srcpkgs/python3-Sphinx/template
+++ b/srcpkgs/python3-Sphinx/template
@@ -16,7 +16,7 @@ checkdepends="$depends python3-html5lib python3-mypy ImageMagick gettext
  graphviz"
 short_desc="Python 3 documentation generator"
 maintainer="Đoàn Trần Công Danh <congdanhqx@gmail.com>"
-license="BSD-3-Clause"
+license="BSD-2-Clause"
 homepage="http://sphinx-doc.org"
 changelog="https://github.com/sphinx-doc/sphinx/raw/master/CHANGES"
 distfiles="${PYPI_SITE}/s/sphinx/sphinx-${version}.tar.gz"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->
I don't really know where does the `BSD-3-Clause` come from. I traced the change to c05b7b81150ade126fe642dd09bba789a0315f72 (the creation of the `python3-` package).

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
