### PR TITLE
flatpak: Update flatpak to 1.16.5

### DIFF
--- a/srcpkgs/flatpak/template
+++ b/srcpkgs/flatpak/template
@@ -1,7 +1,7 @@
 # Template file for 'flatpak'
 pkgname=flatpak
-version=1.16.4
-revision=1
+version=1.16.5
+revision=2
 build_style=meson
 build_helper="gir"
 configure_args="
@@ -26,7 +26,7 @@ license="LGPL-2.1-or-later"
 homepage="https://flatpak.org/"
 changelog="https://github.com/flatpak/flatpak/raw/main/NEWS"
 distfiles="https://github.com/flatpak/flatpak/releases/download/${version}/flatpak-${version}.tar.xz"
-checksum=761ff3ba00c99a26f914c6999e90b12a54cab19cea5888413f17e46ee618d8fe
+checksum=a320e9581649766c264a97304b1563c3d04d87dcc1115427860b658083cbc156
 
 build_options="gir"
 build_options_default="gir"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly **
- Previous version of flatpak (1.16.4)  broke  steam client and probably other software, by reporting correction version of flatpak (or something like that). 1.16.5 fix this bug. Steam client works after update. [For more information](https://github.com/flatpak/flatpak/issues/6568)

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (x64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  -armv7l
  -armv6l
