### PR TITLE
ngrep: update to 1.49.0.

### DIFF
--- a/srcpkgs/ngrep/template
+++ b/srcpkgs/ngrep/template
@@ -1,22 +1,20 @@
 # Template file for 'ngrep'
 pkgname=ngrep
-version=1.47
+version=1.49.0
 revision=1
 build_style=gnu-configure
-configure_args="--enable-ipv6 --enable-pcre EXTRA_LIBS=-lpcre"
+configure_args="--enable-ipv6 --enable-pcre2"
 hostmakedepends="pkg-config"
-makedepends="pcre-devel libpcap-devel"
+makedepends="pcre2-devel libpcap-devel"
 short_desc="Like GNU grep applied to the network layer"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
 homepage="https://github.com/jpr5/ngrep"
-distfiles="https://github.com/jpr5/ngrep/archive/V${version/./_}.tar.gz"
-checksum=dc4dbe20991cc36bac5e97e99475e2a1522fd88c59ee2e08f813432c04c5fff3
+distfiles="https://github.com/jpr5/ngrep/archive/v${version}.tar.gz"
+checksum=6c94b31681316b7469a3ace92d2aeec7c9f490bd6782453dff2ade0e289a3348
 
 if [ "$CROSS_BUILD" ]; then
-	configure_args+=" --with-pcap-includes=$XBPS_CROSS_BASE/usr/include/pcap"
-else
-	configure_args+=" --with-pcap-includes=/usr/include/pcap"
+	configure_args+=" --with-pcap-includes=$XBPS_CROSS_BASE/usr/include"
 fi
 
 post_install() {


### PR DESCRIPTION
<!-- Reviewers, this is a migration, not a trivial bump — changes documented below. -->

#### Testing the changes - build and install

- [x] I've built this PR locally.
- [x] I've tested the changes and everything works as expected (pending reviewer build test on CI)

---

**Summary of changes:**

- Update `ngrep` from **1.47 → 1.49.0**
- Adopt orphaned package (`maintainer` was `Orphaned <orphan@voidlinux.org>`)
- **PCRE1 → PCRE2 migration**: upstream dropped `--enable-pcre` (PCRE1) in 1.49.0; regex backend is now PCRE2 via `--enable-pcre2` (or GNU regex by default). This PR enables PCRE2 to preserve the regex capability the old package provided.
  - `makedepends`: `pcre-devel` → `pcre2-devel`
  - `configure_args`: removed `--enable-pcre EXTRA_LIBS=-lpcre`; added `--enable-pcre2`
- **Tag scheme change**: upstream changed tag format from `V1_47` (uppercase, underscores) to `v1.49.0` (lowercase, semver); updated `distfiles` URL accordingly
- **`--with-pcap-includes` fix**: `configure.ac` changed `BASE_PCAP_H` from `pcap.h` to `pcap/pcap.h` in 1.49.0; the old `/usr/include/pcap` path would have caused CI failure (`could not find a complete set of pcap headers`). Native build now uses `configure`'s default search (finds `/usr/include`); cross-build points to `$XBPS_CROSS_BASE/usr/include`.

Built and installed on Void Linux x86_64 (musl); `ngrep -V` → `V1.49.0, libpcap version 1.10.6`.