### PR TITLE
libXcomposite: update to 0.4.7.

### DIFF
--- a/srcpkgs/libXcomposite/template
+++ b/srcpkgs/libXcomposite/template
@@ -1,6 +1,6 @@
 # Template file for 'libXcomposite'
 pkgname=libXcomposite
-version=0.4.6
+version=0.4.7
 revision=1
 build_style=gnu-configure
 hostmakedepends="pkg-config"
@@ -9,8 +9,8 @@ short_desc="X Composite Library"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="X11"
 homepage="https://wiki.freedesktop.org/xorg/"
-distfiles="${XORG_SITE}/lib/${pkgname}-${version}.tar.xz"
-checksum=fe40bcf0ae1a09070eba24088a5eb9810efe57453779ec1e20a55080c6dc2c87
+distfiles="${XORG_SITE}/lib/libXcomposite-${version}.tar.xz"
+checksum=8bdf310967f484503fa51714cf97bff0723d9b673e0eecbf92b3f97c060c8ccb
 
 post_install() {
 	vlicense COPYING


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures:
  - [x] i686-glibc
  - [x] x86_64-musl
  - [x] aarch64-glibc (x86_64-glibc)
  - [x] aarch64-musl (x86_64-musl)
  - [x] armv7l-glibc (x86_64-glibc)
  - [x] armv6l-musl (x86_64-musl)