### PR TITLE
libXdamage: update to 1.1.7.

### DIFF
--- a/srcpkgs/libXdamage/template
+++ b/srcpkgs/libXdamage/template
@@ -1,6 +1,6 @@
 # Template file for 'libXdamage'
 pkgname=libXdamage
-version=1.1.6
+version=1.1.7
 revision=1
 build_style=gnu-configure
 hostmakedepends="pkg-config"
@@ -9,8 +9,8 @@ short_desc="Xdamage extension Library"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="X11"
 homepage="https://wiki.freedesktop.org/xorg/"
-distfiles="${XORG_SITE}/lib/${pkgname}-${version}.tar.xz"
-checksum=52733c1f5262fca35f64e7d5060c6fcd81a880ba8e1e65c9621cf0727afb5d11
+distfiles="${XORG_SITE}/lib/libXdamage-${version}.tar.xz"
+checksum=127067f521d3ee467b97bcb145aeba1078e2454d448e8748eb984d5b397bde24
 
 post_install() {
 	vlicense COPYING


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures:
  - [x] i686-glibc
  - [x] x86_64-musl
  - [x] aarch64-glibc (x86_64-glibc)
  - [x] aarch64-musl (x86_64-musl)
  - [x] armv7l-glibc (x86_64-glibc)
  - [x] armv6l-musl (x86_64-musl)