### PR TITLE
katifetch: new package (v13.1)

### DIFF
--- a/srcpkgs/katifetch/template
+++ b/srcpkgs/katifetch/template
@@ -1,0 +1,16 @@
+# Template file for 'katifetch'
+pkgname=katifetch
+version=13.1
+revision=1
+short_desc="Lightweight and customizable system information fetch tool"
+maintainer="ximimoments <katifetchs@gmail.com>"
+license="MIT"
+homepage="https://github.com/ximimoments/katifetch"
+distfiles="https://github.com/ximimoments/katifetch/archive/refs/tags/${version}.tar.gz"
+checksum=57018797a61ab6befb80a0b76cdf7ca457421ef8cfc030fe41d77a78b017fd30
+
+do_install() {
+	# vinstall <archivo_origen> <permisos> <destino> <nombre_final>
+	vinstall katifetch.sh 755 usr/bin katifetch
+	vlicense LICENSE
+}


### PR DESCRIPTION
New package: katifetch-13.1. Katifetch is a system information tool written in Bash.

#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

#### Local build testing
- I built this PR locally for my native architecture: **x86_64**