### PR TITLE
soft-serve: update to 0.11.6

### DIFF
--- a/srcpkgs/soft-serve/template
+++ b/srcpkgs/soft-serve/template
@@ -1,6 +1,6 @@
 # Template file for 'soft-serve'
 pkgname=soft-serve
-version=0.11.5
+version=0.11.6
 revision=1
 build_style=go
 build_helper=qemu
@@ -15,7 +15,7 @@ license="MIT"
 homepage="https://github.com/charmbracelet/soft-serve"
 changelog="https://github.com/charmbracelet/soft-serve/releases"
 distfiles="https://github.com/charmbracelet/soft-serve/archive/refs/tags/v${version}.tar.gz"
-checksum=1cdee6932cc65cabfd92e42b3a1bc961d2fdbb514c8e11a6aa14d2a6f253098f
+checksum=0536934663508b1949193d6bd7ebcee227d40c8162a0dcfd338f1f33f74474bb
 if [[ "$XBPS_TARGET_MACHINE" == 'i686' ]] && [[ "$XBPS_TARGET_LIBC" == "glibc" ]]; then
 	make_check=no # The test failure on i686 comes from git-lfs
 	# Pending patch: https://github.com/git-lfs/git-lfs/pull/6200


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, (x64 glibc)