### PR TITLE
New package: lcdf-typetools-2.110

### DIFF
--- a/srcpkgs/lcdf-typetools/template
+++ b/srcpkgs/lcdf-typetools/template
@@ -1,0 +1,18 @@
+# Template file for 'lcdf-typetools'
+pkgname=lcdf-typetools
+version=2.110
+revision=1
+build_style=gnu-configure
+configure_args="$(vopt_with kpathsea)"
+hostmakedepends="pkg-config"
+makedepends="$(vopt_if kpathsea texlive-devel)"
+short_desc="Utilities for manipulating OpenType, Type 1 and Multiple Master fonts"
+maintainer="jl4c <jose.4rellano@gmail.com>"
+license="GPL-2.0-or-later"
+homepage="https://www.lcdf.org/type/"
+changelog="https://raw.githubusercontent.com/kohler/lcdf-typetools/master/NEWS.md"
+distfiles="https://www.lcdf.org/type/${pkgname}-${version}.tar.gz"
+checksum=517f9ee879208679d3224a14d5e6eb20598fc648d5c3562708083d003088a934
+
+build_options="kpathsea"
+desc_option_kpathsea="Enable Kpathsea integration for TeX directory lookups"


### PR DESCRIPTION
#### General
- [x] I tested the changes in this PR.
- [x] I built this PR locally for my native architecture (x86_64-glibc).
- [x] I built this PR locally for these architectures:
  - x86_64-musl
  - aarch64
  - aarch64-musl

#### New package
- [x] This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#package-quality-requirements).

#### Description

LCDF Typetools provides command-line utilities for manipulating
OpenType, PostScript Type 1, and Multiple Master fonts. These
tools are not currently available in Void because the `texlive`
package is built with `--disable-lcdf-typetools`.

Kpathsea integration is provided as an opt-in build option (off
by default) so users who only need the standalone font utilities
don't pull `texlive-devel` as a dependency.

Tested binaries: `cfftot1`, `mmafm`, `mmpfb`, `otfinfo`,
`otftotfm`, `t1dotlessj`, `t1lint`, `t1rawafm`, `t1reencode`,
`t1testpage`, `ttftotype42`.

Homepage: https://www.lcdf.org/type/