### PR TITLE
carapace: update to 1.6.5

### DIFF
--- a/srcpkgs/carapace/template
+++ b/srcpkgs/carapace/template
@@ -1,23 +1,23 @@
 # Template file for 'carapace'
 pkgname=carapace
-version=1.5.7
+version=1.6.5
 revision=1
 build_style=go
 go_import_path=github.com/carapace-sh/carapace-bin
 go_package="${go_import_path}/cmd/carapace"
 go_build_tags="release"
 go_ldflags="-X main.version=${version}"
-make_check_target="./cmd/carapace/..."
+make_check_target="./cmd/carapace/"
 short_desc="Multi-shell multi-command argument completer"
 maintainer="icp <pangolin@vivaldi.net>"
 license="MIT"
 homepage="https://carapace.sh/"
 changelog="https://carapace-sh.github.io/carapace-bin/release_notes.html"
 distfiles="https://github.com/carapace-sh/carapace-bin/archive/refs/tags/v${version}.tar.gz"
-checksum=288f5629d9d842366089c75c388566b62bd452e5d2652384daeb419b134ec354
+checksum=b0d3f3d2c60acc48bce48d27810ca510388699ca1d5a4db2fd154a22797a601e
 
 pre_build() {
-	CGO_ENABLED=0 GOARCH= go generate ./cmd/...
+	GOMODCACHE="${XBPS_BUILDDIR}/gomodcache" CGO_ENABLED=0 GOARCH= go generate ./cmd/...
 }
 
 post_install() {


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->

I wanted to update carapace to a version >1.6 since it merges support for xbps-* auto-completion. However, I encountered the same issue as #59030.

I am no go developer but apparently there is a problem with having the go cache inside the working directory for the `go generate` command in the pre-build phase. By setting `GOMODCACHE`, the package seems to build fine.
