### PR TITLE
python3-nethsm: update to 2.1.1

### DIFF
--- a/srcpkgs/python3-nethsm/template
+++ b/srcpkgs/python3-nethsm/template
@@ -1,13 +1,22 @@
 # Template file for 'python3-nethsm'
 pkgname=python3-nethsm
-version=2.1.0
+version=2.1.1
 revision=1
 build_style=python3-pep517
+make_check_args="--ignore=tests/test_enums.py \
+ --ignore=tests/test_nethsm_config.py \
+ --ignore=tests/test_nethsm_keys.py \
+ --ignore=tests/test_nethsm_other.py \
+ --ignore=tests/test_nethsm_system.py \
+ --ignore=tests/test_nethsm_users.py \
+ --ignore=tests/test_nethsm_namespaces.py" # podman python bindings currently not packaged
 hostmakedepends="python3-poetry-core"
 depends="python3-certifi python3-cryptography python3-dateutil python3-typing_extensions python3-urllib3"
+checkdepends="python3-pytest python3-pycryptodome python3-docker python3-typing_extensions
+ python3-urllib3 python3-distutils-extra"
 short_desc="Python Library to manage NetHSM(s)"
 maintainer="Mateusz Sylwestrzak <slymattz@gmail.com>"
 license="Apache-2.0"
 homepage="https://github.com/Nitrokey/nethsm-sdk-py"
-distfiles="${PYPI_SITE}/n/nethsm/nethsm-${version}.tar.gz"
-checksum=89f64094ecbcfc9adf9dcf6ff474b492c97da2287a03cc3ecfaa62e1fbe0b21f
+distfiles="https://github.com/Nitrokey/nethsm-sdk-py/archive/refs/tags/v${version}.tar.gz"
+checksum=a4cb192816414b2653a08094652b41ff020a339363043a8ec74dc4887c6225a0


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**
https://github.com/Nitrokey/nethsm-sdk-py/compare/v2.1.0...v2.1.1

Switched to GH tarball which contains a set of tests. I had to disable the majority of them due to the lack of podman python bindings. Please let me know if this should be packaged (maybe someone would like to take ownership of this new package.)

#### Local build testing
- I built this PR locally for my native architecture: x86_64-glibc
