### PR TITLE
ccache: update to 4.13.5.

### DIFF
--- a/srcpkgs/ccache/template
+++ b/srcpkgs/ccache/template
@@ -1,6 +1,6 @@
 # Template file for 'ccache'
 pkgname=ccache
-version=4.13.2
+version=4.13.5
 revision=1
 build_style=cmake
 configure_args="-DENABLE_TESTING=OFF -DREDIS_STORAGE_BACKEND=OFF
@@ -13,8 +13,8 @@ homepage="https://ccache.dev"
 changelog="https://ccache.dev/releasenotes.html"
 distfiles="https://github.com/ccache/ccache/releases/download/v${version}/ccache-${version}.tar.xz
  https://github.com/ccache/ccache/releases/download/v${version}/ccache-${version}-linux-x86_64-glibc.tar.xz"
-checksum="4a0d835f1b3fd7e2ac58a511718bbc902532941f377f7990a3d33b5cf8733ba6
- e9e2bcec3cd816ba58ff1c331fdeaa3465760683eeec9f462c31b909e2651e35"
+checksum="7a8945f4ac7d4bb79c0055cd3db7857a6934c2b7ab3d80bb11a0f5271e36fd94
+ ebef319603ba3c4c8c8a8e77f46257b9fb1dc077d6385f7b348a547399bc7f45"
 
 
 if [ -n "$XBPS_CHECK_PKGS" ]; then


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (x86-64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - armv6l

#### Other changes
- Add perl as dependency and remove using the man file from the extracted upstream release, enable man page generation from the package build.