### PR TITLE
wiremix: update to 0.11.0.

### DIFF
--- a/srcpkgs/wiremix/template
+++ b/srcpkgs/wiremix/template
@@ -1,6 +1,6 @@
 # Template file for 'wiremix'
 pkgname=wiremix
-version=0.10.0
+version=0.11.0
 revision=1
 build_style=cargo
 hostmakedepends="pkg-config clang"
@@ -11,7 +11,7 @@ license="MIT OR Apache-2.0"
 homepage="https://github.com/tsowell/wiremix/"
 changelog="https://raw.githubusercontent.com/tsowell/wiremix/refs/heads/main/CHANGELOG.md"
 distfiles="https://github.com/tsowell/wiremix/archive/refs/tags/v${version}.tar.gz"
-checksum=dfb165ff664b804099c5592fd26d2b03d78e67069522bc5d3d8ef75a19505adf
+checksum=62a7cace79c9af537e0917a6d4e5da66b2efe2b4abc5f08c0fbaed727acc8c9f
 
 post_install() {
 	vinstall wiremix.desktop 644 usr/share/applications


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)