### PR TITLE
inlyne: update to 0.5.2

### DIFF
--- a/srcpkgs/inlyne/template
+++ b/srcpkgs/inlyne/template
@@ -1,6 +1,6 @@
 # Template file for 'inlyne'
 pkgname=inlyne
-version=0.5.0
+version=0.5.2
 revision=1
 build_style=cargo
 hostmakedepends="pkg-config"
@@ -9,13 +9,13 @@ short_desc="GPU-powered, browserless, markdown and HTML viewer"
 maintainer="Julian Bigge <j.reedts@gmail.com>"
 license="MIT"
 homepage="https://github.com/Inlyne-Project/inlyne"
+changelog="https://raw.githubusercontent.com/Inlyne-Project/inlyne/main/CHANGELOG.md"
 distfiles="${homepage}/archive/v${version}.tar.gz"
-checksum=0473d154469c4f078029c2fdb58dca19b8d415633934773c41930536b54e71e0
+checksum=4a2f426e88cf192f6aad1bd927640b97350bf6447620d7252bf0d6d01d6d3f40
 
-post_patch() {
-	# fix build with rust 1.94.0
-	cargo update --package metrics:0.24.0 --precise 0.24.3
-}
+if [ "$XBPS_TARGET_MACHINE" = i686 ]; then
+	make_check_args="-- --skip=centered_image_with_size_align_and_link --skip=image_loading_fails_gracefully"
+fi
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **NO**

---

hello! apologies, i didn't do any testing as i don't have void linux installed :smirk_cat: (checksum generated with `sha256sum`)

i'm `inlyne`'s maintainer, and there's a new release out that updates the metrics version, so that things build on recent rust releases again with no patching required 🎉