### PR TITLE
android-studio: update to 2026.1.1.10.

### DIFF
--- a/srcpkgs/android-studio/files/android-studio.desktop
+++ b/srcpkgs/android-studio/files/android-studio.desktop
@@ -1,0 +1,11 @@
+[Desktop Entry]
+Version=1.0
+Type=Application
+Name=Android Studio
+Icon=/opt/android-studio/bin/studio.svg
+Exec=android-studio %f
+Comment=The Drive to Develop
+Categories=Development;IDE;
+Terminal=false
+StartupWMClass=jetbrains-studio
+StartupNotify=true

--- a/srcpkgs/android-studio/template
+++ b/srcpkgs/android-studio/template
@@ -1,8 +1,8 @@
 # Template file for 'android-studio'
 pkgname=android-studio
-version=2025.3.4.7
+version=2026.1.1.10
 revision=1
-_version_description="panda4-patch1"
+_version_description="quail1-patch2"
 archs="x86_64"
 hostmakedepends="tar"
 depends="libbsd"
@@ -12,7 +12,7 @@ license="Apache-2.0"
 homepage="https://developer.android.com/studio/"
 changelog="https://developer.android.com/studio/releases/"
 distfiles="https://edgedl.me.gvt1.com/android/studio/ide-zips/${version}/android-studio-${_version_description}-linux.tar.gz"
-checksum=aae8f332f124afd23ca495dc770915a456da7480c8f859e01535ad42fcb4ca06
+checksum=fbd3f116d12caed724ea8da0d2cdae7e791170f79f2aa11273ea0f2d22a224dc
 repository=nonfree
 restricted=yes
 python_version=3
@@ -59,18 +59,6 @@ skiprdeps="/opt/android-studio/plugins/android/resources/process-tracker-agent/n
  /opt/android-studio/plugins/android-ndk/resources/lldb/lib/python3.11/lib-dynload/_curses.cpython-311-x86_64-linux-gnu.so
  /opt/android-studio/plugins/android-ndk/resources/lldb/lib/python3.11/lib-dynload/_curses_panel.cpython-311-x86_64-linux-gnu.so"
 
-post_extract() {
-	bsdtar xf lib/app.jar entry.desktop
-}
-
-post_patch() {
-	vsed -i -e 's/\$NAME\$/Android Studio/' entry.desktop
-	vsed -i -e 's/\$ICON\$/\/opt\/android-studio\/bin\/studio.svg/' entry.desktop
-	vsed -i -e 's/\$SCRIPT\$/android-studio/' entry.desktop
-	vsed -i -e 's/\$COMMENT\$/The Drive to Develop/' entry.desktop
-	vsed -i -e 's/\$WM_CLASS\$/jetbrains-studio/' entry.desktop
-}
-
 do_install() {
 	vmkdir opt/${pkgname}
 	vcopy bin opt/${pkgname}/
@@ -82,6 +70,6 @@ do_install() {
 	vmkdir usr/bin
 	ln -s /opt/android-studio/bin/studio ${DESTDIR}/usr/bin/android-studio
 
-	vinstall entry.desktop 644 usr/share/applications android-studio.desktop
+	vinstall ${FILESDIR}/android-studio.desktop 644 usr/share/applications
 	chmod -R ugo+rX ${DESTDIR}/opt
 }


### PR DESCRIPTION

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc

Note: the desktop file had to be inlined into Void's repos - it doesn't seem to be shipped with the tarball anymore.