### PR TITLE
common/environment/setup/sourcepkg.sh: fix ccache + distcc

### DIFF
--- a/common/environment/setup/sourcepkg.sh
+++ b/common/environment/setup/sourcepkg.sh
@@ -25,7 +25,7 @@ for var in $(awk 'BEGIN{for (i in ENVIRON) {print i}}' </dev/null); do
 		;;
 	DISTCC_HOSTS | DISTCC_DIR)
 		;;
-	CCACHE_DIR | CCACHE_COMPRESS)
+	CCACHE_DIR | CCACHE_COMPRESS | CCACHE_PREFIX)
 		;;
 	HTTP_PROXY | HTTPS_PROXY | SOCKS_PROXY | NO_PROXY | HTTP_PROXY_AUTH)
 		;;


### PR DESCRIPTION
When both ccache and distcc are used, ccache must be configured to launch distcc with the CCACHE_PREFIX environment variable. This was already set by xbps-src, but it also needs to be allowlisted in sourcepkg.sh in order to be passed to the build environment.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**
<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
