### PR TITLE
virtualbox-ose: update to 7.2.8.

### DIFF
--- a/srcpkgs/virtualbox-ose/template
+++ b/srcpkgs/virtualbox-ose/template
@@ -1,14 +1,14 @@
 # Template file for 'virtualbox-ose'
 pkgname=virtualbox-ose
-version=7.2.6
-revision=2
+version=7.2.8
+revision=1
 short_desc="General-purpose full virtualizer for x86 hardware"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-only, CDDL-1.0"
 homepage="https://www.virtualbox.org"
 changelog="https://www.virtualbox.org/wiki/Changelog"
 distfiles="http://download.virtualbox.org/virtualbox/${version%[a-z]*}/VirtualBox-${version}.tar.bz2"
-checksum=c58443a0e6fcc7fc7e84c1011a10823b3540c6a2b8f2e27c4d8971272baf09f7
+checksum=0642ed4a12b7204cd30c0abbc2c10c1cc7ad55ce1756a01e86a16d4b6b066592
 
 nopie=yes
 lib32disabled=yes


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc

Fixed host support for linux-6.19 and linux7.0.

I'm not sure if any action is needed regarding this part in the [changelog](https://www.virtualbox.org/wiki/Changelog-7.2). As there is `patches/008-no-vboxvideo.patch`and `lsmod` returns no result, I assume Void build does not ship vboxvideo kmod. Brief testing on linux7.0 host seems to work just fine.

> Linux Guest Additions: Deprecated vboxvideo kernel module for kernels 7.0 and newer; please consider using VMSVGA graphics or vboxvideo module which comes with Linux kernel or provided by your Linux distribution if guest running kernel 7.0+; vboxvideo will still be available for older kernels