### PR TITLE
mpd 0.24.12

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -395,7 +395,7 @@ libmp4v2.so.2 libmp4v2-2.0.0_1
 libfaac.so.0 faac-1.28_1
 libfaad.so.2 faad2-2.7_1
 libfaad_drm.so.2 faad2-2.8.0_1
-libid3tag.so.0 libid3tag-0.16.4
+libid3tag.so.0 libid3tag-0.16.4_1
 libgif.so.7 giflib-5.1.0_1
 libImlib2.so.1 imlib2-1.4.2_1
 libmp3lame.so.0 lame-3.98.2_1

--- a/srcpkgs/mpd/template
+++ b/srcpkgs/mpd/template
@@ -1,6 +1,6 @@
 # Template file for 'mpd'
 pkgname=mpd
-version=0.24.9
+version=0.24.12
 revision=1
 build_style=meson
 configure_args="-Dopus=enabled -Dmikmod=enabled -Dneighbor=true
@@ -39,7 +39,7 @@ license="GPL-2.0-or-later"
 homepage="https://www.musicpd.org/"
 changelog="https://raw.githubusercontent.com/MusicPlayerDaemon/MPD/master/NEWS"
 distfiles="https://www.musicpd.org/download/mpd/${version%.*}/mpd-${version}.tar.xz"
-checksum=f3d28b29bbe675970ef205b3d9b835e5691423fed6a89d713dbcbf7839ea92f3
+checksum=14223ca883c35fbf711994bcf745726cecc9d898e3d3964265cf3a2c7519a360
 LDFLAGS="-Wl,-z,stack-size=1048576"
 
 system_accounts="mpd"


### PR DESCRIPTION
- **common/shlibs: fix libid3tag entry**
- **mpd: update to 0.24.12.**

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
#### Local build testing
- I built this PR locally for my native architecture, (x86_64-musl)
<!--
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
