### PR TITLE
New package: pomo-1.0.0

### DIFF
--- a/srcpkgs/pomo/template
+++ b/srcpkgs/pomo/template
@@ -1,0 +1,22 @@
+# Template file for 'pomo'
+pkgname=pomo
+version=1.0.0
+revision=1
+short_desc="Simple Pomodoro timer with i3status and notifications support"
+maintainer="Voctl <denisgulmd@gmail.com>"
+license="GPL-3.0-only"
+homepage="https://github.com/Voctl/pomo"
+distfiles="https://github.com/Voctl/pomo/archive/refs/tags/v${version}.tar.gz"
+checksum=bcc72d1815763e6fd3afa28ef88b7c409f851a56c562c4fc2cad08e14d4b631c
+depends="libnotify"
+
+do_build() {
+	${CC} ${CFLAGS} ${LDFLAGS} src/pomo.c -o pomo
+}
+
+do_install() {
+	vbin pomo
+	vinstall i3/statusw.sh 755 usr/share/pomo/examples pomo-statusw.sh
+	vinstall i3/statusw.py 755 usr/share/pomo/examples pomo-statusw.py
+	vlicense LICENSE
+}


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**|**briefly**|**NO**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->

This is a minimalist Pomodoro timer designed for i3bar.
It reads from a file to display status updates in the bar.
Source: [https://github.com/Voctl/pomo](https://www.google.com/search?q=https://github.com/Voctl/pomo)