### PR TITLE
audiotube: add missing deps

### DIFF
--- a/srcpkgs/audiotube/template
+++ b/srcpkgs/audiotube/template
@@ -1,7 +1,7 @@
 # Template file for 'audiotube'
 pkgname=audiotube
 version=26.04.2
-revision=1
+revision=2
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF"
 hostmakedepends="extra-cmake-modules qt6-tools qt6-base qt6-declarative-host-tools
@@ -10,7 +10,8 @@ makedepends="futuresql-devel kf6-kconfig-devel kf6-kcrash-devel kf6-ki18n-devel
  kf6-kiconthemes-devel kf6-kirigami-devel kirigami-addons-devel
  kf6-kwindowsystem-devel kf6-purpose-devel qt6-multimedia-devel qt6-svg-devel
  python3-devel python3-pybind11 qcoro-qt6-devel"
-depends="python3-ytmusicapi yt-dlp qt6-imageformats gst-plugins-bad1 gst-plugins-good1"
+depends="python3-ytmusicapi yt-dlp qt6-imageformats gst-plugins-bad1 gst-plugins-good1
+ kirigami-addons kf6-purpose qt6-plugin-sqlite"
 short_desc="Client for YouTube Music"
 maintainer="Nafis <mnabid.25@outlook.com>"
 license="GPL-2.0-or-later, LGPL-2.0-or-later"


### PR DESCRIPTION
@mnabid
FYI, running Qt apps in GNOME might report missing dependencies.

1. `kirigami-addons` are required to fix these runtime errors:
> qrc:/qt/qml/org/kde/audiotube/contents/ui/Main.qml:8:1: module "org.kde.kirigami" is not installed
> qrc:/qt/qml/org/kde/audiotube/contents/ui/Main.qml: module "org.kde.desktop" is not installed

2. `kf6-purpose` is required to fix this runtime error:
> qrc:/qt/qml/org/kde/audiotube/contents/ui/ShareMenu.qml:13:1: module "org.kde.purpose" is not installed

3. `qt6-plugin-sqlite` is required to fix this issue:
> qt.sql.qsqldatabase: QSqlDatabase: can not load requested driver 'QSQLITE', available drivers: 
> futuresql: Failed to open database "Driver not loaded Driver not loaded"
> futuresql: Tried to use database "/home/vuser/.local/share/KDE/audiotube/library.sqlite"
> qt.sql.qsqlquery: QSqlQuery::exec: database not open

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)