### PR TITLE
ltris: update to 1.3.2

### DIFF
--- a/srcpkgs/ltris/template
+++ b/srcpkgs/ltris/template
@@ -1,16 +1,15 @@
 # Template file for 'ltris'
 pkgname=ltris
-version=1.2.6
-revision=2
+version=1.3.2
+revision=1
 build_style=gnu-configure
 configure_args="--localstatedir=/var/games/ltris"
-hostmakedepends="bison"
 makedepends="sdl12-compat-devel SDL_mixer-devel"
 short_desc="Tetris clone using SDL"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later"
-homepage="http://lgames.sourceforge.net/index.php?project=LTris"
-distfiles="${SOURCEFORGE_SITE}/lgames/$pkgname-$version.tar.gz"
-checksum=c23ce21454c0389c5297a7ef2e14efe804d940625e7eeb0386a29780ec2c46f6
+homepage="https://lgames.sourceforge.io/LTris/"
+distfiles="${SOURCEFORGE_SITE}/lgames/ltris-${version}.tar.gz"
+checksum=ff28c55a18c61f28a86ba7f30f13222dfed0f7fbeb492acd95c97de9c659cec9
+
 nocheckperms=yes # uses a world-writable .hscr file for global leaderboard
-CFLAGS+=" -fgnu89-inline"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, **x86_64-glibc**
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - armv6l (cross)

<details>
<summary>Local build log (x86_64-musl, pre-patch)</summary>

