### PR TITLE
New package: klickety-26.04.2

### DIFF
--- a/srcpkgs/klickety/template
+++ b/srcpkgs/klickety/template
@@ -1,0 +1,20 @@
+# Template file for 'klickety'
+pkgname=klickety
+version=26.04.2
+revision=1
+build_style=cmake
+configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
+ -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins
+ -DKDE_INSTALL_QMLDIR=lib/qt6/qml
+ -DECM_MKSPECS_INSTALL_DIR=/usr/lib/qt6/mkspecs/modules"
+hostmakedepends="extra-cmake-modules gettext kf6-kconfig kf6-kcoreaddons
+ kf6-kdoctools pkg-config qt6-base"
+makedepends="kf6-kcoreaddons-devel kf6-kcrash-devel kf6-kdbusaddons-devel
+ kf6-kdoctools-devel kf6-kio-devel libkdegames-devel"
+short_desc="Adaptation of the Clickomania game"
+maintainer="Nafis <mnabid.25@outlook.com>"
+license="GPL-2.0-or-later"
+homepage="https://apps.kde.org/klickety"
+changelog="https://kde.org/announcements/changelogs/gear/${version}/#klickety"
+distfiles="${KDE_SITE}/release-service/${version}/src/klickety-${version}.tar.xz"
+checksum=9b7112576a3ae2b884764e2bf6a5e036533a064fa5fc1dac2a59bd507329f4eb


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

[Klickety](https://apps.kde.org/klickety) is an adaptation of the Clickomania game.

#### Testing the changes
- I tested the changes in this PR: **YES**


#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**


<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, `x86_64-glibc`
- I built this PR locally for these architectures:
  - `armv6l-musl` (crossbuild)
