### PR TITLE
wsdd-native: update to 1.24.

### DIFF
--- a/srcpkgs/wsdd-native/template
+++ b/srcpkgs/wsdd-native/template
@@ -1,7 +1,7 @@
 # Template file for 'wsdd-native'
 pkgname=wsdd-native
-version=1.23
-revision=2
+version=1.24
+revision=1
 build_style=cmake
 configure_args="-DWSDDN_PREFER_SYSTEM_LIBXML2=ON
  -DWSDDN_PREFER_SYSTEM_FMT=ON
@@ -12,12 +12,12 @@ conf_files="/etc/wsddn.conf"
 hostmakedepends="cmake pkg-config"
 makedepends="fmt-devel libxml2-devel spdlog tomlplusplus-devel"
 short_desc="WS-Discovery daemon to make Linux visible in Windows Network view"
-maintainer="jl4c <jose.4rellano@gmail.com>"
+maintainer="Jose Arellano <jose.4rellano@gmail.com>"
 license="BSD-3-Clause"
 homepage="https://github.com/gershnik/wsdd-native"
 changelog="https://raw.githubusercontent.com/gershnik/wsdd-native/master/CHANGELOG.md"
 distfiles="https://github.com/gershnik/wsdd-native/archive/refs/tags/v${version}.tar.gz"
-checksum=c3656d9455eb7a488ae014c56d06f3da3a2ea20ebd19fc937fb1a70aa31ae9c6
+checksum=b1f6adb7086f2f7ce3199a1b80cd7091159b6f7e6a66266484efcd50aadcc4bb
 system_accounts="_wsddn"
 
 post_install() {


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures:
  - aarch64
  - i686
  - armv7l
  - x86_64-musl