### PR TITLE
task: update to 3.4.2

### DIFF
--- a/srcpkgs/task/template
+++ b/srcpkgs/task/template
@@ -1,10 +1,11 @@
 # Template file for 'task'
 pkgname=task
-version=3.4.1
-revision=2
+version=3.4.2
+revision=1
 archs="x86_64* aarch64* i686*" # aws-lc
 build_style=cmake
 build_helper="rust qemu"
+configure_args="-DFETCHCONTENT_SOURCE_DIR_CORROSION=${XBPS_BUILDDIR}/${pkgname}-${version}/src/taskchampion-cpp/corrosion"
 hostmakedepends="rust cargo"
 makedepends="libuuid-devel gnutls-devel rust-std sqlite-devel"
 short_desc="Task Warrior command-line todo list manager"
@@ -12,7 +13,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
 homepage="https://taskwarrior.org"
 distfiles="https://github.com/GothenburgBitFactory/taskwarrior/releases/download/v${version}/task-${version}.tar.gz"
-checksum=23eb60f73e42f16111cc3912b44ee12be6768860a2db2a9c6a47f8ac4786bac3
+checksum=d302761fcd1268e4a5a545613a2b68c61abd50c0bcaade3b3e68d728dd02e716
 
 post_extract() {
 	if [ "$CROSS_BUILD" ]; then


### PR DESCRIPTION
~~Needs git now because of the source bundling a corrosion submodule -- we could also provide corrosion as a system dependency, since we happen to ship the same 0.5.2 version they need, but this will break if we update corrosion (I tried)~~ Fixed -- just use the corrosion from the source tar

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, x86_64-libc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl
