### PR TITLE
tmux-mem-cpu-load: update to 3.8.2.

### DIFF
--- a/srcpkgs/tmux-mem-cpu-load/template
+++ b/srcpkgs/tmux-mem-cpu-load/template
@@ -1,6 +1,6 @@
 # Template file for 'tmux-mem-cpu-load'
 pkgname=tmux-mem-cpu-load
-version=3.4.0
+version=3.8.2
 revision=1
 build_style=cmake
 depends="tmux"
@@ -9,7 +9,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="Apache-2.0"
 homepage="https://github.com/thewtex/tmux-mem-cpu-load"
 distfiles="https://github.com/thewtex/tmux-mem-cpu-load/archive/v${version}.tar.gz"
-checksum=a773994e160812a964abc7fc4e8ec16b7d9833edb0a66e5c67f287c7c5949ecb
+checksum=c433e396050a821f915f3fd1e7d932b46204def8d59a46fce4f486b1b4ebef2e
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
Update tmux-mem-cpu-load from 3.4.0 to 3.8.2.

Package was orphaned; adopting as maintainer.

CMake minimum version bumped from 2.6 to 3.5 (satisfied by Void's
toolchain). No new external dependencies. Tested on x86_64 (glibc).