### PR TITLE
python3-ipython: revbump for added psutil dependency

### DIFF
--- a/srcpkgs/python3-ipython/template
+++ b/srcpkgs/python3-ipython/template
@@ -1,7 +1,7 @@
 # Template file for 'python3-ipython'
 pkgname=python3-ipython
 version=9.13.0
-revision=1
+revision=2
 build_style=python3-pep517
 # pexpect module does not find IPython when launching new interpreter
 make_check_args="
@@ -12,7 +12,7 @@ hostmakedepends="python3-setuptools python3-wheel"
 depends="python3-jedi python3-decorator python3-pickleshare
  python3-traitlets python3-prompt_toolkit python3-Pygments python3-backcall
  python3-matplotlib-inline python3-pexpect python3-stack_data
- python3-ipython-pygments-lexers"
+ python3-ipython-pygments-lexers python3-psutil"
 checkdepends="$depends python3-pytest-asyncio python3-testpath python3-curio
  python3-jupyter_nbformat python3-matplotlib python3-numpy python3-pandas
  python3-trio"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, x86_64(glibc)

-------------------------
Fixes a runtime error in IPython 9.13.0 where importing IPython.core.kitty fails due to missing psutil:

```bash
 % ipython
Traceback (most recent call last):
  File "/usr/bin/ipython", line 5, in <module>
    from IPython import start_ipython
  File "/usr/lib/python3.14/site-packages/IPython/__init__.py", line 56, in <module>
    from .terminal.embed import embed
  File "/usr/lib/python3.14/site-packages/IPython/terminal/embed.py", line 16, in <module>
    from IPython.terminal.interactiveshell import TerminalInteractiveShell
  File "/usr/lib/python3.14/site-packages/IPython/terminal/interactiveshell.py", line 11, in <module>
    from IPython.core.kitty import (
    ...<2 lines>...
    )
  File "/usr/lib/python3.14/site-packages/IPython/core/kitty.py", line 36, in <module>
    supports_kitty_graphics = _supports_kitty_graphics()
  File "/usr/lib/python3.14/site-packages/IPython/core/kitty.py", line 27, in _supports_kitty_graphics
    import psutil
ModuleNotFoundError: No module named 'psutil'
```

+ Added in IPython-9.13.0: [+](https://github.com/ipython/ipython/blob/7c1654dcb4bc0d4c841fbee1f5abf7c6c6007111/IPython/core/kitty.py#L27)



cc: @ahesford 