### PR TITLE
ddcutil: don't depend on i2c-tools

### DIFF
--- a/srcpkgs/ddcutil/template
+++ b/srcpkgs/ddcutil/template
@@ -1,13 +1,12 @@
 # Template file for 'ddcutil'
 pkgname=ddcutil
 version=2.2.5
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--libdir=/usr/lib"
 hostmakedepends="automake libtool pkg-config"
-makedepends="i2c-tools-devel libdrm-devel libgudev-devel libkmod-devel
- libusb-devel libXrandr-devel jansson-devel"
-depends="i2c-tools"
+makedepends="libdrm-devel libgudev-devel libkmod-devel libusb-devel
+ libXrandr-devel jansson-devel"
 short_desc="Query and change monitor settings using DDC/CI and USB"
 maintainer="lemmi <lemmi@nerd2nerd.org>"
 license="GPL-2.0-or-later"

--- a/srcpkgs/ddcutil/template
+++ b/srcpkgs/ddcutil/template
@@ -1,13 +1,12 @@
 # Template file for 'ddcutil'
 pkgname=ddcutil
 version=2.2.6
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--libdir=/usr/lib"
 hostmakedepends="automake libtool pkg-config"
-makedepends="i2c-tools-devel libdrm-devel libgudev-devel libkmod-devel
- libusb-devel libXrandr-devel jansson-devel"
-depends="i2c-tools"
+makedepends="libdrm-devel libgudev-devel libkmod-devel libusb-devel
+ libXrandr-devel jansson-devel"
 short_desc="Query and change monitor settings using DDC/CI and USB"
 maintainer="lemmi <lemmi@nerd2nerd.org>"
 license="GPL-2.0-or-later"
@@ -16,14 +15,10 @@ changelog="https://www.ddcutil.com/release_notes_220/"
 distfiles="https://github.com/rockowitz/ddcutil/archive/v${version}.tar.gz"
 checksum=7bf4420778894caf37ca5f7bade34f7a31d996d92618bb85e18de55a5e5ac465
 
-case "$XBPS_TARGET_MACHINE" in
-	*-musl) makedepends+=" libexecinfo-devel musl-legacy-compat"
-		LDFLAGS="-lexecinfo"
-		post_extract() {
-			vsed -i -e "/AM_CFLAGS += -Wpedantic/d" src/app_sysenv/Makefile.am
-		}
-		;;
-esac
+if [ "${XBPS_TARGET_LIBC}" = "musl" ]; then
+	makedepends+=" libexecinfo-devel musl-legacy-compat"
+	LDFLAGS="-lexecinfo"
+fi
 
 pre_configure() {
 	NOCONFIGURE=1 ./autogen.sh


### PR DESCRIPTION
It's not used; the configure script hasn't checked for it since 2022: https://github.com/rockowitz/ddcutil/commit/ec7377e7 It looks like the code that uses it was removed around 2017.

This was "added back" in Void in #39113, but for unclear reason and people are reporting it's not really needed there too. Everything seems to work as near as I can tell. I can't find any references in the code beyond some commented out stuff.

#### Testing the changes
- I tested the changes in this PR: **YES** (on amd64)