### PR TITLE
gnome-text-editor: update to 50.1

### DIFF
--- a/srcpkgs/gnome-text-editor/template
+++ b/srcpkgs/gnome-text-editor/template
@@ -1,17 +1,17 @@
 # Template file for 'gnome-text-editor'
 pkgname=gnome-text-editor
-version=48.3
+version=50.1
 revision=1
 build_style=meson
 hostmakedepends="pkg-config gettext itstool glib-devel
- gtk-update-icon-cache desktop-file-utils"
-makedepends="libglib-devel gtk4-devel gtksourceview5-devel libspelling-devel
+ gtk4-update-icon-cache desktop-file-utils"
+makedepends="glib-devel gtk4-devel gtksourceview5-devel libspelling-devel
  libadwaita-devel editorconfig-devel"
 short_desc="Simple text editor"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-3.0-or-later"
 homepage="https://gitlab.gnome.org/GNOME/gnome-text-editor"
 #changelog="https://gitlab.gnome.org/GNOME/gnome-text-editor/-/raw/main/NEWS"
-changelog="https://gitlab.gnome.org/GNOME/gnome-text-editor/-/raw/gnome-48/NEWS"
-distfiles="${GNOME_SITE}/gnome-text-editor/${version%.*}/gnome-text-editor-$version.tar.xz"
-checksum=3f9e9722394edb4d2145c06d69210b3d3fca5cd2b90d632643be750843d556ba
+changelog="https://gitlab.gnome.org/GNOME/gnome-text-editor/-/raw/gnome-50/NEWS"
+distfiles="${GNOME_SITE}/gnome-text-editor/${version%.*}/gnome-text-editor-${version}.tar.xz"
+checksum=f68036b09d378faa883bfe936e479c6ff37027c2ffed101daf912df70c51d0e6


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl & -glibc
  - i686
  - x86_64-musl