### PR TITLE
python3-enzyme: update to 0.5.2

### DIFF
--- a/srcpkgs/python3-enzyme/template
+++ b/srcpkgs/python3-enzyme/template
@@ -1,13 +1,17 @@
 # Template file for 'python3-enzyme'
 pkgname=python3-enzyme
-version=0.4.1
-revision=9
-build_style=python3-module
-hostmakedepends="python3-setuptools"
+version=0.5.2
+revision=1
+build_style=python3-pep517
+hostmakedepends="python3-setuptools_scm"
 depends="python3"
 short_desc="Enzyme is a Python module to parse video metadata (Python3)"
 maintainer="Orphaned <orphan@voidlinux.org>"
-license="Apache-2.0"
+license="MIT"
 homepage="https://github.com/Diaoul/enzyme"
 distfiles="${PYPI_SITE}/e/enzyme/enzyme-${version}.tar.gz"
-checksum=f2167fa97c24d1103a94d4bf4eb20f00ca76c38a37499821049253b2059c62bb
+checksum=7cf779148d9e66eb2838603eace140c53c3cefc8b8fe5d4d5a03a5fb5d57b3c1
+
+post_install() {
+	vlicense LICENSE
+}


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

The old version produces a warning
```
/usr/lib/python3.14/site-packages/enzyme/parsers/ebml/core.py:4: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
  from pkg_resources import resource_stream  # @UnresolvedImport
```
The new version does not.
I also corrected the license line to match MIT.

#### Local build testing
- I built this PR locally for my native architecture: x86_64-glibc
