### PR TITLE
New package: certiliamiddleware-3.9.8

### DIFF
--- a/srcpkgs/certiliamiddleware/template
+++ b/srcpkgs/certiliamiddleware/template
@@ -1,0 +1,24 @@
+# Template file for 'certiliamiddleware'
+pkgname=certiliamiddleware
+version=3.9.8
+revision=1
+archs="x86_64"
+depends="ca-certificates pcsc-ccid pcsc-acsccid xcb-util-cursor xcb-util-keysyms xcb-util-wm opensc-pkcs11 opensc"
+short_desc="Certilia Middleware for AKD smart cards (Croatian eID, Certilia)"
+maintainer="mabasic <void-packages.attire646@passinbox.com>"
+license="custom:certiliamiddlware"
+homepage="https://www.certilia.com"
+distfiles="https://repo.certilia.com/repository/debian/pool/c/certiliamiddleware/certiliamiddleware_${version}-2_amd64.deb"
+checksum=d043117e3c7bbd3c51c4fb424cdf5e853ab72c3257005049404baa071fe47aa2
+repository=nonfree
+restricted=yes
+
+do_install() {
+	vcopy opt /
+	vcopy usr /
+
+	vmkdir usr/share/ca-certificates/trust-source
+	mv ${DESTDIR}/usr/share/ca-certificates/akd ${DESTDIR}/usr/share/ca-certificates/trust-source/anchors
+
+	vlicense ${DESTDIR}/opt/certiliamiddleware/licenses/MiddlewareLicense LICENSE
+}


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x64-glibc)

#### Notes
I am sad to contribute with a proprietary program :( but the whole country needs it sadly...

There is a package on Arch AUR: https://aur.archlinux.org/packages/certiliamiddleware which is maintained by the company that makes the software. I have managed to get it running on my system by following instructions from  PKGBUILD and applying void specific depends.


To get this package running correctly the user has to:
- enable the service `sudo ln -s /etc/sv/pcscd /var/service/` for the smart card reader
- make sure not to have env variable `QT_QPA_PLATFORM` set, or set to `xcb` otherwise the signer will throw error Internal Server Error 500 on port 55555 during signing
- start the signer program manually (I did not include any autostart)

Then depending on the browser do the following:
- firefox based browser (any) - go to `Privacy -> Security devices` -> Click Load -> Add name "Certilia" with location `/opt/certiliamiddleware/pkcs11/libCertiliaPkcs11.so`
- chromium based browser  - uses `~/.pki/nssdb` (only native, not snap/flatpak), users should add module with:

```
modutil -dbdir sql:/$HOME/.pki/nssdb/ -add "Certilia" -libfile /opt/certiliamiddleware/pkcs11/libCertiliaPkcs11.so
```

But in all my testing I haven't managed to login with a chromium browser because it crashes after I enter the PIN code twice and select the certificate. 

Also, for some reason on void Chromium browser does not see any certificates in Local certificates even though "import local certificates from your operating system" is turned on. On arch it shows the certificates from `usr/share/ca-certificates/trust-source/anchors`. Regardless if there are certificates loaded it crashes in both cases. But on Void it would not load those certificates at all.
I have tried running `update-ca-certificates` on void but it detects none. I assume that this should do the same as `update-ca-trust` on arch?

**Only firefox based browser work login and signing.**

#### Question
I plan to write a detailed blog post regarding on how to setup this program to work. What do you think is the best way to let the user (the person who installs this software) to know what more he needs to do after installing this package?

