### PR TITLE
vtk: added cross compiling capabilities

### DIFF
--- a/srcpkgs/vtk/template
+++ b/srcpkgs/vtk/template
@@ -1,8 +1,9 @@
 # Template file for 'vtk'
 pkgname=vtk
 version=9.5.0
-revision=2
+revision=3
 build_style=cmake
+build_helper=qemu
 # vtk can be huge, especially with -DVTK_BUILD_ALL_MODULES=ON"
 # Build only the core modules plus python bindings for now
 configure_args="-DBUILD_SHARED_LIBS=ON -DVTK_FORBID_DOWNLOADS=ON
@@ -30,7 +31,6 @@ license="BSD-3-Clause"
 homepage="https://www.vtk.org"
 distfiles="https://www.vtk.org/files/release/${version:0:3}/VTK-${version}.tar.gz"
 checksum=04ae86246b9557c6b61afbc534a6df099244fbc8f3937f82e6bc0570953af87d
-nocross="It seems to need vtk compile tools for the host"
 
 case "$XBPS_TARGET_MACHINE" in
 	# List of supported architectures copied from openmpi.
@@ -54,9 +54,13 @@ post_extract() {
 post_install() {
 	vlicense Copyright.txt
 
-	# Mangle CPython extension names in CMake like xbps-src will do
-	vsed -e 's,\(vtkmodules/vtk.*\)\.cpython-.*\.so,\1.so,' \
-		-i "${DESTDIR}/usr/lib/cmake/vtk-${version:0:3}/VTKPython-targets-none.cmake"
+	case "$XBPS_TARGET_MACHINE" in
+		x86_64*)
+			# Mangle CPython extension names in CMake like xbps-src will do
+			vsed -e 's,\(vtkmodules/vtk.*\)\.cpython-.*\.so,\1.so,' \
+				-i "${DESTDIR}/usr/lib/cmake/vtk-${version:0:3}/VTKPython-targets-none.cmake"
+			;;
+	esac
 }
 
 vtk-devel_package() {


### PR DESCRIPTION
vtk can cross compile either with a multi-step compiling scheme using VTKCompileTools, as reported in
https://cmake.org/cmake/help/book/mastering-cmake/chapter/Cross%20Compiling%20With%20CMake.html#cross-compiling-a-complex-project-vtk, or with a cross compiling emulator, as shown in
VTK_source_code/CMake/vtkCrossCompiling.cmake, such as qemu. Given xbps-src capabilities, using qemu is the most convenient option.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC) x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl
  - aarch64-glibc (cross-build)
  - aarch64-musl (cross-build)
  - armv7l-glibc (cross-build)
  - armv7l-musl (cross-build)
  - armv6l-glibc (cross-build)
  - armv6l-musl (cross-build)
