### PR TITLE
moosefs: use mfsgui instead of deprecated cgiserv

### DIFF
--- a/srcpkgs/moosefs/files/mfsgui/run
+++ b/srcpkgs/moosefs/files/mfsgui/run
@@ -1,4 +1,4 @@
 #!/bin/sh
 exec 2>&1
 [ -e conf ] && . ./conf
-exec mfscgiserv -f $OPTS start
+exec mfsgui -f $OPTS start

--- a/srcpkgs/moosefs/template
+++ b/srcpkgs/moosefs/template
@@ -1,11 +1,11 @@
 # Template file for 'moosefs'
 pkgname=moosefs
 version=4.58.3
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--localstatedir=/var/lib --with-default-user=_mfs
  --with-default-group=_mfs"
-hostmakedepends="automake libtool pkg-config"
+hostmakedepends="automake libtool pkg-config python3"
 makedepends="zlib-devel libpcap-devel fuse-devel"
 short_desc="Fault tolerant, network distributed file system"
 maintainer="Orphaned <orphan@voidlinux.org>"
@@ -23,7 +23,7 @@ pre_configure() {
 
 post_install() {
 	mv ${DESTDIR}/sbin/* ${DESTDIR}/usr/bin
-	for f in chunkserver master metalogger cgiserv; do
+	for f in chunkserver master metalogger gui; do
 		vsv mfs${f}
 	done
 }


### PR DESCRIPTION
1. mfscgiserv is deprecated in favor of mfsgui script.
2.  Added python3 to hostmakedepends because it is needed for gui to be properly packaged.

#### Testing the changes
- I tested the changes in this PR: **YES**
- I have installed the locally built package and checked if tools are properly functioning.

#### Local build testing
- I built this PR locally for my native architecture, x86-64
