### PR TITLE
tree-sitter: update to 0.26.7

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -4198,7 +4198,7 @@ libsword-1.9.0.so libsword-1.9.0_1
 libgivaro.so.9 givaro-4.1.1_1
 liblinbox.so.0 linbox-1.6.3_1
 libpari-gmp-tls.so.9 pari-2.17.0_1
-libtree-sitter.so.0.25 tree-sitter-0.25.2_1
+libtree-sitter.so.0.26 tree-sitter-0.26.7_1
 libplanarity.so.2 planarity-4.0.0.0_1
 libgap.so.10 gap-4.15.1_1
 libgtkdatabox.so.1 gtkdatabox3-1.0.0_1

--- a/srcpkgs/emacs/patches/tree-sitter-0.26.patch
+++ b/srcpkgs/emacs/patches/tree-sitter-0.26.patch
@@ -1,0 +1,100 @@
+Based on the following patch:
+   From d587ce8c65a0e22ab0a63ef2873a3dfcfbeba166 Mon Sep 17 00:00:00 2001
+   From: Eli Zaretskii <eliz@gnu.org>
+   Date: Fri, 17 Oct 2025 14:15:41 +0300
+   Subject: [PATCH] Support Tree-sitter version 0.26 and later
+
+diff --git a/src/treesit.c b/src/treesit.c
+index bf982de580bd..69751b5ea106 100644
+--- a/emacs-30.2/src/treesit.c
++++ b/emacs-30.2/src/treesit.c
+@@ -34,7 +34,11 @@ along with GNU Emacs.  If not, see <http
+ # include "w32common.h"
+ 
+ /* In alphabetical order.  */
++#if TREE_SITTER_LANGUAGE_VERSION >= 15
++#undef ts_language_abi_version
++#else
+ #undef ts_language_version
++#endif
+ #undef ts_node_child
+ #undef ts_node_child_by_field_name
+ #undef ts_node_child_count
+@@ -89,7 +93,11 @@ along with GNU Emacs.  If not, see <http
+ #undef ts_tree_get_changed_ranges
+ #undef ts_tree_root_node
+ 
++#if TREE_SITTER_LANGUAGE_VERSION >= 15
++DEF_DLL_FN (uint32_t, ts_language_abi_version, (const TSLanguage *));
++#else
+ DEF_DLL_FN (uint32_t, ts_language_version, (const TSLanguage *));
++#endif
+ DEF_DLL_FN (TSNode, ts_node_child, (TSNode, uint32_t));
+ DEF_DLL_FN (TSNode, ts_node_child_by_field_name,
+ 	    (TSNode, const char *, uint32_t));
+@@ -166,7 +174,11 @@ init_treesit_functions (void)
+   if (!library)
+     return false;
+ 
++#if TREE_SITTER_LANGUAGE_VERSION >= 15
++  LOAD_DLL_FN (library, ts_language_abi_version);
++#else
+   LOAD_DLL_FN (library, ts_language_version);
++#endif
+   LOAD_DLL_FN (library, ts_node_child);
+   LOAD_DLL_FN (library, ts_node_child_by_field_name);
+   LOAD_DLL_FN (library, ts_node_child_count);
+@@ -224,7 +236,11 @@ init_treesit_functions (void)
+   return true;
+ }
+ 
++#if TREE_SITTER_LANGUAGE_VERSION >= 15
++#define ts_language_abi_version fn_ts_language_abi_version
++#else
+ #define ts_language_version fn_ts_language_version
++#endif
+ #define ts_node_child fn_ts_node_child
+ #define ts_node_child_by_field_name fn_ts_node_child_by_field_name
+ #define ts_node_child_count fn_ts_node_child_count
+@@ -632,6 +648,22 @@ treesit_load_language_push_for_each_suff
+     }
+ }
+ 
++/* This function is a compatibility shim.  Tree-sitter 0.25 introduced
++   ts_language_abi_version as a replacement for ts_language_version, and
++   tree-sitter 0.26 removed ts_language_version.  Here we use the fact
++   that 0.25 bumped TREE_SITTER_LANGUAGE_VERSION to 15, to use the new
++   function instead of the old one, when Emacs is compiled against
++   tree-sitter version 0.25 or newer.  */
++static uint32_t
++treesit_language_abi_version (const TSLanguage *ts_lang)
++{
++#if TREE_SITTER_LANGUAGE_VERSION >= 15
++  return ts_language_abi_version (ts_lang);
++#else
++  return ts_language_version (ts_lang);
++#endif
++}
++
+ /* Load the dynamic library of LANGUAGE_SYMBOL and return the pointer
+    to the language definition.
+ 
+@@ -746,7 +778,7 @@ treesit_load_language (Lisp_Object langu
+     {
+       *signal_symbol = Qtreesit_load_language_error;
+       *signal_data = list2 (Qversion_mismatch,
+-			    make_fixnum (ts_language_version (lang)));
++			    make_fixnum (treesit_language_abi_version (lang)));
+       return NULL;
+     }
+   return lang;
+@@ -817,7 +849,7 @@ Return nil if a grammar library for LANG
+ 						       &signal_data);
+       if (ts_language == NULL)
+ 	return Qnil;
+-      uint32_t version =  ts_language_version (ts_language);
++      uint32_t version =  treesit_language_abi_version (ts_language);
+       return make_fixnum((ptrdiff_t) version);
+     }
+ }
+

--- a/srcpkgs/emacs/template
+++ b/srcpkgs/emacs/template
@@ -1,7 +1,7 @@
 # Template file for 'emacs'
 pkgname=emacs
 version=30.2
-revision=2
+revision=3
 create_wrksrc=required
 build_style=gnu-configure
 configure_args="--with-file-notification=inotify --with-modules
@@ -50,7 +50,7 @@ desc_option_xpm="Enable support for XPM images"
 build_options_default="cairo gif gmp gnutls harfbuzz jpeg m17n nativecomp
  png sound sqlite svg tiff treesitter webp xml xpm"
 
-post_extract() {
+post_patch() {
 	# Just configuring in different directories results in
 	# spurious emacs rebuilds with incompatible build numbers.
 	cp -a emacs-* nox

--- a/srcpkgs/neovim/patches/tree-sitter-0.26.patch
+++ b/srcpkgs/neovim/patches/tree-sitter-0.26.patch
@@ -1,0 +1,247 @@
+NOTE: has been slightly edited in order to apply cleanly
+
+From a9c6564bcbee9fb0e00c056d8c88fd9f60e49e7e Mon Sep 17 00:00:00 2001
+From: Riley Bruins <ribru17@hotmail.com>
+Date: Thu, 20 Mar 2025 14:50:15 -0700
+Subject: [PATCH] refactor(treesitter): migrate to ts parser callback API
+
+---
+ runtime/lua/vim/treesitter/_meta/misc.lua   |  4 +-
+ runtime/lua/vim/treesitter/languagetree.lua | 43 ++++++++++------
+ src/nvim/lua/treesitter.c                   | 57 +++++++++++----------
+ 3 files changed, 58 insertions(+), 46 deletions(-)
+
+diff --git a/runtime/lua/vim/treesitter/_meta/misc.lua b/runtime/lua/vim/treesitter/_meta/misc.lua
+index 07a1c921c744c3..9b9cc4eb5469d5 100644
+--- a/runtime/lua/vim/treesitter/_meta/misc.lua
++++ b/runtime/lua/vim/treesitter/_meta/misc.lua
+@@ -5,12 +5,10 @@ error('Cannot require a meta file')
+ ---@alias TSLoggerCallback fun(logtype: 'parse'|'lex', msg: string)
+ 
+ ---@class TSParser: userdata
+----@field parse fun(self: TSParser, tree: TSTree?, source: integer|string, include_bytes: boolean): TSTree, (Range4|Range6)[]
++---@field parse fun(self: TSParser, tree: TSTree?, source: integer|string, include_bytes: boolean, timeout_ns: integer?): TSTree?, (Range4|Range6)[]
+ ---@field reset fun(self: TSParser)
+ ---@field included_ranges fun(self: TSParser, include_bytes: boolean?): integer[]
+ ---@field set_included_ranges fun(self: TSParser, ranges: (Range6|TSNode)[])
+----@field set_timeout fun(self: TSParser, timeout: integer)
+----@field timeout fun(self: TSParser): integer
+ ---@field _set_logger fun(self: TSParser, lex: boolean, parse: boolean, cb: TSLoggerCallback)
+ ---@field _logger fun(self: TSParser): TSLoggerCallback
+ 
+diff --git a/runtime/lua/vim/treesitter/languagetree.lua b/runtime/lua/vim/treesitter/languagetree.lua
+index e7cee33a038866..6f0e377d2f920f 100644
+--- a/runtime/lua/vim/treesitter/languagetree.lua
++++ b/runtime/lua/vim/treesitter/languagetree.lua
+@@ -43,8 +43,10 @@
+ local query = require('vim.treesitter.query')
+ local language = require('vim.treesitter.language')
+ local Range = require('vim.treesitter._range')
++local hrtime = vim.uv.hrtime
+ 
+-local default_parse_timeout_ms = 3
++-- Parse in 3ms chunks.
++local default_parse_timeout_ns = 3 * 1000000
+ 
+ ---@type Range2
+ local entire_document_range = { 0, math.huge }
+@@ -198,16 +200,16 @@ function LanguageTree:_set_logger()
+   self._parser:_set_logger(log_lex, log_parse, self._logger)
+ end
+ 
+----Measure execution time of a function
++---Measure execution time of a function, in nanoseconds.
+ ---@generic R1, R2, R3
+ ---@param f fun(): R1, R2, R3
+ ---@return number, R1, R2, R3
+ local function tcall(f, ...)
+-  local start = vim.uv.hrtime()
++  local start = hrtime()
+   ---@diagnostic disable-next-line
+   local r = { f(...) }
+   --- @type number
+-  local duration = (vim.uv.hrtime() - start) / 1000000
++  local duration = hrtime() - start
+   --- @diagnostic disable-next-line: redundant-return-value
+   return duration, unpack(r)
+ end
+@@ -388,18 +390,29 @@ function LanguageTree:_parse_regions(range, thread_state)
+       )
+     then
+       self._parser:set_included_ranges(ranges)
+-      self._parser:set_timeout(thread_state.timeout and thread_state.timeout * 1000 or 0) -- ms -> micros
+ 
+-      local parse_time, tree, tree_changes =
+-        tcall(self._parser.parse, self._parser, self._trees[i], self._source, true)
++      local parse_time, tree, tree_changes = tcall(
++        self._parser.parse,
++        self._parser,
++        self._trees[i],
++        self._source,
++        true,
++        thread_state.timeout
++      )
+       while true do
+         if tree then
+           break
+         end
+         coroutine.yield(self._trees, false)
+ 
+-        parse_time, tree, tree_changes =
+-          tcall(self._parser.parse, self._parser, self._trees[i], self._source, true)
++        parse_time, tree, tree_changes = tcall(
++          self._parser.parse,
++          self._parser,
++          self._trees[i],
++          self._source,
++          true,
++          thread_state.timeout
++        )
+       end
+ 
+       self:_subtract_time(thread_state, parse_time)
+@@ -503,7 +516,7 @@ function LanguageTree:_async_parse(range, on_parse)
+   local buf = is_buffer_parser and vim.b[source] or nil
+   local ct = is_buffer_parser and buf.changedtick or nil
+   local total_parse_time = 0
+-  local redrawtime = vim.o.redrawtime
++  local redrawtime = vim.o.redrawtime * 1000000
+ 
+   local thread_state = {} ---@type ParserThreadState
+ 
+diff --git a/runtime/lua/vim/treesitter/languagetree.lua b/runtime/lua/vim/treesitter/languagetree.lua
+index a346bf59637fa0..5d3599920ea308 100644
+--- a/runtime/lua/vim/treesitter/languagetree.lua
++++ b/runtime/lua/vim/treesitter/languagetree.lua
+@@ -997,7 +997,7 @@
+ 
+   ---@type table<integer,vim.treesitter.languagetree.Injection>
+   local injections = {}
+-  local start = vim.uv.hrtime()
++  local start = hrtime()
+ 
+   local full_scan = range == true or self._injection_query.has_combined_injections
+ 
+@@ -1021,9 +1021,9 @@
+       end
+ 
+       -- Check the current function duration against the timeout, if it exists.
+-      local current_time = vim.uv.hrtime()
+-      self:_subtract_time(thread_state, (current_time - start) / 1000000)
+-      start = current_time
++      local current_time = hrtime()
++      self:_subtract_time(thread_state, current_time - start)
++      start = hrtime()
+     end
+   end
+
+diff --git a/src/nvim/lua/treesitter.c b/src/nvim/lua/treesitter.c
+index a346bf59637fa0..5d3599920ea308 100644
+--- a/src/nvim/lua/treesitter.c
++++ b/src/nvim/lua/treesitter.c
+@@ -15,6 +15,8 @@
+ #include <tree_sitter/api.h>
+ #include <uv.h>
+ 
++#include "nvim/os/time.h"
++
+ #ifdef HAVE_WASMTIME
+ # include <wasm.h>
+ 
+@@ -54,5 +56,10 @@ typedef struct {
+ } TSLuaTree;
+ 
++typedef struct {
++  uint64_t parse_start_time;
++  uint64_t timeout_threshold_ns;
++} TSLuaParserCallbackPayload;
++
+ #ifdef INCLUDE_GENERATED_DECLARATIONS
+ # include "lua/treesitter.c.generated.h"
+ #endif
+@@ -362,8 +369,6 @@ static struct luaL_Reg parser_meta[] = {
+   { "reset", parser_reset },
+   { "set_included_ranges", parser_set_ranges },
+   { "included_ranges", parser_get_ranges },
+-  { "set_timeout", parser_set_timeout },
+-  { "timeout", parser_get_timeout },
+   { "_set_logger", parser_set_logger },
+   { "_logger", parser_get_logger },
+   { NULL, NULL }
+@@ -487,6 +492,13 @@ static void push_ranges(lua_State *L, const TSRange *ranges, const size_t length
+   }
+ }
+ 
++static bool on_parser_progress(TSParseState *state)
++{
++  TSLuaParserCallbackPayload *payload = state->payload;
++  uint64_t parse_time = os_hrtime() - payload->parse_start_time;
++  return parse_time >= payload->timeout_threshold_ns;
++}
++
+ static int parser_parse(lua_State *L)
+ {
+   TSParser *p = parser_check(L, 1);
+@@ -524,7 +536,17 @@ static int parser_parse(lua_State *L)
+     }
+ 
+     input = (TSInput){ (void *)buf, input_cb, TSInputEncodingUTF8, NULL };
+-    new_tree = ts_parser_parse(p, old_tree, input);
++    if (!lua_isnil(L, 5)) {
++      uint64_t timeout_ns = (uint64_t)lua_tointeger(L, 5);
++      TSLuaParserCallbackPayload payload =
++        (TSLuaParserCallbackPayload){ .parse_start_time = os_hrtime(),
++                                      .timeout_threshold_ns = timeout_ns };
++      TSParseOptions parse_options = { .payload = &payload,
++                                       .progress_callback = on_parser_progress };
++      new_tree = ts_parser_parse_with_options(p, old_tree, input, parse_options);
++    } else {
++      new_tree = ts_parser_parse(p, old_tree, input);
++    }
+ 
+     break;
+ 
+@@ -534,12 +556,11 @@ static int parser_parse(lua_State *L)
+ 
+   bool include_bytes = (lua_gettop(L) >= 4) && lua_toboolean(L, 4);
+ 
+-  // Sometimes parsing fails (timeout, or wrong parser ABI)
+-  // In those case, just return an error.
+   if (!new_tree) {
+-    if (ts_parser_timeout_micros(p) == 0) {
+-      // No timeout set, must have had an error
+-      return luaL_error(L, "An error occurred when parsing.");
++    // Sometimes parsing fails (no language was set, or it was set to one with an incompatible ABI)
++    // In those cases, just return an error.
++    if (!ts_parser_language(p)) {
++      return luaL_error(L, "Language was unset, or has an incompatible ABI.");
+     }
+     return 0;
+   }
+@@ -670,26 +691,6 @@ static int parser_get_ranges(lua_State *L)
+   return 1;
+ }
+ 
+-static int parser_set_timeout(lua_State *L)
+-{
+-  TSParser *p = parser_check(L, 1);
+-
+-  if (lua_gettop(L) < 2) {
+-    luaL_error(L, "integer expected");
+-  }
+-
+-  uint32_t timeout = (uint32_t)luaL_checkinteger(L, 2);
+-  ts_parser_set_timeout_micros(p, timeout);
+-  return 0;
+-}
+-
+-static int parser_get_timeout(lua_State *L)
+-{
+-  TSParser *p = parser_check(L, 1);
+-  lua_pushinteger(L, (lua_Integer)ts_parser_timeout_micros(p));
+-  return 1;
+-}
+-
+ static void logger_cb(void *payload, TSLogType logtype, const char *s)
+ {
+   TSLuaLoggerOpts *opts = (TSLuaLoggerOpts *)payload;

--- a/srcpkgs/neovim/template
+++ b/srcpkgs/neovim/template
@@ -1,7 +1,7 @@
 # Template file for 'neovim'
 pkgname=neovim
 version=0.11.6
-revision=1
+revision=2
 # as per https://github.com/neovim/neovim/blob/master/cmake.deps/deps.txt
 _treesitter_c_version=0.24.1
 _treesitter_lua_version=0.4.0

--- a/srcpkgs/rizin/template
+++ b/srcpkgs/rizin/template
@@ -3,7 +3,7 @@
 # Rebuild cutter on update
 pkgname=rizin
 version=0.7.3
-revision=5
+revision=6
 build_style=meson
 configure_args="-D use_sys_capstone=enabled -D use_capstone_version=v5
  -D use_sys_magic=enabled -D use_sys_libzip=enabled -D use_sys_zlib=enabled

--- a/srcpkgs/tree-sitter/patches/disable-qjs-rt.patch
+++ b/srcpkgs/tree-sitter/patches/disable-qjs-rt.patch
@@ -1,7 +1,8 @@
-diff -ruN tree-sitter-0.26.7.orig/crates/cli/Cargo.toml tree-sitter-0.26.7/crates/cli/Cargo.toml
---- tree-sitter-0.26.7.orig/crates/cli/Cargo.toml
-+++ tree-sitter-0.26.7/crates/cli/Cargo.toml
-@@ -30,7 +30,7 @@
+diff --git a/crates/cli/Cargo.toml b/crates/cli/Cargo.toml
+index c10b465..0a3319b 100644
+--- a/crates/cli/Cargo.toml
++++ b/crates/cli/Cargo.toml
+@@ -30,7 +30,7 @@ name = "benchmark"
  harness = false
  
  [features]
@@ -10,10 +11,11 @@ diff -ruN tree-sitter-0.26.7.orig/crates/cli/Cargo.toml tree-sitter-0.26.7/crate
  wasm = ["tree-sitter/wasm", "tree-sitter-loader/wasm"]
  qjs-rt = ["tree-sitter-generate/qjs-rt"]
  
-diff -ruN tree-sitter-0.26.7.orig/crates/generate/Cargo.toml tree-sitter-0.26.7/crates/generate/Cargo.toml
---- tree-sitter-0.26.7.orig/crates/generate/Cargo.toml
-+++ tree-sitter-0.26.7/crates/generate/Cargo.toml
-@@ -20,7 +20,7 @@
+diff --git a/crates/generate/Cargo.toml b/crates/generate/Cargo.toml
+index 5e93bf4..1ad9cd6 100644
+--- a/crates/generate/Cargo.toml
++++ b/crates/generate/Cargo.toml
+@@ -20,7 +20,7 @@ path = "src/generate.rs"
  workspace = true
  
  [features]

--- a/srcpkgs/tree-sitter/patches/disable-qjs-rt.patch
+++ b/srcpkgs/tree-sitter/patches/disable-qjs-rt.patch
@@ -1,0 +1,23 @@
+diff -ruN tree-sitter-0.26.7.orig/crates/cli/Cargo.toml tree-sitter-0.26.7/crates/cli/Cargo.toml
+--- tree-sitter-0.26.7.orig/crates/cli/Cargo.toml
++++ tree-sitter-0.26.7/crates/cli/Cargo.toml
+@@ -30,7 +30,7 @@
+ harness = false
+ 
+ [features]
+-default = ["qjs-rt"]
++default = []
+ wasm = ["tree-sitter/wasm", "tree-sitter-loader/wasm"]
+ qjs-rt = ["tree-sitter-generate/qjs-rt"]
+ 
+diff -ruN tree-sitter-0.26.7.orig/crates/generate/Cargo.toml tree-sitter-0.26.7/crates/generate/Cargo.toml
+--- tree-sitter-0.26.7.orig/crates/generate/Cargo.toml
++++ tree-sitter-0.26.7/crates/generate/Cargo.toml
+@@ -20,7 +20,7 @@
+ workspace = true
+ 
+ [features]
+-default = ["qjs-rt"]
++default = ["load"]
+ load = ["dep:semver"]
+ qjs-rt = ["load", "rquickjs", "pathdiff"]

--- a/srcpkgs/tree-sitter/template
+++ b/srcpkgs/tree-sitter/template
@@ -15,7 +15,7 @@ checksum=4343107ad1097a35e106092b79e5dd87027142c6fba5e4486b1d1d44d5499f84
 make_check=no # tests require generating fixtures from remote repositories
 
 do_build() {
-	cargo auditable build ${XBPS_VERBOSE+-v} --release --offline \
+	cargo auditable build ${XBPS_VERBOSE+-v} --release \
 		--target ${RUST_TARGET} ${configure_args} ${make_build_args}
 }
 

--- a/srcpkgs/tree-sitter/template
+++ b/srcpkgs/tree-sitter/template
@@ -1,17 +1,23 @@
 # Template file for 'tree-sitter'
 pkgname=tree-sitter
-version=0.25.10
+version=0.26.7
 revision=1
 build_style=cargo
-make_install_args="--path=cli"
+make_install_args="--path=crates/cli"
+hostmakedepends="clang"
 short_desc="Parser generator tool and incremental parsing library"
 maintainer="Érico Nogueira <ericonr@disroot.org>"
 license="MIT"
 homepage="https://tree-sitter.github.io"
 changelog="https://github.com/tree-sitter/tree-sitter/releases"
 distfiles="https://github.com/tree-sitter/tree-sitter/archive/refs/tags/v${version}.tar.gz"
-checksum=ad5040537537012b16ef6e1210a572b927c7cdc2b99d1ee88d44a7dcdc3ff44c
+checksum=4343107ad1097a35e106092b79e5dd87027142c6fba5e4486b1d1d44d5499f84
 make_check=no # tests require generating fixtures from remote repositories
+
+do_build() {
+	cargo auditable build ${XBPS_VERBOSE+-v} --release --offline \
+		--target ${RUST_TARGET} ${configure_args} ${make_build_args}
+}
 
 post_build() {
 	# Build libtree-sitter, since do_build builds the tree-sitter CLI.


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Notes
tree-sitter 0.26 introduced rquickjs (QuickJS JS runtime) as a CLI
dependency, breaking cross-compilation for armv6l-musl, armv7l, aarch64
and aarch64-musl. The disable-qjs-rt.patch disables the qjs-rt feature
to fix this.

neovim and emacs require patches to adapt to the new tree-sitter 0.26
API (ts_language_version was replaced by ts_language_abi_version,
ts_parser_set_timeout_micros was replaced by TSParseOptions callback).

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64 (crossbuild)
  - aarch64-musl (crossbuild)
  - armv6l-musl (crossbuild)
  - armv7l (crossbuild)