### PR TITLE
ty: update to 0.0.35.

### DIFF
--- a/srcpkgs/ty/template
+++ b/srcpkgs/ty/template
@@ -1,6 +1,6 @@
 # Template file for 'ty'
 pkgname=ty
-version=0.0.34
+version=0.0.35
 revision=1
 build_style=python3-pep517
 build_helper="rust qemu"
@@ -12,7 +12,7 @@ license="MIT"
 homepage="https://docs.astral.sh/ty/"
 changelog="https://raw.githubusercontent.com/astral-sh/ty/main/CHANGELOG.md"
 distfiles="https://github.com/astral-sh/ty/releases/download/${version}/source.tar.gz"
-checksum=54d5e78609cc83389ef41aa5a1c5773273cfe1a894d00ce25d10987d6dd749c9
+checksum=5669f5173733a46ea0106f8ab9eb48508eaf7116c002c57d674158ef5553ccb5
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
