### PR TITLE
SDL_gfx: update to 2.0.27 (revbump OpenXcom, freedroidRPG, hyperrogue)

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -2430,7 +2430,7 @@ libcompel.so.1 criu-3.13_2
 libwebsockets.so.21 libwebsockets-4.5.2_1
 libnfc.so.6 libnfc-1.8.0_1
 libfuzzy.so.2 libfuzzy-2.12_1
-libSDL_gfx.so.15 SDL_gfx-2.0.25_2
+libSDL_gfx.so.16 SDL_gfx-2.0.27_1
 libsfml-network.so.2.6 SFML-2.6.1_1
 libsfml-system.so.2.6 SFML-2.6.1_1
 libsfml-window.so.2.6 SFML-2.6.1_1

--- a/srcpkgs/OpenXcom/template
+++ b/srcpkgs/OpenXcom/template
@@ -1,7 +1,7 @@
 # Template file for 'OpenXcom'
 pkgname=OpenXcom
 version=1.0
-revision=6
+revision=7
 build_style=gnu-configure
 configure_args="--disable-silent-rules --disable-werror"
 hostmakedepends="automake pkg-config xmlto"

--- a/srcpkgs/SDL_gfx/template
+++ b/srcpkgs/SDL_gfx/template
@@ -1,38 +1,38 @@
 # Template file for 'SDL_gfx'
 pkgname=SDL_gfx
-version=2.0.26
-revision=3
+version=2.0.27
+revision=1
 build_style=gnu-configure
-hostmakedepends="pkg-config"
+hostmakedepends="automake libtool pkg-config"
 makedepends="sdl12-compat-devel"
 short_desc="Graphics drawing primitives for SDL"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="BSD-3-Clause"
 homepage="http://www.ferzkopp.net/wordpress/2016/01/02/sdl_gfx-sdl2_gfx/"
 distfiles="http://www.ferzkopp.net/Software/SDL_gfx-${version%.*}/SDL_gfx-${version}.tar.gz"
-checksum=7ceb4ffb6fc63ffba5f1290572db43d74386cd0781c123bc912da50d34945446
+checksum=dfb15ac5f8ce7a4952dc12d2aed9747518c5e6b335c0e31636d23f93c630f419
 
 pre_configure() {
+	autoreconf -vfi -I ${XBPS_CROSS_BASE}/usr/share/aclocal
+
 	case "${XBPS_TARGET_MACHINE}" in
-		x86_64*|i686*)
-			configure_args+=" --enable-mmx"
-			;;
-		*)
-			configure_args+=" --disable-mmx"
-			;;
+		x86_64*|i686*) configure_args+=" --enable-mmx" ;;
+		*) configure_args+=" --disable-mmx" ;;
 	esac
 }
+
 post_install() {
 	vlicense COPYING
 	vlicense LICENSE
 }
+
 SDL_gfx-devel_package() {
 	depends="sdl12-compat-devel ${sourcepkg}>=${version}_${revision}"
 	short_desc+=" - development files"
 	pkg_install() {
 		vmove usr/include
 		vmove usr/lib/pkgconfig
-		vmove usr/lib/*.a
-		vmove usr/lib/*.so
+		vmove "usr/lib/*.a"
+		vmove "usr/lib/*.so"
 	}
 }

--- a/srcpkgs/freedroidRPG/template
+++ b/srcpkgs/freedroidRPG/template
@@ -1,7 +1,7 @@
 # Template file for 'freedroidRPG'
 pkgname=freedroidRPG
 version=1.0
-revision=1
+revision=2
 build_style=gnu-configure
 hostmakedepends="pkg-config gettext-devel automake which python3"
 makedepends="SDL_gfx-devel SDL_image-devel SDL_mixer-devel SDL_ttf-devel

--- a/srcpkgs/hyperrogue/template
+++ b/srcpkgs/hyperrogue/template
@@ -1,7 +1,7 @@
 # Template file for 'hyperrogue'
 pkgname=hyperrogue
 version=13.1l
-revision=1
+revision=2
 build_style=gnu-makefile
 hostmakedepends="pkg-config"
 makedepends="glew-devel libpng-devel sdl12-compat-devel SDL_gfx-devel


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture (x86_64)
- I built this PR locally for these architectures using specific masterdirs:
  - x86_64-musl
  - i686
- I built this PR locally for these architectures (crossbuilds):
  - aarch64
  - aarch64-musl
  - armv7l
  - armv7l-musl
  - armv6l
  - armv6l-musl
  - `hyperrogue` was not cross-compiled
  
---

Regenerate build system with `autoreconf -vfi` to fix an incorrect SONAME in the upstream tarball (shipped `configure` was not regenerated since 2.0.25, resulting in `libSDL_gfx.so.15` instead of the correct `libSDL_gfx.so.16`). Update `common/shlibs` and revbump reverse dependencies accordingly.