### PR TITLE
New package: obs-vkcapture-1.5.6

### DIFF
--- a/srcpkgs/obs-vkcapture/template
+++ b/srcpkgs/obs-vkcapture/template
@@ -1,0 +1,13 @@
+# Template file for 'obs-vkcapture'
+pkgname=obs-vkcapture
+version=1.5.5
+revision=1
+build_style=cmake
+hostmakedepends="pkgconf"
+makedepends="vulkan-loader-devel libglvnd-devel obs-devel simde"
+short_desc="OBS Linux Vulkan/OpenGL game capture"
+maintainer="al20ov <nicolas.antauf@gmail.com>"
+license="GPL-2.0-only"
+homepage="https://github.com/nowrep/obs-vkcapture"
+distfiles="https://github.com/nowrep/obs-vkcapture/archive/refs/tags/v${version}.tar.gz"
+checksum=02e79385f5afd6fcc0dbbcdb35adb653a111bf3a0d4d4d7edd82297222f80637

--- a/srcpkgs/obs-vkcapture/template
+++ b/srcpkgs/obs-vkcapture/template
@@ -1,0 +1,13 @@
+# Template file for 'obs-vkcapture'
+pkgname=obs-vkcapture
+version=1.5.6
+revision=1
+build_style=cmake
+hostmakedepends="pkg-config wayland-devel"
+makedepends="vulkan-loader-devel libglvnd-devel obs-devel simde wayland-devel"
+short_desc="OBS Linux Vulkan/OpenGL game capture"
+maintainer="al20ov <nicolas.antauf@gmail.com>"
+license="GPL-2.0-only"
+homepage="https://github.com/nowrep/obs-vkcapture"
+distfiles="https://github.com/nowrep/obs-vkcapture/archive/refs/tags/v${version}.tar.gz"
+checksum=4f0eecd574cf4765bf8a4c5e09b7c764d1c4a9128e6c6fea99e2c6474c494fe0


### PR DESCRIPTION
Closes https://github.com/void-linux/void-packages/issues/46892

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures:
  - i686-glibc (crossbuild)

This package provides a new "Game Capture" source type in OBS once installed and includes wrappers to capture video from a Vulkan or OpenGL application. Example: `obs-gamecapture vkcube` or `OBS_VKCAPTURE=1 vkcube`.
And to capture video from a 32 bit application like Half-Life you just need the 32bit multilib package.

EDIT: I originally only tested this on Wayland but I just took the time to test on X11 and it works too.