### PR TITLE
gallery-dl: update to 1.31.10.

### DIFF
--- a/srcpkgs/gallery-dl/template
+++ b/srcpkgs/gallery-dl/template
@@ -1,7 +1,7 @@
 # Template file for 'gallery-dl'
 pkgname=gallery-dl
-version=1.30.2
-revision=2
+version=1.31.10
+revision=1
 build_style=python3-pep517
 hostmakedepends="python3-setuptools"
 depends="python3-requests"
@@ -11,12 +11,8 @@ maintainer="SolitudeSF <solitudesf@protonmail.com>"
 license="GPL-2.0-only"
 homepage="https://github.com/mikf/gallery-dl"
 changelog="https://raw.githubusercontent.com/mikf/gallery-dl/master/CHANGELOG.md"
-distfiles="https://github.com/mikf/gallery-dl/archive/refs/tags/v${version}.tar.gz"
-checksum=61437c6c457e282ee1bb99d1b87b9710e8bc2834c49c671aa7e68b35a5ec66f4
-
-pre_build() {
-	make man completion
-}
+distfiles="https://codeberg.org/mikf/gallery-dl/releases/download/v${version}/gallery_dl-${version}.tar.gz"
+checksum=d387c41429e14c2646eeb10285bf4777cf0ed3da68ee3f2edcba505f3e137bb7
 
 do_check() {
 	make test


### PR DESCRIPTION
Because of DMCA letter the repo is moved to Codeberg.

#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, (x86-64-LIBC)