### PR TITLE
libpciaccess: update to 0.19., libdrm: update to 2.4.134.

### DIFF
--- a/srcpkgs/libdrm/template
+++ b/srcpkgs/libdrm/template
@@ -1,6 +1,6 @@
 # Template file for 'libdrm'
 pkgname=libdrm
-version=2.4.131
+version=2.4.134
 revision=1
 build_style=meson
 configure_args="-Dudev=true -Dvalgrind=disabled -Dinstall-test-programs=true"
@@ -11,7 +11,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
 homepage="https://dri.freedesktop.org/"
 distfiles="https://gitlab.freedesktop.org/mesa/libdrm/-/archive/libdrm-${version}/libdrm-libdrm-${version}.tar.gz"
-checksum=94fed0e93809d239fcbcf1d652753454e728ba887fb2175534219d0e67a81814
+checksum=28af861f62e7a2c3a48c5ff2ad4d01cf440a419f7f877de5caa7f73d3afa5367
 
 case "$XBPS_TARGET_MACHINE" in
 	aarch64*) configure_args+=" -Dvc4=enabled";;
@@ -23,7 +23,7 @@ post_install() {
 }
 
 libdrm-devel_package() {
-	depends="${makedepends} ${sourcepkg}-${version}_${revision}"
+	depends="${makedepends} ${sourcepkg}>=${version}_${revision}"
 	short_desc+=" - development files"
 	pkg_install() {
 		vmove usr/include
@@ -34,7 +34,7 @@ libdrm-devel_package() {
 }
 
 libdrm-test-progs_package() {
-	depends="${sourcepkg}-${version}_${revision}"
+	depends="${sourcepkg}>=${version}_${revision}"
 	short_desc+=" - test programs"
 	pkg_install() {
 		vmove usr/bin

--- a/srcpkgs/libdrm/update
+++ b/srcpkgs/libdrm/update
@@ -1,1 +1,1 @@
-pkgname=drm-libdrm
+pattern="libdrm-\K[0-9]+\.[0-9]+\.[0-9]+"

--- a/srcpkgs/libpciaccess/template
+++ b/srcpkgs/libpciaccess/template
@@ -1,6 +1,6 @@
 # Template file for 'libpciaccess'
 pkgname=libpciaccess
-version=0.18.1
+version=0.19
 revision=1
 build_style=meson
 short_desc="X11 PCI Access library"
@@ -8,7 +8,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
 homepage="http://xorg.freedesktop.org/"
 distfiles="${XORG_SITE}/lib/$pkgname-$version.tar.xz"
-checksum=4af43444b38adb5545d0ed1c2ce46d9608cc47b31c2387fc5181656765a6fa76
+checksum=3c55aa86c82e54a4e3109786f0463530d53b36b6d1cfd14616454f985dd2aa43
 
 post_install() {
 	vlicense COPYING


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture (x86_64)
- I built this PR locally for these architectures using specific masterdirs:
  - x86_64-musl
  - i686
- I built this PR locally for these architectures (crossbuilds):
  - aarch64
  - aarch64-musl
  - armv7l
  - armv7l-musl
  - armv6l
  - armv6l-musl

---

Split out from the Intel media stack update (#60099) to keep scope contained. `libpciaccess` and `libdrm` are kept together since `libpciaccess` is a build-dep of `libdrm`.

SONAME unchanged on all provided libs, so no common/shlibs changes and no reverse-dep rebuilds. Runtime validated on x86_64.