### PR TITLE
netscanner: update to 0.6.41.

### DIFF
--- a/srcpkgs/netscanner/template
+++ b/srcpkgs/netscanner/template
@@ -1,6 +1,6 @@
 # Template file for 'netscanner'
 pkgname=netscanner
-version=0.6.3
+version=0.6.41
 revision=1
 build_style=cargo
 depends="iw"
@@ -10,12 +10,7 @@ license="MIT"
 homepage="https://github.com/Chleba/netscanner"
 changelog="https://raw.githubusercontent.com/Chleba/netscanner/main/debian/changelog"
 distfiles="https://github.com/Chleba/netscanner/archive/refs/tags/v${version}.tar.gz"
-checksum=ad2df332bb347eac96c0a5d22e9477f9a7fe4b05d565b90009cc1c3fb598b29f
-
-pre_build() {
-	# upstream forgot to update lockfile version before release
-	cargo update --package netscanner --precise ${version}
-}
+checksum=1e913b7d9cde8953d2ea77307d91c55240bc94308ac9e321a8a843f930350e04
 
 post_install() {
 	vman debian/netscanner.manpage netscanner.1


### PR DESCRIPTION

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
