### PR TITLE
linux-asahi: move out of boot

### DIFF
--- a/srcpkgs/linux-asahi/INSTALL.msg
+++ b/srcpkgs/linux-asahi/INSTALL.msg
@@ -1,0 +1,1 @@
+You must set `xbps-alternatives -s m1n1`.

--- a/srcpkgs/linux-asahi/template
+++ b/srcpkgs/linux-asahi/template
@@ -101,11 +101,11 @@ do_install() {
 
 	hdrdest=${DESTDIR}/usr/src/kernel-headers-${_kernver}
 
-	vinstall .config 644 boot config-${_kernver}
-	vinstall System.map 644 boot System.map-${_kernver}
+	vinstall .config 644 usr/lib/modules/${_kernver} config
+	vinstall System.map 644 usr/lib/modules/${_kernver} System.map
 
-	vinstall arch/arm64/boot/Image 644 boot vmlinux-${_kernver}
-	make ${makejobs} ARCH=${arch} INSTALL_DTBS_PATH=${DESTDIR}/boot/dtbs/dtbs-${_kernver} ${_cross} dtbs_install
+	vinstall arch/arm64/boot/Image 644 usr/lib/modules/${_kernver} vmlinux
+	make ${makejobs} ARCH=${arch} INSTALL_DTBS_PATH=${DESTDIR}/usr/lib/modules/${_kernver}/dtbs ${_cross} dtbs_install
 
 	# Switch to /usr.
 	vmkdir usr
@@ -262,6 +262,6 @@ linux-asahi-dbg_package() {
 	short_desc+=" - debugging symbols"
 	pkg_install() {
 		vmove usr/lib/debug
-		vmove "boot/System.map-${_kernver}"
+		vmove "usr/lib/modules/${_kernver}/System.map"
 	}
 }

--- a/srcpkgs/m1n1/files/kernel.d/m1n1.post-install
+++ b/srcpkgs/m1n1/files/kernel.d/m1n1.post-install
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Kernel hook for m1n1, taken from update-m1n1 and efibootmgr.
+# Kernel post-install hook for m1n1, taken from update-m1n1 and efibootmgr.
 #
 # Arguments passed to this script: $1 pkgname, $2 version.
 
@@ -33,15 +33,21 @@ if [ -e "$CONFIG" ]; then
 	done <$CONFIG
 fi
 
+${INITRAMFS_CMD} && echo "initramfs created in ${BOOT}"
+
 case "$PAYLOAD" in
 	kernel)
 		cat "${M1N1}" $m1n1config >"${TARGET}.new"
 		cat ${DTBS} >>"${TARGET}.new"
 		gzip -c "${BOOT}/initramfs-${VERSION}.img" >>"${TARGET}.new"
-		gzip -c "${BOOT}/vmlinux-${VERSION}" >>"${TARGET}.new"
-		echo "Payload: m1n1 config dtbs initram kernel"
+		gzip -c "${MODULE_DIR}/vmlinux" >>"${TARGET}.new"
+		echo "Payload: m1n1 config dtbs initramfs kernel"
+		rm -f "${BOOT}/initramfs-${VERSION}.img"
 	;;
 	uboot)
+		cp -a "${MODULE_DIR}/vmlinux" "${BOOT}/vmlinux-${VERSION}"
+		cp -a "${MODULE_DIR}/config" "${BOOT}/config-${VERSION}"
+		echo "kernel and config copied into ${BOOT}"
 		cat "${M1N1}" ${DTBS} >"${TARGET}.new"
 		gzip -c "${U_BOOT}" >>"${TARGET}.new"
 		cat $m1n1config >>"${TARGET}.new"

--- a/srcpkgs/m1n1/files/kernel.d/m1n1.post-remove
+++ b/srcpkgs/m1n1/files/kernel.d/m1n1.post-remove
@@ -1,0 +1,17 @@
+#!/bin/sh
+#
+# Kernel post-remove hook for m1n1.
+#
+# Arguments passed to this script: $1 pkgname, $2 version.
+#
+
+set -e
+
+PKGNAME="$1"
+VERSION="$2"
+
+[ -e "${ROOTDIR}/etc/default/m1n1-kernel-hook" ] && . "${ROOTDIR}/etc/default/m1n1-kernel-hook"
+
+[ -e "${BOOT}/initramfs-${VERSION}.img" ] && rm -f ${BOOT}/initramfs-${VERSION}.img
+[ -e "${BOOT}/vmlinux-${VERSION}.img" ] && rm -f ${BOOT}/vmlinux-${VERSION}.img
+[ -e "${BOOT}/config-${VERSION}.img" ] && rm -f ${BOOT}/config-${VERSION}.img

