### PR TITLE
nghttp2: update to v1.68.1

### DIFF
--- a/srcpkgs/nghttp2/template
+++ b/srcpkgs/nghttp2/template
@@ -1,6 +1,6 @@
 # Template file for 'nghttp2'
 pkgname=nghttp2
-version=1.68.0
+version=1.68.1
 revision=1
 build_style=gnu-configure
 # build system errors out if python isn't available
@@ -14,7 +14,7 @@ maintainer="skmpz <dem.procopiou@gmail.com>"
 license="MIT"
 homepage="https://nghttp2.org"
 distfiles="https://github.com/nghttp2/nghttp2/releases/download/v${version}/nghttp2-${version}.tar.xz"
-checksum=5511d3128850e01b5b26ec92bf39df15381c767a63441438b25ad6235def902c
+checksum=6abd7ab0a7f1580d5914457cb3c85eb80455657ee5119206edbd7f848c14f0b2
 python_version=3
 
 post_install() {


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, x86-64
- I built this PR locally for these architectures:
  - aarch64 (cross)
  - aarch64-musl (cross)

https://github.com/nghttp2/nghttp2/releases/tag/v1.68.1: Fixes [CVE-2026-27135](https://github.com/nghttp2/nghttp2/security/advisories/GHSA-6933-cjhr-5qg6)

cc: @skmpz 