### PR TITLE
node_exporter: update to 1.11.1.

### DIFF
--- a/srcpkgs/node_exporter/template
+++ b/srcpkgs/node_exporter/template
@@ -1,22 +1,28 @@
 # Template file for 'node_exporter'
 pkgname=node_exporter
-version=1.3.1
-revision=4
+version=1.11.1
+revision=1
 build_style=go
 go_import_path="github.com/prometheus/node_exporter"
-go_ldflags="-X ${go_import_path}/version.Version=${version}
- -X ${go_import_path}/version.Revision=${version}
- -X ${go_import_path}/version.Branch=${version}
- -X ${go_import_path}/version.BuildUser=VoidLinux"
+go_ldflags="-X github.com/prometheus/common/version.Version=${version}
+ -X github.com/prometheus/common/version.Revision=${version}
+ -X github.com/prometheus/common/version.Branch=${version}
+ -X github.com/prometheus/common/version.BuildDate=$(date -u +%Y%m%d-%T)
+ -X github.com/prometheus/common/version.BuildUser=VoidLinux"
 short_desc="Exporter for machine metrics"
 maintainer="Toyam Cox <Vaelatern@voidlinux.org>"
 license="Apache-2.0"
 homepage="https://prometheus.io/"
 changelog="https://raw.githubusercontent.com/prometheus/node_exporter/master/CHANGELOG.md"
 distfiles="https://github.com/prometheus/node_exporter/archive/v${version}.tar.gz"
-checksum=66856b6b8953e094c46d7dd5aabd32801375cf4d13d9fe388e320cbaeaff573a
+checksum=d2b5a7740b7526543429b41a5d741bc530277f406f7b121fc64cb3ca583f7387
 
 system_accounts="_node_exporter"
+
+pre_check() {
+	make collector/fixtures/sys/.unpacked
+	make collector/fixtures/udev/.unpacked
+}
 
 post_install() {
 	vmkdir  usr/share/examples/$pkgname


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

I changed the go_ldflags to get working version strings:
CLI
```
$ node_exporter --version
node_exporter, version 1.11.1 (branch: 1.11.1, revision: 1.11.1)
  build user:       VoidLinux
  build date:       20260502-16:23:04
  go version:       go1.26.1
  platform:         linux/amd64
  tags:             unknown
```
node_exporter_build_info metric
```
$ curl -s localhost:9100/metrics | grep ^node_exporter_build_info
node_exporter_build_info{branch="1.11.1",goarch="amd64",goos="linux",goversion="go1.26.1",revision="1.11.1",tags="unknown",version="1.11.1"} 1
```
<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
