### PR TITLE
python3-dbus-fast: update to 4.0.4.

### DIFF
--- a/srcpkgs/python3-dbus-fast/template
+++ b/srcpkgs/python3-dbus-fast/template
@@ -1,6 +1,6 @@
 # Template file for 'python3-dbus-fast'
 pkgname=python3-dbus-fast
-version=3.1.2
+version=4.0.4
 revision=1
 build_style=python3-pep517
 hostmakedepends="python3-setuptools python3-wheel python3-poetry-core python3-Cython"
@@ -12,7 +12,7 @@ license="MIT"
 homepage="https://github.com/bluetooth-devices/dbus-fast"
 changelog="https://github.com/bluetooth-devices/dbus-fast/raw/main/CHANGELOG.md"
 distfiles="${PYPI_SITE}/d/dbus-fast/dbus_fast-${version}.tar.gz"
-checksum=6c9e1b45e4b5e7df0c021bf1bf3f27649374e47c3de1afdba6d00a7d7bba4b3a
+checksum=43137f0b73a7adbf7d5c0e9eb9d8d34df9e6e0aeafade2166e641c52dfe0a853
 make_check=no # no tests included
 
 post_install() {


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86-64-LIBC)