### PR TITLE
acme-client: update to 1.3.6.

### DIFF
--- a/srcpkgs/acme-client/template
+++ b/srcpkgs/acme-client/template
@@ -1,6 +1,6 @@
 # Template file for 'acme-client'
 pkgname=acme-client
-version=1.3.3
+version=1.3.6
 revision=1
 build_style=gnu-configure
 hostmakedepends="pkg-config sed"
@@ -10,9 +10,9 @@ short_desc="Portable version of OpenBSD's acme-client"
 maintainer="Emil Miler <em@0x45.cz>"
 license="GPL-2.0-only"
 homepage="https://git.wolfsden.cz/acme-client-portable/"
-changelog="https://git.wolfsden.cz/acme-client-portable/blob/master/NEWS"
-distfiles="https://data.wolfsden.cz/sources/acme-client-${version}.tar.gz"
-checksum=1c93a4daf9430fb003acb75ffde2c4a7eb5ebbd5cdd0aae08447bacb81480e82
+changelog="https://git.wolfsden.cz/acme-client-portable/plain/NEWS"
+distfiles="https://files.wolfsden.cz/releases/acme-client/acme-client-${version}.tar.gz"
+checksum=a9427f411992d1ac360a70a5f8c5bded4b27b6682334cea63f8d4c8858a403d6
 make_check=no # requires https://github.com/letsencrypt/pebble which isn't packaged
 
 pre_install() {


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  -  x86_64-musl
  - aarch64 (crossbuild)
