### PR TITLE
caddy: update to 2.11.2.

### DIFF
--- a/srcpkgs/caddy/template
+++ b/srcpkgs/caddy/template
@@ -1,6 +1,6 @@
 # Template file for 'caddy'
 pkgname=caddy
-version=2.10.2
+version=2.11.2
 revision=1
 build_style=go
 go_import_path=github.com/caddyserver/caddy/v2
@@ -13,7 +13,7 @@ license="Apache-2.0"
 homepage="https://caddyserver.com"
 changelog="https://github.com/caddyserver/caddy/releases"
 distfiles="https://github.com/caddyserver/caddy/archive/v${version}.tar.gz"
-checksum=f63f46b7ae68ced0a5c2e31df1b6dfc7656117d162a1bc7fed4bd4afd14ddc8f
+checksum=ee12f7b5f97308708de5067deebb3d3322fc24f6d54f906a47a0a4e8db799122
 
 system_accounts="caddy"
 caddy_homedir="/var/lib/caddy"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64
- I built this PR locally for these architectures:
  - x86_64-musl
  - aarch64 (crossbuild)
