### PR TITLE
sv-netmount: not a metapackage, fix build

### DIFF
--- a/srcpkgs/sv-netmount/template
+++ b/srcpkgs/sv-netmount/template
@@ -2,7 +2,6 @@
 pkgname=sv-netmount
 version=0.1
 revision=3
-metapackage=yes
 short_desc="Service to mount/umount network filesystems from fstab"
 maintainer="Olivier Mauras <olivier@mauras.ch>"
 license="GPL-2.0-or-later"
@@ -10,7 +9,6 @@ homepage="http://www.voidlinux.org/"
 
 depends="runit"
 
-post_install() {
-	# runit services
+do_install() {
 	vsv netmount
 }


### PR DESCRIPTION
- I tested the changes in this PR: **YES**

<!-- Uncomment relevant sections and delete options which are not applicable -->
This package contains a service file, so by definition it is not a metapackage.
Leaving the template as is and trying to package it results in errors:
```
=> ERROR: sv-netmount-0.1_3: PKGDESTDIR of meta package is not empty
=> ERROR: sv-netmount-0.1_3: cannot continue with installation!
```

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->


#### Local build testing
- I built this PR locally for my native architecture: x86_64-glibc
