### PR TITLE
chess-tui: update to 2.7.1. adopt.

### DIFF
--- a/srcpkgs/chess-tui/template
+++ b/srcpkgs/chess-tui/template
@@ -1,17 +1,17 @@
 # Template file for 'chess-tui'
 pkgname=chess-tui
-version=2.1.1
+version=2.7.1
 revision=1
 build_style=cargo
 hostmakedepends="pkg-config"
 makedepends="openssl-devel alsa-lib-devel"
 short_desc="Play chess from your terminal"
-maintainer="Orphaned <orphan@voidlinux.org>"
+maintainer="Dora 'cat' <cat@thenight.club>"
 license="MIT"
-homepage="https://github.com/thomas-mauran/chess-tui"
+homepage="https://thomas-mauran.github.io/chess-tui/"
 changelog="https://github.com/thomas-mauran/chess-tui/releases"
 distfiles="https://github.com/thomas-mauran/chess-tui/archive/refs/tags/${version}.tar.gz"
-checksum=fc23ddc13f0236bc17501705872b957f8c05e873eaa3252b8d3d2a24346ce47b
+checksum=471b6280c8aa0979956b85d54dfd216855a47f8517a9a1d3e5286e4044adaac5
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

Installed stockfish and had 2 games (`chess-tui -e /usr/bin/stockfish` to play with a chessbot). Sound, controls, "graphics", everything was perfect. 

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl
  - aarch64
  - i686