### PR TITLE
booster: update to 0.13.

### DIFF
--- a/srcpkgs/booster/template
+++ b/srcpkgs/booster/template
@@ -1,6 +1,6 @@
 # Template file for 'booster'
 pkgname=booster
-version=0.12
+version=0.13
 revision=1
 build_style=go
 go_import_path=github.com/anatol/booster
@@ -12,16 +12,15 @@ maintainer="travankor <travankor@tuta.io>"
 license="MIT"
 homepage="https://github.com/anatol/booster"
 distfiles="https://github.com/anatol/booster/archive/${version}.tar.gz"
-checksum=a2515923e919c99b69ce50f7828aa5df6e7ff80ea145c93c5a8c981d015d8bd4
+checksum=5d6c2b56758380441a46e38f7f760eb1ffbe3008498d68676cd67458816ef5fe
 conf_files="/etc/booster.yaml"
 alternatives="
  initramfs:/etc/kernel.d/post-install/20-initramfs:/usr/libexec/booster/kernel-hook-postinst
  initramfs:/etc/kernel.d/post-remove/20-initramfs:/usr/libexec/booster/kernel-hook-postrm
 "
 
-# Tests require system tools (lz4, loadkeys) and kernel modules not available in the build environment,
-# moved make_check=ci-skip after alternatives.
-make_check=ci-skip
+# Tests require system tools (lz4, loadkeys) and kernel modules not available in the build environment.
+make_check=no
 export GOFLAGS="-buildmode=pie"
 
 post_build() {


### PR DESCRIPTION
Testing the changes

    I tested the changes in this PR: YES

Local build testing

    I built this PR locally for my native architecture, x86_64-glibc