### PR TITLE
gnome-maps: add missing dependencies

### DIFF
--- a/srcpkgs/gnome-maps/template
+++ b/srcpkgs/gnome-maps/template
@@ -1,7 +1,7 @@
 # Template file for 'gnome-maps'
 pkgname=gnome-maps
 version=50.1
-revision=2
+revision=3
 build_style=meson
 build_helper="gir"
 hostmakedepends="desktop-file-utils glib-devel gettext pkg-config gjs gtk4-update-icon-cache
@@ -9,8 +9,8 @@ hostmakedepends="desktop-file-utils glib-devel gettext pkg-config gjs gtk4-updat
 makedepends="geoclue2-devel gjs-devel geocode-glib-devel libgweather-devel
  libshumate-devel libsecret-devel rest-devel libadwaita-devel libportal-devel
  librsvg-devel libxml2-devel json-glib-devel"
-depends="desktop-file-utils hicolor-icon-theme geoclue2 libportal rest libgweather
- geocode-glib"
+depends="desktop-file-utils hicolor-icon-theme geoclue2 gjs libadwaita
+ libportal rest libgweather geocode-glib"
 short_desc="GNOME maps application"
 maintainer="Enno Boland <gottox@voidlinux.org>"
 license="GPL-2.0-or-later"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**
I removed gnome-maps and manually installed dependencies, then installed the newly built package and checked that the program starts

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-libc)


#### Fixed issue
I installed gnome-maps under KDE and it fails to start with the following error:
```
$ gnome-maps 
bash: /usr/bin/gnome-maps: /usr/bin/gjs: bad interpreter: No such file or directory
```
After manually installing gjs package I got another error:
```
$ gnome-maps 

(org.gnome.Maps:17494): Gjs-Console-CRITICAL **: 17:42:38.660: Error: Requiring Adw, version 1: Typelib file for namespace 'Adw', version '1' not found
require@resource:///org/gnome/gjs/modules/esm/gi.js:16:28
@gi://Adw:3:25
```
After installing libadwaita package the program starts