### PR TITLE
New package: brscan-skey-0.3.4

### DIFF
--- a/srcpkgs/brscan-skey/template
+++ b/srcpkgs/brscan-skey/template
@@ -1,0 +1,31 @@
+# Template file for 'brscan-skey'
+pkgname=brscan-skey
+version=0.3.4
+revision=1
+archs="i686 x86_64"
+short_desc="Brother Scan-Key tool for push-button scanner events"
+maintainer="Anachron <gith@cron.world>"
+license="custom:EULA"
+homepage="https://support.brother.com/"
+repository="nonfree"
+nopie=yes
+
+conf_files="/opt/brother/scanner/brscan-skey/*.config"
+
+case "${XBPS_TARGET_MACHINE}" in
+	"x86_64")
+		distfiles="http://download.brother.com/welcome/dlf006650/${pkgname}-${version}-0.x86_64.rpm"
+		checksum="a0ad98f67f9bb652902544992b9f251e528a410ee1b1b0f37e94f39f1b02262e";;
+	"i686")
+		distfiles="http://download.brother.com/welcome/dlf006649/${pkgname}-${version}-0.i386.rpm"
+		checksum="258b8fdad0cc2cb60499d578c607088a79d5f27d957f0520c891a9f03d74d202";;
+esac
+
+do_install() {
+    # Copy primary contents
+	vmkdir opt/brother/scanner/brscan-skey
+	vcopy brother/scanner/brscan-skey/* opt/brother/scanner/brscan-skey
+
+	# Install license
+	vlicense brother/scanner/brscan-skey/LICENSE_ENG.txt
+}


### PR DESCRIPTION

#### Testing the changes
- I tested the changes in this PR: **YES**

- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - i686

#### Note

Normally this command is run under a user account, I don't think it is neccessary to create a system account and service file for it.
If still wanted for such a little tool, I'll add it.