### PR TITLE
libcloudproviders: update to 0.4.0.

### DIFF
--- a/srcpkgs/libcloudproviders/template
+++ b/srcpkgs/libcloudproviders/template
@@ -1,6 +1,6 @@
 # Template file for 'libcloudproviders'
 pkgname=libcloudproviders
-version=0.3.6
+version=0.4.0
 revision=1
 build_style=meson
 build_helper="gir"
@@ -10,9 +10,10 @@ makedepends="libglib-devel"
 short_desc="DBus API for cloud storage sync clients to expose their services"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="LGPL-3.0-or-later"
-homepage="https://gitlab.gnome.org/World/libcloudproviders"
-distfiles="${homepage}/-/archive/${version}/libcloudproviders-${version}.tar.gz"
-checksum=fa25bdc2e415a717999f3d0bac8756dc0dcfe40e3ada864fadc26df0746a7116
+homepage="https://gitlab.gnome.org/GNOME/libcloudproviders"
+changelog="https://gitlab.gnome.org/GNOME/libcloudproviders/-/raw/main/CHANGELOG"
+distfiles="https://gitlab.gnome.org/GNOME/libcloudproviders/-/archive/${version}/libcloudproviders-${version}.tar.gz"
+checksum=ff65b1d4ed685f5f1659370e7dc503e891fdc0c9174661b1447e04798b98ed83
 
 build_options="gir"
 build_options_default="gir"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures:
  - [x] i686-glibc
  - [x] x86_64-musl
  - [x] aarch64-glibc (x86_64-glibc)
  - [x] aarch64-musl (x86_64-musl)
  - [x] armv7l-glibc (x86_64-glibc)
  - [x] armv6l-musl (x86_64-musl)