### PR TITLE
kea: update to 3.1.8.

### DIFF
--- a/srcpkgs/kea/patches/boost-1.89.patch
+++ b/srcpkgs/kea/patches/boost-1.89.patch
@@ -1,14 +1,3 @@
---- a/meson.build
-+++ b/meson.build
-@@ -189,7 +189,7 @@ message(f'Detected system "@SYSTEM@".')
- 
- #### Dependencies
- 
--boost_dep = dependency('boost', version: '>=1.66', modules: ['system'])
-+boost_dep = dependency('boost', version: '>=1.66')
- dl_dep = dependency('dl')
- threads_dep = dependency('threads')
- add_project_dependencies(boost_dep, dl_dep, threads_dep, language: ['cpp'])
 --- a/src/lib/asiodns/io_fetch.cc
 +++ b/src/lib/asiodns/io_fetch.cc
 @@ -23,6 +23,7 @@

--- a/srcpkgs/kea/template
+++ b/srcpkgs/kea/template
@@ -1,7 +1,7 @@
 # Template file for 'kea'
 pkgname=kea
-version=3.1.1
-revision=3
+version=3.1.8
+revision=1
 build_style=meson
 build_helper=qemu
 configure_args="-Dcpp_std=gnu++20
@@ -20,7 +20,7 @@ license="MPL-2.0, Apache-2.0"
 homepage="https://kea.isc.org"
 changelog="https://gitlab.isc.org/isc-projects/kea/-/wikis/Release-Notes/release-notes-${version}"
 distfiles="https://ftp.isc.org/isc/kea/${version/.P/-P}/kea-${version/.P/-P}.tar.xz"
-checksum=91510c932a81a9b1d3b8c0bd7d6e0f8aa896f9dd4ca7117d06ab57698f09e899
+checksum=fcf91984d61f84353618a66970e39398d22b1ec56ebc5e5bf775dde3f2b9d11d
 
 build_options="botan mysql pgsql"
 desc_option_botan="With Botan SSL support"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64
- I built this PR locally for these architectures:
  - x86_64-musl
  - aarch64 (crossbuild)
