### PR TITLE
libXext: update to 1.3.7.

### DIFF
--- a/srcpkgs/libXext/template
+++ b/srcpkgs/libXext/template
@@ -1,6 +1,6 @@
 # Template file for 'libXext'
 pkgname=libXext
-version=1.3.6
+version=1.3.7
 revision=1
 build_style=gnu-configure
 configure_args="--enable-malloc0returnsnull"
@@ -11,7 +11,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
 homepage="https://gitlab.freedesktop.org/xorg/lib/libxext"
 distfiles="${XORG_SITE}/lib/libXext-${version}.tar.xz"
-checksum=edb59fa23994e405fdc5b400afdf5820ae6160b94f35e3dc3da4457a16e89753
+checksum=6c643c7035cdacf67afd68f25d01b90ef889d546c9fcd7c0adf7c2cf91e3a32d
 
 post_install() {
 	vlicense COPYING


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures:
  - [x] i686-glibc
  - [x] x86_64-musl
  - [x] aarch64-glibc (x86_64-glibc)
  - [x] aarch64-musl (x86_64-musl)
  - [x] armv7l-glibc (x86_64-glibc)
  - [x] armv6l-musl (x86_64-musl)