### PR TITLE
geoclue2: update to 2.8.1.

### DIFF
--- a/srcpkgs/geoclue2/template
+++ b/srcpkgs/geoclue2/template
@@ -1,6 +1,6 @@
 # Template file for 'geoclue2'
 pkgname=geoclue2
-version=2.7.1
+version=2.8.1
 revision=1
 build_style=meson
 build_helper="gir"
@@ -17,7 +17,7 @@ license="LGPL-2.1-or-later"
 homepage="https://gitlab.freedesktop.org/geoclue/geoclue/wikis/home"
 changelog="https://gitlab.freedesktop.org/geoclue/geoclue/-/raw/master/NEWS"
 distfiles="https://gitlab.freedesktop.org/geoclue/geoclue/-/archive/${version}/geoclue-${version}.tar.bz2"
-checksum=5624cd41148643c46d681d39153c7d26fdb8831e7e7c8601c300732fa8a6db1c
+checksum=1b5de03936bd8c031a1f6207c1857fa25a9aa1453ffe742f32a0a4a3281f2629
 system_accounts="_geoclue2"
 lib32disabled=yes
 


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

built:
`% ./xbps-src pkg -Q geoclue2`

installed and tested:
I test on my local machine, so I install it fresh from my local build:
`% sudo xbps-install -R /hostdir/binpkgs/adopt-and-bump-geoclue2/geoclue2-2.8.1-1.x86_64.xbps geoclue2`

once its installed I run the agent:
`% /usr/libexec/geoclue-2.0/demos/agent` 

then I run the `redshift` tool (not a dependency, but a way to test the package) which utilizes the running agent and geoclue2 lib to get my geo coordinates to determine when to increase the temperature of my screen.

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (x86_64 )
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - armv6l
  - armv7l
  - aarch64
