### PR TITLE
ddcutil: update to 2.2.6.

### DIFF
--- a/srcpkgs/ddcutil/template
+++ b/srcpkgs/ddcutil/template
@@ -1,6 +1,6 @@
 # Template file for 'ddcutil'
 pkgname=ddcutil
-version=2.2.5
+version=2.2.6
 revision=1
 build_style=gnu-configure
 configure_args="--libdir=/usr/lib"
@@ -14,7 +14,7 @@ license="GPL-2.0-or-later"
 homepage="https://www.ddcutil.com"
 changelog="https://www.ddcutil.com/release_notes_220/"
 distfiles="https://github.com/rockowitz/ddcutil/archive/v${version}.tar.gz"
-checksum=dd17ee072124c1c2b28426dde6985b503abc475af9fcfc13336363590ba42155
+checksum=7bf4420778894caf37ca5f7bade34f7a31d996d92618bb85e18de55a5e5ac465
 
 case "$XBPS_TARGET_MACHINE" in
 	*-musl) makedepends+=" libexecinfo-devel musl-legacy-compat"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl (yes, crossbuild)
  - armv7l (yes, crossbuild)
  - armv6l-musl (yes, crossbuild)

With the existing ddcutil 2.2.5, I was running into an issue where KDE Plasma would freeze within ~10 seconds of logging in.  Sleeping and resuming would fix it until the next login.  A workaround was setting `POWERDEVIL_NO_DDCUTIL=1`, but this ddcutil update also fixes the issue.  The [release notes](https://www.ddcutil.com/c_api_226/) describe the issue, and confirm that this version has no incompatible changes.

I know this might need to be rebased after #59996, which I'm happy to do.