### PR TITLE
Signal-Desktop: update to 8.18.0.

### DIFF
--- a/srcpkgs/Signal-Desktop/patches/02-no-deb.patch
+++ b/srcpkgs/Signal-Desktop/patches/02-no-deb.patch
@@ -1,16 +1,15 @@
---- a/package.json	2025-07-09 20:58:10.000000000 -0400
-+++ b/package.json	2025-07-16 16:29:52.897055193 -0400
-@@ -494,7 +494,12 @@
-     "linux": {
-       "category": "Network;InstantMessaging;Chat",
+--- a/package.json
++++ b/package.json
+@@ -524,8 +524,10 @@
+       "artifactName": "${name}_${version}_${arch}.${ext}",
        "target": [
--        "deb"
-+        {
+         {
+-          "target": "deb",
+-          "arch": "x64"
 +          "target": "dir",
 +          "arch": [
 +            "xxxtarget"
 +          ]
-+        }
+         }
        ],
        "icon": "build/icons/png",
-       "publish": [],

--- a/srcpkgs/Signal-Desktop/template
+++ b/srcpkgs/Signal-Desktop/template
@@ -1,11 +1,11 @@
 # Template file for 'Signal-Desktop'
 pkgname=Signal-Desktop
-version=8.11.0
+version=8.18.0
 revision=1
 # *-musl could potentially work based on the Alpine port:
 # https://git.alpinelinux.org/aports/tree/testing/signal-desktop
 archs="x86_64 aarch64"
-hostmakedepends="pnpm electron-tasje python3"
+hostmakedepends="pnpm electron-tasje python3 pulseaudio-devel"
 depends="cairo gtk+3 libvips pango desktop-file-utils hicolor-icon-theme"
 checkdepends="glib nss libgbm alsa-lib ${depends}"
 short_desc="Signal Private Messenger for Linux"
@@ -13,7 +13,7 @@ maintainer="dkwo <npiazza@disroot.org>"
 license="AGPL-3.0-only"
 homepage="https://github.com/signalapp/Signal-Desktop"
 distfiles="https://github.com/signalapp/Signal-Desktop/archive/v${version}.tar.gz"
-checksum=eea21fb713d4c3063b8e3b8b3725bc69d9802c5dfe70fb82fb9b9a930962b6f5
+checksum=61a93b2b5b74e696de74efe59d408b9ab8c026a826321379ce96a9b68172bc72
 nostrip_files="signal-desktop"
 nocross="gyp -> aarch64-linux-gnu-gcc: error: unrecognized command-line option '-m64'"
 


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc

