### PR TITLE
android-studio: update to 2025.3.3.6

### DIFF
--- a/srcpkgs/android-studio/template
+++ b/srcpkgs/android-studio/template
@@ -1,8 +1,8 @@
 # Template file for 'android-studio'
 pkgname=android-studio
-version=2025.3.2.6
+version=2025.3.3.6
 revision=1
-_version_description="panda2"
+_version_description="panda3"
 archs="x86_64"
 hostmakedepends="tar"
 depends="libbsd"
@@ -12,7 +12,7 @@ license="Apache-2.0"
 homepage="https://developer.android.com/studio/"
 changelog="https://developer.android.com/studio/releases/"
 distfiles="https://edgedl.me.gvt1.com/android/studio/ide-zips/${version}/android-studio-${_version_description}-linux.tar.gz"
-checksum=32942d8cd7688192cf3cd07bf282fb120035b9bd9b56e6f13c5540e6d39807e9
+checksum=341ac0fc17dbc987d0530e0cfb327125480533d6733a889f2137636becd486a5
 repository=nonfree
 restricted=yes
 python_version=3


### PR DESCRIPTION
Testing the changes
I tested the changes in this PR: YES
Local build testing
I built this PR locally for my native architecture, x86_64-glibc