### PR TITLE
megatools: update to 1.11.5

### DIFF
--- a/srcpkgs/megatools/template
+++ b/srcpkgs/megatools/template
@@ -1,18 +1,18 @@
 # Template file for 'megatools'
 pkgname=megatools
-version=1.11.1
-revision=2
-_release_date=20230212
+version=1.11.5
+revision=1
+_release_date=20250706
 build_style=meson
 hostmakedepends="pkg-config asciidoc docbook2x"
 makedepends="glib-networking gobject-introspection openssl-devel libcurl-devel fuse-devel libsodium-devel glib-devel"
 short_desc="Command line client for Mega.nz file sharing service"
 maintainer="RunningDroid <runningdroid@zoho.com>"
 license="GPL-2.0-or-later"
-homepage="https://megatools.megous.com/"
-changelog="https://megatools.megous.com/builds/NEWS"
-distfiles="https://megatools.megous.com/builds/megatools-${version}.${_release_date}.tar.gz"
-checksum=ecfa2ee4b277c601ebae648287311030aa4ca73ea61ee730bc66bef24ef19a34
+homepage="https://xff.cz/megatools/"
+changelog="https://xff.cz/megatools/builds/NEWS"
+distfiles="https://xff.cz/megatools/builds/megatools-${version}.${_release_date}.tar.gz"
+checksum=51f78a03748a64b1066ce28a2ca75d98dbef5f00fe9789dc894827f9a913b362
 
 post_install() {
 	vinstall contrib/bash-completion/megatools 644 usr/share/bash-completion/completions


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

CI might need restarted a couple times, the server the distfile's on is flaky

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
