### PR TITLE
New package: librewolf-bin-151.0.1_1

### DIFF
--- a/srcpkgs/librewolf-bin/template
+++ b/srcpkgs/librewolf-bin/template
@@ -1,0 +1,50 @@
+# Template file for 'librewolf-bin'
+pkgname=librewolf-bin
+version=151.0.1
+revision=1
+_pkgrev=2
+archs="x86_64 aarch64"
+short_desc="Firefox fork focused on privacy, security and freedom"
+maintainer="Rodrigo Graeff <delphus@delphus.org>"
+hostmakedepends="tar"
+license="MPL-2.0"
+homepage="https://librewolf.net"
+distfiles=""
+checksum=""
+nostrip=yes
+
+case "$XBPS_TARGET_MACHINE" in
+	x86_64)
+		distfiles="https://repo.librewolf.net/pool/librewolf-${version}-${_pkgrev}-linux-x86_64-deb.deb"
+		checksum=cf5ec7498717900421481816a45f9b64965441d3c88b5c0351a30d82856d56be
+		;;
+	aarch64)
+		distfiles="https://repo.librewolf.net/pool/librewolf-${version}-${_pkgrev}-linux-arm64-deb.deb"
+		checksum=24f8f6f9f0858f0d1b70efd97b7843b13530a7f9951064d339a8f970b923f07a
+		;;
+esac
+
+do_extract() {
+	mkdir -p ${DESTDIR}
+	ar x ${XBPS_SRCDISTDIR}/${pkgname}-${version}/librewolf-${version}-${_pkgrev}-linux-*-deb.deb
+}
+
+do_install() {
+	tar xzf data.tar.gz -C ${DESTDIR}
+
+	# Move app to /usr/lib (Void pkglint rejects ELFs in /usr/share)
+	mv ${DESTDIR}/usr/share/librewolf ${DESTDIR}/usr/lib/librewolf
+
+	# Fix /usr/bin symlink to point at the new location
+	ln -sf /usr/lib/librewolf/librewolf ${DESTDIR}/usr/bin/librewolf
+
+	# Fix Exec paths in the .desktop file (binary moved from /usr/share to /usr/lib)
+	sed -i 's|/usr/share/librewolf/librewolf|/usr/lib/librewolf/librewolf|g' \
+		${DESTDIR}/usr/share/applications/librewolf.desktop
+
+	# Add 48x48 icon — the .deb ships 16/32/64/128 but not 48, which XFCE4 prefers
+	install -Dm644 ${DESTDIR}/usr/lib/librewolf/browser/chrome/icons/default/default48.png \
+		${DESTDIR}/usr/share/icons/hicolor/48x48/apps/librewolf.png
+
+	rm -rf ${DESTDIR}/etc
+}

--- a/srcpkgs/librewolf-bin/template
+++ b/srcpkgs/librewolf-bin/template
@@ -3,30 +3,19 @@ pkgname=librewolf-bin
 version=151.0.1
 revision=1
 _pkgrev=2
-archs="x86_64 aarch64"
+only_for_archs="x86_64"
 short_desc="Firefox fork focused on privacy, security and freedom"
-maintainer="Rodrigo Graeff <delphus@delphus.org>"
 hostmakedepends="tar"
+maintainer="Rodrigo Graeff <delphus@delphus.org>"
 license="MPL-2.0"
 homepage="https://librewolf.net"
-distfiles=""
-checksum=""
+distfiles="https://repo.librewolf.net/pool/librewolf-${version}-${_pkgrev}-linux-x86_64-deb.deb"
+checksum=cf5ec7498717900421481816a45f9b64965441d3c88b5c0351a30d82856d56be
 nostrip=yes
-
-case "$XBPS_TARGET_MACHINE" in
-	x86_64)
-		distfiles="https://repo.librewolf.net/pool/librewolf-${version}-${_pkgrev}-linux-x86_64-deb.deb"
-		checksum=cf5ec7498717900421481816a45f9b64965441d3c88b5c0351a30d82856d56be
-		;;
-	aarch64)
-		distfiles="https://repo.librewolf.net/pool/librewolf-${version}-${_pkgrev}-linux-arm64-deb.deb"
-		checksum=24f8f6f9f0858f0d1b70efd97b7843b13530a7f9951064d339a8f970b923f07a
-		;;
-esac
 
 do_extract() {
 	mkdir -p ${DESTDIR}
-	ar x ${XBPS_SRCDISTDIR}/${pkgname}-${version}/librewolf-${version}-${_pkgrev}-linux-*-deb.deb
+	ar x ${XBPS_SRCDISTDIR}/${pkgname}-${version}/librewolf-${version}-${_pkgrev}-linux-x86_64-deb.deb
 }
 
 do_install() {


### PR DESCRIPTION
#### Testing the changes
- [x] I've verified the package builds correctly with `xbps-src pkg librewolf-bin`
- [x] The package installs and runs: `librewolf --version` → `Mozilla LibreWolf 151.0.1-2`

#### Notes
Packages the official LibreWolf prebuilt binary from https://repo.librewolf.net for x86_64 and aarch64.

- Moves app directory to `/usr/lib/librewolf/` (ELFs cannot live in `/usr/share/`)
- Fixes `.desktop` `Exec=` paths accordingly
- Adds missing 48×48 icon from the bundled browser chrome icons