### PR TITLE
cage: update to 0.3.0.

### DIFF
--- a/srcpkgs/cage/template
+++ b/srcpkgs/cage/template
@@ -1,10 +1,10 @@
 # Template file for 'cage'
 pkgname=cage
-version=0.2.1
+version=0.3.0
 revision=1
 build_style=meson
 hostmakedepends="pkg-config wayland-devel scdoc"
-makedepends="libxkbcommon-devel wlroots0.19-devel"
+makedepends="libxkbcommon-devel wlroots0.20-devel"
 depends="xorg-server-xwayland"
 short_desc="Kiosk compositor for Wayland"
 maintainer="Orphaned <orphan@voidlinux.org>"
@@ -12,7 +12,7 @@ license="MIT"
 homepage="https://www.hjdskes.nl/projects/cage/"
 changelog="https://github.com/cage-kiosk/cage/releases"
 distfiles="https://github.com/cage-kiosk/cage/archive/refs/tags/v${version}.tar.gz"
-checksum=acab0c83175164a788d7b9f89338cbdebdc4f7197aff6fdc267c32f7181234a9
+checksum=f32e6885444e365de3bc076d307c20eff59ee42ed0237219eebd3d2fe597e289
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**
- Upgrading fixed launching firefox in kiosk mode for me

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl (crossbuild