### PR TITLE
brotli: build static libraries

### DIFF
--- a/srcpkgs/brotli/template
+++ b/srcpkgs/brotli/template
@@ -9,6 +9,7 @@ license="MIT"
 homepage="https://github.com/google/brotli"
 distfiles="https://github.com/google/${pkgname}/archive/v${version}.tar.gz"
 checksum=816c96e8e8f193b40151dad7e8ff37b1221d019dbcb9c35cd3fadbfe6477dfec
+configure_args="-DBROTLI_BUILD_FOR_PACKAGE=ON"
 
 post_install() {
 	vlicense LICENSE
@@ -20,6 +21,9 @@ brotli-devel_package() {
 	pkg_install() {
 		vmove usr/include
 		vmove usr/lib/*.so
+		vinstall build/libbrotlicommon-static.a 644 usr/lib libbrotlicommon.a
+		vinstall build/libbrotlidec-static.a 644 usr/lib libbrotlidec.a
+		vinstall build/libbrotlienc-static.a 644 usr/lib libbrotlienc.a
 		vmove usr/lib/pkgconfig
 	}
 }


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-musl)
- I built this PR locally for these architectures:
  - aarch64-musl

It may be worth moving the libraries from `*-static.a` to simply `*.a`, or symlinking them.  
For now I've left them as-is.