### PR TITLE
libgphoto2: update to 2.5.34

### DIFF
--- a/srcpkgs/libgphoto2/template
+++ b/srcpkgs/libgphoto2/template
@@ -1,6 +1,6 @@
 # Template file for 'libgphoto2'
 pkgname=libgphoto2
-version=2.5.32
+version=2.5.34
 revision=1
 build_style=gnu-configure
 configure_args="--disable-static --disable-rpath udevscriptdir=/usr/lib/udev"
@@ -14,7 +14,7 @@ license="LGPL-2.1-or-later"
 homepage="http://www.gphoto.org"
 changelog="https://raw.githubusercontent.com/gphoto/libgphoto2/master/NEWS"
 distfiles="https://github.com/gphoto/libgphoto2/releases/download/v${version}/libgphoto2-${version}.tar.bz2"
-checksum=02b29ab0bcfceda1c7f81c75ec7cb5e64d329cf4b8fd0fcd5bc5a89ff09561bc
+checksum=5df9e774eb4ab6087a193afff84dcafe9f666e3443fe29e73e6779f659ff7f28
 
 if [ "$CROSS_BUILD" ]; then
 	hostmakedepends+=" libgphoto2"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly** tested against Ricoh Theta..

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)

