### PR TITLE
virtualenvwrapper: update to 6.1.1

### DIFF
--- a/srcpkgs/virtualenvwrapper/template
+++ b/srcpkgs/virtualenvwrapper/template
@@ -1,17 +1,16 @@
 # Template file for 'virtualenvwrapper'
 pkgname=virtualenvwrapper
-version=4.8.4
-revision=9
-build_style=python3-module
-pycompile_module="virtualenvwrapper"
-hostmakedepends="python3-setuptools python3-pbr"
+version=6.1.1
+revision=1
+build_style=python3-pep517
+hostmakedepends="python3-wheel python3-setuptools_scm python3-pbr"
 depends="python3-virtualenv python3-virtualenv-clone python3-stevedore"
 short_desc="Enhancements to virtualenv"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
 homepage="https://virtualenvwrapper.readthedocs.io/"
-distfiles="${PYPI_SITE}/v/${pkgname}/${pkgname}-${version}.tar.gz"
-checksum=51a1a934e7ed0ff221bdd91bf9d3b604d875afbb3aa2367133503fee168f5bfa
+distfiles="${PYPI_SITE}/v/virtualenvwrapper/virtualenvwrapper-${version}.tar.gz"
+checksum=112e7ea34a9a3ce90aaea54182f0d3afef4d1a913eeb75e98a263b4978cd73c6
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)