### PR TITLE
dhcpcd: update to 10.3.2

### DIFF
--- a/srcpkgs/dhcpcd/template
+++ b/srcpkgs/dhcpcd/template
@@ -1,6 +1,6 @@
 # Template file for 'dhcpcd'
 pkgname=dhcpcd
-version=10.3.1
+version=10.3.2
 revision=1
 build_style=configure
 make_check_target=test
@@ -15,7 +15,7 @@ license="BSD-2-Clause"
 homepage="https://roy.marples.name/projects/dhcpcd"
 changelog="https://github.com/NetworkConfiguration/dhcpcd/releases"
 distfiles="https://github.com/NetworkConfiguration/dhcpcd/archive/refs/tags/v${version}.tar.gz"
-checksum=bd71826930d141c3bd9f7108ff421a66c1b9c36a83613be94347cb4bc197fbf8
+checksum=fa9aa4867e2cd5d1551bf93e34fb8ed6891702448df8a71afffab067ceb66a4f
 lib32disabled=yes
 conf_files=/etc/dhcpcd.conf
 


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, **x86_64-glibc**
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl
 
w/ #53404 still undecided, v10.3.2 is a small [bugfix release](https://github.com/NetworkConfiguration/dhcpcd/releases)


  