### PR TITLE
mbedtls: update to 3.6.6

### DIFF
--- a/srcpkgs/mbedtls/template
+++ b/srcpkgs/mbedtls/template
@@ -1,7 +1,8 @@
 # Template file for 'mbedtls'
 pkgname=mbedtls
-version=3.6.3
+version=3.6.6
 revision=1
+_framework_hash="dff9da04438d712f7647fd995bc90fadd0c0e2ce"
 build_style=cmake
 configure_args="-DENABLE_TESTING=1 -DUSE_SHARED_MBEDTLS_LIBRARY=1"
 hostmakedepends="python3 perl"
@@ -10,9 +11,15 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="Apache-2.0"
 homepage="https://tls.mbed.org/"
 changelog="https://raw.githubusercontent.com/ARMmbed/mbedtls/mbedtls-${version%.*}/ChangeLog"
-distfiles="https://github.com/ARMmbed/mbedtls/archive/refs/tags/v${version}.tar.gz"
-checksum="e69c4c13377e89b9d696006ef9c8258e3be75b6dbd464cfd573360482b1a1f4e
- d46acd6cb103d00d6e545631467e36363f6fc270b2c051be94d543eb0831393b"
+distfiles="https://github.com/ARMmbed/mbedtls/archive/refs/tags/v${version}.tar.gz
+ https://github.com/Mbed-TLS/mbedtls-framework/archive/${_framework_hash}.tar.gz>framework-${_framework_hash}.tar.gz"
+checksum="82dd9b736624a76577635e8ffae688ac3cc3b16eb3813f0b17201aa8ba3fa76c
+ 0f2bc024aceb3d3cbfcd8cfb997bc9a5eadfcf81fbbf0ef9a9053236e1d6506c"
+skip_extraction="framework-${_framework_hash}.tar.gz"
+
+post_extract() {
+	vsrcextract -C framework "framework-${_framework_hash}.tar.gz"
+}
 
 pre_configure() {
 	./scripts/config.pl set MBEDTLS_THREADING_C


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly** (been running for 2 days w/ no issue)

#### Local build testing
- I built this PR locally for my native architecture, **x86_64**
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl (cross)
  - aarch64 (cross)
  - armv6l-musl (cross)
  - armv6l (cross)

Had to add framework downloading, but given that dff9da0 is submoduled in the v3.6.6 ref on the github, I'm fairly sure it's fine.

fixes:
CVE-2026-25833
CVE-2026-25834
CVE-2026-25835

CVE-2026-34871
CVE-2026-34874