### PR TITLE
pstate-frequency: update to 3.17.1

### DIFF
--- a/srcpkgs/pstate-frequency/template
+++ b/srcpkgs/pstate-frequency/template
@@ -1,6 +1,6 @@
 # Template file for 'pstate-frequency'
 pkgname=pstate-frequency
-version=3.11.0
+version=3.17.1
 revision=1
 archs="i686* x86_64*"
 build_style=gnu-makefile
@@ -9,6 +9,6 @@ short_desc="Easily control Intel p-state driver on Linux"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="https://pyamsoft.github.io/pstate-frequency/"
-distfiles="https://github.com/pyamsoft/pstate-frequency/archive/${version}.tar.gz"
-checksum=df232f57de91c6527958a89fc06010d8ed9bffd686f1f682ebf9ef30bd5078d4
+distfiles="https://github.com/pyamsoft/pstate-frequency/archive/refs/tags/${version}.tar.gz"
+checksum=30678befd0d0d759a51cfd02d7ea2f88ffb097f8fa6b1d22308140ff85bd3454
 conf_files="/etc/pstate-frequency.d/*.plan"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)