### PR TITLE
gnome-calculator: upate to 50.0

### DIFF
--- a/srcpkgs/gnome-calculator/template
+++ b/srcpkgs/gnome-calculator/template
@@ -1,19 +1,24 @@
 # Template file for 'gnome-calculator'
 pkgname=gnome-calculator
-version=48.1
+version=50.0
 revision=1
 build_style=meson
 build_helper="gir"
-hostmakedepends="cmake gettext glib-devel itstool pkg-config vala
- gtk-update-icon-cache"
-makedepends="gsettings-desktop-schemas-devel gtksourceview5-devel libgee-devel
- libmpc-devel libsoup3-devel gtk4-devel libadwaita-devel"
-depends="desktop-file-utils gsettings-desktop-schemas hicolor-icon-theme"
+hostmakedepends="gettext glib-devel gtk4-update-icon-cache itstool
+ pkg-config vala blueprint-compiler
+ $(vopt_if gir 'gobject-introspection')"
+makedepends="gsettings-desktop-schemas-devel gtksourceview5-devel libadwaita-devel
+ libgee-devel libmpc-devel libsoup3-devel gtk4-devel"
 short_desc="GNOME calculator"
-maintainer="Enno Boland <gottox@voidlinux.org>"
+maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="https://wiki.gnome.org/Apps/Calculator"
-changelog="https://gitlab.gnome.org/GNOME/gnome-calculator/-/raw/gnome-48/NEWS"
-#changelog="https://gitlab.gnome.org/GNOME/gnome-calculator/-/raw/master/NEWS"
+changelog="https://gitlab.gnome.org/GNOME/gnome-calculator/-/raw/gnome-50/NEWS"
 distfiles="${GNOME_SITE}/gnome-calculator/${version%%.*}/gnome-calculator-${version}.tar.xz"
-checksum=bc4bd41a9ba190f45cbee0d8c6752cdc5d28b0cef1c6bd0c01e2dae1f3c19162
+checksum=8053d6891565e882874b65c1db51c5bf310005eb788b8bac3546390743350a90
+
+pre_build() {
+	if [ "$CROSS_BUILD" ]; then
+		export GI_TYPELIB_PATH="${XBPS_CROSS_BASE}/usr/lib/girepository-1.0"
+	fi
+}


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-glibc & musl
  - armv7l
  - i686
