### PR TITLE
mpv: fix redraw on paused vids for some GPUs

### DIFF
--- a/srcpkgs/mpv/patches/vo-fix.patch
+++ b/srcpkgs/mpv/patches/vo-fix.patch
@@ -1,0 +1,36 @@
+From 64d6e3589a17668cbb1497c1307b576aa6998b46 Mon Sep 17 00:00:00 2001
+From: nanahi <130121847+na-na-hi@users.noreply.github.com>
+Date: Tue, 20 Jan 2026 00:51:32 -0500
+Subject: [PATCH] vo: wake up core when VO requests redraw
+
+a74a324b98a2484995cdf9206f0e586a7249f1af returned responsibility of video
+redraw back to playloop. The playloop is only run if something wakes up
+the core.
+
+However, the logic for VO requested redraw only wakes up the core when
+in->want_redraw is false, which is only resetted by vo_redraw, called
+from the core. This creates a situation where it can never wake up the
+core, so redrawing never happens even when VO requests it.
+
+efc44d05ff199e39de92e646c1a8edbd9e20c602 caused the issue to surface
+because it also throttles VO requested redraws, and in some cases results
+in the above behavior.
+
+Fix this by always waking up core when the VO requests redraw.
+---
+ video/out/vo.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/video/out/vo.c b/video/out/vo.c
+index e8c478b30ab43..9593712663ea0 100644
+--- a/video/out/vo.c
++++ b/video/out/vo.c
+@@ -1166,7 +1166,7 @@ static MP_THREAD_VOID vo_thread(void *ptr)
+                 wakeup_core(vo);
+             }
+         }
+-        if (vo->want_redraw && !in->want_redraw) {
++        if (vo->want_redraw) {
+             in->want_redraw = true;
+             wakeup_core(vo);
+         }

--- a/srcpkgs/mpv/template
+++ b/srcpkgs/mpv/template
@@ -1,7 +1,7 @@
 # Template file for 'mpv'
 pkgname=mpv
 version=0.41.0
-revision=2
+revision=3
 build_style=meson
 configure_args="-Dcdda=enabled -Ddvbin=enabled -Ddvdnav=enabled
  -Dlibmpv=true -Dcplugins=enabled


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

tested with ffmpeg8 but that PR will take a while to get in.

#### Local build testing
- I built this PR locally for my native architecture, **x86_64**

#### bug

original mpv fix - https://github.com/mpv-player/mpv/pull/17293

redraws not triggered on paused videos on my A770 (kms/i915/x11) box until you move the mouse over. xf86-amdgpu/amdgpu/x11 seems fine.