### PR TITLE
podman: update to 5.8.0

### DIFF
--- a/srcpkgs/podman/template
+++ b/srcpkgs/podman/template
@@ -1,8 +1,8 @@
 # Template file for 'podman'
 pkgname=podman
-version=5.7.1
-revision=2
-_container_libs_common=0.66.1
+version=5.8.0
+revision=1
+_container_libs_common=0.67.0
 build_style=go
 build_wrksrc=podman-${version}
 go_import_path="github.com/containers/podman/v5"
@@ -20,8 +20,8 @@ homepage="https://podman.io/"
 changelog="https://raw.githubusercontent.com/containers/podman/main/RELEASE_NOTES.md"
 distfiles="https://github.com/containers/podman/archive/v${version}.tar.gz
  https://github.com/containers/container-libs/archive/refs/tags/common/v${_container_libs_common}.tar.gz"
-checksum="c04c12f90d1bf410ccc4d27a30cff188d6a9361bddb5fceb19659ae08257cc6f
- d008a3cc50d6f68fe84f139081c811384223665c273a520bee174f5b9f2f48af"
+checksum="19723cda810e087ded8903fb0f33918b10d81f7fd1d8964880c41ec30d1daa70
+ 503756a080d66141fc3103952b6a5c0253c45da8475673c8d4ee5c948f4dade4"
 
 case $XBPS_TARGET_MACHINE in
 	aarch64* | x86_64*) ;;


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES** (updated my personal server using runc and many rootless podman containers to latest, restarted all services)

#### Local build testing
- I built this PR (and ran checks) locally for my native architecture, x86-64
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64 (cross)

cc: @CameronNemo 