### PR TITLE
common/shlibs: add entry for libGLdispatch.so.0

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -159,6 +159,7 @@ libglapi.so.0 libglapi-7.11_1
 libgbm.so.1 libgbm-9.0_1
 libOpenGL.so.0 libglvnd-1.3.0_1
 libGLX.so.0 libglvnd-1.3.0_1
+libGLdispatch.so.0 libglvnd-1.3.0_1
 librsvg-2.so.2 librsvg-2.26.0_1
 librist.so.4 librist-0.2.7_1
 libdbus-1.so.3 dbus-libs-1.2.10_1


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **NO**

Found this missing during local builds of teamspeak3.
No reason for it to not be added, I believe, except for I have no way of testing it right now..
