### PR TITLE
New package: audiotube-26.04.2 and futuresql-0.1.1

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -2053,6 +2053,7 @@ libkmailconfirmbeforedeleting.so.6 kdepim-addons-24.02.0_1
 libKUnifiedPush.so.1 kunifiedpush-25.08.0_1
 libKSaneCore6.so.1 ksanecore6-24.02.0_1
 libKSaneWidgets6.so.6 libksane6-24.02.0_1
+libfuturesql6.so.0 futuresql-0.1.1_1
 # Akonadi
 libKPim6GAPIBlogger.so.6 libkgapi-24.02.0_1
 libKPim6GAPICalendar.so.6 libkgapi-24.02.0_1

--- a/srcpkgs/audiotube/template
+++ b/srcpkgs/audiotube/template
@@ -1,0 +1,19 @@
+# Template file for 'audiotube'
+pkgname=audiotube
+version=26.04.2
+revision=1
+build_style=cmake
+configure_args="-DBUILD_TESTING=OFF"
+hostmakedepends="extra-cmake-modules qt6-tools qt6-base qt6-declarative-host-tools
+ kf6-kconfig kf6-kcoreaddons gettext pkg-config yt-dlp python3-ytmusicapi"
+makedepends="futuresql-devel kf6-kconfig-devel kf6-kcrash-devel kf6-ki18n-devel
+ kf6-kiconthemes-devel kf6-kirigami-devel kirigami-addons-devel
+ kf6-kwindowsystem-devel kf6-purpose-devel qt6-multimedia-devel qt6-svg-devel
+ python3-devel python3-pybind11 qcoro-qt6-devel"
+depends="python3-ytmusicapi yt-dlp qt6-imageformats gst-plugins-bad1 gst-plugins-good1"
+short_desc="Client for YouTube Music"
+maintainer="Nafis <mnabid.25@outlook.com>"
+license="GPL-2.0-or-later, LGPL-2.0-or-later"
+homepage="https://apps.kde.org/audiotube/"
+distfiles="${KDE_SITE}/release-service/${version}/src/audiotube-${version}.tar.xz"
+checksum=af049214826346351215c8604e74ab74409cc9bf3005565b2a280fcd5afed393

--- a/srcpkgs/futuresql-devel
+++ b/srcpkgs/futuresql-devel
@@ -1,0 +1,1 @@
+futuresql

--- a/srcpkgs/futuresql/template
+++ b/srcpkgs/futuresql/template
@@ -1,0 +1,24 @@
+# Template file for 'futuresql'
+pkgname=futuresql
+version=0.1.1
+revision=1
+build_style=cmake
+configure_args="-DQT_MAJOR_VERSION=6 -DBUILD_TESTING=OFF"
+hostmakedepends="extra-cmake-modules qt6-base qt6-tools"
+makedepends="qt6-base-devel"
+short_desc="Non-blocking Qt database framework"
+maintainer="Nafis <mnabid.25@outlook.com>"
+license="LGPL-2.1-or-later"
+homepage="https://invent.kde.org/libraries/futuresql"
+distfiles="${KDE_SITE}/futuresql/futuresql-${version}.tar.xz"
+checksum=e44ed8d5a9618b3ca7ba2983ed9c5f7572e6e0a5b199f94868834b71ccbebd43
+
+futuresql-devel_package() {
+	depends="${sourcepkg}>=${version}_${revision} qt6-base-devel"
+	short_desc+=" - development files"
+	pkg_install() {
+		vmove usr/include
+		vmove usr/lib/cmake
+		vmove "usr/lib/*.so"
+	}
+}


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

[AudioTube](https://apps.kde.org/audiotube) is a client for YouTube Music.
Closes: #48311

#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**


<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, `x86_64-glibc`
- I built this PR locally for these architectures:
  - `armv6l-musl` (crossbuild)

