### PR TITLE
libgcrypt: update to 1.12.1.

### DIFF
--- a/srcpkgs/libgcrypt/template
+++ b/srcpkgs/libgcrypt/template
@@ -1,6 +1,6 @@
 # Template file for 'libgcrypt'
 pkgname=libgcrypt
-version=1.12.0
+version=1.12.1
 revision=1
 build_style=gnu-configure
 configure_args="--enable-static --without-capabilities"
@@ -10,7 +10,7 @@ maintainer="skmpz <dem.procopiou@gmail.com>"
 license="LGPL-2.1-or-later"
 homepage="https://www.gnupg.org"
 distfiles="https://gnupg.org/ftp/gcrypt/libgcrypt/libgcrypt-${version}.tar.bz2"
-checksum=0311454e678189bad62a7e9402a9dd793025efff6e7449898616e2fc75e0f4f5
+checksum=7df5c08d952ba33f9b6bdabdb06a61a78b2cf62d2122c2d1d03a91a79832aa3c
 
 if [ "$CROSS_BUILD" ]; then
 	configure_args+=" ac_cv_sys_symbol_underscore=no"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures:
  - [x] i686-glibc
  - [x] x86_64-musl
  - [x] aarch64-glibc (x86_64-glibc)
  - [x] aarch64-musl (x86_64-musl)
  - [x] armv7l-glibc (x86_64-glibc)
  - [x] armv6l-musl (x86_64-musl)