### PR TITLE
speakersafetyd: belong to audio group.

### DIFF
--- a/srcpkgs/speakersafetyd/files/speakersafetyd/run
+++ b/srcpkgs/speakersafetyd/files/speakersafetyd/run
@@ -1,12 +1,13 @@
 #!/bin/sh
 
 _user=_speakersafetyd
-! [ -d /run/speakersafetyd ] && install -m 700 -g $_user -o $_user -d /run/speakersafetyd
-
+_group=audio
 _caps=-all,+sys_nice
 
+! [ -d /run/speakersafetyd ] && install -m 700 -g $_user -o $_user -d /run/speakersafetyd
+
 exec 2>&1
-exec setpriv --reuid $_user --regid audio --clear-groups \
+exec setpriv --reuid $_user --regid $_user --groups $_group \
   --ambient-caps $_caps \
   --inh-caps $_caps \
   --bounding-set $_caps \

--- a/srcpkgs/speakersafetyd/template
+++ b/srcpkgs/speakersafetyd/template
@@ -1,7 +1,7 @@
 # Template file for 'speakersafetyd'
 pkgname=speakersafetyd
 version=2.0.0
-revision=1
+revision=2
 build_style=cargo
 hostmakedepends="pkg-config"
 makedepends="alsa-lib-devel"
@@ -12,6 +12,7 @@ homepage="https://github.com/AsahiLinux/speakersafetyd"
 distfiles="https://github.com/AsahiLinux/speakersafetyd/archive/refs/tags/${version}.tar.gz"
 checksum=33b557bee7385cf42e6662fa1fa738d20b6aa5805a3169495400271db04d59b3
 system_accounts="_speakersafetyd"
+_speakersafetyd_groups="audio"
 
 post_install() {
 	DESTDIR="${DESTDIR}" make install-data


### PR DESCRIPTION
- I tested the changes in this PR: **YES**
- I built this PR locally for my native architecture, (aarch64-gnu)

Explicitly add to `audio` group, which is useful for dinit system service `run-as`.