### PR TITLE
New package: ferrumc-0.3.0

### DIFF
--- a/srcpkgs/ferrumc/template
+++ b/srcpkgs/ferrumc/template
@@ -1,0 +1,15 @@
+# Template file for 'ferrumc'
+pkgname=ferrumc
+version=0.3.0
+revision=1
+archs="x86_64 aarch64"
+short_desc="Ferrum-language compiler with compile-time memory safety"
+maintainer="Ferrum-Language <noreply@ferrum-lang.org>"
+license="GPL-3.0-only"
+homepage="https://ferrum-language.github.io/Ferrum/"
+distfiles="https://github.com/Ferrum-Language/Ferrum/releases/download/v${version}/ferrumc-v${version}-linux-${XBPS_TARGET_MACHINE}.tar.gz"
+checksum="2735cf702ff9c3f3bf9ad95140bde211f3e642590e9222800f81969727ea6029"
+
+do_install() {
+	vbin ferrumc
+}


### PR DESCRIPTION
## New package: ferrumc

**Ferrum-language compiler** — systems programming with C syntax and compile-time memory safety via a borrow checker and ownership model. Compiled to native code through LLVM 18.

- **License:** GPL-3.0-only
- **Homepage:** https://ferrum-language.github.io/Ferrum/
- **Upstream:** https://github.com/Ferrum-Language/Ferrum/releases/tag/v0.3.0
- **Architectures:** x86_64, aarch64

SHA256 verified against upstream GitHub release.