### PR TITLE
Add usage cli 3.2.1 (dependency for mise), Update mise to 2026.4.21

### DIFF
--- a/srcpkgs/mise/template
+++ b/srcpkgs/mise/template
@@ -1,17 +1,18 @@
 # Template file for 'mise'
 pkgname=mise
-version=2026.3.4
+version=2026.4.21
 revision=1
 build_style=cargo
 hostmakedepends="pkg-config"
 makedepends="openssl-devel libzstd-devel bzip2-devel"
+depends="usage"
 short_desc="Polyglot runtime manager (asdf rust clone)"
 maintainer="Daniel Lewan <daniel@teddydd.me>"
 license="MIT"
 homepage="https://github.com/jdx/mise"
 changelog="https://github.com/jdx/mise/releases"
 distfiles="https://github.com/jdx/mise/archive/v${version}.tar.gz>${pkgname}-${version}.tar.gz"
-checksum=7ec15b68e0de9e4286abd4213562c7ba82584c6b75c77227bf70ef420bd94c75
+checksum=7f3e39aa58d354bbf4a0fa184f8900abf91e8b71616b9d6b79e7b1c0a77e9c59
 
 case "$XBPS_TARGET_MACHINE" in
 	i686*) broken="runs out of memory" ;;

--- a/srcpkgs/usage/template
+++ b/srcpkgs/usage/template
@@ -1,0 +1,26 @@
+# Template file for 'usage'
+pkgname=usage
+version=3.2.1
+revision=1
+build_style=cargo
+make_install_args="--path cli"
+make_check_args="-- --skip complete_word_boolean_flags_dont_consume_subcommands
+ --skip complete_word_mixed_global_flags
+ --skip complete_word_mounted_with_global_flags
+ --skip complete_word_mounted
+ --skip empty_defaults_example
+ --skip usage_double_slash_execution
+ --skip usage_double_slash_execution_old"
+hostmakedepends="pkg-config"
+makedepends="openssl-devel"
+short_desc="Specification and CLI for defining CLI tools"
+maintainer="Daniel Lewan <daniel@teddydd.me>"
+license="MIT"
+homepage="https://usage.jdx.dev"
+changelog="https://raw.githubusercontent.com/jdx/usage/refs/heads/main/CHANGELOG.md"
+distfiles="https://github.com/jdx/usage/archive/v${version}.tar.gz"
+checksum=f6da0088295fa095aab5bfb12c18b19cf91fbea25e4a081c6f5220799da39bbe
+
+post_install() {
+	vlicense LICENSE
+}


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

Fixes `mise` CLI completion.

#### Testing the changes
- I tested the changes in this PR: **YES**


#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**


<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
