### PR TITLE
xbps-src: fallback to /usr/libexec/xbps-triggers after srcpkgs/xbps-triggers/files

### DIFF
--- a/xbps-src
+++ b/xbps-src
@@ -621,7 +621,6 @@ fi
 readonly XBPS_SRCPKGDIR=$XBPS_DISTDIR/srcpkgs
 readonly XBPS_COMMONDIR=$XBPS_DISTDIR/common
 readonly XBPS_SHUTILSDIR=$XBPS_COMMONDIR/xbps-src/shutils
-readonly XBPS_TRIGGERSDIR=$XBPS_SRCPKGDIR/xbps-triggers/files
 readonly XBPS_CROSSPFDIR=$XBPS_COMMONDIR/cross-profiles
 readonly XBPS_BUILDSTYLEDIR=$XBPS_COMMONDIR/build-style
 readonly XBPS_LIBEXECDIR=$XBPS_COMMONDIR/xbps-src/libexec
@@ -631,6 +630,13 @@ readonly XBPS_TARGET="$1"
 if [ "$2" ]; then
     XBPS_TARGET_PKG="${2##*/}"
 fi
+
+for d in $XBPS_SRCPKGDIR/xbps-triggers/files /usr/libexec/xbps-triggers; do
+    if [ -d $d ]; then
+	 readonly XBPS_TRIGGERSDIR=$d
+	 break
+    fi
+done
 
 # A temporary masterdir requires xbps-uchroot(1) or bwrap(1).
 if [ -z "$IN_CHROOT" -a -n "$XBPS_TEMP_MASTERDIR" ]; then


### PR DESCRIPTION
Users may want to build/share custom source packages without cloning/forking the entire `void-packages` repository (which, in addition to large download sizes, would require regular merging/rebasing).

While in theory, only `etc/`, `common/` and `xbps-src` are required, `xbps-src` currently depends on a single source-package directory `srcpkgs/xbps-triggers/files`. However, this directory is also installed under `/usr/libexec/xbps-triggers`.

By adding a simple fallback to `/usr/libexec/xbps-triggers` in case `srcpkgs/xbps-triggers/files` does not exist, the build tools may then be used in isolation of this repositories source-packages.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**