### PR TITLE
clifm: update to 1.28.

### DIFF
--- a/srcpkgs/clifm/template
+++ b/srcpkgs/clifm/template
@@ -1,6 +1,6 @@
 # Template file for 'clifm'
 pkgname=clifm
-version=1.27.1
+version=1.28
 revision=1
 build_style=gnu-makefile
 make_install_args="MANDIR=/usr/share/man"
@@ -11,4 +11,4 @@ license="GPL-2.0-or-later"
 homepage="https://github.com/leo-arch/clifm"
 changelog="https://raw.githubusercontent.com/leo-arch/clifm/master/CHANGELOG"
 distfiles="https://github.com/leo-arch/clifm/releases/download/v${version}/clifm-${version}.tar.gz"
-checksum=a35cd1ccbb83f1261c3c5b14b5b4733cf0555be68579b3cb19fa8b36076a5339
+checksum=65ac33825fb55d6388c1044572e464a50ad367b607448774fb396d850b7c4420


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
#### Local build testing
- I built this PR locally for my native architecture, x86_64
- I built this PR locally for these architectures (\* crossbuild):
  - aarch64\*
  - x86_64-musl
