### PR TITLE
New package: tokodon-26.04.2

### DIFF
--- a/srcpkgs/tokodon/template
+++ b/srcpkgs/tokodon/template
@@ -1,0 +1,23 @@
+# Template file for 'tokodon'
+pkgname=tokodon
+version=26.04.2
+revision=1
+build_style=cmake
+configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
+ -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins
+ -DKDE_INSTALL_QMLDIR=lib/qt6/qml"
+hostmakedepends="extra-cmake-modules gettext kf6-kconfig kf6-kcoreaddons
+ pkg-config qt6-base qt6-declarative-host-tools"
+makedepends="kf6-kcolorscheme-devel kf6-kdbusaddons-devel kf6-kdeclarative-devel
+ kf6-ki18n-devel kf6-kio-devel kf6-kirigami-devel kf6-kitemmodels-devel
+ kf6-knotifications-devel kf6-prison-devel kf6-purpose-devel
+ kf6-qqc2-desktop-style-devel kirigami-addons-devel kunifiedpush-devel
+ qcoro-qt6-devel qt6-multimedia-devel qt6-svg-devel qt6-websockets-devel
+ qt6-webview-devel qtkeychain-qt6-devel"
+short_desc="Mastodon client for Plasma"
+maintainer="Nafis <mnabid.25@outlook.com>"
+license="GPL-2.0-or-later, LGPL-2.0-or-later"
+homepage="https://apps.kde.org/tokodon"
+changelog="https://kde.org/announcements/changelogs/gear/${version}/#tokodon"
+distfiles="${KDE_SITE}/release-service/${version}/src/tokodon-${version}.tar.xz"
+checksum=7ec4a2bf6e4825e814bd3230fae620852ce81d163704dcbde2bf3d1979993d0b


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

[Tokodon](https://apps.kde.org/tokodon) is a Mastodon client for Plasma.
Closes: #42357

#### Testing the changes
- I tested the changes in this PR: **YES**


#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**


<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, `x86_64-glibc`
- I built this PR locally for these architectures:
  - `armv6l-musl` (crossbuild)
