### PR TITLE
gnome-maps: fix dependencies

### DIFF
--- a/srcpkgs/gnome-maps/template
+++ b/srcpkgs/gnome-maps/template
@@ -1,7 +1,7 @@
 # Template file for 'gnome-maps'
 pkgname=gnome-maps
 version=50.1
-revision=1
+revision=2
 build_style=meson
 build_helper="gir"
 hostmakedepends="desktop-file-utils glib-devel gettext pkg-config gjs gtk4-update-icon-cache
@@ -9,7 +9,8 @@ hostmakedepends="desktop-file-utils glib-devel gettext pkg-config gjs gtk4-updat
 makedepends="geoclue2-devel gjs-devel geocode-glib-devel libgweather-devel
  libshumate-devel libsecret-devel rest-devel libadwaita-devel libportal-devel
  librsvg-devel libxml2-devel json-glib-devel"
-depends="desktop-file-utils hicolor-icon-theme"
+depends="desktop-file-utils hicolor-icon-theme geoclue2 libportal rest libgweather
+ geocode-glib"
 short_desc="GNOME maps application"
 maintainer="Enno Boland <gottox@voidlinux.org>"
 license="GPL-2.0-or-later"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
#### Local build testing
- I built this PR locally for my native architecture, (x86_64-musl)
<!--
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->

---

Not sure why these got removed, the program refuses to start without them.

Cc: @r0man1an
