### PR TITLE
android-studio: update to 2025.3.2.6

### DIFF
--- a/srcpkgs/android-studio/template
+++ b/srcpkgs/android-studio/template
@@ -1,8 +1,8 @@
 # Template file for 'android-studio'
 pkgname=android-studio
-version=2025.3.1.8
+version=2025.3.2.6
 revision=1
-_version_description="panda1-patch1"
+_version_description="panda2"
 archs="x86_64"
 hostmakedepends="tar"
 depends="libbsd"
@@ -12,7 +12,7 @@ license="Apache-2.0"
 homepage="https://developer.android.com/studio/"
 changelog="https://developer.android.com/studio/releases/"
 distfiles="https://edgedl.me.gvt1.com/android/studio/ide-zips/${version}/android-studio-${_version_description}-linux.tar.gz"
-checksum=678b8495f6368938927a8c8cc1a82484dd47e3640b77ec8b9983dc95722cda42
+checksum=32942d8cd7688192cf3cd07bf282fb120035b9bd9b56e6f13c5540e6d39807e9
 repository=nonfree
 restricted=yes
 python_version=3


### PR DESCRIPTION
Testing the changes
I tested the changes in this PR: YES
Local build testing
I built this PR locally for my native architecture, x86_64-glibc