### PR TITLE
libopenmpt: update to 0.8.6

### DIFF
--- a/srcpkgs/libopenmpt/template
+++ b/srcpkgs/libopenmpt/template
@@ -1,6 +1,6 @@
 # Template file for 'libopenmpt'
 pkgname=libopenmpt
-version=0.8.1
+version=0.8.6
 revision=1
 build_style=gnu-configure
 configure_args="$(vopt_with pulseaudio) $(vopt_with sdl2)
@@ -16,7 +16,7 @@ license="BSD-3-Clause"
 homepage="https://lib.openmpt.org/libopenmpt/"
 changelog="https://lib.openmpt.org/doc/changelog.html"
 distfiles="https://lib.openmpt.org/files/libopenmpt/src/libopenmpt-${version}+release.autotools.tar.gz"
-checksum=5ccc291e4457925f3ca3e8144f5b645c4a3dcc2bc05dc9a39651132b32b83bce
+checksum=caa2fa959e389f4374d9e2df3af5c633452c12dd80442cba2e89cb7ff2b93c5b
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly** (been running for 2 days w/ no issue)

#### Local build testing
- I built this PR locally for my native architecture, **x86_64**
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl (cross)
  - aarch64 (cross)

relevant security patches:

<https://lib.openmpt.org/libopenmpt/2025/07/19/security-updates-0.8.2-0.7.15-0.6.24-0.5.38-0.4.50/>
<https://lib.openmpt.org/libopenmpt/2026/03/22/security-updates-0.8.5-0.7.18-0.6.27-0.5.41-0.4.53/>
<https://lib.openmpt.org/libopenmpt/2026/03/24/security-updates-0.8.6-0.7.19-0.6.28-0.5.42-0.4.54/>