### PR TITLE
qbittorrent: update to 5.2.1.

### DIFF
--- a/srcpkgs/qbittorrent/template
+++ b/srcpkgs/qbittorrent/template
@@ -1,6 +1,6 @@
 # Template file for 'qbittorrent'
 pkgname=qbittorrent
-version=5.1.4
+version=5.2.1
 revision=1
 build_style=cmake
 configure_args="-DSYSTEMD=OFF -DGUI=ON -DWEBUI=ON"
@@ -13,7 +13,7 @@ license="GPL-2.0-or-later"
 homepage="https://www.qbittorrent.org/"
 changelog="https://www.qbittorrent.org/news.php"
 distfiles="${SOURCEFORGE_SITE}/qbittorrent/qbittorrent-${version}.tar.xz"
-checksum=d5d0c2b78386cde08951eaad930ec353d22e69205e163cc39dcfca2400353979
+checksum=becd0878802d4bc977381a41d8496d73ef64d543ba576be5f65fd3ad988ee8fe
 CXXFLAGS=-std=gnu++17
 
 post_configure() { # qbittorrent-nox


### PR DESCRIPTION

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc) with Q flag.
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64
  - aarch64-musl
All 3 architectures i build with the newest libinput 1.31.3, which update break bot compile for aarch64 and aarch64-musl from previous PR: https://github.com/void-linux/void-packages/pull/60891
Right now bot not should have any problems with compile.