### PR TITLE
rio: update to 0.4.3

### DIFF
--- a/srcpkgs/rio/template
+++ b/srcpkgs/rio/template
@@ -1,19 +1,19 @@
 # Template file for 'rio'
 pkgname=rio
-version=0.2.37
+version=0.4.3
 revision=1
 build_style=cargo
 build_wrksrc="frontends/rioterm"
-hostmakedepends="pkg-config scdoc"
-makedepends="libglvnd-devel libxcb-devel libxkbcommon-devel wayland-devel fontconfig-devel"
+hostmakedepends="pkg-config scdoc shaderc"
+makedepends="oniguruma-devel freetype-devel fontconfig-devel glslang-devel"
 depends="rio-terminfo-${version}_${revision}"
 short_desc="Hardware-accelerated GPU terminal emulator powered by WebGPU"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
-homepage="https://raphamorim.io/rio/"
-changelog="https://raw.githubusercontent.com/raphamorim/rio/main/CHANGELOG.md"
+homepage="https://rioterm.com/"
+changelog="https://rioterm.com/changelog"
 distfiles="https://github.com/raphamorim/rio/archive/refs/tags/v${version}.tar.gz"
-checksum=f52bcd0fb3c669cae016c614a77a95547c2769e6a98a17d7bbc703b6e72af169
+checksum=28bedc7022f1862a12ea2b97949fb06f62d9763ed6885d08802ff1113fcdc5e8
 
 case "${XBPS_TARGET_MACHINE}" in
 	i686*)


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: YES (x64)

#### Local build testing
- I built this PR locally for my native architecture, (x64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - armv6l
