### PR TITLE
xbps-triggers: allow parallelism in pycompile

### DIFF
--- a/srcpkgs/xbps-triggers/files/pycompile
+++ b/srcpkgs/xbps-triggers/files/pycompile
@@ -45,46 +45,53 @@ update_ldcache() {
 
 compile()
 {
+	sitelib="usr/lib/python${pycompile_version}/site-packages"
+
+	# Starting with Python 3.5, compileall supports parallelism
+	par=""
+	if [ "${pycompile_version%%.*}" -gt 2 ]; then
+		pycompile_minor="${pycompile_version#*.}"
+		[ "${pycompile_minor}" = "${pycompile_version}" ] && pycompile_minor=""
+		if [ -z "${pycompile_minor}" ] || ! [ "${pycompile_minor}" -lt 5 ] >/dev/null 2>&1; then
+			par="-j0"
+		fi
+	fi
+
 	for f in ${pycompile_dirs}; do
 		echo "Byte-compiling python code in ${f}..."
-		python${pycompile_version} -m compileall -f -q ./${f} && \
-		python${pycompile_version} -O -m compileall -f -q ./${f}
+		python${pycompile_version} -m compileall ${par} -f -q ./${f} && \
+		python${pycompile_version} -O -m compileall ${par} -f -q ./${f}
 	done
+
 	for f in ${pycompile_module}; do
 		echo "Byte-compiling python${pycompile_version} code for module ${f}..."
-		if [ -d "usr/lib/python${pycompile_version}/site-packages/${f}" ]; then
-			python${pycompile_version} -m compileall -f -q \
-				usr/lib/python${pycompile_version}/site-packages/${f} && \
-			python${pycompile_version} -O -m compileall -f -q \
-				usr/lib/python${pycompile_version}/site-packages/${f}
-		else
-			python${pycompile_version} -m compileall -f -q \
-				usr/lib/python${pycompile_version}/site-packages/${f} && \
-			python${pycompile_version} -O -m compileall -f -q \
-				usr/lib/python${pycompile_version}/site-packages/${f}
-		fi
+		python${pycompile_version} -m compileall ${par} -f -q "${sitelib}/${f}" && \
+		python${pycompile_version} -O -m compileall ${par} -f -q "${sitelib}/${f}"
 	done
+
 	update_ldcache
 }
 
 remove()
 {
+	sitelib="usr/lib/python${pycompile_version}/site-packages"
+
 	for f in ${pycompile_dirs}; do
 		echo "Removing byte-compiled python${pycompile_version} files in ${f}..."
 		find ./${f} -type f -name \*.py[co] -delete 2>&1 >/dev/null
 		find ./${f} -type d -name __pycache__ -delete 2>&1 >/dev/null
 	done
+
 	for f in ${pycompile_module}; do
 		echo "Removing byte-compiled python${pycompile_version} code for module ${f}..."
-		if [ -d usr/lib/python${pycompile_version}/site-packages/${f} ]; then
-			find usr/lib/python${pycompile_version}/site-packages/${f} \
-				-type f -name \*.py[co] -delete 2>&1 >/dev/null
-			find usr/lib/python${pycompile_version}/site-packages/${f} \
-				-type d -name __pycache__ -delete 2>&1 >/dev/null
+		if [ -d "${sitelib}/${f}" ]; then
+			find "${sitelib}/${f}" -type f -name \*.py[co] -delete 2>&1 >/dev/null
+			find "${sitelib}/${f}" -type d -name __pycache__ -delete 2>&1 >/dev/null
 		else
-			rm -f usr/lib/python${pycompile_version}/site-packages/${f%.py}.py[co]
+			rm -f "${sitelib}"/${f%.py}.py[co]
 		fi
 	done
+
 	update_ldcache
 }
 

--- a/srcpkgs/xbps-triggers/template
+++ b/srcpkgs/xbps-triggers/template
@@ -1,6 +1,6 @@
 # Template file for 'xbps-triggers'
 pkgname=xbps-triggers
-version=0.129
+version=0.130
 revision=1
 bootstrap=yes
 short_desc="XBPS triggers for Void Linux"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

Starting with Python 3.5, the `compileall` module supports parallel execution. Taking advantage of this greatly reduces configuration time when, for example, the `python3` package is updated.

Also, the test for whether `${py3_sitelib}/${f}` is a directory is superfluous, because the exact same commands are run in both branches. Let's eliminate this useless duplication.