### PR TITLE
fuse-sshfs: update to 3.7.6.

### DIFF
--- a/srcpkgs/fuse-sshfs/template
+++ b/srcpkgs/fuse-sshfs/template
@@ -1,7 +1,7 @@
 # Template file for 'fuse-sshfs'
 pkgname=fuse-sshfs
-version=3.7.5
-revision=2
+version=3.7.6
+revision=1
 build_style=meson
 configure_args="--sbindir=bin"
 hostmakedepends="pkg-config python3-docutils"
@@ -13,7 +13,7 @@ maintainer="skmpz <dem.procopiou@gmail.com>"
 license="GPL-2.0-or-later"
 homepage="https://github.com/libfuse/sshfs"
 distfiles="https://github.com/libfuse/sshfs/releases/download/sshfs-${version}/sshfs-${version}.tar.xz"
-checksum=0e45db63c2d00919db3174134fa234c6e0682d6fe573c46312d1d53d1d61a8bb
+checksum=6a1bcb31450a077e9cb1b7ff158c71de34db697c3c0da6cb362502131e495893
 
 case "${XBPS_TARGET_MACHINE}" in
 	i686|armv6l|armv7l)
@@ -21,5 +21,10 @@ case "${XBPS_TARGET_MACHINE}" in
 esac
 
 do_check() {
-	python3 -m pytest
+	cd build
+	if [ "$XBPS_CHECK_PKGS" = "full" ]; then
+		python3 -m pytest
+	else
+		python3 -m pytest test/test_hostname_validation.py
+	fi
 }


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures:
  - x86_64-musl (native)
  - aarch64-glibc (crossbuild)
  - aarch64-musl (crossbuild)
  - armv7l-glibc (crossbuild)
  - armv6l-glibc (crossbuild)
  - armv6l-musl (crossbuild)
  - i686-glibc (crossbuild)