### PR TITLE
xbps-src: print dependency installation if verbose mode is enabled

### DIFF
--- a/common/xbps-src/shutils/build_dependencies.sh
+++ b/common/xbps-src/shutils/build_dependencies.sh
@@ -79,7 +79,11 @@ install_pkg_from_repos() {
 
     cmd=$XBPS_INSTALL_CMD
     [[ $cross ]] && cmd=$XBPS_INSTALL_XCMD
-    $cmd -Ay "$@" >$tmplogf 2>&1
+    if [ -n "$XBPS_VERBOSE" ]; then
+        $cmd -Ay "$@" 2>&1 | tee "$tmplogf"
+    else
+        $cmd -Ay "$@" >"$tmplogf" 2>&1
+    fi
     rval=$?
 
     case "$rval" in


### PR DESCRIPTION
sometimes its not clear why installing dependencies takes a long time.