### PR TITLE
common/shlibs: add missing rdma-core sonames

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -3699,8 +3699,14 @@ libfrr.so.0 libfrr-6.0_1
 libkaccounts6.so.2 kf6-kaccounts-integration-24.02.0_1
 libfrrospfapiclient.so.0 libfrrospfapiclient-6.0_1
 liborocos-kdl.so.1.5 orocos-kdl-1.5.1_1
+libefa.so.1 rdma-core-22.1_1
+libibmad.so.5 rdma-core-22.1_1
+libibnetdisc.so.5 rdma-core-22.1_1
 libibumad.so.3 rdma-core-22.1_1
 libibverbs.so.1 rdma-core-22.1_1
+libmana.so.1 rdma-core-22.1_1
+libmlx4.so.1 rdma-core-22.1_1
+libmlx5.so.1 rdma-core-22.1_1
 librdmacm.so.1 rdma-core-22.1_1
 libdvdcss.so.2 libdvdcss-1.4.2_1
 libvalapanel.so.0 vala-panel-0.4.87_1


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for these architectures:
  - x86_64-glibc
  - aarch64-glibc

rdma-core ships several shared libraries that were never registered in common/shlibs. Packages linking against them (e.g. perftest) fail with `UNKNOWN PKG PLEASE FIX`. This adds the missing entries matching the existing rdma-core minimum version:

- libefa.so.1
- libibmad.so.5
- libibnetdisc.so.5
- libmana.so.1
- libmlx4.so.1
- libmlx5.so.1