### PR TITLE
xdg-desktop-portal-wlr: update to 0.8.2.

### DIFF
--- a/srcpkgs/xdg-desktop-portal-wlr/template
+++ b/srcpkgs/xdg-desktop-portal-wlr/template
@@ -1,6 +1,6 @@
 # Template file for 'xdg-desktop-portal-wlr'
 pkgname=xdg-desktop-portal-wlr
-version=0.8.1
+version=0.8.2
 revision=1
 build_style=meson
 configure_args="-Dc_args=-Wno-error"
@@ -13,7 +13,7 @@ maintainer="icp <pangolin@vivaldi.net>"
 license="MIT"
 homepage="https://github.com/emersion/xdg-desktop-portal-wlr"
 distfiles="https://github.com/emersion/xdg-desktop-portal-wlr/archive/v${version}.tar.gz"
-checksum=fa7fd63929af054729898c4983ae100e7b0e5c2a91a13d833d2aa7a11c9aeb89
+checksum=f9187def606a6ede1b4df8f31c6bba9b28cfd607dc45dfdbce8d35695cbd2911
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
sway 1.12 requires this version of xdg-desktop-portal-wlr to get working individual window capture. (other wlroots-based compositors offering this function, like labwc 0.20.0, might also depend on it, although I have not tried it)

#### Testing the changes
- I tested the changes in this PR: **briefly**


#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
