### PR TITLE
rustnet: update to 1.2.0

### DIFF
--- a/srcpkgs/rustnet/template
+++ b/srcpkgs/rustnet/template
@@ -1,6 +1,6 @@
 # Template file for 'rustnet'
 pkgname=rustnet
-version=1.1.0
+version=1.2.0
 revision=1
 archs="x86_64* aarch64*"
 build_style=cargo
@@ -13,7 +13,7 @@ license="Apache-2.0"
 homepage="https://github.com/domcyrus/rustnet"
 changelog="https://raw.githubusercontent.com/domcyrus/rustnet/refs/heads/main/CHANGELOG.md"
 distfiles="https://github.com/domcyrus/rustnet/archive/refs/tags/v${version}.tar.gz"
-checksum=a91773ea19848bcd75339d21b1a811944ef2490feaf8602d5cee6064f4d96ff2
+checksum=b91d41bc715f74453a8cd9ac2cd91e2b3808f01f959e8a92cb65c1f2f717312d
 
 _setup_env() {
 	# workaround the cc-rs mixing CFLAGS for host and target.


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, (x64 glibc)