### PR TITLE
dwarffortress, Dwarf-Therapist: pin and document version pairing

### DIFF
--- a/srcpkgs/Dwarf-Therapist/template
+++ b/srcpkgs/Dwarf-Therapist/template
@@ -1,4 +1,7 @@
 # Template file for 'Dwarf-Therapist'
+#
+# MUST BE BUMPED TOGETHER WITH "dwarffortress" TO A SUPPORTED DF RELEASE
+
 pkgname=Dwarf-Therapist
 version=42.1.21
 revision=1

--- a/srcpkgs/dwarffortress/template
+++ b/srcpkgs/dwarffortress/template
@@ -1,4 +1,7 @@
 # Template file for 'dwarffortress'
+#
+# MUST BE PINNED TO THE NEWEST DF RELEASE "Dwarf-Therapist" SUPPORTS
+
 pkgname=dwarffortress
 version=53.02
 revision=1

--- a/srcpkgs/dwarffortress/update
+++ b/srcpkgs/dwarffortress/update
@@ -1,0 +1,2 @@
+site="https://www.bay12games.com/dwarves/older_versions.html"
+pattern="df_\K[0-9]+_[0-9]+(?=_linux\.tar\.bz2)"


### PR DESCRIPTION
`Dwarf-Therapist` relies on per-version memory layouts and only works at
runtime against DF releases it has layouts for. `dwarffortress` is therefore
pinned to the newest release `Dwarf-Therapist` supports, currently 53.02,
rather than the latest upstream (53.14).

- `dwarffortress`: header comment documenting the pin; add an update file so
  update-check reports the releases between the pin and upstream
  (53.03 -> 53.14), giving visibility into the gap while pinned.
- `Dwarf-Therapist`: header comment noting the pairing, so a bump there is
  done together with `dwarffortress`.