### PR TITLE
python3-uvicorn: update to 0.47.0

### DIFF
--- a/srcpkgs/python3-uvicorn/template
+++ b/srcpkgs/python3-uvicorn/template
@@ -1,6 +1,6 @@
 # Template file for 'python3-uvicorn'
 pkgname=python3-uvicorn
-version=0.46.0
+version=0.47.0
 revision=1
 build_style=python3-pep517
 hostmakedepends="hatchling"
@@ -8,10 +8,10 @@ depends="python3-asgiref python3-uvloop python3-click python3-h11"
 short_desc="ASGI web server"
 maintainer="Emil Miler <em@0x45.cz>"
 license="BSD-3-Clause"
-homepage="https://www.uvicorn.org/"
-changelog="https://raw.githubusercontent.com/encode/uvicorn/refs/heads/master/docs/release-notes.md"
+homepage="https://uvicorn.dev/"
+changelog="https://raw.githubusercontent.com/Kludex/uvicorn/refs/heads/main/docs/release-notes.md"
 distfiles="${PYPI_SITE}/u/uvicorn/uvicorn-${version}.tar.gz"
-checksum=fb9da0926999cc6cb22dc7cd71a94a632f078e6ae47ff683c5c420750fb7413d
+checksum=7c9a0ea1a9414106bbab7324609c162d8fa0cdcdcb703060987269d77c7bb533
 
 post_install() {
 	vlicense LICENSE.md


### PR DESCRIPTION
- I tested the changes in this PR: **NO**
- I built this PR locally for my native architecture, (x86_64-glibc)