### PR TITLE
mnamer: update to 2.7.1

### DIFF
--- a/srcpkgs/mnamer/template
+++ b/srcpkgs/mnamer/template
@@ -1,6 +1,6 @@
 # Template file for 'mnamer'
 pkgname=mnamer
-version=2.7.0
+version=2.7.1
 revision=1
 build_style=python3-pep517
 hostmakedepends="python3-poetry-core python3-setuptools_scm python3-wheel"
@@ -12,7 +12,7 @@ maintainer="Mateusz Sylwestrzak <slymattz@gmail.com>"
 license="MIT"
 homepage="https://github.com/jkwill87/mnamer"
 distfiles="${PYPI_SITE}/m/mnamer/mnamer-${version}.tar.gz"
-checksum=26c0c9395e86a9bf7e7db0b77981d0d93da3dd355401ebc6f9a9ba6d22c7182c
+checksum=1318eb800486b8dfec387102edd110a3579fb5b7485da332426ad53651369381
 
 post_install() {
 	vlicense LICENSE.txt


### PR DESCRIPTION

#### Testing the changes
- I tested the changes in this PR: **YES**

> No functional changes from 2.7.0. Updates dependencies avoid setuptools and urllib3 vulnerabilities. Updates CI to publish ghcr.io and docker hub images.
https://github.com/jkwill87/mnamer/releases

#### Local build testing
- I built this PR locally for my native architecture: x86_64-glibc