### PR TITLE
tokyocabinet: fix dead distfiles

### DIFF
--- a/srcpkgs/tokyocabinet/template
+++ b/srcpkgs/tokyocabinet/template
@@ -7,15 +7,9 @@ makedepends="zlib-devel bzip2-devel"
 short_desc="Modern implementation of DBM"
 maintainer="mobinmob <mobinmob@disroot.org>"
 license="LGPL-2.1-only"
-homepage="https://fallabs.com/tokyocabinet/"
-distfiles="https://fallabs.com/tokyocabinet/tokyocabinet-${version}.tar.gz"
+homepage="https://dbmx.net/tokyocabinet/"
+distfiles="https://dbmx.net/tokyocabinet/tokyocabinet-${version}.tar.gz"
 checksum=a003f47c39a91e22d76bc4fe68b9b3de0f38851b160bbb1ca07a4f6441de1f90
-
-post_install() {
-	vlicense "$DESTDIR"/usr/share/tokyocabinet/COPYING
-	rm -f "$DESTDIR"/usr/share/tokyocabinet/COPYING
-	rm -r "$DESTDIR/usr/share/tokyocabinet/doc"
-}
 
 tokyocabinet-devel_package() {
 	depends="$makedepends tokyocabinet-${version}_${revision}"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

This package is _old_, it would probably be better to package `kyotocabinet` or `tkrzw` if not for `duc` needing `tokyocabinet`.

cc @mobinmob 