### PR TITLE
kvantum: update to 1.1.6.

### DIFF
--- a/srcpkgs/kvantum-doc
+++ b/srcpkgs/kvantum-doc
@@ -1,0 +1,1 @@
+kvantum

--- a/srcpkgs/kvantum/template
+++ b/srcpkgs/kvantum/template
@@ -1,20 +1,21 @@
 # Template file for 'kvantum'
 pkgname=kvantum
-version=1.1.5
-revision=2
+version=1.1.6
+revision=1
 build_wrksrc=Kvantum
 build_style=cmake
 configure_args="-DENABLE_QT5=ON"
 hostmakedepends="qt5-tools-devel qt5-host-tools qt6-tools qt6-base"
 makedepends="qt5-devel qt6-base-devel qt5-svg-devel qt6-svg-devel
  qt5-x11extras-devel kwindowsystem-devel kf6-kwindowsystem-devel"
+depends="hicolor-icon-theme"
 short_desc="SVG-based theme engine for Qt5/Qt6, KDE and LXQt"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-3.0-or-later"
 homepage="https://github.com/tsujan/Kvantum"
 changelog="https://raw.githubusercontent.com/tsujan/Kvantum/master/Kvantum/ChangeLog"
 distfiles="https://github.com/tsujan/Kvantum/archive/V${version}.tar.gz"
-checksum=2b47ab7e6494cb0960d1e18164b099b65759516c84463e956c46c8b458fa3e66
+checksum=5f487bbf4141b53d1ef991266a3b9dadece665d8b09d698b4d7ff7bed569c08e
 
 post_configure() {
 	mkdir build6
@@ -33,4 +34,11 @@ post_install() {
 	(cd build6 && do_install)
 	vdoc doc/Theme-Config.pdf
 	vdoc doc/Theme-Making.pdf
+}
+
+kvantum-doc_package() {
+	short_desc+=" - documentation"
+	pkg_install() {
+		vmove usr/share/doc
+	}
 }


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture (x86_64)
- I built this PR locally for these architectures using specific masterdirs:
  - x86_64-musl
  - i686
- I built this PR locally for these architectures (crossbuilds):
  - aarch64
  - aarch64-musl
  - armv7l
  - armv7l-musl
  - armv6l
  - armv6l-musl

---

- Split documentation (Theme-Config.pdf, Theme-Making.pdf) into a `kvantum-doc` subpackage.
- Add `hicolor-icon-theme` to `depends`, since the package installs usr/share/icons/hicolor/scalable/apps/.
- Tested locally with a Kvantum theme I maintain.