### PR TITLE
opera: update to 130.0.5847.92.

### DIFF
--- a/srcpkgs/opera/template
+++ b/srcpkgs/opera/template
@@ -1,6 +1,6 @@
 # Template file for 'opera'
 pkgname=opera
-version=129.0.5823.44
+version=130.0.5847.92
 revision=1
 archs="x86_64"
 create_wrksrc=yes
@@ -10,7 +10,7 @@ maintainer="mobinmob <mobinmob@disroot.org>"
 license="custom:Proprietary"
 homepage="https://www.opera.com/computer"
 distfiles="https://get.geo.opera.com/pub/opera/desktop/${version}/linux/opera-stable_${version}_amd64.rpm"
-checksum=9162180679b19dcc91225cebd494f2748e686c1c7da9438cb92ac47923991864
+checksum=35e97de0498255ed8f1dd33534c7a82e4b8209cc81224fecb89b323f85159178
 repository="nonfree"
 nostrip=yes
 


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, `x86_64-glibc`
<!--
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
