### PR TITLE
keymapper: update to 5.6.0.

### DIFF
--- a/srcpkgs/keymapper/template
+++ b/srcpkgs/keymapper/template
@@ -1,6 +1,6 @@
 # Template file for 'keymapper'
 pkgname=keymapper
-version=5.5.1
+version=5.6.0
 revision=1
 build_style=cmake
 configure_args="-DVERSION=${version}"
@@ -12,7 +12,7 @@ license="GPL-3.0-only"
 homepage="https://github.com/houmain/keymapper"
 changelog="https://raw.githubusercontent.com/houmain/keymapper/main/CHANGELOG.md"
 distfiles="https://github.com/houmain/keymapper/archive/refs/tags/${version}.tar.gz"
-checksum=379f7353a42b690322db69a0500999e465d149176715de4f2cd1aa050b67330c
+checksum=a12c2f540f50cbf8605403e18bb1fcf07bc9eee30519f5a1e4839aa06881a02c
 
 post_install() {
 	vsv keymapperd


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl (cross)
  - armv6l (cross)
  - armv6l-musl (cross)
