### PR TITLE
tldr: update to 1.12.0

### DIFF
--- a/srcpkgs/tldr/template
+++ b/srcpkgs/tldr/template
@@ -1,21 +1,19 @@
 # Template file for 'tldr'
 pkgname=tldr
-version=1.0.0.alpha
-revision=5
-_version=${version/.alpha/-alpha}
-build_style=go
-go_import_path="github.com/isacikgoz/tldr"
-go_package="./cmd/tldr"
+version=1.12.0
+revision=1
+build_style=cargo
 depends="git"
-short_desc="Fast and interactive TLDR client written in Go"
+short_desc="Official tldr client written in Rust"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
-homepage="https://isacikgoz.me/tldr/"
-distfiles="https://github.com/isacikgoz/tldr/archive/v${_version}.tar.gz"
-checksum=d40e1c602d84acc67cdee3b9bed001fb8ec198c7049c1d05eb071ab05af66c19
-alternatives="tldr:tldr:/usr/bin/gtldr"
+homepage="https://tldr.sh/"
+distfiles="https://github.com/tldr-pages/tlrc/archive/v${version}.tar.gz"
+checksum=402942f1bc37301da9dd1870294d7edd8e81989a178c6439cfbd866d9a9bf67a
+alternatives="tldr:tldr:/usr/bin/tlrc"
 
 post_install() {
-	mv ${DESTDIR}/usr/bin/tldr ${DESTDIR}/usr/bin/gtldr
+	# Rename to tlrc + mark as an alternative to avoid conflict with tealdeer and potentially other clients
+	mv ${DESTDIR}/usr/bin/tldr ${DESTDIR}/usr/bin/tlrc
 	vlicense LICENSE
 }


### PR DESCRIPTION
The currrent package is based on an unofficial tldr client that hasn't seen updates in over 3 years, and is no longer fully compatible with tldr's doc format. This commit switches to [the official tlrc client](https://github.com/tldr-pages/tlrc) which is actively maintained. Both clients fundamentally pull from [the content repository](https://github.com/tldr-pages/tldr) for actual content.

~~I haven't copied a `gtldr` alias which exists in the original, happy to add it for backwards compatibility if necessary.~~
upd: Found that was integrating with alternatives, did the same here.

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-libc
