### PR TITLE
libadwaita: move all demo files to libadwaita-demo

### DIFF
--- a/srcpkgs/libadwaita/template
+++ b/srcpkgs/libadwaita/template
@@ -1,7 +1,7 @@
 # Template file for 'libadwaita'
 pkgname=libadwaita
 version=1.8.1
-revision=1
+revision=2
 build_style=meson
 build_helper="gir"
 configure_args="-Dexamples=true -Dtests=true $(vopt_bool gtk_doc)
@@ -51,5 +51,9 @@ libadwaita-demo_package() {
 	short_desc+=" - demonstration application"
 	pkg_install() {
 		vmove usr/bin/adwaita-1-demo
+		vmove usr/share/applications/org.gnome.Adwaita1.Demo.desktop
+		vmove usr/share/metainfo/org.gnome.Adwaita1.Demo.metainfo.xml
+		vmove usr/share/icons/hicolor/symbolic/apps/org.gnome.Adwaita1.Demo-symbolic.svg
+		vmove usr/share/icons/hicolor/scalable/apps/org.gnome.Adwaita1.Demo.svg
 	}
 }


### PR DESCRIPTION
Before this PR, libadwaita included a .desktop file that referenced the executable packaged in libadwaita-demo. This caused some applications (such as menulibre) to complain about an invalid desktop file when libadwaita is installed without libadwaita-demo.

This PR moves all files related to adwaita-1-demo to the appropriate subpackage.

#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):