### PR TITLE
picom: add upstream patch to fix black screen on egl/glx backend

### DIFF
--- a/srcpkgs/picom/patches/0001-fix-64k-textures.patch
+++ b/srcpkgs/picom/patches/0001-fix-64k-textures.patch
@@ -1,0 +1,54 @@
+From 676196359c15bb654696b05700330685db914710 Mon Sep 17 00:00:00 2001
+From: Yuxuan Shui <yshuiv7@gmail.com>
+Date: Sat, 14 Mar 2026 23:37:23 +0000
+Subject: [PATCH] what's going on with 64k textures?
+
+---
+ src/backend/gl/blur.c      | 2 ++
+ src/backend/gl/gl_common.c | 6 ++++++
+ 2 files changed, 8 insertions(+)
+
+diff --git a/src/backend/gl/blur.c b/src/backend/gl/blur.c
+index 2e8f61f784..4f2a1a2048 100644
+--- a/src/backend/gl/blur.c
++++ b/src/backend/gl/blur.c
+@@ -862,6 +862,8 @@ void *gl_create_blur_context(backend_t *base, enum blur_method method,
+ 	// Note: OpenGL matrices are column major
+ 	GLint viewport_dimensions[2];
+ 	glGetIntegerv(GL_MAX_VIEWPORT_DIMS, viewport_dimensions);
++	viewport_dimensions[0] = min2(viewport_dimensions[0], 16384);
++	viewport_dimensions[1] = min2(viewport_dimensions[1], 16384);
+ 	GLfloat projection_matrix[4][4] = {{2.0F / (GLfloat)viewport_dimensions[0], 0, 0, 0},
+ 	                                   {0, 2.0F / (GLfloat)viewport_dimensions[1], 0, 0},
+ 	                                   {0, 0, 0, 0},
+diff --git a/src/backend/gl/gl_common.c b/src/backend/gl/gl_common.c
+index 28c9498318..13273d06b9 100644
+--- a/src/backend/gl/gl_common.c
++++ b/src/backend/gl/gl_common.c
+@@ -778,6 +778,8 @@ void gl_root_change(backend_t *base, session_t *ps) {
+ void gl_resize(struct gl_data *gd, int width, int height) {
+ 	GLint viewport_dimensions[2];
+ 	glGetIntegerv(GL_MAX_VIEWPORT_DIMS, viewport_dimensions);
++	viewport_dimensions[0] = min2(viewport_dimensions[0], 16384);
++	viewport_dimensions[1] = min2(viewport_dimensions[1], 16384);
+ 
+ 	gd->back_image.height = height;
+ 	gd->back_image.width = width;
+@@ -1006,6 +1008,8 @@ gl_create_window_shader_inner(struct gl_shader *out_shader,
+ 
+ 	GLint viewport_dimensions[2];
+ 	glGetIntegerv(GL_MAX_VIEWPORT_DIMS, viewport_dimensions);
++	viewport_dimensions[0] = min2(viewport_dimensions[0], 16384);
++	viewport_dimensions[1] = min2(viewport_dimensions[1], 16384);
+ 
+ 	// Set projection matrix to gl viewport dimensions so we can use screen
+ 	// coordinates for all vertices
+@@ -1084,6 +1088,8 @@ bool gl_init(struct gl_data *gd, session_t *ps) {
+ 	// buffer are skipped anyways, this should have no impact on performance.
+ 	GLint viewport_dimensions[2];
+ 	glGetIntegerv(GL_MAX_VIEWPORT_DIMS, viewport_dimensions);
++	viewport_dimensions[0] = min2(viewport_dimensions[0], 16384);
++	viewport_dimensions[1] = min2(viewport_dimensions[1], 16384);
+ 	glViewport(0, 0, viewport_dimensions[0], viewport_dimensions[1]);
+ 
+ 	// Clear screen

--- a/srcpkgs/picom/template
+++ b/srcpkgs/picom/template
@@ -1,7 +1,7 @@
 # Template file for 'picom'
 pkgname=picom
 version=13
-revision=1
+revision=2
 build_style=meson
 configure_args="-Dwith_docs=true"
 hostmakedepends="pkg-config ruby-asciidoctor"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
The PR adds the patch suggested in this issue where the current version of picom causes a black screen with the egl or glx backend: https://github.com/yshui/picom/issues/1511

With this patch the issue was resolved on my system.