### PR TITLE
asahi-uboot

### DIFF
--- a/srcpkgs/asahi-uboot/template
+++ b/srcpkgs/asahi-uboot/template
@@ -1,6 +1,6 @@
 # Template file for 'asahi-uboot'
 pkgname=asahi-uboot
-version=2025.10+2
+version=2026.04+2
 revision=1
 archs="aarch64*"
 hostmakedepends="bison flex which python3 swig python3-devel
@@ -13,7 +13,7 @@ maintainer="dkwo <npiazza@disroot.org>, Will Springer <skirmisher@protonmail.com
 license="GPL-2.0-or-later, MIT"
 homepage="https://asahilinux.org"
 distfiles="https://github.com/AsahiLinux/u-boot/archive/refs/tags/asahi-v${version/+/-}.tar.gz"
-checksum=899895de62aeef3d6c7360133396089bdf85ac09490429b2b3f69a4dfdfcb415
+checksum=b3cdcc467afbf6737ad7c87d174daa8eb0dcc212feb275ee56c406c1e084768c
 make_check=no # missing python3-libfdt ?
 
 if [ "${CROSS_BUILD}" ]; then
@@ -30,9 +30,6 @@ do_build() {
 
 do_install() {
 	vinstall u-boot-nodtb.bin 0644 usr/lib/asahi-boot
-	for dtb in arch/arm/dts/t[86]*.dtb ; do
-		vinstall ${dtb} 0644 usr/lib/asahi-boot/dtb
-	done
 }
 
 post_install() {

--- a/srcpkgs/asahi-uboot/update
+++ b/srcpkgs/asahi-uboot/update
@@ -1,1 +1,1 @@
-pattern='tags/asahi-v\K[\d.R-]+(?=\.tar\.gz)'
+pattern='refs/tags/asahi-v\K[\d.R-]+($|(?=^))'


### PR DESCRIPTION
- I tested the changes in this PR: **NO**
- I built this PR locally for my native architecture, (aarch64-gnu)

I do not use u-boot: if someone (esp. with M3 hardware) can try this, it would be appreciated (no breakings expected).
This removes dtbs from uboot (we are already using the ones from kernel).