### PR TITLE
video-compare: update to 20260502.

### DIFF
--- a/srcpkgs/video-compare/patches/32bit-type-size-issue.patch
+++ b/srcpkgs/video-compare/patches/32bit-type-size-issue.patch
@@ -1,0 +1,23 @@
+In 32-bit the signature for std::min seem to fail. Since long unsigned int is 64 bits while size_t is 32 bits.
+Remember kids cstdint is your friend. This problem could have been solved with using uint64_t :D
+
+--- a/video_compare.cpp
++++ b/video_compare.cpp
+@@ -678,7 +678,7 @@
+   if (!crop_request.clear_requested && !crop_request.valid) {
+     return false;
+   }
+-  const Side target_right = crop_request.apply_right ? Side::Right(std::min(crop_request.right_target_index, right_video_info_.empty() ? 0UL : (right_video_info_.size() - 1))) : active_right;
++  const Side target_right = crop_request.apply_right ? Side::Right(std::min(crop_request.right_target_index, static_cast<size_t>(right_video_info_.empty() ? 0UL : (right_video_info_.size() - 1)))) : active_right;
+   const bool swap_left_right = display_->get_swap_left_right();
+   const Side resolved_left_side = swap_left_right ? active_right : LEFT;
+   const Side resolved_right_side = swap_left_right ? LEFT : target_right;
+--- a/display.cpp
++++ b/display.cpp
+@@ -3668,5 +3668,5 @@
+ }
+ 
+ void Display::set_active_right_index(const size_t index) {
+-  active_right_index_ = std::min(index, num_right_videos_ > 0 ? num_right_videos_ - 1 : 0UL);
++  active_right_index_ = std::min(index, static_cast<size_t>(num_right_videos_ > 0 ? num_right_videos_ - 1 : 0UL));
+ }

--- a/srcpkgs/video-compare/template
+++ b/srcpkgs/video-compare/template
@@ -1,6 +1,6 @@
 # Template file for 'video-compare'
 pkgname=video-compare
-version=20250420
+version=20260502
 revision=1
 build_style=gnu-makefile
 makedepends="ffmpeg6-devel SDL2-devel SDL2_ttf-devel"
@@ -10,7 +10,7 @@ license="GPL-2.0-only"
 homepage="https://github.com/pixop/video-compare"
 changelog="https://github.com/pixop/video-compare/releases"
 distfiles="https://github.com/pixop/video-compare/archive/refs/tags/${version}.tar.gz"
-checksum=cfb1de9608fa141defa44b62c10ff7a56ea668c87d6c2c102409bddcaa98cd83
+checksum=558e9a97e381929fa6c30ec46e5187cf4ceb3505dffe8c0da0a581a0d2b60202
 
 CXXFLAGS="-std=c++14 -D__STDC_CONSTANT_MACROS"
 


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

From the latest release of video-compare
- `Added fullscreen switching via Alt+Enter, with -u/--fullscreen available for starting in fullscreen mode`: Tested. Works.
- `Added runtime display-mode cycling via Shift+M`: Tested. Works.
- `Added runtime aspect-view cycling via Shift+S, with -x/--aspect-view-mode available for setting the initial aspect ratio mode (stretch, original, 16:9, 4:3, 1:1)`: Tested. Works.
- `Added -V/--version for quick installation and version checks`: Tested. Works.
- `Fixed frame stepping while paused (Shift+D), ensuring deterministic behavior independent of playback timer pacing`: Could not test.

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl
  - aarch64
  - i686 