### PR TITLE
age-plugin-yubikey: update to 0.5.1

### DIFF
--- a/srcpkgs/age-plugin-yubikey/template
+++ b/srcpkgs/age-plugin-yubikey/template
@@ -1,6 +1,6 @@
 # Template file for 'age-plugin-yubikey'
 pkgname=age-plugin-yubikey
-version=0.5.0
+version=0.5.1
 revision=1
 build_style=cargo
 hostmakedepends="pkg-config"
@@ -12,7 +12,7 @@ license="MIT OR Apache-2.0"
 homepage="https://github.com/str4d/age-plugin-yubikey"
 changelog="https://github.com/str4d/age-plugin-yubikey/blob/main/CHANGELOG.md"
 distfiles="https://github.com/str4d/age-plugin-yubikey/archive/refs/tags/v${version}.tar.gz"
-checksum=65807403f0098569a473ffa76302b205da148a7f46b61fd331b8e323959978ba
+checksum=51e4680ad7ad7f56535e4f3018531bd0196815659378709979617d4f17102700
 
 post_install() {
 	vlicense LICENSE-MIT


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (AARCH64-GLIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-glibc
  - x86_64-glibc


