### PR TITLE
runc: update to 1.4.1

### DIFF
--- a/srcpkgs/runc/template
+++ b/srcpkgs/runc/template
@@ -1,6 +1,6 @@
 # Template file for 'runc'
 pkgname=runc
-version=1.4.0
+version=1.4.1
 revision=1
 build_style=go
 go_import_path=github.com/opencontainers/runc
@@ -16,7 +16,7 @@ license="Apache-2.0"
 homepage="https://github.com/opencontainers/runc"
 changelog="https://github.com/opencontainers/runc/raw/main/CHANGELOG.md"
 distfiles="https://github.com/opencontainers/runc/releases/download/v${version}/runc.tar.xz"
-checksum=f67c16fe40d078be6bf40006b086068951ab885ad815dfe8fa96c0a546aac57f
+checksum=9772626f44a7b94e1da98355ec2e0fa37d6b600951ed890716f93d77d1e806c8
 
 post_build() {
 	make man


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES** (works fine on my home-server using rootless podman containers doing a number of restarts and checking all running correctly)

#### Local build testing
- I built this PR locally for my native architecture, x86_64
- I built this PR locally for these architectures:
  - aarch64 (cross)
  - aarch64-musl (cross)
