### PR TITLE
supertux2: link external squirrel lib statically

### DIFF
--- a/srcpkgs/supertux2/template
+++ b/srcpkgs/supertux2/template
@@ -1,12 +1,13 @@
 # Template file for 'supertux2'
 pkgname=supertux2
 version=0.7.0
-revision=1
+revision=2
 build_style=cmake
 configure_args="
  -DAPPDATADIR=/usr/share/supertux2
  -DINSTALL_SUBDIR_BIN=bin
- -DINSTALL_SUBDIR_SHARE=share/supertux2"
+ -DINSTALL_SUBDIR_SHARE=share/supertux2
+ -DUSE_STATIC_SIMPLESQUIRREL=ON"
 hostmakedepends="pkg-config"
 makedepends="SDL2-devel SDL2_image-devel
  libcurl-devel libpng-devel fmt-devel zlib-devel


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
