### PR TITLE
New package: plasmatube-26.04.2

### DIFF
--- a/srcpkgs/plasmatube/template
+++ b/srcpkgs/plasmatube/template
@@ -1,0 +1,22 @@
+# Template file for 'plasmatube'
+pkgname=plasmatube
+version=26.04.2
+revision=1
+build_style=cmake
+configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
+ -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins
+ -DKDE_INSTALL_QMLDIR=lib/qt6/qml"
+hostmakedepends="extra-cmake-modules gettext kf6-kconfig kf6-kcoreaddons
+ pkg-config qt6-base qt6-declarative-host-tools"
+makedepends="kf6-kdbusaddons-devel kf6-kdeclarative-devel kf6-ki18n-devel
+ kf6-kirigami-devel kf6-kitemmodels-devel kf6-knotifications-devel
+ kf6-kwindowsystem-devel kf6-purpose-devel kf6-qqc2-desktop-style-devel
+ kirigami-addons-devel mpvqt-devel qt6-svg-devel qtkeychain-qt6-devel"
+depends="yt-dlp"
+short_desc="Kirigami YouTube video player based on QtMultimedia and mpv"
+maintainer="Nafis <mnabid.25@outlook.com>"
+license="GPL-2.0-or-later, LGPL-2.0-or-later"
+homepage="https://apps.kde.org/plasmatube"
+changelog="https://kde.org/announcements/changelogs/gear/${version}/#plasmatube"
+distfiles="${KDE_SITE}/release-service/${version}/src/plasmatube-${version}.tar.xz"
+checksum=44b261c2b858b981c0f63cab0aa8da3cf4f2f3bc9ec5d8bc513224e6d2332de0


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

[Plasmatube](https://apps.kde.org/plasmatube) is a YouTube video player based on [mpv](https://mpv.io/), [yt-dlp](https://github.com/yt-dlp/yt-dlp), and [Invidious](https://github.com/iv-org/invidious).

#### Testing the changes
- I tested the changes in this PR: **briefly**


#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**


<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, `x86_64-glibc`
- I built this PR locally for these architectures:
  - `armv6l-musl` (crossbuild)

