### PR TITLE
gendesk: update to 1.0.15, adopt.

### DIFF
--- a/srcpkgs/gendesk/template
+++ b/srcpkgs/gendesk/template
@@ -1,25 +1,25 @@
 # Template file for 'gendesk'
 pkgname=gendesk
-version=1.0.10
+version=1.0.15
 revision=1
 build_style=go
 go_import_path=github.com/xyproto/gendesk
 short_desc="Utility to generate .desktop files and download icons"
-maintainer="Orphaned <orphan@voidlinux.org>"
+maintainer="Rutpiv <roger_freitas@live.com>"
 license="BSD-3-Clause"
 homepage="https://gendesk.roboticoverlords.org/"
 distfiles="https://github.com/xyproto/gendesk/archive/v${version}.tar.gz
- https://roboticoverlords.org/images/${pkgname}.png"
-checksum="a9e7a6d7be514f829ebf86d9764d37436539f29d0b8a03a31d8386f9be604fdb
- 4d96eded48e536d02e35727c36dc20844c2e44654e81baf78e10aee4eb48e837"
-skip_extraction="${pkgname}.png"
+ https://gendesk.roboticoverlords.org/default.png"
+checksum="7d8f0a85aad8049d79718c51ccbb4a41bb292e962e9457e1c5fef1dfc896f006
+ 0739303780d078746c7ea65daed73142b9044f6a5a1803f5f9363f749af28559"
+skip_extraction="default.png"
 
 pre_build() {
 	vsed -e 's|gendesk|github.com/xyproto/gendesk|' -i go.mod
 }
 
 post_install() {
-	vinstall ${XBPS_SRCDISTDIR}/${pkgname}-${version}/${pkgname}.png 644 usr/share/pixmaps
+	vinstall ${XBPS_SRCDISTDIR}/${pkgname}-${version}/default.png 644 usr/share/pixmaps gendesk.png
 	vman ${pkgname}.1
 	vlicense LICENSE
 }


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures using specific masterdirs:
  - x86_64-musl
  - i686
- I built this PR locally for these architectures (crossbuilds):
  - aarch64
  - aarch64-musl
  - armv7l
  - armv7l-musl
  - armv6l
  - armv6l-musl
 
---

Update `gendesk` to 1.0.15 and apply for adoption since I have contributed to this package before (#51941).

The package is currently orphaned; I'd like to take over maintenance. Built and tested  generating a `.desktop` file.