### PR TITLE
clapper: update to 0.10

### DIFF
--- a/srcpkgs/clapper/template
+++ b/srcpkgs/clapper/template
@@ -1,7 +1,7 @@
 # Template file for 'clapper'
 pkgname=clapper
-version=0.8.0
-revision=2
+version=0.10.0
+revision=1
 build_style=meson
 build_helper=gir
 hostmakedepends="pkg-config gettext glib-devel vala
@@ -13,7 +13,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-3.0-or-later, LGPL-2.1-or-later"
 homepage="https://github.com/Rafostar/clapper"
 distfiles="https://github.com/Rafostar/clapper/archive/refs/tags/${version}.tar.gz"
-checksum=f0d6faea1285ff4b3a1c3c758181cd1b501cd066f87afd0d6fde5fc7e83eba60
+checksum=344c0f20e540a63c6fb44cdd5de88c168ed145bb66c1307e79b2b08124780118
 
 clapper-libs_package() {
 	short_desc+=" - libraries"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-glibc
  - aarch64-musl
  - x86_64-musl
  - i686-glibc