### PR TITLE
gnutls: update to 3.8.12

### DIFF
--- a/srcpkgs/gnutls/template
+++ b/srcpkgs/gnutls/template
@@ -1,13 +1,13 @@
 # Template file for 'gnutls'
 pkgname=gnutls
-version=3.8.10
+version=3.8.12
 revision=1
 build_style=gnu-configure
 configure_args="--disable-static --disable-valgrind-tests
  --disable-rpath
  --with-default-trust-store-file=/etc/ssl/certs/ca-certificates.crt
  --with-trousers-lib=${XBPS_CROSS_BASE}/usr/lib"
-hostmakedepends="gettext libtool pkg-config which"
+hostmakedepends="gettext libtool pkg-config which texinfo"
 # dependencies listed in pkg-config files
 _develdepends="unbound-devel trousers-devel libunistring-devel nettle-devel
  libtasn1-devel libidn2-devel p11-kit-devel brotli-devel libzstd-devel
@@ -21,7 +21,7 @@ license="GPL-3.0-only, LGPL-2.1-or-later"
 homepage="https://gnutls.org"
 changelog="https://gitlab.com/gnutls/gnutls/-/raw/master/NEWS"
 distfiles="https://www.gnupg.org/ftp/gcrypt/gnutls/v${version%.*}/gnutls-${version}.tar.xz"
-checksum=db7fab7cce791e7727ebbef2334301c821d79a550ec55c9ef096b610b03eb6b7
+checksum=a7b341421bfd459acf7a374ca4af3b9e06608dcd7bd792b2bf470bea012b8e51
 # same as $PASS in tests/cert-tests/certtool.sh
 make_check_pre="env GNUTLS_PIN=1234"
 


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly** (been running for 2 days w/ no issue)

#### Local build testing
- I built this PR locally for my native architecture, **x86_64**

Adding the texinfo hostmakedependency may be unnecessary, but I didn't get too intimate with it.

fixes:
CVE-2025-9820
CVE-2025-14831