### PR TITLE
New package: nih-sftp-server-1.0.0

### DIFF
--- a/srcpkgs/nih-sftp-server/template
+++ b/srcpkgs/nih-sftp-server/template
@@ -1,0 +1,19 @@
+# Template file for 'nih-sftp-server'
+pkgname=nih-sftp-server
+version=1.0.0
+revision=1
+short_desc="Tiny Version 3 SFTP server"
+maintainer="José Miguel Sánchez García <omixann@gmail.com>"
+license="BSD-3-Clause" # no vlicense
+homepage="https://eddylangley.net/nih-sftp-server/"
+distfiles="https://github.com/eddylangley/nih-sftp-server/archive/refs/tags/v${version}.tar.gz"
+checksum=0dab177a0e00780bdad496e3043b13cc23ba345f3bb5dc59733b7e577c4710b4
+conflicts="openssh" # /usr/libexec/sftp-server
+
+do_build() {
+	${CC} ${CFLAGS} ${LDFLAGS} nih-sftp-server.c -o sftp-server
+}
+
+do_install() {
+	vinstall sftp-server 755 usr/libexec
+}


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->
Follow up to #60028, now conforming to the package requirements (the author just made a release). Even though I disagree with them, I understand the concerns raised in the previous PR so this is the last time I will insist on this change (I thought I could update the old one and reopen it for you to reconsider, but it looks like the only way to do it is by creating a new one).

`nih-sftp-server` is a single-file implementation of `sftp-server`, needed to support `sftp` when `openssh` is not in use (for example, in a system using `dropbear` as their SSH server). I've personally tested the SW in my machine and it works as advertised (the "trial by fire" test being remoting from Zed, which uses the `sftp` mechanism to upload its payload).

#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
