### PR TITLE
New package: OSCAR-1.7.1

### DIFF
--- a/srcpkgs/OSCAR/template
+++ b/srcpkgs/OSCAR/template
@@ -1,0 +1,23 @@
+# Template file for 'OSCAR'
+pkgname=OSCAR
+version=1.7.1
+revision=1
+build_style=qmake
+hostmakedepends="qt6-base qt6-core qt6-tools"
+makedepends="glu-devel qt6-serialport-devel qt6-tools-devel zlib-devel"
+short_desc="OpenSource CPAP Analysis Reporter"
+maintainer="Patrick Poitras <void-packages@pfpoitras.com>"
+license="GPL-3.0-only"
+homepage=https://www.sleepfiles.com/OSCAR/
+distfiles="https://gitlab.com/CrimsonNape/OSCAR-code/-/archive/v${version}/OSCAR-code-v${version}.tar.gz"
+checksum=e2638626f2e664ef3974d4a7abd7a24d6123baafbc298cfbd03beb934caa1a7e
+
+configure_args="OSCAR_QT.pro"
+
+do_install() {
+	vbin oscar/OSCAR
+	vmkdir usr/share/applications
+	vmkdir usr/share/hicolor/48x48/apps
+	vcopy Building/Linux/OSCAR.png usr/share/hicolor/48x48/apps
+	vcopy Building/Linux/OSCAR.desktop usr/share/applications
+}

--- a/srcpkgs/OSCAR/template
+++ b/srcpkgs/OSCAR/template
@@ -1,0 +1,24 @@
+# Template file for 'OSCAR'
+pkgname=OSCAR
+version=1.7.1
+revision=1
+build_style=qmake
+hostmakedepends="qt6-base qt6-core qt6-tools"
+makedepends="glu-devel qt6-serialport-devel qt6-network
+qt6-printsupport qt6-xml qt6-tools-devel zlib-devel"
+short_desc="OpenSource CPAP Analysis Reporter"
+maintainer="Patrick Poitras <void-packages@pfpoitras.com>"
+license=GPLv3
+homepage=https://www.sleepfiles.com/OSCAR/
+distfiles="https://gitlab.com/CrimsonNape/OSCAR-code/-/archive/v${version}/OSCAR-code-v${version}.tar.gz"
+checksum=e2638626f2e664ef3974d4a7abd7a24d6123baafbc298cfbd03beb934caa1a7e
+
+configure_args="OSCAR_QT.pro"
+
+do_install() {
+	vbin oscar/OSCAR
+	vmkdir usr/share/applications
+	vmkdir usr/share/hicolor/48x48/apps
+	vcopy Building/Linux/OSCAR.png usr/share/hicolor/48x48/apps
+	vcopy Building/Linux/OSCAR.desktop usr/share/applications
+}


### PR DESCRIPTION
This is OSCAR, a CPAP data analysis suite.

Software history is that it was a fork from Sleepyhead dating from around 2018 when it was abandoned by the previous developer. It's got releases for Windows/MacOS/Linux, a close association with "Apneaboard" forums and several guides on the apneaboard wiki on how to use it. (see here: https://www.apneaboard.com/wiki/index.php?title=OSCAR_-_The_Guide)

Additional information: In case you're wondering about potential orphaning: I will be sticking around as maintainer for this package and some others (e.g. calibre). 

Able to be pinged in irc if there are any questions (PFPoitras)

#### Testing the changes
- I tested the changes in this PR: **YES** (only on x86_64-glibc)

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES** Reason: compiled

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- Cross builds: armv6l, armv6l-musl