### PR TITLE
New package: hare-0.26.0.1

### DIFF
--- a/srcpkgs/hare/files/config.mk
+++ b/srcpkgs/hare/files/config.mk
@@ -1,0 +1,46 @@
+# install locations
+PREFIX = /usr/
+BINDIR = $(PREFIX)/bin
+MANDIR = $(PREFIX)/share/man
+SRCDIR = $(PREFIX)/src
+STDLIB = $(SRCDIR)/hare/stdlib
+LIBEXECDIR = $(PREFIX)/libexec
+TOOLDIR = $(LIBEXECDIR)/hare
+
+# variables used during build
+PLATFORM = linux
+ARCH = @CARCH@
+HAREFLAGS =
+HARECFLAGS =
+QBEFLAGS =
+ASFLAGS =
+LDLINKFLAGS = --gc-sections -z noexecstack
+
+# commands used by the build script
+HAREC = harec
+QBE = qbe
+AS = as
+LD = ld
+SCDOC = scdoc
+
+# build locations
+HARECACHE = .cache
+BINOUT = .bin
+
+# variables that will be embedded in the binary with -D definitions
+HAREPATH = $(SRCDIR)/hare/stdlib:$(SRCDIR)/hare/third-party
+VERSION = @VERSION@
+
+# For cross-compilation, modify the variables below
+LIBC = @LIBC@
+AARCH64_AS=aarch64-linux-$(LIBC)-as
+AARCH64_CC=aarch64-linux-$(LIBC)-gcc
+AARCH64_LD=aarch64-linux-$(LIBC)-ld
+
+RISCV64_AS=riscv64-linux-$(LIBC)-as
+RISCV64_CC=riscv64-linux-$(LIBC)-gcc
+RISCV64_LD=riscv64-linux-$(LIBC)-ld
+
+X86_64_AS=x86_64-linux-$(LIBC)-as
+X86_64_CC=x86_64-linux-$(LIBC)-gcc
+X86_64_LD=x86_64-linux-$(LIBC)-ld

--- a/srcpkgs/hare/template
+++ b/srcpkgs/hare/template
@@ -10,6 +10,7 @@ homepage="https://harelang.org"
 distfiles="https://git.sr.ht/~sircmpwn/hare/archive/${version}.tar.gz"
 depends="harec>=0.26.0 tzdata"
 hostmakedepends="harec scdoc"
+archs="x86_64-* aarch64-* risvc64-*"
 checksum=f76704920a2f457be4d2d6290dc10dcfb7319c1d1990f2305491644383466905
 
 do_configure() {

--- a/srcpkgs/hare/template
+++ b/srcpkgs/hare/template
@@ -1,0 +1,34 @@
+pkgname=hare
+version=0.26.0.1
+revision=1
+build_style=gnu-makefile
+make_use_env=yes
+short_desc="Hare programming language - standard library and build driver"
+maintainer="kurth4cker <kurth4cker@gmail.com>"
+license="GPL-3.0-only AND MPL-2.0"
+homepage="https://harelang.org"
+distfiles="https://git.sr.ht/~sircmpwn/hare/archive/${version}.tar.gz"
+depends="harec>=0.26.0 tzdata"
+hostmakedepends="harec scdoc"
+checksum=f76704920a2f457be4d2d6290dc10dcfb7319c1d1990f2305491644383466905
+
+do_configure() {
+	cp "$FILESDIR"/config.mk config.mk
+
+	libc=musl
+	[ $XBPS_TARGET_LIBC = glibc ] && libc=gnu
+
+	sed -i "s/@LIBC@/$libc/g" config.mk
+	sed -i "s/@CARCH@/$XBPS_TARGET_MACHINE/g" config.mk
+	sed -i "s/@VERSION@/$version-void/g" config.mk
+
+	# use unprefixed toolchain for local target
+	sed -i "s/\(${XBPS_TARGET_MACHINE}_..\)=$XBPS_TARGET_MACHINE-linux-\$(LIBC)-/\1=/Ig" config.mk
+}
+
+do_check() {
+	if [ "$XBPS_CHECK_PKGS" = full ]; then
+		export HARETEST_INCLUDE='slow'
+	fi
+	make check
+}


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

This PR requires #60451  first.

#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **NOT SURE**
- This is a systems programming language. So it will likely be required by other systems programs if it becomes populer enough.
- Includes programs like hare build driver and haredoc module doc viewer. Standard library is not compiled like Go.

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- Since programs hare and haredoc both written in hare itself and compiled with harec and qbe, they will not compile for architectures other than x86_64, aarch64, riscv64. (I forgot to add archs field.)
