### PR TITLE
system-monitoring-center: add missing deps

### DIFF
--- a/srcpkgs/system-monitoring-center/template
+++ b/srcpkgs/system-monitoring-center/template
@@ -4,7 +4,7 @@ version=3.1.0
 revision=2
 build_style=meson
 hostmakedepends="gettext gtk4-update-icon-cache desktop-file-utils"
-depends="dmidecode gir-freedesktop hwids iproute2 python3 python3-cairo 
+depends="dmidecode gir-freedesktop hwids iproute2 python3 python3-cairo
  python3-tkinter python3-Pillow util-linux libadwaita"
 short_desc="Multi-featured system monitor"
 maintainer="zenobit <zenobit@disroot.org>"


### PR DESCRIPTION
Updated dependencies to include python3-tkinter and python3-Pillow. App doesn't run otherwise, see #59260.


<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: briefly

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
