### PR TITLE
[Fix #60216] python3-openssl: update to v. 26.1.0

### DIFF
--- a/srcpkgs/python3-openssl/template
+++ b/srcpkgs/python3-openssl/template
@@ -1,7 +1,7 @@
 # Template file for 'python3-openssl'
 pkgname=python3-openssl
-version=25.3.0
-revision=2
+version=26.1.0
+revision=1
 build_style=python3-pep517
 hostmakedepends="python3-setuptools"
 depends="python3-cryptography"
@@ -12,7 +12,7 @@ license="Apache-2.0"
 homepage="https://pyopenssl.org/"
 changelog="https://raw.githubusercontent.com/pyca/pyopenssl/master/CHANGELOG.rst"
 distfiles="${PYPI_SITE}/p/pyopenssl/pyopenssl-${version}.tar.gz"
-checksum=c981cb0a3fd84e8602d7afc209522773b94c1c2446a3c710a75b06fe1beae329
+checksum=737f0a2275c5bc54f3b02137687e1a765931fb3949b9a92a825e4d33b9eec08b
 
 if [ "$XBPS_TARGET_WORDSIZE" = "32" ]; then
 	# https://github.com/pyca/pyopenssl/issues/974


### PR DESCRIPTION
Fixes #60216

#### Testing the changes
- I tested the changes in this PR: **briefly**

I tried my due diligence to get the package to crash on its own, but was not able to. 

I've also tested it fixes the problem at #60216, and deluge now starts up.