### PR TITLE
turnstile: move dinit service

### DIFF
--- a/srcpkgs/turnstile/template
+++ b/srcpkgs/turnstile/template
@@ -1,7 +1,7 @@
 # Template file for 'turnstile'
 pkgname=turnstile
 version=0.1.11
-revision=1
+revision=2
 build_style=meson
 configure_args="-Ddinit=enabled -Drunit=enabled -Ddefault_backend=runit
  -Dmanage_rundir=true"
@@ -24,4 +24,5 @@ post_install() {
 	chmod +x "${DESTDIR}/usr/share/examples/turnstile/dbus.check"
 	vdoc "${FILESDIR}/README.voidlinux"
 	vlicense COPYING.md
+	mv ${DESTDIR}/etc/dinit.d ${DESTDIR}/usr/lib/dinit.d
 }

--- a/srcpkgs/turnstile/template
+++ b/srcpkgs/turnstile/template
@@ -1,7 +1,7 @@
 # Template file for 'turnstile'
 pkgname=turnstile
 version=0.1.11
-revision=1
+revision=2
 build_style=meson
 configure_args="-Ddinit=enabled -Drunit=enabled -Ddefault_backend=runit
  -Dmanage_rundir=true"
@@ -24,4 +24,6 @@ post_install() {
 	chmod +x "${DESTDIR}/usr/share/examples/turnstile/dbus.check"
 	vdoc "${FILESDIR}/README.voidlinux"
 	vlicense COPYING.md
+	vsconf "${DESTDIR}/etc/dinit.d/turnstiled"
+	rm "${DESTDIR}/etc/dinit.d/turnstiled"
 }


### PR DESCRIPTION
- I tested the changes in this PR: **YES**
- I built this PR locally for my native architecture, (aarch64-gnu)

If the package installs the service to `etc/dinit.d`, there is no safe way to overwrite it, which we need to since it ships a dinit service taylored to Chimera linux. Put it into `usr/lib` instead, which is the same as Chimera does.

cc @classabbyamp 