```
$ ./xbps-src -A x86_64-musl -Q pkg ltris2                                                                                                                          [0] 11:10
=> xbps-src: updating repositories for host (x86_64-musl)...
[*] Updating repository `https://repo-default.voidlinux.org/current/musl/bootstrap/x86_64-musl-repodata' ...
[*] Updating repository `https://repo-default.voidlinux.org/current/musl/x86_64-musl-repodata' ...
x86_64-musl-repodata: 2092KB [avg rate: 12MB/s]
[*] Updating repository `https://repo-default.voidlinux.org/current/musl/nonfree/x86_64-musl-repodata' ...
[*] Updating repository `https://repo-default.voidlinux.org/current/musl/debug/x86_64-musl-repodata' ...
x86_64-musl-repodata: 926KB [avg rate: 17GB/s]
=> xbps-src: updating software in / masterdir...
=> xbps-src: cleaning up / masterdir...
=> ltris2-2.0.4_1: removing autodeps, please wait...
=> ltris2-2.0.4_1: building with [gnu-configure] for x86_64-musl...
   [target] SDL2_image-devel-2.8.10_1: found (https://repo-default.voidlinux.org/current/musl)
   [target] SDL2_mixer-devel-2.8.1_1: found (https://repo-default.voidlinux.org/current/musl)
   [target] SDL2_ttf-devel-2.20.2_2: found (https://repo-default.voidlinux.org/current/musl)
=> ltris2-2.0.4_1: installing target dependencies: SDL2_image-devel-2.8.10_1 SDL2_mixer-devel-2.8.1_1 SDL2_ttf-devel-2.20.2_2 ...
=> ltris2-2.0.4_1: running do-fetch hook: 00-distfiles ...
=> ltris2-2.0.4_1: running do-extract hook: 00-distfiles ...
=> ltris2-2.0.4_1: extracting distfile(s), please wait...
=> ltris2-2.0.4_1: running do-patch hook: 00-patches ...
=> ltris2-2.0.4_1: running pre-configure hook: 00-gnu-configure-asneeded ...
=> ltris2-2.0.4_1: running pre-configure hook: 01-override-config ...
=> ltris2-2.0.4_1: running pre-configure hook: 02-script-wrapper ...
=> ltris2-2.0.4_1: running do_configure ...
checking for a BSD-compatible install... /builddir/.xbps-ltris2/wrappers/install -c
checking whether build environment is sane... yes
checking for a race-free mkdir -p... /usr/bin/mkdir -p
checking for gawk... gawk
checking whether make sets $(MAKE)... yes
checking whether make supports nested variables... yes
checking whether make supports the include directive... yes (GNU style)
checking for x86_64-unknown-linux-musl-gcc... cc
checking whether the C compiler works... yes
checking for C compiler default output file name... a.out
checking for suffix of executables... 
checking whether we are cross compiling... no
checking for suffix of object files... o
checking whether the compiler supports GNU C... yes
checking whether cc accepts -g... yes
checking for cc option to enable C11 features... none needed
checking whether cc understands -c and -o together... yes
checking dependency style of cc... gcc3
checking for stdio.h... yes
checking for stdlib.h... yes
checking for string.h... yes
checking for inttypes.h... yes
checking for stdint.h... yes
checking for strings.h... yes
checking for sys/stat.h... yes
checking for sys/types.h... yes
checking for unistd.h... yes
checking for wchar.h... yes
checking for minix/config.h... no
checking whether it is safe to define __EXTENSIONS__... yes
checking whether _XOPEN_SOURCE should be defined... no
checking for a sed that does not truncate output... /usr/bin/sed
checking whether NLS is requested... no
checking for msgfmt... no
checking for gmsgfmt... :
checking for xgettext... no
checking for msgmerge... no
checking build system type... x86_64-unknown-linux-musl
checking host system type... x86_64-unknown-linux-musl
checking for ld... ld
checking if the linker (ld) is GNU ld... yes
checking for shared library run path origin... done
checking 32-bit host C ABI... no
checking how to run the C preprocessor... cpp
checking for grep that handles long lines and -e... /usr/bin/grep
checking for egrep... /usr/bin/grep -E
checking for ELF binary format... yes
checking for the common suffixes of directories in the library search path... lib,lib,lib64
checking for CFPreferencesCopyAppValue... no
checking for CFLocaleCopyPreferredLanguages... no
checking whether to use NLS... no
checking whether the compiler supports GNU C++... yes
checking whether g++ accepts -g... yes
checking for g++ option to enable C++11 features... none needed
checking dependency style of g++... gcc3
checking for x86_64-unknown-linux-musl-gcc... (cached) cc
checking whether the compiler supports GNU C... (cached) yes
checking whether cc accepts -g... (cached) yes
checking for cc option to enable C11 features... (cached) none needed
checking whether cc understands -c and -o together... (cached) yes
checking dependency style of cc... (cached) gcc3
checking for x86_64-unknown-linux-musl-ranlib... ranlib
checking for main in -lm... yes
checking for main in -lSDL2... yes
checking for main in -lSDL2_ttf... yes
checking for main in -lSDL2_image... yes
checking for main in -lSDL2_mixer... yes
checking for stdlib.h... (cached) yes
checking for string.h... (cached) yes
checking for _Bool... yes
checking for stdbool.h that conforms to C99... yes
checking for inline... inline
checking for size_t... yes
checking for working alloca.h... yes
checking for alloca... yes
checking for GNU libc compatible malloc... yes
checking for GNU libc compatible realloc... yes
checking for working strtod... yes
checking for memset... yes
checking for strchr... yes
checking for strdup... yes
checking for strrchr... yes
checking that generated files are newer than configure... done
configure: creating ./config.status
config.status: creating Makefile
config.status: creating m4/Makefile
config.status: creating po/Makefile.in
config.status: creating libgame/Makefile
config.status: creating src/Makefile
config.status: creating src/themes/Makefile
config.status: creating src/themes/Standard/Makefile
config.status: creating config.h
config.status: executing depfiles commands
config.status: executing po-directories commands
config.status: creating po/POTFILES
config.status: creating po/Makefile
=> ltris2-2.0.4_1: running pre-build hook: 02-script-wrapper ...
=> ltris2-2.0.4_1: running do_build ...
make  all-recursive
make[1]: Entering directory '/builddir/ltris2-2.0.4'
Making all in m4
make[2]: Entering directory '/builddir/ltris2-2.0.4/m4'
make[2]: Nothing to be done for 'all'.
make[2]: Leaving directory '/builddir/ltris2-2.0.4/m4'
Making all in po
make[2]: Entering directory '/builddir/ltris2-2.0.4/po'
make[2]: Nothing to be done for 'all'.
make[2]: Leaving directory '/builddir/ltris2-2.0.4/po'
Making all in libgame
make[2]: Entering directory '/builddir/ltris2-2.0.4/libgame'
cc -DHAVE_CONFIG_H -I. -I..     -fstack-clash-protection -D_FORTIFY_SOURCE=2 -mtune=generic -O2 -pipe    -ffile-prefix-map=/builddir/ltris2-2.0.4=. -Wreturn-type -Wno-int-conversion -Wno-format -Wno-implicit-function-declaration  -DSRC_DIR=\"/usr/share/ltris2\" -DCONFIG_DIR_NAME=\"~/.local/share/ltris2\" -DHI_DIR=\"/var/games/ltris2\" -MT list.o -MD -MP -MF .deps/list.Tpo -c -o list.o list.c
cc -DHAVE_CONFIG_H -I. -I..     -fstack-clash-protection -D_FORTIFY_SOURCE=2 -mtune=generic -O2 -pipe    -ffile-prefix-map=/builddir/ltris2-2.0.4=. -Wreturn-type -Wno-int-conversion -Wno-format -Wno-implicit-function-declaration  -DSRC_DIR=\"/usr/share/ltris2\" -DCONFIG_DIR_NAME=\"~/.local/share/ltris2\" -DHI_DIR=\"/var/games/ltris2\" -MT tools.o -MD -MP -MF .deps/tools.Tpo -c -o tools.o tools.c
mv -f .deps/list.Tpo .deps/list.Po
cc -DHAVE_CONFIG_H -I. -I..     -fstack-clash-protection -D_FORTIFY_SOURCE=2 -mtune=generic -O2 -pipe    -ffile-prefix-map=/builddir/ltris2-2.0.4=. -Wreturn-type -Wno-int-conversion -Wno-format -Wno-implicit-function-declaration  -DSRC_DIR=\"/usr/share/ltris2\" -DCONFIG_DIR_NAME=\"~/.local/share/ltris2\" -DHI_DIR=\"/var/games/ltris2\" -MT parser.o -MD -MP -MF .deps/parser.Tpo -c -o parser.o parser.c
mv -f .deps/parser.Tpo .deps/parser.Po
cc -DHAVE_CONFIG_H -I. -I..     -fstack-clash-protection -D_FORTIFY_SOURCE=2 -mtune=generic -O2 -pipe    -ffile-prefix-map=/builddir/ltris2-2.0.4=. -Wreturn-type -Wno-int-conversion -Wno-format -Wno-implicit-function-declaration  -DSRC_DIR=\"/usr/share/ltris2\" -DCONFIG_DIR_NAME=\"~/.local/share/ltris2\" -DHI_DIR=\"/var/games/ltris2\" -MT config.o -MD -MP -MF .deps/config.Tpo -c -o config.o config.c
mv -f .deps/tools.Tpo .deps/tools.Po
cc -DHAVE_CONFIG_H -I. -I..     -fstack-clash-protection -D_FORTIFY_SOURCE=2 -mtune=generic -O2 -pipe    -ffile-prefix-map=/builddir/ltris2-2.0.4=. -Wreturn-type -Wno-int-conversion -Wno-format -Wno-implicit-function-declaration  -DSRC_DIR=\"/usr/share/ltris2\" -DCONFIG_DIR_NAME=\"~/.local/share/ltris2\" -DHI_DIR=\"/var/games/ltris2\" -MT chart.o -MD -MP -MF .deps/chart.Tpo -c -o chart.o chart.c
mv -f .deps/config.Tpo .deps/config.Po
cc -DHAVE_CONFIG_H -I. -I..     -fstack-clash-protection -D_FORTIFY_SOURCE=2 -mtune=generic -O2 -pipe    -ffile-prefix-map=/builddir/ltris2-2.0.4=. -Wreturn-type -Wno-int-conversion -Wno-format -Wno-implicit-function-declaration  -DSRC_DIR=\"/usr/share/ltris2\" -DCONFIG_DIR_NAME=\"~/.local/share/ltris2\" -DHI_DIR=\"/var/games/ltris2\" -MT cpu.o -MD -MP -MF .deps/cpu.Tpo -c -o cpu.o cpu.c
mv -f .deps/chart.Tpo .deps/chart.Po
cc -DHAVE_CONFIG_H -I. -I..     -fstack-clash-protection -D_FORTIFY_SOURCE=2 -mtune=generic -O2 -pipe    -ffile-prefix-map=/builddir/ltris2-2.0.4=. -Wreturn-type -Wno-int-conversion -Wno-format -Wno-implicit-function-declaration  -DSRC_DIR=\"/usr/share/ltris2\" -DCONFIG_DIR_NAME=\"~/.local/share/ltris2\" -DHI_DIR=\"/var/games/ltris2\" -MT sdl.o -MD -MP -MF .deps/sdl.Tpo -c -o sdl.o sdl.c
mv -f .deps/cpu.Tpo .deps/cpu.Po
cc -DHAVE_CONFIG_H -I. -I..     -fstack-clash-protection -D_FORTIFY_SOURCE=2 -mtune=generic -O2 -pipe    -ffile-prefix-map=/builddir/ltris2-2.0.4=. -Wreturn-type -Wno-int-conversion -Wno-format -Wno-implicit-function-declaration  -DSRC_DIR=\"/usr/share/ltris2\" -DCONFIG_DIR_NAME=\"~/.local/share/ltris2\" -DHI_DIR=\"/var/games/ltris2\" -MT event.o -MD -MP -MF .deps/event.Tpo -c -o event.o event.c
mv -f .deps/sdl.Tpo .deps/sdl.Po
cc -DHAVE_CONFIG_H -I. -I..     -fstack-clash-protection -D_FORTIFY_SOURCE=2 -mtune=generic -O2 -pipe    -ffile-prefix-map=/builddir/ltris2-2.0.4=. -Wreturn-type -Wno-int-conversion -Wno-format -Wno-implicit-function-declaration  -DSRC_DIR=\"/usr/share/ltris2\" -DCONFIG_DIR_NAME=\"~/.local/share/ltris2\" -DHI_DIR=\"/var/games/ltris2\" -MT shrapnells.o -MD -MP -MF .deps/shrapnells.Tpo -c -o shrapnells.o shrapnells.c
mv -f .deps/event.Tpo .deps/event.Po
cc -DHAVE_CONFIG_H -I. -I..     -fstack-clash-protection -D_FORTIFY_SOURCE=2 -mtune=generic -O2 -pipe    -ffile-prefix-map=/builddir/ltris2-2.0.4=. -Wreturn-type -Wno-int-conversion -Wno-format -Wno-implicit-function-declaration  -DSRC_DIR=\"/usr/share/ltris2\" -DCONFIG_DIR_NAME=\"~/.local/share/ltris2\" -DHI_DIR=\"/var/games/ltris2\" -MT bowl.o -MD -MP -MF .deps/bowl.Tpo -c -o bowl.o bowl.c
mv -f .deps/shrapnells.Tpo .deps/shrapnells.Po
cc -DHAVE_CONFIG_H -I. -I..     -fstack-clash-protection -D_FORTIFY_SOURCE=2 -mtune=generic -O2 -pipe    -ffile-prefix-map=/builddir/ltris2-2.0.4=. -Wreturn-type -Wno-int-conversion -Wno-format -Wno-implicit-function-declaration  -DSRC_DIR=\"/usr/share/ltris2\" -DCONFIG_DIR_NAME=\"~/.local/share/ltris2\" -DHI_DIR=\"/var/games/ltris2\" -MT tetris.o -MD -MP -MF .deps/tetris.Tpo -c -o tetris.o tetris.c
mv -f .deps/tetris.Tpo .deps/tetris.Po
mv -f .deps/bowl.Tpo .deps/bowl.Po
rm -f libgame.a
ar cru libgame.a list.o tools.o parser.o config.o chart.o cpu.o sdl.o event.o shrapnells.o bowl.o tetris.o 
ar: `u' modifier ignored since `D' is the default (see `U')
ranlib libgame.a
make[2]: Leaving directory '/builddir/ltris2-2.0.4/libgame'
Making all in src
make[2]: Entering directory '/builddir/ltris2-2.0.4/src'
Making all in themes
make[3]: Entering directory '/builddir/ltris2-2.0.4/src/themes'
Making all in Standard
make[4]: Entering directory '/builddir/ltris2-2.0.4/src/themes/Standard'
make[4]: Nothing to be done for 'all'.
make[4]: Leaving directory '/builddir/ltris2-2.0.4/src/themes/Standard'
make[4]: Entering directory '/builddir/ltris2-2.0.4/src/themes'
make[4]: Nothing to be done for 'all-am'.
make[4]: Leaving directory '/builddir/ltris2-2.0.4/src/themes'
make[3]: Leaving directory '/builddir/ltris2-2.0.4/src/themes'
make[3]: Entering directory '/builddir/ltris2-2.0.4/src'
g++ -DHAVE_CONFIG_H -I. -I..     -fstack-clash-protection -D_FORTIFY_SOURCE=2 -mtune=generic -O2 -pipe    -ffile-prefix-map=/builddir/ltris2-2.0.4=. -Wreturn-type -Wno-format -std=c++11 -Wall  -DLOCALEDIR=\"/usr/share/locale\" -DCONFIGDIR=\"~/.local/share/ltris2\" -DDATADIR=\"/usr/share/ltris2\" -DHISCOREDIR=\"/var/games/ltris2\" -I/usr/include/SDL2 -D_REENTRANT -MT main.o -MD -MP -MF .deps/main.Tpo -c -o main.o main.cpp
g++ -DHAVE_CONFIG_H -I. -I..     -fstack-clash-protection -D_FORTIFY_SOURCE=2 -mtune=generic -O2 -pipe    -ffile-prefix-map=/builddir/ltris2-2.0.4=. -Wreturn-type -Wno-format -std=c++11 -Wall  -DLOCALEDIR=\"/usr/share/locale\" -DCONFIGDIR=\"~/.local/share/ltris2\" -DDATADIR=\"/usr/share/ltris2\" -DHISCOREDIR=\"/var/games/ltris2\" -I/usr/include/SDL2 -D_REENTRANT -MT vconfig.o -MD -MP -MF .deps/vconfig.Tpo -c -o vconfig.o vconfig.cpp
In file included from vconfig.cpp:15:
tools.h:65:9: error: 'uint' does not name a type; did you mean 'int'?
   65 |         uint cur, max;
      |         ^~~~
      |         int
tools.h:73:9: error: 'uint' does not name a type; did you mean 'int'?
   73 |         uint getMax() { return max; }
      |         ^~~~
      |         int
tools.h:74:9: error: 'uint' does not name a type; did you mean 'int'?
   74 |         uint get() { return cur; }
      |         ^~~~
      |         int
tools.h:78:21: error: 'uint' has not been declared
   78 |         bool update(uint ms) {
      |                     ^~~~
tools.h: In constructor 'Timeout::Timeout()':
tools.h:67:21: error: class 'Timeout' does not have any field named 'cur'
   67 |         Timeout() : cur(0), max(0) {}
      |                     ^~~
tools.h:67:29: error: class 'Timeout' does not have any field named 'max'
   67 |         Timeout() : cur(0), max(0) {}
      |                             ^~~
tools.h: In constructor 'Timeout::Timeout(int)':
tools.h:68:27: error: class 'Timeout' does not have any field named 'cur'
   68 |         Timeout(int ms) : cur(ms), max(ms) {}
      |                           ^~~
tools.h:68:36: error: class 'Timeout' does not have any field named 'max'
   68 |         Timeout(int ms) : cur(ms), max(ms) {}
      |                                    ^~~
tools.h: In member function 'void Timeout::set(int)':
tools.h:69:28: error: 'cur' was not declared in this scope
   69 |         void set(int ms) { cur = max = ms; }
      |                            ^~~
tools.h:69:40: error: overloaded function with no contextual type information
   69 |         void set(int ms) { cur = max = ms; }
      |                                        ^~
tools.h: In member function 'void Timeout::add(int)':
tools.h:70:28: error: 'cur' was not declared in this scope
   70 |         void add(int ms) { cur += ms; max += ms; }
      |                            ^~~
tools.h:70:46: error: overloaded function with no contextual type information
   70 |         void add(int ms) { cur += ms; max += ms; }
      |                                              ^~
tools.h: In member function 'void Timeout::reset()':
tools.h:72:24: error: 'cur' was not declared in this scope
   72 |         void reset() { cur = max; }
      |                        ^~~
tools.h: In member function 'bool Timeout::running()':
tools.h:75:37: error: invalid operands of types '<unresolved overloaded function type>' and 'int' to binary 'operator>'
   75 |         bool running() { return max > 0 && cur > 0; }
      |                                 ~~~~^~~
tools.h:75:44: error: 'cur' was not declared in this scope
   75 |         bool running() { return max > 0 && cur > 0; }
      |                                            ^~~
tools.h: In member function 'bool Timeout::expired()':
tools.h:76:37: error: invalid operands of types '<unresolved overloaded function type>' and 'int' to binary 'operator>'
   76 |         bool expired() { return max > 0 && cur == 0; }
      |                                 ~~~~^~~
tools.h:76:44: error: 'cur' was not declared in this scope
   76 |         bool expired() { return max > 0 && cur == 0; }
      |                                            ^~~
tools.h: In member function 'bool Timeout::isSet()':
tools.h:77:35: error: invalid operands of types '<unresolved overloaded function type>' and 'int' to binary 'operator>'
   77 |         bool isSet() { return max > 0; }
      |                               ~~~~^~~
tools.h: In member function 'bool Timeout::update(int)':
tools.h:79:26: error: 'cur' was not declared in this scope
   79 |                 if (ms < cur)
      |                          ^~~
tools.h:83:24: error: 'cur' was not declared in this scope
   83 |                 return cur == 0;
      |                        ^~~
tools.h: At global scope:
tools.h:99:35: error: 'uint' has not been declared
   99 |         int get(const string&  k, uint &v);
      |                                   ^~~~
tools.h:99:13: error: 'int FileParser::get(const std::string&, int&)' cannot be overloaded with 'int FileParser::get(const std::string&, int&)'
   99 |         int get(const string&  k, uint &v);
      |             ^~~
tools.h:98:13: note: previous declaration 'int FileParser::get(const std::string&, int&)'
   98 |         int get(const string&  k, int &v);
      |             ^~~
tools.h:172:19: error: 'uint' has not been declared
  172 |         void init(uint max, uint delay) {
      |                   ^~~~
tools.h:172:29: error: 'uint' has not been declared
  172 |         void init(uint max, uint delay) {
      |                             ^~~~
make[3]: *** [Makefile:468: vconfig.o] Error 1
make[3]: *** Waiting for unfinished jobs....
mv -f .deps/main.Tpo .deps/main.Po
make[3]: Leaving directory '/builddir/ltris2-2.0.4/src'
make[2]: *** [Makefile:488: all-recursive] Error 1
make[2]: Leaving directory '/builddir/ltris2-2.0.4/src'
make[1]: *** [Makefile:477: all-recursive] Error 1
make[1]: Leaving directory '/builddir/ltris2-2.0.4'
make: *** [Makefile:376: all] Error 2
=> ERROR: ltris2-2.0.4_1: do_build: '${make_cmd} ${makejobs} ${XBPS_VERBOSE+${make_verbose}} ${make_build_args} ${make_build_target}' exited with 2
=> ERROR:   in do_build() at common/build-style/gnu-configure.sh:16
```

</details>