### PR TITLE
brother-brscan5: update to 1.6.2.

### DIFF
--- a/srcpkgs/brother-brscan5/template
+++ b/srcpkgs/brother-brscan5/template
@@ -1,6 +1,6 @@
 # Template file for 'brother-brscan5'
 pkgname=brother-brscan5
-version=1.5.1
+version=1.6.2
 revision=1
 archs="i686 x86_64"
 depends="sane libusb-compat"
@@ -15,7 +15,7 @@ conf_files="/opt/brother/scanner/brscan5/brscan5.ini
  /opt/brother/scanner/brscan5/models/*.ini"
 
 _sane_library="libsane-brother5.so.1.0.7"
-_pkg_libraries="libLxBsScanCoreApi.so.3.2.1
+_pkg_libraries="libLxBsScanCoreApi.so.3.2.6
  libLxBsNetDevAccs.so.1.0.0
  libLxBsDeviceAccs.so.1.0.0
  libLxBsUsbDevAccs.so.1.0.0"
@@ -23,12 +23,12 @@ _pkg_libraries="libLxBsScanCoreApi.so.3.2.1
 if [ "$XBPS_TARGET_MACHINE" = "x86_64" ]; then
 	_rpmpkgid="0.x86_64"
 	distfiles="https://download.brother.com/welcome/dlf104036/brscan5-${version}-${_rpmpkgid}.rpm"
-	checksum="1c1d56d05c7b6b010ccd87680c039253ed3275b199412a378c6f6fd524cd5640"
+	checksum="a14b991dafd0279cc92c981154901178825174b8ac2123868037b3614b8f905e"
 	_rpmlibdir="usr/lib64"
 else
 	_rpmpkgid="0.i386"
 	distfiles="https://download.brother.com/welcome/dlf104035/brscan5-${version}-${_rpmpkgid}.rpm"
-	checksum="770583250a70481ca557d20ce0bf3cf63263653dc930540258a29c160aa0b3d2"
+	checksum="0fb59e0eb74f6c46568e314f6c6d5c8da22acdeb9b637519fdb922663be889c7"
 	_rpmlibdir="usr/lib"
 fi
 


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-LIBC)