### PR TITLE
tinymist: update to 0.14.18.

### DIFF
--- a/srcpkgs/tinymist/template
+++ b/srcpkgs/tinymist/template
@@ -1,6 +1,6 @@
 # Template file for 'tinymist'
 pkgname=tinymist
-version=0.14.14
+version=0.14.18
 revision=1
 build_style=cargo
 build_helper="qemu"
@@ -12,7 +12,7 @@ license="Apache-2.0"
 homepage="https://myriad-dreamin.github.io/tinymist/"
 changelog="https://github.com/Myriad-Dreamin/tinymist/releases"
 distfiles="https://github.com/Myriad-Dreamin/tinymist/archive/refs/tags/v${version}.tar.gz"
-checksum=36d28b09cddc126e2b91c48a9c3b07e1c38f951f2e8a5546de8530b6e973c4bf
+checksum=92491d5bcd7ba2a5fe66c3c5e4c3728c2dce19a01a7f755010a905d31ccd0d04
 # takes forever
 make_check=no
 


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

I used the new `tinymist` for an afternoon.

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)