### PR TITLE
discord: update to 1.0.137.

### DIFF
--- a/srcpkgs/discord/template
+++ b/srcpkgs/discord/template
@@ -1,6 +1,6 @@
 # Template file for 'discord'
 pkgname=discord
-version=1.0.136
+version=1.0.137
 revision=1
 archs="x86_64"
 depends="alsa-lib dbus-glib gtk+3 libnotify nss libXtst libcxx libatomic
@@ -10,7 +10,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="custom:Proprietary"
 homepage="https://discord.com"
 distfiles="https://dl.discordapp.net/apps/linux/${version}/discord-${version}.tar.gz"
-checksum=2f582fee93aa4b67e1f00c8cda38541c2bb59fb82ee46bc886268066cea4415b
+checksum=9b2b7b451ae4a0d2dc8dd858be4252d6699c7b4f50f579a9025931431e0d555e
 repository=nonfree
 restricted=yes
 nopie=yes


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**


#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):