### PR TITLE
blocky: update to 0.29.0

### DIFF
--- a/srcpkgs/blocky/template
+++ b/srcpkgs/blocky/template
@@ -1,6 +1,6 @@
 # Template file for 'blocky'
 pkgname=blocky
-version=0.28.1
+version=0.29.0
 revision=1
 build_style=go
 go_import_path=github.com/0xERR0R/blocky
@@ -11,7 +11,7 @@ license="Apache-2.0"
 homepage="https://0xerr0r.github.io/blocky/latest"
 changelog="https://github.com/0xERR0R/blocky/releases"
 distfiles="https://github.com/0xERR0R/blocky/archive/v${version}.tar.gz"
-checksum=28afb06551a0d76790db86a90783abde287531d2dc095164c0bd8647e78bcb36
+checksum=4f384230965c3cf9a6cd977e2c28cfb711e1e383f9d022c78295cf896ecf9bed
 # test requires existing docker socket
 make_check=extended
 


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-musl