### PR TITLE
girara: update to 2026.02.04, zathura: update to 2026.05.20, zathura-pdf-mupdf: update to 2026.05.10, zathura-cb: update to 2026.05.10, zathura-djvu: update to 2026.05.10, zathura-ps: update to 2026.02.03, zathura-pdf-poppler: update to 2026.05.10

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -1672,7 +1672,7 @@ libtelepathy-farstream.so.3 telepathy-farstream-0.6.0_6
 libnetpbm.so.11 libnetpbm-10.66.03_2
 libid3.so id3lib-3.8.3_7
 libid3-3.8.so.3 id3lib-3.8.3_7
-libgirara-gtk3.so.4 girara-0.4.4_1
+libgirara.so.5 girara-2026.02.04_1
 libjq.so.1 jq-1.6_2
 libcrypto.so.3 libcrypto3-3.5.4_1
 libssl.so.3 libssl3-3.5.4_1

--- a/srcpkgs/girara/template
+++ b/srcpkgs/girara/template
@@ -1,6 +1,6 @@
 # Template file for 'girara'
 pkgname=girara
-version=0.4.5
+version=2026.02.04
 revision=1
 build_style=meson
 hostmakedepends="pkg-config intltool doxygen glib-devel"
@@ -12,7 +12,7 @@ license="Zlib"
 homepage="https://pwmt.org/projects/girara/"
 changelog="https://pwmt.org/projects/girara/changelog/${version}/index.html"
 distfiles="https://pwmt.org/projects/girara/download/girara-${version}.tar.xz"
