### PR TITLE
gnome-network-displays: update to 0.99.0

### DIFF
--- a/srcpkgs/gnome-network-displays/template
+++ b/srcpkgs/gnome-network-displays/template
@@ -1,6 +1,6 @@
 # Template file for 'gnome-network-displays'
 pkgname=gnome-network-displays
-version=0.97.0
+version=0.99.0
 revision=1
 build_style=meson
 hostmakedepends="desktop-file-utils gettext glib-devel gtk4-update-icon-cache
@@ -14,4 +14,4 @@ license="GPL-3.0-or-later"
 homepage="https://gitlab.gnome.org/GNOME/gnome-network-displays"
 changelog="https://gitlab.gnome.org/GNOME/gnome-network-displays/-/raw/master/NEWS"
 distfiles="${GNOME_SITE}/gnome-network-displays/${version%.*}/gnome-network-displays-${version}.tar.xz"
-checksum=cdec68c8f9b326baaee545374a8c2b93ca919e48f4b8a42461cb0eb2398dab27
+checksum=1ece4a1bc822c7ebf725e8847b8ce8998b47d1ec1715a4b4ddb9ddd71691ed85


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)