### PR TITLE
wayland-doc: remove obsolete symlink

### DIFF
--- a/srcpkgs/wayland-doc
+++ b/srcpkgs/wayland-doc
@@ -1,1 +1,0 @@
-wayland


### PR DESCRIPTION
Leftover from #59479
