### PR TITLE
heimdall: update to 2.2.2

### DIFF
--- a/srcpkgs/heimdall-frontend
+++ b/srcpkgs/heimdall-frontend
@@ -1,0 +1,1 @@
+heimdall

--- a/srcpkgs/heimdall/template
+++ b/srcpkgs/heimdall/template
@@ -1,21 +1,24 @@
 # Template file for 'heimdall'
 pkgname=heimdall
-version=1.4.2
-revision=2
+version=2.2.2
+revision=1
 build_style=cmake
-hostmakedepends="pkg-config"
-makedepends="libusb-devel qt5-devel"
-short_desc="Tool suite used to flash firmware onto Samsung Galaxy S devices"
+hostmakedepends="pkg-config qt6-base-devel"
+makedepends="libusb-devel qt6-base-devel"
+short_desc="Tool suite used to flash firmware onto Samsung Galaxy devices"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
-homepage="https://gitlab.com/BenjaminDobell/Heimdall"
-distfiles="https://gitlab.com/BenjaminDobell/Heimdall/-/archive/v${version}/Heimdall-v${version}.tar.bz2"
-checksum=2de553496fff1441a3e917b3da9e862192bd7bb05d9cab376fefcc12f82d2f05
+homepage="https://git.sr.ht/~grimler/Heimdall"
+distfiles="https://git.sr.ht/~grimler/Heimdall/archive/v${version}.tar.gz"
+checksum="7d01dd8bf9c2f93ea016ae8b059110c50cea49e78670e8a1333ebd5899cdaaa3"
 
-if [ -n "$CROSS_BUILD" ]; then
-	# Need some devel packages in the host
-	hostmakedepends+=" qt5-tools-devel"
-fi
+heimdall-frontend_package() {
+	short_desc+=" - Qt6 GUI"
+	depends="${sourcepkg}>=${version}_${revision}"
+	pkg_install() {
+		vmove usr/bin/heimdall-frontend
+	}
+}
 
 do_install() {
 	vbin build/bin/heimdall


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES** (tested both the cli version and heimdall-frontend)

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - aarch64-glibc
  - armv7l
  - x86_64-musl
  - i686-glibc

