### PR TITLE
transmission-remote-gtk: update to 1.7.1.

### DIFF
--- a/srcpkgs/transmission-remote-gtk/template
+++ b/srcpkgs/transmission-remote-gtk/template
@@ -1,16 +1,16 @@
 # Template file for 'transmission-remote-gtk'
 pkgname=transmission-remote-gtk
-version=1.6.0
+version=1.7.1
 revision=1
 build_style=meson
-hostmakedepends="pkg-config gettext glib-devel perl appstream-glib
- desktop-file-utils"
+hostmakedepends="pkg-config gettext glib-devel AppStream
+ desktop-file-utils python3-docutils"
 makedepends="gtk+3-devel libglib-devel json-glib-devel libsoup3-devel
- libayatana-appindicator-devel geoip-devel"
+ libayatana-appindicator-devel"
 short_desc="GTK client for remote management of the Transmission BitTorrent client"
 maintainer="SolitudeSF <solitudesf@protonmail.com>"
 license="GPL-2.0-or-later"
 homepage="https://github.com/transmission-remote-gtk/transmission-remote-gtk"
 changelog="https://github.com/transmission-remote-gtk/transmission-remote-gtk/releases"
 distfiles="${homepage}/releases/download/${version}/${pkgname}-${version}.tar.xz"
-checksum=b090844f6a482e6f3588070ff3fdd54b79e8f85df02b39853cfb01fccee10cac
+checksum=5ef98bd96b3b77eb3880474a2d904e316bb29cbd22dfa0ca85d43b04a28fba34


### PR DESCRIPTION
Upstream switched from appstream-glib to appstreamcli for appdata validation; replaced appstream-glib with AppStream in hostmakedepends.

Removed unused dependencies:

- geoip-devel (libgeoip is no longer used by upstream).
- perl (not invoked by the build system).

Added python3-docutils to generate the man page via rst2man.

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture: **x86_64-glibc**
- I built this PR locally for these architectures:
  - x86_64-musl
  - aarch64
  - aarch64-musl
  - i686