### PR TITLE
goldendict-ng: update to 26.5.5

### DIFF
--- a/srcpkgs/goldendict-ng/template
+++ b/srcpkgs/goldendict-ng/template
@@ -1,8 +1,7 @@
 # Template file for 'goldendict-ng'
 pkgname=goldendict-ng
-version=26.5.1
+version=26.5.5
 revision=1
-_version_tag=Release.9973c461
 build_style=cmake
 configure_args="-DUSE_ALTERNATIVE_NAME=ON -DWITH_TTS=OFF"
 hostmakedepends="pkg-config qt6-declarative-host-tools qt6-tools"
@@ -15,8 +14,8 @@ short_desc="Feature-rich dictionary lookup program (goldendict fork)"
 maintainer="Mateusz Sylwestrzak <slymattz@gmail.com>"
 license="GPL-3.0-or-later"
 homepage="https://xiaoyifang.github.io/goldendict-ng/"
-distfiles="https://github.com/xiaoyifang/goldendict-ng/archive/refs/tags/v${version}-${_version_tag}.tar.gz"
-checksum=3031575d7754badabfa0b48729b3dd3765564a16f6f93383445fb89e4029518c
+distfiles="https://github.com/xiaoyifang/goldendict-ng/archive/refs/tags/v${version}.tar.gz"
+checksum=ddf5487759476eb6b8b3f10161be8ece41b63185d4a789690898d722b28e0f03
 
 if [ "$XBPS_WORDSIZE$XBPS_WORDSIZE" != "64$XBPS_TARGET_WORDSIZE" ]; then
 	broken="Qt6 WebEngine"


### PR DESCRIPTION

#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture: x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x64_64-musl
