### PR TITLE
lutris: update to 0.5.22.

### DIFF
--- a/srcpkgs/lutris/template
+++ b/srcpkgs/lutris/template
@@ -1,6 +1,6 @@
 # Template file for 'lutris'
 pkgname=lutris
-version=0.5.20
+version=0.5.22
 revision=1
 build_style=meson
 hostmakedepends="gettext python3-setuptools python3-gobject gtk+3-devel"
@@ -13,4 +13,4 @@ license="GPL-3.0-or-later"
 homepage="https://lutris.net"
 changelog="https://raw.githubusercontent.com/lutris/lutris/master/debian/changelog"
 distfiles="https://github.com/lutris/lutris/archive/v${version}.tar.gz"
-checksum=140165a1a05c6bed57094e75d3c4e810eed81a79e95539a767b96397ec9105cb
+checksum=1001b215d68c7e450b74bcf11510adb3ac60074ed46d5a160eb851bafcc14c3c


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture (x86_64)
- I built this PR locally for these architectures using specific masterdirs:
  - x86_64-musl
  - i686
- I built this PR locally for these architectures (crossbuilds):
  - aarch64
  - aarch64-musl
  - armv7l
  - armv7l-musl
  - armv6l
  - armv6l-musl