### PR TITLE
clevis: update to v22_tpm1u1.

### DIFF
--- a/srcpkgs/clevis/template
+++ b/srcpkgs/clevis/template
@@ -1,7 +1,9 @@
 # Template file for 'clevis'
 pkgname=clevis
-version=20
-revision=2
+version=22
+revision=1
+# Holds non-standard upstream version suffixes when needed.
+_subversion=tpm1u1
 build_style=meson
 hostmakedepends="asciidoc bash-completion cryptsetup curl jq keyutils pkg-config tpm2-tools"
 makedepends="bash-completion cryptsetup-devel dracut jansson-devel
@@ -11,8 +13,8 @@ short_desc="Pluggable framework for automated decryption"
 maintainer="Johannes Heimansberg <git@jhe.dedyn.io>"
 license="GPL-3.0-or-later WITH custom:OpenSSL-Exception"
 homepage="https://github.com/latchset/clevis"
-distfiles="https://github.com/latchset/clevis/archive/v$version/clevis-$version.tar.gz"
-checksum=67eb9cbbb9c90f9802cae76503f74f23d0046ee6570553407035e9fae3b4b4dd
+distfiles="https://github.com/latchset/clevis/archive/v${version}${subversion}/clevis-${version}${subversion}.tar.gz"
+checksum=2814522c755d3cbb26d76630b08fbf09dec2909540e9c78d689f864b5851f851
 make_check="ci-skip" # LUKS tests fail in CI pipeline
 
 post_install() {

--- a/srcpkgs/clevis/update
+++ b/srcpkgs/clevis/update
@@ -1,0 +1,2 @@
+site="https://github.com/latchset/clevis/tags"
+pattern='v\K[0-9.]+(?=(_.*)?$)'

--- a/srcpkgs/luksmeta/template
+++ b/srcpkgs/luksmeta/template
@@ -1,6 +1,6 @@
 # Template file for 'luksmeta'
 pkgname=luksmeta
-version=9
+version=10
 revision=1
 build_style=gnu-configure
 hostmakedepends="asciidoc automake cryptsetup libtool pkg-config"
@@ -10,7 +10,7 @@ maintainer="Johannes Heimansberg <git@jhe.dedyn.io>"
 license="LGPL-2.0-or-later"
 homepage="https://github.com/latchset/luksmeta"
 distfiles="https://github.com/latchset/luksmeta/archive/v$version/luksmeta-$version.tar.gz"
-checksum=0eea7d50a0411e0c1e383fd47073806ed7d435b27410504e33bfbc792a1688fc
+checksum=6d688bc37cdae3b2d11d1ad6ba1882954d5588103b396c5f30962a417b59b3a2
 make_check="no" # fails on some architectures
 
 pre_configure() {


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
#### Local build testing
- I built this PR locally for my native architecture, x86_64(glibc)

----------------------------------

~~**fixes #59909**~~

- **luksmeta: update to 10.**
- **clevis: update to 22.**

