### PR TITLE
kvantum: update to 1.1.8, adopt.

### DIFF
--- a/srcpkgs/kvantum/template
+++ b/srcpkgs/kvantum/template
@@ -1,21 +1,21 @@
 # Template file for 'kvantum'
 pkgname=kvantum
-version=1.1.7
+version=1.1.8
 revision=1
 build_wrksrc=Kvantum
 build_style=cmake
 configure_args="-DENABLE_QT5=ON"
 hostmakedepends="qt5-tools-devel qt5-host-tools qt6-tools qt6-base"
 makedepends="qt5-devel qt6-base-devel qt5-svg-devel qt6-svg-devel
- qt5-x11extras-devel kwindowsystem-devel kf6-kwindowsystem-devel"
+ qt5-x11extras-devel kf6-kwindowsystem-devel"
 depends="hicolor-icon-theme"
 short_desc="SVG-based theme engine for Qt5/Qt6, KDE and LXQt"
-maintainer="Orphaned <orphan@voidlinux.org>"
+maintainer="Rutpiv <roger_freitas@live.com>"
 license="GPL-3.0-or-later"
 homepage="https://github.com/tsujan/Kvantum"
 changelog="https://raw.githubusercontent.com/tsujan/Kvantum/master/Kvantum/ChangeLog"
 distfiles="https://github.com/tsujan/Kvantum/archive/V${version}.tar.gz"
-checksum=d81040b72424fbca02ee543633100c3b3d32ca6b2f4d3b62d08da1aaa824caa2
+checksum=170c0ad369b7f5cc083969f61241498e11721f3da346c750730c2d0c6f3771f5
 
 post_configure() {
 	mkdir build6


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture (x86_64)
- I built this PR locally for these architectures using specific masterdirs:
  - x86_64-musl
  - i686
- I built this PR locally for these architectures (crossbuilds):
  - aarch64
  - aarch64-musl
  - armv7l
  - armv7l-musl
  - armv6l
  - armv6l-musl

---

Update `kvantum` to 1.1.8 and apply for adoption since I have contributed to this package before ([#53179](https://github.com/void-linux/void-packages/pull/53179), [#60331](https://github.com/void-linux/void-packages/pull/60331), [#60741](https://github.com/void-linux/void-packages/pull/60741)). The package is currently orphaned; I'd like to take over maintenance. Also dropped `kwindowsystem-devel` (KF5), which I had forgotten to remove and which upstream no longer uses for the Qt5 plugin.