### PR TITLE
ty: update to 0.0.29.

### DIFF
--- a/srcpkgs/ty/template
+++ b/srcpkgs/ty/template
@@ -1,6 +1,6 @@
 # Template file for 'ty'
 pkgname=ty
-version=0.0.27
+version=0.0.29
 revision=1
 build_style=python3-pep517
 build_helper="rust qemu"
@@ -12,7 +12,7 @@ license="MIT"
 homepage="https://docs.astral.sh/ty/"
 changelog="https://raw.githubusercontent.com/astral-sh/ty/main/CHANGELOG.md"
 distfiles="https://github.com/astral-sh/ty/releases/download/${version}/source.tar.gz"
-checksum=d83bb1a634d7cbbb3a37dc715861ad601bbcfc61c3c2211c1c2a26413df376a2
+checksum=f03fb2349e404bdb62a828fcea96d1d7b97a06722d25de4a27b83e289cf810f2
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, (x86-64_glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
