### PR TITLE
python3-pydot: update to 4.0.1.

### DIFF
--- a/srcpkgs/python3-pydot/template
+++ b/srcpkgs/python3-pydot/template
@@ -1,7 +1,7 @@
 # Template file for 'python3-pydot'
 pkgname=python3-pydot
-version=4.0.0
-revision=2
+version=4.0.1
+revision=1
 build_style=python3-pep517
 hostmakedepends="python3-wheel"
 depends="python3 python3-parsing python3-graphviz"
@@ -10,7 +10,7 @@ maintainer="strlst <satorialist@disroot.org>"
 license="MIT, Python-2.0"
 homepage="https://github.com/pydot/pydot"
 distfiles="${PYPI_SITE}/p/pydot/pydot-${version}.tar.gz"
-checksum=12f16493337cade2f7631b87c8ccd299ba2e251f3ee5d0732a058df2887afe97
+checksum=c2148f681c4a33e08bf0e26a9e5f8e4099a82e0e2a068098f32ce86577364ad5
 
 post_install() {
 	vlicense LICENSES/MIT.txt


### PR DESCRIPTION
This PR updates the `python3-pydot` package from 4.0.0 to 4.0.1.
I tested it by generating visual output with the simulator `gem5`.

#### Testing the changes
- I tested the changes in this PR: YES

#### Local build testing
- I built this PR locally for my native architecture, x86_glibc