### PR TITLE
libvpl: update to 2.16.0

### DIFF
--- a/srcpkgs/libvpl/template
+++ b/srcpkgs/libvpl/template
@@ -1,6 +1,6 @@
 # Template file for 'libvpl'
 pkgname=libvpl
-version=2.15.0
+version=2.16.0
 revision=1
 build_style=cmake
 configure_args="-DBUILD_EXAMPLES=ON"
@@ -12,7 +12,7 @@ license="MIT"
 homepage="https://github.com/intel/libvpl"
 changelog="https://github.com/intel/libvpl/blob/master/CHANGELOG.md"
 distfiles="https://github.com/intel/libvpl/archive/refs/tags/v${version}.tar.gz"
-checksum=7218c3b8206b123204c3827ce0cf7c008d5c693c1f58ab461958d05fe6f847b3
+checksum=d60931937426130ddad9f1975c010543f0da99e67edb1c6070656b7947f633b6
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

still no usr/bin in libvpl-examples but I kept the comment

#### Local build testing
- I built this PR locally for my native architecture: x86_64-glibc

@zlice 