### PR TITLE
update kodi-addon-peripheral-joystick to version 21.1.23

### DIFF
--- a/srcpkgs/kodi-addon-peripheral-joystick/template
+++ b/srcpkgs/kodi-addon-peripheral-joystick/template
@@ -1,7 +1,7 @@
 # Template file for 'kodi-addon-peripheral-joystick'
 pkgname=kodi-addon-peripheral-joystick
 version=21.1.23
-revision=0
+revision=1
 _kodi_release="Omega"
 build_style=cmake
 makedepends="kodi-devel kodi-platform-devel p8-platform-devel

--- a/srcpkgs/kodi-addon-peripheral-joystick/template
+++ b/srcpkgs/kodi-addon-peripheral-joystick/template
@@ -1,8 +1,8 @@
 # Template file for 'kodi-addon-peripheral-joystick'
 pkgname=kodi-addon-peripheral-joystick
-version=1.7.1
-revision=2
-_kodi_release="Matrix"
+version=21.1.23
+revision=0
+_kodi_release="Omega"
 build_style=cmake
 makedepends="kodi-devel kodi-platform-devel p8-platform-devel
  eudev-libudev-devel tinyxml-devel"
@@ -11,7 +11,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="https://github.com/xbmc/peripheral.joystick"
 distfiles="https://github.com/xbmc/peripheral.joystick/archive/${version}-${_kodi_release}.tar.gz"
-checksum=4dc63c6c5bdad25881eeba800765d97c53b2583addf28e71bbcd67775452ecdb
+checksum=7392c30a9e49b0cd219cdca14f5b20ffce9f4a52c349c2cdf37cb603dd21f516
 
 if [ -n "${CROSS_BUILD}" ]; then
 	configure_args+=" -DCMAKE_MODULE_PATH=${XBPS_CROSS_BASE}/usr/share/kodi/cmake"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly** (package works, and joysticks function under Kodi)

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
#### Local build testing
- I built this PR locally for my native architecture, (armv7l-glibc)

Addresses #60635. Note that this package along with kodi-addon-inputstream-adaptive will need to be upgraded when Kodi itself upgrades to a major version. Otherwise, this addon will not function at all.