### PR TITLE
 SPIRV-LLVM-Translator: update 19 to 19.1.18; 21 to 21.1.7; 22 to 22.1.2.

### DIFF
--- a/srcpkgs/SPIRV-LLVM-Translator19/template
+++ b/srcpkgs/SPIRV-LLVM-Translator19/template
@@ -1,6 +1,6 @@
 # Template file for 'SPIRV-LLVM-Translator19'
 pkgname=SPIRV-LLVM-Translator19
-version=19.1.17
+version=19.1.18
 revision=1
 _llvm_ver=${version%%.*}
 build_style=cmake
@@ -17,7 +17,7 @@ maintainer="Daniel Martinez <danielmartinez@cock.li>"
 license="NCSA"
 homepage="https://github.com/KhronosGroup/SPIRV-LLVM-Translator"
 distfiles="https://github.com/KhronosGroup/SPIRV-LLVM-Translator/archive/refs/tags/v${version}.tar.gz"
-checksum=f3575652f1ac70d2123549ef546f4fd754e8272ae6d34a0b9f89bb7ddf0ae532
+checksum=ce9a4424a6373a274f8df9611aa53e7457a58b56ff36acaa74b946178acaffac
 
 alternatives="llvm-spirv:llvm-spirv:/usr/bin/llvm-spirv-${_llvm_ver}"
 

--- a/srcpkgs/SPIRV-LLVM-Translator21/template
+++ b/srcpkgs/SPIRV-LLVM-Translator21/template
@@ -1,6 +1,6 @@
 # Template file for 'SPIRV-LLVM-Translator21'
 pkgname=SPIRV-LLVM-Translator21
-version=21.1.6
+version=21.1.7
 revision=1
 _llvm_ver=${version%%.*}
 build_style=cmake
@@ -16,7 +16,7 @@ maintainer="Daniel Martinez <danielmartinez@cock.li>"
 license="NCSA"
 homepage="https://github.com/KhronosGroup/SPIRV-LLVM-Translator"
 distfiles="https://github.com/KhronosGroup/SPIRV-LLVM-Translator/archive/refs/tags/v${version}.tar.gz"
-checksum=63b0def85f17f7cfe2958efe24220c53c89a8680a82224da318de85f55424e01
+checksum=1a00e06eba69c24ded4ed5708ef3c55ad8786227017271fc335d3cc9abad2def
 
 alternatives="llvm-spirv:llvm-spirv:/usr/bin/llvm-spirv-${_llvm_ver}"
 

--- a/srcpkgs/SPIRV-LLVM-Translator22/template
+++ b/srcpkgs/SPIRV-LLVM-Translator22/template
@@ -1,6 +1,6 @@
 # Template file for 'SPIRV-LLVM-Translator22'
 pkgname=SPIRV-LLVM-Translator22
-version=22.1.1
+version=22.1.2
 revision=1
 _llvm_ver=${version%%.*}
 build_style=cmake
@@ -19,7 +19,7 @@ maintainer="Duncaen <duncaen@voidlinux.org>"
 license="NCSA"
 homepage="https://github.com/KhronosGroup/SPIRV-LLVM-Translator"
 distfiles="https://github.com/KhronosGroup/SPIRV-LLVM-Translator/archive/refs/tags/v${version}.tar.gz"
-checksum=83e7007b8b9b5536b30991661738a98e9cd607d4a203e9342b628aaea5ea32d7
+checksum=b37196b1a1a60282a24cf937ab7d6807d7d54dc718f2a37a78e211be26df57ac
 
 alternatives="llvm-spirv:llvm-spirv:/usr/bin/llvm-spirv-${_llvm_ver}"
 


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture (x86_64)
- I built this PR locally for these architectures using specific masterdirs:
  - x86_64-musl
  - i686
- I built this PR locally for these architectures (crossbuilds):
  - aarch64
  - aarch64-musl
  - armv7l
  - armv7l-musl
  - armv6l
  - armv6l-musl

---

Updated `SPIRV-LLVM-Translator` 19, 21, and 22 to their latest releases. Tested by rebuilding `mesa` (which depends on `SPIRV-LLVM-Translator21-devel` for Rusticl/OpenCL) and everything built successfully.