### PR TITLE
gnome-podcasts: update to 25.3

### DIFF
--- a/srcpkgs/gnome-podcasts/template
+++ b/srcpkgs/gnome-podcasts/template
@@ -1,6 +1,6 @@
 # Template file for 'gnome-podcasts'
 pkgname=gnome-podcasts
-version=0.7.1
+version=25.3
 revision=1
 build_style=meson
 build_helper="rust"
@@ -9,12 +9,12 @@ hostmakedepends="cargo desktop-file-utils gettext glib-devel
 makedepends="gstreamer1-devel gst-plugins-bad1-devel gst-plugins-base1-devel
  gtk4-devel libadwaita-devel openssl-devel sqlite-devel texinfo rust-std"
 short_desc="Listen to your favorite podcasts"
-maintainer="Enno Boland <gottox@voidlinux.org>"
+maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-3.0-or-later"
-homepage="https://wiki.gnome.org/Apps/Podcasts"
-changelog="https://gitlab.gnome.org/World/podcasts/-/raw/master/CHANGELOG.md"
+homepage="https://apps.gnome.org/Podcasts/"
+changelog="https://gitlab.gnome.org/World/podcasts/-/blob/main/CHANGELOG.md"
 distfiles="https://gitlab.gnome.org/World/podcasts/-/archive/${version}/podcasts-${version}.tar.gz"
-checksum=933d33dfd0f36343f9c80f055a48e14307a0665b35097da176767ddbfe583399
+checksum=b2d012e31f20385bbba9919dacf5783ea20fb3e60c86dfd21fdf7d8ea640d600
 make_check=no # Unable to init server: Could not connect: Connection refused
 
 export GETTEXT_BIN_DIR=/usr/bin
@@ -24,6 +24,6 @@ export GETTEXT_INCLUDE_DIR="${XBPS_CROSS_BASE}/usr/include"
 post_patch() {
 	if [ "$CROSS_BUILD" ]; then
 		vsed -i podcasts-gtk/src/meson.build \
-		 	-e "s%rust_target /%'${RUST_TARGET}' / rust_target /%"
+			-e "s%rust_target /%'${RUST_TARGET}' / rust_target /%"
 	fi
 }


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-glibc
  - aarch64-musl
  - i686-glibc