### PR TITLE
ironbar: update to 0.18.0.

### DIFF
--- a/srcpkgs/ironbar/template
+++ b/srcpkgs/ironbar/template
@@ -1,17 +1,18 @@
 # Template file for 'ironbar'
 pkgname=ironbar
-version=0.16.0
+version=0.18.0
 revision=1
 build_style=cargo
 hostmakedepends="pkg-config"
-makedepends="gtk+3-devel gtk-layer-shell-devel pulseaudio-devel"
-short_desc="Customisable gtk-layer-shell wlroots/sway bar"
+makedepends="gtk4-devel gtk4-layer-shell-devel pulseaudio-devel libevdev-devel
+	libinput-devel openssl-devel dbus-devel"
+short_desc="Customisable Wayland GTK4 bar written in Rust"
 maintainer="caughtquick <abhijit@sipahimalani.me>"
 license="MIT"
 homepage="https://github.com/JakeStanger/ironbar"
 changelog="https://github.com/JakeStanger/ironbar/releases/"
 distfiles="https://github.com/JakeStanger/ironbar/archive/refs/tags/v${version}.tar.gz"
-checksum=5b4e96a5f1c96406fa99299b8ad2c0f97dc56c44237b8328cfb64c8daf17d3b5
+checksum=d5fafc7038e99f57b8502a4a7b8a32b0e7438744557658b9e8a3ce100a079a52
 
 if [ "${XBPS_WORDSIZE}" = "${XBPS_TARGET_WORDSIZE}" ]; then
 	makedepends+=" LuaJIT-devel"
@@ -19,17 +20,17 @@ else
 	# Disable cairo feature that requires LuaJIT; otherwise,
 	# keep this feature list in sync with Cargo.toml
 	configure_args+=" --no-default-features
-	 --features=cli,clipboard,clock,config+all,focused,http,ipc
-	 --features=launcher,music+all,network_manager,notifications
-	 --features=sys_info,tray,upower,volume,workspaces+all
+	 --features=battery,bindmode+all,bluetooth,cli,clipboard
+	 --features=clock,config+all,custom,focused,http,ipc
+	 --features=keyboard+all,launcher,label,menu,music+all
+	 --features=network_manager,notifications,script
+	 --features=sys_info,tray,volume,workspaces+all,extras
 	"
 fi
 
 post_install() {
 	vlicense LICENSE
 
-	local f
-	for f in examples/*; do
-		[ -f "${f}" ] && vsconf "${f}"
-	done
+	vmkdir usr/share/examples/ironbar
+	vcopy examples/* usr/share/examples/ironbar
 }


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)

#### Changes

Package now uses GTK4. Updated dependencies and description, synced feature list with `Cargo.toml` and replaced `vsconf` with `vcopy` to reflect current structure of the provided example files. 