### PR TITLE
libXpresent: update to 1.0.2.

### DIFF
--- a/srcpkgs/libXpresent/template
+++ b/srcpkgs/libXpresent/template
@@ -1,6 +1,6 @@
 # Template file for 'libXpresent'
 pkgname=libXpresent
-version=1.0.1
+version=1.0.2
 revision=1
 build_style=gnu-configure
 hostmakedepends="pkg-config xorg-util-macros"
@@ -10,7 +10,11 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="X11"
 homepage="https://cgit.freedesktop.org/xorg/lib/libXpresent/"
 distfiles="${XORG_SITE}/lib/libXpresent-${version}.tar.gz"
-checksum=8ebf8567a8f6afe5a64275a2ecfd4c84e957970c27299d964350f60be9f3541d
+checksum=e98a211e51d8b9381d16b24a57cecb926a23e743b9e0b1ffc3e870206b7dee1a
+
+post_install() {
+	vlicense COPYING
+}
 
 libXpresent-devel_package() {
 	depends="${sourcepkg}-${version}_${revision} libX11-devel libXext-devel


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures:
  - [x] i686-glibc
  - [x] x86_64-musl
  - [x] aarch64-glibc (x86_64-glibc)
  - [x] aarch64-musl (x86_64-musl)
  - [x] armv7l-glibc (x86_64-glibc)
  - [x] armv6l-musl (x86_64-musl)