### PR TITLE
[WIP] mitmproxy

### DIFF
--- a/srcpkgs/bpf-linker/template
+++ b/srcpkgs/bpf-linker/template
@@ -1,0 +1,16 @@
+# Template file for 'bpf-linker'
+pkgname=bpf-linker
+version=0.10.2
+revision=1
+build_style=cargo
+hostmakedepends="llvm21 clang21"
+short_desc="Simple BPF static linker"
+maintainer="Jason Elswick <jason@jasondavid.us>"
+license="MIT, Apache-2.0"
+homepage="https://github.com/aya-rs/bpf-linker"
+distfiles="https://github.com/aya-rs/bpf-linker/archive/refs/tags/v${version}.tar.gz"
+checksum=c4e99d548b6a0d90f6ef35acb348cf4b8944ff4ba62b2795aa688b3178d82141
+
+post_install() {
+	vlicense LICENSE-MIT
+}

--- a/srcpkgs/mitmproxy/template
+++ b/srcpkgs/mitmproxy/template
@@ -1,36 +1,31 @@
 # Template file for 'mitmproxy'
 pkgname=mitmproxy
-version=11.1.3
-revision=2
+version=12.2.1
+revision=1
 build_style=python3-pep517
 hostmakedepends="python3-setuptools"
-depends="python3-aioquic python3-Brotli python3-Flask python3-argon2 python3-asgiref
- python3-certifi python3-cryptography python3-h11 python3-h2 python3-hyperframe
- python3-kaitaistruct python3-ldap3 python3-mitmproxy-rs python3-msgpack python3-openssl
- python3-parsing python3-passlib python3-publicsuffix2 python3-pyperclip python3-ruamel.yaml
- python3-sortedcontainers python3-tornado python3-urwid python3-wsproto python3-zstandard"
-checkdepends="${depends} python3-hypothesis python3-parver
- python3-pytest-asyncio python3-pytest-cov python3-pytest-timeout python3-requests"
+depends="python3-aioquic python3-Brotli python3-Flask python3-argon2 python3-asgiref python3-certifi python3-cryptography python3-h11 python3-h2 python3-hyperframe python3-kaitaistruct python3-ldap3 python3-mitmproxy-rs python3-msgpack python3-openssl python3-parsing python3-publicsuffix2 python3-pyperclip python3-ruamel.yaml python3-sortedcontainers python3-tornado python3-urwid python3-wsproto python3-zstandard python3-bcrypt python3-mitmproxy-rs"
+checkdepends="${depends} python3-hypothesis python3-parver python3-pytest-asyncio python3-pytest-cov python3-pytest-timeout python3-requests"
 short_desc="Interactive TLS-capable intercepting HTTP proxy"
-maintainer="Orphaned <orphan@voidlinux.org>"
+maintainer="Jason Elswick <jason@jasondavid.us>"
 license="MIT"
 homepage="https://mitmproxy.org"
 changelog="https://raw.githubusercontent.com/mitmproxy/mitmproxy/main/CHANGELOG.md"
 distfiles="https://github.com/mitmproxy/mitmproxy/archive/refs/tags/v${version}.tar.gz"
-checksum=bb4f6fc8e9ac64b4c725811983e3e3ff6b2b18b2a992d80d816811709e9efde5
+checksum=73a131a533a163ac4d9da7695d0bf0c19422c2b47757c39da4833257732fdb90
 
