### PR TITLE
stern: fix version flag

### DIFF
--- a/srcpkgs/stern/template
+++ b/srcpkgs/stern/template
@@ -1,9 +1,13 @@
 # Template file for 'stern'
 pkgname=stern
 version=1.34.0
-revision=1
+revision=2
 build_style=go
 go_import_path="github.com/stern/stern"
+go_ldflags="-X github.com/stern/stern/cmd.version=${version}
+ -X github.com/stern/stern/cmd.date=$(date --date @$SOURCE_DATE_EPOCH +%Y-%m-%dT%H:%M:%SZ)
+ -linkmode=external
+ -compressdwarf=false"
 short_desc="Multi pod and container log tailing for Kubernetes"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="Apache-2.0"
@@ -11,8 +15,7 @@ homepage="https://github.com/stern/stern"
 distfiles="https://github.com/stern/stern/archive/v${version}.tar.gz"
 checksum=1cfec22cef9705e68fc46060ba85164af12bd07ede9264bafb67d11400996e71
 
-# fix: collect2: fatal error: cannot find 'ld'
-export LDFLAGS="-fuse-ld=bfd"
+make_check_args="-skip=TestSternCommand"
 
 post_build() {
 	for shell in bash fish zsh; do


### PR DESCRIPTION
The command `stern --version` did not show the correct version. 
Instead, the version is displayed as "dev". Additionally, the "build at" was empty.

The test called TestSernCommand has to be skipped, when the version is correctly configured, because this test expects the version to be "dev".
When testing this changes I noticed that the workaround of setting exporting ldflags is not required anymore.

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl
  - aarch64 (crossbild)
  - armv7l (crossbild)
  - armv6l (crossbild)
