### PR TITLE
streamlink: update to 8.4.0

### DIFF
--- a/srcpkgs/streamlink/template
+++ b/srcpkgs/streamlink/template
@@ -1,6 +1,6 @@
 # Template file for 'streamlink'
 pkgname=streamlink
-version=8.3.0
+version=8.4.0
 revision=1
 build_style=python3-pep517
 hostmakedepends="python3-wheel python3-versioningit"
@@ -14,7 +14,7 @@ license="BSD-2-Clause"
 homepage="https://streamlink.github.io/"
 changelog="https://raw.githubusercontent.com/streamlink/streamlink/master/CHANGELOG.md"
 distfiles="https://github.com/streamlink/streamlink/releases/download/$version/streamlink-$version.tar.gz"
-checksum=6cffe55b42df3b3c2e6dd1c0cc41fc01477afbc496ba86740ffa5eec5c333d34
+checksum=f477e9493336bcb7c3a2b10eea72a60ae9a7f49e968ada0d4d01bff78eac44bb
 make_check_pre="env PYTHONPATH=src"
 
 post_install() {


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):

#### Notes

Release changelog:
https://streamlink.github.io/changelog.html#streamlink-8-4-0-2026-05-06

Resolves [CVE-2026-44353](https://nvd.nist.gov/vuln/detail/CVE-2026-44353) / [GHSA-hgqw-6m45-hw5f](https://github.com/streamlink/streamlink/security/advisories/GHSA-hgqw-6m45-hw5f)
