### PR TITLE
New package: perl-Compress-Raw-Lzma-2.221

### DIFF
--- a/srcpkgs/perl-Compress-Raw-Lzma/template
+++ b/srcpkgs/perl-Compress-Raw-Lzma/template
@@ -1,0 +1,14 @@
+# Template file for 'perl-Compress-Raw-Lzma'
+pkgname=perl-Compress-Raw-Lzma
+version=2.221
+revision=1
+build_style=perl-module
+hostmakedepends="perl"
+makedepends="perl liblzma-devel"
+depends="perl"
+short_desc="Low-Level Perl Interface to lzma/xz compression library"
+maintainer="Orphaned <orphan@voidlinux.org>"
+license="Artistic-1.0-Perl, GPL-1.0-or-later"
+homepage="https://metacpan.org/release/Compress-Raw-Lzma"
+distfiles="http://search.cpan.org/CPAN/authors/id/P/PM/PMQS/Compress-Raw-Lzma-${version}.tar.gz"
+checksum=e8b2d17c7f29b3e4f286cc3d3f5353df8e811615c42298eedad7cdbfec4aed7f


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**


#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)  

When trying to do `7z2john protected.7z > hash.txt`, I got following error.

> Can't locate Compress/Raw/Lzma.pm in @&#8203;INC (you may need to install the Compress::Raw::Lzma module) (@&#8203;inc entries checked: /usr/lib/perl5/site_perl /usr/share/perl5/site_perl /usr/lib/perl5/vendor_perl /usr/share/perl5/vendor_perl /usr/lib/perl5/core_perl /usr/share/perl5/core_perl) at /usr/bin/7z2john line 6.
> BEGIN failed--compilation aborted at /usr/bin/7z2john line 6.  

Building and installing this package solved this.

