### PR TITLE
libdecor: update to 0.2.5

### DIFF
--- a/srcpkgs/libdecor/template
+++ b/srcpkgs/libdecor/template
@@ -1,6 +1,6 @@
 # Template file for 'libdecor'
 pkgname=libdecor
-version=0.2.4
+version=0.2.5
 revision=1
 build_style=meson
 configure_args="-Ddemo=false $(vopt_feature dbus dbus)"
@@ -12,7 +12,7 @@ maintainer="Arda Demir <ddmirarda@gmail.com>"
 license="MIT"
 homepage="https://gitlab.freedesktop.org/libdecor/libdecor"
 distfiles="https://gitlab.freedesktop.org/libdecor/libdecor/-/archive/${version}/libdecor-${version}.tar.gz"
-checksum=1fb3ee6c7c9e238d240772517753bedb2e09e29d21514fb86f19724fccb58cc1
+checksum=39c109a9a7eae943ba34d18a282c447d5729f9c486c8bc05ea305e4acd341522
 
 build_options="dbus"
 build_options_default="dbus"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, **x86_64-glibc**
- I built this PR locally for these architectures:
  - x86_64-musl

cc @ardadem 