### PR TITLE
UEFITool: update to A75.

### DIFF
--- a/srcpkgs/UEFITool/template
+++ b/srcpkgs/UEFITool/template
@@ -1,6 +1,6 @@
 # Template file for 'UEFITool'
 pkgname=UEFITool
-version=A72
+version=A75
 revision=1
 build_style=cmake
 hostmakedepends="qt6-base qt6-tools"
@@ -10,7 +10,7 @@ maintainer="0x5c <dev@0x5c.io>"
 license="BSD-2-Clause"
 homepage="https://github.com/LongSoft/UEFITool/"
 distfiles="https://github.com/LongSoft/UEFITool/archive/${version}.tar.gz"
-checksum=3cace3f617c0023ffed4b95009752a50c55fe22cbba62d760b85f800ce74697f
+checksum=f624ac80cdd716ed5e071d46f1516c84ce99b44fd5ce72663903c0a569c40770
 
 post_install() {
 	vlicense LICENSE.md

--- a/srcpkgs/UEFITool/update
+++ b/srcpkgs/UEFITool/update
@@ -1,1 +1,1 @@
-pattern='/archive/refs/tags/(v?|UEFITool)?\K[A-Z\d.]+(?=\.tar\.gz")'
+pattern='refs/tags/\KA[0-9]+$'


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

---

There is currently a major regression in the form of two segfaults at startup.

- The first is a bug upstream and is fixed by the patch.
- ~~The second is a bug seemingly in Qt6 itself, looking a lot like [this](https://forum.qt.io/topic/153456/qt6-read-access-violation-from-qdockarealayout) (which might be [QTBUG-143708](https://qt-project.atlassian.net/browse/QTBUG-143708), fixed in `6.10.3`)~~.
    Qt 6.10.3 does not fix it, UEFITool upstream bug report: https://github.com/LongSoft/UEFITool/issues/479