### PR TITLE
tlp{,ui}: update to 1.10.1

### DIFF
--- a/srcpkgs/tlp/template
+++ b/srcpkgs/tlp/template
@@ -1,8 +1,13 @@
 # Template file for 'tlp'
 pkgname=tlp
 # Remember to update 'tlpui' asap.
-version=1.9.1
+version=1.10.1
 revision=1
+build_style=gnu-makefile
+make_build_args="TLP_WITH_SYSTEMD=0 TLP_SBIN=/usr/bin
+ TLP_ELOD=/usr/libexec/elogind/system-sleep"
+make_install_args="${make_build_args}"
+make_install_target="install install-man"
 depends="hdparm bash iw util-linux ethtool perl"
 short_desc="Advanced power management tool for Linux"
 maintainer="Orphaned <orphan@voidlinux.org>"
@@ -10,42 +15,26 @@ license="GPL-2.0-or-later"
 homepage="https://linrunner.de/en/tlp/docs/tlp-linux-advanced-power-management.html"
 changelog="https://raw.githubusercontent.com/linrunner/TLP/main/changelog"
 distfiles="https://github.com/linrunner/TLP/archive/${version}.tar.gz"
-checksum=6f7c69a8c56706f83bc3566377caf846c2ccbd8f2621fe8e56c6d1e684d15156
+checksum=c3f1f4b72a603a134e24b21364669a828180a3de5cbe62917ba88f0c53ca6397
 
 conflicts="laptop-mode>=0 perl-Unicode-Tussle>=0"
 conf_files="/etc/tlp.conf /etc/tlp.d/*.conf"
 make_dirs="/var/lib/tlp 0755 root root"
 
-do_install() {
-	make DESTDIR=${DESTDIR} \
-		TLP_SBIN=/usr/bin \
-		TLP_ULIB=/usr/lib/udev \
-		TLP_ELOD=/usr/libexec/elogind/system-sleep \
-		TLP_POLKIT=/usr/share/polkit-1/actions \
-		TLP_WITH_SYSTEMD=0 \
-		install
-
-	vmkdir usr/share/man/man1
-	install -m644 man/*.1 ${DESTDIR}/usr/share/man/man1
-	vmkdir usr/share/man/man8
-	install -m644 man/*.8 ${DESTDIR}/usr/share/man/man8
-	install -m644 man-pd/*.1 ${DESTDIR}/usr/share/man/man1
-	install -m644 man-pd/*.8 ${DESTDIR}/usr/share/man/man8
-	install -m644 man-rdw/*.8 ${DESTDIR}/usr/share/man/man8
-	rm -f ${DESTDIR}/usr/share/man/man8/*.service.8
-
-	vsv tlp
+post_install() {
 	vinstall ${FILESDIR}/tlp.resume 755 etc/zzz.d/resume 50-tlp.sh
 	vinstall ${FILESDIR}/tlp.suspend 755 etc/zzz.d/suspend 50-tlp.sh
 
-	rm -rf ${DESTDIR}/etc/init.d
-	rm -rf ${DESTDIR}/usr/lib/systemd
+	rm ${DESTDIR}/usr/share/man/man8/*.service.8
+	rm -r ${DESTDIR}/etc/init.d
+	rm -r ${DESTDIR}/usr/lib/systemd
+	vsv tlp
 }
 
 tlp-pd_package() {
 	short_desc="TLP Profiles Daemon"
 	conf_files="/etc/tlp-pd.dbus.conf"
-	depends="tlp python3-dbus python3-gobject polkit"
+	depends="tlp python3-gobject polkit"
 
 	conflicts="power-profiles-daemon>=0"
 
@@ -55,8 +44,8 @@ tlp-pd_package() {
 		vmove usr/bin/tlpctl
 		vmove usr/share/man/man1/tlpctl.1
 		vmove usr/share/man/man8/tlp-pd.8
-		vmove "usr/share//dbus-1/system.d/*.conf"
-		vmove "usr/share//dbus-1/system-services/*.service"
+		vmove "usr/share/dbus-1/system.d/*.conf"
+		vmove "usr/share/dbus-1/system-services/*.service"
 		vmove usr/share/polkit-1/actions/tlp-pd.policy
 		vsv tlp-pd
 	}

--- a/srcpkgs/tlpui/template
+++ b/srcpkgs/tlpui/template
@@ -1,6 +1,6 @@
 # Template file for 'tlpui'
 pkgname=tlpui
-version=1.9.0
+version=1.10.1
 revision=1
 build_style="python3-pep517"
 hostmakedepends="python3-poetry-core"
@@ -10,7 +10,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="https://github.com/d4nj1/TLPUI"
 distfiles="https://github.com/d4nj1/TLPUI/archive/refs/tags/tlpui-${version/+/-}.tar.gz"
-checksum=88c026e16bf968d020ac7034a4978ddb51efd2f70eaf0b9e03d319696145e06c
+checksum=041b92149fdbc9e582857c386ac4d2800fb74535a16a8feb4f59398e96f554cc
 make_check=no #tests fail inside chroot
 
 post_install() {


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, **x86_64-glibc**
- I built this PR locally for these architectures:
  - x86_64-musl

Notes:
- `tlpui`: <strike>Upstream hasn't released a new version, yet</strike>

[Changelog](https://raw.githubusercontent.com/linrunner/TLP/main/changelog)