### PR TITLE
py3status: update to 3.63.

### DIFF
--- a/srcpkgs/py3status/template
+++ b/srcpkgs/py3status/template
@@ -1,18 +1,23 @@
 # Template file for 'py3status'
 pkgname=py3status
-version=3.59
-revision=3
+version=3.63
+revision=1
 build_style=python3-pep517
 hostmakedepends="python3-wheel hatchling"
 depends="python3-pyudev"
 checkdepends="python3-pytest"
 short_desc="Alternative i3bar implementation in Python3"
-maintainer="Orphaned <orphan@voidlinux.org>"
+maintainer="Gonzalo Tornaría <tornaria@cmat.edu.uy>"
 license="BSD-3-Clause"
 homepage="https://github.com/ultrabug/py3status"
 changelog="https://raw.githubusercontent.com/ultrabug/py3status/master/CHANGELOG"
 distfiles="${homepage}/archive/${version}.tar.gz"
-checksum=4f86ff7fc4f1a2e133675c4ea441feb44c60a3b751f068bc5c9ac8b1f0f80e9c
+checksum=0117543796804211447176b3dad24cb6a9041aebc94e9ae1b0aa21486baf7032
+
+post_patch() {
+	# no longer necessary
+	vsed -e '/"setuptools/d' -i pyproject.toml
+}
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

@ahesford: this is needed after the update of setuptools removed pkg_resources; the current pkg does NOT work at all due to missing import.

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
