### PR TITLE
nomacs: update to 3.21.1

### DIFF
--- a/srcpkgs/nomacs/template
+++ b/srcpkgs/nomacs/template
@@ -1,31 +1,27 @@
 # Template file for 'nomacs'
 pkgname=nomacs
-version=3.17.2287
-revision=5
-_plugins_ver=3.17.2285
+version=3.21.1
+revision=1
+_plugins_ver=3.21.1
 build_wrksrc=ImageLounge
 build_style=cmake
 configure_args="-DCMAKE_BUILD_TYPE=None -DENABLE_TRANSLATIONS=1
  -DUSE_SYSTEM_QUAZIP=1"
-hostmakedepends="pkg-config qt5-qmake qt5-host-tools quazip-devel"
-makedepends="qt5-tools-devel qt5-svg-devel exiv2-devel libopencv-devel
+hostmakedepends="pkg-config qt6-base qt6-declarative-host-tools quazip-qt6-devel"
+makedepends="qt6-tools-devel qt6-svg-devel qt6-qt5compat-devel exiv2-devel libopencv-devel
  libraw-devel quazip-devel"
+#depends="qt6-core qt6-concurrent qt6-network qt6-printsupport qt6-widgets"
 short_desc="Simple yet powerful Qt imageviewer"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-3.0-or-later"
 homepage="https://github.com/nomacs/nomacs"
 distfiles="https://github.com/nomacs/nomacs/archive/${version}.tar.gz
  https://github.com/novomesk/nomacs-plugins/archive/refs/tags/${_plugins_ver}.tar.gz>plugins.tar.gz"
-checksum="6905ea615358f84a0c83d5b1b7077871dea0526ec667500a1951448cb845a92c
- 946b2d754be9ecca5cb155f7ecc5dcafb164f6c3dcc7bf5c3c0610d3b47774aa"
+checksum="7d0841d00ed6538328d4ffc91d8f3f53f457d50860f231c928deadc8d6e7aaad
+ 9afad6379c3e75f61c434c50d947faa19b47ad3ce0ad7ec6de319998fda2b56f"
 skip_extraction="plugins.tar.gz"
 
 post_extract() {
 	cd ${build_wrksrc}
 	vsrcextract -C plugins "plugins.tar.gz"
-}
-
-post_patch() {
-	# XXX: remove this when updating, it no longer requires git as of 3.17.2295
-	vsed -i -e "s/import subprocess/return '${version}'/" ../scripts/versionupdate.py
 }


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)

Note:

There is a newer version of nomacs available (3.22.1) but no corresponding nomacs-plugins version, yet. The respective latest versions don't seem to work together (build errors). Thus nomacs is set to the same version as the latest nomacs-plugins version.