### PR TITLE
sops: update to 3.12.1

### DIFF
--- a/srcpkgs/sops/template
+++ b/srcpkgs/sops/template
@@ -1,6 +1,6 @@
 # Template file for 'sops'
 pkgname=sops
-version=3.9.1
+version=3.12.1
 revision=1
 build_style=go
 go_import_path="github.com/getsops/sops/v3"
@@ -11,5 +11,5 @@ license="MPL-2.0"
 homepage="https://github.com/getsops/sops"
 changelog="https://raw.githubusercontent.com/getsops/sops/main/CHANGELOG.rst"
 distfiles="https://github.com/getsops/sops/archive/refs/tags/v${version}.tar.gz"
-checksum=d79e8caaef3134d00f759231e8ef587b791996e2e45319ffe83dee1ab01aebda
+checksum=90f9cdc55e653f3c40986cb288f50bd44b6277b7d329714f7a2a1bad6bc97074
 make_check=no # tests require a running docker daemon


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, **x86_64-glibc**
