### PR TITLE
python3-nethsm: update to 2.1.2

### DIFF
--- a/srcpkgs/python3-nethsm/template
+++ b/srcpkgs/python3-nethsm/template
@@ -1,6 +1,6 @@
 # Template file for 'python3-nethsm'
 pkgname=python3-nethsm
-version=2.1.1
+version=2.1.2
 revision=1
 build_style=python3-pep517
 make_check_args="--ignore=tests/test_enums.py \
@@ -11,7 +11,7 @@ make_check_args="--ignore=tests/test_enums.py \
  --ignore=tests/test_nethsm_users.py \
  --ignore=tests/test_nethsm_namespaces.py" # podman python bindings currently not packaged
 hostmakedepends="python3-poetry-core"
-depends="python3-certifi python3-cryptography python3-dateutil python3-typing_extensions python3-urllib3"
+depends="python3-certifi python3-cryptography python3-typing_extensions python3-urllib3"
 checkdepends="python3-pytest python3-pycryptodome python3-docker python3-typing_extensions
  python3-urllib3 python3-distutils-extra"
 short_desc="Python Library to manage NetHSM(s)"
@@ -19,4 +19,4 @@ maintainer="Mateusz Sylwestrzak <slymattz@gmail.com>"
 license="Apache-2.0"
 homepage="https://github.com/Nitrokey/nethsm-sdk-py"
 distfiles="https://github.com/Nitrokey/nethsm-sdk-py/archive/refs/tags/v${version}.tar.gz"
-checksum=a4cb192816414b2653a08094652b41ff020a339363043a8ec74dc4887c6225a0
+checksum=2e86f5fe9b17b7f6f4cb68dbbc397fd0708afc5f397bf20214fa6b8b166e216f


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

https://github.com/Nitrokey/nethsm-sdk-py/commit/7e8c26468865b287f560a91ad12a3daba5002651
dateutil has been dropped as a dependency in favor of stdlib datetime

#### Local build testing
- I built this PR locally for my native architecture: x86_64-glibc
