### PR TITLE
New package: rom-properties-2.7.1

### DIFF
--- a/srcpkgs/rom-properties/template
+++ b/srcpkgs/rom-properties/template
@@ -1,0 +1,45 @@
+# Template file for 'rom-properties'
+pkgname=rom-properties
+version=2.7.1
+revision=1
+build_style=cmake
+configure_args="-DQT_MAJOR_VERSION=6
+	-DCMAKE_BUILD_TYPE=Release
+	-DBUILD_KDE4=OFF
+	-DBUILD_KF5=OFF
+	-DBUILD_KF6=ON
+	-DBUILD_XFCE=OFF
+	-DBUILD_GTK3=ON
+	-DBUILD_GTK4=ON
+	-DBUILD_CLI=ON
+	-DENABLE_NLS=ON
+	-DENABLE_DECRYPTION=ON
+	-DENABLE_XML=ON
+	-DENABLE_ZSTD=ON
+	-DENABLE_LZ4=ON
+	-DENABLE_LZO=ON
+	-DUSE_INTERNAL_ZLIB=OFF
+	-DUSE_INTERNAL_PNG=OFF
+	-DUSE_INTERNAL_JPEG=OFF
+	-DUSE_INTERNAL_XML=OFF
+	-DUSE_INTERNAL_ZSTD=OFF
+	-DUSE_INTERNAL_LZ4=OFF
+	-DUSE_INTERNAL_FMT=OFF
+	-DBUILD_TESTING=OFF"
+hostmakedepends="pkg-config extra-cmake-modules gettext glib-devel
+	qt6-base-devel qt6-tools-devel"
+makedepends="zlib-devel libpng-devel libjpeg-turbo-devel nettle-devel
+	pugixml-devel gettext-devel libseccomp-devel fmt-devel
+	libzstd-devel liblz4-devel lzo-devel
+	qt6-base-devel qt6-tools-devel
+	kf6-kio-devel kf6-kwidgetsaddons-devel kf6-kfilemetadata-devel
+	kf6-kcrash-devel kf6-kcoreaddons-devel
+	libglib-devel gtk+3-devel gtk4-devel cairo-devel
+	gdk-pixbuf-devel nautilus-devel Thunar-devel libcanberra-devel"
+depends="tumbler"
+short_desc="ROM Properties Page shell extension"
+maintainer="goldenslumbers <golden@goldenslumbers.me>"
+license="GPL-2.0-or-later"
+homepage="https://github.com/GerbilSoft/rom-properties"
+distfiles="https://github.com/GerbilSoft/rom-properties/archive/refs/tags/v${version}.tar.gz"
+checksum=6856e3ad88720d0571e82fcac64c0c51605f8ddfbd942130ee5a6e688a2bc399

--- a/srcpkgs/rom-properties/template
+++ b/srcpkgs/rom-properties/template
@@ -3,39 +3,9 @@ pkgname=rom-properties
 version=2.7.1
 revision=1
 build_style=cmake
-configure_args="-DQT_MAJOR_VERSION=6
-	-DCMAKE_BUILD_TYPE=Release
-	-DBUILD_KDE4=OFF
-	-DBUILD_KF5=OFF
-	-DBUILD_KF6=ON
-	-DBUILD_XFCE=OFF
-	-DBUILD_GTK3=ON
-	-DBUILD_GTK4=ON
-	-DBUILD_CLI=ON
-	-DENABLE_NLS=ON
-	-DENABLE_DECRYPTION=ON
-	-DENABLE_XML=ON
-	-DENABLE_ZSTD=ON
-	-DENABLE_LZ4=ON
-	-DENABLE_LZO=ON
-	-DUSE_INTERNAL_ZLIB=OFF
-	-DUSE_INTERNAL_PNG=OFF
-	-DUSE_INTERNAL_JPEG=OFF
-	-DUSE_INTERNAL_XML=OFF
-	-DUSE_INTERNAL_ZSTD=OFF
-	-DUSE_INTERNAL_LZ4=OFF
-	-DUSE_INTERNAL_FMT=OFF
-	-DBUILD_TESTING=OFF"
-hostmakedepends="pkg-config extra-cmake-modules gettext glib-devel
-	qt6-base-devel qt6-tools-devel"
-makedepends="zlib-devel libpng-devel libjpeg-turbo-devel nettle-devel
-	pugixml-devel gettext-devel libseccomp-devel fmt-devel
-	libzstd-devel liblz4-devel lzo-devel
-	qt6-base-devel qt6-tools-devel
-	kf6-kio-devel kf6-kwidgetsaddons-devel kf6-kfilemetadata-devel
-	kf6-kcrash-devel kf6-kcoreaddons-devel
-	libglib-devel gtk+3-devel gtk4-devel cairo-devel
-	gdk-pixbuf-devel nautilus-devel Thunar-devel libcanberra-devel"
+configure_args="-DQT_MAJOR_VERSION=6 -DBUILD_KDE4=OFF -DBUILD_KF5=OFF -DBUILD_KF6=ON -DBUILD_XFCE=OFF -DBUILD_GTK3=ON -DBUILD_GTK4=ON -DBUILD_CLI=ON -DENABLE_NLS=ON -DENABLE_DECRYPTION=ON -DENABLE_XML=ON -DENABLE_ZSTD=ON -DENABLE_LZ4=ON -DENABLE_LZO=ON -DUSE_INTERNAL_ZLIB=OFF -DUSE_INTERNAL_PNG=OFF -DUSE_INTERNAL_JPEG=OFF -DUSE_INTERNAL_XML=OFF -DUSE_INTERNAL_ZSTD=OFF -DUSE_INTERNAL_LZ4=OFF -DUSE_INTERNAL_FMT=OFF -DBUILD_TESTING=OFF"
+hostmakedepends="pkg-config extra-cmake-modules gettext glib-devel qt6-base-devel qt6-tools-devel"
+makedepends="zlib-devel libpng-devel libjpeg-turbo-devel nettle-devel pugixml-devel gettext-devel libseccomp-devel fmt-devel libzstd-devel liblz4-devel lzo-devel qt6-base-devel qt6-tools-devel kf6-kio-devel kf6-kwidgetsaddons-devel kf6-kfilemetadata-devel kf6-kcrash-devel kf6-kcoreaddons-devel libglib-devel gtk+3-devel gtk4-devel cairo-devel gdk-pixbuf-devel nautilus-devel Thunar-devel libcanberra-devel"
 depends="tumbler"
 short_desc="ROM Properties Page shell extension"
 maintainer="goldenslumbers <golden@goldenslumbers.me>"


### PR DESCRIPTION
Submission for the [rom-properties](https://github.com/GerbilSoft/rom-properties) shell extension.

I disabled BUILD_XFCE since some of the GTK2 dependencies it needs weren't packaged, but despite the name this does not affect its compatibility with current Thunar, only with legacy GTK2 Thunar. 

#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86-64
