### PR TITLE
libarchive: update to 3.8.7

### DIFF
--- a/srcpkgs/libarchive/template
+++ b/srcpkgs/libarchive/template
@@ -1,6 +1,6 @@
 # Template file for 'libarchive'
 pkgname=libarchive
-version=3.8.6
+version=3.8.7
 revision=1
 bootstrap=yes
 build_style=gnu-configure
@@ -8,7 +8,7 @@ configure_args="$(vopt_enable acl) $(vopt_enable acl xattr)
  $(vopt_with expat) $(vopt_with lzo lzo2) $(vopt_with lz4)
  $(vopt_with ssl openssl) $(vopt_with zstd) --without-xml2
  --without-libb2 --without-nettle --disable-rpath"
-hostmakedepends="pkgconf"
+hostmakedepends="pkg-config"
 makedepends="zlib-devel bzip2-devel liblzma-devel
  $(vopt_if acl acl-devel) $(vopt_if expat expat-devel) $(vopt_if zstd libzstd-devel)
  $(vopt_if lzo lzo-devel) $(vopt_if lz4 liblz4-devel) $(vopt_if ssl openssl-devel)"
@@ -18,7 +18,7 @@ license="BSD-2-Clause"
 homepage="https://www.libarchive.org/"
 changelog="https://github.com/libarchive/libarchive/releases"
 distfiles="https://github.com/libarchive/libarchive/releases/download/v${version}/libarchive-${version}.tar.xz"
-checksum=8ac57c1f5e99550948d1fe755c806d26026e71827da228f36bef24527e372e6f
+checksum=d3a8ba457ae25c27c84fd2830a2efdcc5b1d40bf585d4eb0d35f47e99e5d4774
 
 build_options="acl expat lzo lz4 ssl zstd"
 build_options_default="acl ssl lz4 zstd"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**
- tested `bsdtar` and packaging w/ `xbps-src`

#### Local build testing
- I built this PR locally for my native architecture, **x86_64-glibc**

[Security and bugfix release](https://github.com/libarchive/libarchive/releases/tag/v3.8.7)