### PR TITLE
emptty: update to 0.16.0

### DIFF
--- a/srcpkgs/emptty/template
+++ b/srcpkgs/emptty/template
@@ -1,16 +1,16 @@
 # Template file for 'emptty'
 pkgname=emptty
-version=0.15.0
+version=0.16.0
 revision=1
 build_style=go
 go_import_path=github.com/tvrzna/emptty
-makedepends="pam-devel libX11-devel"
+makedepends="pam-devel"
 short_desc="Dead simple Display Manager running in CLI as TTY login"
 maintainer="tvrzna <emporeor@gmail.com>"
 license="MIT"
 homepage="https://github.com/tvrzna/emptty"
 distfiles="https://github.com/tvrzna/emptty/archive/v${version}.tar.gz"
-checksum=fae7c04afeeb9ef3dcbb9bca67e9a2fa940e99a91872ebc0775e10253972c7f3
+checksum=35a5d60d21b4496a7df1b14ce7f7b7be0be9dc1e54c1e86e17e49f6dd83732a8
 conf_files="/etc/emptty/conf /etc/pam.d/emptty"
 
 post_install() {


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x64 glibc)