### PR TITLE
libunwind: update to 1.8.3.

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -1303,6 +1303,7 @@ libunwind-aarch64.so.8 libunwind-1.5.0_3
 libunwind-ppc32.so.8 libunwind-1.5.0_3
 libunwind-ppc64.so.8 libunwind-1.5.0_3
 libunwind-setjmp.so.0 libunwind-1.5.0_3
+libunwind-coredump.so.0 libunwind-1.8.3_1
 libmicrohttpd.so.12 libmicrohttpd-0.9.73_1
 libmicrodns.so.1 libmicrodns-0.2.0_1
 libgit2.so.1.7 libgit2-1.7.2_1

--- a/srcpkgs/libunwind/template
+++ b/srcpkgs/libunwind/template
@@ -1,6 +1,6 @@
 # Template file for 'libunwind'
 pkgname=libunwind
-version=1.8.2
+version=1.8.3
 revision=1
 build_style=gnu-configure
 hostmakedepends="libtool automake"
@@ -10,7 +10,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
 homepage="https://www.nongnu.org/libunwind/"
 distfiles="https://github.com/libunwind/libunwind/releases/download/v${version}/libunwind-${version}.tar.gz"
-checksum=7f262f1a1224f437ede0f96a6932b582c8f5421ff207c04e3d9504dfa04c8b82
+checksum=be30d910e67f58d82e753231f1357f326a1a088acf126b21ff77e60aab19b90b
 # many test failures
 make_check=no
 

--- a/srcpkgs/libunwind/update
+++ b/srcpkgs/libunwind/update
@@ -1,0 +1,1 @@
+pattern="refs/tags/v\K[0-9.]+"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture (x86_64)
- I built this PR locally for these architectures using specific masterdirs:
  - x86_64-musl
  - i686
- I built this PR locally for these architectures (crossbuilds):
  - aarch64
  - aarch64-musl
  - armv7l
  - armv7l-musl
  - armv6l
  - armv6l-musl

---

Split out from the Intel media stack update (#60099) to keep scope contained.

Adds `libunwind-coredump.so.0` entry to common/shlibs. SONAME otherwise unchanged, so no reverse-dep rebuilds needed.