### PR TITLE
ImageMagick: update to 7.1.2.18 (include several security fixes)

### DIFF
--- a/srcpkgs/ImageMagick/template
+++ b/srcpkgs/ImageMagick/template
@@ -1,7 +1,7 @@
 # Template file for 'ImageMagick'
 pkgname=ImageMagick
 # Revbump php*-imagick with ImageMagick updates.
-version=7.1.2.13
+version=7.1.2.18
 revision=1
 build_style=gnu-configure
 configure_args="--disable-static --enable-opencl --with-modules --with-gslib
@@ -19,7 +19,7 @@ license="ImageMagick"
 homepage="https://www.imagemagick.org"
 changelog="https://raw.githubusercontent.com/ImageMagick/Website/main/ChangeLog.md"
 distfiles="https://github.com/ImageMagick/ImageMagick/archive/${version%.*}-${version##*.}.tar.gz"
-checksum=3617bffe497690ffe5b731227d026db1150e138ddb129481a1e202442e558512
+checksum=2db8a1f9bac19831c76574e4fd514ecb80a71a49911ee5dc8c1f3fb6d9d550df
 
 subpackages="libmagick libmagick-devel"
 


### PR DESCRIPTION
Over 55 CVEs is fixed ranging from score 4.0 to 8.6

#### Testing the changes
- I tested the changes in this PR: **Briefly**

#### Local build testing
- I built this PR locally for my native architecture, (x86-64-LIBC)