### PR TITLE
New package: keymapper-5.5.0

### DIFF
--- a/srcpkgs/keymapper/files/keymapperd/run
+++ b/srcpkgs/keymapper/files/keymapperd/run
@@ -1,0 +1,3 @@
+#!/bin/sh
+exec 2>&1
+exec keymapperd

--- a/srcpkgs/keymapper/template
+++ b/srcpkgs/keymapper/template
@@ -1,0 +1,19 @@
+# Template file for 'keymapper'
+pkgname=keymapper
+version=5.5.0
+revision=1
+build_style=cmake
+configure_args="-DVERSION=${version}"
+hostmakedepends="pkg-config wayland-devel"
+makedepends="eudev-libudev-devel libusb-devel libX11-devel dbus-devel wayland-devel libxkbcommon-devel libayatana-appindicator-devel"
+short_desc="Cross-platform context-aware key remapper"
+maintainer="deimonn <deimonn@outlook.com>"
+license="GPL-3.0-only"
+homepage="https://github.com/houmain/keymapper"
+changelog="https://raw.githubusercontent.com/houmain/keymapper/main/CHANGELOG.md"
+distfiles="https://github.com/houmain/keymapper/archive/refs/tags/${version}.tar.gz"
+checksum=85160c8f63a6f2a12b9ec8ce9916ff4e892eec54d4d1a9c7785554231fc4ffd5
+
+post_install() {
+	vsv keymapperd
+}


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl (cross)
  - armv7l (cross)
  - armv6l (cross)
  - armv6l-musl (cross)

Closes #36218 (the request was later clarified to be for `input-remapper`, which is now on the repo, so besides `keymapper` I don't see a reason for the issue to remain open).

Tried merging an earlier version once already on #48617 but I let the PR get stale (my bad).