### PR TITLE
go-size-analyzer: update to 1.11.0.

### DIFF
--- a/srcpkgs/go-size-analyzer/template
+++ b/srcpkgs/go-size-analyzer/template
@@ -1,17 +1,18 @@
 # Template file for 'go-size-analyzer'
 pkgname=go-size-analyzer
-version=1.10.2
+version=1.11.0
 revision=1
 build_style=go
 go_import_path="github.com/Zxilly/go-size-analyzer"
 go_package="${go_import_path}/cmd/gsa"
+go_ldflags="-X ${go_import_path}.version=${version}"
 make_check_args="-skip Test(DiffJSONAndBinary|CommonResult|FullOutput)" # require the tui
 short_desc="Tool for analyzing the size of compiled Go binaries"
 maintainer="Bnyro <bnyro@tutanota.com>"
 license="AGPL-3.0-only"
 homepage="https://github.com/Zxilly/go-size-analyzer"
 distfiles="https://github.com/Zxilly/go-size-analyzer/archive/refs/tags/v${version}.tar.gz"
-checksum=4c8a7820564f462a953aaada38f212e0248464205315d6715cc98e274266ba53
+checksum=0e1734c90e6ff1a45b079e4c4eb2c7bc1bfe9a85c9d9110133aeb39323f6ee36
 
 post_install() {
 	# avoid name clash with 'gwenhywfar' package


### PR DESCRIPTION

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
