### PR TITLE
qt6-base: fix segfaults due to freetype failing glyph rendering

### DIFF
--- a/srcpkgs/qt6-base/patches/fix-test-build.patch
+++ b/srcpkgs/qt6-base/patches/fix-test-build.patch
@@ -1,0 +1,12 @@
+# Remove unused QtTest/QTest header from relocatable_change.h
+# Fixes build failure with -DQT_BUILD_TESTS=ON
+
+--- a/tests/auto/corelib/kernel/qvariant/relocatable_change.h
++++ b/tests/auto/corelib/kernel/qvariant/relocatable_change.h
+@@ -8,7 +8,6 @@
+ #endif
+ 
+ #include <qvariant.h>
+-#include <QtTest/QTest>
+ 
+ #include <type_traits>

--- a/srcpkgs/qt6-base/patches/freetype-Handle-failing-glyph-rendering.patch
+++ b/srcpkgs/qt6-base/patches/freetype-Handle-failing-glyph-rendering.patch
@@ -1,0 +1,38 @@
+From 1b4f4b1797bc7db3eea6ef83a34df61d7bf78e17 Mon Sep 17 00:00:00 2001
+From: David Edmundson <davidedmundson@kde.org>
+Date: Wed, 25 Mar 2026 15:32:10 +0000
+Subject: [PATCH] freetype: Handle failing glyph rendering
+
+When FT_Render_Glpyh fails the slot returns a bitmap containing a valid
+width and height but a null buffer.
+
+When we eventually memcpy this buffer we will crash. Existing error
+handling in this method returns null on errors.
+
+Pick-to: 6.8 6.10 6.11
+Fixes: QTBUG-145310
+Change-Id: I4737ab4d769b52f42bd1ef9037c8b9fd681a4ae8
+Reviewed-by: Eskil Abrahamsen Blomfeldt <eskil.abrahamsen-blomfeldt@qt.io>
+---
+
+diff --git a/src/gui/text/freetype/qfontengine_ft.cpp b/src/gui/text/freetype/qfontengine_ft.cpp
+index e331a4c..371e01d 100644
+--- a/src/gui/text/freetype/qfontengine_ft.cpp
++++ b/src/gui/text/freetype/qfontengine_ft.cpp
+@@ -1955,11 +1955,13 @@
+     FT_Library_SetLcdFilter(slot->library, (FT_LcdFilter)lcdFilterType);
+ 
+     err = FT_Render_Glyph(slot, renderMode);
+-    if (err != FT_Err_Ok)
+-        qWarning("render glyph failed err=%x face=%p, glyph=%d", err, face, glyph);
+-
+     FT_Library_SetLcdFilter(slot->library, FT_LCD_FILTER_NONE);
+ 
++    if (err != FT_Err_Ok) {
++        qWarning("render glyph failed err=%x face=%p, glyph=%d", err, face, glyph);
++        return nullptr;
++    }
++
+     info.height = slot->bitmap.rows;
+     info.width = slot->bitmap.width;
+     info.x = slot->bitmap_left;

--- a/srcpkgs/qt6-base/template
+++ b/srcpkgs/qt6-base/template
@@ -5,7 +5,7 @@
 # - rebuild all pkg with qt6-base-private-devel
 pkgname=qt6-base
 version=6.10.2
-revision=1
+revision=2
 build_style=cmake
 configure_args="-DINSTALL_DATADIR=share/qt6
  -DINSTALL_ARCHDATADIR=lib${XBPS_TARGET_WORDSIZE}/qt6
@@ -79,7 +79,8 @@ do_check() {
 		tst_qx11info tst_qcomplextext
 		tst_qaddpreroutine tst_qtextcursor
 		test_widgets_app_deployment tst_qnetworkinterface
-		tst_qgraphicsproxywidget tst_qdnslookup"
+		tst_qgraphicsproxywidget tst_qdnslookup
+		tst_qsavefile tst_inputcontext"
 	# Unknown platform linux-g++ :/
 	failing_tests+=" mockplugins test_import_plugins
 	 test_static_resources test_generating_cpp_exports"
@@ -88,16 +89,17 @@ do_check() {
 	failing_tests+=" tst_seatv4"
 	# cmake
 	failing_tests+=" test_qt_add_resources_rebuild test_collecting_plugins
-	 test_standalone_test test_qt_extract_metatypes"
+	 test_standalone_test test_qt_extract_metatypes RunCMake.Sbom"
 	# Failing readonly and out-of-memory
 	failing_tests+=" tst_qsharedmemory"
 	if [ "$XBPS_TARGET_LIBC" = musl ]; then
 		# Some glibc specific DNS Lookup
-		failing_tests+=" tst_qdnslookup"
+		failing_tests+=" tst_qdnslookup tst_json tst_qarraydata"
 	fi
 	if [ "$XBPS_TARGET_WORDSIZE" = 32 ]; then
 		# failing on i686, not checked on arm
-		failing_tests+=" tst_qvectorrnd tst_json tst_qvectornd tst_qdoublevalidator"
+		failing_tests+=" tst_qvectorrnd tst_json tst_qvectornd
+			tst_qdoublevalidator tst_largefile tst_qpainterpath"
 	fi
 	local ctest_exclude="("
 	for failure in $failing_tests; do


### PR DESCRIPTION
Backports a patch to fix [QTBUG-145310](https://qt-project.atlassian.net/browse/QTBUG-145310), which caused segfaults on my KDE Plasma system since upgrading `freetype` from `2.14.1`.
Related issue: yeyushengfan258/Reversal-icon-theme#138

Also fixed `do_check` issues.
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, `x86_64-glibc`
<!--
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
