### PR TITLE
xkbcomp: update to 1.5.0, xkeyboard-config: update to 2.47

### DIFF
--- a/srcpkgs/xkbcomp/template
+++ b/srcpkgs/xkbcomp/template
@@ -1,8 +1,8 @@
 # Template file for 'xkbcomp'
 pkgname=xkbcomp
-version=1.4.7
+version=1.5.0
 revision=1
-build_style=gnu-configure
+build_style=meson
 hostmakedepends="pkg-config bison"
 makedepends="libX11-devel libxkbfile-devel"
 short_desc="XKBD keymap compiler"
@@ -10,8 +10,8 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
 homepage="https://gitlab.freedesktop.org/xorg/app/xkbcomp"
 distfiles="${XORG_SITE}/app/xkbcomp-${version}.tar.xz"
-checksum=0a288114e5f44e31987042c79aecff1ffad53a8154b8ec971c24a69a80f81f77
+checksum=2ac31f26600776db6d9cd79b3fcd272263faebac7eb85fb2f33c7141b8486060
 
 post_install() {
-	vlicense COPYING LICENSE
+	vlicense COPYING
 }

--- a/srcpkgs/xkeyboard-config/template
+++ b/srcpkgs/xkeyboard-config/template
@@ -1,6 +1,6 @@
 # Template file for 'xkeyboard-config'
 pkgname=xkeyboard-config
-version=2.45
+version=2.47
 revision=1
 build_style=meson
 configure_args="-Dxorg-rules-symlinks=true -Dcompat-rules=true"
@@ -11,9 +11,9 @@ short_desc="X Keyboard Configuration Database"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
 homepage="https://www.freedesktop.org/wiki/Software/XKeyboardConfig"
-changelog="https://gitlab.freedesktop.org/xkeyboard-config/xkeyboard-config/-/raw/master/NEWS"
+changelog="https://gitlab.freedesktop.org/xkeyboard-config/xkeyboard-config/-/raw/master/ChangeLog.md"
 distfiles="${XORG_SITE}/data/xkeyboard-config/xkeyboard-config-${version}.tar.xz"
-checksum=169e075a92d957a57787c199e84e359df2931b7196c1c5b4a3d576ee6235a87c
+checksum=e59984416a72d58b46a52bfec1b1361aa7d84354628227ee2783626c7a6db6b6
 
 post_install() {
 	vlicense COPYING


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**|**briefly**|**NO**
- `xkeyboard-config` being a `libxkbcommon` dep on my system, I haven't experienced any issues running wlroots-based compositors

#### Local build testing
- I built this PR locally for my native architecture, **x86_64-glibc**
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl
  - armv6l (cross)
 
From [ChangeLog.md](https://gitlab.freedesktop.org/xkeyboard-config/xkeyboard-config/-/raw/master/ChangeLog.md) (`xkeyboard-config`):

> \#\# Breaking changes
> 
> \- Made \<ZEHA\> behave like \<FK24\>
> 
>   On Linux Kernel before v6.17, the scancode for F24 was bound to the otherwise
>   unused  \<ZEHA\> keycode. v6.17 fixed this. To have a consistent behaviour across
>   kernel versions, make both  \<ZEHA\> and \<FK24\> behave the same.
> 
> 

cc @dkwo (I saw you did some more extensive testing in the past)
