### PR TITLE
keymapper: update to 5.5.1.

### DIFF
--- a/srcpkgs/keymapper/template
+++ b/srcpkgs/keymapper/template
@@ -1,6 +1,6 @@
 # Template file for 'keymapper'
 pkgname=keymapper
-version=5.5.0
+version=5.5.1
 revision=1
 build_style=cmake
 configure_args="-DVERSION=${version}"
@@ -12,7 +12,7 @@ license="GPL-3.0-only"
 homepage="https://github.com/houmain/keymapper"
 changelog="https://raw.githubusercontent.com/houmain/keymapper/main/CHANGELOG.md"
 distfiles="https://github.com/houmain/keymapper/archive/refs/tags/${version}.tar.gz"
-checksum=85160c8f63a6f2a12b9ec8ce9916ff4e892eec54d4d1a9c7785554231fc4ffd5
+checksum=379f7353a42b690322db69a0500999e465d149176715de4f2cd1aa050b67330c
 
 post_install() {
 	vsv keymapperd


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, x86_64
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - armv6l (cross)
  - armv6l-musl (cross)

