### PR TITLE
mkfontscale: update to 1.2.4

### DIFF
--- a/srcpkgs/mkfontscale/template
+++ b/srcpkgs/mkfontscale/template
@@ -1,9 +1,9 @@
 # Template file for 'mkfontscale'
 pkgname=mkfontscale
-version=1.2.3
+version=1.2.4
 revision=1
-build_style=gnu-configure
-configure_args="--with-bzip2"
+build_style=meson
+configure_args="-Dbzip2=true"
 hostmakedepends="pkg-config"
 makedepends="xorgproto zlib-devel bzip2-devel freetype-devel libfontenc-devel"
 short_desc="X11 Scalable Font Index Generator"
@@ -11,7 +11,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
 homepage="https://gitlab.freedesktop.org/xorg/app/mkfontscale"
 distfiles="${XORG_SITE}/app/${pkgname}-${version}.tar.xz"
-checksum=2921cdc344f1acee04bcd6ea1e29565c1308263006e134a9ee38cf9c9d6fe75e
+checksum=a01492a17a9b6c0ee3f92ee578850e305315b9f298da5f006a1cd4b51db01a5e
 
 post_install() {
 	vlicense COPYING


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**
- briefly tested on `.otf` source

#### Local build testing
- I built this PR locally for my native architecture, **x86_64-glibc**
- I built this PR locally for these architectures:
  - x86_64-musl

Notes:
- Built locally w/ `pkgconf-2.5.1` instead of `pkg-config`

[Changes](https://gitlab.freedesktop.org/xorg/app/mkfontscale/-/commits/master)