### PR TITLE
wsdd-native: fix post_install

### DIFF
--- a/srcpkgs/wsdd-native/template
+++ b/srcpkgs/wsdd-native/template
@@ -1,7 +1,7 @@
 # Template file for 'wsdd-native'
 pkgname=wsdd-native
 version=1.23
-revision=1
+revision=2
 build_style=cmake
 configure_args="-DWSDDN_PREFER_SYSTEM_LIBXML2=ON
  -DWSDDN_PREFER_SYSTEM_FMT=ON
@@ -24,9 +24,7 @@ post_install() {
 	vlicense LICENSE
 	vdoc Acknowledgements.md
 	vsv wsdd-native
-	vinstall installers/wsddn.conf 644 etc wsddn.conf
-	sed -i "s/{RELOAD_INSTRUCTIONS}/# sv reload wsdd-native/" \
-		${DESTDIR}/etc/wsddn.conf
-	sed -i "s/{SAMPLE_IFACE_NAME}/eth0/" \
-		${DESTDIR}/etc/wsddn.conf
+	vconf installers/wsddn.conf wsddn.conf
+	vsed -i ${DESTDIR}/etc/wsddn.conf -e "s/{RELOAD_INSTRUCTIONS}/# sv reload wsdd-native/"
+	vsed -i ${DESTDIR}/etc/wsddn.conf -e "s/{SAMPLE_IFACE_NAME}/eth0/"
 }


### PR DESCRIPTION
Fix `post_install`:
- Use `vconf` instead of `vinstall` for config file installation
- Use `vsed -i` instead of `sed -i`

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)