### PR TITLE
New package: yaml-language-server-1.21.0.

### DIFF
--- a/srcpkgs/yaml-language-server/template
+++ b/srcpkgs/yaml-language-server/template
@@ -1,0 +1,46 @@
+# Template file for 'yaml-language-server'
+pkgname=yaml-language-server
+version=1.21.0
+revision=1
+hostmakedepends="nodejs"
+depends="nodejs"
+short_desc="Language server for YAML files"
+maintainer="Alex March <alex@hosaka.cc>"
+license="MIT"
+homepage="https://github.com/redhat-developer/yaml-language-server"
+changelog="https://raw.githubusercontent.com/redhat-developer/yaml-language-server/refs/heads/main/CHANGELOG.md"
+distfiles="https://github.com/redhat-developer/yaml-language-server/archive/refs/tags/${version}.tar.gz"
+checksum=9a1e16e508d29ab74113b34fa8957b61de81d79ec6c1b7be943c1749e1ac5038
+
+do_configure() {
+	npm ci
+}
+
+do_build() {
+	# UMD (Universal Module Definition) modules and ES Modules (ESM) are not
+	# necessary, compiling to CommonJS is enough to have a working server
+	npm run compile
+}
+
+do_check() {
+	npm test
+}
+
+do_install() {
+	TARGET_PATH="usr/lib/${pkgname}"
+
+	rm -r node_modules
+	npm install --omit=dev --ignore-scripts
+
+	vmkdir ${TARGET_PATH}
+	vcopy bin ${TARGET_PATH}
+	vcopy l10n ${TARGET_PATH}
+	vcopy node_modules ${TARGET_PATH}
+	vcopy out ${TARGET_PATH}
+	vcopy package.json ${TARGET_PATH}
+
+	vmkdir usr/bin
+	ln -sf /${TARGET_PATH}/bin/${pkgname} ${DESTDIR}/usr/bin/${pkgname}
+
+	vlicense LICENSE
+}


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**


#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**


<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl (cross)

Working with neovim/nvim-lspconifg. Compared to previously submitted #54224, this PR does not include the UMD/ESM libs on purpose as they are not required for running the LSP.