### PR TITLE
python3-uvicorn: update to 0.44.0

### DIFF
--- a/srcpkgs/python3-uvicorn/template
+++ b/srcpkgs/python3-uvicorn/template
@@ -1,6 +1,6 @@
 # Template file for 'python3-uvicorn'
 pkgname=python3-uvicorn
-version=0.42.0
+version=0.44.0
 revision=1
 build_style=python3-pep517
 hostmakedepends="hatchling"
@@ -11,7 +11,7 @@ license="BSD-3-Clause"
 homepage="https://www.uvicorn.org/"
 changelog="https://raw.githubusercontent.com/encode/uvicorn/refs/heads/master/docs/release-notes.md"
 distfiles="${PYPI_SITE}/u/uvicorn/uvicorn-${version}.tar.gz"
-checksum=9b1f190ce15a2dd22e7758651d9b6d12df09a13d51ba5bf4fc33c383a48e1775
+checksum=6c942071b68f07e178264b9152f1f16dfac5da85880c4ce06366a96d70d4f31e
 
 post_install() {
 	vlicense LICENSE.md


### PR DESCRIPTION
- I tested the changes in this PR: **NO**
- I built this PR locally for my native architecture, (x86_64-glibc)

