### PR TITLE
eclipse: update to 4.40.0

### DIFF
--- a/srcpkgs/eclipse/template
+++ b/srcpkgs/eclipse/template
@@ -1,9 +1,9 @@
 # Template file for 'eclipse'
 pkgname=eclipse
-version=4.32.0
+version=4.40.0
 revision=1
-_release="2024-06"
-_jna_version="5.14.0.v20231211-1200"  # Found in distfiles at eclipse/plugins/com.sun.jna_<version#>/
+_release="2026-06"
+_jna_version="55.18.1.v20251001-0800"  # Found in distfiles at eclipse/plugins/com.sun.jna_<version#>/
 archs="x86_64 aarch64"
 depends="openjdk21 gtk+3 libwebkit2gtk41 libXtst
  hicolor-icon-theme desktop-file-utils"
@@ -19,26 +19,37 @@ python_version=3
 distfiles="https://mirror.umd.edu/eclipse/technology/epp/downloads/release/${_release}/R/eclipse-java-${_release}-R-linux-gtk-${XBPS_TARGET_MACHINE%-*}.tar.gz"
 case ${XBPS_TARGET_MACHINE} in
 	x86_64)
-		checksum="7d77e3d0f226c9dda73d491a1af3aeec11807881e44e870a1fde2833f55df8b5"
+		checksum="5e0f6c241fd04530618df526d847150163c2a639f2bd6aa570ca608ff878f1ee"
 		;;
 	aarch64)
-		checksum="d046576e781722ca3c7d2f1bbd20cfc91182aded9d174fbac3295d43a1a11a6a"
+		checksum="0dfd043152dfa41dbd470f2ea2cd0f4fc076de231ac481ca0f051ad1b515dd0a"
 		;;
 esac
 
-# Skip JNA cross-platform binary components during dependency checks
-for _jna_arch in freebsd-x86-64 freebsd-x86 linux-aarch64 linux-armel \
-		linux-arm linux-loongarch64 linux-mips64el linux-ppc64le linux-ppc \
-		linux-riscv64 linux-s390x linux-x86-64 linux-x86 openbsd-x86-64 \
-		openbsd-x86 sunos-sparc sunos-sparcv9 sunos-x86-64 sunos-x86; do
-	skiprdeps+="/usr/lib/eclipse/plugins/com.sun.jna_${_jna_version}/com/sun/jna/${_jna_arch}/libjnidispatch.so "
-done
+
 
 do_install() {
 	vmkdir usr/lib/eclipse
 	cp -a ${wrksrc}/* ${DESTDIR}/usr/lib/eclipse
+	
+	
+	# Remove bundled JNA native libraries for foreign platforms
+case ${XBPS_TARGET_MACHINE} in
+	x86_64)
+		_jna_arch="linux-x86-64"
+		;;
+	aarch64)
+		_jna_arch="linux-aarch64"
+		;;
+esac
+
+find ${DESTDIR}/usr/lib/eclipse/plugins/com.sun.jna_* \
+	-type f \
+	-name "*.so" \
+	! -path "*/${_jna_arch}/*" \
+	-delete
 	sed -i '6i-vm' ${DESTDIR}/usr/lib/eclipse/eclipse.ini
-	sed -i '7i/usr/lib/jvm/openjdk11/bin' ${DESTDIR}/usr/lib/eclipse/eclipse.ini
+	sed -i '7i/usr/lib/jvm/openjdk21/bin' ${DESTDIR}/usr/lib/eclipse/eclipse.ini
 
 	vbin ${FILESDIR}/eclipse.sh eclipse
 	vinstall ${FILESDIR}/eclipse.desktop 644 usr/share/applications

--- a/srcpkgs/eclipse/template
+++ b/srcpkgs/eclipse/template
@@ -16,7 +16,7 @@ nopie=yes
 nostrip=yes
 python_version=3
 
-distfiles="https://mirror.umd.edu/eclipse/technology/epp/downloads/release/${_release}/R/eclipse-java-${_release}-R-linux-gtk-${XBPS_TARGET_MACHINE%-*}.tar.gz"
+distfiles="https://mirror.dkm.cz/eclipse/technology/epp/downloads/release/${_release}/R/eclipse-java-${_release}-R-linux-gtk-${XBPS_TARGET_MACHINE%-*}.tar.gz"
 case ${XBPS_TARGET_MACHINE} in
 	x86_64)
 		checksum="5e0f6c241fd04530618df526d847150163c2a639f2bd6aa570ca608ff878f1ee"

--- a/srcpkgs/eclipse/template
+++ b/srcpkgs/eclipse/template
@@ -31,8 +31,8 @@ esac
 do_install() {
 	vmkdir usr/lib/eclipse
 	cp -a ${wrksrc}/* ${DESTDIR}/usr/lib/eclipse
-	
-	
+
+
 	# Remove bundled JNA native libraries for foreign platforms
 case ${XBPS_TARGET_MACHINE} in
 	x86_64)


### PR DESCRIPTION


Updated Eclipse to 4.40.0.

Changes:
- bump Eclipse release to 2026-06
- update JNA version
- update distfile checksums
- remove bundled JNA native libraries for unsupported platforms

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
