### PR TITLE
mesa: enable svga gallium driver on aarch64

### DIFF
--- a/srcpkgs/mesa/template
+++ b/srcpkgs/mesa/template
@@ -1,7 +1,7 @@
 # Template file for 'mesa'
 pkgname=mesa
 version=26.0.6
-revision=1
+revision=2
 build_style=meson
 build_helper="qemu"
 _llvmver=21
@@ -163,13 +163,18 @@ case "$XBPS_TARGET_MACHINE" in
 esac
 
 # x86 additionally gets intel, vmware and gallium nine
+# aarch64 also gets vmware for VMware Fusion on Apple Silicon
 # arm gets its own drivers (for mali, tegra etc.)
 case "$XBPS_TARGET_MACHINE" in
 	i686*|x86_64*)
 		_have_intel=yes
 		_have_vmware=yes
 		;;
-	armv[67]*|aarch64*)
+	aarch64*)
+		_have_arm=yes
+		_have_vmware=yes
+		;;
+	armv[67]*)
 		_have_arm=yes
 		;;
 esac


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, aarch64-glibc
- Verified `vmwgfx_dri.so` present in `/usr/lib64/dri/`
- Confirmed glamor initializes with hardware-accelerated OpenGL 4.3 on VMware Fusion (Apple Silicon), replacing llvmpipe/swrast fallback
- `glxinfo` reports: `OpenGL renderer string: SVGA3D; build: RELEASE; LLVM;`

#### Description

Enable the VMware svga gallium driver (`vmwgfx_dri.so`) for aarch64
targets by adding `_have_vmware=yes` to the aarch64 case.

VMware Fusion on Apple Silicon creates aarch64 Linux VMs that use the
`vmwgfx` kernel driver (SVGA version 3, shader model SM_5_1X). The svga
gallium driver provides hardware-accelerated OpenGL 4.3 in these VMs but
is currently only built for x86. Without it, aarch64 VMware guests fall
back to llvmpipe software rendering — glamor detects llvmpipe and refuses
to initialize, so X runs unaccelerated.

VMware documents 3D acceleration support for arm64 Linux guests with
kernel >= 5.19 and Mesa >= 22.1.1, both satisfied by current Void.

Splits the `armv[67]*|aarch64*` case to add `_have_vmware=yes` for
aarch64 while leaving armv6/armv7 unchanged.

Arch Linux ARM ships the svga driver for aarch64:
https://github.com/archlinuxarm/PKGBUILDs/blob/master/extra/mesa/PKGBUILD
