### PR TITLE
botan: update to 3.12.0.

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -2966,7 +2966,7 @@ libKDb3.so.4 kdb-3.1.0_1
 libKPropertyWidgets3.so.4 kproperty-3.1.0_1
 libKPropertyCore3.so.4 kproperty-3.1.0_1
 libKReport3.so.4 kreport-3.1.0_1
-libbotan-3.so.11 botan-3.11.0_1
+libbotan-3.so.12 botan-3.12.0_1
 libswipl.so.10 swi-prolog-10.0.0_1
 libpcre2-16.so.0 libpcre2-10.22_1
 libpcre2-32.so.0 libpcre2-10.22_1

--- a/srcpkgs/biboumi/template
+++ b/srcpkgs/biboumi/template
@@ -1,7 +1,7 @@
 # Template file for 'biboumi'
 pkgname=biboumi
 version=9.0
-revision=4
+revision=5
 build_style=cmake
 configure_args="-DWITHOUT_SYSTEMD=1"
 conf_files="/etc/biboumi/biboumi.cfg"

--- a/srcpkgs/botan/template
+++ b/srcpkgs/botan/template
@@ -1,6 +1,6 @@
 # Template file for 'botan'
 pkgname=botan
-version=3.11.1
+version=3.12.0
 revision=1
 build_style=gnu-makefile
 hostmakedepends="doxygen python3 python3-packaging-bootstrap"
@@ -11,7 +11,7 @@ license="BSD-2-Clause"
 homepage="https://botan.randombit.net/"
 changelog="https://botan.randombit.net/news.html"
 distfiles="https://botan.randombit.net/releases/Botan-${version}.tar.xz"
-checksum=c1cd7152519f4188591fa4f6ddeb116bc1004491f5f3c58aa99b00582eb8a137
+checksum=5370f98dc15f8c222ee1ce52cd61c8756a53be0dc57cc4c1b0714d5a09ad74fb
 python_version=3
 
 LDFLAGS="-pthread"

--- a/srcpkgs/corectrl/template
+++ b/srcpkgs/corectrl/template
@@ -1,7 +1,7 @@
 # Template file for 'corectrl'
 pkgname=corectrl
 version=1.5.2
-revision=5
+revision=6
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF" # requires https://github.com/rollbear/trompeloeil which isn't packaged
 hostmakedepends="pkg-config extra-cmake-modules qt6-tools qt6-base"

--- a/srcpkgs/keepassxc/template
+++ b/srcpkgs/keepassxc/template
@@ -1,7 +1,7 @@
 # Template file for 'keepassxc'
 pkgname=keepassxc
 version=2.7.12
-revision=2
+revision=3
 build_style=cmake
 configure_args="-DWITH_TESTS=ON -DWITH_XC_UPDATECHECK=OFF -DWITH_XC_DOCS=ON
  -DWITH_XC_AUTOTYPE=$(vopt_if autotype ON OFF)

--- a/srcpkgs/qca-qt5/template
+++ b/srcpkgs/qca-qt5/template
@@ -1,7 +1,7 @@
 # Template file for 'qca-qt5'
 pkgname=qca-qt5
 version=2.3.10
-revision=2
+revision=3
 build_style=cmake
 configure_args="-DQCA_FEATURE_INSTALL_DIR=/usr/share/qca-qt5/mkspecs
  -DUSE_RELATIVE_PATHS=true"

--- a/srcpkgs/qca-qt6/template
+++ b/srcpkgs/qca-qt6/template
@@ -1,7 +1,7 @@
 # Template file for 'qca-qt6'
 pkgname=qca-qt6
 version=2.3.10
-revision=2
+revision=3
 build_style=cmake
 configure_args="-DQT6=ON -DUSE_RELATIVE_PATHS=true"
 hostmakedepends="pkg-config ca-certificates qt6-tools qt6-base"

--- a/srcpkgs/qownnotes/template
+++ b/srcpkgs/qownnotes/template
@@ -1,7 +1,7 @@
 # Template file for 'qownnotes'
 pkgname=qownnotes
 version=26.5.2
-revision=1
+revision=2
 build_helper=qmake
 build_style=cmake
 configure_args="-DQON_QT6_BUILD=ON -DBUILD_WITH_LIBGIT2=1 -DBUILD_WITH_SYSTEM_BOTAN=1"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES** (only botan)

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
#### Local build testing
- I built this PR locally for my native architecture, x86_64(glibc) (only botan)

----------------------------------

- botan: update to 3.12.0.
- qownnotes: revbump for botan
- qca-qt6: revbump for botan
- qca-qt5: revbump for botan
- keepassxc: revbump for botan
- corectrl: revbump for botan
- biboumi: revbump for botan
