### PR TITLE
lua-language-server: don't run internal tests during build

### DIFF
--- a/srcpkgs/lua-language-server/template
+++ b/srcpkgs/lua-language-server/template
@@ -12,7 +12,7 @@ distfiles="https://github.com/LuaLS/lua-language-server/releases/download/${vers
 checksum=cfb54fdf1d812e284477cb2e2d68a40de8b1c33e68e9073dd5d9d83165d97b33
 
 do_build() {
-	ninja -C 3rd/luamake -f compile/ninja/linux.ninja
+	ninja -C 3rd/luamake -f compile/ninja/linux.ninja notest
 	./3rd/luamake/luamake -platform ${XBPS_TARGET_MACHINE} rebuild
 }
 


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

cc @icp1994

these seem to be only for the https://github.com/actboy168/bee.lua internals anyway

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
