### PR TITLE
spectacle: update to 6.6.5

### DIFF
--- a/srcpkgs/spectacle/template
+++ b/srcpkgs/spectacle/template
@@ -1,7 +1,7 @@
 # Template file for 'spectacle'
 pkgname=spectacle
 reverts="24.12.1_1 24.12.0_1 24.08.1_2 24.08.1_1 24.08.0_1 24.05.0_4 24.05.0_3 24.05.0_2 24.05.0_2 24.05.0_2 24.05.0_1 24.02.2_1 23.08.5_1 23.08.4_1 23.08.3_1 23.08.2_1 23.08.0_1 23.04.2_1 23.04.0_1 22.12.1_1 22.08.2_1 22.08.1_1 22.04.3_1 22.04.1_1 21.12.3_1 21.12.2_1 21.12.1_1 21.12.0_1 21.08.3_1 21.08.2_1 21.08.1_1 21.08.0_1 21.04.3_1 21.04.2_1 21.04.1_1 21.04.0_1 20.12.3_1 20.12.2_1 20.12.1_1 20.12.0_1 20.08.3_1 20.08.2_1 20.08.1_1 20.08.0_1 20.04.3_1 20.04.2_1 20.04.2_1 20.04.1_1 20.04.0_1"
-version=6.6.3
+version=6.6.5
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake"
@@ -39,4 +39,4 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.0-or-later, GPL-2.0-or-later"
 homepage="https://apps.kde.org/spectacle/"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=beceaffae061676215582227208b8a29e9dce1689480ba86e76ec8afa0fef13d
+checksum=a37df7731a6bc89bc23ac08ad1f995ce9f1efb330f3ebad9bf926dca6ebb5fc7


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64

#### Package update
i updated the package `spectacle` to the version `6.6.5`
