### PR TITLE
New package: noctalia-qs-0.0.4

### DIFF
--- a/srcpkgs/noctalia-qs/template
+++ b/srcpkgs/noctalia-qs/template
@@ -1,0 +1,16 @@
+# Template file for 'noctalia-qs'
+pkgname=noctalia-qs
+version=0.0.4
+revision=1
+build_style=cmake
+configure_args="-DDISTRIBUTOR=Void -DDISTRIBUTOR_DEBUGINFO_AVAILABLE=YES -DINSTALL_QML_PREFIX=lib/qt6/qml -DCRASH_REPORTER=OFF"
+hostmakedepends="pkg-config wayland-devel qt6-base qt6-declarative-devel qt6-shadertools"
+makedepends="cli11 qt6-base-private-devel qt6-declarative-private-devel qt6-shadertools-devel pipewire-devel jemalloc-devel pam-devel polkit-devel"
+depends="qt6-svg"
+short_desc="Noctalia quickshell fork - Flexible QtQuick-based desktop shell toolkit"
+maintainer="Soulful Sailer <soulful.sailer@entropic.pro>"
+license="LGPL-3.0-only"
+homepage="https://github.com/noctalia-dev/noctalia-qs"
+distfiles="https://github.com/noctalia-dev/noctalia-qs/archive/refs/tags/v${version}.tar.gz"
+checksum=4aee2264b4165dfd99278a545d51d4637da4aca6db3e57443d9320685cb0f749
+conflicts="quickshell"

--- a/srcpkgs/noctalia-qs/update
+++ b/srcpkgs/noctalia-qs/update
@@ -1,0 +1,2 @@
+site="https://github.com/noctalia-dev/noctalia-qs/archive/refs/tags/"
+pattern="(?<!archive/)v?\K[0-9.]+(?=\.tar\.gz)"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**


#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**
  - System
  - Compiled


<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl (crossbuild)

I'm not sure if this meets void's requirements for packaging a fork.
But Noctalia Shell have [moved to their fork of quickshell as a requirement](https://github.com/noctalia-dev/noctalia-shell/releases/tag/v4.6.0) in the latest version, and the effort to adapt the quickshell template was minimal.

So I figured I would submit this here to prompt the discussion.