### PR TITLE
gnome-nibbles: update to 4.5.1, adopt

### DIFF
--- a/srcpkgs/gnome-nibbles/template
+++ b/srcpkgs/gnome-nibbles/template
@@ -1,6 +1,6 @@
 # Template file for 'gnome-nibbles'
 pkgname=gnome-nibbles
-version=4.5.0
+version=4.5.1
 revision=1
 build_style=meson
 build_helper=qemu
@@ -8,9 +8,9 @@ hostmakedepends="gettext glib-devel itstool pkg-config vala desktop-file-utils
  gtk4-update-icon-cache"
 makedepends="gsound-devel libgnome-games-support2-devel libadwaita-devel"
 short_desc="GNOME snake eats diamonds game"
-maintainer="Orphaned <orphan@voidlinux.org>"
+maintainer="Clyhtsuriva <void-packages@adjutor.xyz>"
 license="GPL-3.0-or-later"
 homepage="https://gitlab.gnome.org/GNOME/gnome-nibbles"
 changelog="https://gitlab.gnome.org/GNOME/gnome-nibbles/-/raw/master/NEWS"
 distfiles="${GNOME_SITE}/${pkgname}/${version%.*}/${pkgname}-${version}.tar.xz"
-checksum=92f2d2ec0a33b6814c462b468cd0e83085e063d85e311e6a0c9aa69b62ffe914
+checksum=84bad2825d39b8bf701ef644aab16b2dc7e72bb43e3f8702d23eec9613d29637


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **yes**

#### Local build testing
- I built this PR locally for my native architecture, x86_64
- I crossbuilded this PR locally for these architectures:
  - armv7l
  - aarch64-musl