### PR TITLE
gnome-software: update to 50.1

### DIFF
--- a/srcpkgs/gnome-software/template
+++ b/srcpkgs/gnome-software/template
@@ -1,6 +1,6 @@
 # Template file for 'gnome-software'
 pkgname=gnome-software
-version=48.2
+version=50.1
 revision=1
 build_style=meson
 configure_args="-Dpackagekit=false -Dfwupd=false
@@ -19,7 +19,7 @@ license="GPL-3.0-or-later"
 homepage="https://gitlab.gnome.org/GNOME/gnome-software"
 changelog="https://gitlab.gnome.org/GNOME/gnome-software/-/raw/main/NEWS"
 distfiles="https://gitlab.gnome.org/GNOME/gnome-software/-/archive/${version}/gnome-software-${version}.tar.gz"
-checksum=fe5e9aaaf1e3297e40e11736f89f3b4db07fafc4108f656ae2cd4999224a229a
+checksum=0f609f4f95564fe60e6ecbf0559e0e83c68da6086004967bc5b225a872cf24a5
 make_check=no # Requires system dbus
 
 build_options="gtk_doc"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-glibc & aarch64-musl
  - i686-glibc