### PR TITLE
fuse3: re-enable static libraries

### DIFF
--- a/srcpkgs/fuse3/template
+++ b/srcpkgs/fuse3/template
@@ -1,10 +1,10 @@
 # Template file for 'fuse3'
 pkgname=fuse3
 version=3.18.2
-revision=1
+revision=2
 build_style=meson
 configure_args="--sbindir=bin -Db_lto=false -Dexamples=false -Duseroot=false
- -Dtests=false"
+ -Dtests=false -Ddefault_library=both"
 hostmakedepends="pkg-config"
 makedepends="eudev-libudev-devel"
 short_desc="Filesystem in Userspace 3.x"
@@ -29,6 +29,7 @@ fuse3-devel_package() {
 	pkg_install() {
 		vmove usr/include
 		vmove usr/lib/pkgconfig
+		vmove "usr/lib/*.a"
 		vmove "usr/lib/*.so"
 	}
 }


### PR DESCRIPTION
Fixes: 681ec89d93 ("fuse3: update to 3.2.0.")

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
#### Local build testing
- I built this PR locally for my native architecture, x86_64