### PR TITLE
Nbd: update to 3.27.1

### DIFF
--- a/srcpkgs/nbd/files/nbd/run
+++ b/srcpkgs/nbd/files/nbd/run
@@ -1,3 +1,3 @@
 #!/bin/sh
 exec 2>&1
-exec nbd-server -d 2>&1
+exec nbd-server -n

--- a/srcpkgs/nbd/template
+++ b/srcpkgs/nbd/template
@@ -1,23 +1,21 @@
 # Template file for 'nbd'
 pkgname=nbd
-version=3.24
+version=3.27.0
 revision=1
 build_style=gnu-configure
 configure_args="--enable-syslog"
 hostmakedepends="pkg-config bison"
-makedepends="libglib-devel"
+makedepends="libglib-devel libnl3-devel gnutls-devel"
 short_desc="Network Block Device utilities"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="https://nbd.sourceforge.io/"
-distfiles="${SOURCEFORGE_SITE}/nbd/nbd-${version}.tar.gz"
-checksum=a771022599525fd4f5c17c7b1c88696a91927c227e770425a55f67a7384441b6
+distfiles="https://github.com/NetworkBlockDevice/nbd/releases/download/nbd-${version}/nbd-${version}.tar.xz"
+checksum=422a02adcdbab01c622307c6babeda5c84ca6c6f2d4e0b29936e6ae9b6a7662f
 
 system_accounts="nbd"
 nbd_homedir="/var/chroot"
 conf_files="/etc/nbd-server/config"
-
-CFLAGS+="-DPROG_NAME='\"nbd-client\"'"
 
 post_configure() {
 	# skip systemd unit

--- a/srcpkgs/nbd/template
+++ b/srcpkgs/nbd/template
@@ -6,6 +6,7 @@ build_style=gnu-configure
 configure_args="--enable-syslog"
 hostmakedepends="pkg-config bison"
 makedepends="libglib-devel libnl3-devel gnutls-devel"
+checkdepends="which"
 short_desc="Network Block Device utilities"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later"

--- a/srcpkgs/nbd/template
+++ b/srcpkgs/nbd/template
@@ -1,22 +1,28 @@
 # Template file for 'nbd'
 pkgname=nbd
-version=3.27.0
+version=3.27.1
 revision=1
 build_style=gnu-configure
 configure_args="--enable-syslog"
-hostmakedepends="pkg-config bison"
+hostmakedepends="autoconf-archive automake flex libtool pkg-config bison"
 makedepends="libglib-devel libnl3-devel gnutls-devel"
 checkdepends="which"
 short_desc="Network Block Device utilities"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="https://nbd.sourceforge.io/"
-distfiles="https://github.com/NetworkBlockDevice/nbd/releases/download/nbd-${version}/nbd-${version}.tar.xz"
-checksum=422a02adcdbab01c622307c6babeda5c84ca6c6f2d4e0b29936e6ae9b6a7662f
+distfiles="https://github.com/NetworkBlockDevice/nbd/archive/refs/tags/nbd-${version}.tar.gz"
+checksum=5e99e7556d713663b7926fa9fde53219be170123bff1c1a3835b78f21cc4befc
 
 system_accounts="nbd"
 nbd_homedir="/var/chroot"
 conf_files="/etc/nbd-server/config"
+
+pre_configure() {
+	# Do not require git at build time
+	echo "echo '${version}'" > support/genver.sh
+	autoreconf -f -i
+}
 
 post_configure() {
 	# skip systemd unit


### PR DESCRIPTION
And assorted changes:
- runit config tweaks
- project hosting moved to git
- added dependencies (libnl3, gnutls)
- removed CFLAGS addition
- building fixes (1x warning & 1x error)
- added check dependency: `which` 

I separated the runit tweaks in their own commit, is that useful or should I squash everything together ?

#### Testing the changes
- I tested the changes in this PR: **briefly**

Tested localhost self- export & mount from void x86_64-musl.
Tested mounting on openwrt 25.12.1 (mipsel_24kc) from the x86_64-musl host exports.
Of two different file-based exports, one simple, the other with templated name.
Also tested a real block device (a partition from a SATA SSD drive) exported from the nbd-server on the OpenWRT host and mounted to the x86_64-musl void one.

OpenWRT has different versions:
- nbd-3.25-r2
- kmod-nbd-6.12.74-r1

All tests ran properly.

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-musl)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64 (crossbuild)
  - riscv64-musl (crossbuild)

#### CI Build failure log analysis

The i686 failure is in the check phase, one of the tests FAIL'ed.
with:
```
[...]
2026-03-22T17:55:26.1782013Z 5052: Requests: 2718
2026-03-22T17:55:26.1786510Z 5052: Requests: 2719
2026-03-22T17:55:26.1787514Z ** (process:5052): WARNING **: 17:55:26.177: Could not run test: Could not write to socket: Broken pipe
2026-03-22T17:55:26.1878169Z FAIL: tree
```