### PR TITLE
ol: update to 2.7

### DIFF
--- a/srcpkgs/ol/patches/mips-ppc-build-fix.patch
+++ b/srcpkgs/ol/patches/mips-ppc-build-fix.patch
@@ -1,0 +1,21 @@
+diff --git a/GNUmakefile b/GNUmakefile
+index 8226490a..b9e65c2d 100644
+--- a/GNUmakefile
++++ b/GNUmakefile
+@@ -77,7 +77,7 @@ endif
+ # check submodules
+ # ----------------
+ ifeq ($(shell ls -A libraries/OpenGL),)
+-    $(warning $(red)Submodules not loaded. Run 'git submodule update --init --recursive' once.$(done))
++#    $(warning $(red)Submodules not loaded. Run 'git submodule update --init --recursive' once.$(done))
+ endif
+ 
+ # cleanup while insuccessfull builds
+@@ -128,6 +128,7 @@ CFLAGS += -Wno-int-to-pointer-cast # x86 warnings
+ ifeq ($(UNAME),Linux)
+   CFLAGS += -z noexecstack # required by bin-utils 2.39+
+ endif
++CFLAGS += -Wno-int-conversion -Wno-incompatible-pointer-types -Wno-return-mismatch # mips/ppc build fix
+ 
+ CFLAGS += -DHAVE_SOCKETS=$(if $(HAVE_SOCKETS),$(HAVE_SOCKETS),0)
+ CFLAGS += -DHAVE_DLOPEN=$(if $(HAVE_DLOPEN),$(HAVE_DLOPEN),0)

--- a/srcpkgs/ol/template
+++ b/srcpkgs/ol/template
@@ -1,6 +1,6 @@
 # Template file for 'ol'
 pkgname=ol
-version=2.6
+version=2.7
 revision=1
 build_style=gnu-makefile
 make_use_env=yes
@@ -14,14 +14,18 @@ changelog="https://raw.githubusercontent.com/yuriy-chumak/ol/master/doc/CHANGELO
 distfiles="
  https://github.com/yuriy-chumak/ol/archive/refs/tags/${version}.tar.gz
  https://github.com/yuriy-chumak/libol-opengl/archive/refs/tags/${version}.tar.gz>libopengl-${version}.tar.gz"
-checksum="c5506de4005a63039dc96962322ae94bf6c33eeaf63dcc03b07b1e8cc3a4d8f3
- 386bceb757896bcbe4252b0a1a6e2e7d6dc643129210abf35b203e67b2c5d7fb"
+checksum="32dec0d527d456cce3273b907ffface6386a61288edf33f8724e2dd1bfb22319
+ bc8f55f5d0c39fe5792e923a5a6c72b2a97a242a2fe7da60e9cfa96ba733b133"
 
 if [[ "$XBPS_TARGET_WORDSIZE" -eq 32 ]]; then
 	make_check_args="HAS_64CDEFS=0"
 else
 	make_check_args="HAS_32CDEFS=0"
 fi
+
+do_check() {
+	make check-native
+}
 
 post_extract() {
 	shopt -s dotglob


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built and tested this PR locally for my native architecture, **x86_64 (libc)**
- I built and tested (using `proot` and `qemu`) this PR locally for these architectures:
  - :x: x86_64-musl (*ERROR: cross-x86_64-linux-musl-0.37_5: cannot be built, it's currently broken*)
  - :heavy_check_mark: aarch64, :heavy_check_mark: aarch64-musl
  - :heavy_check_mark: armv5te, :heavy_check_mark: armv5te-musl
  - :heavy_check_mark: armv5tel, :heavy_check_mark: armv5tel-musl
  - :heavy_check_mark: armv6l, :heavy_check_mark: armv6l-musl
  - :heavy_check_mark: armv6hf, :heavy_check_mark: armv6hf-musl
  - :heavy_check_mark: armv7l, :heavy_check_mark: armv7l-musl
  - :heavy_check_mark: armv7hf, :heavy_check_mark: armv7hf-musl
  - :heavy_check_mark: i686, :heavy_check_mark: i686-musl
  - :heavy_check_mark: mips-musl, :heavy_check_mark: mipsel-musl, :heavy_check_mark: mipshf-musl, :heavy_check_mark: mipselhf-musl
  - :heavy_check_mark: ppc64, :heavy_check_mark: ppc64-musl
  - :heavy_check_mark: ppc, :heavy_check_mark: ppc-musl
  - :heavy_check_mark: ppc64le, :heavy_check_mark: ppc64le-musl
- I built but not tested this PR locally for these architectures:
  - :x: ppcle (*ERROR: cross-powerpcle-linux-gnu-0.37_1: cannot be built, it's currently broken*),
  - :heavy_check_mark: ppcle-musl
