### PR TITLE
luarocks: update to 3.11.1

### DIFF
--- a/srcpkgs/luarocks-lua53/template
+++ b/srcpkgs/luarocks-lua53/template
@@ -1,6 +1,6 @@
 # Template file for 'luarocks-lua53'
 pkgname=luarocks-lua53
-version=3.11.0
+version=3.11.1
 revision=1
 build_style=configure
 configure_args="
@@ -17,7 +17,7 @@ license="MIT"
 homepage="https://luarocks.org/"
 changelog="https://github.com/luarocks/luarocks/wiki/Release-history"
 distfiles="https://luarocks.org/releases/luarocks-${version}.tar.gz"
-checksum=25f56b3c7272fb35b869049371d649a1bbe668a56d24df0a66e3712e35dd44a6
+checksum=c3fb3d960dffb2b2fe9de7e3cb004dc4d0b34bb3d342578af84f84325c669102
 alternatives="
  luarocks:luarocks:/usr/bin/luarocks-5.3
  luarocks:luarocks-admin:/usr/bin/luarocks-admin-5.3"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
#### Local build testing
- I built this PR locally for my native architecture, (x86_64)
<!--
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->

---

Cc: @Duncaen

I only bumped the patch version to avoid potential troubles as I have no experience with luarocks. My interest was in the fix for [this issue](https://github.com/luarocks/luarocks/issues/1667) which is contained in this release and without which installing prosody modules doesn't work for me.
