### PR TITLE
mangowc: update to 0.12.4

### DIFF
--- a/srcpkgs/mangowc/template
+++ b/srcpkgs/mangowc/template
@@ -1,6 +1,6 @@
 # Template file for 'mangowc'
 pkgname=mangowc
-version=0.12.3
+version=0.12.4
 revision=1
 conf_files="/etc/mango/config.conf"
 build_style=meson
@@ -13,7 +13,7 @@ license="GPL-3.0-or-later"
 homepage="https://github.com/DreamMaoMao/mangowc"
 changelog="https://github.com/DreamMaoMao/mangowc/releases"
 distfiles="https://github.com/DreamMaoMao/mangowc/archive/refs/tags/${version}.tar.gz"
-checksum=140b1b625e56034c1f042f850364bba7d0c630fea027459eb44fe46c37bcd0f6
+checksum=b866f3c68e998dcba2ebf78d5e9bbc897eccdf48128d5094a006bdc7592a2bdd
 
 build_options="xwayland"
 desc_option_xwayland="Enable Xwayland support"


### PR DESCRIPTION
- I tested the changes in this PR: **briefly**
- I built this PR locally for my native architecture, (x86_64-glibc)

I get the following error when executing mango, though things seem to be working fine.

```
00:00:00.074 [../src/dispatch/bind_define.h:892] mango: execvp 'systemctl' failed: No such file or directory
```