### PR TITLE
gnome-music: update to 49.1

### DIFF
--- a/srcpkgs/gnome-music/template
+++ b/srcpkgs/gnome-music/template
@@ -1,7 +1,7 @@
 # Template file for 'gnome-music'
 pkgname=gnome-music
-version=48.0
-revision=2
+version=49.1
+revision=1
 build_helper="gir"
 build_style=meson
 hostmakedepends="gettext glib-devel itstool pkg-config
@@ -15,9 +15,9 @@ depends="desktop-file-utils python3-dbus python3-gobject python3-requests
 short_desc="GNOME music playing application"
 maintainer="Enno Boland <gottox@voidlinux.org>"
 license="GPL-2.0-or-later"
-homepage="https://wiki.gnome.org/Apps/Music"
+homepage="https://apps.gnome.org/Music"
 #changelog="https://gitlab.gnome.org/GNOME/gnome-music/-/raw/master/NEWS"
-changelog="https://gitlab.gnome.org/GNOME/gnome-music/-/raw/gnome-47/NEWS"
+changelog="https://gitlab.gnome.org/GNOME/gnome-music/-/raw/gnome-49/NEWS"
 distfiles="${GNOME_SITE}/gnome-music/${version%.*}/gnome-music-${version}.tar.xz"
-checksum=8cdaacd05262b63bb1608a25acad516e892c332232357cb9b7f68f2cfb86d66e
+checksum=ba881ae0b55e34e6269fd2d3df8d8bfa3c5ec7e37bac8945aec78b7ff207bc67
 lib32disabled=yes


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl & -glibc