### PR TITLE
openssl: update to 3.5.6

### DIFF
--- a/srcpkgs/openssl/template
+++ b/srcpkgs/openssl/template
@@ -1,6 +1,6 @@
 # Template file for 'openssl'
 pkgname=openssl
-version=3.5.5
+version=3.5.6
 revision=1
 bootstrap=yes
 build_style=configure
@@ -17,7 +17,7 @@ maintainer="classabbyamp <void@placeviolette.net>"
 license="Apache-2.0"
 homepage="https://openssl-library.org"
 distfiles="https://github.com/openssl/openssl/releases/download/openssl-${version}/openssl-${version}.tar.gz"
-checksum=b28c91532a8b65a1f983b4c28b7488174e4a01008e29ce8e69bd789f28bc2a89
+checksum=deae7c80cba99c4b4f940ecadb3c3338b13cb77418409238e57d7f31f2a3b736
 conf_files="/etc/ssl/openssl.cnf"
 replaces="libressl>=0"
 


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly** (been running for 2 days w/ no issue)

#### Local build testing
- I built this PR locally for my native architecture, **x86_64**
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl (cross)
  - aarch64 (cross)
  - armv6l-musl (cross)
  - armv6l (cross)

fixes:

CVE-2026-2673

CVE-2026-28387
CVE-2026-28388
CVE-2026-28389
CVE-2026-28390

CVE-2026-31789
CVE-2026-31790