### PR TITLE
ergo: update to 2.18.0.

### DIFF
--- a/srcpkgs/ergo/template
+++ b/srcpkgs/ergo/template
@@ -1,9 +1,10 @@
 # Template file for 'ergo'
 pkgname=ergo
-version=2.17.0
+version=2.18.0
 revision=1
 build_style=go
 go_import_path="github.com/ergochat/ergo"
+go_build_tags="i18n mysql postgresql sqlite"
 go_ldflags="-X main.version=$version"
 short_desc="Modern IRC server with integrated bouncer features and services"
 maintainer="Lydia Sobot <chilledfrogs@disroot.org>"
@@ -11,7 +12,7 @@ license="MIT"
 homepage="https://ergo.chat/"
 changelog="https://raw.githubusercontent.com/ergochat/ergo/master/CHANGELOG.md"
 distfiles="https://github.com/ergochat/ergo/archive/v${version}.tar.gz"
-checksum=bfda2be82aa133ddd7a03c2121d6807c8a1b9f5c055f0bbb90451baa2a249ce4
+checksum=5dafcdc9b1eaed0273d54dc274a050d983f79057fbc529af0c52704b1a540680
 system_accounts="_ergo"
 _ergo_homedir="/var/lib/ergo"
 make_dirs="/var/lib/ergo 0755 _ergo _ergo"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures:
  - aarch64-musl (cross)

This release introduces build tags for various persistent history database drivers as well as internationalization, I simply replicated what the upstream Makefile does for now, i.e. enable all of them