### PR TITLE
libXfixes: update to 6.0.2.

### DIFF
--- a/srcpkgs/libXfixes/template
+++ b/srcpkgs/libXfixes/template
@@ -1,6 +1,6 @@
 # Template file for 'libXfixes'
 pkgname=libXfixes
-version=6.0.1
+version=6.0.2
 revision=1
 build_style=gnu-configure
 hostmakedepends="pkg-config"
@@ -9,8 +9,8 @@ short_desc="Xfixes library and extension of X RandR from modular X.org"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
 homepage="https://xorg.freedesktop.org"
-distfiles="${XORG_SITE}/lib/${pkgname}-${version}.tar.xz"
-checksum=b695f93cd2499421ab02d22744458e650ccc88c1d4c8130d60200213abc02d58
+distfiles="${XORG_SITE}/lib/libXfixes-${version}.tar.xz"
+checksum=39f115d72d9c5f8111e4684164d3d68cc1fd21f9b27ff2401b08fddfc0f409ba
 
 post_install() {
 	vlicense COPYING


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures:
  - [x] i686-glibc
  - [x] x86_64-musl
  - [x] aarch64-glibc (x86_64-glibc)
  - [x] aarch64-musl (x86_64-musl)
  - [x] armv7l-glibc (x86_64-glibc)
  - [x] armv6l-musl (x86_64-musl)