### PR TITLE
Fix rust build helper, pijul: update to 1.0.0.beta.9

### DIFF
--- a/common/build-helper/rust.sh
+++ b/common/build-helper/rust.sh
@@ -49,9 +49,7 @@ export GETTEXT_INCLUDE_DIR="${XBPS_CROSS_BASE}/usr/include"
 export LIBSSH2_SYS_USE_PKG_CONFIG=1
 
 # sodium-sys
-export SODIUM_LIB_DIR="${XBPS_CROSS_BASE}/usr/include"
-export SODIUM_INC_DIR="${XBPS_CROSS_BASE}/usr/lib"
-export SODIUM_SHARED=1
+export SODIUM_USE_PKG_CONFIG=1
 
 # openssl-sys
 export OPENSSL_NO_VENDOR=1

--- a/srcpkgs/pijul/template
+++ b/srcpkgs/pijul/template
@@ -1,7 +1,7 @@
 # Template file for 'pijul'
 pkgname=pijul
-version=1.0.0.beta.6
-revision=2
+version=1.0.0.beta.9
+revision=1
 _crates_version="${version%.*.*}-${version#*.*.*.}"
 build_style=cargo
 build_helper=qemu
@@ -12,7 +12,7 @@ maintainer="Toyam Cox <Vaelatern@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="https://pijul.org/"
 distfiles="https://static.crates.io/crates/pijul/pijul-${_crates_version}.crate"
-checksum=b7757b1c39487a70d82d5e5f5e432e7d9cf3c24cb837b90cf1c436da8edba802
+checksum=c51a43abf66dfdd63393f9d7e426129a769c7345d64d451a30be9399733062d2
 
 post_install() {
 	for shell in bash fish zsh; do


### PR DESCRIPTION
common/build-helper/rust.sh: use SODIUM_USE_PKG_CONFIG, pijul: update to 1.0.0.beta.9

Fixes #59131

#### Testing the changes
- I tested the changes in this PR: **YES**
- This change to the build helper doesn't break nor remove the dependency on libsodium of any of the other rust packages that use libsodium.

#### Local build testing
- I built this PR locally for my native architecture, x86_64
