### PR TITLE
nextcloud-client: update to 4.0.8

### DIFF
--- a/srcpkgs/nextcloud-client/template
+++ b/srcpkgs/nextcloud-client/template
@@ -1,6 +1,6 @@
 # Template file for 'nextcloud-client'
 pkgname=nextcloud-client
-version=4.0.6
+version=4.0.8
 revision=1
 build_style=cmake
 configure_args="-DBUILD_UPDATER=NO -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins"
@@ -19,7 +19,7 @@ license="GPL-2.0-or-later"
 homepage="https://nextcloud.com/clients/"
 changelog="https://github.com/nextcloud/desktop/releases"
 distfiles="https://github.com/nextcloud/desktop/archive/v${version}.tar.gz"
-checksum=34079396b306be6e99c2f4073e23547ad1723b3da1988e04959b28ec7b9d1c9c
+checksum=e678729f65ce33491c56addb255ad8c07485be738a44279a04b8772b5a123fb7
 # https://github.com/void-linux/void-packages/pull/33358#discussion_r724518549
 make_check=ci-skip
 replaces="nextcloud-client-kwallet>=0 nextcloud-client-dolphin>=0"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture: x86_64-libc

NOTE: I've skipped [latest release (33.0.0)](https://github.com/nextcloud/desktop/releases/tag/v33.0.0) for now, will do some local tests before updating to it.
