### PR TITLE
qxmpp: update to 1.15.1

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -2766,8 +2766,8 @@ leatherman_execution.so.1.12.4 leatherman-1.12.4_1
 leatherman_ruby.so.1.12.4 leatherman-1.12.4_1
 libfbclient.so.2 libfbclient3-3.0.4.33054_1
 libipmiutil.so.1 ipmiutil-3.1.3_4
-libQXmppQt6.so.8 qxmpp-1.14.0_1
-libQXmppOmemoQt6.so.8 qxmpp-1.14.0_1
+libQXmppQt6.so.9 qxmpp-1.15.0_1
+libQXmppOmemoQt6.so.9 qxmpp-1.15.0_1
 libunwind.so.1 llvm-libunwind-3.8.0_1
 libc++abi.so.1 libcxxabi-3.8.0_1
 libfastjson.so.4 libfastjson-0.99.3_1

--- a/srcpkgs/qxmpp/template
+++ b/srcpkgs/qxmpp/template
@@ -1,6 +1,6 @@
 # Template file for 'qxmpp'
 pkgname=qxmpp
-version=1.14.3
+version=1.15.1
 revision=1
 build_style=cmake
 configure_args="-DBUILD_EXAMPLES=false -DBUILD_OMEMO=true -DWITH_GSTREAMER=true -DBUILD_TESTS=false"
@@ -10,8 +10,9 @@ short_desc="Cross-platform C++ XMPP client and server library"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/libraries/qxmpp"
+changelog="https://invent.kde.org/libraries/qxmpp/-/raw/master/CHANGELOG.md"
 distfiles="https://invent.kde.org/libraries/qxmpp/-/archive/v${version}/qxmpp-v${version}.tar.gz"
-checksum=22dffcff941a449fedb531cd979e32ca22bf50b6aec4f86d255d173fcd10176b
+checksum=f459664a9f0ac92266f7e0efab54aac51cc68695e5c3169b92d38668eefc4f8c
 
 qxmpp-devel_package() {
 	short_desc+=" - development files"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)