### PR TITLE
opera: update to 131.0.5877.97.

### DIFF
--- a/srcpkgs/opera/template
+++ b/srcpkgs/opera/template
@@ -1,6 +1,6 @@
 # Template file for 'opera'
 pkgname=opera
-version=131.0.5877.5
+version=131.0.5877.97
 revision=1
 archs="x86_64"
 create_wrksrc=yes
@@ -10,7 +10,7 @@ maintainer="mobinmob <mobinmob@disroot.org>"
 license="custom:Proprietary"
 homepage="https://www.opera.com/computer"
 distfiles="https://get.geo.opera.com/pub/opera/desktop/${version}/linux/opera-stable_${version}_amd64.rpm"
-checksum=4142159021e4d01aa3c6284f3902c7b606f6006dd726d5497468637a6397c655
+checksum=29290108b6a9049c8897cdcfb422f66e0b1f66fb323bb63dee7b43e88a8234ec
 repository="nonfree"
 nostrip=yes
 


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, `x86_64-glibc`
<!--
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
