### PR TITLE
cryptsetup: update to 2.8.6.

### DIFF
--- a/srcpkgs/cryptsetup/template
+++ b/srcpkgs/cryptsetup/template
@@ -1,6 +1,6 @@
 # Template file for 'cryptsetup'
 pkgname=cryptsetup
-version=2.8.4
+version=2.8.6
 revision=1
 build_style=gnu-configure
 configure_args="--with-crypto_backend=openssl --disable-asciidoc
@@ -16,7 +16,7 @@ license="GPL-2.0-or-later"
 homepage="https://gitlab.com/cryptsetup/cryptsetup"
 changelog="https://gitlab.com/cryptsetup/cryptsetup/raw/master/docs/v${version}-ReleaseNotes"
 distfiles="${KERNEL_SITE}/utils/cryptsetup/v${version%.*}/cryptsetup-${version}.tar.xz"
-checksum=443e46f8964c9acc780f455afbb8e23aa0e8ed7ec504cfc59e04f406fa1e8a83
+checksum=8004265fd993885d08f7b633dbe056851de1a210307613a4ebddc743fccefe5a
 subpackages="libcryptsetup cryptsetup-devel"
 build_options="pwquality"
 desc_option_pwquality="Enable support for checking password quality via libpwquality"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
