### PR TITLE
ccache: update to 4.13.6.

### DIFF
--- a/srcpkgs/ccache/template
+++ b/srcpkgs/ccache/template
@@ -1,6 +1,6 @@
 # Template file for 'ccache'
 pkgname=ccache
-version=4.13.5
+version=4.13.6
 revision=1
 build_style=cmake
 configure_args="-DENABLE_TESTING=OFF -DREDIS_STORAGE_BACKEND=OFF
@@ -13,8 +13,8 @@ homepage="https://ccache.dev"
 changelog="https://ccache.dev/releasenotes.html"
 distfiles="https://github.com/ccache/ccache/releases/download/v${version}/ccache-${version}.tar.xz
  https://github.com/ccache/ccache/releases/download/v${version}/ccache-${version}-linux-x86_64-glibc.tar.xz"
-checksum="7a8945f4ac7d4bb79c0055cd3db7857a6934c2b7ab3d80bb11a0f5271e36fd94
- ebef319603ba3c4c8c8a8e77f46257b9fb1dc077d6385f7b348a547399bc7f45"
+checksum="a7de667ca08cf67c3c8af9f213f6aa701a1188a2b3163fb74483858ce5e79fbb
+ 508b2a1217dc6e04a23e967c7b95a0fb45d8a7e16fde9e180919698f2e2be060"
 
 
 if [ -n "$XBPS_CHECK_PKGS" ]; then


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds): armv6l