### PR TITLE
gjs: add gir-freedesktop runtime dependency

### DIFF
--- a/srcpkgs/gjs/template
+++ b/srcpkgs/gjs/template
@@ -1,12 +1,13 @@
 # Template file for 'gjs'
 pkgname=gjs
 version=1.88.0
-revision=1
+revision=2
 build_style=meson
 build_helper="gir qemu"
 configure_args="-Dprofiler=disabled -Dinstalled_tests=false"
 hostmakedepends="glib-devel pkg-config mozjs140"
 makedepends="dbus-glib-devel mozjs140-devel readline-devel sysprof-devel"
+depends="gir-freedesktop"
 checkdepends="xvfb-run cantarell-fonts gtk4-devel"
 short_desc="Mozilla-based javascript bindings for the GNOME platform"
 maintainer="Enno Boland <gottox@voidlinux.org>"


### PR DESCRIPTION
This PR fixes a runtime bug where GJS applications using GTK
fail with errors like:

  Typelib file for namespace 'cairo', version '1.0' not found

#### Root cause

`gjs` links against `libgirepository-2.0.so.0` (provided by
`glib`), not `libgirepository-1.0.so.1` (provided by the
`libgirepository` subpackage of `gobject-introspection`).
Because of this, xbps-src does not automatically detect a
runtime dependency on `libgirepository`, and as a result the
base typelibs (Cairo, GLib, Gio, xlib, etc.) that live in the
`gir-freedesktop` subpackage are not pulled in when `gjs`
is installed.

#### Verification

- `readelf -d /usr/lib/libgjs.so.0` confirms gjs links
  `libgirepository-2.0.so.0`, not `libgirepository-1.0.so.1`.
- `xbps-query -R -f gir-freedesktop` confirms it provides
  `cairo-1.0.typelib`, `GIRepository-2.0.typelib`, etc.
- Reproduced the bug on a minimal system by installing only
  `gjs` and `foliate` from the official repos: foliate failed
  with the cairo typelib error.
- With the patched `gjs` installed, `gir-freedesktop` is
  pulled in automatically and foliate launches without errors.

#### Note on package choice

I declared `gir-freedesktop` directly rather than
`libgirepository`, because gjs does not actually need
`libgirepository-1.0.so.1` (it uses the 2.0 API from glib).
Open to changing this to `libgirepository` for consistency
with `cjs`, `lua-lgi` and `perl-Glib-Object-Introspection`
if preferred.

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture: **x86_64-glibc**
- I built this PR locally for these architectures:
  - x86_64-musl
  - i686
  - aarch64
  - aarch64-musl