### PR TITLE
retroarch: update to 1.22.2.

### DIFF
--- a/srcpkgs/retroarch/template
+++ b/srcpkgs/retroarch/template
@@ -1,101 +1,89 @@
 # Template file for 'retroarch'
 pkgname=retroarch
-version=1.21.0
+version=1.22.2
 revision=1
 build_style=configure
-configure_args="--prefix=/usr --sysconfdir=/etc --enable-networking
- --enable-udev --disable-builtinflac --enable-systemmbedtls
- --disable-builtinbearssl --disable-builtinzlib
- $(vopt_enable ffmpeg) $(vopt_enable flac) $(vopt_enable jack)
- $(vopt_enable pulseaudio pulse) $(vopt_enable qt5 qt)
- $(vopt_enable sdl2) $(vopt_enable vulkan) $(vopt_enable wayland) $(vopt_enable x11)"
+configure_args="--prefix=/usr --sysconfdir=/etc
+ --disable-builtinzlib --enable-builtinflac --disable-builtinbearssl
+ --disable-builtinmbedtls --disable-test_drivers --disable-parport --disable-sdl
+ --disable-tinyalsa --enable-systemmbedtls --enable-networking --enable-udev
+ $(vopt_enable opengl_core) $(vopt_enable vulkan) $(vopt_enable kms)
+ $(vopt_enable wayland) $(vopt_enable x11) $(vopt_enable alsa)
+ $(vopt_enable jack) $(vopt_enable al) $(vopt_enable oss)
+ $(vopt_enable pipewire) $(vopt_enable pulse) $(vopt_enable sdl2)
+ $(vopt_enable cdrom) $(vopt_enable dbus) $(vopt_enable ffmpeg)
+ $(vopt_enable hid) $(vopt_enable v4l2)"
 conf_files="/etc/retroarch.cfg"
 hostmakedepends="pkg-config"
-makedepends="alsa-lib-devel eudev-libudev-devel freetype-devel libusb-devel libxkbcommon-devel
- mbedtls-devel zlib-devel $(vopt_if ffmpeg ffmpeg6-devel) $(vopt_if flac libflac-devel)
- $(vopt_if jack jack-devel) $(vopt_if pulseaudio pulseaudio-devel)
- $(vopt_if qt5 qt5-devel) $(vopt_if sdl2 SDL2-devel) $(vopt_if vulkan vulkan-loader-devel)
- $(vopt_if x11 'libXext-devel libXinerama-devel libXxf86vm-devel')"
+makedepends="zlib-devel freetype-devel fontconfig-devel libxkbcommon-devel
+ eudev-libudev-devel mbedtls-devel liblzma-devel libglvnd-devel
+ $(vopt_if vulkan vulkan-loader-devel) $(vopt_if kms 'libdrm-devel libgbm-devel')
+ $(vopt_if wayland 'wayland-devel wayland-protocols libdecor-devel')
+ $(vopt_if x11 'libX11-devel libxcb-devel libXext-devel libXi-devel libXinerama-devel')
+ $(vopt_if x11 'libXxf86vm-devel libXrandr-devel libXScrnSaver-devel')
+ $(vopt_if alsa alsa-lib-devel) $(vopt_if jack jack-devel) $(vopt_if al libopenal-devel)
+ $(vopt_if pipewire pipewire-devel) $(vopt_if pulse pulseaudio-devel)
+ $(vopt_if sdl2 SDL2-devel) $(vopt_if dbus dbus-devel) $(vopt_if ffmpeg ffmpeg6-devel)
+ $(vopt_if hid libusb-devel) $(vopt_if v4l2 v4l-utils-devel)
+ $(vopt_if qt5 qt5-devel) $(vopt_if qt6 qt6-base-devel)"
 depends="$(vopt_if vulkan vulkan-loader) $(vopt_if x11 xdg-utils)"
-short_desc="Official reference frontend for the libretro API"
+short_desc="Cross-platform, sophisticated frontend for the libretro API"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-3.0-or-later"
-homepage="https://www.retroarch.com/"
+homepage="https://www.retroarch.com"
 changelog="https://raw.githubusercontent.com/libretro/RetroArch/master/CHANGES.md"
 distfiles="https://github.com/libretro/RetroArch/archive/v$version.tar.gz"
-checksum=9da17918c10d91d4ebfde9ff402dba0b1ad6660fdbce7656d32f0c0182b3a538
+checksum=245ef18c8fa8fbd9fbb5eb25cf43e17c6aace2f95c1ed99873cbd794012bb232
 
-build_options="ffmpeg flac glcore gles2 jack neon pulseaudio qt5 sdl2 vulkan wayland x11"
-build_options_default="ffmpeg flac glcore pulseaudio sdl2 vulkan wayland x11"
+build_options="opengl_core vulkan kms wayland x11
+ alsa jack al oss pipewire pulse sdl2
+ cdrom dbus ffmpeg hid qt5 qt6 v4l2"
 
-desc_option_glcore="Enable support for OpenGL 3.2 core+ and OpenGL ES 3+"
-desc_option_neon="Enable support for ARM Neon SIMD extension"
+build_options_default="opengl_core vulkan kms wayland x11
+ alsa pipewire ffmpeg"
 
-vopt_conflict glcore gles2 # gles2 disables glcore support
+vopt_conflict qt5 qt6
 
