### PR TITLE
python3-pynitrokey: update to 0.12.2

### DIFF
--- a/srcpkgs/python3-click-aliases/template
+++ b/srcpkgs/python3-click-aliases/template
@@ -1,7 +1,7 @@
 # Template file for 'python3-click-aliases'
 pkgname=python3-click-aliases
-version=1.0.5
-revision=2
+version=1.0.6
+revision=1
 build_style=python3-pep517
 hostmakedepends="python3-poetry-core python3-wheel"
 depends="python3-click"
@@ -10,7 +10,7 @@ maintainer="Mateusz Sylwestrzak <slymattz@gmail.com>"
 license="MIT"
 homepage="https://github.com/click-contrib/click-aliases"
 distfiles="${PYPI_SITE}/c/click_aliases/click_aliases-${version}.tar.gz"
-checksum=e37d4cabbaad68e1c48ec0f063a59dfa15f0e7450ec901bd1ce4f4b954bc881d
+checksum=9372e58d00aa146f0d235e4e5e8bd280e84fe78e52db5fd80eacb14ecdf2e0d4
 
 post_install() {
 	vlicense LICENSE

--- a/srcpkgs/python3-pynitrokey/template
+++ b/srcpkgs/python3-pynitrokey/template
@@ -1,23 +1,23 @@
 # Template file for 'python3-pynitrokey'
 pkgname=python3-pynitrokey
-version=0.12.1
+version=0.12.2
 revision=1
 build_style=python3-pep517
 hostmakedepends="python3-poetry-core"
 depends="python3-cffi python3-click
- python3-click-aliases python3-semver python3-libusb1
- python3-crcmod python3-hidapi python3-pyserial
+ python3-semver python3-libusb1
+ python3-hidapi python3-pyserial
  python3-cryptography python3-fido2
  python3-usb python3-requests python3-intelhex
- python3-nkdfu python3-nitrokey python3-protobuf
+ python3-nkdfu python3-nitrokey
  python3-nethsm python3-pyscard libnitrokey
- python3-tqdm python3-tlv8 python3-chardet"
+ python3-tqdm python3-tlv8"
 short_desc="CLI for the Nitrokey FIDO2, Nitrokey Start, Nitrokey 3 and NetHSM"
 maintainer="Mateusz Sylwestrzak <slymattz@gmail.com>"
 license="LGPL-3.0-only OR GPL-3.0-or-later OR Apache-2.0 OR MIT"
 homepage="https://github.com/Nitrokey/pynitrokey"
 distfiles="https://github.com/Nitrokey/pynitrokey/archive/refs/tags/v${version}.tar.gz"
-checksum=e6d4e0ead72571603ce54e08a1bb1ed21bf15369137773c8ee6e6f562687f560
+checksum=1fedf0568eb5323108684a12bbd221a746ae0d325ef20251a93925d920ee9d50
 
 post_install() {
 	vlicense LICENSES/MIT.txt


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

python3-click-aliases has been deprecated upstream.
python3-crcmod and python3-protobuf are explicitly required by python3-nitrokey (a runtime dep of pynitrokey.)
python3-chardet is not required by this package.

#### Local build testing
- I built this PR locally for my native architecture: x86_64-glibc
