### PR TITLE
pdsh: re-enable dshgroup support, adopt.

### DIFF
--- a/srcpkgs/pdsh/template
+++ b/srcpkgs/pdsh/template
@@ -1,15 +1,15 @@
 # Template file for 'pdsh'
 pkgname=pdsh
 version=2.36
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--disable-static-modules --with-readline --with-negroup
- --with-exec --with-rsh --with-ssh"
+ --with-exec --with-rsh --with-ssh --with-dshgroups"
 hostmakedepends="automake autoconf libtool"
 makedepends="readline-devel"
 checkdepends="which"
 short_desc="High performance, parallel remote shell utility"
-maintainer="Orphaned <orphan@voidlinux.org>"
+maintainer="Vincent Schweiger <vincent.schweiger@icloud.com>"
 license="GPL-2.0-or-later"
 homepage="https://github.com/chaos/pdsh"
 distfiles="https://github.com/chaos/pdsh/archive/pdsh-${version}.tar.gz"

--- a/srcpkgs/pdsh/template
+++ b/srcpkgs/pdsh/template
@@ -1,10 +1,10 @@
 # Template file for 'pdsh'
 pkgname=pdsh
 version=2.36
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--disable-static-modules --with-readline --with-negroup
- --with-exec --with-rsh --with-ssh"
+ --with-exec --with-rsh --with-ssh --with-dshgroups"
 hostmakedepends="automake autoconf libtool"
 makedepends="readline-devel"
 checkdepends="which"


### PR DESCRIPTION
After updating my system I noticed pdsh lacked support for dshgroups again... I originally contributed that part before and I still require it. I frequently use pdsh, so I'd adopt it.

#### Testing the changes
- I tested the changes in this PR: **yes**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
