### PR TITLE
ghc: patch readthedocs layout to work with our sphinx

### DIFF
--- a/srcpkgs/ghc/patches/sphinx-9-compat.patch
+++ b/srcpkgs/ghc/patches/sphinx-9-compat.patch
@@ -1,0 +1,31 @@
+Adapted from changes to sphinx_rtd_theme (which is vendored in ghc):
+commit d34b71bb0977b4265ceff07955e974cfa73a2405
+From: Manuel Kaufmann <humitos@gmail.com>
+Date: Tue, 29 Aug 2023 11:43:41 +0200
+Subject: [PATCH] Use `css_tag` helper to inject CSS files (#1519)
+
+* Use `css_tag` helper to inject CSS files
+
+* Typo
+---
+ sphinx_rtd_theme/layout.html | 8 ++------
+ 1 file changed, 2 insertions(+), 6 deletions(-)
+
+diff --git a/docs/users_guide/rtd-theme/layout.html b/docs/users_guide/rtd-theme/layout.html
+index a83bdd29e..f3de11ad0 100644
+--- a/docs/users_guide/rtd-theme/layout.html
++++ b/docs/users_guide/rtd-theme/layout.html
+@@ -29,11 +29,7 @@
+     <link rel="stylesheet" href="{{ pathto('_static/pygments.css', 1) }}" type="text/css" />
+   {%- endif %}
+-  {%- for css in css_files %}
++  {%- for css_file in css_files %}
+-    {%- if css|attr("rel") %}
+-      <link rel="{{ css.rel }}" href="{{ pathto(css.filename, 1) }}" type="text/css"{% if css.title is not none %} title="{{ css.title }}"{% endif %} />
+-    {%- else %}
+-      <link rel="stylesheet" href="{{ pathto(css, 1) }}" type="text/css" />
+-    {%- endif %}
++    {{ css_tag(css_file) }}
+   {%- endfor %}
+ 
+   {%- for cssfile in extra_css_files %}

--- a/srcpkgs/ghc/template
+++ b/srcpkgs/ghc/template
@@ -2,7 +2,7 @@
 pkgname=ghc
 # Keep this synchronized with http://www.stackage.org/lts
 version=9.8.4
-revision=1
+revision=2
 build_helper="haskell"
 _configure_args="--prefix=/usr"
 _hadrian_args="--prefix=/usr"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **partially** (I do not have any Void Linux machines to test it on, this was confirmed to build within an Arch Linux container)

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl
  - i686

Thanks @JkktBkkt for giving me this patch. This is the first step to closing #59852, the next will be updating GHC.
