### PR TITLE
snapper: update to 0.13.0

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -1409,7 +1409,7 @@ libgfrpc.so.0 libglusterfs-8.3_2
 libgfxdr.so.0 libglusterfs-8.3_2
 libgfapi.so.0 libglusterfs-8.3_2
 libglusterd.so.0 libglusterfs-8.3_2
-libsnapper.so.7 libsnapper-0.11.2_1
+libsnapper.so.8 libsnapper-0.13.0_1
 libtsm.so.4 libtsm-4.0.2_1
 libxine.so.2 libxine-1.2.4_1
 libjbig2dec.so.0 libjbig2dec-0.11_1

--- a/srcpkgs/snapper/template
+++ b/srcpkgs/snapper/template
@@ -1,15 +1,14 @@
 # Template file for 'snapper'
 pkgname=snapper
-version=0.12.2
-revision=4
+version=0.13.0
+revision=1
 build_style=gnu-configure
 configure_args="--disable-zypp --disable-systemd --with-conf=/etc/conf.d"
 conf_files="/etc/conf.d/snapper"
 make_dirs="/etc/snapper/configs 0755 root root"
 hostmakedepends="automake docbook-xsl libtool libxml2-devel libxslt
  gettext pkg-config"
-makedepends="acl-devel boost-devel-minimal libboost_thread
- dbus-devel e2fsprogs-devel libbtrfs-devel
+makedepends="acl-devel boost-devel-minimal dbus-devel libbtrfs-devel
  libmount-devel libxml2-devel pam-devel ncurses-devel ncurses-libtinfo-devel
  json-c-devel"
 depends="dbus"
@@ -17,8 +16,9 @@ short_desc="Tool for Linux filesystem snapshot management"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-only"
 homepage="http://snapper.io"
+changelog="https://raw.githubusercontent.com/openSUSE/snapper/refs/tags/v${version}/package/snapper.changes"
 distfiles="https://github.com/openSUSE/snapper/archive/v${version}.tar.gz"
-checksum=0b902c9e6e4917ae035b60d20166b176e417718b9a853534fff057b14a2cbff8
+checksum=b660b34ea175443404fc109cf2a1d20f699f0d62358d44807079600962c413ed
 lib32disabled=yes
 
 if [ "$XBPS_TARGET_LIBC" = musl ]


### PR DESCRIPTION
In addition to the version update cleaned some build deps:
  - libboost_thread: part of boost-devel-minimal as of at least 0a420a4ae
  - e2fsprogs-devel: no longer a snapper dependency as of 0.12.2

#### Testing the changes
- I tested the changes in this PR: **YES**, snapshot browsing+creating+rollback

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, x86_64-LIBC

