### PR TITLE
occt: update to 7.9.3

### DIFF
--- a/srcpkgs/occt/template
+++ b/srcpkgs/occt/template
@@ -1,6 +1,6 @@
 # Template file for 'occt'
 pkgname=occt
-version=7.9.1
+version=7.9.3
 revision=1
 _gittag="V${version//./_}"
 build_style=cmake
@@ -12,8 +12,8 @@ license="custom:LGPL-2.1-only-with-exceptions"
 homepage="https://www.opencascade.com"
 # distfile: use git instead of official tarball, which requires registration
 # see https://www.opencascade.com/content/packaging-again-debian
-distfiles="https://git.dev.opencascade.org/gitweb/?p=occt.git;a=snapshot;h=refs/tags/${_gittag};sf=tgz>occt-${_gittag}.tar.gz"
-checksum=e70b8c08c74f9693cbc91baa48610f1f5448ad167425fb8b957cf5a8f2cafed5
+distfiles="https://github.com/Open-Cascade-SAS/OCCT/archive/refs/tags/${_gittag}.tar.gz"
+checksum=5ecf094ec6b12d5413dfb851d8c3590c354058aee556e32e408bdfbf8c357d57
 conflicts="oce>=0"
 if [ "$XBPS_TARGET_LIBC" = musl ]; then
 	makedepends+=" libexecinfo-devel"


### PR DESCRIPTION
The old repository at https://git.dev.opencascade.org/gitweb seems to be deprecated. Switched to https://github.com/Open-Cascade-SAS/OCCT/archive

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures:
  - x86_64-musl
  - aarch64-glibc (cross-build)
  - aarch64-musl (cross-build)
  - armv7l-glibc (cross-build)
  - armv7l-musl (cross-build)
  - armv6l-glibc (cross-build)
  - armv6l-musl (cross-build)

