### PR TITLE
python3-fastapi: update  to 0.136.3.

### DIFF
--- a/srcpkgs/python3-fastapi/template
+++ b/srcpkgs/python3-fastapi/template
@@ -1,6 +1,6 @@
 # Template file for 'python3-fastapi'
 pkgname=python3-fastapi
-version=0.136.1
+version=0.136.3
 revision=1
 build_style=python3-pep517
 hostmakedepends="python3-pdm-backend"
@@ -10,7 +10,7 @@ maintainer="Jason Elswick <jason@jasondavid.us>"
 license="MIT"
 homepage="https://github.com/FastAPI/FastAPI"
 distfiles="https://github.com/fastapi/fastapi/archive/refs/tags/${version}.tar.gz"
-checksum=f404f589213d6ee0bf8c859342e9bcc02ccc7e8929600240f7b92dcfc8924c06
+checksum=8fcc91d75439fdd3384b8a685bc830363aa1a2cd50b48e7a28f46820f835cd84
 make_check=no # too many unpackaged dependencies
 
 post_install() {


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-libc
