### PR TITLE
grub-btrfs: Update to 4.14

### DIFF
--- a/srcpkgs/grub-btrfs/files/grub-btrfs/run
+++ b/srcpkgs/grub-btrfs/files/grub-btrfs/run
@@ -3,10 +3,5 @@
 exec 2>&1
 [ -r conf ] && . ./conf
 
-if [ -d "${SNAPSHOTS_PATH}" ]
-then
-	exec wendy ${OPTS} -m 960 -w "${SNAPSHOTS_PATH}" sh -c \
-	 'if [ -s "/boot/grub/grub-btrfs.cfg" ]; then /etc/grub.d/41_snapshots-btrfs; else update-grub; fi'
-else
-  exit 1
-fi
+exec grub-btrfsd ${GRUB_BTRFSD_OPTS} "${SNAPSHOTS_PATH}"
+

--- a/srcpkgs/grub-btrfs/template
+++ b/srcpkgs/grub-btrfs/template
@@ -1,25 +1,24 @@
 # Template file for 'grub-btrfs'
 pkgname=grub-btrfs
-version=4.13
+version=4.14
 revision=1
 build_style=gnu-makefile
-depends="grub bash"
+conf_files="/etc/sv/grub-btrfs/conf"
+depends="grub bash inotify-tools"
 short_desc="Include btrfs snapshots at Grub menu"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-3.0-or-later"
 homepage="https://github.com/Antynea/grub-btrfs"
-distfiles="https://github.com/Antynea/grub-btrfs/archive/${version}.tar.gz"
-checksum=c493d0d5a6548c01993641ce586c98d461cabe40df4dff79d974d0c59068ff1d
+distfiles="https://github.com/Antynea/grub-btrfs/archive/v${version}.tar.gz"
+checksum=4fe2f8a49b39e3e561fc51bbc5a0f81a7222c1e9ef8672e014e0ba3bedad20c6
 
 post_install() {
 	rm -rf -- "${DESTDIR}"/usr/lib/systemd
+	vsv grub-btrfs
 }
 
 grub-btrfs-runit_package() {
-	depends="wendy ${sourcepkg}>=${version}_${revision}"
-	short_desc+=" - runit service"
-
-	pkg_install() {
-		vsv grub-btrfs
-	}
+	depends="${sourcepkg}>=${version}_${revision}"
+	short_desc+=" (transitional dummy package)"
+	metapackage=yes
 }


### PR DESCRIPTION
The current template is directly watching snapshots directory entries and refreshing the grub entries accordingly. This commit updates it to use the grub-btrfsd script shipped with grub-btrfs, which does the same thing and some change.

Notes:
- I checked the original PR (#28288) to see why we're rolling our own version, I found [a comment](https://github.com/void-linux/void-packages/pull/28288#issuecomment-772122154) describing some messiness with `inotify-tools` but I didn't run into any issues. (Possibly silently fixed in the years since)
- ~~There's also a new version bump for `grub-btrfs` available, I'm not sure the etiquette for doing multiple things in one PR so for the moment I'm planning to contribute that in a new PR after this.~~
- It doesn't look like this implementation is logging anything (the old one isn't logging anything either, but this daemon does have logs to emit). I'm new to void-packages and not sure how to make that happen. There's [a `--syslog` option](https://github.com/Antynea/grub-btrfs/blob/master/grub-btrfsd#L39) and my understanding of vlogger is that it gives a sort-of syslog interface, but trying to use it spawns a perpetual `runsvdir` process with errors like `runsv grub-btrfs: warning: unable to open log/supervise/pid.new: file does not exist`.
  - For future readers: With the merged version, if you want logs you can manually set them by adding `GRUB_BTRFSD_OPTS="--log-file /var/log/grub-btrfsd.log"` or similar to `/conf`.

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-LIBC)
