### PR TITLE
perl-Crypt-CBC: update to 3.07.

### DIFF
--- a/srcpkgs/perl-Crypt-CBC/template
+++ b/srcpkgs/perl-Crypt-CBC/template
@@ -1,16 +1,16 @@
 # Template file for 'perl-Crypt-CBC'
 pkgname=perl-Crypt-CBC
-version=3.04
+version=3.07
 revision=1
 build_style=perl-module
 hostmakedepends="perl"
-makedepends="perl"
-depends="perl"
+makedepends="${hostmakedepends} perl-Crypt-Rijndael perl-Crypt-PBKDF2 perl-Crypt-Blowfish perl-CryptX perl-Crypt-URandom"
+depends="${makedepends}"
+checkdepends="perl-Crypt-Blowfish_PP perl-Crypt-CAST5 perl-Crypt-DES perl-Math-Int128 perl-Crypt-IDEA"
 short_desc="Encrypt Data with Cipher Block Chaining Mode"
 maintainer="newbluemoon <blaumolch@mailbox.org>"
-license="Artistic-1.0-Perl, GPL-1.0-or-later"
+license="Artistic-2.0"
 homepage="https://metacpan.org/release/Crypt-CBC"
+changelog="https://metacpan.org/dist/Crypt-CBC/changes"
 distfiles="${CPAN_SITE}/Crypt/Crypt-CBC-${version}.tar.gz"
-checksum=4026c57d0dbf6496c0d561a26f161b763d3b8edf351139c073492e21b5fbce07
-# check requires a lot of new cascading dependencies
-make_check=no
+checksum=f4ddfb4dd6ac5013df8341bfa734d9c9ee0f10e2e71215ec8fe5bf780b7c9127

--- a/srcpkgs/perl-Crypt-PBKDF2/template
+++ b/srcpkgs/perl-Crypt-PBKDF2/template
@@ -1,0 +1,16 @@
+# Template file for 'perl-Crypt-PBKDF2'
+pkgname=perl-Crypt-PBKDF2
+version=0.161520
+revision=1
+build_style=perl-module
+hostmakedepends="perl"
+makedepends="${hostmakedepends} perl-Digest-HMAC perl-Module-Runtime perl-Moo perl-Try-Tiny perl-Type-Tiny perl-strictures perl-namespace-autoclean"
+depends="${makedepends}"
+checkdepends="perl-Test-Fatal"
+short_desc="PBKDF2 password hashing algorithm"
+maintainer="Luc Saccoccio--Le Guennec <lucsaccoccio@disroot.org>"
+license="Artistic-1.0-Perl, GPL-1.0-or-later"
+homepage="https://metacpan.org/dist/Crypt-PBKDF2"
+changelog="https://metacpan.org/dist/Crypt-PBKDF2/changes"
+distfiles="https://cpan.metacpan.org/authors/id/A/AR/ARODLAND/Crypt-PBKDF2-${version}.tar.gz"
+checksum=97dfa79a309a086e184a4e61047f8a10ffb3db051025e7d222a25f19130ba417


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

`perl-Crypt-BBC` needed a new dependency, `perl-Crypt-PBKDF2`, for checks to pass.

CC @newbluemoon