### PR TITLE
libpng: update to 1.6.56.

### DIFF
--- a/srcpkgs/libpng/template
+++ b/srcpkgs/libpng/template
@@ -1,6 +1,6 @@
 # Template file for 'libpng'
 pkgname=libpng
-version=1.6.55
+version=1.6.56
 revision=1
 build_style=gnu-configure
 makedepends="zlib-devel"
@@ -10,7 +10,7 @@ license="Libpng"
 homepage="http://www.libpng.org/pub/png/libpng.html"
 changelog="https://github.com/pnggroup/libpng/blob/master/CHANGES"
 distfiles="${SOURCEFORGE_SITE}/libpng/libpng-${version}.tar.xz"
-checksum=d925722864837ad5ae2a82070d4b2e0603dc72af44bd457c3962298258b8e82d
+checksum=f7d8bf1601b7804f583a254ab343a6549ca6cf27d255c302c47af2d9d36a6f18
 
 case "$XBPS_TARGET_MACHINE" in
 	arm*) configure_args="--enable-arm-neon=no";;


### PR DESCRIPTION
- I tested the changes in this PR: briefly
- I built this PR locally for my native architecture, (aarch64-gnu)

cc @leahneukirchen https://www.openwall.com/lists/oss-security/2026/03/26/1