### PR TITLE
libjpeg-turbo: update to 3.1.4.1

### DIFF
--- a/srcpkgs/libjpeg-turbo/template
+++ b/srcpkgs/libjpeg-turbo/template
@@ -1,6 +1,6 @@
 # Template file for 'libjpeg-turbo'
 pkgname=libjpeg-turbo
-version=3.1.1
+version=3.1.4.1
 revision=1
 build_style=cmake
 configure_args="-DWITH_JPEG8=1"
@@ -11,12 +11,13 @@ license="IJG, BSD-3-Clause, Zlib"
 homepage="https://libjpeg-turbo.org/"
 changelog="https://raw.githubusercontent.com/libjpeg-turbo/libjpeg-turbo/main/ChangeLog.md"
 distfiles="https://github.com/libjpeg-turbo/libjpeg-turbo/releases/download/${version}/libjpeg-turbo-${version}.tar.gz"
-checksum=aadc97ea91f6ef078b0ae3a62bba69e008d9a7db19b34e4ac973b19b71b4217c
+checksum=ecae8008e2cc9ade2f2c1bb9d5e6d4fb73e7c433866a056bd82980741571a022
 
 provides="jpeg-8_1"
 replaces="jpeg>=0"
 
 post_install() {
+	rm ${DESTDIR}/usr/share/doc/${pkgname}/LICENSE.md
 	vlicense LICENSE.md
 
 	vinstall src/jpegint.h 644 usr/include


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**
- I haven't experienced any jpeg-related issues after the update running e.g. `ART` `chafa` `firefox` `imv` `jp2a`

#### Local build testing
- I built this PR locally for my native architecture, **x86_64-glibc**

[Changelog](https://raw.githubusercontent.com/libjpeg-turbo/libjpeg-turbo/main/ChangeLog.md)

cc @Calandracas606 
