### PR TITLE
python3-peewee: update to 4.0.5.

### DIFF
--- a/srcpkgs/python3-peewee/template
+++ b/srcpkgs/python3-peewee/template
@@ -1,6 +1,6 @@
 # Template file for 'python3-peewee'
 pkgname=python3-peewee
-version=4.0.4
+version=4.0.5
 revision=1
 build_style=python3-pep517
 hostmakedepends="python3-setuptools python3-wheel python3-Cython"
@@ -12,7 +12,7 @@ license="MIT"
 homepage="https://github.com/coleifer/peewee"
 changelog="https://raw.githubusercontent.com/coleifer/peewee/master/CHANGELOG.md"
 distfiles="https://github.com/coleifer/peewee/archive/${version}.tar.gz"
-checksum=a19d5fc897dff9eca3394f3fe66cae2c0e589e7eb1b2d382cb79b8ab2f5db275
+checksum=a0e101e884a89c0692017c806c601be7df048a9ea2f13acb0fd6347ea24767a5
 make_check=no # tests require postgres instance
 
 post_install() {


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-libc
