### PR TITLE
duckdb: update to 1.5.0.

### DIFF
--- a/srcpkgs/duckdb/template
+++ b/srcpkgs/duckdb/template
@@ -1,12 +1,12 @@
 # Template file for 'duckdb'
 pkgname=duckdb
-version=1.4.3
+version=1.5.0
 revision=1
 archs="x86_64* aarch64*" # 32-bit FTBFS
 build_style=cmake
 build_helper="python3"
 build_wrksrc="${pkgname}-${version}"
-configure_args="-DOVERRIDE_GIT_DESCRIBE=v${version}-0-gdeadbeeff
+configure_args="-DOVERRIDE_GIT_DESCRIBE=v${version}
  -DBUILD_EXTENSIONS='autocomplete;icu;json;parquet'"
 hostmakedepends="pkg-config cmake ninja python3-build python3-installer python3-scikit-build-core
  python3-pybind11 python3-setuptools_scm"
@@ -18,14 +18,16 @@ homepage="https://duckdb.org"
 changelog="https://github.com/duckdb/duckdb/releases"
 distfiles="https://github.com/duckdb/duckdb/archive/refs/tags/v${version}.tar.gz>duckdb.tar.gz
  https://github.com/duckdb/duckdb-python/archive/refs/tags/v${version}.tar.gz>duckdb-python.tar.gz"
-checksum="b6a2afd09d9cf07e50d5cd07077df7f7697b61cca2eb00754f5adf89a1ae6c64
- af6d368ed8f95690fadae958b538f89f697657d88a53159d72e73523619277ff"
+checksum="fb039699c5a91dec9876540aed7904b6b4e713b800014840dbf641168147a556
+ 4102194e49600650e90d3408a7c5ffcd4cfd35165c836da1be34f81e2901331b"
 
 _pypkg_wrksrc="${XBPS_BUILDDIR}/duckdb-${version}/duckdb-python-${version}"
 
 case "${XBPS_TARGET_MACHINE}" in
-	x86_64*) configure_args+=" -DDUCKDB_EXPLICIT_PLATFORM=linux_amd64" ;;
-	aarch64*) configure_args+=" -DDUCKDB_EXPLICIT_PLATFORM=linux_arm64" ;;
+	x86_64) configure_args+=" -DDUCKDB_EXPLICIT_PLATFORM=linux_amd64" ;;
+	x86_64-musl) configure_args+=" -DDUCKDB_EXPLICIT_PLATFORM=linux_amd64_musl" ;;
+	aarch64) configure_args+=" -DDUCKDB_EXPLICIT_PLATFORM=linux_arm64" ;;
+	aarch64-musl) configure_args+=" -DDUCKDB_EXPLICIT_PLATFORM=linux_arm64_musl" ;;
 esac
 
 post_extract() {


### PR DESCRIPTION
Update version which adds musl support for extensions.

Change build flag to use musl platform for correct extension behaviour on musl based environment. Additional update to version var used in build to allow it to get correct extension too. 

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**
<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, x86_64-musl.
<!--- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
