### PR TITLE
streamlink: update to 8.3.0

### DIFF
--- a/srcpkgs/streamlink/template
+++ b/srcpkgs/streamlink/template
@@ -1,6 +1,6 @@
 # Template file for 'streamlink'
 pkgname=streamlink
-version=8.2.1
+version=8.3.0
 revision=1
 build_style=python3-pep517
 hostmakedepends="python3-wheel python3-versioningit"
@@ -14,7 +14,7 @@ license="BSD-2-Clause"
 homepage="https://streamlink.github.io/"
 changelog="https://raw.githubusercontent.com/streamlink/streamlink/master/CHANGELOG.md"
 distfiles="https://github.com/streamlink/streamlink/releases/download/$version/streamlink-$version.tar.gz"
-checksum=afa26582cabf343f49733d79e2bc9a5bbe90aec7dbb246ec5f97796499c637ee
+checksum=6cffe55b42df3b3c2e6dd1c0cc41fc01477afbc496ba86740ffa5eec5c333d34
 make_check_pre="env PYTHONPATH=src"
 
 post_install() {


### PR DESCRIPTION
Simple version bump:
https://github.com/streamlink/streamlink/releases/tag/8.3.0

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)

