### PR TITLE
python3-urwid: update to 3.0.5

### DIFF
--- a/srcpkgs/python3-urwid/template
+++ b/srcpkgs/python3-urwid/template
@@ -1,6 +1,6 @@
 # Template file for 'python3-urwid'
 pkgname=python3-urwid
-version=3.0.4
+version=3.0.5
 revision=1
 build_style=python3-pep517
 make_check_target="tests"
@@ -14,4 +14,4 @@ license="LGPL-2.1-or-later"
 homepage="http://urwid.org/"
 changelog="https://raw.githubusercontent.com/urwid/urwid/master/docs/changelog.rst"
 distfiles="${PYPI_SITE}/u/urwid/urwid-${version}.tar.gz"
-checksum=c3d0d2f47602b21949ffb8669a7ef0a8ca5fa13ed5c1ee1d2d81edf05616187f
+checksum=24be27ffafdb68c09cd95dc21b60ccfd02843320b25ce5feee1708b34fad5a23


### PR DESCRIPTION
- I tested the changes in this PR: **NO**
- I built this PR locally for my native architecture, (x86_64-glibc)