### PR TITLE
zoom: update to 7.0.5.3034

### DIFF
--- a/srcpkgs/zoom/template
+++ b/srcpkgs/zoom/template
@@ -1,43 +1,33 @@
 # Template file for 'zoom'
 pkgname=zoom
-version=7.0.0.1666
+version=7.0.5.3034
 revision=1
 archs="x86_64"
 create_wrksrc=yes
-depends="libglvnd pulseaudio-utils"
 short_desc="Video Conferencing and Web Conferencing Service"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="custom:Proprietary"
 homepage="https://zoom.us/"
 distfiles="https://cdn.zoom.us/prod/${version}/zoom_x86_64.rpm"
-checksum=b29270444fedc8dad195fe2b8f584a3d53dddbe3432431e75b1b62ec32495023
+checksum=f11f0c4bea9236b5d89842be532e8dfdb1e61c92416461f5cae02ec0f7224a24
 repository=nonfree
+skiprdeps="/opt/zoom/Qt/qml/Qt/labs/lottieqt/liblottieqtplugin.so"
 noshlibprovides=yes
 restricted=yes
 nopie=yes
 build_options="systemqt"
 desc_option_systemqt="Use system QT libraries"
 
+if [ "$build_option_systemqt" ]; then
+	make_dirs="/opt/zoom/Qt/lib 0755 root root"
+fi
+
 pre_install() {
-	if [ "${build_option_systemqt}" ]; then
-		rm -f opt/zoom/libQt5*.so{,.*}
-		rm -f opt/zoom/libicu*.so{,.*}
-
-		rm -rf opt/zoom/*integrations
-		rm -rf opt/zoom/audio
-		rm -rf opt/zoom/generic
-		rm -rf opt/zoom/iconengines
-		rm -rf opt/zoom/imageformats
-		rm -rf opt/zoom/platforms
-		rm -rf opt/zoom/platforminputcontexts
-		rm -rf opt/zoom/platformthemes
-		rm -rf opt/zoom/Qt{,GraphicalEffects,Qml,Quick,Quick.2,Wayland}
-		rm -rf opt/zoom/wayland-*
-		rm -f opt/zoom/libmpg123.so
-		rm -f opt/zoom/libfaac1.so
-		rm -f opt/zoom/libturbojpeg.so{,.*}
-		rm -f opt/zoom/libquazip.so{,.*}
-
+	if [ "$build_option_systemqt" ]; then
+		rm -r opt/zoom/Qt
+		rm opt/zoom/libquazip.so
+		rm opt/zoom/libmpg123.so
+		rm opt/zoom/libKF6GlobalAccel.so.6
 		rm opt/zoom/qt.conf
 	fi
 }


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

Closes #60526 

`libQt6Bodymovin.so` was required by the non-`systemqt` build of zoom. This seems to be a new dependency not present in previous versions.

Unfortunately because Zoom 7.0.5 doesn’t ship `libQt6Bodymovin.so`, therefor the new Zoom version was broken with the most recent `qt6-lottie`.

This PR removes the `systemqt` option and forces Zoom to use the system’s Qt6. I don’t think there is much value in using Zoom’s own Qt6 libraries anyway. It also removes the outdated `rm -rf ...` calls, since most of these files are not in the Zoom 7.0.0 and 7.0.5 RPM.
<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
