### PR TITLE
xrandr: update to 1.5.4

### DIFF
--- a/srcpkgs/xrandr/template
+++ b/srcpkgs/xrandr/template
@@ -1,8 +1,8 @@
 # Template file for 'xrandr'
 pkgname=xrandr
-version=1.5.3
+version=1.5.4
 revision=1
-build_style=gnu-configure
+build_style=meson
 hostmakedepends="pkg-config"
 makedepends="libXrandr-devel"
 short_desc="Primitive command line interface to RandR extension"
@@ -10,7 +10,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
 homepage="http://xorg.freedesktop.org"
 distfiles="${XORG_SITE}/app/$pkgname-$version.tar.xz"
-checksum=f8dd7566adb74147fab9964680b6bbadee87cf406a7fcff51718a5e6949b841c
+checksum=2cafccb2aaf2491a4068676117a0d4f90ab307724b96fffc54cd1da953779400
 
 post_install() {
 	vlicense COPYING


### PR DESCRIPTION
Includes changing the build to "meson" recipe as per release notes suggesting to do so. Autoconf method will eventually be removed.

#### Testing the changes
- I tested the changes in this PR: **briefly**


#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (crossbuilds):
  - i686
  - i686-musl
  - x86_64-musl
  - aarch64
  - aarch64-musl
  - armv7l
  - armv7l-musl
  - armv6l
  - armv6l-musl

