### PR TITLE
zig: update to 0.16.0.

### DIFF
--- a/srcpkgs/zig/template
+++ b/srcpkgs/zig/template
@@ -1,6 +1,6 @@
 # Template file for 'zig'
 pkgname=zig
-version=0.13.0
+version=0.16.0
 revision=1
 archs="x86_64* aarch64*"
 build_style=cmake
@@ -8,13 +8,13 @@ configure_args="-DZIG_TARGET_MCPU=baseline"
 make_cmd=make
 # we add xml2, zstd, zlib and ncurses
 # because our lld is static-only and requires those to work
-makedepends="clang18-devel llvm18-devel lld18-devel libxml2-devel libzstd-devel ncurses-devel zlib-devel"
+makedepends="clang21-devel llvm21-devel lld21-devel libxml2-devel libzstd-devel ncurses-devel zlib-devel"
 short_desc="Programming language designed for robustness, optimality, and clarity"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
 homepage="https://ziglang.org"
 distfiles="https://ziglang.org/download/${version}/zig-${version}.tar.xz"
-checksum=06c73596beeccb71cc073805bdb9c0e05764128f16478fa53bf17dfabc1d4318
+checksum=43186959edc87d5c7a1be7b7d2a25efffd22ce5807c7af99067f86f99641bfdf
 nopie=yes
 nocross=yes
 


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **NO**


#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (crossbuilds):
  - x86_64-musl
