### PR TITLE
mumble: update to 1.5.901

### DIFF
--- a/srcpkgs/mumble/template
+++ b/srcpkgs/mumble/template
@@ -1,7 +1,7 @@
 # Template file for 'mumble'
 pkgname=mumble
-version=1.5.857
-revision=2
+version=1.5.901
+revision=1
 build_style=cmake
 make_cmd=make
 configure_args="-Doverlay-xcompile=OFF -DCMAKE_CXX_STANDARD=17
@@ -20,7 +20,7 @@ maintainer="Helmut Pozimski <helmut@pozimski.eu>"
 license="BSD-3-Clause"
 homepage="https://mumble.info"
 distfiles="https://github.com/mumble-voip/${pkgname}/releases/download/v${version}/${pkgname}-${version}.tar.gz"
-checksum=e062ee0cb22f99283d21e9266b44587b92995f29141c6381c533a1803e9c3b47
+checksum=fd8d31add7458d157a1087b2b163ccbd340db35708bb2fac16f10e22cbb120b9
 
 build_options="jack portaudio"
 build_options_default="jack portaudio"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - armv6l (crossbuild)

