### PR TITLE
update_check: auto-prefix refs/tags/ for info/refs patterns; adapt 101 update files

### DIFF
--- a/Manual.md
+++ b/Manual.md
@@ -913,6 +913,14 @@ file in the same directory as the relevant `template` file:
   mentioned.  If unset, defaults to `homepage` and the directories where
 `distfiles` reside.
 
+- `distfiles_only` if set to `yes`, the package homepage is excluded
+  from the URLs scanned for version detection.  Only the directories
+  derived from `distfiles` (and any URL set via `site`) are checked.
+  This is useful when a custom `pattern` is tuned for a specific
+  endpoint format (such as a git forge's `info/refs`) and would
+  produce spurious matches against unrelated numbers appearing in the
+  homepage HTML.
+
 - `pkgname` is the package name the default pattern checks for.
 If unset, defaults to `pkgname` from the template.
 
@@ -943,6 +951,51 @@ in url. Defaults to `(|\.x)`.
 - `disabled` can be set to disable update checking for the package,
 in cases where checking for updates is impossible or does not make sense.
 This should be set to a string describing why it is disabled.
+
+#### Git forge endpoints
+
+When `update_check.sh` scans URLs against a git forge's `info/refs`
+endpoint (used automatically for `github.com`, `gitlab.*`,
+`bitbucket.org`, `codeberg.org`, and `git.sr.ht` URLs), custom
+`pattern` entries may omit the `refs/tags/` prefix; it is auto-prefixed
+when not already present.  For example, these two patterns are
+equivalent for a GitHub-hosted package:
+
+	pattern='refs/tags/vulkan-sdk-\K[\d.]+'
+	pattern='vulkan-sdk-\K[\d.]+'
+
+The second form is preferred: it keeps the pattern focused on the
+package-specific tag convention rather than restating the endpoint
+format.
+
+This auto-prefixing only applies when the URL contains `info/refs`;
+patterns used against URLs set explicitly via `site` are matched
+as-written.
+
+#### Choosing between `site`, `distfiles_only` and the default behavior
+
+Most packages need neither `site` nor `distfiles_only`: the default
+behavior of scanning the homepage and distfiles directories works
+well when the `pattern` (or the default regex) has a strong anchor
+that won't match unrelated content.
+
+Use `distfiles_only=yes` when:
+
+- A custom `pattern` is specific enough to detect versions on the
+  distfiles URL, but matches unrelated numbers when applied to the
+  package homepage.
+
+Use `site=URL` when:
+
+- The version cannot be detected from `homepage` or `distfiles`
+  directories alone (e.g., upstream lists versions on a separate
+  release page).
+- One of the URLs in `distfiles` is a secondary file (such as a
+  pkg-config template fetched from `raw.githubusercontent.com`) that
+  produces unwanted matches independently of the homepage.
+- A non-standard `info/refs` endpoint must be targeted (e.g., a
+  self-hosted forge whose URL doesn't match the automatic patterns
+  above).
 
 <a id="patches"></a>
 ### Handling patches

--- a/common/xbps-src/shutils/update_check.sh
+++ b/common/xbps-src/shutils/update_check.sh
@@ -43,7 +43,7 @@ update_check() {
             *ftp.gnome.org*|*download.gnome.org*) ;;
             *archive.xfce.org*) ;;
             *)
-                printf '%s\n' "$homepage" ;;
+                [ "$distfiles_only" = yes ] || printf '%s\n' "$homepage" ;;
         esac
         for i in $distfiles; do
             printf '%s\n' "${i%/*}/"

