### PR TITLE
libcpuid: update to 0.8.1; CPU-X: update to 5.4.0

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -630,7 +630,7 @@ libexempi.so.8 exempi-2.5.0_1
 libatasmart.so.4 libatasmart-0.17_1
 libsgutils2-1.45.so.2 libsgutils-1.45_1
 libcpufreq.so.0 libcpufreq-007_1
-libcpuid.so.17 libcpuid-0.7.0_1
+libcpuid.so.18 libcpuid-0.8.1_1
 libgucharmap_2_90.so.7 gucharmap-3.0.0_1
 libgphoto2.so.6 libgphoto2-2.5.7_1
 libgphoto2_port.so.12 libgphoto2-2.5.7_1

--- a/srcpkgs/CPU-X/patches/disable_tests.patch
+++ b/srcpkgs/CPU-X/patches/disable_tests.patch
@@ -1,17 +1,20 @@
-*** a/CMakeLists.txt	2024-10-21 10:03:31.920419079 -0300
---- b/CMakeLists.txt	2024-10-21 10:13:21.248594699 -0300
-*************** endif(EXISTS ${CMAKE_SOURCE_DIR}/.git)
-*** 123,125 ****
-  
-! enable_testing()
-  find_package(PkgConfig REQUIRED)
---- 123,125 ----
-  
-! 
-  find_package(PkgConfig REQUIRED)
-*************** add_subdirectory(po)
-*** 141,143 ****
-  add_subdirectory(src)
-- add_subdirectory(tests)
-  
---- 141,142 ----
+--- a/CMakeLists.txt	2026-04-20 10:40:14.153796068 +0100
++++ a/CMakeLists.txt	2026-04-20 10:40:14.154796068 +0100
+@@ -159,7 +159,7 @@
+ 	endif(GIT_FOUND)
+ endif()
+ 
+-enable_testing()
++
+ find_package(PkgConfig REQUIRED)
+ find_package(Threads REQUIRED)
+ find_package(Backtrace REQUIRED)
+@@ -179,7 +179,7 @@
+ add_subdirectory(data)
+ add_subdirectory(po)
+ add_subdirectory(src)
+-add_subdirectory(tests)
++
+ 
+ configure_file("${CMAKE_MODULE_PATH}/cmake_uninstall.cmake.in"
+ 	"${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake"

--- a/srcpkgs/CPU-X/patches/fix-no-pie-check.patch
+++ b/srcpkgs/CPU-X/patches/fix-no-pie-check.patch
@@ -1,16 +1,14 @@
-This shouldn't exist and erroneously fails for us.
---- a/CMakeLists.txt
-+++ b/CMakeLists.txt
-@@ -35,12 +35,6 @@
+--- a/CMakeLists.txt	2026-04-20 10:40:14.185796065 +0100
++++ a/CMakeLists.txt	2026-04-20 10:40:14.185796065 +0100
+@@ -61,11 +61,6 @@
  set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-z,noexecstack -Wl,-z,relro -Wl,-z,now")
  set(CMAKE_EXE_LINKER_FLAGS    "${CMAKE_EXE_LINKER_FLAGS} -Wl,-z,noexecstack -Wl,-z,relro -Wl,-z,now")
  
 -include(CheckCCompilerFlag)
 -check_c_compiler_flag("-no-pie" HAS_NO_PIE)
--if(${CMAKE_SYSTEM_NAME} MATCHES "Linux" AND HAS_NO_PIE)
+-if(CMAKE_SYSTEM_NAME MATCHES "Linux" AND HAS_NO_PIE)
 -	set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -no-pie")
--endif(${CMAKE_SYSTEM_NAME} MATCHES "Linux" AND HAS_NO_PIE)
--
+-endif(CMAKE_SYSTEM_NAME MATCHES "Linux" AND HAS_NO_PIE)
+ 
  # Options
  option(WITH_GTK           "Build support for GUI in GTK3+"                                    ON)
- option(WITH_NCURSES       "Build support for TUI in NCurses"                                  ON)

--- a/srcpkgs/CPU-X/patches/fix_musl.patch
+++ b/srcpkgs/CPU-X/patches/fix_musl.patch
@@ -1,11 +1,10 @@
-*** a/src/daemon_client.cpp	2024-10-07 08:16:51.000000000 -0300
---- b/src/daemon_client.cpp	2024-10-21 11:43:37.561779747 -0300
-***************
-*** 22,24 ****
-  */
-! 
-  #include <unistd.h>
---- 22,24 ----
-  */
-! #include <cstring>
-  #include <unistd.h>
+--- a/src/daemon/client.cpp	2026-04-20 10:40:14.187796065 +0100
++++ a/src/daemon/client.cpp	2026-04-20 10:40:14.187796065 +0100
+@@ -21,6 +21,7 @@
+ * FILE daemon/client.cpp
+ */
+ 
++#include <cstring>
+ # include "client.hpp"
+ namespace fs = std::filesystem;
+ 

--- a/srcpkgs/CPU-X/template
+++ b/srcpkgs/CPU-X/template
@@ -1,8 +1,8 @@
 # Template file for 'CPU-X'
 pkgname=CPU-X
-version=5.1.0
-revision=3
-archs="x86_64* i686*"
+version=5.4.0
+revision=1
+archs="x86_64* i686* aarch64*"
 build_style=cmake
 hostmakedepends="pkg-config nasm gettext"
 makedepends="ncurses-devel libcpuid-devel pciutils-devel glfw-devel
@@ -13,7 +13,7 @@ license="GPL-3.0-or-later"
 homepage="https://thetumultuousunicornofdarkness.github.io/CPU-X/"
 changelog="https://github.com/TheTumultuousUnicornOfDarkness/CPU-X/blob/master/ChangeLog.md"
 distfiles="https://github.com/thetumultuousunicornofdarkness/CPU-X/archive/v${version}.tar.gz"
-checksum=a99f963dd9cb982966fdfce9e9a9b569f852c1bfffb51e7b9f154abc8c0d40c5
+checksum=57cdd4695aa2271d94161f59bbce380ecbed46cb16eb7c28e8a78271f976e875
 
 if [ "$XBPS_TARGET_LIBC" = musl ]; then
 	makedepends+=" libexecinfo-devel"

--- a/srcpkgs/libcpuid/template
+++ b/srcpkgs/libcpuid/template
@@ -1,18 +1,18 @@
 # Template file for 'libcpuid'
 pkgname=libcpuid
-version=0.7.0
+version=0.8.1
 revision=1
-archs="i686* x86_64*"
+archs="i686* x86_64* aarch64*"
 build_style=cmake
 hostmakedepends="doxygen"
 checkdepends="python3"
-short_desc="Small C library for x86 CPU detection and feature extraction"
+short_desc="Small C library for x86 and ARM CPU detection and feature extraction"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="BSD-2-Clause"
 homepage="https://github.com/anrieff/libcpuid"
 changelog="https://raw.githubusercontent.com/anrieff/libcpuid/master/ChangeLog"
 distfiles="https://github.com/anrieff/libcpuid/archive/v${version}.tar.gz"
-checksum=cfd9e6bcda5da3f602273e55f983bdd747cb93dde0b9ec06560e074939314210
+checksum=81f2f40da5d66b8220476e116cb40bca4e6a62c0d22bdeeb8e3856cf14607007
 
 post_install() {
 	vlicense COPYING

--- a/srcpkgs/nix/template
+++ b/srcpkgs/nix/template
@@ -1,7 +1,7 @@
 # Template file for 'nix'
 pkgname=nix
 version=2.30.2
-revision=6
+revision=7
 build_style=meson
 build_helper=qemu
 # Use /nix/var as suggested by the official Manual.


### PR DESCRIPTION
#### libcpuid: update to 0.8.1.
#### nix: revbump for libcpuid-0.8.1.
#### CPU-X: update to 5.4.0.
#### testing the changes
- I tested the changes in this PR: **yes**

#### Local build testing
- I built this PR locally for my native architecture, **x86_64**
- I built this PR locally for these cross architectures (if applicable):
  - **x86_64-musl** (verified `vsed` fixes for musl)
