### PR TITLE
caddy: update to 2.11.4

### DIFF
--- a/srcpkgs/caddy/template
+++ b/srcpkgs/caddy/template
@@ -1,6 +1,6 @@
 # Template file for 'caddy'
 pkgname=caddy
-version=2.11.2
+version=2.11.4
 revision=1
 build_style=go
 go_import_path=github.com/caddyserver/caddy/v2
@@ -13,7 +13,7 @@ license="Apache-2.0"
 homepage="https://caddyserver.com"
 changelog="https://github.com/caddyserver/caddy/releases"
 distfiles="https://github.com/caddyserver/caddy/archive/v${version}.tar.gz"
-checksum=ee12f7b5f97308708de5067deebb3d3322fc24f6d54f906a47a0a4e8db799122
+checksum=2c3d02078286a6282cdb4d1d8744077788d556659dac0b64d8ed5886a7e5aeb9
 
 system_accounts="caddy"
 caddy_homedir="/var/lib/caddy"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture:
  - x86_64-glibc
  - aarch64-glibc
- I built this PR locally for these architectures:
  - armv6l (cross-build) 

