### PR TITLE
libmtp: update to 1.1.23.

### DIFF
--- a/srcpkgs/libmtp/template
+++ b/srcpkgs/libmtp/template
@@ -1,6 +1,6 @@
 # Template file for 'libmtp'
 pkgname=libmtp
-version=1.1.22
+version=1.1.23
 revision=1
 build_style=gnu-configure
 configure_args="--disable-static --with-udev=/usr/lib/udev
@@ -13,7 +13,7 @@ license="LGPL-2.1-or-later"
 homepage="https://libmtp.sourceforge.net"
 changelog="https://sourceforge.net/projects/libmtp/files/libmtp/${version}/README"
 distfiles="${SOURCEFORGE_SITE}/${pkgname}/${pkgname}-${version}.tar.gz"
-checksum=c3fcf411aea9cb9643590cbc9df99fa5fe30adcac695024442973d76fa5f87bc
+checksum=74a2b6e8cb4a0304e95b995496ea3ac644c29371649b892b856e22f12a0bdeed
 
 if [ "$CROSS_BUILD" ]; then
 	# use mtp-hotplug from host, needed to create udev rules and hwdb


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
