### PR TITLE
ty: update to 0.0.27.

### DIFF
--- a/srcpkgs/ty/template
+++ b/srcpkgs/ty/template
@@ -1,6 +1,6 @@
 # Template file for 'ty'
 pkgname=ty
-version=0.0.24
+version=0.0.27
 revision=1
 build_style=python3-pep517
 build_helper="rust qemu"
@@ -12,7 +12,7 @@ license="MIT"
 homepage="https://docs.astral.sh/ty/"
 changelog="https://raw.githubusercontent.com/astral-sh/ty/main/CHANGELOG.md"
 distfiles="https://github.com/astral-sh/ty/releases/download/${version}/source.tar.gz"
-checksum=cddb2c6022e2b96faf289c9a275bf4ee05a3430e922ffe9e123fad6a9542a325
+checksum=d83bb1a634d7cbbb3a37dc715861ad601bbcfc61c3c2211c1c2a26413df376a2
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
