### PR TITLE
New package: NetExec-1.5.1

### DIFF
--- a/srcpkgs/NetExec/patches/dynamic-versioning.patch
+++ b/srcpkgs/NetExec/patches/dynamic-versioning.patch
@@ -1,0 +1,31 @@
+Dynamic versioning doesn't work with release sources as it is missing a .git
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -1,6 +1,6 @@
+ [project]
+ name = "netexec"
+-dynamic = ["version"]
++version = "0.0.0"
+ description = "The Network Execution tool"
+ readme = "README.md"
+ requires-python = ">=3.10,<4.0"
+@@ -69,18 +69,8 @@
+ packages = [{ include = "nxc" }]
+ version = "0.0.0" # Poetry placeholder, do not remove
+
+-[tool.poetry.requires-plugins]
+-poetry-dynamic-versioning = { version = ">=1.7.0,<2.0.0", extras = ["plugin"] }
+-
+-[tool.poetry-dynamic-versioning]
+-enable = true
+-style = "pep440"
+-pattern = "(?P<base>\\d+\\.\\d+\\.\\d+)"
+-format = "{base}+{distance}.{commit}"
+-
+ [build-system]
+-requires = ["poetry-core>=1.0.0", "poetry-dynamic-versioning>=1.0.0,<2.0.0"]
+-build-backend = "poetry_dynamic_versioning.backend"
++requires = ["poetry-core>=1.0.0"]
+
+ [tool.poetry.group.dev.dependencies]
+ flake8 = "*"

--- a/srcpkgs/NetExec/template
+++ b/srcpkgs/NetExec/template
@@ -1,0 +1,22 @@
+# Template file for 'NetExec'
+pkgname=NetExec
+version=1.5.1
+revision=1
+build_style=python3-pep517
+hostmakedepends="python3-poetry-core python3-build python3-installer python3-wheel PyInstaller"
+depends="python3-termcolor python3-rich python3-libnmap python3-xmltodict python3-SQLAlchemy2 python3-pycryptodomex python3-argcomplete python3-BeautifulSoup4 python3-PyJWT python3-paramiko	python3-pefile python3-requests python3-terminaltables python3-dateutil python3-dnspython python3-pyasn1-modules impacket python3-openssl"
+short_desc="Network Execution Tool"
+maintainer="Soulful Sailer <soulful.sailer@entropic.pro>"
+license="BSD-2-Clause"
+homepage="https://netexec.wiki/"
+distfiles="https://github.com/Pennyw0rth/${pkgname}/archive/refs/tags/v${version}.tar.gz"
+checksum=75de40a2f93b39f502d80487c2cdad08b86167882daccb78c43cf4ebad817fa5
+
+post_patch() {
+	# Insert version as dynamic versioning is disabled (see dynamic-versioning.patch)
+	sed -i "s|version = \"0.0.0\"|version = \"${version}\"|g" pyproject.toml
+}
+
+post_install() {
+	vlicense LICENSE
+}

--- a/srcpkgs/python3-libnmap/template
+++ b/srcpkgs/python3-libnmap/template
@@ -1,0 +1,13 @@
+# Template file for 'python3-libnmap'
+pkgname=python3-libnmap
+version=0.7.3
+revision=1
+build_style=python3-module
+hostmakedepends="python3-build python3-installer python3-setuptools python3-wheel"
+depends="python3"
+short_desc="Python library to run nmap scans, parse and diff scan results"
+maintainer="Soulful Sailer <soulful.sailer@entropic.pro>"
+license="Apache-2.0"
+homepage="https://github.com/savon-noir/python-libnmap/"
+distfiles="https://github.com/savon-noir/python-libnmap/archive/refs/tags/v${version}.tar.gz"
+checksum=18a890dd2a2615fdc1219a0e74e3d8b468b4adf6aeb19a9167a8d70c35e28afc


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**


#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)

Closes #58462 

Package builds (but is missing python dependencies), installs and runs. 

However, in testing with those missing dependencies, it is not usable for even basic functions, and will need to be added.

Here is the list of missing dependencies:
- aardwolf
- asyauth
- bloodhound-ce
- dploot
- dsinternals
- jwt
- lsassy
- masky
- minikerberos
- neo4j
- pylnk3
- pypsrp
- pypykatz
- certipy-ad
- oscrypto
- pynfsclient

Also ran into it telling me I'm missing the modules `impacket.examples.regsecrets` and `impacket.dcerpc.v5.gkdi` impacket is installed as a dependency, but seems to still be missing some modules?

I did also get `python3-poetry-dynamic-versioning` (and it's missing dependencies `python3-cleo` + `python3-crashtest`) to build fine, but it doesn't seem to work for the version release source files, because it can't get git info. So I patched it out, which seems to work fine. But let me know if there's a better way to go about that!