### PR TITLE
Fix python3-rst2ansi

### DIFF
--- a/srcpkgs/python3-rst2ansi/patches/buffer-overflow-in-TIOCGWINSZ.patch
+++ b/srcpkgs/python3-rst2ansi/patches/buffer-overflow-in-TIOCGWINSZ.patch
@@ -1,0 +1,40 @@
+From 3728e16f8b8b1dc338e5df90ba2c4a93ee054b3f Mon Sep 17 00:00:00 2001
+From: Michal Przadka <przadka@gmail.com>
+Date: Mon, 24 Nov 2025 11:14:03 +0100
+Subject: [PATCH 2/2] Fix buffer overflow in TIOCGWINSZ ioctl call for Python
+ 3.14+
+
+TIOCGWINSZ ioctl expects struct winsize which contains 4 unsigned shorts
+(8 bytes total), not 2. Python 3.14 introduced stricter buffer validation
+that detects this mismatch and raises SystemError.
+
+Changes:
+- Increase buffer size from 4 to 8 bytes (b"\x00" * 4 -> b"\x00" * 8)
+- Update struct format from "hh" to "hhhh" to unpack all 4 shorts
+- Unpack all values but only use first two (rows, columns)
+
+Fixes #18
+---
+ rst2ansi/get_terminal_size.py | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/rst2ansi/get_terminal_size.py b/rst2ansi/get_terminal_size.py
+index a25d16b..9c4f1fd 100644
+--- a/rst2ansi/get_terminal_size.py
++++ b/rst2ansi/get_terminal_size.py
+@@ -72,10 +72,10 @@ except ImportError:
+ 
+     def _get_terminal_size(fd):
+         try:
+-            res = fcntl.ioctl(fd, termios.TIOCGWINSZ, b"\x00" * 4)
++            res = fcntl.ioctl(fd, termios.TIOCGWINSZ, b"\x00" * 8)
+         except IOError as e:
+             raise OSError(e)
+-        lines, columns = struct.unpack("hh", res)
++        lines, columns, *_ = struct.unpack("hhhh", res)
+ 
+         return terminal_size(columns, lines)
+ 
+-- 
+2.54.0
+

--- a/srcpkgs/python3-rst2ansi/patches/issue-16.patch
+++ b/srcpkgs/python3-rst2ansi/patches/issue-16.patch
@@ -1,0 +1,40 @@
+From 81758ed43336833a77deb2a7c751abf362ff8761 Mon Sep 17 00:00:00 2001
+From: Paul Galbraith <paul@galbraiths.ca>
+Date: Fri, 31 Oct 2025 12:45:12 -0400
+Subject: [PATCH 1/2] Fix issue #16
+
+Removed unused, deprecated, docutils imports.  These
+imports cause modern builds of apps which depend on
+rst2ansi to fail due to the (unused) references to the docutils error_reporting package, which no longer exists.
+---
+ rst2ansi/ansi.py    | 1 -
+ rst2ansi/visitor.py | 1 -
+ 2 files changed, 2 deletions(-)
+
+diff --git a/rst2ansi/ansi.py b/rst2ansi/ansi.py
+index ec91c8d..bce8b39 100644
+--- a/rst2ansi/ansi.py
++++ b/rst2ansi/ansi.py
+@@ -26,7 +26,6 @@ THE SOFTWARE.
+ from __future__ import unicode_literals
+ 
+ from docutils import core, frontend, nodes, utils, writers, languages, io
+-from docutils.utils.error_reporting import SafeString
+ from docutils.transforms import writer_aux
+ from docutils.parsers.rst import roles
+ 
+diff --git a/rst2ansi/visitor.py b/rst2ansi/visitor.py
+index ef77aa0..4581195 100644
+--- a/rst2ansi/visitor.py
++++ b/rst2ansi/visitor.py
+@@ -24,7 +24,6 @@ THE SOFTWARE.
+ """
+ 
+ from docutils import core, frontend, nodes, utils, writers, languages, io
+-from docutils.utils.error_reporting import SafeString
+ from docutils.transforms import writer_aux
+ from docutils.parsers.rst import roles
+ 
+-- 
+2.54.0
+

--- a/srcpkgs/python3-rst2ansi/template
+++ b/srcpkgs/python3-rst2ansi/template
@@ -1,7 +1,7 @@
 # Template file for 'python3-rst2ansi'
 pkgname=python3-rst2ansi
 version=0.1.5
-revision=4
+revision=5
 build_style=python3-module
 hostmakedepends="python3-setuptools"
 depends="python3-docutils"


### PR DESCRIPTION
This adds two patches from GitHub master to fix two issues that make python3-rst2ansi unusable.

This fixes backblaze-b2, which is currently broken.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