--- a/common/xbps-src/shutils/update_check.sh
+++ b/common/xbps-src/shutils/update_check.sh
@@ -216,6 +216,13 @@ update_check() {
         rx=${pattern:-$rx}
         rx=${rx:-'(?<!-)\b\Q'"$pkgname"'\E[-_]?((src|source)[-_])?v?\K([^-/_\s]*?\d[^-/_\s]*?)(?=(?:[-_.](?:src|source|orig))?\.(?:[jt]ar|shar|t[bglx]z|tbz2|zip))\b'}
 
+        # When using a git forge's info/refs endpoint, custom patterns may
+        # omit the refs/tags/ anchor for brevity. Auto-prefix it if absent.
+        if [ -n "$pattern" ] && [[ "$url" == *info/refs* ]] && [[ "$rx" != refs/tags/* ]]; then
+            msg_verbose "auto-prefixing refs/tags/ to custom pattern\n"
+            rx="refs/tags/$rx"
+        fi
+
         if [ "${fetchedurls[$url]}" ]; then
             msg_verbose "already fetched $url\n"
             continue

--- a/srcpkgs/CImg/update
+++ b/srcpkgs/CImg/update
@@ -1,1 +1,1 @@
-pattern="/archive/refs/tags/v.\K[\d.]+(?=\.tar\.gz)"
+pattern="v\.\K\d+\.[\d.]+"

--- a/srcpkgs/EternalTerminal/update
+++ b/srcpkgs/EternalTerminal/update
@@ -1,1 +1,1 @@
-pattern='/archive/refs/tags/et-v?\K[\d\.]+(?=\.tar\.gz")'
+pattern="et-v?\K[\d.]+"

--- a/srcpkgs/ImageMagick/update
+++ b/srcpkgs/ImageMagick/update
@@ -1,1 +1,2 @@
-pattern='/archive/refs/tags/\K[\d\.]+-\d+(?=\.tar\.gz)'
+distfiles_only=yes
+pattern="\K[\d.]+-\d+"

--- a/srcpkgs/Lucene++/update
+++ b/srcpkgs/Lucene++/update
@@ -1,1 +1,1 @@
-pattern="rel_\K[\d.]+(?=\.tar\.gz)"
+pattern="rel_\K[\d.]+"

--- a/srcpkgs/OpenSubdiv/update
+++ b/srcpkgs/OpenSubdiv/update
@@ -1,1 +1,3 @@
-pattern="v\K[\d_+]+(?=\.tar\.gz)"
+distfiles_only=yes
+pattern="v\K\d+(?:_\d+)*(_RC\d*)?"
+ignore="*RC*"

--- a/srcpkgs/SPIRV-Headers/update
+++ b/srcpkgs/SPIRV-Headers/update
@@ -1,1 +1,1 @@
-pattern="/vulkan-sdk-\K[0-9.]+(?=.tar.gz)"
+pattern="vulkan-sdk-\K[\d.]+"

--- a/srcpkgs/SPIRV-LLVM-Translator19/update
+++ b/srcpkgs/SPIRV-LLVM-Translator19/update
@@ -1,1 +1,1 @@
-pattern="/v\K19\.[0-9.]+(?=\.tar\.gz)"
+pattern="v\K19\.[\d.]+"

--- a/srcpkgs/SPIRV-LLVM-Translator21/update
+++ b/srcpkgs/SPIRV-LLVM-Translator21/update
@@ -1,1 +1,1 @@
-pattern="/v\K21\.[0-9.]+(?=\.tar\.gz)"
+pattern="v\K21\.[\d.]+"

--- a/srcpkgs/SPIRV-LLVM-Translator22/update
+++ b/srcpkgs/SPIRV-LLVM-Translator22/update
@@ -1,1 +1,1 @@
-pattern="/v\K22\.[0-9.]+(?=\.tar\.gz)"
+pattern="v\K22\.[\d.]+"

--- a/srcpkgs/SPIRV-Tools/update
+++ b/srcpkgs/SPIRV-Tools/update
@@ -1,1 +1,1 @@
-pattern="/v\K[0-9.]+(?=.tar.gz)"
+pattern="vulkan-sdk-\K[\d.]+"

--- a/srcpkgs/UEFITool/update
+++ b/srcpkgs/UEFITool/update
@@ -1,1 +1,2 @@
-pattern='/archive/refs/tags/(v?|UEFITool)?\K[A-Z\d.]+(?=\.tar\.gz")'
+distfiles_only=yes
+pattern="\K[A-Z\d.]+"

--- a/srcpkgs/Vulkan-Headers/update
+++ b/srcpkgs/Vulkan-Headers/update
@@ -1,1 +1,1 @@
-pattern="/vulkan-sdk-\K[0-9.]+(?=.tar.gz)"
+pattern="vulkan-sdk-\K[\d.]+"

--- a/srcpkgs/Vulkan-Tools/update
+++ b/srcpkgs/Vulkan-Tools/update
@@ -1,1 +1,1 @@
-pattern="/vulkan-sdk-\K[0-9.]+(?=.tar.gz)"
+pattern="vulkan-sdk-\K[\d.]+"

--- a/srcpkgs/Vulkan-Utility-Libraries/update
+++ b/srcpkgs/Vulkan-Utility-Libraries/update
@@ -1,1 +1,1 @@
-pattern="/vulkan-sdk-\K[0-9.]+(?=.tar.gz)"
+pattern="vulkan-sdk-\K[\d.]+"

--- a/srcpkgs/Vulkan-ValidationLayers/update
+++ b/srcpkgs/Vulkan-ValidationLayers/update
@@ -1,1 +1,1 @@
-pattern="/vulkan-sdk-\K[0-9.]+(?=.tar.gz)"
+pattern="vulkan-sdk-\K[\d.]+"

--- a/srcpkgs/asahi-uboot/update
+++ b/srcpkgs/asahi-uboot/update
@@ -1,1 +1,1 @@
-pattern='tags/asahi-v\K[\d.R-]+(?=\.tar\.gz)'
+pattern="asahi-v\K[\d.A-Za-z+-]+"

--- a/srcpkgs/atomicparsley/update
+++ b/srcpkgs/atomicparsley/update
@@ -1,2 +1,2 @@
+pattern="(v?|${pkgname}-)?\K[\d.a-f]+"
 version="${version}.${_commit}"
-pattern='/archive/refs/tags/(v?|\Qatomicparsley\E-)?\K[\d.a-f]+(?=\.tar\.gz")'

--- a/srcpkgs/cgal/update
+++ b/srcpkgs/cgal/update
@@ -1,1 +1,2 @@
-pattern="releases/CGAL-\K[\d\.]*(?=\.tar\.gz)"
+pattern="v\K[\d.]+(-beta\d*)?"
+ignore="*beta*"

--- a/srcpkgs/cronutils/update
+++ b/srcpkgs/cronutils/update
@@ -1,1 +1,1 @@
-pattern="/archive/refs/tags/version/\K[\d.]+(?=\.tar\.gz)"
+pattern="version/\K[\d.]+"

--- a/srcpkgs/discount/update
+++ b/srcpkgs/discount/update
@@ -1,1 +1,1 @@
-pattern='v\K[\d.a-z]+(?=\.tar\.gz")'
+pattern="v\K[\d.a-z]+"

--- a/srcpkgs/eigen3.2/update
+++ b/srcpkgs/eigen3.2/update
@@ -1,2 +1,3 @@
-pattern='eigen/get/\K[\d.]+(?=.tar.bz2)'
-ignore="3.3.*"
+distfiles_only=yes
+pattern="\K[\d.]+"
+ignore="3.[3-9]* [4-9]*"

--- a/srcpkgs/faac/update
+++ b/srcpkgs/faac/update
@@ -1,1 +1,2 @@
-pattern='/archive/refs/tags/(v?|\Q${pkgname}\E-)?\K[\d\._]+(?=\.tar\.gz")'
+distfiles_only=yes
+pattern="(v?|${pkgname}-)?\K[\d._]+"

--- a/srcpkgs/faad2/update
+++ b/srcpkgs/faad2/update
@@ -1,2 +1,3 @@
-pattern='/archive/refs/tags/(v?|\Q${pkgname}\E-)?\K[\d\._]+(?=\.tar\.gz")'
+distfiles_only=yes
+pattern="(v?|${pkgname}-)?\K[\d._]+"
 ignore="2003*"

--- a/srcpkgs/flintlib/update
+++ b/srcpkgs/flintlib/update
@@ -1,4 +1,5 @@
-pattern="/archive/refs/tags/v?\K[\d.]+(-(p|rc)[0-9]+)?(?=\.tar\.gz)"
+distfiles_only=yes
+pattern="v?\K[\d.]+(-(p|rc)[0-9]+)?"
 version=${version/+/.}
 if [[ "$version" != *rc* ]]; then
 	ignore=*rc*

--- a/srcpkgs/fntsample/update
+++ b/srcpkgs/fntsample/update
@@ -1,1 +1,1 @@
-pattern='/archive/refs/tags/(release/|v?|\Q'"$pkgname"'\E-)?\K[\d\.]+(?=\.tar\.gz")'
+pattern="release/\K[\d.]+"

--- a/srcpkgs/font-adobe-source-code-pro/update
+++ b/srcpkgs/font-adobe-source-code-pro/update
@@ -1,1 +1,2 @@
-pattern='(?!archive/refs/tags/)[0-9.]+(?=R?-[0-9./VARuivfr-]+[.]tar[.]gz)'
+distfiles_only=yes
+pattern="\K[\d.]+"

--- a/srcpkgs/gdmd/update
+++ b/srcpkgs/gdmd/update
@@ -1,1 +1,1 @@
-pattern='(?<=script-)[0-9.]*(?=.tar.gz)'
+pattern="script-\K[\d.]+"

--- a/srcpkgs/gnome-epub-thumbnailer/update
+++ b/srcpkgs/gnome-epub-thumbnailer/update
@@ -1,1 +1,1 @@
-pattern="\Q$pkgname\E-\K[0-9.]+(?=\.tar)"
+pattern="${pkgname}-\K[0-9.]+"

--- a/srcpkgs/godot/update
+++ b/srcpkgs/godot/update
@@ -1,1 +1,1 @@
-pattern='/archive/refs/tags/(v?|\Q'"$pkgname"'\E-)?\K[\d\.]+(?=-stable\.tar\.gz")'
+pattern="(v?|${pkgname}-)?\K[\d.]+(?=-stable)"

--- a/srcpkgs/gopls/update
+++ b/srcpkgs/gopls/update
@@ -1,1 +1,2 @@
-pattern='/archive/refs/tags/\Q'"$pkgname"'\E/v\K[\d\.]+(?=\.tar\.gz")'
+pattern="${pkgname}/v\K[\d.]+(-pre\.[0-9]+)?"
+ignore="*pre*"

--- a/srcpkgs/gzdoom/update
+++ b/srcpkgs/gzdoom/update
@@ -1,1 +1,2 @@
-pattern='/archive/refs/tags/(g|v?|\Q'"$pkgname"'\E-)?\K[\d\.]+(?=\.tar\.gz")'
+pattern="g\K[\d.]+(pre)?"
+ignore="*pre*"

--- a/srcpkgs/incron/update
+++ b/srcpkgs/incron/update
@@ -1,1 +1,1 @@
-pattern="${pkgname}-\K[\d.]+(?=\.tar.bz2)"
+pattern="incron-\K[\d.]+"

--- a/srcpkgs/inih/update
+++ b/srcpkgs/inih/update
@@ -1,1 +1,1 @@
-pattern='/r\K[\d.]+(?=.tar.gz)'
+pattern="r\K[\d.]+"

--- a/srcpkgs/intel-ucode/update
+++ b/srcpkgs/intel-ucode/update
@@ -1,1 +1,1 @@
-pattern="microcode-\K[0-9]+(?=.tar)"
+pattern="microcode-\K[\d]+"

--- a/srcpkgs/inxi/update
+++ b/srcpkgs/inxi/update
@@ -1,2 +1,2 @@
-pattern="/archive/\K[\d.]+(?=[0-9a-z-]+\.tar\.gz)"
-version=${version%\.*}
+distfiles_only=yes
+pattern="\K[\d.]+"

--- a/srcpkgs/iverilog/update
+++ b/srcpkgs/iverilog/update
@@ -1,1 +1,2 @@
-pattern='/archive/refs/tags/(v?|\Q'"$pkgname"'\E-)?\K[\d\_]+(?=\.tar\.gz")'
+distfiles_only=yes
+pattern="(v?|${pkgname}-)?\K[\d_]+"

--- a/srcpkgs/j4-dmenu-desktop/update
+++ b/srcpkgs/j4-dmenu-desktop/update
@@ -1,1 +1,2 @@
-pattern='/archive/refs/tags/(v?|\Q'"$pkgname"'\E-)?r\K[\d\.]+(?=\.tar\.gz")'
+pattern="r\K[\d.]+(-(rc|beta)[0-9]*)?"
+ignore="*rc* *beta*"

--- a/srcpkgs/kodi/update
+++ b/srcpkgs/kodi/update
@@ -1,1 +1,2 @@
-pattern="\d+\.[\d.]+(?=-\w+\.tar\.gz)"
+distfiles_only=yes
+pattern="\K\d+\.[\d.]+(?=-\w+)"

--- a/srcpkgs/lf/update
+++ b/srcpkgs/lf/update
@@ -1,1 +1,1 @@
-pattern='archive/refs/tags/\Kr[0-9]+(?=\.tar.gz)'
+pattern="\Kr[\d.]+"

--- a/srcpkgs/libaccounts-qt/update
+++ b/srcpkgs/libaccounts-qt/update
@@ -1,1 +1,2 @@
-pattern='/archive/[^/]+/'"$pkgname"'?-VERSION_\K[\d\.]+(?=\.tar\.gz")'
+distfiles_only=yes
+pattern="VERSION_\K[\d.]+"

--- a/srcpkgs/libblockdev/update
+++ b/srcpkgs/libblockdev/update
@@ -1,1 +1,2 @@
-pattern="\K[\d\.]*(?=-1\.tar\.gz)"
+distfiles_only=yes
+pattern="\K[\d.]+"

--- a/srcpkgs/libcgroup/update
+++ b/srcpkgs/libcgroup/update
@@ -1,1 +1,2 @@
-pattern="${pkgname}-v?\K[\d.]+(?=\.tar)"
+distfiles_only=yes
+pattern="v?\K[\d.]+"

--- a/srcpkgs/libeot/update
+++ b/srcpkgs/libeot/update
@@ -1,1 +1,2 @@
-pattern="(?<=v)[0-9][0-9.]+(?=.tar)|(?<=libeot-)[0-9][0-9.]+(?=.tar)"
+site="https://github.com/umanwizard/libeot/info/refs?service=git-upload-pack"
+pattern="v\K[\d.]+"

--- a/srcpkgs/libgit2-1.8/update
+++ b/srcpkgs/libgit2-1.8/update
@@ -1,1 +1,1 @@
-pattern="v\K1\.8\.[\d.]+(?=\.tar\.gz)"
+pattern="v\K1\.8\.[\d.]+"

--- a/srcpkgs/libgit2-1.9/update
+++ b/srcpkgs/libgit2-1.9/update
@@ -1,1 +1,1 @@
-pattern="v\K1\.9\.[\d.]+(?=\.tar\.gz)"
+pattern="v\K1\.9\.[\d.]+"

--- a/srcpkgs/libgme/update
+++ b/srcpkgs/libgme/update
@@ -1,1 +1,2 @@
-pattern="game-music-emu-\K[\d.]+"
+distfiles_only=yes
+pattern="\K[\d.]+"

--- a/srcpkgs/libhomfly/update
+++ b/srcpkgs/libhomfly/update
@@ -1,1 +1,2 @@
-pattern='/archive/refs/tags/\K[\d.r]+(?=\.tar\.gz")'
+distfiles_only=yes
+pattern="\K[\d.r]+"

--- a/srcpkgs/libkeybinder3/update
+++ b/srcpkgs/libkeybinder3/update
@@ -1,1 +1,1 @@
-pattern='/archive/refs/tags/(keybinder-3.0-v|v?|\Q'"$pkgname"'\E-)?\K[\d\.]+(?=\.tar\.gz")'
+pattern="keybinder-3.0-v\K[\d.]+"

--- a/srcpkgs/libluv/update
+++ b/srcpkgs/libluv/update
@@ -1,1 +1,2 @@
-pattern='/archive/refs/tags/(v?|\Q'"$pkgname"'\E-)?\K[-\d\.]+(?=\.tar\.gz")'
+site="https://github.com/luvit/luv/info/refs?service=git-upload-pack"
+pattern="(v?|${pkgname}-)?\K[-\d.]+"

--- a/srcpkgs/libmygui/update
+++ b/srcpkgs/libmygui/update
@@ -1,2 +1,2 @@
 pkgname=MyGUI
-pattern='/archive/refs/tags/(v?|\Q'"$pkgname"'\E)?\K[\d\.]+(?=\.tar\.gz")'
+pattern="(v?|${pkgname})?\K[\d.]+"

--- a/srcpkgs/libui/update
+++ b/srcpkgs/libui/update
@@ -1,1 +1,2 @@
-pattern='/libui/archive/refs/tags/\K[a-z]+[\d+.]+(?=.tar.gz)'
+distfiles_only=yes
+pattern="\K[a-z]+[\d.]+"

--- a/srcpkgs/libvidstab/update
+++ b/srcpkgs/libvidstab/update
@@ -1,1 +1,1 @@
-pattern='tag/release-\K.*(?=")'
+pattern="v\K[\d.]+"

--- a/srcpkgs/lilypond-doc/update
+++ b/srcpkgs/lilypond-doc/update
@@ -1,2 +1,3 @@
-version="${version}-1"
-pattern="lilypond-\K[\d.-]+(?=.documentation)"
+distfiles_only=yes
+pattern="v\K[\d.]+"
+ignore="2.27*"

--- a/srcpkgs/linux-asahi/update
+++ b/srcpkgs/linux-asahi/update
@@ -1,1 +1,1 @@
-pattern='tags/asahi-\K[\d.-]+(?=\.tar\.gz)'
+pattern="asahi-\K${version%%.*}\.[\d.A-Za-z+-]+"

--- a/srcpkgs/liteide/update
+++ b/srcpkgs/liteide/update
@@ -1,1 +1,1 @@
-pattern='/archive/refs/tags/(x|v?|\Q'"$pkgname"'\E-)?\K[\d\.]+(?=\.tar\.gz")'
+pattern="x\K[\d.]+"

--- a/srcpkgs/lm_sensors/update
+++ b/srcpkgs/lm_sensors/update
@@ -1,1 +1,1 @@
-pattern='V\K[\d-]+(?=</a>)'
+pattern="V\K[\d-]+"

--- a/srcpkgs/lmdb/update
+++ b/srcpkgs/lmdb/update
@@ -1,1 +1,1 @@
-pattern='LMDB_\K[\d.]+(?=\.tar)'
+pattern="LMDB_\K[\d.]+"

--- a/srcpkgs/love/update
+++ b/srcpkgs/love/update
@@ -1,1 +1,2 @@
-pattern='/(get|downloads)/(v?|\Q'"$pkgname"'\E-)?\K[\d\.]+(?=(-linux-src)?\.tar)'
+distfiles_only=yes
+pattern="\K[\d.]+"

--- a/srcpkgs/lsyncd/update
+++ b/srcpkgs/lsyncd/update
@@ -1,1 +1,1 @@
-pattern="release-\K[\d\.]*(?=\.tar.gz)"
+pattern="release-\K[\d.]+"

--- a/srcpkgs/lua54-luafilesystem/update
+++ b/srcpkgs/lua54-luafilesystem/update
@@ -1,2 +1,2 @@
-pattern='/archive/refs/tags/(v?|\Q'"$pkgname"'\E-)?\K[\d._]+(?=\.tar\.gz")'
+pattern="(v?|${pkgname}-)?\K[\d._]+"
 version=${version//_/.}

--- a/srcpkgs/mame/update
+++ b/srcpkgs/mame/update
@@ -1,1 +1,1 @@
-pattern="${pkgname}\K\d+(?=\.tar)"
+pattern="mame\K\d+"

--- a/srcpkgs/mathjax2/update
+++ b/srcpkgs/mathjax2/update
@@ -1,1 +1,2 @@
-pattern='refs/tags/\K2[.][0-9.]*(?=.tar.gz)'
+distfiles_only=yes
+pattern="\K2\.[\d.]+"

--- a/srcpkgs/md4c/update
+++ b/srcpkgs/md4c/update
@@ -1,1 +1,1 @@
-pattern="release-\K[0-9.]+(?=.tar.gz)"
+pattern="release-\K[\d.]+"

--- a/srcpkgs/minio/update
+++ b/srcpkgs/minio/update
@@ -1,1 +1,1 @@
-pattern="/archive/refs/tags/RELEASE\.\K[-\d]+(?=T[-\d]+Z\.tar\.gz)"
+pattern="RELEASE\.\K[\d-]+"

--- a/srcpkgs/miruo/update
+++ b/srcpkgs/miruo/update
@@ -1,1 +1,1 @@
-pattern='/archive/refs/tags/(v?|\Q'"$pkgname"'\E-)?\K[\d\.]+[a-z]*(?=\.tar\.gz")'
+pattern="(v?|${pkgname}-)?\K[\d.]+[a-z]*"

--- a/srcpkgs/moosefs/update
+++ b/srcpkgs/moosefs/update
@@ -1,1 +1,2 @@
-pattern="$pkgname-\K[\d\.]*(?=\-1\.tar\.gz)"
+distfiles_only=yes
+pattern="v\K[\d.]+"

--- a/srcpkgs/openimageio/update
+++ b/srcpkgs/openimageio/update
@@ -1,1 +1,3 @@
-pattern="Release-\K[\d\.]+(?=\.tar)"
+distfiles_only=yes
+pattern="v\K[\d.]+(-dev)?"
+ignore="*dev*"

--- a/srcpkgs/openjdk8/update
+++ b/srcpkgs/openjdk8/update
@@ -1,1 +1,1 @@
-pattern='shenandoah\K8u[\db-]+(?=\.tar\.gz)'
+pattern="shenandoah\K8u[\db-]+"

--- a/srcpkgs/otfcc/update
+++ b/srcpkgs/otfcc/update
@@ -1,2 +1,2 @@
-pattern='/archive/refs/tags/(v?|\Q'"$pkgname"'\E-)?\K[-\d\.a-z]+(?=\.tar\.gz")'
+pattern="(v?|${pkgname}-)?\K[-\d.a-z]+"
 version="${version/alpha/.alpha}"

--- a/srcpkgs/pgbackrest/update
+++ b/srcpkgs/pgbackrest/update
@@ -1,1 +1,1 @@
-pattern='/archive/refs/tags/(v?|\Qrelease/\E)?\K[\d\.]+(?=\.tar\.gz")'
+pattern="release/\K[\d.]+"

--- a/srcpkgs/poedit/update
+++ b/srcpkgs/poedit/update
@@ -1,1 +1,1 @@
-pattern='/archive/refs/tags/(v?|\Q'"$pkgname"'\E-)?\K[\d\.]+(?=-oss\.tar\.gz")'
+pattern="(v?|${pkgname}-)?\K[\d.]+(?=-oss)"

--- a/srcpkgs/python3-aioamqp/update
+++ b/srcpkgs/python3-aioamqp/update
@@ -1,1 +1,1 @@
-pattern="${pkgname#*-}-\K[0-9.]*(?=.tar.gz)"
+pattern="aioamqp-\K[0-9.]+"

--- a/srcpkgs/python3-hypothesis/update
+++ b/srcpkgs/python3-hypothesis/update
@@ -1,2 +1,2 @@
 pkgname=hypothesis-python
-pattern="${pkgname}-\K[0-9.]+\.0(?=\.tar\.gz)"
+pattern="${pkgname}-\K[0-9.]+"

--- a/srcpkgs/python3-pyqtgraph/update
+++ b/srcpkgs/python3-pyqtgraph/update
@@ -1,1 +1,2 @@
-pattern='pyqtgraph-\K[\d.]+(?=")'
+distfiles_only=yes
+pattern="pyqtgraph-\K[\d.]+"

--- a/srcpkgs/re2/update
+++ b/srcpkgs/re2/update
@@ -1,1 +1,2 @@
-pattern="\K[\d\-]*([\d\-]+)(?=\.tar\.gz)"
+distfiles_only=yes
+pattern="\K[\d-]+"

--- a/srcpkgs/redshift/update
+++ b/srcpkgs/redshift/update
@@ -1,1 +1,2 @@
-pattern='Redshift \K[\d.]+'
+distfiles_only=yes
+pattern="v\K[\d.]+"

--- a/srcpkgs/redsocks/update
+++ b/srcpkgs/redsocks/update
@@ -1,1 +1,2 @@
-pattern="release-\K[\d.]*(?=\.tar\.gz)"
+distfiles_only=yes
+pattern="release-\K[\d.]+"

--- a/srcpkgs/sane/update
+++ b/srcpkgs/sane/update
@@ -1,1 +1,2 @@
-pattern='href="/sane-project/backends/-/tags/[^\d\.]*\K[\d\.]*'
+distfiles_only=yes
+pattern="\K[\d.]+"

--- a/srcpkgs/sasm/update
+++ b/srcpkgs/sasm/update
@@ -1,1 +1,2 @@
-pattern=".*/archive/refs/tags/v\K.+(?=\.tar\.gz)"
+distfiles_only=yes
+pattern="v\K[\d.]+"

--- a/srcpkgs/sdl12-compat/update
+++ b/srcpkgs/sdl12-compat/update
@@ -1,1 +1,1 @@
-pattern='release-\K[\d.]+(?=\.tar\.gz")'
+pattern="release-\K[\d.]+"

--- a/srcpkgs/slurm-wlm/update
+++ b/srcpkgs/slurm-wlm/update
@@ -1,2 +1,3 @@
 pkgname=slurm
-pattern='slurm-\K[-\d]+(?=.tar.gz)'
+pattern="${pkgname}-\K[\d-]+(rc\d*)?"
+ignore="*rc*"

--- a/srcpkgs/spectrwm/update
+++ b/srcpkgs/spectrwm/update
@@ -1,1 +1,1 @@
-pattern="SPECTRWM_\K[\d\_]*(?=\.tar\.gz)"
+pattern="SPECTRWM_\K[\d_]+"

--- a/srcpkgs/swayr/update
+++ b/srcpkgs/swayr/update
@@ -1,1 +1,2 @@
-pattern='<title>Release swayr-\K[\d.]+(?=</title>)'
+distfiles_only=yes
+pattern="swayr-\K[\d.]+"

--- a/srcpkgs/swayrbar/update
+++ b/srcpkgs/swayrbar/update
@@ -1,1 +1,2 @@
-pattern='<title>Release swayrbar-\K[\d.]+(?=</title>)'
+distfiles_only=yes
+pattern="swayrbar-\K[\d.]+"

--- a/srcpkgs/taplo/update
+++ b/srcpkgs/taplo/update
@@ -1,1 +1,1 @@
-pattern="release-taplo-cli-\K[\d.]+(?=\.tar\.gz)"
+pattern="release-taplo-cli-\K[\d.]+"

--- a/srcpkgs/tectonic/update
+++ b/srcpkgs/tectonic/update
@@ -1,1 +1,1 @@
-pattern="tectonic@\K[\d.]+(?=.tar.gz)"
+pattern="tectonic@\K[\d.]+"

--- a/srcpkgs/tinymist/update
+++ b/srcpkgs/tinymist/update
@@ -1,2 +1,3 @@
+distfiles_only=yes
 # odd patches are nightlies
-pattern='/archive/refs/tags/(v?|\Qtinymist\E)?\K[\d.]+\.\d*[02468](?=\.tar\.gz)'
+pattern="(v?|${pkgname})?\K[\d.]+\.\d*[02468]"

--- a/srcpkgs/tmux/update
+++ b/srcpkgs/tmux/update
@@ -1,2 +1,1 @@
-#site="https://github.com/tmux/tmux/releases"
-pattern="(?<=refs/tags/)[0-9.]+[a-z]*(?=.tar)"
+pattern="\K[0-9.]+[a-z]*"

--- a/srcpkgs/vapoursynth/update
+++ b/srcpkgs/vapoursynth/update
@@ -1,1 +1,2 @@
-pattern="R[\d\.]+(?=\.tar\.gz)"
+pattern="R[\d.]+(-?RC\d*)?"
+ignore="*RC*"

--- a/srcpkgs/w3m/update
+++ b/srcpkgs/w3m/update
@@ -1,1 +1,2 @@
-pattern="/archive/refs/tags/v\K[\d\.]+\+git\d+(?=(\+deb[u\+.\d]+)?\.tar)"
+distfiles_only=yes
+pattern="v\K[\d.]+"

--- a/srcpkgs/wire-desktop/update
+++ b/srcpkgs/wire-desktop/update
@@ -1,1 +1,1 @@
-pattern="(?<=linux/)[0-9.]+(?=.tar.gz)"
+pattern="linux/\K[\d.]+"

--- a/srcpkgs/wlroots0.18/update
+++ b/srcpkgs/wlroots0.18/update
@@ -1,1 +1,1 @@
-pattern="/wlroots-\K0\.18\.[\d.]+(?=\.tar\.gz)"
+pattern="\K0\.18\.[\d.]+"

--- a/srcpkgs/wlroots0.19/update
+++ b/srcpkgs/wlroots0.19/update
@@ -1,1 +1,1 @@
-pattern="/wlroots-\K0\.19\.[\d.]+(?=\.tar\.gz)"
+pattern="\K0\.19\.[\d.]+"

--- a/srcpkgs/wlroots0.20/update
+++ b/srcpkgs/wlroots0.20/update
@@ -1,1 +1,1 @@
-pattern="/wlroots-\K0\.20\.[\d.]+(?=\.tar\.gz)"
+pattern="\K0\.20\.[\d.]+"

--- a/srcpkgs/x265/update
+++ b/srcpkgs/x265/update
@@ -1,1 +1,2 @@
-pattern='/(get|downloads)/(v?|\Q'"$pkgname"'\E_)?\K[\d\.]+(?=\.tar\.gz")'
+distfiles_only=yes
+pattern="\K[\d.]+"

--- a/srcpkgs/xdelta3/update
+++ b/srcpkgs/xdelta3/update
@@ -1,2 +1,3 @@
 pkgname=xdelta
-pattern=$pkgname'-\K[\d.]+\d+'
+distfiles_only=yes
+pattern="v\K[\d.]+"

--- a/srcpkgs/yaydl/update
+++ b/srcpkgs/yaydl/update
@@ -1,1 +1,1 @@
-pattern="/archive/refs/tags/release-\K[\d\.]+(?=\.tar\.gz)"
+pattern="release-\K[\d.]+"

--- a/srcpkgs/zeux-volk/update
+++ b/srcpkgs/zeux-volk/update
@@ -1,1 +1,1 @@
-pattern="/vulkan-sdk-\K[0-9.]+(?=.tar.gz)"
+pattern="vulkan-sdk-\K[\d.]+"

--- a/srcpkgs/zfs-auto-snapshot/update
+++ b/srcpkgs/zfs-auto-snapshot/update
@@ -1,1 +1,1 @@
-pattern="upstream/\K[\d\.]*(?=\.tar\.gz)"
+pattern="upstream/\K[\d.]+"

--- a/srcpkgs/zfs-lts/update
+++ b/srcpkgs/zfs-lts/update
@@ -1,3 +1,3 @@
 pkgname=zfs
+pattern="${pkgname}-\K\Q${version%.*}\E\.[\d.]+"
 ignore="*.*.99"
-pattern="${pkgname}-\K\Q${version%.*}\E\.[0-9.]+(?=\.tar\.gz)"

--- a/srcpkgs/zimg/update
+++ b/srcpkgs/zimg/update
@@ -1,1 +1,1 @@
-pattern='release-\K[\d.]+(?=")'
+pattern="release-\K[\d.]+"


### PR DESCRIPTION
[@classabbyamp's PR #60025](https://github.com/void-linux/void-packages/pull/60025) migrated `update_check.sh` from HTML scraping to git `info/refs?service=git-upload-pack`. This avoids fragile HTML parsing and reduces bandwidth usage.

The `info/refs` endpoint emits tag entries in the form `<sha>\trefs/tags/<tag>`. While investigating why Vulkan-Headers and related packages weren't appearing in `void-updates.txt`, I found that custom `pattern=` entries in `update` files, originally written against HTML output, no longer match because they don't account for the `refs/tags/` prefix. This PR fixes the 101 affected packages (of 152 with custom patterns reaching `info/refs`) and proposes two small additions to `update_check.sh` that aim to keep `update` files concise and resilient going forward.

## Infrastructure changes

Two additions to `update_check.sh`:

1. **Auto-prefix `refs/tags/`** when (a) the URL is an `info/refs` endpoint and (b) the custom pattern doesn't already start with `refs/tags/`. Existing patterns with explicit anchor remain unchanged. Fully backward compatible.

2. **`distfiles_only=yes`** variable for `update` files. When set, homepage scanning is skipped and only distfile URLs are checked.

`Manual.md` is updated to describe both features and provide guidance on choosing between the default behavior, `distfiles_only=yes`, and `site=URL`.

## Design rationale

### Why auto-prefix `refs/tags/`?

The `info/refs` endpoint (used by `update_check.sh` since #60025) emits tag lines in a uniform format: every line ends with `refs/tags/<tag>`. Since the `refs/tags/` prefix is a property of the wire format rather than something each package needs to express, it seemed reasonable to handle it at the script level.

The alternative would be adding `refs/tags/` to each affected `update` file individually. That works, but spreads endpoint-format knowledge across ~100 packages. Centralizing it in the script keeps `update` files focused on what's package-specific (the tag naming convention upstream chose) rather than protocol-level detail.

The condition is narrow (URL contains `info/refs` AND pattern doesn't already start with `refs/tags/`), so explicit-anchor patterns continue working unchanged. The 44 untouched custom-pattern packages were cross-checked against `master` to confirm this. No regressions observed.

I'm happy to revisit this approach if you'd prefer the per-package path. The script change is small and easy to drop.

### Why `distfiles_only=yes`?

The homepage scan is a useful heuristic when patterns live in HTML space, since a single broad pattern can catch versions in either the homepage or the distfiles page. With `info/refs`, the situation changes a bit: the endpoint already provides a uniformly-structured tag listing, while the homepage remains a human-facing page whose layout can change for unrelated reasons.

In practice, two patterns emerge:

* **Patterns that survive the homepage tend to anchor on decorative strings** (e.g., "Latest release: X", `<title>Release foo-X</title>`). When upstream redesigns the site, these break even when the tags themselves are stable.
* **Patterns scoped to `info/refs` can stay simpler and more structural** (e.g., `vulkan-sdk-\K[\d.]+` against a `refs/tags/` listing). Adding homepage-survival logic to them tends to bloat the regex.

`distfiles_only=yes` is meant as an opt-in for packages where the homepage adds noise rather than signal. Default behavior is unchanged.

### Why a new variable instead of `site=URL` to `info/refs`?

`site=` works for this. It's used in this PR for `libeot` and `libluv`, where upstream's tag scheme requires it. The reason I went with a separate variable is that `site=URL` requires each package to spell out the full `info/refs` URL, duplicating information already derivable from the template's `homepage` / `distfiles`. `distfiles_only=yes` is one line and lets the framework keep deriving the endpoint from the template.

The Manual update describes this as a small spectrum: default for most packages, `distfiles_only=yes` when the homepage adds noise, `site=URL` when a different endpoint is genuinely required.

## Package changes (101)

Adapted custom patterns so `./xbps-src update-check <pkg>` returns the correct latest version via `info/refs`. Each was verified individually with `./xbps-src update-check`, often with `XBPS_VERBOSE=yes` to confirm the URL and regex being used. Pre-release tags (`rc`, `beta`, `pre`) were caught by inspecting upstream tags via `curl 'info/refs?service=git-upload-pack'` and filtered with `ignore=` where needed.

34 of these also gained `distfiles_only=yes`.

<details>
<summary>Full list of touched packages</summary>

CImg, EternalTerminal, ImageMagick, Lucene++, OpenSubdiv, SPIRV-Headers, SPIRV-LLVM-Translator19, SPIRV-LLVM-Translator21, SPIRV-LLVM-Translator22, SPIRV-Tools, UEFITool, Vulkan-Headers, Vulkan-Tools, Vulkan-Utility-Libraries, Vulkan-ValidationLayers, asahi-uboot, atomicparsley, cgal, cronutils, discount, eigen3.2, faac, faad2, flintlib, fntsample, font-adobe-source-code-pro, gdmd, gnome-epub-thumbnailer, godot, gopls, gzdoom, incron, inih, intel-ucode, inxi, iverilog, j4-dmenu-desktop, kodi, lf, libaccounts-qt, libblockdev, libcgroup, libeot, libgit2-1.8, libgit2-1.9, libgme, libhomfly, libkeybinder3, libluv, libmygui, libui, libvidstab, lilypond-doc, linux-asahi, liteide, lm_sensors, lmdb, love, lsyncd, lua54-luafilesystem, mame, mathjax2, md4c, minio, miruo, moosefs, openimageio, openjdk8, otfcc, pgbackrest, poedit, python3-aioamqp, python3-hypothesis, python3-pyqtgraph, re2, redshift, redsocks, sane, sasm, sdl12-compat, slurm-wlm, spectrwm, swayr, swayrbar, taplo, tectonic, tinymist, tmux, vapoursynth, w3m, wire-desktop, wlroots0.18, wlroots0.19, wlroots0.20, x265, xdelta3, yaydl, zeux-volk, zfs-auto-snapshot, zfs-lts, zimg

</details>

## Numbers

Of 1,574 unique `update` files:

* **942** have no `site=` set, so the URL is transformed to `info/refs` when the template references a git forge.
  * **426** of these reach a git forge, meaning `info/refs` is actually used.
    * **152** have custom `pattern=`:
      * **101** had patterns incompatible with the `refs/tags/` prefix and are updated here.
      * **44** of the remaining 51 were already compatible.
      * **7** of the remaining 51 return `NO VERSION` for unrelated reasons.
    * **274** use the default regex; **8** of these still return `NO VERSION` due to template peculiarities.
  * **516** reach other hosts (PyPI, etc.), so `info/refs` is not engaged.
* **632** have `site=` set, so the URL is used as-is and `info/refs` is not engaged.
  * **85** of these still have legacy patterns (referencing `tar.gz`/`archive/refs/tags`); they continue working via HTML scraping, so migrating them is cosmetic.

Commands used to gather these numbers:

```bash
# Total unique update files
find srcpkgs -maxdepth 2 -name update -type f | wc -l                                # 1574

# With custom pattern
find srcpkgs -maxdepth 2 -name update -type f \
    -exec grep -l '^pattern=' {} \; | wc -l                                          # 682

# Touched in this PR
git diff --diff-filter=AM --name-only master..HEAD -- 'srcpkgs/*/update' \
    | grep -oP 'srcpkgs/\K[^/]+' | sort -u | wc -l                                   # 101

# distfiles_only=yes added in this PR
git diff master..HEAD -- 'srcpkgs/*/update' \
    | grep -c '^+distfiles_only=yes'                                                 # 34
```

## Validation

Each of the 101 modified `update` files was individually verified with `./xbps-src update-check` (often with `XBPS_VERBOSE=yes`) to confirm the URL fetched, the regex applied (including the auto-prefix), and the version detected.

In addition, the 51 untouched custom-pattern packages (44 already compatible with the `refs/tags/` prefix, 7 with pre-existing `NO VERSION` causes) were cross-checked against the `master` baseline to confirm the `update_check.sh` changes introduce no regressions on the unmodified set. No regressions were observed.

## Out of scope / follow-up

* **Packages with `site=` pointing to git-forge HTML pages** (~85). These still work via HTML scraping but could be migrated to `info/refs` for consistency. This is a different class of change (modifying `site=` rather than `pattern=`), left as a potential cosmetic follow-up.

* **Templates with version-format mismatches.** Some packages have pattern migration that works correctly but the template's `version=` itself follows an older convention than current upstream (e.g., `slurm-wlm` template `19.05.5.1` vs upstream `25-11-6-1`). The pattern migration is included since it makes detection work again; the version-format bump is left as separate per-package work.

* **Upstream-archived packages** (`cronutils`, `otfcc`, `minio`, `redshift`). Patterns are migrated for consistency, but these may warrant removal or orphan in separate cleanup PRs.

* **SPIRV-Tools tag format.** The pattern migration here aligns detection with the other Khronos packages in this PR. The template currently consumes a release-candidate tag format; aligning with the Vulkan SDK release cycle would be a separate decision.

* **libgme upstream move.** Upstream migrated from Bitbucket (`mpyne/game-music-emu`) to GitHub (`libgme/game-music-emu`). The template still points at the old Bitbucket location, which a future PR may want to address.

Feedback welcome, particularly on the auto-prefix condition scope and whether `distfiles_only=yes` reads well alongside the existing `site=` mechanism in `Manual.md`.