### PR TITLE
glslang: update to 16.3.0; shaderc: update to 2026.2.

### DIFF
--- a/srcpkgs/glslang/template
+++ b/srcpkgs/glslang/template
@@ -1,7 +1,7 @@
 # Template file for 'glslang'
 # Libraries are unversioned, beware of ABI breakage (rebuild shaderc on updates)
 pkgname=glslang
-version=16.2.0
+version=16.3.0
 revision=1
 build_style=cmake
 hostmakedepends="python3 bison gtest-devel"
@@ -11,7 +11,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="BSD-3-Clause"
 homepage="https://github.com/KhronosGroup/glslang"
 distfiles="https://github.com/KhronosGroup/glslang/archive/${version}.tar.gz"
-checksum=01985335785c97906a91afe3cb5ee015997696181ec6c125bab5555602ba08e2
+checksum=efff5a15258dce1ca2d323bf64c974f5fca03778174615dbc30c8d36db645bf5
 
 if [ "$CROSS_BUILD" ]; then
 	export cmake_crossopts="-DCMAKE_SYSTEM_NAME=Linux -DCMAKE_HOST_SYSTEM_NAME=Linux"

--- a/srcpkgs/shaderc/template
+++ b/srcpkgs/shaderc/template
@@ -1,6 +1,6 @@
 # Template file for 'shaderc'
 pkgname=shaderc
-version=2026.1
+version=2026.2
 revision=1
 build_style=cmake
 configure_args="-DSHADERC_SKIP_TESTS=ON"
@@ -11,7 +11,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="Apache-2.0"
 homepage="https://github.com/google/shaderc"
 distfiles="https://github.com/google/shaderc/archive/v${version}.tar.gz"
-checksum=245002feccbe7f8361b223545a5654cea69780745886872d7efff50a38d96c66
+checksum=f924178e75e3293082481b25ed64d5e48a795b479dac3bd3c83d23070855df42
 
 CXXFLAGS="-I${XBPS_CROSS_BASE}/usr/include/glslang"
 LDFLAGS="-Wl,--no-undefined"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures using specific masterdirs:
  - x86_64-musl
  - i686
- I built this PR locally for these architectures (crossbuilds):
  - aarch64
  - aarch64-musl
  - armv7l
  - armv7l-musl
  - armv6l
  - armv6l-musl