### PR TITLE
OpenRCT2: update to 0.5.3.

### DIFF
--- a/srcpkgs/OpenRCT2/template
+++ b/srcpkgs/OpenRCT2/template
@@ -2,12 +2,12 @@
 # based on https://raw.githubusercontent.com/AluisioASG/void-packages/openrct2/srcpkgs/OpenRCT2/template
 # and https://github.com/void-linux/void-packages/issues/1014#issuecomment-417372421
 pkgname=OpenRCT2
-version=0.5.0
+version=0.5.3
 revision=1
 # versions pulled from https://raw.githubusercontent.com/OpenRCT2/OpenRCT2/v${version}/CMakeLists.txt
-_objects_version=1.7.9
+_objects_version=1.7.10
 _titles_version=0.4.26
-_replays_version=0.0.92
+_replays_version=0.0.95
 _opensfx_version=1.0.6
 _openmsx_version=1.6.1
 build_style=cmake
@@ -39,11 +39,11 @@ distfiles="https://github.com/OpenRCT2/OpenRCT2/archive/v${version}.tar.gz
  https://github.com/OpenRCT2/OpenMusic/releases/download/v${_openmsx_version}/openmusic.zip>openmusic-${_openmsx_version}.zip
  https://github.com/OpenRCT2/replays/releases/download/v${_replays_version}/replays.zip>replays-${_replays_version}.zip
  https://github.com/OpenRCT2/title-sequences/releases/download/v${_titles_version}/title-sequences.zip>title-sequences-${_titles_version}.zip"
-checksum="d9b2f34205c3fddc127be0623eae13c3e970917fa69714c861ec564c2d54d6d0
- 55461ed20c6e82f14e9a279cd844654b0264999bb94034d58fa912fdee26ead6
+checksum="cde0192b50cddaffc32c28b066afa81943563850c295f201e9f4be396b7b6be8
+ f483be266dc22077ba8517bbf32ffe388c3543b2ee585e0afbd4102db4528021
  06b90f3e19c216752df441d551b26a9e3e1ba7755bdd2102504b73bf993608be
  994b350d3b180ee1cb9619fe27f7ebae3a1a5232840c4bd47a89f33fa89de1a1
- 455a19172a8df81b935a942bbbda20167b4740b34653fdb74127740686bf4cbe
+ df4082741c6f1fda1f10cfaf091abbcbbd5078670926b548feb29ee8aa85e3f5
  dabb9787b1576342fca4dd9f64b3f8cfa04a7e6ce9c2bb9610f47b762905c858"
 skip_extraction="objects-${_objects_version}.zip
  opensound-${_opensfx_version}.zip

