### PR TITLE
New package: tipitaka-pali-reader-2.8.0

### DIFF
--- a/srcpkgs/tipitaka-pali-reader/template
+++ b/srcpkgs/tipitaka-pali-reader/template
@@ -1,0 +1,59 @@
+# Template file for 'tipitaka-pali-reader'
+pkgname=tipitaka-pali-reader
+version=2.8.0
+revision=1
+archs="x86_64"
+short_desc="Pali text reader for studying the Tipitaka"
+maintainer="akincano <akincano@proton.me>"
+license="GPL-2.0-or-later"
+homepage="https://github.com/bksubhuti/tipitaka-pali-reader"
+distfiles="https://github.com/bksubhuti/tipitaka-pali-reader/releases/download/v${version}/linux-build-bundle.zip"
+checksum=6cebb416aaed0a95bc854a21785b2e60753483d31d06348603488d5b92c1c696
+depends="gtk+3 sqlite"
+noshlibprovides=yes
+nopie=yes
+nostrip=yes
+nocross=yes
+wrksrc=bundle
+
+do_install() {
+	local appdir="usr/lib/${pkgname}"
+
+	# Install the Flutter bundle (executable + bundled libs + assets)
+	vmkdir ${appdir}
+	vcopy tipitaka_pali_reader ${appdir}/
+	vcopy lib ${appdir}/
+	vcopy data ${appdir}/
+	# sqflite_common_ffi dlopen()s the unversioned 'libsqlite3.so' at runtime;
+	# Void only ships the versioned .so.0 — provide a symlink in our lib dir
+	ln -s /usr/lib/libsqlite3.so.0 ${DESTDIR}/usr/lib/${pkgname}/lib/libsqlite3.so
+	chmod 755 ${DESTDIR}/${appdir}/tipitaka_pali_reader
+
+	# Wrapper script: Flutter looks for lib/ and data/ relative to the executable,
+	# so we cd into the app dir before launching
+	vmkdir usr/bin
+	cat > ${DESTDIR}/usr/bin/${pkgname} << 'EOF'
+#!/bin/sh
+export LD_LIBRARY_PATH=/usr/lib/tipitaka-pali-reader/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
+cd /usr/lib/tipitaka-pali-reader
+exec ./tipitaka_pali_reader "$@"
+EOF
+	chmod 755 ${DESTDIR}/usr/bin/${pkgname}
+
+	# Icon (embedded in flutter_assets)
+	vinstall data/flutter_assets/assets/icon/icon.png 644 \
+		usr/share/pixmaps tipitaka-pali-reader.png
+
+	# Desktop entry
+	vmkdir usr/share/applications
+	cat > ${DESTDIR}/usr/share/applications/${pkgname}.desktop << 'EOF'
+[Desktop Entry]
+Name=Tipitaka Pali Reader
+Comment=Pali text reader for studying the Tipitaka
+Exec=tipitaka-pali-reader
+Icon=tipitaka-pali-reader
+Type=Application
+Categories=Education;
+StartupWMClass=tipitaka_pali_reader
+EOF
+}


### PR DESCRIPTION
> Tipitaka Pali Reader is a GPL-licensed Flutter application for studying the Pāli Tipitaka. This packages the upstream pre-built Linux bundle, as the Flutter build toolchain is not available in void-packages.

#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

#### Local build testing
- I built this PR locally for my native architecture,  x86_64-glibc