### PR TITLE
chessx: update to 1.6.10.

### DIFF
--- a/srcpkgs/chessx/patches/musl-cstdint-missing.patch
+++ b/srcpkgs/chessx/patches/musl-cstdint-missing.patch
@@ -1,0 +1,12 @@
+in musl cstdint is not included by including other headers. It has to be specifically included.
+
+--- a/dep/scid/code/src/bytebuf.h
++++ b/dep/scid/code/src/bytebuf.h
+@@ -34,6 +34,7 @@
+ #include <cassert>
+ #include <cstring>
+ #include <string_view>
++#include <cstdint>
+ 
+ /**
+  * The Tag section is a list of <tag,value> variable length records:

--- a/srcpkgs/chessx/template
+++ b/srcpkgs/chessx/template
@@ -1,6 +1,6 @@
 # Template file for 'chessx'
 pkgname=chessx
-version=1.5.6
+version=1.6.10
 revision=1
 build_style=qmake
 hostmakedepends="qt5-tools qt5-qmake qt5-host-tools"
@@ -9,8 +9,9 @@ short_desc="Open Source chess database"
 maintainer="cipr3s <cipr3s@gmx.com>"
 license="GPL-2.0-only"
 homepage="https://chessx.sourceforge.io"
+changelog="https://raw.githubusercontent.com/Isarhamster/chessx/refs/heads/master/ChangeLog.md"
 distfiles="${SOURCEFORGE_SITE}/${pkgname}/${pkgname}-${version}.tgz"
-checksum=d09a4b534a909c5f1a398c64065049a2fdf30497bc81ccbdf0d940412364d205
+checksum=77c6ef3f89d8c3ea137a5f4bb0dcd83b261046facbde06eaee223437ad1c732f
 
 do_install() {
 	vinstall unix/${pkgname}.desktop 644 usr/share/applications


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

Program runs fine, I was able to "play" a game of chess with myself and see the best moves. Draw on the board, load games, etc... 

I did see in the changelogs the mention of Qt6 (and some lines of code for it) but it seems to be not ready, so it might be worth keeping an eye on.

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl
  - aarch64
  - i686