### PR TITLE
libtasn1: update to 4.21.0

### DIFF
--- a/srcpkgs/libtasn1/template
+++ b/srcpkgs/libtasn1/template
@@ -1,16 +1,16 @@
 # Template file for 'libtasn1'
 pkgname=libtasn1
-version=4.20.0
+version=4.21.0
 revision=1
 build_style=gnu-configure
-hostmakedepends="perl"
+hostmakedepends="perl texinfo"
 short_desc="ASN.1 structure parser library"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-3.0-only, LGPL-2.1-only"
 homepage="https://www.gnu.org/software/libtasn1/"
 changelog="https://gitlab.com/gnutls/libtasn1/-/raw/master/NEWS"
 distfiles="${GNU_SITE}/$pkgname/$pkgname-$version.tar.gz"
-checksum=92e0e3bd4c02d4aeee76036b2ddd83f0c732ba4cda5cb71d583272b23587a76c
+checksum=1d8a444a223cc5464240777346e125de51d8e6abf0b8bac742ac84609167dc87
 
 libtasn1-devel_package() {
 	depends="${sourcepkg}-${version}_${revision}"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly** (been running for 2 days w/ no issue)

#### Local build testing
- I built this PR locally for my native architecture, **x86_64**
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl (cross)
  - aarch64 (cross)
  - armv5tel-musl (cross)
  - armv5tel (cross)
  - armv6l-musl (cross)
  - armv6l (cross)
  - armv7l-musl (cross)
  - armv7l (cross)
  - i686-musl (cross)
  - i686 (cross)
 
Adding the texinfo hostmakedependency may be unnecessary, but I didn't get too intimate with it.

fixes:

CVE-2025-13151