### PR TITLE
xdg-desktop-portal-termfilechooser: update to 1.4.0.

### DIFF
--- a/srcpkgs/xdg-desktop-portal-termfilechooser/template
+++ b/srcpkgs/xdg-desktop-portal-termfilechooser/template
@@ -1,6 +1,6 @@
 # Template file for 'xdg-desktop-portal-termfilechooser'
 pkgname=xdg-desktop-portal-termfilechooser
-version=1.3.0
+version=1.4.0
 revision=1
 build_style=meson
 hostmakedepends="pkg-config gettext glib-devel xdg-desktop-portal cmake scdoc"
@@ -11,7 +11,7 @@ maintainer="zlice <zlice555@gmail.com>"
 license="MIT"
 homepage="https://github.com/hunkyburrito/xdg-desktop-portal-termfilechooser"
 distfiles="https://github.com/hunkyburrito/xdg-desktop-portal-termfilechooser/archive/refs/tags/v${version}.tar.gz"
-checksum=f53062071f514c67be0a6cc66cefa74c1bd51c54df57483372d98c049c8d2044
+checksum=b6f26213e869d6d68d41503f4e60674bfbcae5db86d65ec1fba57bdcfa93765f
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **yes**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (aarch64-glibc)
