### PR TITLE
cargo-about: update to 0.9.0

### DIFF
--- a/srcpkgs/cargo-about/template
+++ b/srcpkgs/cargo-about/template
@@ -1,19 +1,20 @@
 # Template file for 'cargo-about'
 pkgname=cargo-about
-version=0.7.1
+version=0.9.0
 revision=1
 # depends on rustls/ring
 archs="x86_64* aarch64* i686* arm*"
 build_style=cargo
+configure_args="--features=cli"
 hostmakedepends="pkg-config"
 makedepends="libzstd-devel"
 short_desc="Cargo plugin to generate list of all licenses for a crate"
 maintainer="Orphaned <orphan@voidlinux.org>"
-license="MIT, Apache-2.0"
+license="Apache-2.0 OR MIT"
 homepage="https://github.com/EmbarkStudios/cargo-about"
 changelog="https://raw.githubusercontent.com/EmbarkStudios/cargo-about/main/CHANGELOG.md"
 distfiles="https://github.com/EmbarkStudios/cargo-about/archive/refs/tags/${version}.tar.gz"
-checksum=5b090871bda2c2cf645de826c219b41486c36ffe0b474ad9f6ecba7e21d279a0
+checksum=7dc9b5f87d25b57c044618655a1948857bd03196e3b20cbb8700b41ad6f1614f
 
 if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
 	broken="broken on architectures without atomic8"


### PR DESCRIPTION
+ enable cli feature (which is now disabled by default)

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architectures, (aarch64-musl, x64-glibc)
<!-- - I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
