### PR TITLE
deja-dup: update to 50.0

### DIFF
--- a/srcpkgs/deja-dup/template
+++ b/srcpkgs/deja-dup/template
@@ -1,19 +1,19 @@
 # Template file for 'deja-dup'
 pkgname=deja-dup
-version=45.1
-revision=2
+version=50.0
+revision=1
 build_style=meson
-hostmakedepends="appstream-glib dbus glib-devel gettext itstool
- libgpg-error-devel pkg-config vala desktop-file-utils"
-makedepends="gnome-online-accounts-devel json-glib-devel libgpg-error-devel
- libadwaita-devel libpeas-devel libsecret-devel libsoup3-devel"
-depends="dbus duplicity"
+configure_args="-Dpackagekit=disabled"
+hostmakedepends="blueprint-compiler desktop-file-utils gettext glib-devel gtk-update-icon-cache gtk4-devel libadwaita-devel itstool meson pkg-config vala"
+makedepends="gtk4-devel json-glib-devel libadwaita-devel libsecret-devel libsoup3-devel"
+depends="dbus duplicity restic"
 short_desc="Simple backup tool that uses duplicity as the backend"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-3.0-or-later"
 homepage="https://gitlab.gnome.org/World/deja-dup"
 changelog="https://gitlab.gnome.org/World/deja-dup/-/raw/main/NEWS.md"
 distfiles="https://gitlab.gnome.org/World/deja-dup/-/archive/${version}/deja-dup-${version}.tar.gz"
-checksum=5685a19cc84b6f8e48995995d557ae1e7a9ee716cd3cd6ff22fc77bb3efafc8f
+checksum=7f1efb56aab43b622f9e23acad5c2433b94ca2edab0cce458e4475e199311b42
+
 # TODO: fix tests
 make_check=no


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-glibc
  - aarch64-musl
  - armv7l
  - i686
