### PR TITLE
cutechess: updated to 1.5.1.

### DIFF
--- a/srcpkgs/cutechess-gui/template
+++ b/srcpkgs/cutechess-gui/template
@@ -1,6 +1,6 @@
 # Template file for 'cutechess-gui'
 pkgname=cutechess-gui
-version=1.4.0
+version=1.5.1
 revision=1
 build_style=cmake
 hostmakedepends="qt6-tools qt6-base"
@@ -9,10 +9,10 @@ depends="hicolor-icon-theme"
 short_desc="GUI for playing chess"
 maintainer="Imran Khan <imran@khan.ovh>"
 license="GPL-3.0-or-later AND MIT"
-homepage="https://github.com/cutechess/cutechess"
-changelog="https://github.com/cutechess/cutechess/raw/master/CHANGELOG.md"
+homepage="https://cutechess.com/"
+changelog="https://raw.githubusercontent.com/cutechess/cutechess/master/CHANGELOG.md"
 distfiles="https://github.com/cutechess/cutechess/archive/refs/tags/v${version}.tar.gz"
-checksum=7adf8e8d867c13acf5273b568a39bf9d0d722d3de0141cea953e624f8839b506
+checksum=063f94f8a421952487cc49acddd218962c3881bfdf0219ad8f159954678fb375
 
 do_install() {
 	vbin build/cutechess


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

For testing I have downloaded stockfish and cutechess-gui-1.5.1 and made two bots have a small game. Everything seemed fine. UI was working fine. Game seemed to play/run as expected. I was also able to play a game of chess just fine. (I did also test the CLI with same results)

Compiles just fine as-is. The project says Qt5 support is dropped entirely with 1.5.0 release. The project is now using Qt6.8 and above. 

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64
  - i686