### PR TITLE
New package: tabby-1.0.234

### DIFF
--- a/srcpkgs/tabby/template
+++ b/srcpkgs/tabby/template
@@ -1,0 +1,33 @@
+# Template file for 'tabby'
+pkgname=tabby
+version=1.0.234
+revision=1
+archs="x86_64"
+depends="xdg-utils libsecret"
+short_desc="Terminal emulator with SSH client, built on Electron"
+maintainer="silenthooligan <erik.skean@gmail.com>"
+license="MIT"
+homepage="https://tabby.sh"
+changelog="https://github.com/Eugeny/tabby/releases"
+distfiles="https://github.com/Eugeny/tabby/releases/download/v${version}/${pkgname}-${version}-linux-x64.deb"
+checksum=1872080af06c962347c7a5411de682478e087df33eae67c2b57a517461702fd4
+nopie=yes
+noverifyrdeps=yes
+noshlibprovides=yes
+
+do_install() {
+	mkdir -p ${DESTDIR}/opt
+	vcopy opt/Tabby opt
+
+	mkdir -p ${DESTDIR}/usr/bin
+	ln -s /opt/Tabby/tabby ${DESTDIR}/usr/bin/tabby
+
+	vinstall usr/share/applications/tabby.desktop 644 usr/share/applications
+
+	for s in 16 32 64 128 256 512; do
+		vinstall usr/share/icons/hicolor/${s}x${s}/apps/tabby.png 644 \
+			usr/share/icons/hicolor/${s}x${s}/apps
+	done
+
+	vlicense opt/Tabby/LICENSE.electron.txt
+}


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc

Tabby is a configurable terminal emulator with built-in SSH and serial-port support, MIT-licensed, built on Electron. Upstream ships an x86_64 `.deb` on GitHub releases; this template extracts and installs from that.

Runtime tested: launches on KDE Plasma 6 Wayland, local zsh profile and SSH profiles to remote hosts both connect, settings persist to `~/.config/tabby/`. `xlint` clean.
