### PR TITLE
perl-Proc-Govern: update to 0.214

### DIFF
--- a/srcpkgs/perl-IPC-Run-Patch-Setuid/template
+++ b/srcpkgs/perl-IPC-Run-Patch-Setuid/template
@@ -1,0 +1,15 @@
+# Template file for 'perl-IPC-Run-Patch-Setuid'
+pkgname=perl-IPC-Run-Patch-Setuid
+version=0.003
+revision=1
+build_style=perl-module
+hostmakedepends="perl"
+makedepends="perl perl-Log-ger perl-Module-Patch"
+depends="${makedepends}"
+short_desc="Set EUID of the child process after forking"
+maintainer="Luc Saccoccio--Le Guennec <lucsaccoccio@disroot.org>"
+license="Artistic-1.0-Perl, GPL-1.0-or-later"
+homepage="https://metacpan.org/dist/IPC-Run-Patch-Setuid"
+changelog="https://metacpan.org/dist/IPC-Run-Patch-Setuid/changes"
+distfiles="https://cpan.metacpan.org/authors/id/P/PE/PERLANCAR/IPC-Run-Patch-Setuid-${version}.tar.gz"
+checksum=cf03ba67c9bf51e5e037d6e58e41b356cb2ebeaaff83eabc7cd7aad955c37b64

--- a/srcpkgs/perl-Log-ger/template
+++ b/srcpkgs/perl-Log-ger/template
@@ -1,0 +1,15 @@
+# Template file for 'perl-Log-ger'
+pkgname=perl-Log-ger
+version=0.042
+revision=1
+build_style=perl-module
+hostmakedepends="perl"
+makedepends="perl perl-Data-Dumper"
+depends="${makedepends}"
+short_desc="Lightweight, flexible logging framework"
+maintainer="Luc Saccoccio--Le Guennec <lucsaccoccio@disroot.org>"
+license="Artistic-1.0-Perl, GPL-1.0-or-later"
+homepage="https://metacpan.org/dist/Log-ger"
+changelog="https://metacpan.org/dist/Log-ger/changes"
+distfiles="https://cpan.metacpan.org/authors/id/P/PE/PERLANCAR/Log-ger-${version}.tar.gz"
+checksum=7996bca5be595e3ed0dab6c1cfe351ec3784ee2447bc0f249e1a795ab83d12d9

--- a/srcpkgs/perl-Module-Patch/template
+++ b/srcpkgs/perl-Module-Patch/template
@@ -1,0 +1,16 @@
+# Template file for 'perl-Module-Patch'
+pkgname=perl-Module-Patch
+version=0.278
+revision=1
+build_style=perl-module
+hostmakedepends="perl"
+makedepends="perl perl-Log-ger perl-Monkey-Patch-Action perl-Package-Stash perl-Package-Util-Lite"
+depends="${makedepends}"
+checkdepends="perl-Test-Exception perl-Capture-Tiny"
+short_desc="Patch package with a set of patches"
+maintainer="Luc-Saccoccio <lucsaccoccio@disroot.org>"
+license="Artistic-1.0-Perl, GPL-1.0-or-later"
+homepage="https://metacpan.org/dist/Module-Patch"
+changelog="https://metacpan.org/dist/Module-Patch/changes"
+distfiles="https://cpan.metacpan.org/authors/id/P/PE/PERLANCAR/Module-Patch-${version}.tar.gz"
+checksum=b6d13cd5805930cce52b2d87514f30149ce45357ec3c108937a486732d893207

--- a/srcpkgs/perl-Package-Util-Lite/template
+++ b/srcpkgs/perl-Package-Util-Lite/template
@@ -1,0 +1,15 @@
+# Template file for 'perl-Package-Util-Lite'
+pkgname=perl-Package-Util-Lite
+version=0.001
+revision=1
+build_style=perl-module
+hostmakedepends="perl"
+makedepends="${hostmakedepends}"
+depends="${hostmakedepends}"
+short_desc="Package-related utilities"
+maintainer="Luc Saccoccio--Le Guennec <lucsaccoccio@disroot.org>"
+license="Artistic-1.0-Perl, GPL-1.0-or-later"
+homepage="https://metacpan.org/dist/Package-Util-Lite"
+changelog="https://metacpan.org/dist/Package-Util-Lite/changes"
+distfiles="https://cpan.metacpan.org/authors/id/P/PE/PERLANCAR/Package-Util-Lite-${version}.tar.gz"
+checksum=0c49dfd6f2db50b74b90a5bdb517382657d4ef56a5b2be36aef4e6c4bfb01d26

--- a/srcpkgs/perl-Proc-Govern/template
+++ b/srcpkgs/perl-Proc-Govern/template
@@ -1,14 +1,15 @@
 # Template file for 'perl-Proc-Govern'
 pkgname=perl-Proc-Govern
-version=0.211
-revision=2
+version=0.214
+revision=1
 build_style=perl-module
 hostmakedepends="perl"
-makedepends="perl perl-IPC-Run perl-File-Write-Rotate perl-Unix-Uptime"
-depends="$makedepends"
+makedepends="perl perl-IPC-Run perl-IPC-Run-Patch-Setuid perl-Log-ger"
+depends="${makedepends}"
 short_desc="Run child process and govern its various aspects"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="Artistic-1.0-Perl, GPL-1.0-or-later"
 homepage="https://metacpan.org/release/Proc-Govern"
-distfiles="${CPAN_SITE}/Proc/${pkgname/perl-/}-${version}.tar.gz"
-checksum=ad7a90b8a85cd16de59e7bfdfe5f512796a658b94f42897e5091b63e11fa95d2
+changelog="https://metacpan.org/release/Proc-Govern/changes"
+distfiles="https://cpan.metacpan.org/authors/id/P/PE/PERLANCAR/Proc-Govern-${version}.tar.gz"
+checksum=d0955316b3bf390176b5e6c3230bc2c56d5c3565e03be7778ce97c2e5a20fee3


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

I had to add `perl-IPC-Run-Patch-Setuid` and `perl-Log-ger`, the former requiring `perl-Module-Patch`, which needed `perl-Package-Util-Lite`...

I hope it's not too much for a PR, and that the title is adequate.