### PR TITLE
Update Zig site URL and version pattern

### DIFF
--- a/srcpkgs/zig/update
+++ b/srcpkgs/zig/update
@@ -1,2 +1,2 @@
 site=https://ziglang.org/download/index.json
-pattern='"(?!master)\K[0-9]+\.[0-9]+\.[0-9]+'
+pattern='"(?!master)\K[0-9]+\.[0-9]+\.[0-9]+(?!-dev)'

--- a/srcpkgs/zig/update
+++ b/srcpkgs/zig/update
@@ -1,2 +1,2 @@
-site=https://ziglang.org
-pattern="<b>\K[\d.]+(?=</b>)"
+site=https://ziglang.org/download/index.json
+pattern='"(?!master)\K[0-9]+\.[0-9]+\.[0-9]+'


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
zig is too outdate also the webpage logic changed and update file broken
```
rain@void ~/void-packages (master)> ./xbps-src update-check zig
zig-0.13.0 -> zig-0.14.0
zig-0.13.0 -> zig-0.14.1
zig-0.13.0 -> zig-0.15.1
zig-0.13.0 -> zig-0.15.2
zig-0.13.0 -> zig-0.16.0
```