### PR TITLE
New package: kf6-kio-fuse-5.1.1

### DIFF
--- a/srcpkgs/kf6-kio-fuse/template
+++ b/srcpkgs/kf6-kio-fuse/template
@@ -1,0 +1,14 @@
+# Template file for 'kf6-kio-fuse'
+pkgname=kf6-kio-fuse
+version=5.1.1
+revision=1
+build_style=cmake
+configure_args="-DQT_MAJOR_VERSION=6 -DBUILD_WITH_QT6=ON"
+hostmakedepends="extra-cmake-modules pkg-config qt6-base kf6-kconfig-devel"
+makedepends="base-devel cmake extra-cmake-modules qt6-base qt6-base-devel kf6-kcoreaddons-devel kf6-kcoreaddons kf6-kio-devel fuse3 fuse3-devel"
+short_desc="FUSE Interface for KIO"
+maintainer="Orphaned <orphan@voidlinux.org>"
+license="GPL-2.0-or-later, LGPL-2.0-or-later"
+homepage="https://invent.kde.org/system/kio-fuse"
+distfiles="$KDE_SITE/kio-fuse/kio-fuse-${version}.tar.xz"
+checksum=adf6aa7ce055c0987e716a93ac01f3c0a97c1280421443cd6b21e0e71d763d14


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
#### Local build testing
- I built this PR locally for my native architecture, x86-64 glibc
- I built this PR locally for these architectures: armv6l (crossbuild), i686 (crossbuild)

Notes: this package is needed for ability to stream files from remote shares (like smb NAS) in KDE. Without it KDE starts to copy file to the local folder before opening, which is usually not what you want when double-clicking on a large file.

Was requested a long time ago in #34071