### PR TITLE
taglib: update to 2.2.1

### DIFF
--- a/srcpkgs/taglib/template
+++ b/srcpkgs/taglib/template
@@ -1,6 +1,6 @@
 # Template file for 'taglib'
 pkgname=taglib
-version=2.1.1
+version=2.2.1
 revision=1
 build_style=cmake
 configure_args="-DWITH_MP4=ON -DWITH_ASF=ON -DBUILD_SHARED_LIBS=ON"
@@ -12,7 +12,7 @@ license="LGPL-2.1-or-later, MPL-1.1"
 homepage="https://taglib.github.io/"
 changelog="https://raw.githubusercontent.com/taglib/taglib/master/CHANGELOG.md"
 distfiles="https://github.com/taglib/taglib/archive/v${version}.tar.gz"
-checksum=bd57924496a272322d6f9252502da4e620b6ab9777992e8934779ebd64babd6e
+checksum=8d920bfe302c943bab204ad5183fa0ea13cedee7f72f7256b665888de964d081
 
 taglib-devel_package() {
 	depends="${sourcepkg}>=${version}_${revision} zlib-devel"


### PR DESCRIPTION

#### Testing the changes
- I tested the changes in this PR: **YES**

Tested writing and reading tags in VLC, strawberry and kid3.

#### Local build testing
- I built this PR locally for my native architecture: x86_64-glibc