### PR TITLE
swayimg: update to 5.2.

### DIFF
--- a/srcpkgs/swayimg/template
+++ b/srcpkgs/swayimg/template
@@ -1,29 +1,29 @@
 # Template file for 'swayimg'
 pkgname=swayimg
-reverts="5.0_1"
-version=4.7
-revision=3
+version=5.2
+revision=1
 build_style=meson
 configure_args="-D version=${version}"
 hostmakedepends="pkg-config wayland-devel"
 makedepends="wayland-devel cairo-devel json-c-devel libxkbcommon-devel
  wayland-protocols libheif-devel giflib-devel libjpeg-turbo-devel
- libpng-devel librsvg-devel libwebp-devel libexif-devel tiff-devel
- libopenexr-devel libjxl-devel libdrm-devel"
+ libpng-devel librsvg-devel libwebp-devel libexif-devel libavif-devel
+ tiff-devel libsixel-devel libraw-devel libopenexr-devel libjxl-devel
+ freetype-devel libdrm-devel LuaJIT-devel"
+conf_files="/etc/xdg/swayimg/init.lua"
 short_desc="Image viewer for Sway/Wayland"
 maintainer="voidbert <humbertogilgomes@protonmail.com>"
 license="MIT"
 homepage="https://github.com/artemsen/swayimg"
 distfiles="https://github.com/artemsen/swayimg/archive/v${version}.tar.gz"
-checksum=342952aa30f62f163dfcb36448d7f2a860abf972bb24690d2e49b28b6f2ba7cc
+checksum=14c6171e18f07bf9aa17c38a93f9c634fa5b9f2402294c38acff6fb52d2a5df3
 
 post_install() {
 	vcompletion extra/bash.completion bash
 	vcompletion extra/zsh.completion zsh
 
-	# upstream installs the config file into 'datadir'
-	rm ${DESTDIR}/usr/share/swayimg/swayimgrc
-	vsconf extra/swayimgrc
+	# Default configuration file
+	vinstall extra/example.lua 0644 etc/xdg/swayimg init.lua
 
 	vlicense LICENSE
 }


### PR DESCRIPTION
Updates swayimg (new Lua configuration files are required) and adds support for new image formats.

#### Testing the changes
- I tested the changes in this PR: **YES**

I have confirmed all files required by [`CONFIG.md`](https://github.com/artemsen/swayimg/blob/master/CONFIG.md) are present (see #59385):

 - [x] /etc/xdg/swayimg/init.lua
 - [x] /usr/share/swayimg/example.lua
 - [x] /usr/share/swayimg/swayimg.lua

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-musl)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - armv6l-musl