### PR TITLE
atuin: update to 18.16.1.

### DIFF
--- a/srcpkgs/atuin/template
+++ b/srcpkgs/atuin/template
@@ -1,6 +1,6 @@
 # Template file for 'atuin'
 pkgname=atuin
-version=18.13.3
+version=18.16.1
 revision=1
 build_style=cargo
 build_helper=qemu
@@ -18,7 +18,7 @@ license="MIT"
 homepage="https://atuin.sh"
 changelog="https://raw.githubusercontent.com/atuinsh/atuin/main/CHANGELOG.md"
 distfiles="https://github.com/atuinsh/atuin/archive/refs/tags/v${version}.tar.gz"
-checksum=f16f43e373808e58b9645772359de662f082757e6ae350d767e360dc2a420e75
+checksum=752802d4e8eef4896e9bc779b82f85e3d433c5934df5169e9b0f2537acf7f6e9
 
 _setup_env() {
 	# workaround the cc-rs mixing CFLAGS for host and target.


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc

Please note that there appears to be a new separate binary for the server, `atuin-server`, however I didn't deal with that as of yet