### PR TITLE
libexif: update to 0.6.26

### DIFF
--- a/srcpkgs/libexif/template
+++ b/srcpkgs/libexif/template
@@ -1,6 +1,6 @@
 # Template file for 'libexif'
 pkgname=libexif
-version=0.6.25
+version=0.6.26
 revision=1
 build_style=gnu-configure
 configure_args="ac_cv_path_DOXYGEN=false"
@@ -10,7 +10,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="LGPL-2.1-or-later"
 homepage="https://github.com/libexif/libexif"
 distfiles="https://github.com/libexif/libexif/archive/libexif-${version//./_}-release.tar.gz"
-checksum=ee0795432c20d2fdb2a8a579dd6fc0e19d402e36f14f42c03ab60d2345950f09
+checksum=974329442c4b0515814aa700073abbac592a29d1c2c14e4ec2bf0209764dabe9
 
 pre_configure() {
 	autoreconf -if


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly** (running 2 days no issue)

#### Local build testing
- I built this PR locally for my native architecture, x86_64 glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl (cross)
  - aarch64 (cross)
  - armv6l-musl (cross)
  - armv6l (cross)
  - armv7l-musl (cross)
  - armv7l (cross)
  - i686-musl (cross)
  - i686 (cross)

fixes:

CVE-2026-32775

CVE-2026-40386
CVE-2026-40385