### PR TITLE
Cockatrice: update to 3.0.2.

### DIFF
--- a/srcpkgs/Cockatrice/template
+++ b/srcpkgs/Cockatrice/template
@@ -1,6 +1,6 @@
 # Template file for 'Cockatrice'
 pkgname=Cockatrice
-version=3.0.1
+version=3.0.2
 revision=1
 build_style=cmake
 configure_args="-DWITH_SERVER=1 -DWITH_CLIENT=1 -DWITH_ORACLE=1 -DTEST=1"
@@ -11,8 +11,8 @@ short_desc="Cross-platform virtual tabletop for multiplayer card games"
 maintainer="Jason Elswick <jason@jasondavid.us>"
 license="GPL-2.0-only"
 homepage="https://github.com/Cockatrice/Cockatrice"
-distfiles="https://github.com/Cockatrice/Cockatrice/archive/refs/tags/2026-05-23-Release-${version}.tar.gz"
-checksum=4818edf6d5d6c35c15165c2ed95ded465fcb7b56f73227ff52685b806c80edc8
+distfiles="https://github.com/Cockatrice/Cockatrice/archive/refs/tags/2026-06-26-Release-${version}.tar.gz"
+checksum=b088cbf865bd6cbf694fd8c5a8d403c38931053a1deede22cb49158e2eb7d2e9
 
 if [ -n "$CROSS_BUILD" ]; then
 	configure_args+="-DQt6_DIR=${XBPS_CROSS_BASE}/usr/lib/cmake/Qt6"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-libc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
