### PR TITLE
python3-pyelftools: remove alternatives

### DIFF
--- a/srcpkgs/python3-pyelftools/template
+++ b/srcpkgs/python3-pyelftools/template
@@ -1,7 +1,7 @@
 # Template file for 'python3-pyelftools'
 pkgname=python3-pyelftools
 version=0.33
-revision=1
+revision=2
 build_style=python3-pep517
 hostmakedepends="python3-wheel"
 depends="python3"
@@ -12,7 +12,6 @@ license="Public Domain"
 homepage="https://github.com/eliben/pyelftools"
 distfiles="${PYPI_SITE}/p/pyelftools/pyelftools-${version}.tar.gz"
 checksum=660d82dcbeb8e83d1702bd97f223f761625da06111c0cc988eac6b8ab0c1b61f
-alternatives="pyelftools:readelf.py:/usr/bin/readelf.py3"
 make_check_pre="env PYTHONPATH=test"
 
 post_install() {


### PR DESCRIPTION
Commit c03c6900fe44ea1eda64290cac77348b089231df removed the rename from readelf.py to readelf.py3, but kept the alternative named readelf.py and pointing to readelf.py.3. This resulted in readelf.py being replaced by a symlink pointing to a non-existent file when the package is installed. Also, no other package currently provides this executable, so there's no need for alternatives.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

@leahneukirchen

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
