### PR TITLE
dfu-programmer: update to 1.1.0

### DIFF
--- a/srcpkgs/dfu-programmer/template
+++ b/srcpkgs/dfu-programmer/template
@@ -1,18 +1,16 @@
 # Template file for 'dfu-programmer'
 pkgname=dfu-programmer
-version=0.7.2
-revision=2
+version=1.1.0
+revision=1
 build_style=gnu-configure
-configure_args="--includedir=${XBPS_CROSS_BASE}/usr/include"
-hostmakedepends="automake"
 makedepends="libusb-devel"
 short_desc="Device Firmware Upgrade class USB driver and flasher"
 maintainer="Matt Carroll <oholiab@gmail.com>"
 license="GPL-2.0-or-later"
 homepage="http://dfu-programmer.github.io"
-distfiles="${SOURCEFORGE_SITE}/dfu-programmer/dfu-programmer/${version}/dfu-programmer-${version}.tar.gz"
-checksum=1db4d36b1aedab2adc976e8faa5495df3cf82dc4bf883633dc6ba71f7c4af995
+distfiles="https://github.com/dfu-programmer/dfu-programmer/releases/download/v${version}/dfu-programmer-${version}.tar.gz"
+checksum=844e469be559657bc52c9d9d03c30846acd11ffbb1ddd42438fa8af1d2b8587d
 
-pre_configure() {
-	./bootstrap.sh
+post_install() {
+	vcompletion dfu_completion bash
 }


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

- I built this PR locally for my native architecture, x86_64-glibc

@oholiab apparently dfu-programmer moved back to github for their tarballs > 0.7.2 and there's no need to run bootstrap.sh anymore since they run it as part of their tarball releases