### PR TITLE
New package: zed-1.0.0

### DIFF
--- a/srcpkgs/zed/patches/0001-tweak-default-settings.patch
+++ b/srcpkgs/zed/patches/0001-tweak-default-settings.patch
@@ -1,0 +1,25 @@
+diff --git a/assets/settings/default.json b/assets/settings/default.json
+index c0ec7b74f5..4cda90f46f 100644
+--- a/assets/settings/default.json
++++ b/assets/settings/default.json
+@@ -1466,9 +1466,9 @@
+   // Control what info is collected by Zed.
+   "telemetry": {
+     // Send debug info like crash reports.
+-    "diagnostics": true,
++    "diagnostics": false,
+     // Send anonymized usage data like what languages you're using Zed with.
+-    "metrics": true,
++    "metrics": false,
+   },
+   // Whether to disable all AI features in Zed.
+   //
+@@ -1476,7 +1476,7 @@
+   "disable_ai": false,
+   // Automatically update Zed. This setting may be ignored on Linux if
+   // installed through a package manager.
+-  "auto_update": true,
++  "auto_update": false,
+   // How to render LSP `textDocument/documentColor` colors in the editor.
+   //
+   // Possible values:

--- a/srcpkgs/zed/template
+++ b/srcpkgs/zed/template
@@ -1,0 +1,30 @@
+# Template file for 'zed'
+pkgname=zed
+version=1.0.0
+revision=1
+archs="x86_64 aarch64"
+build_style=cargo
+make_install_args="--path crates/zed"
+# see: https://github.com/zed-industries/zed/blob/24f62484e936aa355c72f2009313bbe2898a9fd5/script/linux#L228
+hostmakedepends="pkg-config cmake gettext"
+makedepends="libX11-devel gettext-devel libgit2-1.9-devel alsa-lib-devel
+fontconfig-devel glib-devel libva-devel libxcb-devel libxkbcommon-devel
+libzstd-devel openssl-devel wayland-devel
+sqlite-devel"
+depends="pipewire xdg-desktop-portal"
+short_desc="High-performance, multiplayer code editor"
+maintainer="Folling <mail@folling.io>"
+license="GPL-3.0-or-later, Apache-2.0, AGPL-3.0-or-later"
+homepage="https://zed.dev"
+changelog="https://zed.dev/releases/stable"
+distfiles="https://github.com/zed-industries/zed/archive/refs/tags/v${version}.tar.gz>zed-${version}.tar.gz"
+checksum=9e1547910d9840295e562fe383182abf633c514e27cc312ace369c2220192162
+
+post_install() {
+	vlicense LICENSE-AGPL
+	vlicense LICENSE-APACHE
+	vlicense LICENSE-GPL
+	APP_NAME="Zed" DO_STARTUP_NOTIFY="true" APP_CLI="zed" APP_ICON="zed" APP_ARGS="%U" envsubst < ${wrksrc}/crates/zed/resources/zed.desktop.in > ${wrksrc}/crates/zed/resources/Zed.desktop
+	vinstall ${wrksrc}/crates/zed/resources/Zed.desktop 644 /usr/share/applications/
+	vinstall ${wrksrc}/crates/zed/resources/app-icon.png 644 /usr/share/icons/hicolor/512x512/apps/ zed.png
+}


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

- I built this PR locally for my native architecture: x86

I only wanted to try out zed after the 1.0 release, I don't think I'll use it for my daily driver, so I'm probably not the best owner for this package. Thought it'd still be neat to have it packaged as the default install script from zed is pretty bad for void linux.
I've used this PR as my primary template: https://github.com/void-linux/void-packages/pull/50476