### PR TITLE
strongswan: enabled eap-gtc plugin

### DIFF
--- a/srcpkgs/strongswan/template
+++ b/srcpkgs/strongswan/template
@@ -1,17 +1,17 @@
 # Template file for 'strongswan'
 pkgname=strongswan
 version=6.0.2
-revision=1
+revision=2
 build_style=gnu-configure
 # tpm support waits on libtss2
 configure_args="--disable-static --enable-blowfish --enable-curl --enable-md4
- --enable-eap-radius --enable-eap-mschapv2 --enable-eap-md5
+ --enable-eap-radius --enable-eap-mschapv2 --enable-eap-md5 --enable-eap-gtc
  --enable-eap-identity --enable-eap-dynamic --enable-led --enable-ha --enable-dhcp
  --enable-mediation --disable-soup --enable-chapoly --enable-nm --enable-stroke
- --enable-pkcs11 --with-capabilities=libcap"
+ --enable-pkcs11 --enable-xauth-pam --with-capabilities=libcap"
 hostmakedepends="pkg-config automake flex bison python3"
 makedepends="libldns-devel unbound-devel libcurl-devel
- NetworkManager-devel openssl-devel libcap-devel"
+ NetworkManager-devel openssl-devel libcap-devel pam-devel"
 depends="iproute2 sqlite"
 checkdepends="iana-etc"
 conf_files="/etc/strongswan.conf /etc/strongswan.d/*.conf /etc/strongswan.d/charon/*.conf


### PR DESCRIPTION
In order to enable the eap-gtc plugin, the xauth-pam plugin must be enabled as well. See
https://docs.strongswan.org/docs/latest/plugins/eap-gtc.html

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, x86_64
- I built this PR locally for these architectures:
  - aarch64
  - armv7l
  - armv6l
