### PR TITLE
New package: hidamari-3.6

### DIFF
--- a/srcpkgs/hidamari/template
+++ b/srcpkgs/hidamari/template
@@ -1,0 +1,20 @@
+# Template file for 'hidamari'
+pkgname=hidamari
+version=3.6
+revision=1
+build_style=meson
+hostmakedepends="gettext-devel pkg-config glib-devel gtk4-update-icon-cache desktop-file-utils"
+depends="python3 python3-gobject python3-Pillow python3-pydbus python3-vlc
+ python3-requests python3-setproctitle yt-dlp vlc libvlc gnome-desktop
+ libwnck libayatana-appindicator libwebkit2gtk41 ffmpeg6 vdpauinfo
+ xdg-user-dirs libX11 mesa-demos"
+short_desc="Video wallpaper for Linux"
+maintainer="Alex <alexiulian.tanase@gmail.com>"
+license="GPL-3.0-only"
+homepage="https://github.com/jeffshee/hidamari"
+distfiles="https://github.com/jeffshee/hidamari/archive/refs/tags/v${version}.tar.gz"
+checksum="fbfa754db13bb5bad6cecce07375bede047b3cacbc38c503ebe98e02ac418a81"
+
+post_extract() {
+	vsed -i 's/AppIndicator3/AyatanaAppIndicator3/' src/menu.py
+}


### PR DESCRIPTION
Video wallpaper application for Linux, written in Python/GTK4.

Built and runtime-tested locally (Local Video and Web Page tabs both confirmed working).

Note: patches src/menu.py to use AyatanaAppIndicator3 instead of AppIndicator3, since Void only ships the Ayatana fork (no legacy libappindicator-gtk3 package). The two are intentionally API-compatible, so this is a namespace-only substitution with no changes in behaviour.