### PR TITLE
tuxedo-drivers: udpate to 4.22.1

### DIFF
--- a/srcpkgs/tuxedo-drivers/template
+++ b/srcpkgs/tuxedo-drivers/template
@@ -1,6 +1,6 @@
 # Template file for 'tuxedo-drivers'
 pkgname=tuxedo-drivers
-version=4.21.3
+version=4.22.1
 revision=1
 depends="dkms"
 short_desc="TUXEDO hardware drivers"
@@ -8,7 +8,7 @@ maintainer="newbluemoon <blaumolch@mailbox.org>"
 license="GPL-3.0-or-later"
 homepage="https://gitlab.com/tuxedocomputers/development/packages/tuxedo-drivers"
 distfiles="https://gitlab.com/tuxedocomputers/development/packages/tuxedo-drivers/-/archive/v${version}/tuxedo-drivers-v${version}.tar.gz"
-checksum=7dcd7dc06fbf21d44ef61b216fc251035b2ab97004c6a690e1a1ef866be183af
+checksum=9e2161f128d5d7235a0d51bdf2121a1fb0a9ded8bc2ca48dcf6521986736f571
 
 dkms_modules="tuxedo-drivers ${version}"
 


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)
- Built for kernels 6.1, 6.3–6.19; running on 6.19.12