### PR TITLE
libinput{,-debug-gui}: update to 1.31.3

### DIFF
--- a/srcpkgs/libinput-debug-gui/template
+++ b/srcpkgs/libinput-debug-gui/template
@@ -2,7 +2,7 @@
 # keep in sync with libinput
 # split to avoid cycle: gst-plugins-bad1 -> zbar -> qt5 -> libinput -> gtk4 -> gst-plugins-bad1
 pkgname=libinput-debug-gui
-version=1.31.2
+version=1.31.3
 revision=1
 build_style=meson
 configure_args="-Db_ndebug=false -Dtests=false -Ddebug-gui=true"
@@ -15,7 +15,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
 homepage="https://www.freedesktop.org/wiki/Software/libinput"
 distfiles="https://gitlab.freedesktop.org/libinput/libinput/-/archive/${version}/libinput-${version}.tar.gz"
-checksum=507a40b8a74568ed7c2bd05acf2e15ee3d9f4703102dca86d4f6a804e73bf1f6
+checksum=b6749bf6f1890f6631c0a70a027c35fec9d2e096a39f720548896e41474a9854
 
 post_install() {
 	mv ${DESTDIR}/usr/libexec/libinput/libinput-debug-gui ${DESTDIR}/libinput-debug-gui

--- a/srcpkgs/libinput/template
+++ b/srcpkgs/libinput/template
@@ -1,7 +1,7 @@
 # Template file for 'libinput'
 # keep in sync with libinput-debug-gui
 pkgname=libinput
-version=1.31.2
+version=1.31.3
 revision=1
 build_style=meson
 configure_args="-Db_ndebug=false -Ddebug-gui=false"
@@ -15,7 +15,7 @@ license="MIT"
 homepage="https://www.freedesktop.org/wiki/Software/libinput"
 changelog="https://gitlab.freedesktop.org/libinput/libinput/-/releases"
 distfiles="https://gitlab.freedesktop.org/libinput/libinput/-/archive/${version}/libinput-${version}.tar.gz"
-checksum=507a40b8a74568ed7c2bd05acf2e15ee3d9f4703102dca86d4f6a804e73bf1f6
+checksum=b6749bf6f1890f6631c0a70a027c35fec9d2e096a39f720548896e41474a9854
 
 if [ -z "$CROSS_BUILD" ] && [ "$XBPS_CHECK_PKGS" ]; then
 	configure_args+=" -Dtests=true"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, **x86_64-glibc**
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl
 
[Changes](https://gitlab.freedesktop.org/libinput/libinput/-/releases) including fix for [arbitrary root code execution vulnerability](https://lore.freedesktop.org/wayland-devel/aiDRA35Gggyi5mTY@quokka/T/#u)
