### PR TITLE
R: update to 4.6.0.

### DIFF
--- a/srcpkgs/R/template
+++ b/srcpkgs/R/template
@@ -1,6 +1,6 @@
 # Template file for 'R'
 pkgname=R
-version=4.5.2
+version=4.6.0
 revision=1
 build_style=gnu-configure
 configure_args="--docdir=/usr/share/doc/R rdocdir=/usr/share/doc/R
@@ -13,7 +13,7 @@ hostmakedepends="gcc-fortran pkg-config perl less which tar"
 makedepends="libgomp-devel readline-devel libXmu-devel libXt-devel
  libpng-devel libjpeg-turbo-devel tiff-devel cairo-devel icu-devel
  zlib-devel bzip2-devel pcre2-devel liblzma-devel
- libcurl-devel tcl-devel tk-devel libxml2-devel
+ libcurl-devel tcl-devel tk-devel libxml2-devel libdeflate-devel
  $(vopt_if openblas openblas-devel 'blas-devel lapack-devel')"
 depends="xdg-utils less which"
 checkdepends="texlive texlive-fontsextra texinfo"
@@ -23,7 +23,7 @@ license="GPL-2.0-or-later"
 homepage="https://www.r-project.org/"
 changelog="https://cran.r-project.org/doc/manuals/r-release/NEWS.html"
 distfiles="https://cran.r-project.org/src/base/R-4/${pkgname}-${version}.tar.gz"
-checksum=0d71ff7106ec69cd7c67e1e95ed1a3cee355880931f2eb78c530014a9e379f20
+checksum=b8dc9b4543660c7b596b87938df532394350360976527d344228ee0ed12e45ec
 nocross=yes
 shlib_provides="libR.so"
 # tests require texlive distribution


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**


#### Local build testing
- I built this PR locally for my native architecture, (X86_64)

#### Template changes
I've added libdeflate as R will now use that to decompress Lazy loaded data, which should result in faster decompression times. 

After R has been updated, I will work on getting all of the R-cran packages updated.
