### PR TITLE
google-chrome: update to 146.0.7680.164.

### DIFF
--- a/srcpkgs/google-chrome/template
+++ b/srcpkgs/google-chrome/template
@@ -1,6 +1,6 @@
 # Template file for 'google-chrome'
 pkgname=google-chrome
-version=144.0.7559.132
+version=146.0.7680.164
 revision=1
 _channel=stable
 archs="x86_64"
@@ -11,7 +11,7 @@ maintainer="Michael Aldridge <maldridge@voidlinux.org>"
 license="custom:chrome"
 homepage="https://www.google.com/chrome/"
 distfiles="https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-${_channel}_${version}-1_amd64.deb"
-checksum=e55b896a2c65c3da3ea03d5ba7a4b7a36911f0a7289689921725a93194327703
+checksum=f6dd8715a3f10f0cd37b2e7b8831a96359ea856c747da222d3b2623ae651b374
 
 skiprdeps="/opt/google/chrome/libqt5_shim.so /opt/google/chrome/libqt6_shim.so"
 repository=nonfree


### PR DESCRIPTION
Updated google-chrome to the latest stable version. Tested on x86_64.