### PR TITLE
python3-pynitrokey: update to 0.12.3

### DIFF
--- a/srcpkgs/python3-pynitrokey/template
+++ b/srcpkgs/python3-pynitrokey/template
@@ -1,6 +1,6 @@
 # Template file for 'python3-pynitrokey'
 pkgname=python3-pynitrokey
-version=0.12.2
+version=0.12.3
 revision=1
 build_style=python3-pep517
 hostmakedepends="python3-poetry-core"
@@ -17,7 +17,7 @@ maintainer="Mateusz Sylwestrzak <slymattz@gmail.com>"
 license="LGPL-3.0-only OR GPL-3.0-or-later OR Apache-2.0 OR MIT"
 homepage="https://github.com/Nitrokey/pynitrokey"
 distfiles="https://github.com/Nitrokey/pynitrokey/archive/refs/tags/v${version}.tar.gz"
-checksum=1fedf0568eb5323108684a12bbd221a746ae0d325ef20251a93925d920ee9d50
+checksum=d74427bd9cc5ad25fa7ec55db19f273015ffa09f975069dc02e3e6a2865485f6
 
 post_install() {
 	vlicense LICENSES/MIT.txt


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**
https://github.com/Nitrokey/pynitrokey/compare/v0.12.2...v0.12.3

#### Local build testing
- I built this PR locally for my native architecture: x86_64-glibc