### PR TITLE
lua-language-server: update to 3.18.2.

### DIFF
--- a/srcpkgs/lua-language-server/template
+++ b/srcpkgs/lua-language-server/template
@@ -1,6 +1,6 @@
 # Template file for 'lua-language-server'
 pkgname=lua-language-server
-version=3.17.0
+version=3.18.2
 revision=1
 hostmakedepends="ninja"
 short_desc="Lua LSP implementation written in Lua"
@@ -9,7 +9,7 @@ license="MIT"
 homepage="https://luals.github.io"
 changelog="https://raw.githubusercontent.com/LuaLS/lua-language-server/master/changelog.md"
 distfiles="https://github.com/LuaLS/lua-language-server/releases/download/${version}/lua-language-server-${version}-submodules.zip"
-checksum=a5d77d6092fe3776c2ca51fc6dd25d1c0e5f407310f78b606e05917ebbd5488c
+checksum=cfb54fdf1d812e284477cb2e2d68a40de8b1c33e68e9073dd5d9d83165d97b33
 
 do_build() {
 	ninja -C 3rd/luamake -f compile/ninja/linux.ninja


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, `aarch64-glibc`
