### PR TITLE
botan: update to 3.11.0.

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -2957,7 +2957,7 @@ libKDb3.so.4 kdb-3.1.0_1
 libKPropertyWidgets3.so.4 kproperty-3.1.0_1
 libKPropertyCore3.so.4 kproperty-3.1.0_1
 libKReport3.so.4 kreport-3.1.0_1
-libbotan-3.so.9 botan-3.9.0_1
+libbotan-3.so.11 botan-3.11.0_1
 libswipl.so.10 swi-prolog-10.0.0_1
 libpcre2-16.so.0 libpcre2-10.22_1
 libpcre2-32.so.0 libpcre2-10.22_1

--- a/srcpkgs/biboumi/patches/backport-botan3.patch
+++ b/srcpkgs/biboumi/patches/backport-botan3.patch
@@ -1,7 +1,7 @@
 From 8c4769e27b71ead73863c896ef9702add73cba8e Mon Sep 17 00:00:00 2001
 From: Luca Matei Pintilie <luca@lucamatei.com>
 Date: Tue, 29 Jul 2025 15:52:16 +0200
-Subject: [PATCH 1/2] Revert "Replace a useless shared_ptr by a unique_ptr"
+Subject: [PATCH 1/3] Revert "Replace a useless shared_ptr by a unique_ptr"
 
 This reverts commit 248e25c22fc15105d2a9db695ddb93ed5a8e0802.
 
@@ -86,7 +86,7 @@ index a7aef3d..e9e5473 100644
 From e4d32f939240ed726e9981e42c0dc251cd9879da Mon Sep 17 00:00:00 2001
 From: Luca Matei Pintilie <luca@lucamatei.com>
 Date: Mon, 28 Jul 2025 12:10:58 +0200
-Subject: [PATCH 2/2] biboumi: Update botan to version 3
+Subject: [PATCH 2/3] biboumi: Update botan to version 3
 
 The botan dependency has introduced a number of breaking changes with
 version 3, a couple of which impact biboumi as well
@@ -622,3 +622,40 @@ index e915646..052dd9c 100644
  #endif
 -- 
 2.47.3
+From 2c9d56ed9cef75d487ae233458767f75d4079dd3 Mon Sep 17 00:00:00 2001
+From: Komeil Parseh <komeilparseh@disroot.org>
+Date: Tue, 28 Apr 2026 13:11:06 +0330
+Subject: [PATCH 3/3] bridge: add <cstring> include to fix missing declarations for
+ C string functions
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+The build fails when compiling bridge.cpp because several C string
+functions (such `strlen()`, `memcpy()`, etc)
+are used without including <cstring>. Newer compilers (GCC 14)
+no longer implicitly include these symbols through unrelated headers.
+
+Error seen during build:
+    error: ‘strlen’ was not declared in this scope
+
+Adding <cstring> restores the expected declarations and fixes the build
+on modern toolchains.
+---
+ src/bridge/bridge.cpp | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/bridge/bridge.cpp b/src/bridge/bridge.cpp
+index 8577e22..1804e86 100644
+--- a/src/bridge/bridge.cpp
++++ b/src/bridge/bridge.cpp
+@@ -8,6 +8,7 @@
+ #include <utils/uuid.hpp>
+ #include <logger/logger.hpp>
+ #include <utils/revstr.hpp>
++#include <cstring>
+ #include <utils/split.hpp>
+ #include <xmpp/jid.hpp>
+ #include <database/database.hpp>
+-- 
+2.53.0

--- a/srcpkgs/biboumi/template
+++ b/srcpkgs/biboumi/template
@@ -1,7 +1,7 @@
 # Template file for 'biboumi'
 pkgname=biboumi
 version=9.0
-revision=3
+revision=4
 build_style=cmake
 configure_args="-DWITHOUT_SYSTEMD=1"
 conf_files="/etc/biboumi/biboumi.cfg"

--- a/srcpkgs/botan/template
+++ b/srcpkgs/botan/template
@@ -1,7 +1,7 @@
 # Template file for 'botan'
 pkgname=botan
-version=3.9.0
-revision=2
+version=3.11.0
+revision=1
 build_style=gnu-makefile
 hostmakedepends="doxygen python3 python3-packaging-bootstrap"
 makedepends="bzip2-devel liblzma-devel sqlite-devel zlib-devel"
@@ -11,7 +11,7 @@ license="BSD-2-Clause"
 homepage="https://botan.randombit.net/"
 changelog="https://botan.randombit.net/news.html"
 distfiles="https://botan.randombit.net/releases/Botan-${version}.tar.xz"
