### PR TITLE
cloudflared: update to 2026.1.2.

### DIFF
--- a/srcpkgs/cloudflared/template
+++ b/srcpkgs/cloudflared/template
@@ -1,19 +1,20 @@
 # Template file for 'cloudflared'
 pkgname=cloudflared
-version=2024.9.1
+version=2026.1.2
 revision=1
 build_style=go
 go_import_path=github.com/cloudflare/cloudflared
 go_package="${go_import_path}/cmd/cloudflared"
 go_ldflags="-X \"main.Version=${version}\""
+make_check_args="-skip ^(TestFunnelIdleTimeout|TestReuseFunnel|TestICMPRouterEcho|TestTraceICMPRouterEcho|TestConcurrentRequestsToSameDst|TestICMPRouterRejectNotEcho|TestHTTP2ConfigurationSet|TestServeHTTP|TestServeWS|TestNoWriteAfterServeHTTPReturns|TestServeControlStream|TestFailRegistration|TestGracefulShutdownHTTP2|TestServeTCP_RateLimited)$"
 hostmakedepends="go"
 short_desc="Cloudflare Tunnel client"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="Apache-2.0"
 homepage="https://developers.cloudflare.com/argo-tunnel/"
-changelog="https://raw.githubusercontent.com/cloudflare/cloudflared/master/CHANGES.md"
+changelog="https://github.com/cloudflare/cloudflared/raw/refs/heads/master/RELEASE_NOTES"
 distfiles="https://github.com/cloudflare/cloudflared/archive/${version}.tar.gz"
-checksum=f96b703ea848bc538322eb957749b0b2395e0cf83213cf310cbde0a3f598eac4
+checksum=5e6a8e81de61f180ddee8cfb1b58e4978729bfacd774affa343867dca6fa244f
 
 pre_build() {
 	go_ldflags+=" -X \"main.BuildTime=$(date -u '+%Y-%m-%d-%H:%M UTC')\""


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl (cross)

#### Changes

This version is not the latest, latest 2026.2.0 introduced a [breaking change](https://github.com/cloudflare/cloudflared/blob/master/CHANGES.md#202620) and I'd need some advice on how this is handled. Perhaps it is better to have a separate PR that also adds INSTALL.msg if that is the best practice.

Skipping tests that attempt to create a local ICMP proxy and an HTTP server.
