### PR TITLE
New package: sudo-rs-0.2.15

### DIFF
--- a/srcpkgs/sudo-rs/INSTALL
+++ b/srcpkgs/sudo-rs/INSTALL
@@ -1,0 +1,11 @@
+#
+# Sets up permissions for /etc/sudoers.
+#
+case "${ACTION}" in
+post)
+	if [ -f etc/sudoers ]; then
+		echo "Setting up permissions to /etc/sudoers..."
+		chmod 0440 etc/sudoers
+	fi
+	;;
+esac

--- a/srcpkgs/sudo-rs/REMOVE
+++ b/srcpkgs/sudo-rs/REMOVE
@@ -1,0 +1,8 @@
+#
+# Cleans the sudo ticket database at purge.
+#
+case "${ACTION}" in
+purge)
+	[ -d var/db/sudo ] && rm -rf var/db/sudo
+	;;
+esac

--- a/srcpkgs/sudo-rs/files/sudo.pam
+++ b/srcpkgs/sudo-rs/files/sudo.pam
@@ -1,0 +1,4 @@
+#%PAM-1.0
+auth 		include 	system-auth
+account 	include 	system-auth
+session 	include 	system-auth

--- a/srcpkgs/sudo-rs/template
+++ b/srcpkgs/sudo-rs/template
@@ -1,0 +1,68 @@
+# Template file for 'sudo-rs'
+pkgname=sudo-rs
+version=0.2.14
+revision=1
+build_style=cargo
+make_build_args="--bin sudo --bin visudo --features gettext"
+make_install_args="--path . --bin sudo --bin visudo --features gettext"
+hostmakedepends="gettext pkg-config"
+makedepends="pam-devel"
+short_desc="Memory-safe implementation of sudo"
+maintainer="Nafis <mnabid.25@outlook.com>"
+license="Apache-2.0 OR MIT"
+homepage="https://github.com/trifectatechfoundation/sudo-rs"
+distfiles="${homepage}/archive/refs/tags/v${version}.tar.gz"
+checksum=54216f894622b2c31c657843cfd943e4a468bdf518b8ecdbcb81cbcfd4195729
+conflicts="sudo"
+replaces="sudo>=0"
+conf_files="
+ /etc/pam.d/sudo
+ /etc/sudoers"
+make_dirs="
+ /etc/sudoers.d 0750 root root
+ /var/db/sudo 0750 root root"
+
+make_check=no # tests fail in chroot
+# Failed tests:
+#  common::context::tests::test_build_run_context
+#  common::resolve::test::canonicalization
+#  su::context::tests::invalid_shell
+#  sudo::env::environment::tests::test_tzinfo
+#  system::audit::test::secure_open_is_predictable
+#  system::audit::test::test_traverse_secure_open_negative
+#  system::audit::test::test_traverse_secure_open_positive
+#  system::interface::test::test_unix_user
+#  system::tests::test_get_user_and_group_by_id
+
+post_install() {
+	# sudoers and PAM config
+	vsed -i docs/sudoers.example -e 's|/usr\(/etc/sudoers\.d\)|\1|'
+	vinstall docs/sudoers.example 440 etc sudoers
+	vinstall docs/sudoers.example 664 usr/share/examples/sudo-rs
+	vinstall ${FILESDIR}/sudo.pam 644 etc/pam.d sudo
+
+	# setuid for sudo binary
+	chmod 4755 ${DESTDIR}/usr/bin/sudo
+
+	# documentation
+	vman docs/man/sudo.8.man sudo.8
+	vman docs/man/sudoers.5.man sudoers.5
+	vman docs/man/visudo.8.man visudo.8
+
+	# symlink for sudoedit
+	ln -s sudo ${DESTDIR}/usr/bin/sudoedit
+	ln -s sudo.8 ${DESTDIR}/usr/share/man/man8/sudoedit.8
+
+	# translations
+	for po in po/*.po; do
+		if [ -f "${po}" ]; then
+			lang=$(basename "${po}" .po)
+			dir="${DESTDIR}/usr/share/locale/${lang}/LC_MESSAGES"
+			install -d "${dir}"
+			msgfmt -o "${dir}/sudo-rs.mo" "${po}"
+		fi
+	done
+
+	vlicense LICENSE-APACHE
+	vlicense LICENSE-MIT
+}

--- a/srcpkgs/sudo-rs/template
+++ b/srcpkgs/sudo-rs/template
@@ -1,0 +1,68 @@
+# Template file for 'sudo-rs'
+pkgname=sudo-rs
+version=0.2.15
+revision=1
+build_style=cargo
+make_build_args="--bin sudo --bin visudo --features gettext"
+make_install_args="--path . --bin sudo --bin visudo --features gettext"
+hostmakedepends="gettext pkg-config"
+makedepends="pam-devel"
+short_desc="Memory-safe implementation of sudo"
+maintainer="Nafis <mnabid.25@outlook.com>"
+license="Apache-2.0 OR MIT"
+homepage="https://github.com/trifectatechfoundation/sudo-rs"
+distfiles="${homepage}/archive/refs/tags/v${version}.tar.gz"
+checksum=ae857c3cde962a1ade2b981f7e01cf95e9fa05d5c5f95f94cf5f35394c1bf899
+conflicts="sudo"
+replaces="sudo>=0"
+conf_files="
+ /etc/pam.d/sudo
+ /etc/sudoers"
+make_dirs="
+ /etc/sudoers.d 0750 root root
+ /var/db/sudo 0750 root root"
+
+make_check=no # tests fail in chroot
+# Failed tests:
+#  common::context::tests::test_build_run_context
+#  common::resolve::test::canonicalization
+#  su::context::tests::invalid_shell
+#  sudo::env::environment::tests::test_tzinfo
+#  system::audit::test::secure_open_is_predictable
+#  system::audit::test::test_traverse_secure_open_negative
+#  system::audit::test::test_traverse_secure_open_positive
+#  system::interface::test::test_unix_user
+#  system::tests::test_get_user_and_group_by_id
+
+post_install() {
+	# sudoers and PAM config
+	vsed -i docs/sudoers.example -e 's|/usr\(/etc/sudoers\.d\)|\1|'
+	vinstall docs/sudoers.example 440 etc sudoers
+	vinstall docs/sudoers.example 664 usr/share/examples/sudo-rs
+	vinstall ${FILESDIR}/sudo.pam 644 etc/pam.d sudo
+
+	# setuid for sudo binary
+	chmod 4755 ${DESTDIR}/usr/bin/sudo
+
+	# documentation
+	vman docs/man/sudo.8.man sudo.8
+	vman docs/man/sudoers.5.man sudoers.5
+	vman docs/man/visudo.8.man visudo.8
+
+	# symlink for sudoedit
+	ln -s sudo ${DESTDIR}/usr/bin/sudoedit
+	ln -s sudo.8 ${DESTDIR}/usr/share/man/man8/sudoedit.8
+
+	# translations
+	for po in po/*.po; do
+		if [ -f "${po}" ]; then
+			lang=$(basename "${po}" .po)
+			dir="${DESTDIR}/usr/share/locale/${lang}/LC_MESSAGES"
+			install -d "${dir}"
+			msgfmt -o "${dir}/sudo-rs.mo" "${po}"
+		fi
+	done
+
+	vlicense LICENSE-APACHE
+	vlicense LICENSE-MIT
+}


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

[sudo-rs](https://github.com/trifectatechfoundation/sudo-rs) is a memory safe implementation of sudo and su written in Rust.

#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, `x86_64-glibc`
- I built this PR locally for these architectures:
  - `armv6l-musl` (crossbuild)
