### PR TITLE
jp2a: update to 1.3.3

### DIFF
--- a/srcpkgs/jp2a/template
+++ b/srcpkgs/jp2a/template
@@ -1,14 +1,22 @@
 # Template file for 'jp2a'
 pkgname=jp2a
-version=1.3.2
+version=1.3.3
 revision=1
 build_style=gnu-configure
+hostmakedepends="pkg-config"
 makedepends="libjpeg-turbo-devel libpng-devel libcurl-devel ncurses-devel
  libwebp-devel libexif-devel"
 short_desc="JPEG image to ASCII art converter"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-only"
 homepage="https://github.com/Talinx/jp2a"
+changelog="https://raw.githubusercontent.com/Talinx/jp2a/refs/heads/master/ChangeLog"
 distfiles="https://github.com/Talinx/jp2a/releases/download/v${version}/jp2a-${version}.tar.gz"
-checksum=758757b6713ce0af8cfa5abe7a137c2adb64b2e93566e83bdacad5b5bf40ca58
-export bashcompdir=/usr/share/bash-completion/completions
+checksum=733a4dfc847ab9b020b26f7b90dbe3ff1dce7489a91bfc06fe8fd38764e9e246
+
+post_install() {
+	#move bash completions into the correct dir
+	vmkdir usr/share/bash-completion/completions
+	mv ${DESTDIR}/etc/bash_completion.d/* \
+		${DESTDIR}/usr/share/bash-completion/completions
+}


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, **x86_64-glibc**
- I built this PR locally for these architectures:
  - x86_64-musl
 
[Changelog](https://raw.githubusercontent.com/Talinx/jp2a/refs/heads/master/ChangeLog)

Notes:

Basically all changes to the template were made in order to successfully build the package locally (previous merges happened w/o CI checks).

Also:

```
./run-tests.sh
-------------------------------------------------------------
 TESTING JP2A BUILD
 
 Note that the output may vary a bit on different platforms,
 so some tests may fail.  This does not mean that jp2a is
 completely broken.
-------------------------------------------------------------
```
 
Btw: the package is being built from a fork, since the original one isn't maintained.