### PR TITLE
fonts-roboto-mono: Use variable TTF for Roboto Mono.

### DIFF
--- a/srcpkgs/fonts-roboto-ttf/template
+++ b/srcpkgs/fonts-roboto-ttf/template
@@ -7,8 +7,11 @@ short_desc="Google's signature family of fonts"
 maintainer="travankor <travankor@tuta.io>"
 license="Apache-2.0"
 homepage="https://fonts.google.com/specimen/Roboto"
+
+_mono_version=3.001
+
 distfiles="https://github.com/googlefonts/roboto-3-classic/releases/download/v${version}/Roboto_v${version}.zip
- https://github.com/googlefonts/RobotoMono/archive/refs/tags/v3.001.tar.gz"
+ https://github.com/googlefonts/RobotoMono/archive/refs/tags/v${_mono_version}.tar.gz"
 checksum="1653dbe12f248da8fb0b9920db7b9496cd677ed3981154f6f15285c8bd4e334f
  677d8513918572700531a3115f721a416557a5c701b150abc4d118a7177c8bdc"
 font_dirs="/usr/share/fonts/roboto"
@@ -17,5 +20,5 @@ provides="font:sans-serif-0_1 font:monospace-0_1"
 do_install() {
 	vmkdir usr/share/fonts/roboto
 	vcopy hinted/*.ttf usr/share/fonts/roboto
-	vcopy RobotoMono*/fonts/otf/*.otf usr/share/fonts/roboto
+	vcopy RobotoMono*/fonts/variable/*.ttf usr/share/fonts/roboto
 }


### PR DESCRIPTION
Use the variable variant of Roboto Mono because variable TTF of Roboto is used, this makes the package content more consistent.

#### Testing the changes

- I tested the changes in this PR: **YES**