### PR TITLE
freetype: update to 2.14.3

### DIFF
--- a/srcpkgs/freetype/template
+++ b/srcpkgs/freetype/template
@@ -1,6 +1,6 @@
 # Template file for 'freetype'
 pkgname=freetype
-version=2.14.2
+version=2.14.3
 revision=1
 build_style=gnu-configure
 configure_args="--enable-freetype-config"
@@ -13,7 +13,7 @@ homepage="https://www.freetype.org/"
 # Should be using NONGNU_SITE instead, but that often redirects to outdated
 # mirrors, causing fetching the distfile to fail.
 distfiles="https://download-mirror.savannah.gnu.org/releases/freetype/freetype-${version}.tar.xz"
-checksum=4b62dcab4c920a1a860369933221814362e699e26f55792516d671e6ff55b5e1
+checksum=36bc4f1cc413335368ee656c42afca65c5a3987e8768cc28cf11ba775e785a5f
 
 post_patch() {
 	vsed -i -e "s/%PKG_CONFIG%/pkg-config/" builds/unix/freetype-config.in


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**
- `firefox` `fnott` `foot` and `Waybar` are rendering fonts as expected after the update

#### Local build testing
- I built this PR locally for my native architecture, **x86_64-glibc**

[Changelog](https://sourceforge.net/projects/freetype/files/freetype2/2.14.3/)