### PR TITLE
cups: update to 2.4.18.

### DIFF
--- a/srcpkgs/cups/template
+++ b/srcpkgs/cups/template
@@ -1,6 +1,6 @@
 # Template file for 'cups'
 pkgname=cups
-version=2.4.13
+version=2.4.18
 revision=1
 build_style=gnu-configure
 make_install_args="BUILDROOT=${DESTDIR}"
@@ -14,7 +14,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="Apache-2.0 WITH custom:GPL-2.0-LGPL-2.0-Exception, Zlib"
 homepage="https://github.com/OpenPrinting/cups"
 distfiles="https://github.com/OpenPrinting/cups/releases/download/v${version}/cups-${version}-source.tar.gz"
-checksum=8255ecf037be72660de24a73bcada042fc5bf509fc87bc8ad16cd0675735c1a8
+checksum=8fe23bf4905f8889f4bd5ebf375e81916e84754bfc59eccc88cfd7b1e97a741b
 
 if [ "$XBPS_TARGET_LIBC" = "glibc" ]; then
 	makedepends+=" libxcrypt-devel"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64
- I built this PR locally for these architectures:
  - x86_64-musl
  - aarch64 (crossbuild)
