### PR TITLE
wayland: update to 1.25.0

### DIFF
--- a/srcpkgs/wayland-doc
+++ b/srcpkgs/wayland-doc
@@ -1,0 +1,1 @@
+wayland

--- a/srcpkgs/wayland/template
+++ b/srcpkgs/wayland/template
@@ -1,18 +1,18 @@
 # Template file for 'wayland'
 pkgname=wayland
-version=1.24.0
+version=1.25.0
 revision=1
 build_style=meson
 # "Tests must not be built with NDEBUG defined, they rely on assert()."
-configure_args="-Ddocumentation=false -Db_ndebug=false"
-hostmakedepends="flex pkg-config"
+configure_args="-Ddocumentation=true -Db_ndebug=false"
+hostmakedepends="flex pkg-config mdBook doxygen graphviz libxslt xmlto"
 makedepends="expat-devel libffi-devel libfl-devel libxml2-devel"
 short_desc="Core Wayland window system code and protocol"
 maintainer="Érico Nogueira <ericonr@disroot.org>"
 license="MIT"
 homepage="https://wayland.freedesktop.org/"
 distfiles="https://gitlab.freedesktop.org/wayland/wayland/-/releases/${version}/downloads/wayland-${version}.tar.xz"
-checksum=82892487a01ad67b334eca83b54317a7c86a03a89cfadacfef5211f11a5d0536
+checksum=c065f040afdff3177680600f249727e41a1afc22fccf27222f15f5306faa1f03
 
 if [ "$XBPS_CHECK_PKGS" ]; then
 	configure_args+=" -Dtests=true"
@@ -36,7 +36,15 @@ wayland-devel_package() {
 		vmove usr/include
 		vmove usr/share/aclocal
 		vmove usr/share/wayland
+		vmove usr/share/man/man3
 		vmove usr/lib/pkgconfig
 		vmove "usr/lib/*.so"
+	}
+}
+
+wayland-doc_package() {
+	short_desc+=" - documentation"
+	pkg_install() {
+		vmove usr/share/doc
 	}
 }


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**
- no issues so far running these applications:

```
[*] Waybar-0.15.0_2          Polybar-like Wayland Bar for Sway and Wlroots based compositors
[*] bemenu-0.6.23_1          Dynamic menu library and client program inspired by dmenu
[*] cliphist-0.7.0_1         Wayland clipboard manager
[*] firefox-148.0.2_1        Mozilla Firefox web browser
[*] foot-1.26.1_1            Fast, lightweight and minimalistic Wayland terminal emulator
[*] foot-terminfo-1.26.1_1   Fast, lightweight and minimalistic Wayland terminal emulator - terminfo data
[*] grim-1.5.0_1             Grab images from a Wayland compositor
[*] gtk-layer-shell-0.10.0_1 Library to create panels and other desktop components for Wayland
[*] imv-5.0.1_2              Image viewer for X11/Wayland
[*] labwc-0.9.6_1            Wayland window-stacking compositor
[*] libdecor-0.2.5_1         Client-side decorations library for Wayland client
[*] libinput-1.31.0_1        Provides handling input devices in Wayland compositors and X
[*] slurp-1.5.0_1            Select a region in a Wayland compositor
[*] swaybg-1.2.2_1           Wallpaper tool for Wayland compositors
[*] swayidle-1.9.0_1         Idle management daemon for Wayland
[*] swaylock-1.8.5_1         Screen locker for Wayland
[*] wayfire-0.10.1_1         3D wayland compositor
[*] wayland-1.25.0_0         Core Wayland window system code and protocol
[*] wl-clipboard-2.2.1_1     Wayland clipboard utilities
[*] wlroots0.19-0.19.2_1     Modular Wayland compositor library 0.19
[*] wlsunset-0.4.0_1         Day/night gamma adjustments for Wayland compositors
[*] wob-0.16_1               Lightweight overlay volume/backlight/progress/anything bar for Wayland
[*] wtype-0.4_1              Wayland version of xdotool
[*] wvkbd-0.19.4_1           On-screen keyboard for wlroots
```

#### Local build testing
- I built this PR locally for my native architecture, **x86_64-glibc**
- I built this PR locally for these architectures:
  - x86_64-musl
  - armv6l (cross)
  
closes #55929

cc @ericonr 