### PR TITLE
python3-urllib3: fix building under setuptools-scm 10

### DIFF
--- a/srcpkgs/python3-urllib3/patches/allow_using_setuptools_scm_10.patch
+++ b/srcpkgs/python3-urllib3/patches/allow_using_setuptools_scm_10.patch
@@ -1,0 +1,23 @@
+From 166f66faa5ef23e255f654e8c6b66ad8590fe630 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Miro=20Hron=C4=8Dok?= <miro@hroncok.cz>
+Date: Wed, 1 Apr 2026 19:09:22 +0200
+Subject: [PATCH] Allow using setuptools_scm 10 (#4954)
+
+It works in Fedora, so I hope it will work upstream as well.
+---
+ pyproject.toml | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/pyproject.toml b/pyproject.toml
+index 88c6afd85d..f084e9c1cc 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -1,7 +1,7 @@
+ # This file is protected via CODEOWNERS
+ 
+ [build-system]
+-requires = ["hatchling>=1.27.0,<2", "hatch-vcs>=0.4.0,<0.6.0", "setuptools-scm>=8,<10"]
++requires = ["hatchling>=1.27.0,<2", "hatch-vcs>=0.4.0,<0.6.0", "setuptools-scm>=8,<11"]
+ build-backend = "hatchling.build"
+ 
+ [project]


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

Currently python3-urllib3 fails to build with: `ERROR Missing dependencies: setuptools-scm<10,>=8`

There's an upstream fix for this in https://github.com/urllib3/urllib3/commit/166f66faa5ef23e255f654e8c6b66ad8590fe630 not yet in release. This simply adds a patch for it.