### PR TITLE
slurp: fix use-after-free crash on exit

### DIFF
--- a/srcpkgs/slurp/patches/fix-frame-callback-use-after-free.patch
+++ b/srcpkgs/slurp/patches/fix-frame-callback-use-after-free.patch
@@ -1,0 +1,20 @@
+Reason: fix intermittent use-after-free segfault on exit. send_frame()
+overwrote output->frame_callback with a new wl_surface_frame() callback
+without destroying the previous one, leaving a stale callback whose listener
+still pointed at the output; when its done event was dispatched after the
+output had been freed during teardown, slurp crashed.
+Upstream: https://github.com/emersion/slurp/commit/414760a341c34d08b598555561a3630133d1a81c
+
+diff --git a/main.c b/main.c
+--- a/main.c
++++ b/main.c
+@@ -586,6 +586,9 @@ static void send_frame(struct slurp_output *output) {
+ 	render(output);
+
+ 	// Schedule a frame in case the output becomes dirty again
++	if (output->frame_callback) {
++		wl_callback_destroy(output->frame_callback);
++	}
+ 	output->frame_callback = wl_surface_frame(output->surface);
+ 	wl_callback_add_listener(output->frame_callback,
+ 		&output_frame_listener, output);

--- a/srcpkgs/slurp/template
+++ b/srcpkgs/slurp/template
@@ -1,7 +1,7 @@
 # Template file for 'slurp'
 pkgname=slurp
 version=1.5.0
-revision=1
+revision=2
 build_style=meson
 hostmakedepends="pkg-config wayland-devel scdoc"
 makedepends="wayland-devel wayland-protocols cairo-devel libxkbcommon-devel"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

slurp 1.5.0 has a use-after-free in `send_frame()`: it overwrites `output->frame_callback` without destroying the previous `wl_surface_frame()` callback, so the orphaned callback's listener can fire on a freed `output` during teardown and crash slurp on exit. Reported and fixed upstream in https://github.com/emersion/slurp/commit/414760a341c34d08b598555561a3630133d1a81c (fixes https://github.com/emersion/slurp/issues/177), which landed after v1.5.0 was tagged, so the current release is affected. The crash is intermittent (depends on whether a frame callback is in flight at exit); for me it hit about half the time.