### PR TITLE
gnome-boxes: update to 50.0

### DIFF
--- a/srcpkgs/gnome-boxes/template
+++ b/srcpkgs/gnome-boxes/template
@@ -1,6 +1,6 @@
 # Template file for 'gnome-boxes'
 pkgname=gnome-boxes
-version=48.0
+version=50.0
 revision=1
 build_helper="gir"
 build_style=meson
@@ -13,9 +13,9 @@ makedepends="clutter-gtk-devel libarchive-devel
  tracker-devel libgcrypt-devel libportal-gtk3-devel"
 depends="desktop-file-utils hicolor-icon-theme qemu"
 short_desc="GNOME application to access remote or virtual systems"
-maintainer="Enno Boland <gottox@voidlinux.org>"
+maintainer="Orphaned <orphan@voidlinux.org>"
 license="LGPL-2.0-or-later"
 homepage="https://wiki.gnome.org/Apps/Boxes"
 changelog="https://gitlab.gnome.org/GNOME/gnome-boxes/-/raw/main/NEWS"
 distfiles="${GNOME_SITE}/gnome-boxes/${version%%.*}/gnome-boxes-${version}.tar.xz"
-checksum=d05f5f42568fafbf6d88771161b06ed5f739d43121278d418cae95c56e513ead
+checksum=fd6a5de18d1090946ca99f1f5a34aa3e15dc8183f6a72226e8d1504a13672d67


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-glibc & aarch64-musl
  - i686-glibc