### PR TITLE
UxPlay: fix README.voidlinux gstreamer-vaapi reference

### DIFF
--- a/srcpkgs/UxPlay/files/README.voidlinux
+++ b/srcpkgs/UxPlay/files/README.voidlinux
@@ -1,5 +1,5 @@
 Additional GStreamer plugins you may need to install:
-- `gstreamer-vaapi` is needed for hardware-accelerated h264 video decoding by Intel or AMD graphics (but not for use with NVIDIA using proprietary drivers)
+- `gst-plugins-bad1` is needed for hardware-accelerated h264 video decoding by Intel or AMD graphics (but not for use with NVIDIA using proprietary drivers)
 - `gstreamer1-pipewire` may be needed for audio sharing when your system is set up to use pipewire
 
 Additionally, UxPlay requires a running DNS-SD server (for example `avahi`).


### PR DESCRIPTION
`gstreamer-vaapi` is no longer available (removed in #58378). Update
`README.voidlinux` to reflect that hardware-accelerated decoding is now
provided by `gst-plugins-bad1`.