### PR TITLE
goldendict-ng: update to 26.3.0

### DIFF
--- a/srcpkgs/goldendict-ng/template
+++ b/srcpkgs/goldendict-ng/template
@@ -1,10 +1,10 @@
 # Template file for 'goldendict-ng'
 pkgname=goldendict-ng
-version=26.1.1
+version=26.3.0
 revision=1
-_version_tag=Release.5491ffca
+_version_tag=Release.fce2b872
 build_style=cmake
-configure_args="-DUSE_ALTERNATIVE_NAME=ON -DUSE_SYSTEM_FMT=ON -DWITH_TTS=OFF"
+configure_args="-DUSE_ALTERNATIVE_NAME=ON -DWITH_TTS=OFF"
 hostmakedepends="pkg-config qt6-declarative-host-tools qt6-tools"
 makedepends="ffmpeg6-devel fmt-devel hunspell-devel libeb-devel libvorbis-devel
  libzim-devel opencc-devel qt6-base-devel qt6-declarative-devel
@@ -16,7 +16,7 @@ maintainer="Mateusz Sylwestrzak <slymattz@gmail.com>"
 license="GPL-3.0-or-later"
 homepage="https://xiaoyifang.github.io/goldendict-ng/"
 distfiles="https://github.com/xiaoyifang/goldendict-ng/archive/refs/tags/v${version}-${_version_tag}.tar.gz"
-checksum=e59b343b4ecd2b34c110797119e700a25628d0ef6c7f589511e411bcf85adf7d
+checksum=1620aa15f2d2d4fcf1b33772dd781d8387841c4d30266ed75f416ff13239a46c
 
 if [ "$XBPS_WORDSIZE$XBPS_WORDSIZE" != "64$XBPS_TARGET_WORDSIZE" ]; then
 	broken="Qt6 WebEngine"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

https://github.com/xiaoyifang/goldendict-ng/commit/bd8c480eef05b31827d3b4332af9a603e0fab3d2 I had the obsolete flag `-DUSE_SYSTEM_FMT=ON` removed. Goldendict-ng links against fmt anyway. 

#### Local build testing
- I built this PR locally for my native architecture: x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl