### PR TITLE
go: update to 1.26.2.

### DIFF
--- a/srcpkgs/go/template
+++ b/srcpkgs/go/template
@@ -1,6 +1,6 @@
 # Template file for 'go'
 pkgname=go
-version=1.26.1
+version=1.26.2
 revision=1
 _bootstrap="1.24.6"
 create_wrksrc=yes
@@ -13,7 +13,7 @@ license="BSD-3-Clause"
 homepage="https://go.dev/"
 changelog="https://go.dev/doc/devel/release.html"
 distfiles="https://go.dev/dl/go${version}.src.tar.gz"
-checksum=3172293d04b209dc1144698e7ba13f0477f6ba8c5ffd0be66c20fdbc9785dfbb
+checksum=2e91ebb6947a96e9436fb2b3926a8802efe63a6d375dffec4f82aa9dbd6fd43b
 nostrip=yes
 noverifyrdeps=yes
 # on CI it tries to use `git submodule`, which is not part of chroot-git


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64
- I built this PR locally for these architectures:
  - x86_64-musl
  - aarch64 (crossbuild)
