### PR TITLE
gnome-usage: update to 48.0

### DIFF
--- a/srcpkgs/gnome-usage/template
+++ b/srcpkgs/gnome-usage/template
@@ -1,14 +1,14 @@
 # Template file for 'gnome-usage'
 pkgname=gnome-usage
-version=46.1
+version=48.0
 revision=1
 build_style=meson
 hostmakedepends="glib-devel pkg-config vala gettext"
-makedepends="gtk4-devel libadwaita-devel libglib-devel libgtop-devel vala-devel
- tinysparql-devel libgee-devel"
+makedepends="gtk4-devel libadwaita-devel libgee-devel libgtop-devel
+ json-glib-devel NetworkManager-devel tinysparql-devel"
 short_desc="Nice way to view information about use of system resources"
 maintainer="Enno Boland <gottox@voidlinux.org>"
 license="GPL-3.0-or-later"
-homepage="https://wiki.gnome.org/Apps/Usage"
+homepage="https://apps.gnome.org/Baobab"
 distfiles="${GNOME_SITE}/gnome-usage/${version%.*}/gnome-usage-${version}.tar.xz"
-checksum=7bda088e4bf6f582bb3c0245dd4ed59cb8064ac56cf2be4682196beccad880e3
+checksum=501de3c6d4d653d59ce0d707758dccf83dc3ea81a2ed1492d2f333162fee0a17


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-glibc
  - i686
