### PR TITLE
uosc: include 'Updater.lua'

### DIFF
--- a/srcpkgs/uosc/template
+++ b/srcpkgs/uosc/template
@@ -1,7 +1,7 @@
 # Template file for 'uosc'
 pkgname=uosc
 version=5.12.0
-revision=1
+revision=2
 conf_files="/etc/mpv/script-opts/uosc.conf"
 depends="mpv"
 short_desc="Feature-rich minimalist proximity-based UI for MPV player"
@@ -16,7 +16,7 @@ do_install() {
 	vinstall src/uosc.conf 0644 etc/mpv/script-opts
 	vinstall src/uosc/main.lua 0644 usr/share/mpv/scripts/uosc
 
-	rm src/uosc/{main.lua,elements/Updater.lua}
+	rm src/uosc/main.lua
 	vcopy src/uosc usr/share/mpv/scripts
 	vcopy src/fonts usr/share/mpv
 


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, **x86_64-glibc**

We [intentionally](https://github.com/void-linux/void-packages/pull/58792) do not ship `uosc`'s utility binary which enables checking for updates for manual installations (upstream provides an install-script). Applying `mpv`'s default `input.conf` does not hide the "Update uosc" item from the "Utils" submenu, and clicking on it w/o `Updater.lua` present will crash the UI instead of simply reporting an error about the missing binary. I've always used a custom `input.conf` in my `$HOME`, that's why this kind of crash never occurred to me before.

cc @Duncaen 