### PR TITLE
ffmpeg6: add JPEG XL support

### DIFF
--- a/srcpkgs/ffmpeg6/template
+++ b/srcpkgs/ffmpeg6/template
@@ -2,7 +2,7 @@
 # audacity also needs to be bumped when a new ffmpeg version bumps libavformat's soname!
 pkgname=ffmpeg6
 version=6.1.4
-revision=2
+revision=3
 hostmakedepends="pkg-config perl"
 makedepends="zlib-devel bzip2-devel freetype-devel alsa-lib-devel libXfixes-devel
  libXext-devel libXvMC-devel libxcb-devel lame-devel libtheora-devel
@@ -12,9 +12,10 @@ makedepends="zlib-devel bzip2-devel freetype-devel alsa-lib-devel libXfixes-deve
  libbs2b-devel libvidstab-devel vmaf-devel libbluray-devel pulseaudio-devel
  x265-devel v4l-utils-devel libvpx-devel libaom-devel libdav1d-devel
  libwebp-devel libdrm-devel srt-devel librist-devel vulkan-loader-devel
- zimg-devel libmysofa-devel libsvt-av1-devel $(vopt_if vaapi libva-devel)
+ zimg-devel libmysofa-devel libsvt-av1-devel libjxl-devel
  $(vopt_if vdpau libvdpau-devel) $(vopt_if fdk_aac fdk-aac-devel)
- $(vopt_if libvpl libvpl-devel) $(vopt_if nvcodec nv-codec-headers)"
+ $(vopt_if libvpl libvpl-devel) $(vopt_if nvcodec nv-codec-headers)
+ $(vopt_if vaapi libva-devel)"
 depends="ffplay6>=${version}_${revision}"
 short_desc="Decoding, encoding and streaming software"
 maintainer="Orphaned <orphan@voidlinux.org>"
@@ -99,6 +100,7 @@ do_configure() {
 		--enable-libsrt --enable-librist --enable-libwebp \
 		--enable-vulkan --enable-libdrm --enable-libsvtav1 \
 		--enable-libfreetype --enable-libharfbuzz --enable-libfontconfig \
+		--enable-libjxl \
 		$(vopt_if fdk_aac '--enable-nonfree --enable-libfdk-aac') \
 		$(vopt_enable vaapi) $(vopt_enable vdpau) \
 		$(vopt_enable zimg libzimg) \


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc


