### PR TITLE
rio: update to 0.4.4

### DIFF
--- a/srcpkgs/rio/template
+++ b/srcpkgs/rio/template
@@ -1,6 +1,6 @@
 # Template file for 'rio'
 pkgname=rio
-version=0.4.3
+version=0.4.4
 revision=1
 build_style=cargo
 build_wrksrc="frontends/rioterm"
@@ -13,7 +13,7 @@ license="MIT"
 homepage="https://rioterm.com/"
 changelog="https://rioterm.com/changelog"
 distfiles="https://github.com/raphamorim/rio/archive/refs/tags/v${version}.tar.gz"
-checksum=28bedc7022f1862a12ea2b97949fb06f62d9763ed6885d08802ff1113fcdc5e8
+checksum=b5adc4960b9e08cbcb72d8bb0fa6f1f5196a374f3ab418b97d676261db9e56fc
 
 case "${XBPS_TARGET_MACHINE}" in
 	i686*)


### PR DESCRIPTION
Testing the changes

- I tested the changes in this PR: YES (x64)

Local build testing

 - I built this PR locally for my native architecture, (x64-glibc)
 - I built this PR locally for these architectures (if supported. mark crossbuilds):
        armv6l
