### PR TITLE
droidcam: update to 2.1.5.

### DIFF
--- a/srcpkgs/droidcam/template
+++ b/srcpkgs/droidcam/template
@@ -1,6 +1,6 @@
 # Template file for 'droidcam'
 pkgname=droidcam
-version=2.1.4
+version=2.1.5
 revision=1
 build_style=gnu-makefile
 make_use_env=true
@@ -15,7 +15,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="https://www.dev47apps.com/"
 distfiles="https://github.com/dev47apps/droidcam/archive/v${version}.tar.gz"
-checksum=785c2d760b410b90b78a4f9604656e462a5c2eb9c1a351c61237dd57c36c0a4a
+checksum=00ec96ec7a660e4e3ffb2adc536d14af89c635766dadbf53326c1216187021f8
 
 post_patch() {
 	vsed -e "s/^Icon=.*/Icon=droidcam-icon.png/" -e "s,/local,," -i droidcam.desktop


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures using specific masterdirs:
  - x86_64-musl
  - i686
- I built this PR locally for these architectures (crossbuilds):
  - aarch64
  - aarch64-musl
  - armv7l
  - armv7l-musl
  - armv6l
  - armv6l-musl