### PR TITLE
xdg-desktop-portal-wlr: update to 0.8.4

### DIFF
--- a/srcpkgs/xdg-desktop-portal-wlr/template
+++ b/srcpkgs/xdg-desktop-portal-wlr/template
@@ -1,6 +1,6 @@
 # Template file for 'xdg-desktop-portal-wlr'
 pkgname=xdg-desktop-portal-wlr
-version=0.8.2
+version=0.8.4
 revision=1
 build_style=meson
 configure_args="-Dc_args=-Wno-error"
@@ -13,7 +13,7 @@ maintainer="icp <pangolin@vivaldi.net>"
 license="MIT"
 homepage="https://github.com/emersion/xdg-desktop-portal-wlr"
 distfiles="https://github.com/emersion/xdg-desktop-portal-wlr/archive/v${version}.tar.gz"
-checksum=f9187def606a6ede1b4df8f31c6bba9b28cfd607dc45dfdbce8d35695cbd2911
+checksum=3122966d46ab108f505525bcb2498f9121b446ee8438fbfceb73a7a1fa1ad400
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture x86_64 glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl
  - aarch64 (cross-built)
  - aarch64-musl (cross-built)
