### PR TITLE
moor: update to 2.12.1.

### DIFF
--- a/srcpkgs/moor/template
+++ b/srcpkgs/moor/template
@@ -1,6 +1,6 @@
 # Template file for 'moor'
 pkgname=moor
-version=2.9.5
+version=2.12.1
 revision=1
 build_style=go
 go_import_path=github.com/walles/moor/v2
@@ -12,7 +12,7 @@ license="BSD-2-Clause"
 homepage="https://github.com/walles/moor"
 changelog="https://github.com/walles/moor/releases"
 distfiles="https://github.com/walles/moor/archive/refs/tags/v${version}.tar.gz"
-checksum=4899e65b6251871c9376814c0bebf2c2702bfbf295dcec2ecccd8e98141288a0
+checksum=807c36867ea07878143236ed1bd2053aba1064529401b730639be4d028dc7648
 
 post_install() {
 	vman moor.1


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
