### PR TITLE
dropbox: update to 2026-3-20

### DIFF
--- a/srcpkgs/dropbox/template
+++ b/srcpkgs/dropbox/template
@@ -1,6 +1,6 @@
 # Template file for 'dropbox'
 pkgname=dropbox
-version=2024.04.17
+version=2026.03.20
 revision=1
 archs="x86_64 i686"
 build_style=gnu-configure
@@ -14,7 +14,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-3.0-or-later, CC-BY-ND-3.0"
 homepage="https://www.dropbox.com"
 distfiles="https://github.com/dropbox/nautilus-dropbox/archive/refs/tags/v${version}.tar.gz"
-checksum=dd10f84d7fab941f1fb70d9e538d20b10627a645fc02f1fde7e1f179dc018e0e
+checksum=1c839801bf07fbbe9a709a055bf272387e1090b4c96737d3b375cc70e2e64f15
 # - The ND part of CC-BY-ND-3.0 is nonfree
 # - The package is just a wrapper to download and start proprietary dropbox
 # binary programs from dropbox.com, which are necessary for its function.


### PR DESCRIPTION
Update dropbox wrapper to 2026-3-20 which is the latest tagged version as of today.

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, `x86_64`
- I tested the functionality of this package, including insuring the proprietary daemon updates successfully and syncs files.
