### PR TITLE
dbeaver: update to 26.1.0.

### DIFF
--- a/srcpkgs/dbeaver/template
+++ b/srcpkgs/dbeaver/template
@@ -1,6 +1,6 @@
 # Template file for 'dbeaver'
 pkgname=dbeaver
-version=26.0.5
+version=26.1.0
 revision=1
 _version=${version//./_}
 # the build downloads binaries linked to glibc
@@ -16,9 +16,9 @@ changelog="https://dbeaver.io/news/"
 distfiles="https://github.com/dbeaver/dbeaver/archive/${version}.tar.gz
  https://github.com/dbeaver/dbeaver-common/archive/refs/heads/release_${_version}.tar.gz>dbeaver-common-${version}.tar.gz
  https://github.com/dbeaver/dbeaver-jdbc-libsql/archive/refs/heads/release_${_version}.tar.gz>dbeaver-jdbc-libsql-${version}.tar.gz"
-checksum="3fdd348cc59a357a9ae016ec110018d7a6d87ba146b6f5d91884790ed424dee9
- c202fda84109733b64b78116e551eaa134e810eee9f1522e6c9e5c5bc36a8a21
- 08ba62a214294a92c2b892a4ac26c454a8027e33c5f9b4c4b4c25726c1e81758"
+checksum="44bd31ac58a21b82d897e81d3bef5ef542558c460dd8f31863079be759c5f1da
+ 356cdf56c2768b4e22e78892d37f912466fcc0b2b5b74382d401af154ccc0ab9
+ 087ecdaf417948f5f1291cc77940abf8abf00c8580bf8b489480b485bc8e4a34"
 nopie=true
 
 post_extract() {


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
