### PR TITLE
SPIRV-LLVM-Translator{19,21,22}: fix update file

### DIFF
--- a/srcpkgs/SPIRV-LLVM-Translator19/update
+++ b/srcpkgs/SPIRV-LLVM-Translator19/update
@@ -1,1 +1,1 @@
-pattern="/v\K19\.[0-9.]+(?=\.tar\.gz)"
+pattern="refs/tags/v\K19\.[0-9.]+($|(?=^))"

--- a/srcpkgs/SPIRV-LLVM-Translator21/update
+++ b/srcpkgs/SPIRV-LLVM-Translator21/update
@@ -1,1 +1,1 @@
-pattern="/v\K21\.[0-9.]+(?=\.tar\.gz)"
+pattern="refs/tags/v\K21\.[0-9.]+($|(?=^))"

--- a/srcpkgs/SPIRV-LLVM-Translator22/update
+++ b/srcpkgs/SPIRV-LLVM-Translator22/update
@@ -1,1 +1,1 @@
-pattern="/v\K22\.[0-9.]+(?=\.tar\.gz)"
+pattern="refs/tags/v\K22\.[0-9.]+($|(?=^))"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

---
`SPIRV-LLVM-Translator{19,21,22}` had their `update` files broken by #60025
(info/refs migration); this migrates all three to the `refs/tags` pattern so
`update-check` reports them again.

No version bump here, on purpose: recent releases pull in the
`SPV_INTEL_predicated_io` extension, whose opcodes only exist in SPIRV-Headers
`master`, not in any released tag (including `1.4.350.1` from #61152). Building
against them fails until a SPIRV-Headers release ships those symbols, so the
templates stay pinned for now.

`update-check` will start flagging these once tracking is back. They should be
held, not bumped, until SPIRV-Headers catches up.