### PR TITLE
v2ray: update to 5.48.0

### DIFF
--- a/srcpkgs/v2ray/template
+++ b/srcpkgs/v2ray/template
@@ -1,26 +1,24 @@
 # Template file for 'v2ray'
 pkgname=v2ray
-version=5.3.0
-revision=5
+version=5.48.0
+revision=1
 build_style=go
 go_import_path="github.com/v2fly/v2ray-core/v5"
 go_ldflags="-X github.com/v2fly/v2ray-core/v5.codename=$pkgname
  -X github.com/v2fly/v2ray-core/v5.version=$version
  -X github.com/v2fly/v2ray-core/v5.build=$SOURCE_DATE_EPOCH -buildid="
-hostmakedepends="go1.20"
+hostmakedepends="go"
 short_desc="Platform for building proxies to bypass network restrictions"
-maintainer="ipkalm <ipkalm@outlook.com>"
+maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
 homepage="https://github.com/v2fly/v2ray-core"
 distfiles="https://github.com/v2fly/v2ray-core/archive/v${version}/${pkgname}-${version}.tar.gz"
-checksum=8e97e2647cb1dee8aa7e71df276c56d74258b2d97bb490a362afa84bdf1b9e25
+checksum=7900d9ec61014c1b87c149e43aa4f3b03be4bc756cbfe9a75926d5a7ac86105e
 conf_files="/etc/v2ray/config.json"
 
 system_accounts="_v2ray"
 
-export GOTOOLCHAIN=go1.20
 export GOFLAGS="-x -p=$XBPS_MAKEJOBS -buildmode=pie -trimpath"
-export CGO_ENABLED=0
 
 do_build() {
 	go build -ldflags "${go_ldflags}" -o "${GOPATH}/bin/v2ray" ./main


### PR DESCRIPTION
Last version bump was 3 years ago and not done by the package maintainer, orphaned. 
 
#### Testing the changes
- I tested the changes in this PR: **NO** 

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
