### PR TITLE
gcompris-qt: update to 26.1

### DIFF
--- a/srcpkgs/gcompris-qt/template
+++ b/srcpkgs/gcompris-qt/template
@@ -5,7 +5,7 @@
 # Otherwise, they may remove it at a random time.
 #
 pkgname=gcompris-qt
-version=26.0
+version=26.1
 revision=1
 build_style=cmake
 configure_args="-DQT_NO_PRIVATE_MODULE_WARNING=ON"
@@ -19,7 +19,7 @@ license="AGPL-3.0-only"
 homepage="https://gcompris.net/index-en.html"
 changelog="https://www.gcompris.net/news-en.html"
 distfiles="https://gcompris.net/download/qt/src/gcompris-qt-${version}.tar.xz"
-checksum=7d3df8be96dd6e883990abe14f9137900030d508d3a30e2b38e39d0eb31ef333
+checksum=c389b863b29f012ccc1b3eef740982ff6c7654c13a2e343397ee466124f31339
 
 post_install() {
 	vlicense LICENSES/AGPL-3.0-only.txt


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, (x64 glibc)
- and for aarch64-musl