### PR TITLE
Fritzing: fix: missing fritzing-parts

### DIFF
--- a/srcpkgs/Fritzing/template
+++ b/srcpkgs/Fritzing/template
@@ -34,8 +34,8 @@ post_patch() {
 }
 
 post_install() {
-	vmkdir usr/share/fritzing
-	vsrcextract -C /usr/share/fritzing $skip_extraction
+	vmkdir usr/share/fritzing/parts
+	vsrcextract -C ${DESTDIR}/usr/share/fritzing/parts $skip_extraction
 	mv ${DESTDIR}/usr/bin/Fritzing{,-bin}
 	vbin ${FILESDIR}/Fritzing
 	sed -i -e "s;^Icon=.*;Icon=fritzing;" ${DESTDIR}/usr/share/applications/fritzing.desktop


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)