### PR TITLE
xbps-triggers: use absolute paths when setting PATH

### DIFF
--- a/srcpkgs/xbps-triggers/files/binfmts
+++ b/srcpkgs/xbps-triggers/files/binfmts
@@ -17,7 +17,7 @@ PKGNAME="$3"
 VERSION="$4"
 UPDATE="$5"
 
-export PATH="usr/bin:usr/sbin:/usr/sbin:/usr/bin:/sbin:/bin"
+export PATH="${PWD}/usr/sbin:${PWD}/usr/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 
 # {install,remove}_binfmts: legacy installation style
 install_binfmts() {
@@ -60,7 +60,7 @@ targets)
 	echo "post-install pre-remove"
 	;;
 run)
-	[ -x /usr/bin/update-binfmts ] || exit 0
+	[ -x usr/bin/update-binfmts ] || exit 0
 
 	case "$TARGET" in
 	post-install)

--- a/srcpkgs/xbps-triggers/files/initramfs-regenerate
+++ b/srcpkgs/xbps-triggers/files/initramfs-regenerate
@@ -23,7 +23,7 @@ PKGNAME="$3"
 VERSION="$4"
 UPDATE="$5"
 
-export PATH="usr/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+export PATH="${PWD}/usr/sbin:${PWD}/usr/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 
 case "$ACTION" in
 	targets)

--- a/srcpkgs/xbps-triggers/files/pycompile
+++ b/srcpkgs/xbps-triggers/files/pycompile
@@ -34,7 +34,7 @@ PKGNAME="$3"
 VERSION="$4"
 UPDATE="$5"
 
-export PATH="usr/bin:/usr/sbin:/usr/sbin:/usr/bin:/sbin:/bin"
+export PATH="${PWD}/usr/sbin:${PWD}/usr/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 
 update_ldcache() {
 	if [ -x sbin/ldconfig -o -x bin/ldconfig ]; then

--- a/srcpkgs/xbps-triggers/files/system-accounts
+++ b/srcpkgs/xbps-triggers/files/system-accounts
@@ -14,7 +14,7 @@ PKGNAME="$3"
 VERSION="$4"
 UPDATE="$5"
 
-export PATH="usr/sbin:usr/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+export PATH="${PWD}/usr/sbin:${PWD}/usr/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 
 # Determine whether useradd/groupadd/usermod need a prefix argument
 if [ "$(readlink -f . 2>/dev/null || echo .)" != "/" ]; then

--- a/srcpkgs/xbps-triggers/template
+++ b/srcpkgs/xbps-triggers/template
@@ -1,6 +1,6 @@
 # Template file for 'xbps-triggers'
 pkgname=xbps-triggers
-version=0.130
+version=0.131
 revision=1
 bootstrap=yes
 short_desc="XBPS triggers for Void Linux"


### PR DESCRIPTION
At least two users have reported an issue with dracut failing to find system utilities like `usr/bin/grep` and `usr/bin/cp`. This seems to be a combination of setting `PATH=usr/bin:...` in the trigger and dracut performing a `chdir` away from the target root at some point. Changing these relative paths to absolute should avoid the problem, so let's correct this everywhere it appears.

@zdykstra would you mind confirming that `xbps-reconfigure -f zfs` reliably throws the same error before this patch is applied, and that it does not afterwards?

#### Testing the changes
- I tested the changes in this PR: **in process**