### PR TITLE
ironbar: update to 0.19

### DIFF
--- a/srcpkgs/ironbar/template
+++ b/srcpkgs/ironbar/template
@@ -1,11 +1,11 @@
 # Template file for 'ironbar'
 pkgname=ironbar
-version=0.18.0
+version=0.19.0
 revision=1
 build_style=cargo
-hostmakedepends="pkg-config"
-makedepends="gtk-layer-shell-devel gtk4-devel gtk4-layer-shell-devel pulseaudio-devel
-	libevdev-devel autoconf-archive libinput-devel"
+hostmakedepends="pkg-config cmake automake autoconf libtool python3 git libgit2-1.9-devel"
+makedepends="gtk-layer-shell-devel gtk4-devel gtk4-layer-shell-devel libgit2-1.9-devel
+ zlib-devel pulseaudio-devel libevdev-devel autoconf-archive libinput-devel LuaJIT-devel"
 depends="lua51-lgi"
 short_desc="Customisable Wayland GTK4 bar written in Rust"
 maintainer="caughtquick <abhijit@sipahimalani.me>"
@@ -13,12 +13,13 @@ license="MIT"
 homepage="https://github.com/JakeStanger/ironbar"
 changelog="https://github.com/JakeStanger/ironbar/releases/"
 distfiles="https://github.com/JakeStanger/ironbar/archive/refs/tags/v${version}.tar.gz"
-checksum=d5fafc7038e99f57b8502a4a7b8a32b0e7438744557658b9e8a3ce100a079a52
+checksum=0d25c2f0c72f839b4018ae12b876a71d04b946ce6fe629a0bb12b8b279ca3699
+nocross=yes  # GIR symlink hook fails during cross-compilation; native builds work fine
 
 # i686 has issues with the "devil" crate
 if [ "${XBPS_TARGET_MACHINE}" = "i686" ]; then
-	 configure_args+=" --no-default-features"
-	 configure_args+=" --features=battery,bindmode+all,bluetooth,cli,clipboard,clock,config+all"
+	configure_args+=" --no-default-features"
+	configure_args+=" --features=battery,bindmode+all,bluetooth,cli,clipboard,clock,config+all"
 	configure_args+=" --features=custom,focused,http,ipc,launcher,label,menu"
 	configure_args+=" --features=music+all,network_manager,notifications,script"
 	configure_args+=" --features=sys_info,tray,volume,workspaces+all,extras"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl & glibc
  - armv7l
  - i686

