### PR TITLE
cotp: update to 1.9.9

### DIFF
--- a/srcpkgs/cotp/template
+++ b/srcpkgs/cotp/template
@@ -1,6 +1,6 @@
 # Template file for 'cotp'
 pkgname=cotp
-version=1.9.7
+version=1.9.9
 revision=1
 build_style=cargo
 short_desc="Command line TOTP/HOTP authenticator"
@@ -9,7 +9,7 @@ license="GPL-3.0-or-later"
 homepage="https://github.com/replydev/cotp"
 changelog="https://github.com/replydev/cotp/raw/main/CHANGELOG.md"
 distfiles="https://github.com/replydev/cotp/archive/refs/tags/v${version}.tar.gz"
-checksum=6234805a8eb20a71d2acb07ad8d7827bd5c98c653b7eb733bab0f90cbb9f6212
+checksum=f3866e29130078a14ff3da4f544709d1a7a1edb257a77321254a5a87530b6a5e
 
 post_install() {
 	vmkdir /usr/share/cotp


### PR DESCRIPTION
- I tested the changes in this PR: **briefly**
- I built this PR locally for my native architecture, (x86_64-glibc)