### PR TITLE
gnome-nibbles: update to 4.5.2

### DIFF
--- a/srcpkgs/gnome-nibbles/template
+++ b/srcpkgs/gnome-nibbles/template
@@ -1,6 +1,6 @@
 # Template file for 'gnome-nibbles'
 pkgname=gnome-nibbles
-version=4.5.1
+version=4.5.2
 revision=1
 build_style=meson
 build_helper=qemu
@@ -13,4 +13,4 @@ license="GPL-3.0-or-later"
 homepage="https://gitlab.gnome.org/GNOME/gnome-nibbles"
 changelog="https://gitlab.gnome.org/GNOME/gnome-nibbles/-/raw/master/NEWS"
 distfiles="${GNOME_SITE}/${pkgname}/${version%.*}/${pkgname}-${version}.tar.xz"
-checksum=84bad2825d39b8bf701ef644aab16b2dc7e72bb43e3f8702d23eec9613d29637
+checksum=76729d3b562cd7862ad30590c3bd40fd251f9d4bb5c53baa84150197f231a5fa


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **yes**

#### Local build testing
- I built this PR locally for my native architecture, x86_64
- I crossbuilded this PR locally for these architectures:
  - armv7l
  - armv6l-musl
  - aarch64-musl