### PR TITLE
[ci skip]New Package: openfoam13

### DIFF
--- a/srcpkgs/openfoam13/INSTALL
+++ b/srcpkgs/openfoam13/INSTALL
@@ -1,0 +1,9 @@
+case "${ACTION}" in
+post)
+	echo "** To use OpenFOAM please add"
+	echo "**"
+	echo "**    . /opt/OpenFOAM-13/etc/bashrc"
+	echo "**"
+	echo "** To your ~/.bashrc"
+	;;
+esac

--- a/srcpkgs/openfoam13/template
+++ b/srcpkgs/openfoam13/template
@@ -28,7 +28,7 @@ do_extract() {
 }
 post_extract() {
 	mv "OpenFOAM-${version}-version-${version}" "OpenFOAM-${version}"
-	mv "ThirdParty-${version}-version-${version}" "ThirdParty-${version}"
+	mv "ThirdParty-${version}-version-${version}" "OpenFOAM-${version}/thirdparty"
 }
 do_patch() {
 	# patch the aliases file
@@ -38,6 +38,10 @@ do_patch() {
 	# patch the openmpi file
 	sed -i '46d' "OpenFOAM-${version}/etc/config.sh/mpi"
 	sed -i "46alibDir=\`mpicc --showme:link | sed -e \'s/.*\\\(-L\\\|-Wl,-rpath=\\\|-Wl,-rpath,\\\|-Wl,-rpath -Wl,\\\)\\\([^ ]*\\\).*/\\\2/\'\`" "OpenFOAM-${version}/etc/config.sh/mpi"
+
+	# patch the bashrc to accomodate for renaming ThirdParty -> thirdparty
+	sed -i 's/export WM_THIRD_PARTY=ThirdParty/export WM_THIRD_PARTY=thirdparty/' "OpenFOAM-${version}/etc/bashrc"
+	sed -i 's;export WM_THIRD_PARTY_DIR=$WM_PROJECT_INST_DIR/$WM_THIRD_PARTY-$WM_PROJECT_VERSION;export WM_THIRD_PARTY_DIR=$WM_PROJECT_INST_DIR/$WM_PROJECT-$WM_PROJECT_VERSION/$WM_THIRD_PARTY;' "OpenFOAM-${version}/etc/bashrc"
 }
 do_build() {
 	export HOME="/builddir"

--- a/srcpkgs/openfoam13/template
+++ b/srcpkgs/openfoam13/template
@@ -1,0 +1,54 @@
+# Template file for 'openfoam13'
+pkgname=openfoam13
+version=13
+revision=1
+build_style=""
+configure_args=""
+hostmakedepends="wget"
+makedepends="openmpi-devel flex base-devel openmpi"
+depends="openmpi libboost_thread flex openmpi gnuplot"
+short_desc="OpenFOAM is a free, open source computational fluid dynamics (CFD) software package released by the OpenFOAM Foundation"
+maintainer="muez <muezabdalla777@gmail.com>"
+license="GPL-3.0"
+homepage="https://www.openfoam.org/"
+distfiles="http://dl.openfoam.org/source/13
+http://dl.openfoam.org/third-party/13"
+checksum="9969d7f09411d72450855f855f2f37760ff147e3f137fd7063ce6bc26d629632
+ 05c91a450113d0f728fa37677147a30fc19f1c04ebf8d70e478db2664f2e6fd9"
+python_version=3
+
+do_fetch() {
+	mkdir -p $wrksrc
+	cd $wrksrc
+	wget ${distfiles}
+}
+do_extract() {
+	vtar -xf "13"
+	vtar -xf "13.1"
+}
+post_extract() {
+	mv "OpenFOAM-${version}-version-${version}" "OpenFOAM-${version}"
+	mv "ThirdParty-${version}-version-${version}" "ThirdParty-${version}"
+}
+do_patch() {
+	# patch the aliases file
+	sed -i '78d' "OpenFOAM-${version}/etc/config.sh/aliases"
+	sed -i '77aelif command -V wmRefresh 2> /dev/null\nthen' "OpenFOAM-${version}/etc/config.sh/aliases"
+
+	# patch the openmpi file
+	sed -i '46d' "OpenFOAM-${version}/etc/config.sh/mpi"
+	sed -i "46alibDir=\`mpicc --showme:link | sed -e \'s/.*\\\(-L\\\|-Wl,-rpath=\\\|-Wl,-rpath,\\\|-Wl,-rpath -Wl,\\\)\\\([^ ]*\\\).*/\\\2/\'\`" "OpenFOAM-${version}/etc/config.sh/mpi"
+}
+do_build() {
+	export HOME="/builddir"
+	mkdir -p "$HOME/.OpenFOAM"
+	echo "export ParaView_TYPE=none" > $HOME/.OpenFOAM/prefs.sh
+	cd "OpenFOAM-${version}"
+	source ./etc/bashrc
+	./Allwmake -j ${makejobs}
+}
+do_install() {
+	mkdir ${PKGDESTDIR}/opt/
+	mv *-${version} ${PKGDESTDIR}/opt/
+	#mv ThirdParty-${version} ${PKGDESTDIR}/opt/
+}


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->
this is a new package called openfoam specifically the foundation version I tried to make it as close to the official build that is made for debian based distros that is why I made it install in `/opt`

#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)

I added `[ci skip]` because if having less than 8 cores I am not sure it will take less than 2 hours