-_skip="(test_get_version)" # This test fails without a git repository
-_skip+="or(test_wireguard)" # Tries to execute a helper binary compiled for glibc
-
-if [ "${XBPS_TARGET_MACHINE%-musl}" = 'i686' ]; then
-	_skip+="or(test_refresh)"
-fi
-
-if [ "${XBPS_BUILD_ENVIRONMENT}" = 'void-packages-ci' ]; then
-	_skip+="or(test_tun_mode)"
-fi
-
-make_check_args="-k not($_skip)"
+#_skip="(test_get_version)" # This test fails without a git repository
+#_skip+="or(test_wireguard)" # Tries to execute a helper binary compiled for glibc
+#
+#if [ "${XBPS_TARGET_MACHINE%-musl}" = 'i686' ]; then
+#	_skip+="or(test_refresh)"
+#fi
+#
+#if [ "${XBPS_BUILD_ENVIRONMENT}" = 'void-packages-ci' ]; then
+#	_skip+="or(test_tun_mode)"
+#fi
+#
+#make_check_args="-k not($_skip)"
 
 post_install() {
 	vlicense LICENSE

--- a/srcpkgs/python3-mitmproxy-linux/template
+++ b/srcpkgs/python3-mitmproxy-linux/template
@@ -1,0 +1,26 @@
+# Template file for 'python3-mitmproxy-linux'
+pkgname=python3-mitmproxy-linux
+version=0.12.9
+revision=1
+build_style=python3-pep517
+build_helper=rust
+build_wrksrc=mitmproxy-linux
+hostmakedepends="maturin cargo git rustup bpf-linker rust-src"
+makedepends="rust-std libbpf-devel"
+short_desc="Python bindings for mitmproxy's Rust code"
+maintainer="Jason Elswick <jason@jasondavid.us>"
+license="MIT"
+homepage="https://github.com/mitmproxy/mitmproxy_rs"
+changelog="https://github.com/mitmproxy/mitmproxy_rs/raw/main/CHANGELOG.md"
+distfiles="https://github.com/mitmproxy/mitmproxy_rs/archive/refs/tags/v${version}.tar.gz"
+checksum=fc20e6f576ab6e5726754555dc96f7753e3580de233f4f911cfbf224bf6dd790
+replaces="python3-mitmproxy_wireguard>=0"
+
+pre_build() {
+	export RUSTUP_TOOLCHAIN=nightly
+	export RUSTC_BOOTSTRAP=1
+}
+
+post_install() {
+	vlicense ${wrksrc}/LICENSE
+}

--- a/srcpkgs/python3-mitmproxy-rs/template
+++ b/srcpkgs/python3-mitmproxy-rs/template
@@ -1,20 +1,21 @@
 # Template file for 'python3-mitmproxy-rs'
 pkgname=python3-mitmproxy-rs
-version=0.11.1
-revision=2
+version=0.12.9
+revision=1
 build_style=python3-pep517
-build_helper="rust"
-hostmakedepends="maturin cargo"
-makedepends="rust-std python3"
-short_desc="Rust bits in mitmproxy"
-maintainer="Orphaned <orphan@voidlinux.org>"
+build_helper=rust
+build_wrksrc=mitmproxy-rs
+hostmakedepends="maturin cargo git rustup bpf-linker rust-src"
+depends="python3-mitmproxy-linux"
+short_desc="Python bindings for mitmproxy's Rust code"
+maintainer="Jason Elswick <jason@jasondavid.us>"
 license="MIT"
 homepage="https://github.com/mitmproxy/mitmproxy_rs"
 changelog="https://github.com/mitmproxy/mitmproxy_rs/raw/main/CHANGELOG.md"
-distfiles="${PYPI_SITE}/m/mitmproxy_rs/mitmproxy_rs-${version}.tar.gz"
-checksum=a77c022bc0563f9d56fa0809a27013ed2fb5d3145c599098cb1175e7326e7829
+distfiles="https://github.com/mitmproxy/mitmproxy_rs/archive/refs/tags/v${version}.tar.gz"
+checksum=fc20e6f576ab6e5726754555dc96f7753e3580de233f4f911cfbf224bf6dd790
 replaces="python3-mitmproxy_wireguard>=0"
 
 post_install() {
-	vlicense LICENSE
+	vlicense ${wrksrc}/LICENSE
 }


### PR DESCRIPTION
- **New package: bpf-linker-0.10.2**
- **New package: python3-mitmproxy-linux-0.12.9.**
- **python3-mitmproxy-rs: update to 0.12.9, adopt.**
- **mitmproxy: update to 0.12.9, adopt.**

#### Testing the changes
- I tested the changes in this PR: **NO**
Testing will be done once everything compiles.

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-libc

Running into issues compiling this (new?) dependency python3-mitmproxy-linux. This arch pkgbuild takes an interesting approach, that I have heard from maintainers here when linking this in IRC that this is NOT a good approach, and did not pass CI when I used it. Still here as a reference.
https://gitlab.archlinux.org/archlinux/packaging/packages/python-mitmproxy-rs/-/raw/main/PKGBUILD?ref_type=heads

```
error: failed to run custom build command for `mitmproxy-linux v0.12.9 (/builddir/python3-mitmproxy-linux-0.12.9/mitmproxy-linux)`

Caused by:
  process didn't exit successfully: `/builddir/python3-mitmproxy-linux-0.12.9/target/release/build/mitmproxy-linux-4ee17dbffa305b0f/build-script-build` (exit status: 1)
  --- stdout
  cargo:rerun-if-changed=/builddir/python3-mitmproxy-linux-0.12.9/mitmproxy-linux-ebpf

  --- stderr
  Error: failed to spawn env -u RUSTC -u RUSTC_WORKSPACE_WRAPPER CARGO_ENCODED_RUSTFLAGS="--cfg=bpf_target_arch=\"x86_64\"\u{1f}-Cdebuginfo=2\u{1f}-Clink-arg=--btf" "rustup" "run" "nightly" "cargo" "build" "--package" "mitmproxy-linux-ebpf" "-Z" "build-std=core" "--bins" "--message-format=json" "--release" "--target" "bpfel-unknown-none" "--features" "" "--target-dir" "/builddir/python3-mitmproxy-linux-0.12.9/target/release/build/mitmproxy-linux-7f4baed8fc763a7f/out/mitmproxy-linux-ebpf"

  Caused by:
      No such file or directory (os error 2)
warning: build failed, waiting for other jobs to finish...
💥 maturin failed
  Caused by: Failed to build a native library through cargo
  Caused by: Cargo build finished with "exit status: 101": `env -u CARGO "cargo" "rustc" "--profile" "release" "--message-format" "json-render-diagnostics" "--manifest-path" "/builddir/python3-mitmproxy-linux-0.12.9/mitmproxy-linux/Cargo.toml" "--bin" "mitmproxy-linux-redirector"`
Error: command ['maturin', 'pep517', 'build-wheel', '-i', '/usr/bin/python3', '--compatibility', 'off'] returned non-zero exit status 1

ERROR Backend subprocess exited when trying to invoke build_wheel
=> ERROR: python3-mitmproxy-linux-0.12.9_1: do_build: 'python3 -m build --no-isolation --wheel ${make_build_args} ${make_build_target}' exited with 1
=> ERROR:   in do_build() at common/build-style/python3-pep517.sh:17
```
