### PR TITLE
srcpkg/*: depend on 7zip, not p7zip

### DIFF
--- a/srcpkgs/SLADE/template
+++ b/srcpkgs/SLADE/template
@@ -1,10 +1,10 @@
 # Template file for 'SLADE'
 pkgname=SLADE
 version=3.2.7
-revision=1
+revision=2
 build_style=cmake
 build_helper=cmake-wxWidgets-gtk3
-hostmakedepends="pkg-config p7zip which"
+hostmakedepends="pkg-config 7zip which"
 makedepends="SFML-devel fluidsynth-devel freeimage-devel ftgl-devel glew-devel
  gtk+3-devel libcurl-devel wxWidgets-gtk3-devel bzip2-devel zlib-devel
  lua53-devel dumb-devel liblzma-devel"

--- a/srcpkgs/Z80Explorer/template
+++ b/srcpkgs/Z80Explorer/template
@@ -1,18 +1,18 @@
 # Template file for 'Z80Explorer'
 pkgname=Z80Explorer
 version=1.02
-revision=1
+revision=2
 _z80_githash=6abf07adb65fcb2343f74c7a014cd6421a7dad5d
 create_wrksrc=yes
 build_style=qmake
-hostmakedepends="qt5-qmake qt5-host-tools p7zip"
+hostmakedepends="qt5-qmake qt5-host-tools 7zip"
 makedepends="qt5-devel qt5-script-devel"
 short_desc="Visual Zilog Z-80 netlist-level simulator"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-3.0-or-later"
 homepage="https://github.com/gdevic/Z80Explorer"
 distfiles="https://github.com/gdevic/Z80Explorer/archive/v${version}.tar.gz
- https://github.com/gdevic/Z80Explorer_Z80/archive/${_z80_githash}.tar.gz"
+ https://github.com/gdevic/Z80Explorer/archive/${_z80_githash}.tar.gz"
 checksum="8140eaeff215e49df2c0abb7c10f84c4c721adaced6a756d30e584348078b29b
  f6980e5bf3cadcc050d70a359fae7813d3d3b1805935a57dea564caed67b3192"
 

--- a/srcpkgs/ark/template
+++ b/srcpkgs/ark/template
@@ -1,14 +1,14 @@
 # Template file for 'ark'
 pkgname=ark
 version=25.12.2
-revision=1
+revision=2
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins"
 hostmakedepends="extra-cmake-modules qt6-base gettext
  kf6-kdoctools kf6-kconfig pkg-config python3 kf6-kcoreaddons"
 makedepends="libarchive-devel kf6-kpty-devel kf6-kparts-devel kf6-kitemmodels-devel libzip-devel kf6-kfilemetadata-devel kf6-kdbusaddons-devel kf6-kdoctools-devel kf6-ki18n-devel kf6-kio-devel kf6-kwindowsystem-devel kf6-kiconthemes-devel kf6-kwidgetsaddons-devel kf6-kconfig-devel kf6-kcrash-devel"
-checkdepends="p7zip p7zip-unrar lzop lrzip unrar unzip zip zstd"
+checkdepends="7zip 7zip-unrar lzop lrzip unrar unzip zip zstd"
 short_desc="KDE Archiving Tool"
 maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later"

--- a/srcpkgs/cbp2make/template
+++ b/srcpkgs/cbp2make/template
@@ -1,8 +1,8 @@
 # Template file for 'cbp2make'
 pkgname=cbp2make
 version=147
-revision=2
-hostmakedepends="doxygen p7zip"
+revision=3
+hostmakedepends="doxygen 7zip"
 short_desc="Makefile generation tool for Code::Blocks IDE"
 maintainer="Michael Aldridge <maldridge@voidlinux.org>"
 license="GPL-3.0-or-later"

--- a/srcpkgs/lutris/template
+++ b/srcpkgs/lutris/template
@@ -1,11 +1,11 @@
 # Template file for 'lutris'
 pkgname=lutris
 version=0.5.22
-revision=1
+revision=2
 build_style=meson
 hostmakedepends="gettext python3-setuptools python3-gobject gtk+3-devel"
 depends="python3-dbus python3-gobject python3-yaml python3-evdev python3-Pillow
- pciutils cabextract gtk+3 xrandr unzip p7zip gnome-desktop python3-requests libwebkit2gtk41
+ pciutils cabextract gtk+3 xrandr unzip 7zip gnome-desktop python3-requests libwebkit2gtk41
  glxinfo python3-distro python3-lxml python3-magic python3-certifi"
 short_desc="Open gaming platform for managing games in a unified way"
 maintainer="Orphaned <orphan@voidlinux.org>"

--- a/srcpkgs/multibootusb/template
+++ b/srcpkgs/multibootusb/template
@@ -1,11 +1,10 @@
 # Template file for 'multibootusb'
 pkgname=multibootusb
 version=9.2.0
-revision=9
+revision=10
 build_style=python3-module
-pycompile_module="scripts"
 hostmakedepends="python3-setuptools"
-depends="libparted util-linux python3-dbus python3-PyQt5 mtools p7zip parted
+depends="libparted util-linux python3-dbus python3-PyQt5 mtools 7zip parted
  python3-six python3-pyudev udisks2"
 short_desc="Create multiboot live Linux on a USB disk"
 maintainer="John <me@johnnynator.dev>"

--- a/srcpkgs/playonlinux/template
+++ b/srcpkgs/playonlinux/template
@@ -1,12 +1,12 @@
 # Template file for 'playonlinux'
 pkgname=playonlinux
 version=4.4
-revision=6
+revision=7
 # contains pre-compiled binaries linked against glibc
 archs="i686 x86_64"
 pycompile_dirs="usr/share/$pkgname/python"
 depends="icoutils netcat ImageMagick xterm wxPython cabextract unzip glxinfo
- gnupg xdg-user-dirs libXmu wget p7zip curl jq python3-natsort xrdb gettext
+ gnupg xdg-user-dirs libXmu wget 7zip curl jq python3-natsort xrdb gettext
  perl python3-pyasyncore"
 short_desc="GUI for managing Windows programs under linux"
 maintainer="Helmut Pozimski <helmut@pozimski.eu>"

--- a/srcpkgs/winegui/template
+++ b/srcpkgs/winegui/template
@@ -1,12 +1,12 @@
 # Template file for 'winegui'
 pkgname=winegui
 version=2.8.1
-revision=1
+revision=2
 archs="i686* x86_64*"
 build_style=cmake
 hostmakedepends="pkg-config"
 makedepends="gtkmm-devel"
-depends="wine wget unzip p7zip cabextract zenity"
+depends="wine wget unzip 7zip cabextract zenity"
 short_desc="User-friendly WINE manager"
 maintainer="Melroy van den Berg <melroy@melroy.org>"
 license="AGPL-3.0-only"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

Fixes 34859da21e1919d06027649d77e3a4f152b90e4f
@classabbyamp

Now that 7zip replaces p7zip, dependants of p7zip must depend on 7zip directly, otherwise 7zip will also be uninstalled unless it was manually installed, breaking dependant packages.