### PR TITLE
xdg-user-dirs: update to 0.20.

### DIFF
--- a/srcpkgs/xdg-user-dirs/template
+++ b/srcpkgs/xdg-user-dirs/template
@@ -1,8 +1,8 @@
 # Template file for 'xdg-user-dirs'
 pkgname=xdg-user-dirs
-version=0.18
+version=0.20
 revision=1
-build_style=gnu-configure
+build_style=meson
 hostmakedepends="libxslt docbook-xsl"
 conf_files="
 	/etc/xdg/user-dirs.conf
@@ -12,5 +12,5 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="http://www.freedesktop.org/wiki/Software/xdg-user-dirs"
 changelog="https://gitlab.freedesktop.org/xdg/xdg-user-dirs/-/raw/master/NEWS"
-distfiles="http://user-dirs.freedesktop.org/releases/$pkgname-$version.tar.gz"
-checksum=ec6f06d7495cdba37a732039f9b5e1578bcb296576fde0da40edb2f52220df3c
+distfiles="http://user-dirs.freedesktop.org/releases/$pkgname-$version.tar.xz"
+checksum=b8e34286278f4fef3e1bfe9685c395ccc0eb50c14d3a2fb4953dd00fbfd3af39


### PR DESCRIPTION
xdg-user-dirs: update to 0.20.

first time contributing, please point me to the right documentation if I missed something.

I tried to cross build for the arm7l and arm6l architectures but got
`=> ERROR: xbps-src: XBPS_CROSS_TRIPLET not defined.`

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
 
