### PR TITLE
qtile-wayland: add missing dependencies

### DIFF
--- a/srcpkgs/qtile/template
+++ b/srcpkgs/qtile/template
@@ -1,7 +1,7 @@
 # Template file for 'qtile'
 pkgname=qtile
 version=0.36.0
-revision=1
+revision=2
 build_style=python3-pep517
 _wlroots=0.19
 make_build_args="--config-setting backend=wayland"
@@ -35,7 +35,7 @@ post_install() {
 }
 
 qtile-wayland_package() {
-	depends="${sourcepkg}>=${version}_${revision}"
+	depends="${sourcepkg}>=${version}_${revision} xorg-server-xwayland virtual?font:sans-serif"
 	pkg_install() {
 		vmove ${py3_sitelib}/libqtile/backend/wayland
 		vmove usr/share/wayland-sessions


### PR DESCRIPTION
#### Reason for Change

- Without `xorg-server-xwayland` qtile freezes/crashes
- Without `dejavu-fonts-ttf` firefox & status bar have squares appear for all font characters

#### Testing the changes

- I tested the changes in this PR: **YES

#### Local build testing

- I built this PR locally for my native architecture, (ARCH-LIBC)
