### PR TITLE
binwalk: update to 3.1.0.

### DIFF
--- a/srcpkgs/binwalk/template
+++ b/srcpkgs/binwalk/template
@@ -1,28 +1,19 @@
 # Template file for 'binwalk'
 pkgname=binwalk
-version=2.4.3
-revision=3
-build_style=python3-module
-hostmakedepends="python3-setuptools"
-depends="python3 tar"
-checkdepends="${depends} python3-pytest"
+version=3.1.0
+revision=1
+archs="~i686* ~armv*"
+build_style=cargo
+make_check_args="--lib --bins"
+hostmakedepends="pkg-config"
+makedepends="fontconfig-devel"
 short_desc="Easy tool for analyzing/reversing/extracting firmware images"
 maintainer="Duncaen <duncaen@voidlinux.org>"
 license="MIT"
-homepage="https://github.com/OSPG/binwalk"
-distfiles="https://github.com/OSPG/binwalk/archive/v${version}.tar.gz"
-checksum=1b48aa2167dda6b434d6c98bdfbf513358ed65ca10d5e5dd90893718cabcdfab
-
-post_extract() {
-	vsed -i -e 's;/etc/bash_completion.d/%s;%s.bash;' setup.py
-}
+homepage="https://github.com/ReFirmLabs/binwalk"
+distfiles="https://github.com/ReFirmLabs/binwalk/archive/refs/tags/v${version}.tar.gz"
+checksum=06f595719417b70a592580258ed980237892eadc198e02363201abe6ca59e49a
 
 post_install() {
 	vlicense LICENSE
-
-	# calls `binwalk --help`
-	PATH="$DESTDIR/usr/bin/:$PATH" \
-	PYTHONPATH="${DESTDIR}/${py3_sitelib}" \
-		python3 setup.py autocomplete
-	vcompletion binwalk.bash bash
 }


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
#### Local build testing
- I built this PR locally for my native architecture, x64-glibc

@Duncaen, I updated binwalk to 3.1.0, just wanna let ya know.

Related: #60660
