### PR TITLE
rustup: update to 1.29.0

### DIFF
--- a/srcpkgs/rustup/patches/0001-Symlink-rustup-instead-of-copying-it.patch
+++ b/srcpkgs/rustup/patches/0001-Symlink-rustup-instead-of-copying-it.patch
@@ -10,24 +10,24 @@ rustup into $CARGO_HOME/bin instead of copying it.
 Upstream doesn't want the patch as it is right now.
 
 diff --git a/src/cli/self_update.rs b/src/cli/self_update.rs
-index 89ee515..26a98cd 100644
+index e37dc25..bdd1b41 100644
 --- a/src/cli/self_update.rs
 +++ b/src/cli/self_update.rs
-@@ -731,8 +731,7 @@ fn install_bins(process: &Process) -> Result<()> {
+@@ -842,8 +842,7 @@ fn install_bins(process: &Process) -> Result<()> {
      if rustup_path.exists() {
          utils::remove_file("rustup-bin", &rustup_path)?;
      }
--    utils::copy_file(&this_exe_path, &rustup_path)?;
+-    utils::copy_file_symlink_to_source(&this_exe_path, &rustup_path)?;
 -    utils::make_executable(&rustup_path)?;
 +    utils::symlink_file(&this_exe_path, &rustup_path)?;
      install_proxies(process)
  }
  
 diff --git a/src/utils/mod.rs b/src/utils/mod.rs
-index 52c76ac..fc40ae4 100644
+index 649cfb9..405d398 100644
 --- a/src/utils/mod.rs
 +++ b/src/utils/mod.rs
-@@ -397,7 +397,7 @@ pub fn hardlink_file(src: &Path, dest: &Path) -> Result<()> {
+@@ -211,7 +211,7 @@ pub fn hardlink_file(src: &Path, dest: &Path) -> Result<()> {
  }
  
  #[cfg(unix)]

--- a/srcpkgs/rustup/template
+++ b/srcpkgs/rustup/template
@@ -1,22 +1,22 @@
 # Template file for 'rustup'
 pkgname=rustup
-version=1.28.2
+version=1.29.0
 revision=1
 # rustup doesn't recognize this target
 archs="~armv*-musl"
 build_style=cargo
 build_helper=qemu
 configure_args="--bin rustup-init --no-default-features
- --features curl-backend,reqwest-native-tls,no-self-update"
+ --features=curl-backend,reqwest-native-tls,no-self-update"
 hostmakedepends="pkg-config"
-makedepends="openssl-devel zlib-devel libcurl-devel liblzma-devel libzstd-devel"
+makedepends="openssl-devel libcurl-devel liblzma-devel libzstd-devel"
 short_desc="Rust toolchain installer"
 maintainer="tranzystorekk <tranzystorek.io@protonmail.com>"
 license="Apache-2.0 OR MIT"
 homepage="https://www.rustup.rs"
 changelog="https://raw.githubusercontent.com/rust-lang/rustup/master/CHANGELOG.md"
 distfiles="https://github.com/rust-lang/rustup/archive/refs/tags/${version}.tar.gz"
-checksum=5987dcb828068a4a5e29ba99ab26f2983ac0c6e2e4dc3e5b3a3c0fafb69abbc0
+checksum=de73d1a62f4d5409a2f6bdb1c523d8dc08aa6d9d63588db62493c19ca8f8bf55
 
 do_install() {
 	vbin target/${RUST_TARGET}/release/rustup-init


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
