### PR TITLE
python3-fastapi: update to 0.133.0.

### DIFF
--- a/srcpkgs/python3-fastapi/template
+++ b/srcpkgs/python3-fastapi/template
@@ -1,6 +1,6 @@
 # Template file for 'python3-fastapi'
 pkgname=python3-fastapi
-version=0.131.0
+version=0.133.0
 revision=1
 build_style=python3-pep517
 hostmakedepends="python3-pdm-backend"
@@ -10,7 +10,7 @@ maintainer="Jason Elswick <jason@jasondavid.us>"
 license="MIT"
 homepage="https://github.com/FastAPI/FastAPI"
 distfiles="https://github.com/fastapi/fastapi/archive/refs/tags/${version}.tar.gz"
-checksum=fb873e46216ea0476b4e8d6bacf6508821377d25c59cc9a5331bb1bbd6649e9b
+checksum=8a7d94bac10aaf994a49bc0a4ff15ab47b04510479446e629419a98376fcc8e4
 make_check=no # too many unpackaged dependencies
 
 post_install() {


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-libc
