### PR TITLE
google-earth-pro: update to 7.3.7.1094.

### DIFF
--- a/srcpkgs/google-earth-pro/template
+++ b/srcpkgs/google-earth-pro/template
@@ -1,7 +1,7 @@
 # Template file for 'google-earth-pro'
 
 pkgname=google-earth-pro
-version=7.3.6.10441
+version=7.3.7.1094
 revision=1
 archs="x86_64"
 depends="alsa-lib desktop-file-utils fontconfig glu gst-plugins-base1
@@ -12,7 +12,7 @@ maintainer="Jason Manley <jason@jasondavid.tv>"
 license="custom:Google"
 homepage="https://www.google.com/earth/index.html"
 distfiles="https://dl.google.com/dl/earth/client/current/google-earth-pro-stable_current_amd64.deb"
-checksum=3f74f02231e2bb473996d4b5a72530f0cf7a0d6e7f93b2523dfe0a47dfb10dbc
+checksum=1aef3c6a075b159d3b7ea9bafdcf5a40cc75a64439bac436f5bb95bea9e9cbea
 repository=nonfree
 restricted=yes
 nostrip=yes


### PR DESCRIPTION
Upstream silently updated the rolling distfile URL to a new build (7.3.7.1094). Updated version and checksum accordingly.

- tested: built and installed successfully with `xbps-src`