### PR TITLE
flashrom: update to 1.7.0.

### DIFF
--- a/srcpkgs/flashrom/template
+++ b/srcpkgs/flashrom/template
@@ -1,6 +1,6 @@
 # Template file for 'flashrom'
 pkgname=flashrom
-version=1.6.0
+version=1.7.0
 revision=1
 build_style=meson
 configure_args="-Duse_internal_dmi=false -Ddocumentation=enabled"
@@ -12,7 +12,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-only"
 homepage="https://www.flashrom.org"
 distfiles=https://github.com/flashrom/flashrom/archive/refs/tags/v${version}.tar.gz
-checksum=735c077ee8ac08e236ef7b7db894ab22d5f4b75f10156a4732bd818a1e21fcc5
+checksum=c5a8892158bd749aadfee6e114eec268130cdd8c2027fd1ddf44273755b07b59
 make_check=no # can't run without special setup..?
 
 flashrom-devel_package() {


### PR DESCRIPTION
Update flashrom from 1.6.0 to 1.7.0.

Package was orphaned; adopting as maintainer.

No new external dependencies. The new nv_sma_spi programmer reuses
the existing libusb1 dependency already present in makedepends.
Tested on x86_64 (glibc).