### PR TITLE
llvm21: drop libcxx and libunwind options (now part of llvm22)

### DIFF
--- a/srcpkgs/llvm21/template
+++ b/srcpkgs/llvm21/template
@@ -72,7 +72,7 @@ fi
 build_options="clang clang_tools_extra lld mlir libclc polly lldb flang bolt
  openmp libc libcxx libunwind offload lto graphviz full_debug"
 build_options_default="clang clang_tools_extra lld libclc polly lldb
- libcxx libunwind mlir"
+ mlir"
 
 # fails to build with libquadmth on musl
 case "$XBPS_TARGET_MACHINE" in
@@ -163,13 +163,11 @@ $(vopt_if lld 'lld;')\
 $(vopt_if mlir 'mlir;')\
 $(vopt_if flang 'flang;')"
 
-_enabled_runtimes="compiler-rt\
+_enabled_runtimes="compiler-rt;libunwind;libcxx;libcxxabi\
 $(vopt_if openmp ';openmp')\
 $(vopt_if offload ';offload')\
 $(vopt_if libc ';libc')\
-$(vopt_if libclc ';libclc')\
-$(vopt_if libunwind ';libunwind')\
-$(vopt_if libcxx ';libcxxabi;libcxx')"
+$(vopt_if libclc ';libclc')"
 
 configure_args+=" -DLLVM_ENABLE_RUNTIMES=${_enabled_runtimes}"
 configure_args+=" -DLLVM_ENABLE_PROJECTS=${_enabled_projects}"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly** — successfully built gifski and pwmenu via x86_64, x86_64-musl and i686 using rebuilt clang21

#### Local build testing
- I built this PR locally for my native architecture, x86_64
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl
  - i686
  - armv6l
  - armv6l-musl
  - armv7l
  - armv7l-musl
  - aarch64
  - aarch64-musl

Closes #61005

I'm unsure if the revbump is necessary, there should be no functionality change from this, and this is addressing one of the roadblocks encountered in #59704

Based on bbdaa352ab4c22dcb62ad917e26e1a731b098222 but I did not remove the lldb python integration.

[ci skip]