### PR TITLE
iwd: fix installation of D-Bus service files

### DIFF
--- a/srcpkgs/iwd/template
+++ b/srcpkgs/iwd/template
@@ -1,11 +1,11 @@
 # Template file for 'iwd'
 pkgname=iwd
 version=3.12
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--disable-systemd-service --enable-pie
  --enable-dbus-policy --enable-wired"
-hostmakedepends="python3-docutils pkg-config"
+hostmakedepends="python3-docutils pkg-config automake libtool"
 makedepends="readline-devel dbus-devel"
 depends="dbus openresolv"
 checkdepends="python3 $depends"
@@ -22,6 +22,10 @@ make_dirs="/var/lib/iwd 0600 root root
 # tests depend on kernel features
 make_check=extended
 make_check_pre="dbus-run-session"
+
+pre_configure() {
+	autoreconf -fi
+}
 
 post_install() {
 	vsv ead


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc

`fix-name-request.patch` already moves installation of `net.connman.iwd.service` and `net.connman.ead.service` out of the `SYSTEMD_SERVICE` Makefile conditional, so they are installed even with `--disable-systemd-service`. However, the `gnu-configure` build style uses the pre-generated `configure` and `Makefile.in` shipped in the tarball — patching `Makefile.am` has no effect without re-running `autoreconf`.

This adds `automake` and `libtool` to `hostmakedepends` and runs `autoreconf -fi` in `pre_configure()` so the patched `Makefile.am` takes effect, causing both D-Bus activation service files to be installed to `/usr/share/dbus-1/system-services/`.

Without these files, `dbus-daemon` cannot activate iwd on demand. Clients like NetworkManager (with `wifi.backend=iwd`) fail to bring up the wireless device if iwd is not already registered on D-Bus at the time NM starts, which depends on iwd vs. NM startup ordering.