### PR TITLE
libde265: move 'usr/lib/cmake' into -devel

### DIFF
--- a/srcpkgs/libde265/template
+++ b/srcpkgs/libde265/template
@@ -1,7 +1,7 @@
 # Template file for 'libde265'
 pkgname=libde265
 version=1.0.18
-revision=1
+revision=2
 build_style=cmake
 hostmakedepends="pkg-config"
 short_desc="Open h.265 video codec implementation"
@@ -25,6 +25,7 @@ libde265-devel_package() {
 	pkg_install() {
 		vmove usr/include
 		vmove "usr/lib/*.so"
+		vmove usr/lib/cmake
 		vmove usr/lib/pkgconfig
 	}
 }


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### Local build testing
- I built this PR locally for my native architecture, **x86_64-glibc**
