### PR TITLE
dbeaver: update to 26.0.5.

### DIFF
--- a/srcpkgs/dbeaver/template
+++ b/srcpkgs/dbeaver/template
@@ -1,6 +1,6 @@
 # Template file for 'dbeaver'
 pkgname=dbeaver
-version=26.0.4
+version=26.0.5
 revision=1
 _version=${version//./_}
 # the build downloads binaries linked to glibc
@@ -16,9 +16,9 @@ changelog="https://dbeaver.io/news/"
 distfiles="https://github.com/dbeaver/dbeaver/archive/${version}.tar.gz
  https://github.com/dbeaver/dbeaver-common/archive/refs/heads/release_${_version}.tar.gz>dbeaver-common-${version}.tar.gz
  https://github.com/dbeaver/dbeaver-jdbc-libsql/archive/refs/heads/release_${_version}.tar.gz>dbeaver-jdbc-libsql-${version}.tar.gz"
-checksum="75fd3e6b8ab5762090b0f50f9763d843b72cc5cfb8881bc2eba5c53e22dea7d3
- 060f01d3e42bd31839026c1fd549f466c297464424fb35077109f6b19d3ab293
- e3749459205f2d8c13dd06f83f5da67c2724e135115c30ec5cbe5c62d5889f25"
+checksum="3fdd348cc59a357a9ae016ec110018d7a6d87ba146b6f5d91884790ed424dee9
+ c202fda84109733b64b78116e551eaa134e810eee9f1522e6c9e5c5bc36a8a21
+ 08ba62a214294a92c2b892a4ac26c454a8027e33c5f9b4c4b4c25726c1e81758"
 nopie=true
 
 post_extract() {


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, x86_64_glibc