-checksum=8c3f284b58ddd42e8e43e9fa86a7129d87ea7c3f776a80d3da63ec20722b0883
+checksum=e8dd48556818da2c03a9a30932ad05db9e50b12fec90809301ecc64ea51bd11e
 python_version=3
 
 LDFLAGS="-pthread"

--- a/srcpkgs/corectrl/template
+++ b/srcpkgs/corectrl/template
@@ -1,7 +1,7 @@
 # Template file for 'corectrl'
 pkgname=corectrl
 version=1.5.2
-revision=4
+revision=5
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF" # requires https://github.com/rollbear/trompeloeil which isn't packaged
 hostmakedepends="pkg-config extra-cmake-modules qt6-tools qt6-base"

--- a/srcpkgs/keepassxc/template
+++ b/srcpkgs/keepassxc/template
@@ -1,7 +1,7 @@
 # Template file for 'keepassxc'
 pkgname=keepassxc
 version=2.7.12
-revision=1
+revision=2
 build_style=cmake
 configure_args="-DWITH_TESTS=ON -DWITH_XC_UPDATECHECK=OFF -DWITH_XC_DOCS=ON
  -DWITH_XC_AUTOTYPE=$(vopt_if autotype ON OFF)
@@ -27,7 +27,7 @@ license="GPL-3.0-or-later, BSD-3-Clause, CC0-1.0, LGPL-2.0-only, LGPL-2.1-only,
 homepage="https://keepassxc.org/"
 changelog="https://raw.githubusercontent.com/keepassxreboot/keepassxc/${version}/CHANGELOG.md"
 distfiles="https://github.com/keepassxreboot/keepassxc/releases/download/${version}/keepassxc-${version}-src.tar.xz"
-checksum=c9f5c4fe4b93d232795a9d8bfb58d129a492fcaa79c846eb637399164bcdb2d8
+checksum=be34eeb297881adea4f894c7c6e4a1835bd7927f8043ddea495040df4792a7de
 
 build_options="autotype browser fdosecrets keeshare network passkey sshagent yubikey"
 desc_option_autotype="Include auto-type"

--- a/srcpkgs/qca-qt5/template
+++ b/srcpkgs/qca-qt5/template
@@ -1,7 +1,7 @@
 # Template file for 'qca-qt5'
 pkgname=qca-qt5
 version=2.3.10
-revision=1
+revision=2
 build_style=cmake
 configure_args="-DQCA_FEATURE_INSTALL_DIR=/usr/share/qca-qt5/mkspecs
  -DUSE_RELATIVE_PATHS=true"

--- a/srcpkgs/qca-qt6/template
+++ b/srcpkgs/qca-qt6/template
@@ -1,7 +1,7 @@
 # Template file for 'qca-qt6'
 pkgname=qca-qt6
 version=2.3.10
-revision=1
+revision=2
 build_style=cmake
 configure_args="-DQT6=ON -DUSE_RELATIVE_PATHS=true"
 hostmakedepends="pkg-config ca-certificates qt6-tools qt6-base"

--- a/srcpkgs/qownnotes/template
+++ b/srcpkgs/qownnotes/template
@@ -1,6 +1,6 @@
 # Template file for 'qownnotes'
 pkgname=qownnotes
-version=25.8.3
+version=26.4.24
 revision=1
 build_helper=qmake
 build_style=cmake
@@ -15,4 +15,4 @@ license="GPL-2.0-only"
 homepage="https://www.qownnotes.org"
 changelog="https://raw.githubusercontent.com/pbek/QOwnNotes/main/CHANGELOG.md"
 distfiles="https://github.com/pbek/QOwnNotes/releases/download/v${version}/qownnotes-${version}.tar.xz"
-checksum=22361e4604abecc64e39413bb4422d0a77b54b18da8ee2a7fff9b9e87295efa8
+checksum=f65fab0a8f2abb4be5e59a8a4ccc1c0ba23a08c34ce9144b1eca949a059ffbb0


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->


#### Testing the changes
- I tested the changes in this PR: **YES** 

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
#### Local build testing
- I built this PR locally for my native architecture, x86_64(glibc) **(only botan)**

#### See Also:

+ [CVE-2026-32883](https://ubuntu.com/security/CVE-2026-32883)

----------------------------------------------------------------

- **botan: update to 3.11.0.**
- **biboumi: revbump for botan**
- **corectrl: revbump for botan**
- **keepassxc: revbump for botan**
- **qca-qt5: revbump for botan**
- **qca-qt6: revbump for botan**
- **qownnotes: update to 26.4.24.**