### PR TITLE
mixxx: update to 2.5.4

### DIFF
--- a/srcpkgs/mixxx/template
+++ b/srcpkgs/mixxx/template
@@ -1,17 +1,17 @@
 # Template file for 'mixxx'
 pkgname=mixxx
-version=2.5.1
-revision=6
+version=2.5.4
+revision=1
 build_style=cmake
 configure_args="-DCMAKE_BUILD_TYPE=Release -DENGINEPRIME=OFF"
 hostmakedepends="extra-cmake-modules pkg-config protobuf qt6-tools qt6-base
- qt6-declarative-host-tools qt6-shadertools"
+ qt6-declarative-host-tools qt6-shadertools mold"
 makedepends="benchmark-devel chromaprint-devel faad2-devel ffmpeg6-devel
  glib-devel glu-devel gperftools-devel gtest-devel lame-devel libid3tag-devel
  libsndfile-devel libmad-devel libmodplug-devel libusb-devel opusfile-devel
- libflac-devel libogg-devel libvorbis-devel lilv-devel lv2
+ libflac-devel libogg-devel libvorbis-devel lilv-devel lv2 libmp4v2-devel
  wavpack-devel portaudio-devel portmidi-devel protobuf-devel rubberband-devel
- taglib-devel upower-devel hidapi-devel speex-devel soundtouch-devel
+ taglib-devel upower-devel hidapi-devel soundtouch-devel libshout-idjc-devel
  qt6-qt5compat-devel qt6-base-devel qt6-declarative-devel
  qt6-base-private-devel qt6-declarative-private-devel qt6-svg-devel
  qt6-tools-devel qtkeychain-qt6-devel qt6-shadertools-devel libebur128-devel
@@ -21,5 +21,6 @@ short_desc="Open source digital DJing software that allows mixing music"
 maintainer="prez <prez@national.shitposting.agency>"
 license="GPL-2.0-or-later"
 homepage="https://www.mixxx.org"
+changelog="https://raw.githubusercontent.com/mixxxdj/mixxx/refs/tags/${version}/CHANGELOG.md"
 distfiles="https://github.com/mixxxdj/mixxx/archive/${version}.tar.gz"
-checksum=626f7a64292c1ef77d8aace4a746140f455596d44a6984db9d1e4caf4c4ce09d
+checksum=53fb1a2a6c5ac6eb3562cb99c5bcae8777d81e48b96b5b3c292794c0c105b269


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly** (I mixed a few songs with a Pioneer controller with no issues)

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)

#### Summary
- libshout-idjc is in void repo, use it (instead of the one vendored with mixxx)
- speex is already included in libshout-idjc
- libmp4v2 for MP4 support
- mold for faster linking

cc @prez 
