### PR TITLE
New package: openfpgaloader-1.1.1

### DIFF
--- a/srcpkgs/openfpgaloader/template
+++ b/srcpkgs/openfpgaloader/template
@@ -1,0 +1,22 @@
+# Template file for 'openfpgaloader'
+pkgname=openfpgaloader
+version=1.1.1
+revision=1
+build_style=cmake
+configure_args="
+ -DENABLE_UDEV=ON
+ -DENABLE_CMSISDAP=ON
+ -DCMAKE_DISABLE_FIND_PACKAGE_LibFTDI1=ON"
+hostmakedepends="pkg-config"
+makedepends="eudev-libudev-devel hidapi-devel libftdi1-devel libusb-devel zlib-devel"
+short_desc="Universal utility for programming FPGA"
+maintainer="Mohamad Alsadhan <mo@sdhn.cc>"
+license="Apache-2.0"
+homepage="https://trabucayre.github.io/openFPGALoader/"
+changelog="https://github.com/trabucayre/openFPGALoader/releases"
+distfiles="https://github.com/trabucayre/openFPGALoader/archive/refs/tags/v${version}.tar.gz"
+checksum=ca965f933c52a2a9dbb318df4d4de70fac5f095a8e64523f81036ab467a4b567
+
+post_install() {
+	vinstall 99-openfpgaloader.rules 644 usr/lib/udev/rules.d/
+}


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES** 
  - System
  - Compiled

#### Local build testing
- I built this PR locally for my native architecture (x86_64-glibc)

#### Notes
- Installs upstream `99-openfpgaloader.rules`
- On Void, non-root access requires the user to be in `plugdev`, then re-login/replug the device