### PR TITLE
waydroid: update to 1.6.3 (libgbinder 1.1.47; libglibutil 1.0.82)

### DIFF
--- a/srcpkgs/libgbinder/template
+++ b/srcpkgs/libgbinder/template
@@ -1,6 +1,6 @@
 # Template file for 'libgbinder'
 pkgname=libgbinder
-version=1.1.45
+version=1.1.47
 revision=1
 build_style=gnu-makefile
 make_use_env=1
@@ -16,7 +16,7 @@ license="BSD-3-Clause"
 homepage="https://github.com/mer-hybris/libgbinder"
 changelog="https://raw.githubusercontent.com/mer-hybris/libgbinder/master/debian/changelog"
 distfiles="https://github.com/mer-hybris/libgbinder/archive/refs/tags/${version}.tar.gz"
-checksum=3740e8853c380fbe642f4655acc81990c3106dc563bb68cc9b55b2d6c0ef09a1
+checksum=570a878cf99fcd4396f4b4eb4c97137cb032b6fe1a4786d80620ea287b1f14a5
 
 post_install() {
 	vlicense LICENSE

--- a/srcpkgs/libglibutil/template
+++ b/srcpkgs/libglibutil/template
@@ -1,6 +1,6 @@
 # Template file for 'libglibutil'
 pkgname=libglibutil
-version=1.0.81
+version=1.0.82
 revision=1
 build_style=gnu-makefile
 make_use_env=1
@@ -16,7 +16,7 @@ license="BSD-3-Clause"
 homepage="https://github.com/sailfishos/libglibutil"
 changelog="https://raw.githubusercontent.com/sailfishos/libglibutil/master/debian/changelog"
 distfiles="https://github.com/sailfishos/libglibutil/archive/refs/tags/${version}.tar.gz"
-checksum=e7fead630198b7fdcc61d032bc1046f99c0a320dd51739d63a09d47e7c091308
+checksum=f05586a0b5496ecf763a268a9f78ee71096b222aada0e78013befda5e999db63
 
 post_install() {
 	vlicense LICENSE

--- a/srcpkgs/waydroid/template
+++ b/srcpkgs/waydroid/template
@@ -1,6 +1,6 @@
 # Template file for 'waydroid'
 pkgname=waydroid
-version=1.6.2
+version=1.6.3
 revision=1
 # https://developer.android.com/ndk/guides/abis#sa
 archs="aarch64* armv7* i686* x86_64*"
@@ -14,7 +14,7 @@ license="GPL-3.0-or-later"
 homepage="https://waydro.id"
 changelog="https://raw.githubusercontent.com/waydroid/waydroid/main/debian/changelog"
 distfiles="https://github.com/waydroid/waydroid/archive/refs/tags/${version}.tar.gz"
-checksum=4b963aceb9de2884020e98b26e40147b3f26a0444606633adc45b63752f57dca
+checksum=f138a287eb8b0be7be7f7060971446490138bc2c8315665c8aa9c2c85576d8a5
 
 python_version=3
 pycompile_dirs="usr/lib/waydroid"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture (x86_64)
- I built this PR locally for these architectures using specific masterdirs:
  - x86_64-musl
  - i686
- I built this PR locally for these architectures (crossbuilds):
  - aarch64
  - aarch64-musl
  - armv7l
  - armv7l-musl
  - armv6l
  - armv6l-musl