### PR TITLE
rdma-core: update to 62.0.

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -3699,8 +3699,15 @@ libfrr.so.0 libfrr-6.0_1
 libkaccounts6.so.2 kf6-kaccounts-integration-24.02.0_1
 libfrrospfapiclient.so.0 libfrrospfapiclient-6.0_1
 liborocos-kdl.so.1.5 orocos-kdl-1.5.1_1
+libefa.so.1 rdma-core-22.1_1
+libhns.so.1 rdma-core-22.1_1
+libibmad.so.5 rdma-core-22.1_1
+libibnetdisc.so.5 rdma-core-22.1_1
 libibumad.so.3 rdma-core-22.1_1
 libibverbs.so.1 rdma-core-22.1_1
+libmana.so.1 rdma-core-22.1_1
+libmlx4.so.1 rdma-core-22.1_1
+libmlx5.so.1 rdma-core-22.1_1
 librdmacm.so.1 rdma-core-22.1_1
 libdvdcss.so.2 libdvdcss-1.4.2_1
 libvalapanel.so.0 vala-panel-0.4.87_1

--- a/srcpkgs/rdma-core/files/09-rdma.sh
+++ b/srcpkgs/rdma-core/files/09-rdma.sh
@@ -1,0 +1,10 @@
+# Load RDMA kernel modules at boot
+for conf in rdma infiniband roce iwarp; do
+    [ -r "/etc/rdma/modules/${conf}.conf" ] || continue
+    while read -r mod; do
+        case "$mod" in
+            "#"*|"") continue ;;
+        esac
+        modprobe -q "$mod" 2>/dev/null
+    done < "/etc/rdma/modules/${conf}.conf"
+done

--- a/srcpkgs/rdma-core/files/rdma-ndd/run
+++ b/srcpkgs/rdma-core/files/rdma-ndd/run
@@ -1,0 +1,3 @@
+#!/bin/sh
+exec 2>&1
+exec rdma-ndd --systemd

--- a/srcpkgs/rdma-core/template
+++ b/srcpkgs/rdma-core/template
@@ -1,10 +1,12 @@
 # Template file for 'rdma-core'
 pkgname=rdma-core
-version=44.0
+version=62.0
 revision=1
 build_style=cmake
 configure_args="-DENABLE_VALGRIND=OFF
- -DCMAKE_INSTALL_MODPROBEDIR=/usr/lib/modprobe.d"
+ -DCMAKE_INSTALL_MODPROBEDIR=/usr/lib/modprobe.d
+ -DCMAKE_INSTALL_RUNDIR=/run
+ -DCMAKE_INSTALL_PERLDIR=/usr/share/perl5/vendor_perl"
 hostmakedepends="pkg-config python3 $(vopt_if docs 'pandoc python3-docutils')"
 makedepends="libnl3-devel eudev-libudev-devel python3-devel"
 short_desc="RDMA core userspace libraries and daemons"
@@ -12,7 +14,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later, BSD-2-Clause, MIT"
 homepage="https://github.com/linux-rdma/rdma-core"
 distfiles="https://github.com/linux-rdma/rdma-core/releases/download/v${version}/rdma-core-${version}.tar.gz"
-checksum=25d6601e60f27bbcd75e07fe340400cb80e6c3c487679700535385cfc9d9858b
+checksum=c00ad60e614162ba4d731db941d4d653bb426938d8d33ef1a11f204cbc5302a0
 build_options="docs"
 desc_option_docs="Enable documentation"
 
@@ -31,8 +33,17 @@ case "$XBPS_MACHINE" in
 esac
 
 post_install() {
-	# not needed
 	rm -rf ${DESTDIR}/usr/lib/systemd ${DESTDIR}/etc/init.d
+	rm -f ${DESTDIR}/usr/lib/udev/rules.d/60-srp_daemon.rules
+	rm -f ${DESTDIR}/usr/lib/udev/rules.d/90-rdma-ulp-modules.rules
+	rm -f ${DESTDIR}/usr/lib/udev/rules.d/60-rdma-ndd.rules
+	rm -f ${DESTDIR}/usr/lib/udev/rules.d/90-rdma-umad.rules
+	rm -f ${DESTDIR}/usr/lib/udev/rules.d/90-iwpmd.rules
+
+	vinstall kernel-boot/dracut/50rdma/module-setup.sh 755 \
+		usr/lib/dracut/modules.d/50rdma
+	vinstall ${FILESDIR}/09-rdma.sh 644 etc/runit/core-services
+	vsv rdma-ndd
 
 	vlicense COPYING.BSD_FB
 	vlicense COPYING.BSD_MIT


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for these architectures:
  - aarch64-glibc

Bumps rdma-core from 44.0 to 62.0. Changes beyond the version bump:

- Added cmake flags for correct Void paths (sbindir, libexecdir, rundir, perldir)
- Added `pre_configure` to fix hardcoded paths in dracut/redhat scripts
- Install dracut module for RDMA (`50rdma`)
- Remove systemd-dependent udev rules that don't work without systemd
- Added runit core-service `09-rdma.sh` to load RDMA kernel modules at boot (replaces systemd `rdma-load-modules@.service`)
- Added runit service for `rdma-ndd` (replaces systemd `rdma-ndd.service`)