### PR TITLE
qtkeychain-qt6: update to 0.16.0.

### DIFF
--- a/srcpkgs/qtkeychain-qt6/template
+++ b/srcpkgs/qtkeychain-qt6/template
@@ -1,6 +1,6 @@
 # Template file for 'qtkeychain-qt6'
 pkgname=qtkeychain-qt6
-version=0.15.0
+version=0.16.0
 revision=1
 build_style=cmake
 configure_args="-DBUILD_WITH_QT6=ON
@@ -13,7 +13,7 @@ license="BSD-2-Clause"
 homepage="https://github.com/frankosterfeld/qtkeychain"
 changelog="https://raw.githubusercontent.com/frankosterfeld/qtkeychain/main/ChangeLog"
 distfiles="https://github.com/frankosterfeld/${pkgname%-*}/archive/${version}.tar.gz"
-checksum=f4254dc8f0933b06d90672d683eab08ef770acd8336e44dfa030ce041dc2ca22
+checksum=3be26ec4ae30eecf0c2ff7572ba83799791b157c76e15a05ef35f23dc25e4054
 make_check=no # tests need X11 ?
 
 post_install() {


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
