### PR TITLE
papis: enable check.

### DIFF
--- a/srcpkgs/papis/template
+++ b/srcpkgs/papis/template
@@ -1,7 +1,7 @@
 # Template file for 'papis'
 pkgname=papis
 version=0.15.0
-revision=1
+revision=2
 build_style=python3-pep517
 hostmakedepends="hatchling"
 depends="python3-yaml python3-arxiv python3-BeautifulSoup4 python3-bibtexparser python3-click python3-colorama python3-dominate python3-filetype python3-habanero python3-lxml python3-platformdirs python3-prompt_toolkit python3-Pygments python3-parsing python3-doi python3-slugify python3-requests
@@ -14,4 +14,3 @@ homepage="https://github.com/papis/papis"
 changelog="https://raw.githubusercontent.com/papis/papis/main/CHANGELOG.md"
 distfiles="https://github.com/papis/${pkgname}/archive/refs/tags/v${version}.tar.gz"
 checksum=40ffd77cde44c7af482ab4523a521754d7c5388d021b01a51eb3c908c6b3cef2
-make_check=no # test_utils.py failed, some issue with python3-habanero

--- a/srcpkgs/python3-habanero/template
+++ b/srcpkgs/python3-habanero/template
@@ -1,17 +1,20 @@
 # Template file for 'python3-habanero'
 pkgname=python3-habanero
-version=0.6.2
-revision=9
-build_style=python3-module
-hostmakedepends="python3-setuptools"
-depends="python3-requests"
+version=2.3.0
+revision=1
+build_style=python3-pep517
+# Disable unstable tests, needs external API
+make_check_args="--ignore=test/test-funders.py --ignore=test/test-journals.py --ignore=test/test-types.py --ignore=test/test-workscontainer.py"
+hostmakedepends="hatchling python3-pytest"
+depends="python3-yaml python3-httpx python3-tqdm python3-urllib3 python3-packaging"
+checkdepends="python3-yaml python3-httpx python3-tqdm python3-urllib3"
 short_desc="Python3 low level client for Crossref Search API"
 maintainer="xaltsc <xaltsc@protonmail.ch>"
 license="MIT"
 homepage="https://github.com/sckott/habanero"
 distfiles="${PYPI_SITE}/h/habanero/habanero-${version}.tar.gz"
-checksum=806c74298e0fb8a838514307ef3eca73685a968b8efd00e5dfe1ea604200f59d
+checksum=871e5d088ef641b05514d44b004af512852b309bcd0d81f10545e58d54a654ab
 
 post_install() {
-	vlicense docs/license.rst
+	vlicense LICENSE.md
 }


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (x86-64)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - i686

Papis package had checks disabled because one failed test. Because this the command `papis add --from doi DOI file.pdf` could not collect information form doi service. I think, this behavior occurred because `papis` uses actually a old `habanero` version than the void one.