### PR TITLE
broadcom-wl-dkms: fix DKMS builds for linux 6.15 through 6.17

### DIFF
--- a/srcpkgs/broadcom-wl-dkms/patches/020-linux-6.15.patch
+++ b/srcpkgs/broadcom-wl-dkms/patches/020-linux-6.15.patch
@@ -1,0 +1,135 @@
+From a0acb522ad849b2e2a3019794a293fdeb717ba03 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Joan=20Bruguera=20Mic=C3=B3?= <joanbrugueram@gmail.com>
+Date: Sun, 23 Feb 2025 14:29:21 +0000
+Subject: [PATCH] Tentative patch for broadcom-wl 6.30.223.271 driver for Linux
+ 6.15-rc1
+
+Due to the fact that the driver is unmaintained, and can't be adapted
+to the current Linux kernel security standards (e.g. IBT), as it has a
+proprietary blob; and this is likely to be an ever-growing security
+risk, I have added a warning when the module is loaded.
+Use at your own risk; no warranty of any kind is provided.
+See also the objtool changes on the Makefile below.
+
+The changes to replace EXTRA_CFLAGS and EXTRA_LDFLAGS with ccflags-y
+and ldflags-y are rel. commit "kbuild: remove EXTRA_*FLAGS support"
+(Masahiro Yamada, 6 Feb 2025), according to which they have been
+deprecated since 2007, so no need to add any fallback for old kernels.
+
+NB: If the package build also contains references to EXTRA_*FLAGS
+(e.g. Arch Linux's broadcom-wl-dkms PKGBUILD), replace those as well!
+---
+ Makefile              | 33 ++++++++++++++++++++++++---------
+ src/wl/sys/wl_linux.c | 11 +++++++++++
+ 2 files changed, 35 insertions(+), 9 deletions(-)
+
+diff --git a/Makefile b/Makefile
+index a323a0d..3cca0ca 100644
+--- a/Makefile
++++ b/Makefile
+@@ -117,15 +117,15 @@ GCCVERSION := $(subst $(space),$(empty),$(GCCVERSION))
+ GCCVERSION := $(shell expr `echo $(GCCVERSION)` | cut -b1-3)
+ GE_49 := $(shell expr `echo $(GCCVERSION)` \>= 490)
+ 
+-EXTRA_CFLAGS :=
++ccflags-y :=
+ 
+ ifeq ($(APIFINAL),CFG80211)
+-  EXTRA_CFLAGS += -DUSE_CFG80211
++  ccflags-y += -DUSE_CFG80211
+   $(info Using CFG80211 API)
+ endif
+ 
+ ifeq ($(APIFINAL),WEXT)
+-  EXTRA_CFLAGS += -DUSE_IW
++  ccflags-y += -DUSE_IW
+   $(info Using Wireless Extension API)
+ endif
+ 
+@@ -137,17 +137,17 @@ wl-objs            += src/wl/sys/wl_linux.o
+ wl-objs            += src/wl/sys/wl_iw.o
+ wl-objs            += src/wl/sys/wl_cfg80211_hybrid.o
+ 
+-EXTRA_CFLAGS       += -I$(src)/src/include -I$(src)/src/common/include
+-EXTRA_CFLAGS       += -I$(src)/src/wl/sys -I$(src)/src/wl/phy -I$(src)/src/wl/ppr/include
+-EXTRA_CFLAGS       += -I$(src)/src/shared/bcmwifi/include
+-#EXTRA_CFLAGS       += -DBCMDBG_ASSERT -DBCMDBG_ERR
++ccflags-y          += -I$(src)/src/include -I$(src)/src/common/include
++ccflags-y          += -I$(src)/src/wl/sys -I$(src)/src/wl/phy -I$(src)/src/wl/ppr/include
++ccflags-y          += -I$(src)/src/shared/bcmwifi/include
++#ccflags-y          += -DBCMDBG_ASSERT -DBCMDBG_ERR
+ ifeq "$(GE_49)" "1"
+-EXTRA_CFLAGS       += -Wno-date-time
++ccflags-y          += -Wno-date-time
+ endif
+ 
+-EXTRA_CFLAGS       += -Wno-date-time
++ccflags-y          += -Wno-date-time
+
+-EXTRA_LDFLAGS      := $(src)/lib/wlc_hybrid.o_shipped
++ldflags-y          := $(src)/lib/wlc_hybrid.o_shipped
+ 
+ KBASE              ?= /lib/modules/${KV_FULL}
+ KBUILD_DIR         ?= $(KBASE)/build
+@@ -155,6 +155,21 @@ MDEST_DIR          ?= $(KBASE)/kernel/drivers/net/wireless
+ CROSS_TOOLS        = /path/to/tools
+ CROSS_KBUILD_DIR   = /path/to/kernel/tree
+ 
++# Rel. commit "objtool: Always fail on fatal errors" (Josh Poimboeuf, 31 Mar 2025)
++# This is a *ugly* hack to disable objtool during the final processing of wl.o.
++# Since is embeds the proprietary blob (wlc_hybrid.o_shipped), objtool can't
++# process it, as it does not follow the requirements of current kernels,
++# including support for critical security features. As of Linux v6.15+, it causes
++# a build error. Disable it, at your own risk. Note the MIT license applies:
++# THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
++# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
++# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
++# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
++# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
++# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
++# SOFTWARE.
++wl.o: override objtool-enabled =
++
+ all:
+ 	KBUILD_NOPEDANTIC=1 make -C $(KBUILD_DIR) M=`pwd`
+ 
+diff --git a/src/wl/sys/wl_linux.c b/src/wl/sys/wl_linux.c
+index 5ddbc4d..09a4af5 100644
+--- a/src/wl/sys/wl_linux.c
++++ b/src/wl/sys/wl_linux.c
+@@ -168,6 +168,8 @@ static int wl_set_radio_block(void *data, bool blocked);
+ static void wl_report_radio_state(wl_info_t *wl);
+ #endif
+ 
++// Rel. commit "modpost: require a MODULE_DESCRIPTION()" (Jeff Johnson, 11 Mar 2025)
++MODULE_DESCRIPTION("Broadcom-wl wireless driver [unmaintained, out-of-tree]");
+ MODULE_LICENSE("MIXED/Proprietary");
+ 
+ static struct pci_device_id wl_id_table[] =
+@@ -914,6 +916,10 @@ static struct pci_driver wl_pci_driver __refdata = {
+ static int __init
+ wl_module_init(void)
+ {
++	printk(KERN_WARNING "You are using the broadcom-wl driver, which is not "
++		"maintained and is incompatible with Linux kernel security mitigations. "
++		"It is heavily recommended to replace the hardware and remove the driver. "
++		"Proceed at your own risk!");
+ 	int error = -ENODEV;
+ 
+ #ifdef BCMDBG
+@@ -2457,7 +2463,12 @@ wl_del_timer(wl_info_t *wl, wl_timer_t *t)
+ 	ASSERT(t);
+ 	if (t->set) {
+ 		t->set = FALSE;
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
++		// Rel. commit "treewide: Switch/rename to timer_delete[_sync]()" (Thomas Gleixner, 5 Apr 2025)
++		if (!timer_delete(&t->timer)) {
++#else
+ 		if (!del_timer(&t->timer)) {
++#endif
+ #ifdef BCMDBG
+ 			WL_INFORM(("wl%d: Failed to delete timer %s\n", wl->unit, t->name));
+ #endif
+-- 
+2.49.0
+

--- a/srcpkgs/broadcom-wl-dkms/patches/021-linux-6.16.patch
+++ b/srcpkgs/broadcom-wl-dkms/patches/021-linux-6.16.patch
@@ -1,0 +1,14 @@
+--- a/src/wl/sys/wl_linux.c	2026-05-02 17:56:33.089723584 +0200
++++ b/src/wl/sys/wl_linux.c	2026-05-02 17:56:05.185723570 +0200
+@@ -2357,8 +2357,10 @@
+ {
+ #if LINUX_VERSION_CODE < KERNEL_VERSION(4, 15, 0)
+ 	wl_timer_t *t = (wl_timer_t *)data;
+-#else
++#elif LINUX_VERSION_CODE < KERNEL_VERSION(6, 16, 0)
+     wl_timer_t *t = from_timer(t, tl, timer);
++#else
++    wl_timer_t *t = timer_container_of(t, tl, timer);
+ #endif
+ 
+ 	if (!WL_ALL_PASSIVE_ENAB(t->wl))

--- a/srcpkgs/broadcom-wl-dkms/patches/022-linux-6.17.patch
+++ b/srcpkgs/broadcom-wl-dkms/patches/022-linux-6.17.patch
@@ -1,0 +1,70 @@
+--- a/src/wl/sys/wl_cfg80211_hybrid.c	2026-05-02 18:01:35.997607405 +0200
++++ b/src/wl/sys/wl_cfg80211_hybrid.c	2026-05-02 18:04:44.686635183 +0200
+@@ -71,7 +71,11 @@
+ static s32 wl_cfg80211_scan(struct wiphy *wiphy, struct net_device *ndev,
+            struct cfg80211_scan_request *request);
+ #endif
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 17, 0)
++static s32 wl_cfg80211_set_wiphy_params(struct wiphy *wiphy, int radio_idx, u32 changed);
++#else
+ static s32 wl_cfg80211_set_wiphy_params(struct wiphy *wiphy, u32 changed);
++#endif
+ static s32 wl_cfg80211_join_ibss(struct wiphy *wiphy, struct net_device *dev,
+            struct cfg80211_ibss_params *params);
+ static s32 wl_cfg80211_leave_ibss(struct wiphy *wiphy, struct net_device *dev);
+@@ -90,7 +94,9 @@
+            struct cfg80211_connect_params *sme);
+ static s32 wl_cfg80211_disconnect(struct wiphy *wiphy, struct net_device *dev, u16 reason_code);
+ 
+-#if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 8, 0)
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 17, 0)
++static s32 wl_cfg80211_set_tx_power(struct wiphy *wiphy, struct wireless_dev *wdev, int radio_idx, enum nl80211_tx_power_setting type, s32 dbm);
++#elif LINUX_VERSION_CODE >= KERNEL_VERSION(3, 8, 0)
+ static s32
+ wl_cfg80211_set_tx_power(struct wiphy *wiphy, struct wireless_dev *wdev,
+                          enum nl80211_tx_power_setting type, s32 dbm);
+@@ -102,7 +108,9 @@
+            enum tx_power_setting type, s32 dbm);
+ #endif
+ 
+-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 14, 0)
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 17, 0)
++static s32 wl_cfg80211_get_tx_power(struct wiphy *wiphy, struct wireless_dev *wdev, int radio_idx, u32 link_id, s32 *dbm);
++#elif LINUX_VERSION_CODE >= KERNEL_VERSION(6, 14, 0)
+ static s32 wl_cfg80211_get_tx_power(struct wiphy *wiphy, struct wireless_dev *wdev, u32 /*link_id*/, s32 *dbm);
+ #elif LINUX_VERSION_CODE >= KERNEL_VERSION(3, 8, 0)
+ static s32 wl_cfg80211_get_tx_power(struct wiphy *wiphy, struct wireless_dev *wdev, s32 *dbm);
+@@ -664,7 +672,11 @@
+ 	return err;
+ }
+ 
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 17, 0)
++static s32 wl_cfg80211_set_wiphy_params(struct wiphy *wiphy, int radio_idx, u32 changed)
++#else
+ static s32 wl_cfg80211_set_wiphy_params(struct wiphy *wiphy, u32 changed)
++#endif
+ {
+ 	struct wl_cfg80211_priv *wl = wiphy_to_wl(wiphy);
+ 	struct net_device *ndev = wl_to_ndev(wl);
+@@ -1098,7 +1110,9 @@
+ 	return err;
+ }
+ 
+-#if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 8, 0)
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 17, 0)
++static s32 wl_cfg80211_set_tx_power(struct wiphy *wiphy, struct wireless_dev *wdev, int radio_idx, enum nl80211_tx_power_setting type, s32 dbm)
++#elif LINUX_VERSION_CODE >= KERNEL_VERSION(3, 8, 0)
+ static s32
+ wl_cfg80211_set_tx_power(struct wiphy *wiphy, struct wireless_dev *wdev,
+                          enum nl80211_tx_power_setting type, s32 dbm)
+@@ -1159,7 +1173,9 @@
+ 	return err;
+ }
+ 
+-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 14, 0)
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 17, 0)
++static s32 wl_cfg80211_get_tx_power(struct wiphy *wiphy, struct wireless_dev *wdev, int radio_idx, u32 link_id, s32 *dbm)
++#elif LINUX_VERSION_CODE >= KERNEL_VERSION(6, 14, 0)
+ static s32 wl_cfg80211_get_tx_power(struct wiphy *wiphy, struct wireless_dev *wdev, u32 /*link_id*/, s32 *dbm)
+ #elif LINUX_VERSION_CODE >= KERNEL_VERSION(3, 8, 0)
+ static s32 wl_cfg80211_get_tx_power(struct wiphy *wiphy, struct wireless_dev *wdev, s32 *dbm)

--- a/srcpkgs/broadcom-wl-dkms/template
+++ b/srcpkgs/broadcom-wl-dkms/template
@@ -1,7 +1,7 @@
 # Template file for 'broadcom-wl-dkms'
 pkgname=broadcom-wl-dkms
 version=6.30.223.271
-revision=17
+revision=18
 archs="i686* x86_64*"
 create_wrksrc=yes
 depends="dkms"


### PR DESCRIPTION
I adapted the patches from Archlinux

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built the module for all of my installed kernels successfully:
5.15.204_1 
6.11.11_1 
6.12.85_1  
6.18.25_1  <--- this build was failing before
6.6.137_1