### PR TITLE
mako: update to 1.11.0.

### DIFF
--- a/srcpkgs/mako/template
+++ b/srcpkgs/mako/template
@@ -1,6 +1,6 @@
 # Template file for 'mako'
 pkgname=mako
-version=1.10.0
+version=1.11.0
 revision=1
 build_style=meson
 configure_args="-Dicons=enabled -Dman-pages=enabled -Dzsh-completions=true
@@ -13,7 +13,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
 homepage="https://wayland.emersion.fr/mako/"
 distfiles="https://github.com/emersion/mako/archive/v${version}.tar.gz"
-checksum=3ca44f6bb85c941a4f637a9787931c22ee9a7fe6b8039e6985baf863719b0f95
+checksum=72d11d3fca20a3dfbca0107ff875eace479751be0cf2ddd1dd5bafa131ac7282
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**


#### Local build testing
- I built this PR locally for my native architecture, x86_64
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64 (crossbuild)

