### PR TITLE
runc: update to 1.4.0

### DIFF
--- a/srcpkgs/runc/template
+++ b/srcpkgs/runc/template
@@ -1,6 +1,6 @@
 # Template file for 'runc'
 pkgname=runc
-version=1.3.3
+version=1.4.0
 revision=1
 build_style=go
 go_import_path=github.com/opencontainers/runc
@@ -16,7 +16,7 @@ license="Apache-2.0"
 homepage="https://github.com/opencontainers/runc"
 changelog="https://github.com/opencontainers/runc/raw/main/CHANGELOG.md"
 distfiles="https://github.com/opencontainers/runc/releases/download/v${version}/runc.tar.xz"
-checksum=3488f287ec8dd88a7599647a5d119c628b86bfffd176786871e1ffd98d8049cc
+checksum=f67c16fe40d078be6bf40006b086068951ab885ad815dfe8fa96c0a546aac57f
 
 post_build() {
 	make man


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES** (updated my personal server using runc and many rootless podman containers to latest, restarted all services)

#### Local build testing
- I built this PR (and ran checks) locally for my native architecture, x86-64
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64 (cross)
