### PR TITLE
input-remapper: update to 2.2.1 New package: python3-dasbus-1.7

### DIFF
--- a/srcpkgs/input-remapper/template
+++ b/srcpkgs/input-remapper/template
@@ -1,17 +1,19 @@
 # Template file for 'input-remapper'
 pkgname=input-remapper
-version=2.2.0
+version=2.2.1
 revision=1
-build_style=python3-module
+build_style=python3-pep517
 hostmakedepends="python3-setuptools gettext"
-depends="dbus python3-evdev python3-gobject python3-setuptools python3-psutil python3-pydbus python3-pydantic"
+depends="dbus python3-evdev python3-gobject python3-psutil python3-dasbus python3-pydantic python3-packaging python3-cairo"
 short_desc="GUI Tool to change the behaviour of your input devices"
 maintainer="Soulful Sailer <soulful.sailer@entropic.pro>"
 license="GPL-3.0-or-later"
 homepage="https://github.com/sezanzeb/input-remapper"
 distfiles="https://github.com/sezanzeb/input-remapper/archive/refs/tags/${version}.tar.gz"
-checksum=62b44d9589cf256262240cb49667ef5ce63d36f9de50578321f148329d539a2d
+checksum=6ad3d58829e29f2943cbc874b910a94e699428547240f3e5b2a4acbd34e62d2f
 
 post_install() {
+	# copies data files (bin, desktop, icons, ect) to their install location
+	python3 -m install --root ${DESTDIR} --components data_files
 	vsv input-remapper
 }

--- a/srcpkgs/python3-dasbus/template
+++ b/srcpkgs/python3-dasbus/template
@@ -1,0 +1,13 @@
+# Template file for 'python3-dasbus'
+pkgname=python3-dasbus
+version=1.7
+revision=1
+build_style=python3-pep517
+hostmakedepends="hatchling python3-setuptools"
+depends="python3-gobject"
+short_desc="DBus library in Python 3"
+maintainer="Soulful Sailer <soulful.sailer@entropic.pro>"
+license="LGPL-2.1-or-later"
+homepage="https://dasbus.readthedocs.io/"
+distfiles="https://github.com/dasbus-project/dasbus/releases/download/v${version}/dasbus-${version}.tar.gz"
+checksum=a8850d841adfe8ee5f7bb9f82cf449ab9b4950dc0633897071718e0d0036b6f6

--- a/srcpkgs/python3-dasbus/update
+++ b/srcpkgs/python3-dasbus/update
@@ -1,0 +1,2 @@
+site="https://github.com/dasbus-project/dasbus/tags/"
+pattern="(?<!tags/)v?\K[0-9.]+(?=\.tar\.gz)"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)

#### Upstream made the following changes:
- Changed the build style to the modern pep517
  - Needed to add their new method to install data files to the post_install()
- Moved to a less outdated python dbus module (pydbus -> dasbus)
  - dasbus was not packaged yet, so it is included in this pull https://github.com/dasbus-project/dasbus