### PR TITLE
gnome-font-viewer: update to 50.0

### DIFF
--- a/srcpkgs/gnome-font-viewer/template
+++ b/srcpkgs/gnome-font-viewer/template
@@ -1,9 +1,9 @@
 # Template file for 'gnome-font-viewer'
 pkgname=gnome-font-viewer
-version=48.0
+version=50.0
 revision=1
 build_style=meson
-hostmakedepends="pkg-config glib-devel gettext"
+hostmakedepends="pkg-config glib-devel gettext desktop-file-utils"
 makedepends="fontconfig-devel freetype-devel glib-devel gtk4-devel
  gnome-desktop-devel harfbuzz-devel libadwaita-devel"
 depends="desktop-file-utils"
@@ -12,7 +12,5 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="https://gitlab.gnome.org/GNOME/gnome-font-viewer"
 changelog="https://gitlab.gnome.org/GNOME/gnome-font-viewer/-/raw/main/NEWS"
-# FIXME: dead link
-#changelog="https://gitlab.gnome.org/GNOME/gnome-font-viewer/-/raw/gnome-48/NEWS"
 distfiles="${GNOME_SITE}/gnome-font-viewer/${version%.*}/gnome-font-viewer-${version}.tar.xz"
-checksum=732624231b624ff5c7ac03a8ce71be12393daa53551d11550b20d7b0a3a872a7
+checksum=9564b088c5b150c54e2a3a7bc7014deec6ee551261e98488f891b1f1b8dc6b80


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-glibc 
  - aarch64-musl
  - i686