### PR TITLE
beets: update to 2.10.0.

### DIFF
--- a/srcpkgs/beets/patches/pytest-capteesys.patch
+++ b/srcpkgs/beets/patches/pytest-capteesys.patch
@@ -1,0 +1,24 @@
+capteesys is only available in pytest>=8.4.0
+
+diff --git a/test/conftest.py b/test/conftest.py
+index bff8117..5ee8a90 100644
+--- a/test/conftest.py
++++ b/test/conftest.py
+@@ -113,7 +113,7 @@ def config():
+ def io(
+     request: pytest.FixtureRequest,
+     monkeypatch: pytest.MonkeyPatch,
+-    capteesys: pytest.CaptureFixture[str],
++    capsys: pytest.CaptureFixture[str],
+ ) -> DummyIO:
+     """Fixture for tests that need controllable stdin and captured stdout.
+ 
+@@ -122,7 +122,7 @@ def io(
+     attribute to make it available to all test methods, including
+     ``unittest.TestCase``-based ones.
+     """
+-    io = DummyIO(monkeypatch, capteesys)
++    io = DummyIO(monkeypatch, capsys)
+ 
+     if request.instance:
+         request.instance.io = io

--- a/srcpkgs/beets/template
+++ b/srcpkgs/beets/template
@@ -1,6 +1,6 @@
 # Template file for 'beets'
 pkgname=beets
-version=2.6.1
+version=2.10.0
 revision=1
 build_style=python3-pep517
 # tests requires unpackaged librosa, pytest-flask
@@ -21,7 +21,7 @@ license="MIT"
 homepage="https://beets.io"
 changelog="https://raw.githubusercontent.com/beetbox/beets/master/docs/changelog.rst"
 distfiles="${PYPI_SITE}/b/${pkgname}/${pkgname}-${version}.tar.gz"
-checksum=1376b992ee18ee1b5de08d3586625e78d4338edb6b47e24f8e74932d8551f672
+checksum=af2ca69e0dfd8281b921d71834ec4a0d04e7ea61a9afc69f90dd63c1454cbfca
 
 post_install() {
 	vman man/beet.1

--- a/srcpkgs/python3-confuse/template
+++ b/srcpkgs/python3-confuse/template
@@ -1,20 +1,18 @@
 # Template file for 'python3-confuse'
 pkgname=python3-confuse
-version=2.1.0
+version=2.2.0
 revision=1
 build_style=python3-pep517
 hostmakedepends="python3-poetry-core"
 depends="python3-yaml"
-checkdepends="${depends} python3-pytest"
+checkdepends="${depends} python3-pytest python3-typing_extensions"
 short_desc="Painless YAML config files for Python"
 maintainer="Joel Beckmeyer <joel@beckmeyer.us>"
 license="MIT"
 homepage="https://github.com/beetbox/confuse"
 changelog="https://raw.githubusercontent.com/beetbox/confuse/master/docs/changelog.rst"
 distfiles="${PYPI_SITE}/c/confuse/confuse-${version}.tar.gz"
-checksum=abb9674a99c7a6efaef84e2fc84403ecd2dd304503073ff76ea18ed4176e218d
-
-make_check=no # this release has no tests, next one does
+checksum=35c1b53e81be125f441bee535130559c935917b26aeaa61289010cd1f55c2b9e
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
- **python3-confuse: update to 2.2.0.**
- **beets: update to 2.10.0.**

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
