### PR TITLE
gomuks: update to 26.06. adopt.

### DIFF
--- a/srcpkgs/gomuks/template
+++ b/srcpkgs/gomuks/template
@@ -1,17 +1,26 @@
 # Template file for 'gomuks'
 pkgname=gomuks
-version=0.3.1
+version=0.2606.0
 revision=1
+archs="~i686*"
 build_style=go
-go_import_path="maunium.net/go/gomuks"
+go_import_path=go.mau.fi/gomuks
+go_package="go.mau.fi/gomuks/cmd/gomuks"
+go_build_tags="sqlite_fts5"
+go_ldflags="-X go.mau.fi/gomuks/version.Tag=${version}"
+hostmakedepends="nodejs"
 makedepends="olm-devel"
-short_desc="Terminal Matrix client"
-maintainer="Orphaned <orphan@voidlinux.org>"
+short_desc="Matrix web-client written in Go"
+maintainer="Dora 'cat' <cat@thenight.club>"
 license="AGPL-3.0-or-later"
-homepage="https://maunium.net/go/gomuks/"
-changelog="https://github.com/tulir/gomuks/raw/master/CHANGELOG.md"
-distfiles="https://github.com/tulir/gomuks/archive/refs/tags/v${version}.tar.gz"
-checksum=e5212c416a84a5e8f46ab6b36cf9cfec36918930dbf7a155cce00570887600f7
+homepage="https://gomuks.app/"
+changelog="https://raw.githubusercontent.com/gomuks/gomuks/refs/heads/main/CHANGELOG.md"
+distfiles="https://github.com/gomuks/gomuks/archive/refs/tags/v${version}.tar.gz"
+checksum=b55ecc9bb050ad00553077e2f1e451a1ae56ee0f39240a359354ab29b390ff46
+
+pre_build() {
+	GOARCH= go generate ./web
+}
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl
  - i686 <-- Does not compile due to 
```
_build-gomuks-xbps/pkg/mod/[go.mau.fi/goheif@v0.1.0/dav1d/config.h:30:2](https://go.mau.fi/goheif@v0.1.0/dav1d/config.h:30:2): error: #error "Unsupported architecture. Only x86_64, ARM64, and RISC-V are supported."
```
Additionally from the lead dev:
> tulir: 32-bit x86 isn't supported since nobody uses that anymore, 32-bit arm is still supported for now
