### PR TITLE
udiskie: update to 2.6.2.

### DIFF
--- a/srcpkgs/udiskie/template
+++ b/srcpkgs/udiskie/template
@@ -1,6 +1,6 @@
 # Template file for 'udiskie'
 pkgname=udiskie
-version=2.6.1
+version=2.6.2
 revision=1
 build_style=python3-pep517
 hostmakedepends="gettext asciidoc python3-setuptools"
@@ -13,7 +13,7 @@ license="MIT"
 homepage="https://github.com/coldfix/udiskie"
 changelog="https://raw.githubusercontent.com/coldfix/udiskie/master/CHANGES.rst"
 distfiles="https://github.com/coldfix/udiskie/archive/refs/tags/v${version}.tar.gz"
-checksum=225a0316d56a33d8dc67607d8b2103d1d216feb304d72724d2512fb54eeedc66
+checksum=9d758efd4e3706ce824e693708cce1e0a840dae9aa5b130e3592d3588da8279c
 make_check=ci-skip # privilege issue with keyring in container
 
 post_build() {


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture (x86_64)
- I built this PR locally for these architectures using specific masterdirs:
  - x86_64-musl
  - i686
- I built this PR locally for these architectures (crossbuilds):
  - aarch64
  - aarch64-musl
  - armv7l
  - armv7l-musl
  - armv6l
  - armv6l-musl