### PR TITLE
[RFC] pkgconf

### DIFF
--- a/common/hooks/pre-configure/02-script-wrapper.sh
+++ b/common/hooks/pre-configure/02-script-wrapper.sh
@@ -101,7 +101,7 @@ pkgconfig_wrapper() {
 #!/bin/sh
 
 export PKG_CONFIG_SYSROOT_DIR="$XBPS_CROSS_BASE"
-export PKG_CONFIG_PATH="$XBPS_CROSS_BASE/usr/lib/pkgconfig:$XBPS_CROSS_BASE/usr/share/pkgconfig\${PKG_CONFIG_PATH:+:\${PKG_CONFIG_PATH}}"
+export PKG_CONFIG_PATH="$XBPS_CROSS_BASE/usr/lib/pkgconfig:$XBPS_CROSS_BASE/usr/share/pkgconfig:/usr/share/pkgconfig\${PKG_CONFIG_PATH:+:\${PKG_CONFIG_PATH}}"
 export PKG_CONFIG_LIBDIR="$XBPS_CROSS_BASE/usr/lib/pkgconfig\${PKG_CONFIG_LIBDIR:+:\${PKG_CONFIG_LIBDIR}}"
 exec /usr/bin/pkg-config "\$@"
 _EOF

--- a/common/shlibs
+++ b/common/shlibs
@@ -3681,7 +3681,7 @@ libgaminggear.so.0 libgaminggear-0.15.1_1
 libgaminggearfx.so.0 libgaminggear-0.15.1_1
 libgaminggearwidget.so.0 libgaminggear-0.15.1_1
 libopkg.so.1 libopkg-0.4.4_2
-libpkgconf.so.4 libpkgconf-1.9.3_1
+libpkgconf.so.7 libpkgconf-2.5.1_1
 libkodiplatform.so.19.0 kodi-platform-20180302_1
 libQuotient.so.0.9 libQuotient-0.9.1_1
 libQuotientQt6.so.0.9 libQuotient-0.9.1_1

--- a/srcpkgs/muon/template
+++ b/srcpkgs/muon/template
@@ -1,7 +1,7 @@
 # Template file for 'muon'
 pkgname=muon
 version=0.5.0
-revision=1
+revision=2
 build_style=meson
 build_helper="qemu"
 configure_args="

--- a/srcpkgs/pkgconf/template
+++ b/srcpkgs/pkgconf/template
@@ -1,6 +1,6 @@
 # Template file for 'pkgconf'
 pkgname=pkgconf
-version=2.1.0
+version=2.5.1
 revision=1
 bootstrap=yes
 build_style=gnu-configure # cmake and meson also available
@@ -11,7 +11,7 @@ license="MIT"
 homepage="http://pkgconf.org/"
 changelog="https://raw.githubusercontent.com/pkgconf/pkgconf/master/NEWS"
 distfiles="https://distfiles.ariadne.space/pkgconf/pkgconf-${version}.tar.xz"
-checksum=266d5861ee51c52bc710293a1d36622ae16d048d71ec56034a02eb9cf9677761
+checksum=cd05c9589b9f86ecf044c10a2269822bc9eb001eced2582cfffd658b0a50c243
 
 alternatives="
  pkg-config:pkg-config:/usr/bin/pkgconf


### PR DESCRIPTION
[ci skip][skip ci]

As an alternative to #59948, instead of making `pkg-config` the default make `pkgconf` the default. This PR is to track and figure out what would need to be changed and possibly fixed.

Current major issues would be `pkgconf` adding the sysroot path to all variables, including things like `host_bins` which breaks some packages using pkg-config to look up those variables.

Fix would probably to separate those pkg-config calls to actually use `PKG_CONFIG_FOR_BUILD` instead of `PKG_CONFIG`.