### PR TITLE
hatch: update to 1.17.0 (and add new package dependencies).

### DIFF
--- a/srcpkgs/hatch/template
+++ b/srcpkgs/hatch/template
@@ -1,27 +1,51 @@
 # Template file for 'hatch'
 pkgname=hatch
-version=1.6.3
-revision=5
+version=1.17.0
+revision=1
 build_style=python3-pep517
 # ignore backend tests, because updating hatchling when there is no new hatch
 # version yet breaks these in hatch.
+# ignore all cli tests that assume that hatch was installed via pip
+# ignore tests that create temporary files in /tmp, which doesn't work in the build env
+# ignore tests that don't run on i686
 make_check_args="--ignore tests/backend
- --deselect tests/cli/run/test_run.py::test_scripts_no_environment"
-_deps="python3-click hatchling python3-httpx python3-hyperlink python3-keyring
- python3-packaging python3-pexpect python3-platformdirs python3-pyperclip
- python3-rich python3-shellingham python3-tomli-w python3-tomlkit
- python3-userpath python3-virtualenv"
-hostmakedepends="hatchling ${_deps}"
+
+ --deselect tests/cli/run/test_run.py::test_scripts_no_environment
+ --deselect tests/cli/self/test_report.py::test_pyenv
+ --deselect tests/cli/env/test_create.py::test_plugin_dependencies_met
+ --deselect tests/cli/env/test_create.py::test_plugin_dependencies_met_as_app
+ --deselect tests/cli/self/test_report.py::TestDefault::test_open
+ --deselect tests/cli/self/test_report.py::TestDefault::test_no_open
+
+ --deselect tests/cli/python/test_install.py::test_installation
+ --deselect tests/cli/run/test_run.py::test_install_python_specific
+ --deselect tests/cli/run/test_run.py::test_update_python_specific
+ --deselect tests/cli/run/test_run.py::test_install_python_max_compatible
+ --deselect tests/cli/run/test_run.py::test_update_python_max_compatible
+ --deselect tests/cli/run/test_run.py::test_python_installation_with_metadata_hook
+ --deselect tests/python/test_core.py::test_installation
+ --deselect tests/workspaces/test_config.py::TestWorkspaceConfiguration::test_workspace_overrides_matrix_conditional_members
+ --deselect tests/workspaces/test_config.py::TestWorkspaceConfiguration::test_workspace_overrides_combined_conditions
+
+ --deselect tests/dep/test_sync.py::test_unknown_extra
+ --deselect tests/dep/test_sync.py::test_extra_met
+ --deselect tests/workspaces/test_config.py::TestWorkspaceConfiguration::test_workspace_development_workflow
+"
+_deps="python3-click python3-distro hatchling python3-httpx2 python3-hyperlink
+ python3-keyring python3-packaging python3-pexpect python3-python-discovery
+ python3-platformdirs python3-rich python3-shellingham python3-tomli-w
+ python3-tomlkit python3-userpath uv python3-virtualenv python3-pyproject-hooks"
+hostmakedepends="hatch-vcs ${_deps}"
 depends="${_deps}"
-checkdepends="${_deps} python3-pytest python3-pytest-mock
- python3-pytest-xdist git python3-pip"
-short_desc="Modern, extensible Python project management "
+checkdepends="${_deps} python3-pytest python3-pytest-mock python3-pytest-xdist
+ git python3-pip python3-flit_core"
+short_desc="Modern, extensible Python project management"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
 homepage="https://hatch.pypa.io/latest/"
 changelog="https://raw.githubusercontent.com/pypa/hatch/master/docs/history/hatch.md"
 distfiles="${PYPI_SITE}/h/hatch/hatch-${version}.tar.gz"
-checksum=650e671ba300318e498ef93bbe3b99b32ce14920764fb8753f89993f63eed79a
+checksum=2bbbf4aa8f6fda71a61fc24c22619261327b53d272b22d4cc16f4a6e9a8592bb
 make_check_pre="env PYTHONPATH=./src"
 
 post_install() {

--- a/srcpkgs/python3-httpcore2/template
+++ b/srcpkgs/python3-httpcore2/template
@@ -1,0 +1,20 @@
+# Template file for 'python3-httpcore2'
+pkgname=python3-httpcore2
+version=2.4.0
+revision=1
+build_style=python3-pep517
+hostmakedepends="hatchling hatch-fancy-pypi-readme python3-uv-dynamic-versioning"
+depends="python3-h11 python3-h2 python3-truststore python3-socksio python3-trio python3-anyio"
+short_desc="Minimal HTTP client"
+maintainer="Bnyro <bnyro@tutanota.com>"
+license="BSD-3-Clause"
+homepage="https://pypi.org/project/httpcore2/"
+changelog="https://raw.githubusercontent.com/pydantic/httpx2/refs/heads/main/src/httpcore2/CHANGELOG.md"
+distfiles="${PYPI_SITE}/h/httpcore2/httpcore2-${version}.tar.gz"
+checksum=3093a8ab8980d9f910b9cb4351df9186a0ad2350a6284a9107ac9a362a584422
+# the pypi tarball doesn't contain tests
+make_check=no
+
+post_install() {
+	vlicense LICENSE.md
+}

--- a/srcpkgs/python3-httpx2/template
+++ b/srcpkgs/python3-httpx2/template
@@ -1,0 +1,22 @@
+# Template file for 'python3-httpx2'
+pkgname=python3-httpx2
+# note: also bump httpcore2 when bumping this
+version=2.4.0
+revision=1
+build_style=python3-pep517
+hostmakedepends="hatchling hatch-fancy-pypi-readme python3-uv-dynamic-versioning"
+depends="python3-idna python3-h2 python3-Brotli python3-httpcore2 python3-click
+ python3-rich python3-Pygments python3-anyio python3-truststore"
+short_desc="Next generation HTTP client for Python"
+maintainer="Bnyro <bnyro@tutanota.com>"
+license="BSD-3-Clause"
+homepage="https://httpx2.pydantic.dev/"
+changelog="https://github.com/pypa/hatch/releases"
+distfiles="${PYPI_SITE}/h/httpx2/httpx2-${version}.tar.gz"
+checksum=32e0734b61eb0824b3f56a9e98d6d92d381a3ef12c0045aa917ee63df6c411ef
+# the pypi tarball doesn't contain tests
+make_check=no
+
+post_install() {
+	vlicense LICENSE.md LICENSE
+}

--- a/srcpkgs/python3-python-discovery/template
+++ b/srcpkgs/python3-python-discovery/template
@@ -1,0 +1,19 @@
+# Template file for 'python3-python-discovery'
+pkgname=python3-python-discovery
+version=1.4.2
+revision=1
+build_style=python3-pep517
+hostmakedepends="hatchling hatch-vcs"
+depends="python3-filelock python3-platformdirs"
+checkdepends="$depends python3-pytest python3-pytest-mock"
+short_desc="Python library for finding installed Python interpreters"
+maintainer="Bnyro <bnyro@tutanota.com>"
+license="MIT"
+homepage="https://python-discovery.readthedocs.io/en/latest/"
+changelog="https://github.com/tox-dev/python-discovery/releases"
+distfiles="${PYPI_SITE}/p/python-discovery/python_discovery-${version}.tar.gz"
+checksum=8f3746c4b4968d22afbb97d36e1a0e5b66e6c0f297290f2e95f05b9b8bf18690
+
+post_install() {
+	vlicense LICENSE
+}


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc

httpx2 and httpcore2 are forks of httpx and httpcore respectively, so I based their templates on the existing packages (although there are lots of dependency changes, and they don't include tests like their ancestor packages)
