### PR TITLE
OpenCL-CLHPP: update to 2025.07.22.

### DIFF
--- a/srcpkgs/OpenCL-CLHPP-doc
+++ b/srcpkgs/OpenCL-CLHPP-doc
@@ -1,0 +1,1 @@
+OpenCL-CLHPP

--- a/srcpkgs/OpenCL-CLHPP/template
+++ b/srcpkgs/OpenCL-CLHPP/template
@@ -1,9 +1,10 @@
 # Template file for 'OpenCL-CLHPP'
 pkgname=OpenCL-CLHPP
-version=2024.10.24
+version=2025.07.22
 revision=1
 build_style=cmake
-configure_args="-DBUILD_EXAMPLES=OFF -DBUILD_TESTING=OFF"
+configure_args="-DBUILD_EXAMPLES=OFF -DBUILD_TESTING=OFF -DBUILD_DOCS=ON"
+hostmakedepends="doxygen graphviz"
 makedepends="OpenCL-Headers ocl-icd-devel"
 depends="OpenCL-Headers"
 short_desc="OpenCL API C++ bindings"
@@ -11,4 +12,17 @@ maintainer="Daniel Martinez <danielmartinez@cock.li>"
 license="Apache-2.0"
 homepage="https://github.com/KhronosGroup/OpenCL-CLHPP"
 distfiles="https://github.com/KhronosGroup/OpenCL-CLHPP/archive/refs/tags/v${version}.tar.gz"
-checksum=51aebe848514b3bc74101036e111f8ee98703649eec7035944831dc6e05cec14
+checksum=c1031afde6e9eb042e6fcfbc17078f4b437a7e8d55482a1ca6e0fa762d262a89
+
+post_install() {
+	ninja -C ${cmake_builddir} docs
+	vmkdir usr/share/doc/${pkgname}
+	vcopy ${cmake_builddir}/docs/html usr/share/doc/${pkgname}
+}
+
+OpenCL-CLHPP-doc_package() {
+	short_desc+=" - documentation"
+	pkg_install() {
+		vmove usr/share/doc
+	}
+}


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture (x86_64)
- I built this PR locally for these architectures using specific masterdirs:
  - x86_64-musl
  - i686
- I built this PR locally for these architectures (crossbuilds):
  - aarch64
  - aarch64-musl
  - armv7l
  - armv7l-musl
  - armv6l
  - armv6l-musl

---

Add `OpenCL-CLHPP-doc` subpackage with Doxygen-generated HTML documentation.