### PR TITLE
gdb: fix runtime search path on cross architectures

### DIFF
--- a/srcpkgs/gdb/patches/armsim-c23.patch
+++ b/srcpkgs/gdb/patches/armsim-c23.patch
@@ -1,0 +1,15 @@
+C23 changes the meaning of fun() to be equivalent to a fun(void).
+
+diff -rup sim/arm/armdefs.h.orig sim/arm/armdefs.h
+--- a/sim/arm/armdefs.h.orig	2025-04-20 10:22:06.000000000 -0700
++++ b/sim/arm/armdefs.h	2026-05-11 12:51:37.833267581 -0700
+@@ -264,7 +264,7 @@ extern ARMword ARMul_DoInstr (ARMul_Stat
+ \***************************************************************************/
+ 
+ extern void ARMul_ScheduleEvent (ARMul_State * state, unsigned long delay,
+-				 unsigned (*func) ());
++				 unsigned (*func) (ARMul_State *));
+ extern void ARMul_EnvokeEvent (ARMul_State * state);
+ extern unsigned long ARMul_Time (ARMul_State * state);
+ 
+

--- a/srcpkgs/gdb/patches/d10vsim-c23.patch
+++ b/srcpkgs/gdb/patches/d10vsim-c23.patch
@@ -1,0 +1,35 @@
+From 888a2e22a83582e437d128b6a498c2d8502a7ad0 Mon Sep 17 00:00:00 2001
+From: Tom Tromey <tromey@adacore.com>
+Date: Fri, 25 Apr 2025 11:38:34 -0600
+Subject: [PATCH] Fix d10v sim build with GCC 15
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+The d10v sim fails when built with GCC 15.  From the bug:
+
+d10v/table.c:171:17: error: initialization of ‘void (*)(struct sim_state *, SIM_CPU *)’ {aka ‘void (*)(struct sim_state *, struct _sim_cpu *)’} from incompatible pointer type ‘void (*)(void)’ [-Wincompatible-pointer-types]
+  171 | { 0,0,0,0,0,0,0,(void (*)())0,0,{0,0,0}},
+      |                 ^
+d10v/table.c:171:17: note: (near initialization for ‘Simops[165].func’)
+
+The bug here is that this is the wrong function pointer type.  Since
+'0' is perfectly fine here, this patch simply removes the cast.
+
+Bug: https://sourceware.org/bugzilla/show_bug.cgi?id=32900
+Approved-By: Tom de Vries <tdevries@suse.de>
+---
+ sim/d10v/gencode.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/sim/d10v/gencode.c b/sim/d10v/gencode.c
+index 3a37bac6256..763e2f57a46 100644
+--- a/sim/d10v/gencode.c
++++ b/sim/d10v/gencode.c
+@@ -150,5 +150,5 @@ write_opcodes (void)
+ 	  printf ("},\n");
+ 	}
+     }
+-  printf ("{ 0,0,0,0,0,0,0,(void (*)())0,0,{0,0,0}},\n};\n");
++  printf ("{ 0,0,0,0,0,0,0,0,0,{0,0,0}},\n};\n");
+ }

--- a/srcpkgs/gdb/patches/simsh-c23.patch
+++ b/srcpkgs/gdb/patches/simsh-c23.patch
@@ -1,0 +1,26 @@
+From 9385922d3fb9304622bbd78b2437bcfa50e7491a Mon Sep 17 00:00:00 2001
+From: Jan-Benedict Glaw <jbglaw@lug-owl.de>
+Date: Fri, 7 Mar 2025 10:32:39 +0100
+Subject: [PATCH] Fix missing int argument warning
+
+This warning (per -Werror) breaks the build using a recent GCC
+with recent userland.
+
+Approved-By: Tom Tromey <tom@tromey.com>
+---
+ sim/sh/interp.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/sim/sh/interp.c b/sim/sh/interp.c
+index 379b44f82ba..c8c2a7429ce 100644
+--- a/sim/sh/interp.c
++++ b/sim/sh/interp.c
+@@ -1712,7 +1712,7 @@ sim_resume (SIM_DESC sd, int step, int siggnal)
+   register int endianw = global_endianw;
+ 
+   int tick_start = get_now ();
+-  void (*prev_fpe) ();
++  void (*prev_fpe) (int);
+ 
+   register unsigned short *jump_table = sh_jump_table;
+ 

--- a/srcpkgs/gdb/template
+++ b/srcpkgs/gdb/template
@@ -1,7 +1,7 @@
 # Template file for 'gdb'
 pkgname=gdb
 version=16.3
-revision=2
+revision=3
 build_style=gnu-configure
 pycompile_dirs="/usr/share/gdb/python"
 configure_args="--disable-werror --disable-nls --with-system-readline
@@ -59,6 +59,12 @@ if [ "$build_option_multiarch" ]; then
 	fi
 	subpackages="gdb-multiarch ${subpackages}"
 fi
+
+pre_configure() {
+	# --with-sysroot sets the runtime sysroot used by GDB, whereas --with-build-sysroot
+	# only sets the sysroot used at compile time
+	configure_args="${configure_args//--with-sysroot/--with-build-sysroot}"
+}
 
 post_install() {
 	# resolve conflicts with binutils


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

cc: @Duncaen 

Currently gdb fails to load libraries on architectures where gdb has been cross compiled, such as armv7l-musl and aarch64, unless `set solib-search-path` or `set sysroot` is done manually.
This is due to `--with-sysroot` setting the sysroot used for both compile time and run time. This is an known issue with binutils, where `--with-build-sysroot` is used instead of `--with-sysroot`. The same should be done for gdb.


Before this change `show sysroot` on armv7l-musl outputs `/usr/armv7l-linux-musleabihf`, after this change, it outputs `target:` as it does on x86_64.
<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
