### PR TITLE
borgmatic: update to 2.1.6.

### DIFF
--- a/srcpkgs/borgmatic/template
+++ b/srcpkgs/borgmatic/template
@@ -1,21 +1,22 @@
 # Template file for 'borgmatic'
 pkgname=borgmatic
-version=2.1.5
+version=2.1.6
 revision=1
 build_style=python3-pep517
 make_check_args="--deselect=tests/integration/commands/test_borgmatic.py::test_borgmatic_version_matches_news_version"
 hostmakedepends="python3-setuptools python3-wheel"
 depends="borg python3-ruamel.yaml python3-jsonschema python3-requests
  python3-packaging"
-checkdepends="${depends} python3-pytest python3-pytest-timeout python3-flexmock
- python3-apprise"
+checkdepends="${depends} python3-pytest python3-pytest-timeout
+ python3-pytest-asyncio python3-flexmock python3-apprise python3-textual
+ python3-binaryornot"
 short_desc="Wrapper script for the Borg backup software"
 maintainer="Joel Beckmeyer <joel@beckmeyer.us>"
 license="GPL-3.0-or-later"
 homepage="https://torsion.org/borgmatic/"
 changelog="https://projects.torsion.org/borgmatic-collective/borgmatic/raw/branch/master/NEWS"
 distfiles="${PYPI_SITE}/b/borgmatic/borgmatic-${version}.tar.gz"
-checksum=4f4f84ea8a727ebef3c5f3f8e0e94dba1aac750ca2ece7485e2139af7d742da5
+checksum=320c7c3e719f4dae63ebee774559ed3c76b91032406363500b77ef9b2463db86
 
 post_patch() {
 	vsed -i pyproject.toml -e 's/--cov-report.*--cov-fail-under=100//'

--- a/srcpkgs/python3-flexmock/template
+++ b/srcpkgs/python3-flexmock/template
@@ -1,7 +1,7 @@
 # Template file for 'python3-flexmock'
 pkgname=python3-flexmock
-version=0.12.1
-revision=3
+version=0.13.0
+revision=1
 build_style=python3-pep517
 hostmakedepends="python3-poetry-core"
 depends="python3"
@@ -12,7 +12,7 @@ license="BSD-2-Clause"
 homepage="https://flexmock.readthedocs.io/en/latest/"
 changelog="https://raw.githubusercontent.com/flexmock/flexmock/master/CHANGELOG.md"
 distfiles="${PYPI_SITE}/f/flexmock/flexmock-${version}.tar.gz"
-checksum=20b690afa4ff8c6f31548d896d6d41cca1fc9050a4cf628b965ea434ec548ee3
+checksum=6829d7a0d7f746db3087da8fda62f924e52df7ece4051c2f59ad586cf5ad7977
 
 post_install() {
 	vlicense LICENSE

--- a/srcpkgs/python3-textual/template
+++ b/srcpkgs/python3-textual/template
@@ -1,12 +1,12 @@
 # Template file for 'python3-textual'
 pkgname=python3-textual
-version=5.3.0
-revision=2
+version=8.2.7
+revision=1
 build_style=python3-pep517
-make_check_args="-k not((snapshot)or(markdown)or(feature)or(language)or(slug)or(demo)or(disabled))"
+make_check_args="-k not((snapshot)or(markdown)or(feature)or(language)or(slug)or(demo)or(disabled)or(progress_bar))"
 hostmakedepends="python3-poetry-core"
-depends="python3-markdown-it python3-rich python3-typing_extensions
- python3-platformdirs python3-Pygments"
+depends="python3-markdown-it python3-mdit-py-plugins python3-rich
+ python3-typing_extensions python3-platformdirs python3-Pygments"
 checkdepends="${depends} python3-pytest-asyncio python3-pytest-xdist"
 short_desc="Modern Text User Interface framework"
 maintainer="icp <pangolin@vivaldi.net>"
@@ -14,7 +14,7 @@ license="MIT"
 homepage="https://textual.textualize.io"
 changelog="https://raw.githubusercontent.com/Textualize/textual/main/CHANGELOG.md"
 distfiles="${PYPI_SITE}/t/textual/textual-${version}.tar.gz"
-checksum=1b6128b339adef2e298cc23ab4777180443240ece5c232f29b22960efd658d4d
+checksum=658f568ff81e30ed43890c3e07520390e5cf1b4763822006e060656b0a88f105
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
Bumped optional dependencies so that tests pass and optional functionality works if needed:

- **python3-flexmock: update to 0.13.0.**
- **python3-textual: update to 8.2.7.**

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
