### PR TITLE
exiv2: update to 0.28.8

### DIFF
--- a/srcpkgs/exiv2/template
+++ b/srcpkgs/exiv2/template
@@ -1,6 +1,6 @@
 # Template file for 'exiv2'
 pkgname=exiv2
-version=0.28.7
+version=0.28.8
 revision=1
 build_style=cmake
 configure_args="-DEXIV2_BUILD_SAMPLES=OFF -DEXIV2_ENABLE_BMFF=ON"
@@ -12,7 +12,7 @@ license="GPL-2.0-or-later"
 homepage="https://exiv2.org"
 changelog="https://exiv2.org/whatsnew.html"
 distfiles="https://github.com/Exiv2/exiv2/archive/refs/tags/v${version}.tar.gz"
-checksum=5e292b02614dbc0cee40fe1116db2f42f63ef6b2ba430c77b614e17b8d61a638
+checksum=ea51b0609f58a9afa063b60daa1539948b62247721e154f4fff0ad3aec9f9756
 
 if [ -n "$XBPS_CHECK_PKGS" ]; then
 	configure_args+=" -DEXIV2_BUILD_UNIT_TESTS=ON"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, **x86_64-glibc**

This update contains mostly [CVE fixes](https://exiv2.org/whatsnew.html)

cc @Gottox 