### PR TITLE
ngtcp2: update to 1.22.0

### DIFF
--- a/srcpkgs/ngtcp2/template
+++ b/srcpkgs/ngtcp2/template
@@ -1,6 +1,6 @@
 # Template file for 'ngtcp2'
 pkgname=ngtcp2
-version=1.21.0
+version=1.22.0
 revision=1
 build_style=gnu-configure
 hostmakedepends="pkg-config automake libtool"
@@ -11,7 +11,7 @@ license="MIT"
 homepage="https://nghttp2.org/ngtcp2"
 changelog="https://github.com/ngtcp2/ngtcp2/releases"
 distfiles="https://github.com/ngtcp2/ngtcp2/releases/download/v${version}/ngtcp2-${version}.tar.gz"
-checksum=cff43747548dc930acdd9f2950ee11422e6897288725081878852abebf978733
+checksum=9622e2f6606afb6c0a6b2d96584963d47f97b85b7c79f3f9d6adbe1215140e5b
 
 post_install() {
 	rm ${DESTDIR}/usr/share/doc/ngtcp2/README.rst


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, x86_64
- I built this PR locally for these architectures:
  - aarch64 (cross)
  - aarch64-musl (cross)

cc: @tranzystorekk 