### PR TITLE
nebula: update to 1.10.3

### DIFF
--- a/srcpkgs/nebula/patches/riscv64.patch
+++ b/srcpkgs/nebula/patches/riscv64.patch
@@ -1,9 +1,0 @@
---- a/udp_linux_64.go	2021-05-11 03:23:49.000000000 +0200
-+++ -	2023-01-28 22:54:02.482711168 +0100
-@@ -1,5 +1,5 @@
- // +build linux
--// +build amd64 arm64 ppc64 ppc64le mips64 mips64le s390x
-+// +build amd64 arm64 ppc64 ppc64le mips64 mips64le s390x riscv64
- // +build !android
- // +build !e2e_testing
- 

--- a/srcpkgs/nebula/template
+++ b/srcpkgs/nebula/template
@@ -1,7 +1,7 @@
 # Template file for 'nebula'
 pkgname=nebula
-version=1.4.0
-revision=4
+version=1.10.3
+revision=1
 build_style=go
 make_dirs="/etc/nebula 0750 root root"
 go_import_path=github.com/slackhq/nebula
@@ -12,7 +12,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
 homepage="https://github.com/slackhq/nebula"
 distfiles="https://github.com/slackhq/nebula/archive/v${version}.tar.gz"
-checksum=e8d79231f6100a2cd240d6a092d0dcc2bfccadffa83cb40e99b7328f6c75c2ec
+checksum=12972f5a1dc37b89dff6af91685f7f7eb643b7f75da760c036d1e8d850387e54
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: YES
- The update was straigtforward as it's a go package

#### Local build testing
- I built this PR locally for my native architecture, x86-64-libc

#### Other
- The certificates produced by default by `nebula-cert` are now v2 by default, producing v1 is still possible but requires the use of a flag in the cli when create certificates.
