### PR TITLE
New package: ddcui-0.6.0

### DIFF
--- a/srcpkgs/ddcui/template
+++ b/srcpkgs/ddcui/template
@@ -1,0 +1,14 @@
+# Template file for 'ddcui'
+pkgname=ddcui
+version=0.6.0
+revision=1
+build_style=cmake
+configure_args="-DUSE_QT6=ON"
+hostmakedepends="cmake pkg-config qt6-base qt6-tools qt6-help"
+makedepends="ddcutil-devel qt6-base-devel qt6-tools-devel"
+short_desc="GUI for ddcutil"
+maintainer="JudahJL <judahlegy@gmail.com>"
+license="GPL-2.0-or-later"
+homepage="https://www.ddcutil.com/"
+distfiles="https://github.com/rockowitz/ddcui/archive/refs/tags/v${version}.tar.gz"
+checksum=89a0e33314c7bf046ab09b0e68aa3c758b8eba69f06973987522c75843237c39


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: briefly

Note: Runtime testing is limited due to my monitor (Gigabyte G24F 2) lacking USB/DDC support, which causes the application to crash on feature assertion. However, the package builds successfully.

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): YES

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (crossbuilds):
  - i686
