### PR TITLE
libjxl: update to 0.11.2, adopt

### DIFF
--- a/srcpkgs/libjxl/template
+++ b/srcpkgs/libjxl/template
@@ -1,7 +1,7 @@
 # Template file for 'libjxl'
 pkgname=libjxl
-version=0.11.1
-revision=3
+version=0.11.2
+revision=1
 _testdata_hash=ff8d743aaba05b3014f17e5475e576242fa979fc
 build_style=cmake
 configure_args="-DJPEGXL_ENABLE_BENCHMARK=OFF -DJPEGXL_ENABLE_EXAMPLES=OFF
@@ -12,13 +12,13 @@ makedepends="brotli-devel highway-devel libpng-devel giflib-devel libjpeg-turbo-
  libopenexr-devel libwebp-devel gdk-pixbuf-devel lcms2-devel"
 checkdepends="gtest-devel xdg-utils"
 short_desc="JPEG XL image format reference implementation"
-maintainer="Joshua Krämer <joshua@kraemer.link>"
+maintainer="yosh <yosh-git@riseup.net>"
 license="BSD-3-Clause, custom:Patent grant"
 homepage="https://jpeg.org/jpegxl/"
 changelog="https://raw.githubusercontent.com/libjxl/libjxl/main/CHANGELOG.md"
 distfiles="https://github.com/libjxl/libjxl/archive/v${version}.tar.gz
  https://github.com/libjxl/testdata/archive/${_testdata_hash}.tar.gz>testdata-${_testdata_hash}.tar.gz"
-checksum="1492dfef8dd6c3036446ac3b340005d92ab92f7d48ee3271b5dac1d36945d3d9
+checksum="ab38928f7f6248e2a98cc184956021acb927b16a0dee71b4d260dc040a4320ea
  9c45a108df32a002a69465df896d33acf77d97c88fb59dffa0dff5628370e96f"
 skip_extraction="testdata-${_testdata_hash}.tar.gz"
 


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- `x86-64-glibc`

[the original maintainer](https://github.com/joshuakraemer) hasn't contributed to void [in ~1.5 years](https://github.com/void-linux/void-packages/issues?q=is%3Apr+author%3Ajoshuakraemer) nor has kept libjxl up to date since adding it. I actively use jxl so I might as well take the steed for now.