### PR TITLE
booster: update to 0.12

### DIFF
--- a/srcpkgs/booster/template
+++ b/srcpkgs/booster/template
@@ -1,7 +1,7 @@
 # Template file for 'booster'
 pkgname=booster
-version=0.11
-revision=2
+version=0.12
+revision=1
 build_style=go
 go_import_path=github.com/anatol/booster
 go_package="${go_import_path}/generator"
@@ -12,12 +12,16 @@ maintainer="travankor <travankor@tuta.io>"
 license="MIT"
 homepage="https://github.com/anatol/booster"
 distfiles="https://github.com/anatol/booster/archive/${version}.tar.gz"
-checksum=2f111b1729143c38ec287e5567ae9f57e0fb8118cc11afa22657da8ac9b0105a
+checksum=a2515923e919c99b69ce50f7828aa5df6e7ff80ea145c93c5a8c981d015d8bd4
 conf_files="/etc/booster.yaml"
 alternatives="
  initramfs:/etc/kernel.d/post-install/20-initramfs:/usr/libexec/booster/kernel-hook-postinst
  initramfs:/etc/kernel.d/post-remove/20-initramfs:/usr/libexec/booster/kernel-hook-postrm
 "
+
+# Tests require system tools (lz4, loadkeys) and kernel modules not available in the build environment,
+# moved make_check=ci-skip after alternatives.
+make_check=ci-skip
 export GOFLAGS="-buildmode=pie"
 
 post_build() {


### PR DESCRIPTION

Testing the changes

    I tested the changes in this PR: YES

Local build testing

    I built this PR locally for my native architecture, x86_64-glibc

I've added `make_check=ci-skip` as the test suite requires system tools (lz4, loadkeys, kernel modules) that are not available in the CI build environment it seems.