### PR TITLE
WIP: libseccomp: update to 2.6.0.

### DIFF
--- a/srcpkgs/libseccomp/template
+++ b/srcpkgs/libseccomp/template
@@ -1,6 +1,6 @@
 # Template file for 'libseccomp'
 pkgname=libseccomp
-version=2.5.5
+version=2.6.0
 revision=1
 build_style=gnu-configure
 hostmakedepends="automake libtool gperf"
@@ -11,7 +11,7 @@ license="LGPL-2.1-or-later"
 homepage="https://github.com/seccomp/libseccomp/"
 changelog="https://raw.githubusercontent.com/seccomp/libseccomp/main/CHANGELOG"
 distfiles="https://github.com/seccomp/${pkgname}/archive/v${version}.tar.gz"
-checksum=7082b016d3cbda3e15c0e71ebd018023d693bb7507389b32f943db13f935e01d
+checksum=0889a8da98e37f86019c90789fd4ff7eda6e1ceb9ef07d4c51c67aeb50a77860
 
 pre_configure() {
 	NOCONFIGURE=1 ./autogen.sh


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64
- I built this PR locally for these architectures:
  - x86_64-musl
  - aarch64 (crossbuild)
