### PR TITLE
New package: bun-bootstrap-1.3.14

### DIFF
--- a/srcpkgs/bun-bootstrap/template
+++ b/srcpkgs/bun-bootstrap/template
@@ -1,0 +1,55 @@
+# Template file for 'bun-bootstrap'
+pkgname=bun-bootstrap
+version=1.3.14
+revision=1
+archs="x86_64* aarch64*"
+hostmakedepends="patchelf unzip"
+short_desc="Bootstrap package for bun (prebuilt binary)"
+maintainer="zenobit <zen@osowoso.org>"
+license="MIT"
+homepage="https://bun.sh"
+distfiles="https://github.com/oven-sh/bun/releases/download/bun-v${version}/bun-linux-x64.zip
+ https://github.com/oven-sh/bun/releases/download/bun-v${version}/bun-linux-x64-musl.zip
+ https://github.com/oven-sh/bun/releases/download/bun-v${version}/bun-linux-aarch64.zip
+ https://github.com/oven-sh/bun/releases/download/bun-v${version}/bun-linux-aarch64-musl.zip
+ https://raw.githubusercontent.com/oven-sh/bun/refs/heads/main/LICENSE.md"
+checksum="951ee2aee855f08595aeec6225226a298d3fea83a3dcd6465c09cbccdf7e848f
+ 14bd9aedeebf1dba67e8def9531c89bc989ecfdf1de42e5bfcaf1b8cd9294719
+ a27ffb63a8310375836e0d6f668ae17fa8d8d18b88c37c821c65331973a19a3b
+ b98e0ad3625c5c00d1d5b5ff55605c7adddbfae151861e68ade57b2d3b8703bb
+ 2c6160ec8fb853f7e8f97d9b249e756c9b0ac44860a68b6bf4f1b0bcbc5c3741"
+skip_extraction="bun-linux-x64.zip bun-linux-x64-musl.zip bun-linux-aarch64.zip bun-linux-aarch64-musl.zip LICENSE.md"
+repository=bootstrap
+nostrip=yes
+nocross=yes
+
+do_extract() {
+	local arch_zip
+	case "$XBPS_TARGET_MACHINE" in
+		x86_64)      arch_zip="bun-linux-x64.zip" ;;
+		x86_64-musl) arch_zip="bun-linux-x64-musl.zip" ;;
+		aarch64)     arch_zip="bun-linux-aarch64.zip" ;;
+		aarch64-musl) arch_zip="bun-linux-aarch64-musl.zip" ;;
+	esac
+	unzip -o "${XBPS_SRCDISTDIR}/${pkgname}-${version}/${arch_zip}" -d "${wrksrc}"
+}
+
+do_install() {
+	case "$XBPS_TARGET_MACHINE" in
+		aarch64)
+			vbin bun-linux-aarch64/bun
+			;;
+		aarch64-musl)
+			patchelf --replace-needed "libc.musl-${XBPS_TARGET_MACHINE%-musl}.so.1" libc.so "${wrksrc}/bun-linux-aarch64-musl/bun"
+			vbin bun-linux-aarch64-musl/bun
+			;;
+		x86_64-musl)
+			patchelf --replace-needed "libc.musl-${XBPS_TARGET_MACHINE%-musl}.so.1" libc.so "${wrksrc}/bun-linux-x64-musl/bun"
+			vbin bun-linux-x64-musl/bun
+			;;
+		*)
+			vbin bun-linux-x64/bun
+			;;
+	esac
+	vlicense ${XBPS_SRCDISTDIR}/${pkgname}-${version}/LICENSE.md
+}

--- a/srcpkgs/bun-bootstrap/update
+++ b/srcpkgs/bun-bootstrap/update
@@ -1,0 +1,2 @@
+site=https://github.com/oven-sh/bun/tags
+pattern='/tag/bun-v\K[\d.]+(?=")'