-if [ "$build_option_gles2" ]; then
-	configure_args+=" --enable-opengles --enable-opengles3"
-else
-	configure_args+=" --disable-opengles --disable-opengles3"
-fi
-
-if [ "$build_option_glcore" ]; then
-	configure_args+=" --enable-opengl_core"
-else
-	configure_args+=" --disable-opengl_core"
-fi
-
-if [ "$build_option_gles2" -o "$build_option_glcore" ]; then
-	configure_args+=" --enable-egl --enable-kms"
-	makedepends+=" MesaLib-devel"
-fi
-
-if [ "$build_option_qt5" ]; then
-	if [ "$CROSS_BUILD" ]; then
-		hostmakedepends+=" qt5-host-tools"
-	fi
-fi
-
-if [ "$build_option_wayland" ]; then
-	if [ -z "$build_option_gles2" -a -z "$build_option_glcore" ]; then
-		msg_error "$pkgname: 'wayland' option requires 'gles2' or 'glcore'.\n"
-	fi
-	makedepends+=" wayland-devel wayland-protocols libdecor-devel"
-	if [ "$CROSS_BUILD" ]; then
-		hostmakedepends+=" wayland-devel wayland-protocols"
-	fi
-fi
-
-if [ "$build_option_x11" ]; then
-	if [ -z "$build_option_gles2" -a -z "$build_option_glcore" ]; then
-		msg_error "$pkgname: 'x11' option requires 'gles2' or 'glcore'.\n"
-	fi
-fi
+desc_option_opengl_core="Enable support for modern OpenGL (GL3.2+/GLES3+)"
+desc_option_kms="Enable support for KMS/DRM display context"
+desc_option_al="Enable support for OpenAL"
+desc_option_oss="Enable support for OSS"
+desc_option_pipewire="Enable support for PipeWire"
+desc_option_pulse="Enable support for PulseAudio"
+desc_option_cdrom="Enable support for CD-ROM"
+desc_option_hid="Enable support for low-level HID input"
+desc_option_qt5="Enable support for Qt5 companion UI"
+desc_option_qt6="Enable support for Qt6 companion UI"
+desc_option_neon="Enable support for ARM NEON SIMD (armv7 only)"
+desc_option_opengles="Enable support for OpenGL ES (replaces desktop OpenGL)"
 
 case "$XBPS_TARGET_MACHINE" in
-	i686*|x86_64*)
-		configure_args+=" --enable-sse --enable-threads"
-		;;
-	ppc*)
-		configure_args+=" --enable-threads"
-		;;
-	aarch64*)
-		configure_args+=" --enable-threads"
-		;;
 	armv7*)
-		build_options_default+=" neon"
-
-		configure_args+=" --enable-threads $(vopt_enable neon)"
-
-		if [ "$build_option_neon" ]; then
-			CFLAGS+=" -mfpu=neon"
-		fi
+		# NEON is not universally supported on all armv7 hardware
+		build_options+=" neon"
+		configure_args+=" $(vopt_if neon --enable-neon)"
+		[ "$build_option_neon" ] && CFLAGS+=" -mfpu=neon"
+		;;&
+	armv7*|aarch64*)
+		# Some platforms in this family have full desktop GL support
+		build_options+=" opengles"
+		build_options_default+=" opengles"
+		configure_args+=" $(vopt_if opengles '--enable-opengles --enable-opengles3')"
+		configure_args+=" $(vopt_if opengles '--enable-opengles3_1 --enable-opengles3_2')"
 		;;
-	arm*)
-		configure_args+=" --disable-neon"
+	i686*|x86_64*)
+		configure_args+=" --enable-sse"
 		;;
-	esac
+esac
+
+if [ "$build_option_qt5" ] || [ "$build_option_qt6" ]; then
+	configure_args+=" --enable-qt"
+	[ "$build_option_qt6" ] && build_helper="qmake6"
+else
+	configure_args+=" --disable-qt"
+fi
 
 if [ "$CROSS_BUILD" ]; then
 	configure_args+=" --host=${XBPS_CROSS_TRIPLET}"
+	hostmakedepends+=" $(vopt_if qt5 qt5-host-tools) $(vopt_if wayland wayland-devel)"
 fi


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures:
  - aarch64
  - armv7l
  - i686
  - x86_64-musl

Update to 1.22.2.

This PR also includes a refactor of the template:

- New build options: `kms`, `al`, `oss`, `pipewire`, `cdrom`, `dbus`, `hid`, `qt6`, `v4l2`, `opengles`
- `glcore`/`gles2` build options replaced by `opengl_core` and an opt-in `opengles` (armv7/aarch64 only). Defaulting to desktop GL on those arches preserves compatibility with cores that require OpenGL HW context on platforms with full desktop GL support. See #32246 for context.
- `pulseaudio` build option renamed to `pulse` to match upstream's configure flag name; default audio backend changed to `pipewire`.
- Added `qt6` build option (mutually exclusive with `qt5`).

~~A patch (`fix-system-flac.patch`) was added to fix building against system libFLAC. libchdr's FLAC decoder in 1.22.x uses dr_flac exclusively, guarded by `HAVE_DR_FLAC`. Without it, the build fails at link time. Patch sourced from Debian.~~

**Edit:** Switched to `--enable-builtinflac` and dropped this patch.
The system-libFLAC route was misleading: libchdr decodes FLAC only via
dr_flac, so `libFLAC.so` got linked but never used. builtinflac is
cleaner — it builds the real libFLAC in, with no patch to carry.

Build tested with multiple option combinations (defaults, all-on with qt5, qt6, minimal, opengles enabled/disabled on ARM, etc.) across the architectures listed above.