### PR TITLE
SDL2_image: update to 2.8.10.

### DIFF
--- a/srcpkgs/SDL2_image/template
+++ b/srcpkgs/SDL2_image/template
@@ -1,19 +1,19 @@
 # Template file for 'SDL2_image'
 pkgname=SDL2_image
-version=2.8.8
-revision=2
+version=2.8.10
+revision=1
 build_style=cmake
-configure_args="-DSDL2IMAGE_WEBP=ON"
+configure_args="-DSDL2IMAGE_JXL=ON"
 hostmakedepends="pkg-config"
 makedepends="SDL2-devel libavif-devel libjpeg-turbo-devel libpng-devel libwebp-devel
- tiff-devel zlib-devel"
+ libjxl-devel tiff-devel zlib-devel"
 short_desc="Load images as SDL surfaces (SDL 2.x)"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="Zlib"
 homepage="https://github.com/libsdl-org/SDL_image"
 changelog="https://raw.githubusercontent.com/libsdl-org/SDL_image/SDL2/CHANGES.txt"
 distfiles="http://www.libsdl.org/projects/SDL_image/release/SDL2_image-${version}.tar.gz"
-checksum=2213b56fdaff2220d0e38c8e420cbe1a83c87374190cba8c70af2156097ce30a
+checksum=ebc059d01c007a62f4b04f10cf858527c875062532296943174df9a80264fd65
 
 post_install() {
 	vlicense LICENSE.txt LICENSE


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture (x86_64)
- I built this PR locally for these architectures using specific masterdirs:
  - x86_64-musl
  - i686
- I built this PR locally for these architectures (crossbuilds):
  - aarch64
  - aarch64-musl
  - armv7l
  - armv7l-musl
  - armv6l
  - armv6l-musl