### PR TITLE
zfs / zfs-lts version bumps

### DIFF
--- a/srcpkgs/zfs-lts/template
+++ b/srcpkgs/zfs-lts/template
@@ -1,6 +1,6 @@
 # Template file for 'zfs-lts'
 pkgname=zfs-lts
-version=2.3.6
+version=2.3.7
 revision=1
 build_style=gnu-configure
 configure_args="--with-config=user --with-mounthelperdir=/usr/bin
@@ -16,7 +16,7 @@ maintainer="Toyam Cox <Vaelatern@voidlinux.org>"
 license="CDDL-1.0"
 homepage="https://openzfs.github.io/openzfs-docs/"
 distfiles="https://github.com/openzfs/zfs/releases/download/zfs-${version}/zfs-${version}.tar.gz"
-checksum=e6ffe489ae5a7e823d5c519dc14febb639c83e7a4455a7b6bfd5f214c7cc9848
+checksum=446180ce0567e4bb5576c607596444dbe3768788ee7efc64d826b42b70be6dea
 # dkms must be before initramfs-regenerate to build modules before images
 triggers="dkms initramfs-regenerate"
 dkms_modules="zfs ${version}"

--- a/srcpkgs/zfs/template
+++ b/srcpkgs/zfs/template
@@ -1,6 +1,6 @@
 # Template file for 'zfs'
 pkgname=zfs
-version=2.4.1
+version=2.4.2
 revision=1
 build_style=gnu-configure
 configure_args="--with-config=user --with-mounthelperdir=/usr/bin
@@ -16,7 +16,7 @@ maintainer="Toyam Cox <Vaelatern@voidlinux.org>"
 license="CDDL-1.0"
 homepage="https://openzfs.github.io/openzfs-docs/"
 distfiles="https://github.com/openzfs/zfs/releases/download/zfs-${version}/zfs-${version}.tar.gz"
-checksum=c17b69770f0023154f578eb8c7536a70f07d6a3bb0bd38f04fa0e8811c3c1390
+checksum=7e260d0e6af295bea4c5e241cac0a1aef07b58d8dd8035f7898ade3b1bbec78f
 # dkms must be before initramfs-regenerate to build modules before images
 triggers="dkms initramfs-regenerate"
 dkms_modules="zfs ${version}"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

Both `zfs` and `zfs-lts` produce a working userland and kernel modules on x86_64/glibc hosts.