### PR TITLE
New package: cloudflare-warp-bin-2026.4.1350.0

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -587,6 +587,7 @@ libevolution-mail-composer.so evolution-3.48.0_1
 libevolution-mail-formatter.so evolution-3.40.0_1
 libevolution-shell.so evolution-3.28.0_1
 libedata-cal-2.0.so.2 evolution-data-server-3.46.0_1
+libpcap.so.0.8 libpcap-1.0_1
 libpcap.so.1 libpcap-1.1.1_1
 libiptc.so.0 iptables-1.4.7_1
 libip6tc.so.2 iptables-1.8.3_1

--- a/srcpkgs/cloudflare-warp-bin/files/LICENSE
+++ b/srcpkgs/cloudflare-warp-bin/files/LICENSE
@@ -1,0 +1,1 @@
+See https://www.cloudflare.com/application/terms/

--- a/srcpkgs/cloudflare-warp-bin/files/README.voidlinux
+++ b/srcpkgs/cloudflare-warp-bin/files/README.voidlinux
@@ -1,0 +1,13 @@
+Enable the main connectivity daemon:
+
+	sudo ln -s /etc/sv/warp-svc /var/service/
+
+For the system tray icon (optional):
+
+	ln -s /etc/sv/warp-taskbar ~/.config/service/
+
+Optional packages:
+
+- gnupg2:       GnuPG support
+- libcap-progs: Run `warp-cli` with capabilities instead of root (setcap)
+- traceroute:   Network diagnostics via `warp-cli`

--- a/srcpkgs/cloudflare-warp-bin/files/warp-svc/run
+++ b/srcpkgs/cloudflare-warp-bin/files/warp-svc/run
@@ -1,0 +1,7 @@
+#!/bin/sh
+exec 2>&1
+
+exec setpriv \
+    --inh-caps=+net_admin,+net_bind_service,+net_raw,+sys_ptrace,+dac_read_search,+setuid,+setgid \
+    --ambient-caps=+net_admin,+net_bind_service,+net_raw,+sys_ptrace,+dac_read_search,+setuid,+setgid \
+    /bin/warp-svc

--- a/srcpkgs/cloudflare-warp-bin/files/warp-taskbar/run
+++ b/srcpkgs/cloudflare-warp-bin/files/warp-taskbar/run
@@ -1,0 +1,4 @@
+#!/bin/sh
+exec 2>&1
+
+exec /bin/warp-taskbar

--- a/srcpkgs/cloudflare-warp-bin/template
+++ b/srcpkgs/cloudflare-warp-bin/template
@@ -1,0 +1,44 @@
+# Template file for 'cloudflare-warp-bin'
+pkgname=cloudflare-warp-bin
+version=2026.4.1350.0
+revision=1
+_dist=noble
+archs="x86_64"
+
+hostmakedepends="dpkg tar"
+depends="iproute2 nftables desktop-file-utils ca-certificates hicolor-icon-theme"
+
+short_desc="Cloudflare One Client (formerly WARP)"
+maintainer="Nadeŭka <me@nadevko.cc>"
+license="custom:Proprietary"
+homepage="https://1.1.1.1/"
+changelog="https://developers.cloudflare.com/cloudflare-one/changelog/cloudflare-one-client/index.md"
+repository=nonfree
+restricted=yes
+nostrip=yes
+
+distfiles="https://pkg.cloudflareclient.com/pool/${_dist}/main/c/cloudflare-warp/cloudflare-warp_${version}_amd64.deb"
+checksum=f35ae16dd97e8a78dd970341cb6ae3e8131af1962f79cb7b9d698a874eab7f2a
+
+do_extract() {
+	dpkg-deb -x ${XBPS_SRCDISTDIR}/${pkgname}-${version}/cloudflare-warp_${version}_amd64.deb ${wrksrc}
+}
+
+do_install() {
+	rm -rf lib usr/lib/systemd usr/share/doc
+
+	vcopy usr .
+
+	vbin bin/warp-cli
+	vbin bin/warp-dex
+	vbin bin/warp-diag
+	vbin bin/warp-svc
+	ln -sr ${DESTDIR}/usr/lib/warp/warp-taskbar ${DESTDIR}/usr/bin/warp-taskbar
+
+	vsv warp-svc
+	vsv warp-taskbar
+	vdoc "${FILESDIR}/README.voidlinux"
+	vlicense "${FILESDIR}/LICENSE"
+
+	ln -sf libpcap.so.1 "${DESTDIR}/usr/lib/libpcap.so.0.8"
+}

--- a/srcpkgs/cloudflare-warp-bin/update
+++ b/srcpkgs/cloudflare-warp-bin/update
@@ -1,0 +1,18 @@
+# cloudflare didn't provide any convinient way to get latest version
+
+pattern='^Version:\s*\K\S+'
+disabled="Cloudflare APT repository is offline or all Ubuntu releases returned 404"
+
+# z->a ubuntu releases check until first supported
+for _dist in $(
+		curl -s "https://changelogs.ubuntu.com/meta-release" |
+		grep "^Dist:" |
+		awk '{print $2}' |
+		tac); do
+	# if found, undo disabling and exit loop
+	site="https://pkg.cloudflareclient.com/dists/${_dist}/main/binary-amd64/Packages"
+	if curl -s -f -I -o /dev/null "$site"; then
+		disabled=""
+		break
+	fi
+done


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **System, Required**

Why this package should be included:
- **Restricted/Non-free:** This is a proprietary binary package provided by Cloudflare. It is marked as `restricted=yes` and targets the `nonfree` repository, following the standard procedure for reputable proprietary software (similar to `google-chrome` or `1password`).
- **System-wide utility:** It installs a system-wide background daemon (`warp-svc`) managed via `runit`, matching the "System" requirement.
- **High demand:** Cloudflare WARP is a widely used tool for network security and privacy, providing significant value to the Void Linux community.

I built this PR locally for my native architecture, x86_64-glibc