### PR TITLE
pong-command: update to 2.0.9

### DIFF
--- a/srcpkgs/pong-command/template
+++ b/srcpkgs/pong-command/template
@@ -1,18 +1,20 @@
 # Template file for 'pong-command'
 pkgname=pong-command
-version=2.02
-revision=4
+# Upstream changed versioning.
+# Restore variables once a version ">=2.1.*" is released
+version=2.09
+revision=1
+_verdist=2.0.9
 build_style=go
 go_import_path=github.com/kurehajime/pong-command
 go_package="${go_import_path}/pong"
-hostmakedepends="git"
 short_desc="POng is Not pinG. pong is CLI game"
 maintainer="travankor <travankor@tuta.io>"
 license="MIT"
 homepage="https://github.com/kurehajime/pong-command"
-distfiles="https://github.com/kurehajime/pong-command/archive/${version}.tar.gz"
-checksum=940771c53d083616c52ed75b13f3568e224c4f4e04ca813cebc87d2da7dfebe8
-broken="missing go.mod"
+changelog="https://github.com/kurehajime/pong-command/releases"
+distfiles="https://github.com/kurehajime/pong-command/archive/refs/tags/v${_verdist}.tar.gz"
+checksum=b5c886d94503d8f4eb1b361f5adddbbfa6ddb2394aba61f1f4289ebfeabbbbf8
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
Upstream changed versioning

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, **x86_64-glibc**
- I built this PR locally for these architectures:
  - x86_64-musl
 
cc @travankor EDIT: On second thought we may just as well remove it, since it uses a ridiculous amount of CPU for "nothing"..