### PR TITLE
toot: update to 0.52.1

### DIFF
--- a/srcpkgs/toot/template
+++ b/srcpkgs/toot/template
@@ -1,20 +1,21 @@
 # Template file for 'toot'
 pkgname=toot
-version=0.47.1
+version=0.52.1
 revision=3
 build_style=python3-pep517
 _depends="python3-click python3-requests python3-BeautifulSoup4 python3-wcwidth
- python3-urwid python3-urwidgets python3-tomlkit python3-Pillow python3-term-image"
+ python3-urwid python3-urwidgets python3-tomlkit python3-Pillow python3-term-image
+ python3-dateutil"
 hostmakedepends="python3-setuptools python3-wheel python3-setuptools_scm ${_depends}"
 depends="${_depends}"
 checkdepends="${depends} python3-pytest-xdist"
 short_desc="Mastodon CLI client"
-maintainer="Jon Levin <jon@jefferiestube.net>"
+maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-3.0-or-later"
 homepage="https://toot.bezdomni.net"
 changelog="https://raw.githubusercontent.com/ihabunek/toot/master/CHANGELOG.md"
 distfiles="${PYPI_SITE}/t/toot/toot-${version}.tar.gz"
-checksum=fae758b50d22c019379a1f90ac0fe7adfc152ce8899005e463b36ee2e88abc2b
+checksum=b737173be5587522077c18c4024eb1741a4a30e59d3165e72fd6ce4519d2fecb
 
 post_install() {
 	for shell in bash zsh fish; do

--- a/srcpkgs/toot/template
+++ b/srcpkgs/toot/template
@@ -1,11 +1,11 @@
 # Template file for 'toot'
 pkgname=toot
 version=0.52.1
-revision=3
+revision=1
 build_style=python3-pep517
 _depends="python3-click python3-requests python3-BeautifulSoup4 python3-wcwidth
  python3-urwid python3-urwidgets python3-tomlkit python3-Pillow python3-term-image
- python3-dateutil"
+ python3-dateutil python3-pysocks"
 hostmakedepends="python3-setuptools python3-wheel python3-setuptools_scm ${_depends}"
 depends="${_depends}"
 checkdepends="${depends} python3-pytest-xdist"


### PR DESCRIPTION
Orphan package because old maintainer mail address is not active anymore and the package is outdated.