### PR TITLE
libarchive: update to 3.8.6

### DIFF
--- a/srcpkgs/libarchive/template
+++ b/srcpkgs/libarchive/template
@@ -1,6 +1,6 @@
 # Template file for 'libarchive'
 pkgname=libarchive
-version=3.8.5
+version=3.8.6
 revision=1
 bootstrap=yes
 build_style=gnu-configure
@@ -18,7 +18,7 @@ license="BSD-2-Clause"
 homepage="https://www.libarchive.org/"
 changelog="https://github.com/libarchive/libarchive/releases"
 distfiles="https://github.com/libarchive/libarchive/releases/download/v${version}/libarchive-${version}.tar.xz"
-checksum=d68068e74beee3a0ec0dd04aee9037d5757fcc651591a6dcf1b6d542fb15a703
+checksum=8ac57c1f5e99550948d1fe755c806d26026e71827da228f36bef24527e372e6f
 
 build_options="acl expat lzo lz4 ssl zstd"
 build_options_default="acl ssl lz4 zstd"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**
- tested `bsdtar` `xbps` and packaging w/ `xbps-src`

#### Local build testing
- I built this PR locally for my native architecture, **x86_64-glibc**

[Security and bugfix release](https://github.com/libarchive/libarchive/releases/tag/v3.8.6)
