### PR TITLE
evolution: prevent crash when opening attachments

### DIFF
--- a/srcpkgs/evolution/patches/attachments.patch
+++ b/srcpkgs/evolution/patches/attachments.patch
@@ -1,0 +1,90 @@
+From 811a6df1f990855e49ecc0ba7b1a7f7a5ec251e6 Mon Sep 17 00:00:00 2001
+From: Milan Crha <mcrha@redhat.com>
+Date: Fri, 29 Aug 2025 07:42:10 +0200
+Subject: [PATCH] I#3124 - JavaScript: Correct dictionary objects creation
+ (WebKitGTK 2.49.4)
+
+The arrays do not have named indexes, though it worked only by a chance
+with the previous WebKitGTK versions. Correct how the objects are created
+to follow the standard.
+
+Closes https://gitlab.gnome.org/GNOME/evolution/-/issues/3124
+---
+ data/webkit/e-editor.js   | 10 +++++-----
+ data/webkit/e-web-view.js |  4 ++--
+ 2 files changed, 7 insertions(+), 7 deletions(-)
+
+diff --git a/data/webkit/e-editor.js b/data/webkit/e-editor.js
+index c4e643d9ea..340ff54643 100644
+--- a/data/webkit/e-editor.js
++++ b/data/webkit/e-editor.js
+@@ -4409,7 +4409,7 @@ EvoEditor.LinkGetProperties = function()
+ 	var res = null, anchor = EvoEditor.getParentElement("A", null, false);
+ 
+ 	if (anchor) {
+-		res = [];
++		res = {};
+ 		res["href"] = anchor.hasAttribute("href") ? anchor.getAttribute("href") : "";
+ 		res["text"] = anchor.innerText;
+ 		res["name"] = anchor.name;
+@@ -4419,7 +4419,7 @@ EvoEditor.LinkGetProperties = function()
+ 		range = document.getSelection().getRangeAt(0);
+ 
+ 		if (range) {
+-			res = [];
++			res = {};
+ 			res["text"] = range.toString();
+ 		}
+ 	}
+@@ -5513,7 +5513,7 @@ EvoEditor.InsertSignature = function(content, isHTML, canRepositionCaret, uid, f
+ 		EvoUndoRedo.StopRecord(EvoUndoRedo.RECORD_KIND_GROUP, "InsertSignature");
+ 	}
+ 
+-	var res = [];
++	var res = {};
+ 
+ 	res["fromMessage"] = fromMessage;
+ 	res["checkChanged"] = checkChanged;
+@@ -6722,7 +6722,7 @@ EvoEditor.onContextMenu = function(event)
+ 	if (document.getSelection().isCollapsed)
+ 		nodeFlags |= EvoEditor.E_CONTENT_EDITOR_NODE_IS_TEXT_COLLAPSED;
+ 
+-	res = [];
++	res = {};
+ 
+ 	res["nodeFlags"] = nodeFlags;
+ 	res["caretWord"] = EvoEditor.GetCaretWord();
+@@ -6743,7 +6743,7 @@ document.onselectionchange = function() {
+ 	EvoEditor.maybeUpdateFormattingState(EvoEditor.forceFormatStateUpdate ? EvoEditor.FORCE_YES : EvoEditor.FORCE_MAYBE);
+ 	EvoEditor.forceFormatStateUpdate = false;
+ 
+-	var sel = document.getSelection(), args = [];
++	var sel = document.getSelection(), args = {};
+ 
+ 	args["isCollapsed"] = sel.isCollapsed;
+ 
+diff --git a/data/webkit/e-web-view.js b/data/webkit/e-web-view.js
+index 591ee4f20e..b83899ba32 100644
+--- a/data/webkit/e-web-view.js
++++ b/data/webkit/e-web-view.js
+@@ -399,7 +399,7 @@ Evo.elementClicked = function(elem)
+ 		dom_window = parent_dom_window;
+ 	}
+ 
+-	var res = [];
++	var res = {};
+ 
+ 	res["iframe-id"] = parent_iframe_id;
+ 	res["elem-id"] = elem.id;
+@@ -617,7 +617,7 @@ Evo.GetElementFromPoint = function(xx, yy)
+ 	if (!elem)
+ 		return null;
+ 
+-	var res = [], iframe;
++	var res = {}, iframe;
+ 
+ 	iframe = elem.ownerDocument.defaultView.frameElement;
+ 
+-- 
+GitLab
+

--- a/srcpkgs/evolution/template
+++ b/srcpkgs/evolution/template
@@ -1,7 +1,7 @@
 # Template file for 'evolution'
 pkgname=evolution
 version=3.56.2
-revision=1
+revision=2
 build_style=cmake
 build_helper="qemu"
 configure_args="-DSYSCONF_INSTALL_DIR=/etc


### PR DESCRIPTION
The current version of evolution shipped by void crashes when the user attempts to open an attachment from the message preview (opening the message, then opening the attachment works).

This is caused by a change in webkit from 2.49.4 onwards as per this [bug 298016](https://bugs.webkit.org/show_bug.cgi?id=298016). Void ships a newer version of webkit and, while Milan Crha fixed the issue downstream, the version for evolution currently shipped by void does not include this patch. 

After applying this patch and updating evolution, attachment can be now opened from the message preview.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
#### Local build testing
- I built this PR locally for my native architecture, x86-64
