### PR TITLE
docker-cli: generate man pages

### DIFF
--- a/srcpkgs/docker-cli/template
+++ b/srcpkgs/docker-cli/template
@@ -2,7 +2,7 @@
 # should be kept in sync with moby
 pkgname=docker-cli
 version=29.4.1
-revision=1
+revision=2
 build_style=go
 go_package="github.com/docker/cli/cmd/docker"
 go_import_path="github.com/docker/cli"
@@ -25,10 +25,18 @@ pre_build() {
 	go_ldflags+=" -X \"${_cli_ver_path}.BuildTime=$(date +%Y-%m-%dT%H:%M:%SZ)\""
 }
 
+post_build() {
+	GOARCH= GOARM= GOOS= CGO_ENABLED=0 DISABLE_WARN_OUTSIDE_CONTAINER=1 make manpages
+}
+
 post_install() {
 	vcompletion contrib/completion/fish/docker.fish fish docker
 	vcompletion contrib/completion/zsh/_docker zsh docker
 	vcompletion contrib/completion/bash/docker bash docker
+
+	for f in man/man1/*.1 man/man5/*.5; do
+		vman "$f"
+	done
 }
 
 docker_package() {

--- a/srcpkgs/docker-cli/template
+++ b/srcpkgs/docker-cli/template
@@ -2,7 +2,7 @@
 # should be kept in sync with moby
 pkgname=docker-cli
 version=29.6.2
-revision=1
+revision=2
 build_style=go
 go_package="github.com/docker/cli/cmd/docker"
 go_import_path="github.com/docker/cli"
@@ -25,10 +25,18 @@ pre_build() {
 	go_ldflags+=" -X \"${_cli_ver_path}.BuildTime=$(date +%Y-%m-%dT%H:%M:%SZ)\""
 }
 
+post_build() {
+	GOARCH= GOARM= GOOS= CGO_ENABLED=0 DISABLE_WARN_OUTSIDE_CONTAINER=1 make manpages
+}
+
 post_install() {
 	vcompletion contrib/completion/fish/docker.fish fish docker
 	vcompletion contrib/completion/zsh/_docker zsh docker
 	vcompletion contrib/completion/bash/docker bash docker
+
+	for f in man/man1/*.1 man/man5/*.5; do
+		vman "$f"
+	done
 }
 
 docker_package() {


### PR DESCRIPTION
https://github.com/void-linux/void-packages/issues/60209

#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- [X] x86_64-glibc                                                                                                              
- [X] aarch64-glibc                                                                                                             
- [X] armv7l-glibc                                                                                                              
- [ ] armv6l-musl                                                                                                               
- [ ] aarch64-musl  

Uses the upstream Makefile `manpages` target to generate and install man pages for `docker` and all subcommands (section 1) and reference pages for Dockerfile and config JSON (section 5).                                                                                     