### PR TITLE
New package: expert-0.1.4

### DIFF
--- a/srcpkgs/expert/template
+++ b/srcpkgs/expert/template
@@ -1,0 +1,31 @@
+# Template file for 'expert'
+pkgname=expert
+version=0.1.4
+revision=1
+build_style=fetch
+archs="x86_64 aarch64"
+short_desc="Official Elixir Language Server Protocol implementation"
+maintainer="velrest+void-packages@gmail.com"
+license="Apache-2.0"
+homepage="https://expert-lsp.org/"
+
+case "$XBPS_TARGET_MACHINE" in
+x86_64)
+	distfiles="https://github.com/expert-lsp/expert/releases/download/v${version}/expert_linux_amd64"
+	checksum="3c80e8b4b1428d6e87fba29056fd6ac7c52ea9edc2344f2c4388a318d131d361"
+	_bin="expert_linux_amd64"
+	;;
+aarch64)
+	distfiles="https://github.com/expert-lsp/expert/releases/download/v${version}/expert_linux_arm64"
+	checksum="128f0eb2b477892fe1cc0567e996f8674ef2d36809541952a2bf1375c9d178c4"
+	_bin="expert_linux_arm64"
+	;;
+esac
+
+do_check() {
+	./${_bin} --version
+}
+
+do_install() {
+	vbin ${_bin} expert
+}


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**


#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **PARTIALLY** as this uses a pre-built binary

**Why this uses pre-built binaries:**
Building from source is currently not feasible. The build tool ([Burrito](https://github.com/burrito-elixir/burrito)) requires Zig 0.15.2, but void-packages currently ships Zig 0.13.0 and there is a PR open to go directly to 16 [here](https://github.com/void-linux/void-packages/pull/59955). The pre-built binaries are official upstream releases with verified checksums. Coverage is limited to `x86_64` and `aarch64` glibc; musl is not supported.

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)


