### PR TITLE
update primesieve to 12.4, primecount to 8.5.

### DIFF
--- a/srcpkgs/primecount/template
+++ b/srcpkgs/primecount/template
@@ -1,6 +1,6 @@
 # Template file for 'primecount'
 pkgname=primecount
-version=8.4
+version=8.5
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTS=ON -DBUILD_LIBPRIMESIEVE=OFF
@@ -12,7 +12,7 @@ license="BSD-2-Clause"
 homepage="https://github.com/kimwalisch/primecount/"
 changelog="https://raw.githubusercontent.com/kimwalisch/primecount/master/ChangeLog"
 distfiles="https://github.com/kimwalisch/primecount/archive/refs/tags/v${version}.tar.gz"
-checksum=c7bf47c041bfe4c3912a0d503ea44c1bb6c9003427c12574a6b497748b387612
+checksum=a2dd9714e723388987183776d068d6845b82b2cf8ea44ecb6cea3fd9dde938ea
 
 post_install() {
 	vlicense COPYING

--- a/srcpkgs/primesieve/template
+++ b/srcpkgs/primesieve/template
@@ -1,6 +1,6 @@
 # Template file for 'primesieve'
 pkgname=primesieve
-version=12.13
+version=12.14
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTS=ON -DBUILD_SHARED_LIBS=ON -DBUILD_STATIC_LIBS=OFF"
@@ -10,7 +10,7 @@ license="BSD-2-Clause"
 homepage="https://github.com/kimwalisch/primesieve"
 changelog="https://raw.githubusercontent.com/kimwalisch/primesieve/master/ChangeLog"
 distfiles="https://github.com/kimwalisch/primesieve/archive/refs/tags/v${version}.tar.gz"
-checksum=4cd3f1b70f6b02d695e6495e6a0fc0fa99b4dc043e0f21686d2cf409e98295c9
+checksum=65cf173e11bc9aff1b189f2cd19c6b6c502c30e966876b5c5ef71e138f49c8c9
 
 post_install() {
 	vlicense COPYING


### PR DESCRIPTION
- **primesieve: update to 12.14.**
- **primecount: update to 8.5.**

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
