### PR TITLE
goldendict-ng: update to 26.5.6

### DIFF
--- a/srcpkgs/goldendict-ng/template
+++ b/srcpkgs/goldendict-ng/template
@@ -1,6 +1,6 @@
 # Template file for 'goldendict-ng'
 pkgname=goldendict-ng
-version=26.5.5
+version=26.5.6
 revision=1
 build_style=cmake
 configure_args="-DUSE_ALTERNATIVE_NAME=ON -DWITH_TTS=OFF"
@@ -15,7 +15,7 @@ maintainer="Mateusz Sylwestrzak <slymattz@gmail.com>"
 license="GPL-3.0-or-later"
 homepage="https://xiaoyifang.github.io/goldendict-ng/"
 distfiles="https://github.com/xiaoyifang/goldendict-ng/archive/refs/tags/v${version}.tar.gz"
-checksum=ddf5487759476eb6b8b3f10161be8ece41b63185d4a789690898d722b28e0f03
+checksum=d0748b7448723cb105b3e1f706fb0f0b2dddc8ad94b5373b02fbfccca5d18941
 
 if [ "$XBPS_WORDSIZE$XBPS_WORDSIZE" != "64$XBPS_TARGET_WORDSIZE" ]; then
 	broken="Qt6 WebEngine"


### PR DESCRIPTION

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture: x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl