### PR TITLE
podman: update to 5.8.3.

### DIFF
--- a/srcpkgs/podman/template
+++ b/srcpkgs/podman/template
@@ -1,6 +1,6 @@
 # Template file for 'podman'
 pkgname=podman
-version=5.8.2
+version=5.8.3
 revision=1
 _container_libs_common=0.67.1
 build_style=go
@@ -20,7 +20,7 @@ homepage="https://podman.io/"
 changelog="https://raw.githubusercontent.com/containers/podman/main/RELEASE_NOTES.md"
 distfiles="https://github.com/containers/podman/archive/v${version}.tar.gz
  https://github.com/containers/container-libs/archive/refs/tags/common/v${_container_libs_common}.tar.gz"
-checksum="b20ea65afc5a58ea1cea019bd51a5d84eb9042d25d3eb82c55010c8815732d84
+checksum="c54a2ec4b4fb5577288992aaa78684397ec3552fb2d1234d910ec50097d05c0f
  5438aa7763acd6d0ddb39426bec20bc344c53161716d88a9d75ac1fed0172b64"
 
 case $XBPS_TARGET_MACHINE in


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc


Podman v5.8.3 addresses CVE-2026-44517.

The release mentions an update to buildah v1.43.2. Should I also update buildah in this PR? I see no direct dependency.