### PR TITLE
better-blur-dx: update to 2.5.1, enable building for kwin-x11

### DIFF
--- a/srcpkgs/better-blur-dx-x11
+++ b/srcpkgs/better-blur-dx-x11
@@ -1,0 +1,1 @@
+better-blur-dx

--- a/srcpkgs/better-blur-dx/template
+++ b/srcpkgs/better-blur-dx/template
@@ -1,6 +1,6 @@
 # Template file for 'better-blur-dx'
 pkgname=better-blur-dx
-version=2.4.1
+version=2.5.1
 revision=1
 build_style=cmake
 configure_args="-DFORCE_CROSSCOMPILED_TOOLS=ON -DKF6_HOST_TOOLING=/usr/lib/cmake
@@ -19,4 +19,25 @@ maintainer="Cass Spencer <casscardboard@gmail.com>"
 license="GPL-3.0-or-later"
 homepage="https://github.com/xarblu/kwin-effects-better-blur-dx"
 distfiles="${homepage}/archive/refs/tags/v${version}.tar.gz"
-checksum=e039cdfce81d93761bcf2baeade9d1b2ba83a899ec2954ddf62760a758bf7905
+checksum=42152f040434f0adfef55eab510000a5fc00b0afe1935e0dc6f01c766b4c9dbb
+
+post_configure() {
+	configure_args+=" -DBETTERBLUR_X11=ON"
+	cmake_builddir=build-x11 do_configure
+}
+
+post_build() {
+	cmake_builddir=build-x11 do_build
+}
+
+post_install() {
+	cmake_builddir=build-x11 do_install
+}
+
+better-blur-dx-x11_package() {
+	depends="plasma-desktop>=6.5.0"
+	short_desc+=" - X11 version"
+	pkg_install() {
+		vmove usr/lib/qt6/plugins/kwin-x11
+	}
+}


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

The package needs `-DBETTERBLUR_X11=ON` to build for kwin-x11, which was missing before.

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, `x86_64-glibc`
<!--
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
