### PR TITLE
UxPlay: update to 1.73.6.

### DIFF
--- a/srcpkgs/UxPlay/template
+++ b/srcpkgs/UxPlay/template
@@ -1,6 +1,6 @@
 # Template file for 'UxPlay'
 pkgname=UxPlay
-version=1.72.3
+version=1.73.6
 revision=1
 build_style=cmake
 configure_args="-DNO_MARCH_NATIVE=ON"
@@ -13,7 +13,7 @@ license="GPL-3.0-or-later"
 homepage="https://github.com/FDH2/UxPlay"
 changelog="https://github.com/FDH2/UxPlay/releases"
 distfiles="https://github.com/FDH2/UxPlay/archive/refs/tags/v${version}.tar.gz"
-checksum=a2f41c5481c2c3c8f125c38f8142a99d69b21d727be816616b66dd96af9a9c63
+checksum=3a1a754bc7ed4b0f72b6237aa4d769238b9c20a71b651bc3fe9ac679e2a67f18
 
 post_install() {
 	vdoc ${FILESDIR}/README.voidlinux


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Testing log
* `Render Audio cover-art inside UxPlay with -ca option (no file specified)`: While I wasn't able to get it to display it 1 to 1 it seems to do as advertised with right image viewers.
* `Add password support (-pw) using a displayed pin code as a password that changes every time (and not as a one-time pin)`: Works.
* `New option -lang to specify language preferences for YouTube HLS videos when they offer a choice`: Works.
* `New option -mp4 for recording to a mp4 file (Mirror and Audio/ALAC mode, not HLS)`: Works, records both audio and video.
* `Small fix for broken -vol option`: Works as expected.
* `Simplified (Linux only) screensaver inhibitor option "-scrsv 1"`: I couldn't test it myself since I don't use a screensaver, but a friend was able to attest to it working.

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-glibc