### PR TITLE
WIP: libunistring: update to 1.4.1

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -1362,7 +1362,7 @@ libgda-ui-5.0.so.4 libgda-5.2.9_4
 libgda-xslt-5.0.so.4 libgda-5.2.9_4
 libamtk-5.so.0 amtk-5.0.0_1
 libdevhelp-3.so.6 devhelp-libs-3.30.0_1
-libunistring.so.2 libunistring-0.9.4_1
+libunistring.so.5 libunistring-1.4.1_1
 libguile-3.0.so.1 libguile-3.0.10_1
 libopts.so.25 libopts-5.18.4_6
 libanjuta-3.so.0 anjuta-3.8.4_1

--- a/srcpkgs/base-chroot/template
+++ b/srcpkgs/base-chroot/template
@@ -1,7 +1,7 @@
 # Template file for 'base-chroot'
 pkgname=base-chroot
 version=0.67
-revision=4
+revision=5
 bootstrap=yes
 metapackage=yes
 short_desc="Minimal set of packages required for chroot with xbps-src"
@@ -17,7 +17,7 @@ case "$XBPS_TARGET_MACHINE" in
 esac
 
 depends+="
- base-files binutils gcc gcc-ada libada-devel
+ base-files chroot-binutils gcc gcc-ada libada-devel
  patch sed findutils diffutils make gzip coreutils
  file bsdtar xbps mpfr ncurses libreadline8
  chroot-bash chroot-grep chroot-gawk chroot-distcc

--- a/srcpkgs/binutils/template
+++ b/srcpkgs/binutils/template
@@ -1,8 +1,7 @@
 # Template file for 'binutils'
 pkgname=binutils
 version=2.44
-revision=2
-bootstrap=yes
+revision=3
 hostmakedepends="pkgconf tar"
 makedepends="zlib-devel libzstd-devel"
 short_desc="GNU binary utilities"
@@ -11,6 +10,8 @@ license="GPL-3.0-or-later"
 homepage="http://www.gnu.org/software/binutils/"
 distfiles="${GNU_SITE}/binutils/binutils-${version}.tar.xz"
 checksum=ce2017e059d63e67ddb9240e9d4ec49c2893605035cd60e92ad53177f4377237
+
+conflicts="chroot-binutils>=0"
 
 build_options="all_targets"
 desc_option_all_targets="Enable all supported targets"

--- a/srcpkgs/chroot-binutils/patches
+++ b/srcpkgs/chroot-binutils/patches
@@ -1,0 +1,1 @@
+../binutils/patches/

