### PR TITLE
libopenraw: add missing boost-devel from makedepends

### DIFF
--- a/srcpkgs/libopenraw/template
+++ b/srcpkgs/libopenraw/template
@@ -5,7 +5,7 @@ revision=3
 build_style=gnu-configure
 configure_args="--with-boost=${XBPS_CROSS_BASE}/usr"
 hostmakedepends="pkg-config curl"
-makedepends="glib-devel gdk-pixbuf-devel boost-headers libxml2-devel libjpeg-turbo-devel"
+makedepends="glib-devel gdk-pixbuf-devel boost-headers boost-devel libxml2-devel libjpeg-turbo-devel"
 short_desc="Library for camera RAW files decoding"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="LGPL-3.0-or-later"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, x86-64
- I built this PR locally for these architectures:
  - aarch64 (cross)
