### PR TITLE
dbeaver: update to 26.0.4.

### DIFF
--- a/srcpkgs/dbeaver/template
+++ b/srcpkgs/dbeaver/template
@@ -1,6 +1,6 @@
 # Template file for 'dbeaver'
 pkgname=dbeaver
-version=26.0.3
+version=26.0.4
 revision=1
 _version=${version//./_}
 # the build downloads binaries linked to glibc
@@ -16,9 +16,9 @@ changelog="https://dbeaver.io/news/"
 distfiles="https://github.com/dbeaver/dbeaver/archive/${version}.tar.gz
  https://github.com/dbeaver/dbeaver-common/archive/refs/heads/release_${_version}.tar.gz>dbeaver-common-${version}.tar.gz
  https://github.com/dbeaver/dbeaver-jdbc-libsql/archive/refs/heads/release_${_version}.tar.gz>dbeaver-jdbc-libsql-${version}.tar.gz"
-checksum="97e39193602bfbbc5b5b8d497106803877197f8bf120a590b6eacd2a7935df46
- 121038cb515e48680c938bc0580452596039276013b669e08e0638f430452ab3
- 8e88543737d3f973c2468db01b3c2b5796811b656856cc365c953710a93baec4"
+checksum="75fd3e6b8ab5762090b0f50f9763d843b72cc5cfb8881bc2eba5c53e22dea7d3
+ 060f01d3e42bd31839026c1fd549f466c297464424fb35077109f6b19d3ab293
+ e3749459205f2d8c13dd06f83f5da67c2724e135115c30ec5cbe5c62d5889f25"
 nopie=true
 
 post_extract() {


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
