### PR TITLE
dnsmasq: update to 2.92rel2

### DIFF
--- a/srcpkgs/dnsmasq/template
+++ b/srcpkgs/dnsmasq/template
@@ -1,6 +1,6 @@
 # Template file for 'dnsmasq'
 pkgname=dnsmasq
-version=2.92
+version=2.92rel2
 revision=1
 conf_files="/etc/dnsmasq.conf"
 hostmakedepends="pkg-config"
@@ -11,7 +11,7 @@ license="GPL-2.0-or-later"
 homepage="https://www.thekelleys.org.uk/dnsmasq/doc.html"
 changelog="https://www.thekelleys.org.uk/dnsmasq/CHANGELOG"
 distfiles="https://www.thekelleys.org.uk/dnsmasq/dnsmasq-${version}.tar.gz"
-checksum=fd908e79ff37f73234afcb6d3363f78353e768703d92abd8e3220ade6819b1e1
+checksum=75e34cd7fd951c809928dbcb5bf43eccb02f4c8c8f49298763b706ae3c2de5a1
 system_accounts="dnsmasq"
 dnsmasq_homedir="/var/chroot"
 


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, **x86_64-glibc**
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl

Point release w/ fixes for [several CVEs](https://www.thekelleys.org.uk/dnsmasq/CHANGELOG)
