### PR TITLE
wl-clipboard: update to 2.3.0.

### DIFF
--- a/srcpkgs/wl-clipboard/template
+++ b/srcpkgs/wl-clipboard/template
@@ -1,6 +1,6 @@
 # Template file for 'wl-clipboard'
 pkgname=wl-clipboard
-version=2.2.1
+version=2.3.0
 revision=1
 build_style=meson
 hostmakedepends="wayland-devel pkg-config"
@@ -10,4 +10,4 @@ maintainer="skmpz <dem.procopiou@gmail.com>"
 license="GPL-3.0-or-later"
 homepage="https://github.com/bugaevc/wl-clipboard"
 distfiles="https://github.com/bugaevc/wl-clipboard/archive/v${version}.tar.gz"
-checksum=6eb8081207fb5581d1d82c4bcd9587205a31a3d47bea3ebeb7f41aa1143783eb
+checksum=b4dc560973f0cd74e02f817ffa2fd44ba645a4f1ea94b7b9614dacc9f895f402


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture: amd64

finally supports the --sensitive flag to avoid pushing passwords into a clipboard manager's unencrypted local store, as well as some other goodies.