### PR TITLE
ImageMagick: update to 7.1.2.21; enable JPEG XL support

### DIFF
--- a/srcpkgs/ImageMagick/template
+++ b/srcpkgs/ImageMagick/template
@@ -1,7 +1,7 @@
 # Template file for 'ImageMagick'
 pkgname=ImageMagick
 # Revbump php*-imagick with ImageMagick updates.
-version=7.1.2.19
+version=7.1.2.21
 revision=1
 build_style=gnu-configure
 configure_args="--disable-static --enable-opencl --with-modules --with-gslib
@@ -11,7 +11,7 @@ hostmakedepends="automake libtool pkg-config autoconf"
 makedepends="djvulibre-devel fftw-devel ghostscript-devel glib-devel lcms2-devel
  libXt-devel libgomp-devel libltdl-devel librsvg-devel libwebp-devel libwmf-devel
  ocl-icd-devel pango-devel libopenjpeg2-devel graphviz-devel liblqr-devel
- libraqm-devel libopenexr-devel libheif-devel"
+ libraqm-devel libopenexr-devel libheif-devel libjxl-devel"
 checkdepends="ttf-opensans"
 short_desc="Create, edit, compose, or convert bitmap images"
 maintainer="Orphaned <orphan@voidlinux.org>"
@@ -19,7 +19,7 @@ license="ImageMagick"
 homepage="https://www.imagemagick.org"
 changelog="https://raw.githubusercontent.com/ImageMagick/Website/main/ChangeLog.md"
 distfiles="https://github.com/ImageMagick/ImageMagick/archive/${version%.*}-${version##*.}.tar.gz"
-checksum=91ffe35706ef01d0fc9630e3a81b168b9bdb10b5e1e0b0983c287063cce21210
+checksum=4ba5b81797910efa93e65fb5a02b496284b8069d64513c6d2687c80d180dd70f
 
 subpackages="libmagick libmagick-devel"
 

--- a/srcpkgs/php8.1-imagick/template
+++ b/srcpkgs/php8.1-imagick/template
@@ -1,7 +1,7 @@
 # Template file for 'php8.1-imagick'
 pkgname=php8.1-imagick
 version=3.7.0
-revision=14
+revision=15
 build_style=gnu-configure
 configure_args="--with-imagick=${XBPS_CROSS_BASE}/usr \
  --with-php-config=/usr/bin/php-config8.1"

--- a/srcpkgs/php8.2-imagick/template
+++ b/srcpkgs/php8.2-imagick/template
@@ -1,7 +1,7 @@
 # Template file for 'php8.2-imagick'
 pkgname=php8.2-imagick
 version=3.7.0
-revision=15
+revision=16
 build_style=gnu-configure
 configure_args="--with-imagick=${XBPS_CROSS_BASE}/usr \
  --with-php-config=/usr/bin/php-config8.2"

--- a/srcpkgs/php8.3-imagick/template
+++ b/srcpkgs/php8.3-imagick/template
@@ -1,7 +1,7 @@
 # Template file for 'php8.3-imagick'
 pkgname=php8.3-imagick
 version=3.7.0
-revision=8
+revision=9
 build_style=gnu-configure
 configure_args="--with-imagick=${XBPS_CROSS_BASE}/usr \
  --with-php-config=/usr/bin/php-config8.3"

--- a/srcpkgs/php8.4-imagick/template
+++ b/srcpkgs/php8.4-imagick/template
@@ -1,7 +1,7 @@
 # Template file for 'php8.4-imagick'
 pkgname=php8.4-imagick
 version=3.8.0
-revision=3
+revision=4
 build_style=gnu-configure
 configure_args="--with-imagick=${XBPS_CROSS_BASE}/usr \
  --with-php-config=/usr/bin/php-config8.4"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
