### PR TITLE
liblo: update to 0.36.

### DIFF
--- a/srcpkgs/liblo/template
+++ b/srcpkgs/liblo/template
@@ -1,6 +1,6 @@
 # Template file for 'liblo'
 pkgname=liblo
-version=0.35
+version=0.36
 revision=1
 build_style=gnu-configure
 hostmakedepends="autoconf automake libtool doxygen"
@@ -9,7 +9,7 @@ maintainer="Rutpiv <roger_freitas@live.com>"
 license="LGPL-2.1-or-later"
 homepage="https://liblo.sourceforge.net/"
 distfiles="https://github.com/radarsat1/liblo/archive/${version}.tar.gz"
-checksum=d3d807faa89fc42a5f2468246d212decfa7d2775da879d6aaaa97768aaf8e183
+checksum=31b48e5fc61e9fc953c906f5abce97200cde86fba630f755c9fd9d1d7724a6d2
 
 disable_parallel_check=yes
 


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures using specific masterdirs:
  - x86_64-musl
  - i686
- I built this PR locally for these architectures (crossbuilds):
  - aarch64
  - aarch64-musl
  - armv7l
  - armv7l-musl
  - armv6l
  - armv6l-musl