### PR TITLE
glab: update to 1.88.0.

### DIFF
--- a/srcpkgs/glab/template
+++ b/srcpkgs/glab/template
@@ -1,21 +1,26 @@
 # Template file for 'glab'
 pkgname=glab
-version=1.76.2
+version=1.88.0
 revision=1
 build_style=go
 build_helper=qemu
 go_ldflags="-X main.version=$version"
 go_import_path=gitlab.com/gitlab-org/cli
 go_package="${go_import_path}/cmd/glab"
-make_check_args="-skip=Schedule"
 short_desc="Command line tool bringing GitLab's features to your command line"
 maintainer="Enno Boland <gottox@voidlinux.org>"
 license="MIT"
 homepage="https://gitlab.com/gitlab-org/cli"
 changelog="https://gitlab.com/gitlab-org/cli/-/releases"
 distfiles="https://gitlab.com/gitlab-org/cli/-/archive/v$version/cli-v$version.tar.gz"
-checksum=e97ff8c49c318e36847c1d8ba96e5624466eb1d7e82aa196899add2f0f60d5e0
+checksum=ab03ddd72cef9f0ec7ccd4359143718b5695f4526ee3ed946ec0a00bac8075f6
 make_check_pre="env PATH=/usr/libexec/chroot-git:${PATH}"
+
+if [ $XBPS_MACHINE = "i686" ]; then
+	# https://gitlab.com/gitlab-org/cli/-/issues/8198
+	# https://gitlab.com/gitlab-org/cli/-/issues/8199
+	make_check_args+=" -skip=TestDetectPlatform|Test_helperRun/support_OAuth2"
+fi
 
 pre_check() {
 	/usr/libexec/chroot-git/git init -q


### PR DESCRIPTION
I was annoyed by https://gitlab.com/gitlab-org/cli/-/commit/b514a082d86b574c174ff1b31ddcedb3a7bd3ae4, so I want to update glab.

cc @Gottox 

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**
  - I read all changelogs since 1.76.2 and found nothing concerning
  - I tested basic functionality (auth, cloning)

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