--- a/srcpkgs/chroot-binutils/template
+++ b/srcpkgs/chroot-binutils/template
@@ -1,0 +1,119 @@
+# Template file for 'chroot-binutils'
+pkgname=chroot-binutils
+version=2.44
+revision=1
+bootstrap=yes
+hostmakedepends="pkgconf tar"
+makedepends="zlib-devel libzstd-devel"
+short_desc="GNU binary utilities"
+maintainer="kim <grufwub@gmail.com>"
+license="GPL-3.0-or-later"
+homepage="http://www.gnu.org/software/binutils/"
+distfiles="${GNU_SITE}/binutils/binutils-${version}.tar.xz"
+checksum=ce2017e059d63e67ddb9240e9d4ec49c2893605035cd60e92ad53177f4377237
+
+provides="binutils-${version}_${revision}"
+conflicts="binutils>=0"
+
+
+
+_get_triplet() {
+	if [ -z "$XBPS_TRIPLET" ]; then
+		echo $(
+			source "${XBPS_COMMONDIR}/build-profiles/${XBPS_MACHINE}.sh"
+			echo "$XBPS_TRIPLET"
+		)
+	else
+		echo "$XBPS_TRIPLET"
+	fi
+}
+
+do_configure() {
+	local conf
+
+	sed -i "
+		s;zlibinc=\$;&-I${XBPS_MASTERDIR}/usr/include;
+		s;zlibdir=\$;&-L${XBPS_MASTERDIR}/usr/lib;
+	" */configure
+
+	if [ "$CROSS_BUILD" ]; then
+		# we don't want --with-sysroot=${XBPS_CROSS_BASE} like gnu-configure
+		conf+=" --host=${XBPS_CROSS_TRIPLET} --with-build-sysroot=${XBPS_CROSS_BASE}"
+		# pkgconf adds sysroot includes to cflags and ldflags, which breaks binutils cross-compile with zstd
+		vsed -e '/PKG_CONFIG_SYSROOT_DIR/d' -i ${XBPS_WRAPPERDIR}/${XBPS_CROSS_TRIPLET}-pkg-config
+	fi
+
+	case "$XBPS_TARGET_MACHINE" in
+		ppc*)
+			conf+=" --enable-secureplt"
+			;;
+		x86_64*|i686*)
+			extra_targets=x86_64-pep
+			;;
+	esac
+
+	# target archs supported by Void
+	void_targets="aarch64,armv5tel,armv6l,armv7l,i686,mips,mipsel,ppc,ppcle,ppc64,ppc64le,riscv64,x86_64"
+	conf+=" --enable-targets=$(echo "$void_targets" | sed -E -e 's/(,|$)/-linux-gnu\1/g'),${extra_targets}"
+
+	# enable multilib on x86_64 glibc
+	if [ "$XBPS_TARGET_MACHINE" = "x86_64" ]; then
+		conf+=" --enable-multilib"
+	else
+		conf+=" --disable-multilib"
+	fi
+
+	# ensure softfloat on sf mips targets and set the default hash style
+	case "$XBPS_TARGET_MACHINE" in
+		mips*hf*) conf+=" --enable-default-hash-style=sysv" ;;
+		mips*) conf+=" --without-fp --enable-default-hash-style=sysv" ;;
+		*) conf+=" --enable-default-hash-style=gnu";;
+	esac
+
+	mkdir build && cd build
+	../configure --build=$(_get_triplet) \
+		--prefix=/usr \
+		--libdir=/usr/lib \
+		--sysconfdir=/etc \
+		--disable-werror \
+		--disable-nls \
+		--enable-threads \
+		--enable-deterministic-archives \
+		--without-debuginfod \
+		--disable-gprofng \
+		--disable-shared \
+		--enable-64-bit-bfd \
+		--enable-ld=default \
+		--with-system-zlib \
+		--with-mmap \
+		--with-pic \
+		--with-zstd \
+		$conf
+}
+
+do_build() {
+	cd ${wrksrc}/build && make ${makejobs} ${_makeinfo}
+}
+
+do_install() {
+	cd ${wrksrc}/build
+
+	local _triplet=$(_get_triplet)
+	make DESTDIR=${DESTDIR} tooldir=/usr install ${_makeinfo}
+
+	cd ..
+
+	# Remove ld (hardlink) and make a symlink to ld.bfd.
+	rm -f ${DESTDIR}/usr/bin/ld
+	ln -sfr ${DESTDIR}/usr/bin/ld.bfd ${DESTDIR}/usr/bin/ld
+
+	# Remove useless manpages.
+	for f in dlltool nlmconv windres windmc; do
+		rm -f ${DESTDIR}/usr/share/man/man1/${f}.1
+	done
+
+	# Create triplet symlinks
+	for f in ${DESTDIR}/usr/bin/*; do
+		ln -s ${f##*/} ${DESTDIR}/usr/bin/${XBPS_CROSS_TRIPLET:-${_triplet}}-${f##*/}
+	done
+}

--- a/srcpkgs/chroot-git/template
+++ b/srcpkgs/chroot-git/template
@@ -1,7 +1,7 @@
 # Template file for 'chroot-git'
 pkgname=chroot-git
 version=2.49.0
-revision=1
+revision=2
 bootstrap=yes
 makedepends="zlib-devel"
 short_desc="GIT Tree History Storage Tool -- for xbps-src use"
@@ -11,11 +11,6 @@ homepage="https://git-scm.com/"
 distfiles="https://www.kernel.org/pub/software/scm/git/git-${version}.tar.xz"
 checksum=618190cf590b7e9f6c11f91f23b1d267cd98c3ab33b850416d8758f8b5a85628
 repository=bootstrap
-
-if [ "$CHROOT_READY" ]; then
-	checkdepends="perl gnupg"
-	makedepends+=" libcurl-devel"
-fi
 
 do_configure() {
 	cat <<-EOF >config.mak
@@ -60,9 +55,6 @@ do_configure() {
 
 do_build() {
 	make ${makejobs} git
-	if [ "$CHROOT_READY" ]; then
-		make ${makejobs} git-http-fetch git-remote-http
-	fi
 }
 
 do_check() {

--- a/srcpkgs/gcc/template
+++ b/srcpkgs/gcc/template
@@ -4,7 +4,7 @@
 
 pkgname=gcc
 version=14.2.1+20250405
-revision=4
+revision=5
 bootstrap=yes
 _patchver="${version%+*}"
 _minorver="${version%.*}"
@@ -57,6 +57,11 @@ depends="binutils libgcc-devel-${version}_${revision}
  libstdc++-devel-${version}_${revision} libatomic-devel-${version}_${revision}"
 checkdepends="dejagnu"
 subpackages="libgcc libgomp libgomp-devel libatomic libatomic-devel"
+
+if [ ! "$CHROOT_READY" ]; then
+	# Use chroot-binutils when bootstrapping
+	depends="${depends/binutils/chroot-binutils}"
+fi
 
 build_options="ada gnatboot bindist gccbin"
 build_options_default="ada"

--- a/srcpkgs/gnunet/template
+++ b/srcpkgs/gnunet/template
@@ -1,7 +1,7 @@
 # Template file for 'gnunet'
 pkgname=gnunet
 version=0.12.2
-revision=5
+revision=6
 build_style=gnu-configure
 conf_files="/etc/gnunet/gnunet.conf"
 hostmakedepends="automake gettext gettext-devel libtool pkg-config tar texinfo"

--- a/srcpkgs/gnutls/template
+++ b/srcpkgs/gnutls/template
@@ -1,7 +1,7 @@
 # Template file for 'gnutls'
 pkgname=gnutls
 version=3.8.10
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--disable-static --disable-valgrind-tests
  --disable-rpath

--- a/srcpkgs/guile/template
+++ b/srcpkgs/guile/template
@@ -1,7 +1,7 @@
 # Template file for 'guile'
 pkgname=guile
 version=3.0.11
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--disable-static --disable-error-on-warning
  --with-libgmp-prefix=${XBPS_CROSS_BASE}/usr

--- a/srcpkgs/lagrange/template
+++ b/srcpkgs/lagrange/template
@@ -1,7 +1,7 @@
 # Template file for 'lagrange'
 pkgname=lagrange
 version=1.20.4
-revision=1
+revision=2
 build_style=cmake
 configure_args="-DTFDN_ENABLE_SSE41=NO"
 hostmakedepends="pkg-config zip"

--- a/srcpkgs/libidn2/template
+++ b/srcpkgs/libidn2/template
@@ -1,7 +1,7 @@
 # Template file for 'libidn2'
 pkgname=libidn2
 version=2.3.4
-revision=1
+revision=2
 build_style=gnu-configure
 hostmakedepends="gettext-devel libtool pkg-config gtk-doc"
 makedepends="libunistring-devel"

--- a/srcpkgs/libpsl/template
+++ b/srcpkgs/libpsl/template
@@ -1,7 +1,7 @@
 # Template file for 'libpsl'
 pkgname=libpsl
 version=0.21.5
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--enable-runtime=libidn2
  --with-psl-distfile=/usr/share/publicsuffix/public_suffix_list.dafsa

--- a/srcpkgs/libratbag/template
+++ b/srcpkgs/libratbag/template
@@ -1,7 +1,7 @@
 # Template file for 'libratbag'
 pkgname=libratbag
 version=0.18
-revision=1
+revision=2
 build_style=meson
 configure_args="-Dtests=false -Dsystemd-unit-dir=''
  -Dsystemd=false -Db_ndebug=false"

--- a/srcpkgs/libt3widget/template
+++ b/srcpkgs/libt3widget/template
@@ -1,7 +1,7 @@
 # Template file for 'libt3widget'
 pkgname=libt3widget
 version=1.2.2
-revision=2
+revision=3
 build_style=configure
 configure_args="--prefix=/usr LIBTOOL=./hack/libtool"
 hostmakedepends="pkg-config gettext autoconf automake libtool"

--- a/srcpkgs/libt3window/template
+++ b/srcpkgs/libt3window/template
@@ -1,7 +1,7 @@
 # Template file for 'libt3window'
 pkgname=libt3window
 version=0.4.2
-revision=2
+revision=3
 build_style=configure
 configure_args="--prefix=/usr LIBTOOL=./hack/libtool"
 hostmakedepends="pkg-config gettext autoconf automake libtool"

--- a/srcpkgs/libunistring/template
+++ b/srcpkgs/libunistring/template
@@ -1,6 +1,6 @@
 # Template file for 'libunistring'
 pkgname=libunistring
-version=1.0
+version=1.4.1
 revision=1
 build_style=gnu-configure
 short_desc="Library for manipulating Unicode strings and C strings"
@@ -8,7 +8,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="LGPL-3.0-or-later"
 homepage="https://www.gnu.org/software/libunistring"
 distfiles="${GNU_SITE}/${pkgname}/${pkgname}-${version}.tar.gz"
-checksum=3c0184c0e492d7c208ce31d25dd1d2c58f0c3ed6cbbe032c5b248cddad318544
+checksum=12542ad7619470efd95a623174dcd4b364f2483caf708c6bee837cb53a54cb9d
 
 libunistring-devel_package() {
 	short_desc+=" - development files"

--- a/srcpkgs/lnav/template
+++ b/srcpkgs/lnav/template
@@ -1,7 +1,7 @@
 # Template file for 'lnav'
 pkgname=lnav
 version=0.14.0
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--disable-static"
 hostmakedepends="automake openssh zlib-devel"

--- a/srcpkgs/notcurses/template
+++ b/srcpkgs/notcurses/template
@@ -1,7 +1,7 @@
 # Template file for 'notcurses'
 pkgname=notcurses
 version=3.0.9
-revision=3
+revision=4
 build_style=cmake
 configure_args="-DUSE_STATIC=ON -DUSE_QRCODEGEN=On $(vopt_bool man USE_PANDOC)"
 hostmakedepends="pkg-config $(vopt_if man pandoc)"

--- a/srcpkgs/rygel/template
+++ b/srcpkgs/rygel/template
@@ -1,7 +1,7 @@
 # Template file for 'rygel'
 pkgname=rygel
 version=0.44.2
-revision=2
+revision=3
 build_style=meson
 build_helper="gir"
 configure_args="-Dexamples=false -Dtests=false"

--- a/srcpkgs/sssd/template
+++ b/srcpkgs/sssd/template
@@ -1,7 +1,7 @@
 # Template file for 'sssd'
 pkgname=sssd
 version=2.11.1
-revision=1
+revision=2
 # upstream explicitly hardcodes to use glibc:
 # https://github.com/SSSD/sssd/blob/2.8.2/src/util/nss_dl_load.c
 archs="~*-musl"

--- a/srcpkgs/tilde/template
+++ b/srcpkgs/tilde/template
@@ -1,7 +1,7 @@
 # Template file for 'tilde'
 pkgname=tilde
 version=1.1.3
-revision=1
+revision=2
 build_style=configure
 configure_args="--prefix=/usr"
 hostmakedepends="pkg-config gettext"

--- a/srcpkgs/zmap/template
+++ b/srcpkgs/zmap/template
@@ -1,7 +1,7 @@
 # Template file for 'zmap'
 pkgname=zmap
 version=4.3.4
-revision=1
+revision=2
 build_style=cmake
 hostmakedepends="flex byacc gengetopt pkg-config"
 makedepends="libpcap-devel gmp-devel json-c-devel libunistring-devel


### PR DESCRIPTION
- splits bootstrappable binutils into a separate chroot-binutils that doesn't rely on debuginfod (which pulls in curl, and so libidn2 / libpsl, which causes a dependency cycle on libunistring update)
- removes curl as a possible dependency of chroot-git to avoid potentially pulling in a curl dependency (see above)
- updates libunistring to latest

given i'm not quite so seasoned a contributor here, if anyone would prefer someone else take maintainer role of chroot-binutils by all means go ahead.

i'm also totally open to less destructive alternatives to manage this dependency cycle in trying to update libunistring! though it does seem like a similar situation to this could come about in the future with other dependencies, given our bootstrappable packages can potentially pull in non-bootstrap dependencies during binary-bootstrap.

binary-bootstrap works as expected, currently testing a full bootstrap now.

cc: @Duncaen (these were the changes i was asking about in IRC last week)
cc: @Gottox 