--- a/srcpkgs/bun/patches/fix-uws-usockets-ifdef.patch
+++ b/srcpkgs/bun/patches/fix-uws-usockets-ifdef.patch
@@ -1,0 +1,22 @@
+--- a/src/jsc/bindings/BunProcess.cpp
++++ b/src/jsc/bindings/BunProcess.cpp
+@@ -225,7 +225,9 @@
+     object->putDirect(vm, JSC::Identifier::fromString(vm, "libarchive"_s), JSC::jsOwnedString(vm, ASCIILiteral::fromLiteralUnsafe(BUN_VERSION_LIBARCHIVE)), 0);
+     object->putDirect(vm, JSC::Identifier::fromString(vm, "mimalloc"_s), JSC::jsOwnedString(vm, ASCIILiteral::fromLiteralUnsafe(BUN_VERSION_MIMALLOC)), 0);
+     object->putDirect(vm, JSC::Identifier::fromString(vm, "picohttpparser"_s), JSC::jsOwnedString(vm, ASCIILiteral::fromLiteralUnsafe(BUN_VERSION_PICOHTTPPARSER)), 0);
++#ifdef BUN_VERSION_UWS
+     object->putDirect(vm, JSC::Identifier::fromString(vm, "uwebsockets"_s), JSC::jsOwnedString(vm, ASCIILiteral::fromLiteralUnsafe(BUN_VERSION_UWS)), 0);
++#endif
+     object->putDirect(vm, JSC::Identifier::fromString(vm, "webkit"_s), JSC::jsOwnedString(vm, ASCIILiteral::fromLiteralUnsafe(BUN_VERSION_WEBKIT)), 0);
+     // Zig version from CMake-generated header
+     object->putDirect(vm, JSC::Identifier::fromString(vm, "zig"_s), JSC::jsOwnedString(vm, ASCIILiteral::fromLiteralUnsafe(BUN_VERSION_ZIG)), 0);
+@@ -240,7 +242,9 @@
+     // Use commit hash for libdeflate to match test expectations
+     object->putDirect(vm, JSC::Identifier::fromString(vm, "libdeflate"_s), JSC::jsOwnedString(vm, ASCIILiteral::fromLiteralUnsafe(BUN_VERSION_LIBDEFLATE_HASH)), 0);
+ 
++#ifdef BUN_VERSION_USOCKETS
+     object->putDirect(vm, JSC::Identifier::fromString(vm, "usockets"_s), JSC::jsOwnedString(vm, ASCIILiteral::fromLiteralUnsafe(BUN_VERSION_USOCKETS)), 0);
++#endif
+     object->putDirect(vm, JSC::Identifier::fromString(vm, "lshpack"_s), JSC::jsOwnedString(vm, ASCIILiteral::fromLiteralUnsafe(BUN_VERSION_LSHPACK)), 0);
+ 
+     // Use commit hash for zstd (semantic version extraction not working yet)

--- a/srcpkgs/bun/template
+++ b/srcpkgs/bun/template
@@ -1,0 +1,55 @@
+# Template file for 'bun'
+pkgname=bun
+version=1.3.14
+revision=1
+archs="aarch64* x86_64*"
+hostmakedepends="bun-bootstrap cargo clang21 llvm21 lld21 rustup cmake ninja
+ pkg-config perl python3 tar unzip git"
+makedepends="llvm21-devel compiler-rt21"
+checkdepends="procps-ng"
+short_desc="JavaScript runtime, bundler, transpiler, and package manager"
+maintainer="zenobit <zen@osowoso.org>"
+license="MIT"
+homepage="https://bun.sh"
+distfiles="https://github.com/oven-sh/bun/archive/refs/tags/bun-v${version}.tar.gz"
+checksum=112a5915992807f04b183854d360c2bf87ac7c1587fb5da3c560bdbb75b8c92e
+nopie_files="/usr/bin/bun"
+replaces="bun-bin>=0 bun-musl-bin>=0 bun-arm-bin>=0 bun-arm-musl-bin>=0"
+
+do_patch() {
+	export RUSTUP_HOME="${XBPS_BUILDDIR}/.rustup"
+	export CARGO_HOME="${XBPS_BUILDDIR}/.cargo"
+	export PATH="${CARGO_HOME}/bin:${RUSTUP_HOME}/bin:$PATH"
+	RUSTUP_INIT_SKIP_PATH_CHECK=yes rustup-init -y --no-modify-path --default-toolchain none --profile minimal
+	. "${CARGO_HOME}/env"
+	rustup toolchain install nightly-2026-05-06 --profile minimal
+	rustup component add rust-src --toolchain nightly-2026-05-06
+}
+
+do_configure() {
+	export RUSTUP_HOME="${XBPS_BUILDDIR}/.rustup"
+	export CARGO_HOME="${XBPS_BUILDDIR}/.cargo"
+	export PATH="${CARGO_HOME}/bin:${RUSTUP_HOME}/bin:/usr/lib/llvm/21/bin:$PATH"
+	bun scripts/build.ts --profile=release --configure-only
+}
+
+do_build() {
+	export RUSTUP_HOME="${XBPS_BUILDDIR}/.rustup"
+	export CARGO_HOME="${XBPS_BUILDDIR}/.cargo"
+	export PATH="${CARGO_HOME}/bin:${RUSTUP_HOME}/bin:/usr/lib/llvm/21/bin:$PATH"
+	ninja -C build/release
+}
+
+do_check() {
+	export RUSTUP_HOME="${XBPS_BUILDDIR}/.rustup"
+	export CARGO_HOME="${XBPS_BUILDDIR}/.cargo"
+	export PATH="${CARGO_HOME}/bin:${RUSTUP_HOME}/bin:/usr/lib/llvm/21/bin:$PATH"
+	ninja -C build/release check
+}
+
+do_install() {
+	vbin build/release/bun-profile
+	mv ${DESTDIR}/usr/bin/bun-profile ${DESTDIR}/usr/bin/bun
+	vlicense LICENSE.md
+	vdoc README.md
+}

--- a/srcpkgs/bun/update
+++ b/srcpkgs/bun/update
@@ -1,0 +1,2 @@
+site=https://github.com/oven-sh/bun/tags
+pattern='/tag/bun-v\K[\d.]+(?=")'


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**, but `bun-bootstrap` is binary package

#### Local build testing
- I built this PR locally for my native architecture, (x64 glibc)
nocross built:
- x86_64-musl
- aarch64
- aarch64-musl
