### PR TITLE
moby: generate dockerd man page

### DIFF
--- a/srcpkgs/moby/template
+++ b/srcpkgs/moby/template
@@ -2,10 +2,10 @@
 # should be kept in sync with docker-cli
 pkgname=moby
 version=29.4.1
-revision=1
+revision=2
 build_style=go
 go_import_path="github.com/docker/docker"
-hostmakedepends="go pkg-config"
+hostmakedepends="go pkg-config go-md2man"
 makedepends="libbtrfs-devel device-mapper-devel libnftables-devel libseccomp-devel"
 depends="containerd iptables xz"
 short_desc="Container engine for the Docker ecosystem"
@@ -25,10 +25,12 @@ do_build() {
 	export DISABLE_WARN_OUTSIDE_CONTAINER=1
 
 	GOPATH="$PWD" VERSION="$version" hack/make.sh dynbinary
+	go-md2man -in man/dockerd.8.md -out man/dockerd.8
 }
 
 do_install() {
 	vbin bundles/dynbinary-daemon/dockerd
 	vbin bundles/dynbinary-daemon/docker-proxy
 	vsv docker
+	vman man/dockerd.8
 }


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for these architectures (if supported. mark crossbuilds):
     - [X] x86_64-glibc                                                                                                              
     - [X] aarch64-glibc                                                                                                             
     - [X] armv7l-glibc                                                                                                              
     - [ ] armv6l-musl                                                                                                               
     - [ ] aarch64-musl 

Adds `go-md2man` to `hostmakedepends` and uses it to generate and install the `dockerd(8)` man page from the upstream markdown source.