### PR TITLE
retroarch: update to 1.22.2

### DIFF
--- a/srcpkgs/retroarch/template
+++ b/srcpkgs/retroarch/template
@@ -1,18 +1,18 @@
 # Template file for 'retroarch'
 pkgname=retroarch
-version=1.21.0
+version=1.22.2
 revision=1
 build_style=configure
 configure_args="--prefix=/usr --sysconfdir=/etc --enable-networking
- --enable-udev --disable-builtinflac --enable-systemmbedtls
+ --enable-udev --enable-builtinflac --enable-systemmbedtls
  --disable-builtinbearssl --disable-builtinzlib
- $(vopt_enable ffmpeg) $(vopt_enable flac) $(vopt_enable jack)
+ $(vopt_enable ffmpeg) $(vopt_enable jack)
  $(vopt_enable pulseaudio pulse) $(vopt_enable qt5 qt)
  $(vopt_enable sdl2) $(vopt_enable vulkan) $(vopt_enable wayland) $(vopt_enable x11)"
 conf_files="/etc/retroarch.cfg"
 hostmakedepends="pkg-config"
 makedepends="alsa-lib-devel eudev-libudev-devel freetype-devel libusb-devel libxkbcommon-devel
- mbedtls-devel zlib-devel $(vopt_if ffmpeg ffmpeg6-devel) $(vopt_if flac libflac-devel)
+ mbedtls-devel zlib-devel $(vopt_if ffmpeg ffmpeg6-devel)
  $(vopt_if jack jack-devel) $(vopt_if pulseaudio pulseaudio-devel)
  $(vopt_if qt5 qt5-devel) $(vopt_if sdl2 SDL2-devel) $(vopt_if vulkan vulkan-loader-devel)
  $(vopt_if x11 'libXext-devel libXinerama-devel libXxf86vm-devel')"
@@ -23,10 +23,10 @@ license="GPL-3.0-or-later"
 homepage="https://www.retroarch.com/"
 changelog="https://raw.githubusercontent.com/libretro/RetroArch/master/CHANGES.md"
 distfiles="https://github.com/libretro/RetroArch/archive/v$version.tar.gz"
-checksum=9da17918c10d91d4ebfde9ff402dba0b1ad6660fdbce7656d32f0c0182b3a538
+checksum=245ef18c8fa8fbd9fbb5eb25cf43e17c6aace2f95c1ed99873cbd794012bb232
 
-build_options="ffmpeg flac glcore gles2 jack neon pulseaudio qt5 sdl2 vulkan wayland x11"
-build_options_default="ffmpeg flac glcore pulseaudio sdl2 vulkan wayland x11"
+build_options="ffmpeg glcore gles2 jack neon pulseaudio qt5 sdl2 vulkan wayland x11"
+build_options_default="ffmpeg glcore pulseaudio sdl2 vulkan wayland x11"
 
 desc_option_glcore="Enable support for OpenGL 3.2 core+ and OpenGL ES 3+"
 desc_option_neon="Enable support for ARM Neon SIMD extension"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Notes
RetroArch 1.22.2 updated libchdr with ZStandard support (see changelog:
https://raw.githubusercontent.com/libretro/RetroArch/master/CHANGES.md).
The new libchdr uses dr_flac (a header-only library from dr_libs) instead
of system libFLAC, breaking the build with --disable-builtinflac.

Changes:
- replaced --disable-builtinflac with --enable-builtinflac in configure_args
- removed flac build option (no longer meaningful)
- removed libflac-devel from makedepends

Arch Linux made the same change, dropping flac from depends in 1.22.2.

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc