### PR TITLE
checksec: update to 3.1.0

### DIFF
--- a/srcpkgs/checksec/template
+++ b/srcpkgs/checksec/template
@@ -1,17 +1,24 @@
 # Template file for 'checksec'
 pkgname=checksec
-version=2.7.1
+version=3.1.0
 revision=1
-depends="binutils"
+build_style=go
+go_import_path=github.com/slimm609/checksec/v3
 short_desc="Check for protections like RELRO, NoExec, Stack protection, ASLR, PIE"
 maintainer="Leah Neukirchen <leah@vuxu.org>"
 license="BSD-3-Clause"
-homepage="https://github.com/slimm609/checksec.sh"
-distfiles="https://github.com/slimm609/checksec.sh/archive/${version}.tar.gz"
-checksum=a0d7a444d4603fb3d62fa25ef678e544ef39fa7b3c9bd5d22f1a8c526152cdde
+homepage="https://github.com/slimm609/checksec"
+changelog="https://github.com/slimm609/checksec/blob/main/CHANGELOG.md"
+distfiles="https://github.com/slimm609/checksec/archive/${version}.tar.gz"
+checksum=cd3112fb02577726dd6945a11d9225d508ac0d59984d772fbbda5d9cf2d2c290
+nocross=yes
 
-do_install() {
-	vbin checksec
-	vlicense LICENSE.txt
+post_install() {
 	vman extras/man/checksec.1
+	vlicense LICENSE
+	"${DESTDIR}/usr/bin/checksec" completion bash > checksec.bash
+	"${DESTDIR}/usr/bin/checksec" completion zsh > _checksec
+	"${DESTDIR}/usr/bin/checksec" completion fish > checksec.fish
+	vinstall _checksec 644 usr/share/zsh/site-functions
+	vinstall checksec.fish 644 usr/share/fish/vendor_completions.d
 }


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - i686
  - x86_64-musl

NOTE: Upstream transitioned from 2.x to 3.x by rewriting from bash to Go. `nocross=yes` was used because `post_install` runs the binary to generate completions, which fails during cross-compilation. Native builds work fine though.