### PR TITLE
vte3: update to 0.84.0

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -4572,3 +4572,4 @@ libgpiodcxx.so.2 libgpiod-2.2_4
 libigloo.so.0 libigloo-0.9.5_1
 libfyaml.so.0 libfyaml-0.9.6_1
 libcpptrace.so.1 cpptrace-1.0.4_1
+libsimdutf.so.33 simdutf-8.2.0_1

--- a/srcpkgs/simdutf-devel
+++ b/srcpkgs/simdutf-devel
@@ -1,0 +1,1 @@
+simdutf

--- a/srcpkgs/simdutf/template
+++ b/srcpkgs/simdutf/template
@@ -1,0 +1,51 @@
+# Template file for 'simdutf'
+pkgname=simdutf
+version=8.2.0
+revision=1
+build_style=cmake
+configure_args="-DBUILD_SHARED_LIBS=ON"
+hostmakedepends="pkg-config"
+short_desc="Unicode routines (UTF8, UTF16, UTF32) and Base64 using SIMD"
+maintainer="kim <grufwub@gmail.com>"
+license="Apache-2.0 OR MIT"
+homepage="https://github.com/simdutf/simdutf"
+distfiles="https://github.com/simdutf/simdutf/archive/refs/tags/v${version}.tar.gz"
+checksum=033a91b1d7d1cb818c1eff49e61faaa1b64a3a530d59ef9efef0195e56bda8b1
+
+post_configure() {
+	cmake_builddir=build-static configure_args="" do_configure
+}
+
+do_build() {
+	_build() { ninja ${XBPS_VERBOSE+-v} ${makejobs}; }
+	(cd build-static; _build)
+	(cd build; _build)
+}
+
+do_check() {
+	_check() { ninja ${XBPS_VERBOSE+-v} ${makejobs} test; }
+	(cd build-static; _check)
+	(cd build; _check)
+}
+
+do_install() {
+	_install() { DESTDIR=${DESTDIR} ninja ${XBPS_VERBOSE+-v} install; }
+	(cd build-static; _install)
+	(cd build; _install)
+}
+
+post_install() {
+	vlicense LICENSE-MIT
+}
+
+simdutf-devel_package() {
+	depends="${sourcepkg}>=${version}_${revision}"
+	short_desc+=" - development files"
+	pkg_install() {
+		vmove usr/include
+		vmove usr/lib/pkgconfig
+		vmove usr/lib/cmake
+		vmove "usr/lib/*.so"
+		vmove "usr/lib/*.a"
+	}
+}

--- a/srcpkgs/vte3/template
+++ b/srcpkgs/vte3/template
@@ -1,6 +1,6 @@
 # Template file for 'vte3'
 pkgname=vte3
-version=0.82.1
+version=0.84.0
 revision=1
 build_style=meson
 build_helper="gir"
@@ -9,14 +9,14 @@ configure_args="-Db_ndebug=false -Db_lto=false -D_systemd=false
 hostmakedepends="glib-devel gettext pkg-config
  $(vopt_if gir vala)"
 makedepends="gnutls-devel gtk4-devel gtk+3-devel pcre2-devel liblz4-devel
- $(vopt_if gir vala-devel)"
+ $(vopt_if gir vala-devel) simdutf-devel"
 depends="vte3-profile>=${version}_${revision}"
 short_desc="Terminal widget with improved accessibility and I18N support"
 maintainer="Enno Boland <gottox@voidlinux.org>"
-license="GPL-3.0-or-later, LGPL-2.1-or-later, LGPL-3.0-or-later"
+license="LGPL-3.0-or-later AND GPL-3.0-or-later"
 homepage="https://gitlab.gnome.org/GNOME/vte/"
 distfiles="${GNOME_SITE}/vte/${version%.*}/vte-${version}.tar.xz"
-checksum=79376d70402d271e2d38424418e1aea72357934d272e321e3906b71706a78e3a
+checksum=0414e31583836aeb7878da25f67c515f7e8879917ecc37c92e26b83e8d8fc3e3
 
 # Suppress warnings as errors for NULL format strings (musl libc)
 CXXFLAGS="-Wno-error=format="


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES** (have been running this for [nearly 2 weeks](https://codeberg.org/gruf/void-packages/commits/branch/main/patches/vte3/version-bump.patch) without issue)

#### Local build testing
- I built this PR locally for my native architecture, x86-64
- I built this PR locally for these architectures:
  - aarch64-musl
  - aarch64

New package simdutf is a vte3 dependency which they do bundle, but attempting build on aarch64 with supplied copy runs into failures. ~~It provides two shell utilities /usr/bin/{sutf,fastbase64} and development files with only static archive, hence no shlib.~~ Have modified template to build both static and shared libs.

cc: @Gottox 