### PR TITLE
mise: update to 2026.5.3.

### DIFF
--- a/srcpkgs/mise/template
+++ b/srcpkgs/mise/template
@@ -1,18 +1,19 @@
 # Template file for 'mise'
 pkgname=mise
-version=2026.4.21
+version=2026.5.3
 revision=1
 build_style=cargo
 hostmakedepends="pkg-config"
 makedepends="openssl-devel libzstd-devel bzip2-devel"
 depends="usage"
+checkdepends="git"
 short_desc="Polyglot runtime manager (asdf rust clone)"
 maintainer="Daniel Lewan <daniel@teddydd.me>"
 license="MIT"
 homepage="https://github.com/jdx/mise"
 changelog="https://github.com/jdx/mise/releases"
 distfiles="https://github.com/jdx/mise/archive/v${version}.tar.gz>${pkgname}-${version}.tar.gz"
-checksum=7f3e39aa58d354bbf4a0fa184f8900abf91e8b71616b9d6b79e7b1c0a77e9c59
+checksum=a40b3ecc7f3b92de703f016ade49f250fb9a280d48a0aae0bfab608bb0c48b98
 
 case "$XBPS_TARGET_MACHINE" in
 	i686*) broken="runs out of memory" ;;


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)

