### PR TITLE
elfutils: update to 0.195.

### DIFF
--- a/srcpkgs/elfutils/template
+++ b/srcpkgs/elfutils/template
@@ -1,6 +1,6 @@
 # Template file for 'elfutils'
 pkgname=elfutils
-version=0.194
+version=0.195
 revision=1
 build_style=gnu-configure
 configure_args="--program-prefix=eu- --enable-debuginfod --enable-libdebuginfod"
@@ -15,7 +15,7 @@ license="GPL-3.0-or-later"
 homepage="https://sourceware.org/elfutils/"
 changelog="https://sourceware.org/git/?p=elfutils.git;a=blob_plain;f=NEWS;hb=HEAD"
 distfiles="https://sourceware.org/pub/elfutils/${version}/elfutils-${version}.tar.bz2"
-checksum=09e2ff033d39baa8b388a2d7fbc5390bfde99ae3b7c67c7daaf7433fbcf0f01e
+checksum=37629fdf7f1f3dc2818e138fca2b8094177d6c2d0f701d3bb650a561218dc026
 # subpackages require explicit ordering
 subpackages="debuginfod libdebuginfod libelf elfutils-devel"
 CFLAGS="-Wno-error=deprecated-declarations" # curl 7.55+


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture (x86_64)
- I built this PR locally for these architectures using specific masterdirs:
  - x86_64-musl
  - i686
- I built this PR locally for these architectures (crossbuilds):
  - aarch64
  - aarch64-musl
  - armv7l
  - armv7l-musl
  - armv6l
  - armv6l-musl

---

Split out from the Intel media stack update (#60099) to keep scope contained.

SONAME unchanged (`libelf.so.1`, `libdw.so.1`, `libasm.so.1`), so no common/shlibs changes and no reverse-dep rebuilds needed.