### PR TITLE
New package: Impression-3.7.0

### DIFF
--- a/srcpkgs/impression/template
+++ b/srcpkgs/impression/template
@@ -1,0 +1,33 @@
+# Template file for 'impression'
+pkgname=impression
+version=3.7.0
+revision=1
+build_style=meson
+build_helper="rust"
+hostmakedepends="cargo pkg-config gettext desktop-file-utils
+ glib-devel blueprint-compiler gtk4-update-icon-cache"
+makedepends="gtk4-devel libadwaita-devel openssl-devel udisks2-devel rust-std"
+depends="udisks2 hicolor-icon-theme"
+short_desc="Application to create bootable drives from disk images"
+maintainer="Fabian Constantinescu <fabian.constantinescu@protonmail.com>"
+license="GPL-3.0-only"
+homepage="https://apps.gnome.org/Impression/"
+distfiles="https://gitlab.com/adhami3310/Impression/-/archive/v${version}/Impression-v${version}.tar.gz"
+checksum=5177736de22c8d959c73650ed885ac6a393db8e8739d6b983d635da5108b6452
+
+pre_build() {
+	 if [ "$CROSS_BUILD" ]; then
+		 export GI_TYPELIB_PATH="${XBPS_CROSS_BASE}/usr/lib/girepository-1.0"
+	 fi
+}
+
+post_patch() {
+	# Fix CARGO_HOME path so it is shared across masterdirs
+	vsed -i src/meson.build \
+		-e "s|cargo_env = \[ 'CARGO_HOME='.*|cargo_env = [ 'CARGO_HOME=${CARGO_HOME}' ]|g"
+
+	if [ "$CROSS_BUILD" ]; then
+		vsed -i src/meson.build \
+			-e "s|'cp', 'src' / rust_target / meson.project_name(),|'cp', 'src' / '${RUST_TARGET}' / rust_target / meson.project_name(),|"
+	fi
+}


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl & -glibc
  - x86_64-musl