### PR TITLE
libXScrnSaver: update to 1.2.5.

### DIFF
--- a/srcpkgs/libXScrnSaver/template
+++ b/srcpkgs/libXScrnSaver/template
@@ -1,6 +1,6 @@
 # Template file for 'libXScrnSaver'
 pkgname=libXScrnSaver
-version=1.2.4
+version=1.2.5
 revision=1
 build_style=gnu-configure
 configure_args="--enable-malloc0returnsnull"
@@ -9,9 +9,9 @@ makedepends="xorgproto libX11-devel libXext-devel"
 short_desc="X11 Screen Saver Library"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
-homepage="$XORG_SITE"
-distfiles="${XORG_SITE}/lib/${pkgname}-${version}.tar.xz"
-checksum=75cd2859f38e207a090cac980d76bc71e9da99d48d09703584e00585abc920fe
+homepage="https://cgit.freedesktop.org/xorg/lib/libXScrnSaver/"
+distfiles="${XORG_SITE}/lib/libXScrnSaver-${version}.tar.xz"
+checksum=5057365f847253e0e275871441e10ff7846c8322a5d88e1e187d326de1cd8d00
 
 post_install() {
 	vlicense COPYING


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures:
  - [x] i686-glibc
  - [x] x86_64-musl
  - [x] aarch64-glibc (x86_64-glibc)
  - [x] aarch64-musl (x86_64-musl)
  - [x] armv7l-glibc (x86_64-glibc)
  - [x] armv6l-musl (x86_64-musl)