### PR TITLE
opustags: update to 1.10.1.

### DIFF
--- a/srcpkgs/opustags/template
+++ b/srcpkgs/opustags/template
@@ -1,6 +1,6 @@
 # Template file for 'opustags'
 pkgname=opustags
-version=1.9.0
+version=1.10.1
 revision=1
 build_style=cmake
 hostmakedepends="pkg-config"
@@ -11,7 +11,7 @@ license="BSD-3-Clause"
 homepage="https://github.com/fmang/opustags"
 changelog="https://github.com/fmang/opustags/raw/master/CHANGELOG.md"
 distfiles="https://github.com/fmang/opustags/archive/${version}.tar.gz"
-checksum=ea937f48a011bbacf37324c159149625c1ab66110e6d279693a92659bd38cf02
+checksum=703096e9c41481e30ab90eefdd8fafc4c3a138998b3f8281aa4f023e7058bc86
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture (x86_64)
- I built this PR locally for these architectures using specific masterdirs:
  - x86_64-musl
  - i686
- I built this PR locally for these architectures (crossbuilds):
  - aarch64
  - aarch64-musl
  - armv7l
  - armv7l-musl
  - armv6l
  - armv6l-musl