### PR TITLE
libdockapp: remove fonts.dir and add fonts_dir variable

### DIFF
--- a/srcpkgs/libdockapp/template
+++ b/srcpkgs/libdockapp/template
@@ -1,23 +1,27 @@
 # Template file for 'libdockapp'
 pkgname=libdockapp
-version=0.7.2
+version=0.7.3
 revision=1
 build_style=gnu-configure
 hostmakedepends="autoconf automake font-util libtool m4 pkg-config"
 makedepends="libX11-devel libXext-devel libXpm-devel"
+depends="font-util"
 short_desc="DockApp Development Standard Library"
 maintainer="Orphaned <orphan@voidlinux.org>"
-license="3-clause-BSD"
-homepage="http://www.dockapps.net/libdockapp"
-distfiles="http://www.dockapps.net/download/libdockapp-${version}.tar.gz"
-checksum=df7a24f32a70b878bf280f0754529335ffa3bac44bf7a59cd1277f5cf13f4264
+license="BSD-3-Clause"
+homepage="https://www.dockapps.net/libdockapp"
+changelog="https://repo.or.cz/dockapps.git/blob_plain/HEAD:/libdockapp/ChangeLog"
+distfiles="https://www.dockapps.net/download/libdockapp-${version}.tar.gz"
+checksum=16d992f684dfcdb19e3682822d495f473615fba6e9e2fa7a106307bc767b389c
+
+font_dirs="/usr/share/fonts/X11/misc"
 
 pre_configure() {
 	autoreconf -fi
 }
 
 libdockapp-devel_package() {
-	depends="libdockapp>=${version}_${revision} $makedepends"
+	depends="${sourcepkg}>=${version}_${revision} ${makedepends}"
 	short_desc+=" - development files"
 	pkg_install() {
 		vmove usr/include
@@ -27,6 +31,6 @@ libdockapp-devel_package() {
 }
 
 post_install() {
+	rm -f "${DESTDIR}/usr/share/fonts/X11/misc/fonts.dir"
 	vlicense README
 }
-


### PR DESCRIPTION
Along with its two font files, libdockapp ships its own /usr/share/fonts/X11/misc/fonts.dir, overwriting the system's fonts.dir. This leaves the system's X font files index in an inconsistent state after installation.

This PR fixes the bug by including the proper x11-fonts trigger.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**


#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
