### PR TITLE
python3-markdown2: update to 2.5.5

### DIFF
--- a/srcpkgs/python3-markdown2/template
+++ b/srcpkgs/python3-markdown2/template
@@ -1,7 +1,7 @@
 # Template file for 'python3-markdown2'
 pkgname=python3-markdown2
-version=2.4.0
-revision=7
+version=2.5.5
+revision=1
 build_style=python3-module
 hostmakedepends="python3-setuptools"
 depends="python3"
@@ -10,7 +10,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
 homepage="https://github.com/trentm/python-markdown2"
 distfiles="https://github.com/trentm/python-markdown2/archive/${version}.tar.gz"
-checksum=372fc64b1a6f949fb6379cc0fdb47c832b875b575d50b9c641d09c4971ca9f30
+checksum=4dc908966f556568dbb553bbd6efb48d301db57a44fb5d47cf2ea12f398daef8
 
 do_check() {
 	PY3PATH="${PWD}/build/lib"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, (x64 glibc)