### PR TITLE
common/xbps-src/shutils/update_check: use info/refs for checking common git forges

### DIFF
--- a/common/xbps-src/shutils/update_check.sh
+++ b/common/xbps-src/shutils/update_check.sh
@@ -151,19 +151,19 @@ update_check() {
                 url="https://pypi.org/simple/$pkgname";;
             *github.com*)
                 pkgurlname="$(printf %s "$url" | cut -d/ -f4,5)"
-                url="https://github.com/$pkgurlname/tags"
-                rx='/archive/refs/tags/(\Q'"$pkgname"'\E|[-_v])*\K[\d.]+(?=\.tar\.gz")';;
+                url="https://github.com/$pkgurlname/info/refs?service=git-upload-pack"
+                rx='refs/tags/(\Q'"$pkgname"'\E|[-_v])?\K[\d.]+($|(?=^))';;
             *//gitlab.*|*code.videolan.org*)
                 case "$url" in
                     */-/*) pkgurlname="$(printf %s "$url" | sed -e 's%/-/.*%%g; s%/$%%')";;
                     *) pkgurlname="$(printf %s "$url" | cut -d / -f 1-5)";;
                 esac
-                url="$pkgurlname/-/tags"
-                rx='/archive/[^/]+/\Q'"$pkgname"'\E-v?\K[\d.]+(?=\.tar\.gz)';;
+                url="$pkgurlname.git/info/refs?service=git-upload-pack"
+                rx='refs/tags/(\Q'"$pkgname"'\E|[-_v])?\K[\d.]+($|(?=^))';;
             *bitbucket.org*)
                 pkgurlname="$(printf %s "$url" | cut -d/ -f4,5)"
-                url="https://bitbucket.org/$pkgurlname/downloads"
-                rx='/(get|downloads)/(v?|\Q'"$pkgname"'\E-)?\K[\d.]+(?=\.tar)';;
+                url="https://bitbucket.org/$pkgurlname/info/refs?service=git-upload-pack"
+                rx='refs/tags/(\Q'"$pkgname"'\E|[-_v])?\K[\d.]+($|(?=^))';;
             *ftp.gnome.org*|*download.gnome.org*)
                 rx='(?<=LATEST-IS-)([0-24-9]|3\.[0-9]*[02468]|[4-9][0-9]+)\.[0-9.]*[0-9](?=\")'
                 url="https://download.gnome.org/sources/$pkgname/cache.json";;
@@ -184,16 +184,16 @@ update_check() {
                 rx='/crates/'${pkgname#rust-}'/\K[0-9.]*(?=/download)' ;;
             *codeberg.org*)
                 pkgurlname="$(printf %s "$url" | cut -d/ -f4,5)"
-                url="https://codeberg.org/$pkgurlname/tags"
-                rx='/archive/(v-?|\Q'"$pkgname"'\E-)?\K[\d.]+(?=\.tar\.gz)' ;;
+                url="https://codeberg.org/$pkgurlname/info/refs"
+                rx='refs/tags/(\Q'"$pkgname"'\E|[-_v])?\K[\d.]+($|(?=^))';;
             *hg.sr.ht*)
                 pkgurlname="$(printf %s "$url" | cut -d/ -f4,5)"
                 url="https://hg.sr.ht/$pkgurlname/tags"
                 rx='/archive/(v?|\Q'"$pkgname"'\E-)?\K[\d.]+(?=\.tar\.gz")';;
             *git.sr.ht*)
                 pkgurlname="$(printf %s "$url" | cut -d/ -f4,5)"
-                url="https://git.sr.ht/$pkgurlname/refs/rss.xml"
-                rx='<guid>\Q'"${url%/*}"'\E/(v-?|\Q'"$pkgname"'\E-)?\K[\d.]+(?=</guid>)' ;;
+                url="https://git.sr.ht/$pkgurlname/info/refs"
+                rx='refs/tags/(\Q'"$pkgname"'\E|[-_v])?\K[\d.]+($|(?=^))';;
             *pkgs.fedoraproject.org*)
                 url="https://pkgs.fedoraproject.org/repo/pkgs/$pkgname" ;;
             *software.sil.org/downloads/*)
@@ -223,7 +223,7 @@ update_check() {
 
         msg_verbose "fetching $url and scanning with $rx\n"
         curl "${curlargs[@]}" -H 'Accept: text/html,application/xhtml+xml,application/xml,text/plain,application/rss+xml,application/json' "$url" |
-            grep -Po -i "$rx"
+            grep -Pao -i "$rx"
         fetchedurls[$url]=yes
     done |
     tr _ . |


### PR DESCRIPTION
this endpoint is intended for git usage and while it is "binary", it is text and has all the tags, which is what we care about

these pages are also much smaller than the web or even an atom feed, so this should be more efficient

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**
