### PR TITLE
bash-language-server: update to 5.6.0.

### DIFF
--- a/srcpkgs/bash-language-server/template
+++ b/srcpkgs/bash-language-server/template
@@ -1,6 +1,6 @@
 # Template file for 'bash-language-server'
 pkgname=bash-language-server
-version=5.0.0
+version=5.6.0
 revision=1
 hostmakedepends="pnpm"
 depends="nodejs"
@@ -9,7 +9,7 @@ maintainer="sirkhancision <jsantiago12tone@gmail.com>"
 license="MIT"
 homepage="https://github.com/bash-lsp/bash-language-server"
 distfiles="https://github.com/bash-lsp/bash-language-server/archive/refs/tags/server-${version}.tar.gz"
-checksum=ef8d104591cfcddf85da14af9585d8f0ab97f12e158df67ab50900f7342e353a
+checksum=54025af2243bcb7a08300662ad919847c084abfa1913dee2151b2ff7ca0cf8c9
 
 do_build() {
 	pnpm install --frozen-lockfile
@@ -21,10 +21,13 @@ do_install() {
 	cd server
 
 	rm -r node_modules
-	npm install --production
+	npm install --omit=dev
 
 	vmkdir ${TARGET_PATH}
-	vcopy * ${TARGET_PATH}
+	vcopy node_modules ${TARGET_PATH}
+	vcopy out ${TARGET_PATH}
+	vcopy package.json ${TARGET_PATH}
+	vcopy tree-sitter-bash.wasm ${TARGET_PATH}
 
 	vmkdir usr/bin
 	ln -sf /${TARGET_PATH}/out/cli.js ${DESTDIR}/usr/bin/${pkgname}


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl (cross)

#### Changes
- Fixed a warning about using `--production` instead of `--omit=dev` with npm install.
- Copy only what is necessary to run the LSP (previously included sources, tsconfig, CHANGELOG etc.)
