### PR TITLE
New package: font-nasin-nanpa-4.0.2

### DIFF
--- a/srcpkgs/font-nasin-nanpa/template
+++ b/srcpkgs/font-nasin-nanpa/template
@@ -1,0 +1,18 @@
+# Template file for 'font-nasin-nanpa'
+pkgname=font-nasin-nanpa
+version=4.0.2
+revision=1
+depends="font-util"
+short_desc="Monospaced sitelen pona typeface"
+maintainer="jade-ish <eightbitgiraffe@gmail.com>"
+license="MIT"
+homepage="https://github.com/etbcor/nasin-nanpa/releases"
+distfiles="https://github.com/etbcor/nasin-nanpa/archive/refs/tags/n${version}.tar.gz"
+checksum=952d5c599b365fb5911c1d8e566cb7d7298fded9d732713c3bdff14304cdc448
+font_dirs="/usr/share/fonts/OTF"
+
+do_install() {
+	vmkdir usr/share/fonts/OTF
+	vcopy "versions/nasin-nanpa-${version}-UCSUR.otf" usr/share/fonts/OTF
+	vlicense LICENSE
+}


### PR DESCRIPTION
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

this is especially a question of whether or not toki pona is notable enough to be included. as of right now, this font uses a private use area to encode characters of sitelen pona. these codepoints are designated by the under-conscript unicode registry, or ucsur, for sitelen pona, a writing system not currently represented by any fonts in the repos. currently, the sitelen pona publishers & typographers association is working toward its inclusion in unicode, but fonts like this exist in the meantime to represent sitelen pona over text.