### PR TITLE
New package: analitza and kalgebra-26.08.0

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -2020,6 +2020,10 @@ libkwin.so.6 kwin-6.5.1_1
 libkwin-x11.so.6 kwin-x11-6.5.1_1
 libLayerShellQtInterface.so.6 layer-shell-qt-6.5.1_1
 # KDE Gear
+libAnalitza.so.9 analitza-26.04.2_1
+libAnalitzaGui.so.9 analitza-26.04.2_1
+libAnalitzaPlot.so.9 analitza-26.04.2_1
+libAnalitzaWidgets.so.9 analitza-26.04.2_1
 libKMahjongg6.so.6 libkmahjongg-24.08.2_1
 libKF6BalooWidgets.so.6 baloo-widgets-24.02.0_1
 libKCddb6.so.5 libkcddb6-24.02.2_1

--- a/srcpkgs/analitza-devel
+++ b/srcpkgs/analitza-devel
@@ -1,0 +1,1 @@
+analitza

--- a/srcpkgs/analitza/template
+++ b/srcpkgs/analitza/template
@@ -1,0 +1,26 @@
+# Template file for 'analitza'
+# group=kde-gear
+pkgname=analitza
+version=26.08.0
+revision=1
+build_style=cmake
+configure_args="-DBUILD_TESTING=OFF -DKDE_INSTALL_QMLDIR=lib/qt6/qml"
+hostmakedepends="extra-cmake-modules kf6-kdoctools qt6-base
+ qt6-declarative-host-tools qt6-tools"
+makedepends="eigen kf6-kdoctools-devel qt6-declarative-devel qt6-svg-devel"
+short_desc="KDE library to add mathematical features to your program"
+maintainer="Nafis <mnabid.25@outlook.com>"
+license="GPL-2.0-or-later, LGPL-2.0-or-later"
+homepage="https://invent.kde.org/education/analitza"
+distfiles="${KDE_SITE}/release-service/${version}/src/analitza-${version}.tar.xz"
+checksum=78e29638b71d9789405773cb6d8613bdef0f989abb6f6f3eef7662ebaad01d7f
+
+analitza-devel_package() {
+	depends="${sourcepkg}>=${version}_${revision} ${makedepends}"
+	short_desc+=" - development files"
+	pkg_install() {
+		vmove usr/include
+		vmove usr/lib/cmake
+		vmove "usr/lib/*.so"
+	}
+}

--- a/srcpkgs/kalgebra/template
+++ b/srcpkgs/kalgebra/template
@@ -1,0 +1,37 @@
+# Template file for 'kalgebra'
+# group=kde-gear
+pkgname=kalgebra
+version=26.08.0
+revision=1
+build_style=cmake
+configure_args="-DBUILD_TESTING=OFF -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins
+ -DKDE_INSTALL_QMLDIR=lib/qt6/qml"
+hostmakedepends="extra-cmake-modules gettext kf6-kconfig kf6-kcoreaddons
+ kf6-kdoctools kf6-kpackage pkg-config qt6-base qt6-declarative-host-tools"
+makedepends="analitza-devel kf6-ki18n-devel kf6-kio-devel kf6-kxmlgui-devel
+ libplasma-devel qt6-webengine-devel readline-devel"
+short_desc="2D and 3D Graph Calculator"
+maintainer="Nafis <mnabid.25@outlook.com>"
+license="GPL-2.0-or-later, LGPL-2.0-or-later"
+homepage="https://apps.kde.org/kalgebra"
+changelog="https://kde.org/announcements/changelogs/gear/${version}/#kalgebra"
+distfiles="${KDE_SITE}/release-service/${version}/src/kalgebra-${version}.tar.xz"
+checksum=260d9b93a5ae7a6cddb42878994ff27bddaca5f28b7a1fcb096a2dacba066fba
+
+if [ "$XBPS_WORDSIZE$XBPS_WORDSIZE" != "64$XBPS_TARGET_WORDSIZE" ]; then
+	broken="Qt6 WebEngine"
+fi
+
+kalgebramobile_package() {
+	short_desc+=" - mobile version"
+	homepage="https://apps.kde.org/kalgebramobile"
+	depends="kirigami-addons"
+	pkg_install() {
+		vmove usr/bin/kalgebramobile
+		vmove usr/share/applications/org.kde.kalgebramobile.desktop
+		vmove usr/share/metainfo/org.kde.kalgebramobile.appdata.xml
+		for f in ${DESTDIR}/usr/share/locale/*/LC_MESSAGES/kalgebramobile.mo; do
+			vmove ${f#$DESTDIR}
+		done
+	}
+}

--- a/srcpkgs/kalgebramobile
+++ b/srcpkgs/kalgebramobile
@@ -1,0 +1,1 @@
+kalgebra


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

[KAlgebra](https://apps.kde.org/kalgebra) is a 2D and 3D Graph Calculator.

#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, `x86_64-glibc`
- I built this PR locally for these architectures:
  - `aarch64-musl` (crossbuild)

NOTE: 32-bit builds aren't possible due to `qt6-webengine` missing.