### PR TITLE
libgdal: add libopenjpeg2 support

### DIFF
--- a/srcpkgs/libgdal/template
+++ b/srcpkgs/libgdal/template
@@ -1,7 +1,7 @@
 # Template file for 'libgdal'
 pkgname=libgdal
 version=3.8.4
-revision=6
+revision=7
 build_style=cmake
 build_helper=python3
 configure_args="-DGDAL_USE_OPENCL=ON
@@ -13,7 +13,7 @@ makedepends="python3-devel freexl-devel c-blosc-devel geos-devel expat-devel
  libxml2-devel liblzma-devel zlib-devel libzstd-devel libdeflate-devel
  netcdf-devel OpenCL-Headers pcre2-devel proj-devel sqlite-devel
  ocl-icd-devel libxerces-c-devel libspatialite-devel
- postgresql-libs-devel hdf5-devel"
+ postgresql-libs-devel hdf5-devel libopenjpeg2-devel"
 checkdepends="python3-pytest"
 short_desc="Geospatial Data Abstraction Library"
 maintainer="Orphaned <orphan@voidlinux.org>"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - armv6l

I verified that the JP2OpenJPEG driver is now listed in the supported formats with `gdalinfo --formats`.
I also tested adding a JP2 raster layer in QGIS and it now works.
