### PR TITLE
pgpdump: update to 0.37

### DIFF
--- a/srcpkgs/pgpdump/template
+++ b/srcpkgs/pgpdump/template
@@ -1,15 +1,20 @@
 # Template file for 'pgpdump'
 pkgname=pgpdump
-version=0.36
+version=0.37
 revision=1
 build_style=gnu-configure
+hostmakedepends="autoconf automake"
 short_desc="PGP packet visualizer"
 maintainer="Michael Aldridge <maldridge@voidlinux.org>"
 license="BSD-3-Clause"
 homepage="https://www.mew.org/~kazu/proj/pgpdump"
 changelog="https://raw.githubusercontent.com/kazu-yamamoto/pgpdump/main/CHANGES"
 distfiles="https://github.com/kazu-yamamoto/pgpdump/archive/refs/tags/v${version}.tar.gz"
-checksum=9831fb578175f97f77e269326cb06e5367161e9ddbbfb7f753cef12f0f479c1d
+checksum=bc3b6b85f3c95c68010883675283c1c905e6c4070ac5609ced1a87c53b3ee814
+
+pre_configure() {
+	autoreconf -i
+}
 
 post_install() {
 	vlicense COPYRIGHT


### PR DESCRIPTION
They removed the pre-built configure so we have to add an autoconf step.

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-libc

Cc. @the-maldridge 