### PR TITLE
coredns: update to 1.14.2

### DIFF
--- a/srcpkgs/coredns/template
+++ b/srcpkgs/coredns/template
@@ -1,9 +1,10 @@
 # Template file for 'coredns'
 pkgname=coredns
-version=1.10.1
-revision=4
+version=1.14.2
+revision=1
 build_style=go
 go_import_path=github.com/coredns/coredns
+go_build_tags=grpcnotrace
 hostmakedepends="mmark"
 short_desc="CoreDNS is a DNS server that chains plugins"
 maintainer="Orphaned <orphan@voidlinux.org>"
@@ -11,13 +12,22 @@ license="Apache-2.0"
 homepage="https://coredns.io"
 changelog="https://github.com/coredns/coredns/releases"
 distfiles="https://github.com/coredns/coredns/archive/v${version}.tar.gz"
-checksum=f47186452e5f2925e2c71135669afd9e03b9b55831417d33d612ef2fa69924a7
+checksum=ab933ed4f04de3cf377d0ecc8399fa1a6613cecdd7a1c40d90eb0a7471463fdb
 make_dirs="/etc/coredns 0750 root root"
 conf_files="/etc/coredns/Corefile"
 
 # Update this on each version bump.
-_git_commit=055b2c31a9cf28321734e5f71613ea080d216cd3
+_git_commit=dd1df4f5db93767a44e37638df44969503b320d2
 go_ldflags="-X github.com/coredns/coredns/coremain.GitCommit=${_git_commit}"
+
+do_check() {
+	local ignore="github.com/coredns/coredns/test$"
+	if [ "$XBPS_TARGET_MACHINE" = "i686" ]; then
+		ignore="${ignore}|github.com/coredns/coredns/plugin/trace$"
+	fi
+	go test -p "$XBPS_MAKEJOBS" -tags "${go_build_tags}" -ldflags "${go_ldflags}" \
+		$(go list ./... | grep -vE "$ignore")
+}
 
 post_build() {
 	make -f Makefile.doc MMARK="$(command -v mmark) -man" man/coredns.1 man/corefile.5 plugins


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc

New release and I added `go_build_tags=grpcnotrace` because that's what coredns's Makefile builds with now: https://github.com/coredns/coredns/commit/86d9bc721601a55907c44c8e0c7ea0fe5171c192

Also had to ignore tests for coredns/plugin/trace on i686 since datadog-go triggers a panic: unaligned 64-bit atomic operation on 32 bit systems