### PR TITLE
common/hooks/pre-pkg/04-generate-runtime-deps.sh: handle skiprdeps correctly

### DIFF
--- a/common/hooks/pre-pkg/04-generate-runtime-deps.sh
+++ b/common/hooks/pre-pkg/04-generate-runtime-deps.sh
@@ -48,10 +48,17 @@ store_pkgdestdir_rundeps() {
 parse_shlib_needed() {
     while read -r f; do
         lf=${f#${PKGDESTDIR}}
-	    if [ "${skiprdeps/${lf}/}" != "${skiprdeps}" ]; then
-		    msg_normal "Skipping dependency scan for ${lf}\n" >&3
-		    continue
-	    fi
+        for x in ${skiprdeps}; do
+            if [ "$x" = "$lf" -o "$x" = "${lf#$PKGDESTDIR}" ]; then
+                found=1
+                break
+            fi
+        done
+        if [ -n "$found" ]; then
+            msg_normal "Skipping dependency scan for ${lf}\n" >&3
+            unset found
+            continue
+        fi
         read -n4 elfmagic < "$f"
         if [ "$elfmagic" = $'\177ELF' ]; then
             $OBJDUMP -p "$f" |


### PR DESCRIPTION
Previously it skipped files that were a prefix of any other file, the new behaviour is in line with e.g. nopie_files.

#### Testing the changes
- I tested the changes in this PR: **YES**

Relevant issue: #59128 