### PR TITLE
asahi-base: make tinyramfs hook portable

### DIFF
--- a/srcpkgs/asahi-base/files/tinyramfs-hook-asahi
+++ b/srcpkgs/asahi-base/files/tinyramfs-hook-asahi
@@ -15,7 +15,7 @@ do
 	copy_kmod "$_mod"
 done
 
-for _bin in umount cpio cp grep cat sed seq
+for _bin in umount cpio cp grep cat tr seq
 do
 	copy_exec "$_bin"
 done

--- a/srcpkgs/asahi-base/files/tinyramfs-hook-asahi.init
+++ b/srcpkgs/asahi-base/files/tinyramfs-hook-asahi.init
@@ -14,8 +14,8 @@ mkdir -p "$mountpoint"
 while grep -q "$mountpoint" /proc/mounts; do
 	umount "$mountpoint"
 done
-esp_uuid="$(cat /proc/device-tree/chosen/asahi,efi-system-partition 2> /dev/null | sed 's/\x00//')"
-mount "PARTUUID=$esp_uuid" "$mountpoint"
+esp_uuid="$(cat /proc/device-tree/chosen/asahi,efi-system-partition 2> /dev/null | tr -d '\0')"
+mount -t vfat "/dev/disk/by-partuuid/$esp_uuid" "$mountpoint"
 
 print 'asahi: unpacking vendor firmware into initramfs'
 cpio -i < "$mountpoint/vendorfw/firmware.cpio"

--- a/srcpkgs/asahi-base/template
+++ b/srcpkgs/asahi-base/template
@@ -1,7 +1,7 @@
 # Template file for 'asahi-base'
 pkgname=asahi-base
-version=20250716
-revision=2
+version=20260506
+revision=1
 archs="aarch64*"
 depends="linux-asahi m1n1 asahi-uboot speakersafetyd dracut asahi-scripts"
 short_desc="Void Linux Apple Silicon support package"


### PR DESCRIPTION
- I tested the changes in this PR: **YES**
- I built this PR locally for my native architecture, (aarch64-gnu)

I received this patch via email. I implemented (except for dropping udev, maybe in the future) and tested the suggestions.