### PR TITLE
atop: update to 2.12.1.

### DIFF
--- a/srcpkgs/atop/template
+++ b/srcpkgs/atop/template
@@ -1,6 +1,6 @@
 # Template file for 'atop'
 pkgname=atop
-version=2.12.0
+version=2.12.1
 revision=1
 build_style=gnu-makefile
 make_install_target="sysvinstall"
@@ -12,7 +12,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="https://www.atoptool.nl/"
 distfiles="https://www.atoptool.nl/download/atop-${version}.tar.gz"
-checksum=0d09ecc90c14e6ef41c22e3c57c142c3e4fb9cf3c94379077a33c961d5343086
+checksum=4fdbe67c5dfaf89405639e18599f4eae77978073ffa54f3c78c368ab54bd12f6
 
 make_dirs="/var/log/atop 755 root root"
 


### PR DESCRIPTION
#### Testing the changes - build and install

- [x] I've built this PR locally.
- [x] I've tested the changes and everything works as expected.

Bugfix release. Upstream changelog: fixes stricter-than-necessary tests during append of existing raw logs (Atoptool/atop#346).

Built and installed on Void Linux x86_64 (musl); `atop -V` → `Version: 2.12.1`.