### PR TITLE
typos: update to 1.46.0.

### DIFF
--- a/srcpkgs/typos/template
+++ b/srcpkgs/typos/template
@@ -1,6 +1,6 @@
 # Template file for 'typos'
 pkgname=typos
-version=1.42.3
+version=1.46.0
 revision=1
 build_style=cargo
 make_install_args="--path crates/typos-cli"
@@ -10,7 +10,7 @@ license="Apache-2.0 OR MIT"
 homepage="https://github.com/crate-ci/typos"
 changelog="https://raw.githubusercontent.com/crate-ci/typos/refs/heads/master/CHANGELOG.md"
 distfiles="https://github.com/crate-ci/typos/archive/refs/tags/v${version}.tar.gz"
-checksum=d1b5fcd3ddc49c279c1813086e80dabb6a524d9fb67befb4e3619d236ada5781
+checksum=268459bd3b03d4e6c398280ade11d5280850fdb392ed50d3c67e41ddfa083dbc
 
 post_install() {
 	vlicense LICENSE-MIT


### PR DESCRIPTION

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