--- a/srcpkgs/json-c++/patches/char8_t_support_fallback.patch
+++ b/srcpkgs/json-c++/patches/char8_t_support_fallback.patch
@@ -1,0 +1,145 @@
+From 34868f90149de02432ea758a29227a6ad74f098c Mon Sep 17 00:00:00 2001
+From: Sergiu Deitsch <sergiu.deitsch@gmail.com>
+Date: Fri, 11 Apr 2025 21:11:52 +0200
+Subject: [PATCH] Provide fallback for missing `char8_t` support
+
+Clang 11.0.x with libc++ fails to compile tests in C++20 mode due to
+incomplete char8_t support in std::filesystem::path.
+
+Signed-off-by: Sergiu Deitsch <sergiu.deitsch@gmail.com>
+---
+ .../nlohmann/detail/conversions/from_json.hpp |  5 +++-
+ .../nlohmann/detail/conversions/to_json.hpp   | 21 ++++++++++-----
+ single_include/nlohmann/json.hpp              | 26 +++++++++++++------
+ tests/src/unit-deserialization.cpp            |  5 ++--
+ 4 files changed, 39 insertions(+), 18 deletions(-)
+
+diff --git a/include/nlohmann/detail/conversions/from_json.hpp b/include/nlohmann/detail/conversions/from_json.hpp
+index d647d74239..e161a4282f 100644
+--- a/include/nlohmann/detail/conversions/from_json.hpp
++++ b/include/nlohmann/detail/conversions/from_json.hpp
+@@ -540,7 +540,10 @@ inline void from_json(const BasicJsonType& j, std_fs::path& p)
+         JSON_THROW(type_error::create(302, concat("type must be string, but is ", j.type_name()), &j));
+     }
+     const auto& s = *j.template get_ptr<const typename BasicJsonType::string_t*>();
+-#ifdef JSON_HAS_CPP_20
++    // Checking for C++20 standard or later can be insufficient in case the
++    // library support for char8_t is either incomplete or was disabled
++    // altogether. Use the __cpp_lib_char8_t feature test instead.
++#if defined(__cpp_lib_char8_t) && (__cpp_lib_char8_t >= 201907L)
+     p = std_fs::path(std::u8string_view(reinterpret_cast<const char8_t*>(s.data()), s.size()));
+ #else
+     p = std_fs::u8path(s); // accepts UTF-8 encoded std::string in C++17, deprecated in C++20
+diff --git a/include/nlohmann/detail/conversions/to_json.hpp b/include/nlohmann/detail/conversions/to_json.hpp
+index ead45665f1..b17e8af437 100644
+--- a/include/nlohmann/detail/conversions/to_json.hpp
++++ b/include/nlohmann/detail/conversions/to_json.hpp
+@@ -15,7 +15,8 @@
+ 
+ #include <algorithm> // copy
+ #include <iterator> // begin, end
+-#include <string> // string
++#include <memory> // allocator_traits
++#include <string> //  basic_string, char_traits
+ #include <tuple> // tuple, get
+ #include <type_traits> // is_same, is_constructible, is_floating_point, is_enum, underlying_type
+ #include <utility> // move, forward, declval, pair
+@@ -440,15 +441,21 @@ inline void to_json(BasicJsonType& j, const T& t)
+ }
+ 
+ #if JSON_HAS_FILESYSTEM || JSON_HAS_EXPERIMENTAL_FILESYSTEM
++#if defined(__cpp_lib_char8_t)
++template<typename BasicJsonType, typename Tr, typename Allocator>
++inline void to_json(BasicJsonType& j, const std::basic_string<char8_t, Tr, Allocator>& s)
++{
++    using OtherAllocator = typename std::allocator_traits<Allocator>::template rebind_alloc<char>;
++    j = std::basic_string<char, std::char_traits<char>, OtherAllocator>(s.begin(), s.end(), s.get_allocator());
++}
++#endif
++
+ template<typename BasicJsonType>
+ inline void to_json(BasicJsonType& j, const std_fs::path& p)
+ {
+-#ifdef JSON_HAS_CPP_20
+-    const std::u8string s = p.u8string();
+-    j = std::string(s.begin(), s.end());
+-#else
+-    j = p.u8string(); // returns std::string in C++17
+-#endif
++    // Returns either a std::string or a std::u8string depending whether library
++    // support for char8_t is enabled.
++    j = p.u8string();
+ }
+ #endif
+ 
+diff --git a/single_include/nlohmann/json.hpp b/single_include/nlohmann/json.hpp
+index 82d69f7c5d..be3493efa8 100644
+--- a/single_include/nlohmann/json.hpp
++++ b/single_include/nlohmann/json.hpp
+@@ -5325,7 +5325,10 @@ inline void from_json(const BasicJsonType& j, std_fs::path& p)
+         JSON_THROW(type_error::create(302, concat("type must be string, but is ", j.type_name()), &j));
+     }
+     const auto& s = *j.template get_ptr<const typename BasicJsonType::string_t*>();
+-#ifdef JSON_HAS_CPP_20
++    // Checking for C++20 standard or later can be insufficient in case the
++    // library support for char8_t is either incomplete or was disabled
++    // altogether. Use the __cpp_lib_char8_t feature test instead.
++#if defined(__cpp_lib_char8_t) && (__cpp_lib_char8_t >= 201907L)
+     p = std_fs::path(std::u8string_view(reinterpret_cast<const char8_t*>(s.data()), s.size()));
+ #else
+     p = std_fs::u8path(s); // accepts UTF-8 encoded std::string in C++17, deprecated in C++20
+@@ -5380,7 +5383,8 @@ NLOHMANN_JSON_NAMESPACE_END
+ 
+ #include <algorithm> // copy
+ #include <iterator> // begin, end
+-#include <string> // string
++#include <memory> // allocator_traits
++#include <string> //  basic_string, char_traits
+ #include <tuple> // tuple, get
+ #include <type_traits> // is_same, is_constructible, is_floating_point, is_enum, underlying_type
+ #include <utility> // move, forward, declval, pair
+@@ -6087,15 +6091,21 @@ inline void to_json(BasicJsonType& j, const T& t)
+ }
+ 
+ #if JSON_HAS_FILESYSTEM || JSON_HAS_EXPERIMENTAL_FILESYSTEM
++#if defined(__cpp_lib_char8_t)
++template<typename BasicJsonType, typename Tr, typename Allocator>
++inline void to_json(BasicJsonType& j, const std::basic_string<char8_t, Tr, Allocator>& s)
++{
++    using OtherAllocator = typename std::allocator_traits<Allocator>::template rebind_alloc<char>;
++    j = std::basic_string<char, std::char_traits<char>, OtherAllocator>(s.begin(), s.end(), s.get_allocator());
++}
++#endif
++
+ template<typename BasicJsonType>
+ inline void to_json(BasicJsonType& j, const std_fs::path& p)
+ {
+-#ifdef JSON_HAS_CPP_20
+-    const std::u8string s = p.u8string();
+-    j = std::string(s.begin(), s.end());
+-#else
+-    j = p.u8string(); // returns std::string in C++17
+-#endif
++    // Returns either a std::string or a std::u8string depending whether library
++    // support for char8_t is enabled.
++    j = p.u8string();
+ }
+ #endif
+ 
+diff --git a/tests/src/unit-deserialization.cpp b/tests/src/unit-deserialization.cpp
+index 84a970a183..5c450c23d3 100644
+--- a/tests/src/unit-deserialization.cpp
++++ b/tests/src/unit-deserialization.cpp
+@@ -1134,9 +1134,10 @@ TEST_CASE("deserialization")
+     }
+ }
+ 
+-// select the types to test - char8_t is only available in C++20
++// select the types to test - char8_t is only available since C++20 if and only
++// if __cpp_char8_t is defined.
+ #define TYPE_LIST(...) __VA_ARGS__
+-#ifdef JSON_HAS_CPP_20
++#if defined(__cpp_char8_t) && (__cpp_char8_t >= 201811L)
+     #define ASCII_TYPES TYPE_LIST(char, wchar_t, char16_t, char32_t, char8_t)
+ #else
+     #define ASCII_TYPES TYPE_LIST(char, wchar_t, char16_t, char32_t)

--- a/srcpkgs/json-c++/template
+++ b/srcpkgs/json-c++/template
@@ -1,7 +1,7 @@
 # Template file for 'json-c++'
 pkgname=json-c++
 version=3.12.0
-revision=1
+revision=2
 build_style=cmake
 configure_args="-DJSON_MultipleHeaders=ON"
 checkdepends="git"


### PR DESCRIPTION
- **json-c++: patch to work when missing char8_t support**
- **OpenRCT2: update to 0.5.1.**

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
