### PR TITLE
gnome-clocks: update to 50.0, adopt

### DIFF
--- a/srcpkgs/gnome-clocks/template
+++ b/srcpkgs/gnome-clocks/template
@@ -1,22 +1,17 @@
 # Template file for 'gnome-clocks'
 pkgname=gnome-clocks
-version=48.0
+version=50.0
 revision=1
-build_helper="gir"
 build_style=meson
-hostmakedepends="pkg-config gettext itstool glib-devel vala
- gtk-update-icon-cache desktop-file-utils"
-makedepends="glib-devel vala-devel gnome-desktop-devel
- gtk4-devel libadwaita-devel libnotify-devel gsound-devel
- libgweather-devel geocode-glib-devel geoclue2-devel
- hicolor-icon-theme"
+hostmakedepends="desktop-file-utils gettext glib-devel gtk4-update-icon-cache
+ itstool pkg-config vala vorbis-tools"
+makedepends="geocode-glib-devel geoclue2-devel gnome-desktop-devel gtk4-devel
+ icu-devel libadwaita-devel libgweather-devel"
 depends="desktop-file-utils hicolor-icon-theme"
 short_desc="Clock application for the GNOME Desktop"
-maintainer="Orphaned <orphan@voidlinux.org>"
+maintainer="Fabian Constantinescu <fabian.constantinescu@protonmail.com>"
 license="GPL-2.0-or-later"
-homepage="https://wiki.gnome.org/Apps/Clocks"
-changelog="https://gitlab.gnome.org/GNOME/gnome-clocks/-/raw/master/NEWS"
-# FIXME: dead link
-changelog="https://gitlab.gnome.org/GNOME/gnome-clocks/-/raw/gnome-48/NEWS"
+homepage="https://apps.gnome.org/Clocks"
+changelog="https://gitlab.gnome.org/GNOME/gnome-clocks/-/raw/50/NEWS"
 distfiles="${GNOME_SITE}/gnome-clocks/${version%.*}/gnome-clocks-${version}.tar.xz"
-checksum=616ee1fb75300b1f26b9766219e954751360ca0fa0f491311bcf83bf38087c62
+checksum=bf167f7f44f4f2fb424d4716652c9ba1f29e16e49071e26a1bb833f8dce794c6


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-glibc 
  - aarch64-musl
  - armv7l
  - i686