### PR TITLE
tree-sitter: update to 0.26.8.

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -4206,7 +4206,7 @@ libsword-1.9.0.so libsword-1.9.0_1
 libgivaro.so.9 givaro-4.1.1_1
 liblinbox.so.0 linbox-1.6.3_1
 libpari-gmp-tls.so.9 pari-2.17.0_1
-libtree-sitter.so.0.25 tree-sitter-0.25.2_1
+libtree-sitter.so.0.26 tree-sitter-0.26.8_1
 libplanarity.so.2 planarity-4.0.0.0_1
 libgap.so.10 gap-4.15.1_1
 libgtkdatabox.so.1 gtkdatabox3-1.0.0_1

--- a/srcpkgs/neovim/template
+++ b/srcpkgs/neovim/template
@@ -1,7 +1,7 @@
 # Template file for 'neovim'
 pkgname=neovim
 version=0.12.2
-revision=1
+revision=2
 build_style=cmake
 build_helper="qemu"
 configure_args="-DCOMPILE_LUA=OFF -DENABLE_TRANSLATIONS=ON -DPREFER_LUA=$(vopt_if luajit OFF ON)"

--- a/srcpkgs/rizin/template
+++ b/srcpkgs/rizin/template
@@ -3,7 +3,7 @@
 # Rebuild cutter on update
 pkgname=rizin
 version=0.7.3
-revision=5
+revision=6
 build_style=meson
 configure_args="-D use_sys_capstone=enabled -D use_capstone_version=v5
  -D use_sys_magic=enabled -D use_sys_libzip=enabled -D use_sys_zlib=enabled

--- a/srcpkgs/tree-sitter/template
+++ b/srcpkgs/tree-sitter/template
@@ -1,16 +1,17 @@
 # Template file for 'tree-sitter'
 pkgname=tree-sitter
-version=0.25.10
-revision=2
+version=0.26.8
+revision=1
 build_style=cargo
-make_install_args="--path=cli"
+hostmakedepends="clang"
+make_install_args="--path=crates/cli"
 short_desc="Parser generator tool and incremental parsing library"
 maintainer="Érico Nogueira <ericonr@disroot.org>"
 license="MIT"
 homepage="https://tree-sitter.github.io"
 changelog="https://github.com/tree-sitter/tree-sitter/releases"
 distfiles="https://github.com/tree-sitter/tree-sitter/archive/refs/tags/v${version}.tar.gz"
-checksum=ad5040537537012b16ef6e1210a572b927c7cdc2b99d1ee88d44a7dcdc3ff44c
+checksum=e6826b7533ec3a885aba598377a6d20b5a6321ff3db76968e960c2352d3a5077
 make_check=no # tests require generating fixtures from remote repositories
 
 post_build() {


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, `aarch64-glibc`
