### PR TITLE
New package: osslsigncode-2.13

### DIFF
--- a/srcpkgs/osslsigncode/template
+++ b/srcpkgs/osslsigncode/template
@@ -1,0 +1,13 @@
+# Template file for 'osslsigncode'
+pkgname=osslsigncode
+version=2.13
+revision=1
+build_style=cmake
+hostmakedepends="pkg-config"
+makedepends="openssl-devel libcurl-devel zlib-devel"
+short_desc="Authenticode signing and verification"
+maintainer="Andrew Benson <abenson+void@gmail.com>"
+license="GPL-3.0-or-later"
+homepage="https://github.com/mtrojnar/osslsigncode"
+distfiles="https://github.com/mtrojnar/osslsigncode/archive/${version}.tar.gz"
+checksum=ee95638b8bec0c019ddf28cb14988645abbd180dcd017536338b7d0d5eaaea96


### PR DESCRIPTION

#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64

```
pkg           host         target        cross  result
osslsigncode  x86_64       x86_64        n      OK
osslsigncode  x86_64-musl  x86_64-musl   n      OK
osslsigncode  i686         i686          n      OK
osslsigncode  x86_64-musl  aarch64-musl  y      OK
osslsigncode  x86_64       aarch64       y      OK
osslsigncode  x86_64-musl  armv7l-musl   y      OK
osslsigncode  x86_64       armv7l        y      OK
osslsigncode  x86_64-musl  armv6l-musl   y      OK
osslsigncode  x86_64       armv6l        y      OK
```