### PR TITLE
discord: update to 1.0.136.

### DIFF
--- a/srcpkgs/discord/patches/discord.desktop.patch
+++ b/srcpkgs/discord/patches/discord.desktop.patch
@@ -1,8 +1,0 @@
-*** a/discord.desktop
---- a/discord.desktop
-*************** GenericName=Internet Messenger
-*** 6 ****
-! Exec=/usr/share/discord/Discord
---- 6 ----
-! Exec=/usr/lib/discord/Discord
-

--- a/srcpkgs/discord/template
+++ b/srcpkgs/discord/template
@@ -1,6 +1,6 @@
 # Template file for 'discord'
 pkgname=discord
-version=0.0.135
+version=1.0.136
 revision=1
 archs="x86_64"
 depends="alsa-lib dbus-glib gtk+3 libnotify nss libXtst libcxx libatomic
@@ -10,45 +10,25 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="custom:Proprietary"
 homepage="https://discord.com"
 distfiles="https://dl.discordapp.net/apps/linux/${version}/discord-${version}.tar.gz"
-checksum=bccba8cf5391d1c2afadf4ff8a590d5c4b443f7cc4c3234687a016e624000f0b
+checksum=2f582fee93aa4b67e1f00c8cda38541c2bb59fb82ee46bc886268066cea4415b
 repository=nonfree
 restricted=yes
 nopie=yes
 nostrip=yes
 
 do_install() {
-	local package_location="usr/lib/$pkgname" item
 	vmkdir usr/share/pixmaps
 	vcopy discord.png /usr/share/pixmaps/
 	vmkdir usr/share/applications
 	vcopy discord.desktop /usr/share/applications/
-	vmkdir ${package_location}
-	chmod +x Discord
-	for item in \
-		locales \
-		resources \
-		Discord \
-		libffmpeg.so \
-		snapshot_blob.bin \
-		discord.png \
-		icudtl.dat \
-		libEGL.so \
-		libGLESv2.so \
-		chrome_100_percent.pak \
-		chrome_200_percent.pak \
-		chrome-sandbox \
-		chrome_crashpad_handler \
-		resources.pak \
-		libvulkan.so.1 \
-		v8_context_snapshot.bin \
-		postinst.sh \
-		libvk_swiftshader.so \
-		vk_swiftshader_icd.json
-	do
-		vcopy "${item}" "${package_location}"
-	done
+	vmkdir usr/libexec/${pkgname}
+	chmod +x updater_bootstrap
+	vcopy updater_bootstrap /usr/libexec/${pkgname}/
+	vmkdir usr/share/${pkgname}
+	ln -s /usr/libexec/${pkgname}/updater_bootstrap ${DESTDIR}/usr/share/${pkgname}/updater_bootstrap
 	vmkdir usr/bin
-	ln -sfr $DESTDIR/${package_location}/Discord $DESTDIR/usr/bin/Discord
+	chmod +x discord
+	vcopy discord /usr/bin/
 }
 
 post_install() {


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

Update discord to 1.0.136 which switches to a new bootstrap model.

The upstream tarball no longer ships the full Electron runtime, instead
shipping a bootstrap script and a `updater_bootstrap` binary that downloads
and installs the actual client on first run.

- Remove `discord.desktop.patch` (upstream now ships correct `Exec` path)
- Rewrite `do_install` for the new tarball structure
- Install `updater_bootstrap` to `/usr/libexec/discord/` with a symlink
  in `/usr/share/discord/` where the bootstrap script expects it