### PR TITLE
New package: sone-0.19.0

### DIFF
--- a/srcpkgs/sone/template
+++ b/srcpkgs/sone/template
@@ -1,0 +1,22 @@
+# Template file for 'sone'
+pkgname=sone
+version=0.19.0
+revision=1
+archs="x86_64"
+makedepends="xdg-utils base-devel cargo rust nodejs pnpm patchelf libwebkit2gtk41-devel libayatana-appindicator-devel gtk+3-devel librsvg-devel openssl-devel dbus-devel gst-plugins-base1-devel gstreamer1-devel libsecret-devel alsa-lib-devel"
+depends="dbus wget curl gst-plugins-base1 gst-plugins-good1 gst-plugins-bad1 gst-libav xdg-utils pulseaudio-utils "
+short_desc="Native TIDAL desktop client for Linux with lossless audio"
+maintainer="HubrisO <oskar@bisanz-online.de>"
+license="GPL-3.0-only"
+homepage="https://github.com/lullabyX/sone"
+distfiles="https://github.com/lullabyX/sone/archive/refs/tags/v${version}.tar.gz"
+checksum=e10ac3b59a6bd58cc282693a6272a97c4ff6724a230ec2fa351d2abc6e4eca7e
+
+do_build() {
+	pnpm install
+	pnpm tauri build --no-bundle
+}
+
+do_install() {
+	vbin src-tauri/target/release/sone
+}


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**


#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **Mostly**
- Only the Required section does not fit. But there is no other Tidal-Hifi client packaged for void-linux.


<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
<!--
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
