### PR TITLE
ntpd-rs: update to 1.9.0

### DIFF
--- a/srcpkgs/ntpd-rs/patches/use-ring.patch
+++ b/srcpkgs/ntpd-rs/patches/use-ring.patch
@@ -1,15 +1,16 @@
 diff --git a/Cargo.toml b/Cargo.toml
-index e36919e..d5e07b8 100644
+index f3f4c80a..e14970da 100644
 --- a/Cargo.toml
 +++ b/Cargo.toml
-@@ -45,9 +45,9 @@ clock-steering = "0.2.1"
- pps-time = "0.2.3"
+@@ -46,10 +46,10 @@ tracing = "0.1.37"
+ tracing-subscriber = { version = "0.3.0", default-features = false, features = ["std", "fmt", "ansi"] }
  
  # TLS
--rustls23 = { package = "rustls", version = "0.23.16", features = ["logging", "std"] }
-+rustls23 = { package = "rustls", version = "0.23.16", default-features = false, features = ["ring", "logging", "std"] }
+-rustls23 = { package = "rustls", version = "0.23.22", default-features = false, features = ["logging", "std", "tls12"] }
++rustls23 = { package = "rustls", version = "0.23.22", default-features = false, features = ["ring", "logging", "std"] }
+ rustls-openssl = ">=0.3.0,<0.9"
  rustls-platform-verifier = "0.5.0"
--tokio-rustls = { version = "0.26.0", features = ["logging"] }
+-tokio-rustls = { version = "0.26.0", default-features = false, features = ["logging", "tls12"] }
 +tokio-rustls = { version = "0.26.0", default-features = false, features = ["ring", "logging"] }
  
  # crypto

--- a/srcpkgs/ntpd-rs/template
+++ b/srcpkgs/ntpd-rs/template
@@ -1,12 +1,27 @@
 # Template file for 'ntpd-rs'
 pkgname=ntpd-rs
-version=1.7.2
+version=1.9.0
 revision=1
 build_style=cargo
 make_check_args="--
  --skip daemon::keyexchange::tests::client_connection_refused
  --skip daemon::keyexchange::tests::key_exchange_connection_limiter
  --skip daemon::keyexchange::tests::key_exchange_weird_packet
+ --skip nts::tests::test_key_exchange_roundtrip_no_cookies
+ --skip nts::tests::test_keyexchange_fixed_key_no_permission
+ --skip nts::tests::test_keyexchange_roundtrip_fixed_key
+ --skip nts::tests::test_keyexchange_roundtrip_fixed_key_keep_alive
+ --skip nts::tests::test_keyexchange_roundtrip_fixed_key_no_permit
+ --skip nts::tests::test_keyexchange_roundtrip_no_proto_overlap
+ --skip nts::tests::test_keyexchange_roundtrip_no_upgrade_possible
+ --skip nts::tests::test_keyexchange_roundtrip_supports
+ --skip nts::tests::test_keyexchange_roundtrip_upgrading
+ --skip nts::tests::test_keyexchange_roundtrip_v4
+ --skip nts::tests::test_keyexchange_roundtrip_v5
+ --skip nts::tests::test_keyexchange_supports_no_permission
+ --skip daemon::keyexchange::tests::key_exchange_roundtrip_with_port_server
+ --skip daemon::spawn::nts::tests::allow_srv_direct_name_resolution
+ --skip daemon::spawn::nts::tests::direct_name_resolution
 "
 make_install_args="--path ntpd"
 short_desc="Full-featured implementation of the Network Time Protocol"
@@ -15,7 +30,7 @@ license="Apache-2.0 OR MIT"
 homepage="https://github.com/pendulum-project/ntpd-rs"
 changelog="https://raw.githubusercontent.com/pendulum-project/ntpd-rs/main/CHANGELOG.md"
 distfiles="https://github.com/pendulum-project/ntpd-rs/archive/refs/tags/v${version}.tar.gz"
-checksum=f375018e496d0d268dc5ed3c362566afafa239d67369546f9c04b8d2e3163dda
+checksum=b25d560c4ae5a704d9509984b040123675052d27fe7a3e7cbc5bedc9e392c932
 
 system_accounts="_ntpd_rs"
 conf_files="/etc/ntpd-rs/ntp.toml"
@@ -23,26 +38,6 @@ provides="ntp-daemon-0_1"
 alternatives="
  ntpd:ntpd:/usr/bin/ntp-daemon
  ntpd:ntpd:/etc/sv/ntpd-rs"
-
-case "$XBPS_TARGET_MACHINE" in
-	i686|x86_64*)
-		make_check_args+="
-		 --skip nts::tests::test_key_exchange_roundtrip_no_cookies
-		 --skip nts::tests::test_keyexchange_fixed_key_no_permission
-		 --skip nts::tests::test_keyexchange_roundtrip_fixed_key
-		 --skip nts::tests::test_keyexchange_roundtrip_fixed_key_keep_alive
-		 --skip nts::tests::test_keyexchange_roundtrip_fixed_key_no_permit
-		 --skip nts::tests::test_keyexchange_roundtrip_no_proto_overlap
-		 --skip nts::tests::test_keyexchange_roundtrip_no_upgrade_possible
-		 --skip nts::tests::test_keyexchange_roundtrip_supports
-		 --skip nts::tests::test_keyexchange_roundtrip_upgrading
-		 --skip nts::tests::test_keyexchange_roundtrip_v4
-		 --skip nts::tests::test_keyexchange_roundtrip_v5
-		 --skip nts::tests::test_keyexchange_supports_no_permission
-		 --skip daemon::keyexchange::tests::key_exchange_roundtrip_with_port_server
-		"
-	;;
-esac
 
 post_patch() {
 	# apply patched Cargo.toml changes to lockfile


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

```
$ doas sv restart ntpd-rs
[waiting a few minutes for it to fully sync]
$ ntp-ctl status                                
Synchronization status:
        Dispersion:     0.000129s
        Delay:          0.008670s
        Stratum:        4


Sources:

ntpd-rs.pool.ntp.org:123 46.175.224.7:123 (1)
        Offset:                 -0.000954
        Uncertainty:            ±0.000083
        Delay:                  ±0.012180
        Poll interval:          16s
        Missing polls:          0
        Root dispersion:        0.026428s
        Root delay:             0.007431s
```
#### Local build testing
- I built this PR locally for my native architecture: x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl (crossbuild)