--- a/srcpkgs/m1n1/files/m1n1-kernel-hook.confd
+++ b/srcpkgs/m1n1/files/m1n1-kernel-hook.confd
@@ -1,11 +1,17 @@
 CONFIG=/etc/m1n1.conf
 # payload can be either kernel or uboot (default)
 PAYLOAD=uboot
-# location where kernel, initramfs, dtbs are located
-BOOT=/boot
-DTBS=${BOOT}/dtbs/"dtbs-${VERSION}"/apple/*.dtb
-U_BOOT=/usr/lib/asahi-boot/u-boot-nodtb.bin
-M1N1=/usr/lib/asahi-boot/m1n1.bin
-# location in ESP where m1n1 payload is put
-M1N1_T=/boot/efi/m1n1
+# location of copied kernel and initramfs
+BOOT=boot
+# location of kernel and dtbs
+MODULE_DIR=usr/lib/modules/${VERSION}
+DTBS=${MODULE_DIR}/dtbs/apple/*.dtb
+U_BOOT=usr/lib/asahi-boot/u-boot-nodtb.bin
+M1N1=usr/lib/asahi-boot/m1n1.bin
+# location of m1n1 payload
+M1N1_T=boot/efi/m1n1
 TARGET=${M1N1_T}/boot.bin
+# initramfs generator (must use a supported one)
+INITRAMFS_CMD="usr/bin/dracut --force ${BOOT}/initramfs-${VERSION}.img ${VERSION}"
+# INITRAMFS_CMD="usr/bin/tinyramfs -f -k ${VERSION} ${BOOT}/initramfs-${VERSION}.img"
+# INITRAMFS_CMD="usr/bin/mkinitcpio -g ${BOOT}/initramfs-${VERSION}.img -k ${VERSION}"

--- a/srcpkgs/m1n1/template
+++ b/srcpkgs/m1n1/template
@@ -1,7 +1,7 @@
 # Template file for 'm1n1'
 pkgname=m1n1
 version=1.5.2
-revision=1
+revision=2
 archs="aarch64*"
 hostmakedepends="ImageMagick void-artwork"
 short_desc="Asahi Linux bootloader"
@@ -11,6 +11,10 @@ homepage="https://asahilinux.org"
 distfiles="https://github.com/AsahiLinux/m1n1/archive/refs/tags/v${version}.tar.gz"
 checksum=01d4c8a75999ab388f9e3d87245f041c195f05e068237b6918435368afd3db99
 conf_files="/etc/m1n1.conf /etc/default/m1n1-kernel-hook"
+alternatives="
+ initramfs:/etc/kernel.d/post-install/20-m1n1:/usr/libexec/m1n1/kernel-hook-postinst
+ initramfs:/etc/kernel.d/post-remove/20-m1n1:/usr/libexec/m1n1/kernel-hook-postremove
+"
 
 pre_build() {
 	for size in 128 256; do
@@ -30,5 +34,6 @@ post_install() {
 	vlicense LICENSE
 	vinstall m1n1.conf.example 644 etc m1n1.conf
 	vinstall ${FILESDIR}/m1n1-kernel-hook.confd 644 etc/default m1n1-kernel-hook
-	vinstall ${FILESDIR}/kernel.d/m1n1.post-install 744 etc/kernel.d/post-install 50-m1n1
+	vinstall ${FILESDIR}/kernel.d/m1n1.post-install 755 usr/libexec/m1n1 kernel-hook-postinst
+	vinstall ${FILESDIR}/kernel.d/m1n1.post-remove 755 usr/libexec/m1n1 kernel-hook-postremove
 }


### PR DESCRIPTION
- I tested the changes in this PR: yes
- I built this PR locally for my native architecture, (aarch64-glibc)

The move out of `/boot` requires changes to `mkimage` and docs.

[ci skip] as this is hooks.