### PR TITLE
New package: wch-isp-0.5.0

### DIFF
--- a/srcpkgs/wch-isp/template
+++ b/srcpkgs/wch-isp/template
@@ -1,0 +1,17 @@
+# Template file for 'wch-isp'
+pkgname=wch-isp
+version=0.5.0
+revision=1
+build_style=gnu-makefile
+hostmakedepends="pkgconf scdoc"
+makedepends="libusb-devel"
+short_desc="USB firmware flasher for WCH microcontrollers"
+maintainer="al20ov <nicolas.antauf@gmail.com>"
+license="GPL-2.0-only"
+homepage="https://git.sr.ht/~jmaselbas/wch-isp"
+distfiles="https://git.sr.ht/~jmaselbas/${pkgname}/archive/v${version}.tar.gz"
+checksum=216fd59e16a15d4d29c13ba47fbbe5c688514dec99b51758efaed34ddc2de3e7
+
+post_install() {
+	vinstall 50-wchisp.rules 644 usr/lib/udev/rules.d/
+}


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures:
  - aarch64-glibc (crossbuilt)
  - i686

Works well, it comes with udev rules and I'm able to flash a custom CH32V203 (G6U6) board over USB-C. I don't own any other WCH boards but their own README says it was tested on a couple other chips and it should work with all of the ones listed in [devices.h](https://git.sr.ht/~jmaselbas/wch-isp/tree/main/item/devices.h).

The only runtime dependency is libusb.