### PR TITLE
systemd-boot: Fix kernel.d post files for XBOOTLDR

### DIFF
--- a/srcpkgs/systemd-boot/files/kernel.d/systemd-boot.conf
+++ b/srcpkgs/systemd-boot/files/kernel.d/systemd-boot.conf
@@ -1,11 +1,9 @@
 ## uncomment this line to disable the systemd-boot hook
 #SYSTEMD_BOOT_DISABLE=1
 
+## This variable corresponds to where systemd-boot should look for your kernel & initramfs
 ## Default $BOOT is /boot
 #BOOT="/boot"
-
-## Default ESP is $BOOT
-#ESP="$BOOT"
 
 ## If unset, cmdline will be generated using UUID from fstab
 #CMDLINE=""

--- a/srcpkgs/systemd-boot/files/kernel.d/systemd-boot.post-install
+++ b/srcpkgs/systemd-boot/files/kernel.d/systemd-boot.post-install
@@ -19,13 +19,20 @@ if ! bootctl is-installed >/dev/null; then
 	exit 0
 fi
 
-BOOT="${BOOT:-/boot}"
-ESP="${ESP:-"$BOOT"}"
+if [ -z "$ESP" ]; then
+	# This branch corresponds to "new" configs, as well as old configs that left $ESP to default value
+	BOOT="${BOOT:-/boot}"
+else
+	# This branch corresponds to old configs that explicitly set $ESP to something exotic
+	# # It is a good idea to not source `$BOOT` from the user because this variable was previously unused
+	# i.e. held no significance to the execution of this script. We don't want to suddenly give it significance
+	# By doing this, users with $BOOT=/some/really/dumb/path in the config are not affected.
+	BOOT="${ESP}"
+fi
 
 BOOT="$ROOTDIR/$BOOT"
-ESP="$ROOTDIR/$ESP"
 
-[ -d "$ESP" ] || exit 0
+[ -d "$BOOT" ] || exit 0
 
 ARCH="$(xbps-uhelper arch)"
 
@@ -36,24 +43,24 @@ case "$ARCH" in
 	aarch64*) EFI_ARCH="aa64";;
 esac
 
-entries="$ESP/loader/entries"
+entries="$BOOT/loader/entries"
 name="void-$ARCH-$VERSION"
 entry="$entries/$name.conf"
 
 LINUX="vmlinuz-${VERSION}"
 
-if [ ! -f "$ESP/$LINUX" ]; then
+if [ ! -f "$BOOT/$LINUX" ]; then
 	LINUX="vmlinux-${VERSION}"
-	if [ ! -f "$ESP/$LINUX" ]; then
-		echo "Failed to find kernel at $ESP/vmlinuz-${VERSION} or $ESP/vmlinux-${VERSION}, aborting"
+	if [ ! -f "$BOOT/$LINUX" ]; then
+		echo "Failed to find kernel at $BOOT/vmlinuz-${VERSION} or $BOOT/vmlinux-${VERSION}, aborting"
 		exit 1
 	fi
 fi
 
 INITRD="initramfs-${VERSION}.img"
 
-if [ ! -f "$ESP/$INITRD" ]; then
-	echo "Failed to find initramfs at $ESP/$INITRD, aborting"
+if [ ! -f "$BOOT/$INITRD" ]; then
+	echo "Failed to find initramfs at $BOOT/$INITRD, aborting"
 	exit 1
 fi
 

--- a/srcpkgs/systemd-boot/files/kernel.d/systemd-boot.post-remove
+++ b/srcpkgs/systemd-boot/files/kernel.d/systemd-boot.post-remove
@@ -13,19 +13,26 @@ if [ "$SYSTEMD_BOOT_DISABLE" ]; then
 	exit 0
 fi
 
-BOOT="${BOOT:-/boot}"
-ESP="${ESP:-"$BOOT"}"
+if [ -z "$ESP" ]; then
+	# This branch corresponds to "new" configs, as well as old configs that left $ESP to default value
+	BOOT="${BOOT:-/boot}"
+else
+	# This branch corresponds to old configs that explicitly set $ESP to something exotic
+	# # It is a good idea to not source `$BOOT` from the user because this variable was previously unused
+	# i.e. held no significance to the execution of this script. We don't want to suddenly give it significance
+	# By doing this, users with $BOOT=/some/really/dumb/path in the config are not affected.
+	BOOT="${ESP}"
+fi
 
 BOOT="$ROOTDIR/$BOOT"
-ESP="$ROOTDIR/$ESP"
 
 ARCH="$(xbps-uhelper arch)"
 
-entries="$ESP/loader/entries"
+entries="$BOOT/loader/entries"
 name="void-$ARCH-$VERSION"
 entry="$entries/$name.conf"
 
-[ -d "$ESP" ] || exit 0
+[ -d "$BOOT" ] || exit 0
 
 rm -f "$entry"
 

--- a/srcpkgs/systemd-boot/template
+++ b/srcpkgs/systemd-boot/template
@@ -1,7 +1,7 @@
 # Template file for 'systemd-boot'
 pkgname=systemd-boot
 version=256.6
-revision=2
+revision=3
 build_style=meson
 conf_files="/etc/default/systemd-boot"
 configure_args="-Defi=true -Dman=enabled -Dbootloader=enabled


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architectures: x86_64-musl and aarch64-glibc (tested on two machines).

The kernel post-install and post-remove scripts for systemd-boot have been treating it as a given that the kernel resides under `$ESP`. This is not accurate when the user has an extended boot partition (XBOOTLDR). In this case, the user will change `$BOOT` in `/etc/default/systemd-boot` to point to their XBOOTLDR and notice an error due to the post-install script failing to find the kernel.

This PR makes the scripts look under `$BOOT`. It does not alter the behaviour for anyone with `$BOOT == $EFI`. It only corrects behaviour for the case where `$BOOT != $EFI`.