### PR TITLE
freetype: update to 2.14.2

### DIFF
--- a/srcpkgs/freetype/template
+++ b/srcpkgs/freetype/template
@@ -1,6 +1,6 @@
 # Template file for 'freetype'
 pkgname=freetype
-version=2.14.1
+version=2.14.2
 revision=1
 build_style=gnu-configure
 configure_args="--enable-freetype-config"
@@ -8,12 +8,12 @@ hostmakedepends="pkg-config"
 makedepends="bzip2-devel libpng-devel brotli-devel"
 short_desc="Font rendering engine and library API"
 maintainer="Orphaned <orphan@voidlinux.org>"
-license="GPL-2.0-or-later, FTL"
+license="GPL-2.0-or-later OR FTL"
 homepage="https://www.freetype.org/"
 # Should be using NONGNU_SITE instead, but that often redirects to outdated
 # mirrors, causing fetching the distfile to fail.
 distfiles="https://download-mirror.savannah.gnu.org/releases/freetype/freetype-${version}.tar.xz"
-checksum=32427e8c471ac095853212a37aef816c60b42052d4d9e48230bab3bdf2936ccc
+checksum=4b62dcab4c920a1a860369933221814362e699e26f55792516d671e6ff55b5e1
 
 post_patch() {
 	vsed -i -e "s/%PKG_CONFIG%/pkg-config/" builds/unix/freetype-config.in


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**
- `firefox` `fnott` `foot` `swayimg` and `Waybar` are rendering fonts as expected after updating

#### Local build testing
- I built this PR locally for my native architecture, **x86_64-glibc**
- I built this PR locally for these architectures:
  - x86_64-musl

From [release notes](https://sourceforge.net/projects/freetype/files/freetype2/2.14.2/):

> A bunch of potential security problems have been found.  All users should update.