-checksum=6b7f7993f82796854d5036572b879ffaaf7e0b619d12abdb318ce14757bdda91
+checksum=342eca8108bd05a2275e3eacb18107fa3170fa89a12c77e541a5f111f7bba56d
 make_check_pre="xvfb-run"
 
 post_install() {

--- a/srcpkgs/zathura-cb/template
+++ b/srcpkgs/zathura-cb/template
@@ -1,6 +1,6 @@
 # Template file for 'zathura-cb'
 pkgname=zathura-cb
-version=0.1.11
+version=2026.05.10
 revision=1
 build_style=meson
 hostmakedepends="pkg-config"
@@ -12,7 +12,7 @@ license="Zlib"
 homepage="https://pwmt.org/projects/zathura-cb/"
 changelog="https://pwmt.org/projects/zathura-cb/changelog/${version}/index.html"
 distfiles="https://pwmt.org/projects/zathura-cb/download/zathura-cb-${version}.tar.xz"
-checksum=4e201ea54cdc20a93258c43556f6389441af99740de7dca6ca1ff524172fbd47
+checksum=32b2fa420fbb8a55f6baca6501fce2820a2acc900453f9b993a3ef84026ae251
 
 post_install() {
 	vlicense LICENSE

--- a/srcpkgs/zathura-djvu/template
+++ b/srcpkgs/zathura-djvu/template
@@ -1,6 +1,6 @@
 # Template file for 'zathura-djvu'
 pkgname=zathura-djvu
-version=0.2.10
+version=2026.05.10
 revision=1
 build_style=meson
 hostmakedepends="pkg-config"
@@ -12,7 +12,7 @@ license="Zlib"
 homepage="https://git.pwmt.org/pwmt/zathura-djvu/"
 changelog="https://pwmt.org/projects/zathura-djvu/changelog/${version}/index.html"
 distfiles="https://pwmt.org/projects/zathura-djvu/download/zathura-djvu-${version}.tar.xz"
-checksum=32e9d89929a76cd7d3fcbaf79f441868bdabedf17317d1d1843faa1f19338d95
+checksum=a0815efe0e0f9dd01bda9b1348a0202e38b52284039f9f1b406b604f58bd0947
 
 post_install() {
 	vlicense LICENSE

--- a/srcpkgs/zathura-pdf-mupdf/patches/mupdf-third.patch
+++ b/srcpkgs/zathura-pdf-mupdf/patches/mupdf-third.patch
@@ -1,0 +1,11 @@
+--- a/meson.build
++++ b/meson.build
+@@ -32,7 +32,7 @@
+   cairo,
+ ]
+ 
+-if not mupdf.found()
++if true
+   # normal build of mupdf
+   mupdf = cc.find_library('mupdf', has_headers: ['mupdf/fitz/version.h', 'mupdf/fitz.h', 'mupdf/pdf.h'], required: true)
+   mupdfthird = cc.find_library('mupdf-third')

--- a/srcpkgs/zathura-pdf-mupdf/template
+++ b/srcpkgs/zathura-pdf-mupdf/template
@@ -1,7 +1,7 @@
 # Template file for 'zathura-pdf-mupdf'
 pkgname=zathura-pdf-mupdf
-version=0.4.4
-revision=4
+version=2026.05.10
+revision=1
 build_style=meson
 hostmakedepends="pkg-config"
 makedepends="mupdf-devel zathura-devel libopenjpeg2-devel tesseract-ocr-devel
@@ -13,7 +13,7 @@ license="Zlib"
 homepage="https://pwmt.org/projects/zathura-pdf-mupdf/"
 changelog="https://pwmt.org/projects/zathura-pdf-mupdf/changelog/${version}/index.html"
 distfiles="https://pwmt.org/projects/zathura-pdf-mupdf/download/zathura-pdf-mupdf-${version}.tar.xz"
-checksum=0125624901cabe3a2fe63315a46e7d966a323c028ff53890dfaf7856adb1f4fc
+checksum=e57c046e80b65e0a8df82cb04b537102099c38b3ed4d7f30161c2e7dcd9a6e28
 conflicts="zathura-pdf-poppler>=0"
 
 post_install() {

--- a/srcpkgs/zathura-pdf-poppler/template
+++ b/srcpkgs/zathura-pdf-poppler/template
@@ -1,6 +1,6 @@
 # Template file for 'zathura-pdf-poppler'
 pkgname=zathura-pdf-poppler
-version=0.3.3
+version=2026.05.10
 revision=1
 build_style=meson
 hostmakedepends="pkg-config"
@@ -12,7 +12,7 @@ license="Zlib"
 homepage="https://git.pwmt.org/pwmt/zathura-pdf-poppler/"
 changelog="https://pwmt.org/projects/zathura-pdf-poppler/changelog/${version}/index.html"
 distfiles="https://pwmt.org/projects/zathura-pdf-poppler/download/zathura-pdf-poppler-${version}.tar.xz"
-checksum=c812f2f4446fd5de16734e13c02ea9aa25ba4e3ba9f72b732c0ff90f9ba34935
+checksum=364c38634273c06252087324bf01dbde2885b932795265aee44006aa2701fe23
 
 conflicts="zathura-pdf-mupdf>=0"
 

--- a/srcpkgs/zathura-ps/template
+++ b/srcpkgs/zathura-ps/template
@@ -1,6 +1,6 @@
 # Template file for 'zathura-ps'
 pkgname=zathura-ps
-version=0.2.8
+version=2026.02.03
 revision=1
 build_style=meson
 hostmakedepends="pkg-config"
@@ -12,7 +12,7 @@ license="Zlib"
 homepage="https://git.pwmt.org/pwmt/zathura-ps/"
 changelog="https://pwmt.org/projects/zathura-ps/changelog/${version}/index.html"
 distfiles="https://pwmt.org/projects/zathura-ps/download/zathura-ps-${version}.tar.xz"
-checksum=07ca594f7277f9876d0038048418343ea2964028e93c90f9569eff36a8932e4a
+checksum=b3556ff2960b7a5d014e873bd0474c37f3f082e370c6ed8efb9487ba6167eda8
 
 post_install() {
 	vlicense LICENSE

--- a/srcpkgs/zathura/template
+++ b/srcpkgs/zathura/template
@@ -1,6 +1,6 @@
 # Template file for 'zathura'
 pkgname=zathura
-version=0.5.13
+version=2026.05.20
 revision=1
 build_style=meson
 configure_args="-Dsynctex=enabled"
@@ -8,14 +8,14 @@ hostmakedepends="pkg-config gettext python3-Sphinx desktop-file-utils
  appstream-glib glib-devel librsvg-utils"
 makedepends="girara-devel sqlite-devel file-devel zlib-devel libseccomp-devel
  libglib-devel texlive-devel"
-checkdepends="AppStream gettext-devel check-devel xvfb-run"
+checkdepends="AppStream gettext-devel check-devel xvfb-run weston"
 short_desc="Highly customizable and functional document viewer"
 maintainer="lemmi <lemmi@nerd2nerd.org>"
 license="Zlib"
 homepage="https://pwmt.org/projects/zathura/"
 changelog="https://pwmt.org/projects/zathura/changelog/${version}/index.html"
 distfiles="https://pwmt.org/projects/zathura/download/zathura-${version}.tar.xz"
-checksum=6302173bcd46f897e5209c883a5b51ad1dab4946c2f3861cba374a3b80d8f3c1
+checksum=e2e6dc695ebb0170eaa3d39d295c6997c93f23061e6c2b7d3347e03415a2254b
 
 if [ -z "$CROSS_BUILD" ] && [ "$XBPS_CHECK_PKGS" ]; then
 	configure_args+=" -Dtests=enabled"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc

Please note that current versions of zathura and zathura-* involved in this PR require libgirara-gtk3 to build. girara-2026.02.04_1 provides libgirara instead of libgirara-gtk3 ([reference](https://pwmt.org/news/girara-2026-02-03/index.html)). Therefore it is necessary to bundle these commits in a single PR.

@lemmi