### PR TITLE
opentofu: update to 1.12.2.

### DIFF
--- a/srcpkgs/opentofu/patches/test-version-mismatch.patch
+++ b/srcpkgs/opentofu/patches/test-version-mismatch.patch
@@ -1,0 +1,22 @@
+Fixes failing tests due to tfplan tests generated for the -dev version suffix
+
+diff --git a/internal/plans/planfile/tfplan.go b/internal/plans/planfile/tfplan.go
+index b6c0e1b537..6737e96ccd 100644
+--- a/internal/plans/planfile/tfplan.go
++++ b/internal/plans/planfile/tfplan.go
+@@ -8,6 +8,7 @@ package planfile
+ import (
+ 	"fmt"
+ 	"io"
++	"strings"
+ 	"time"
+
+ 	"github.com/zclconf/go-cty/cty"
+@@ -55,7 +56,7 @@ func readTfplan(r io.Reader) (*plans.Plan, error) {
+ 		return nil, fmt.Errorf("unsupported plan file format version %d; only version %d is supported", rawPlan.Version, tfplanFormatVersion)
+ 	}
+
+-	if rawPlan.TerraformVersion != version.String() {
++	if strings.TrimSuffix(rawPlan.TerraformVersion, "-dev") != strings.TrimSuffix(version.String(), "-dev") {
+ 		return nil, fmt.Errorf("plan file was created by OpenTofu or Terraform %s, but this is %s; plan files cannot be transferred between different versions of OpenTofu / Terraform", rawPlan.TerraformVersion, version.String())
+ 	}

--- a/srcpkgs/opentofu/template
+++ b/srcpkgs/opentofu/template
@@ -1,16 +1,15 @@
 # Template file for 'opentofu'
 pkgname=opentofu
-version=1.11.3
+version=1.12.2
 revision=1
 build_style=go
 go_import_path="github.com/opentofu/$pkgname"
 go_package="${go_import_path}/cmd/tofu"
 go_ldflags="-X ${go_import_path}/version.dev=no"
-make_check_args="-skip=TestPrimaryChdirOption"
 short_desc="Tool for building and changing infrastructure, from community"
 maintainer="Emil Tomczyk <emru@emru.xyz>"
 license="MPL-2.0"
 homepage="https://opentofu.org/"
 changelog="https://github.com/opentofu/opentofu/releases"
 distfiles="https://github.com/opentofu/opentofu/archive/v$version.tar.gz"
-checksum=bb79b27e586913f301ecf57e9aaac008582cc133a30c424d6775c5253f2acbeb
+checksum=f1e13ed2c1552ea7828156a10588a544d8b6b0d2c25f801a07fdf666734604fd


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl
  - i686

@Emru1