### PR TITLE
xbps-triggers: Add *_uname variable for system_accounts

### DIFF
--- a/Manual.md
+++ b/Manual.md
@@ -1404,6 +1404,7 @@ Additional variables for the **system accounts** can be specified to change its 
 	- `<account>_descr` the description for the new user. If unset defaults to `<account> unprivileged user`.
 	- `<account>_groups` additional groups to be added to for the new user.
 	- `<account>_pgroup` to set the primary group, by default primary group is set to `<account>`.
+	- `<account>_uname` to specify the account user name, by default the user name is set to `<account>`.
 
 The **system user** is created by using a dynamically allocated **uid/gid** in your system
 and it's created as a `system account`, unless the **uid** is set. A new group will be created for the

--- a/common/hooks/post-install/04-create-xbps-metadata-scripts.sh
+++ b/common/hooks/post-install/04-create-xbps-metadata-scripts.sh
@@ -86,11 +86,15 @@ _EOF
 			local _uname="${f%:*}"
 			local _uid="${f#*:}"
 
+			eval user_name="\$${_uname}_uname"
 			eval homedir="\$${_uname}_homedir"
 			eval shell="\$${_uname}_shell"
 			eval descr="\$${_uname}_descr"
 			eval groups="\$${_uname}_groups"
 			eval pgroup="\$${_uname}_pgroup"
+			if [ -n "$user_name" ]; then
+				echo "export ${_uname}_uname=\"$user_name\"" >> $tmpf
+			fi
 			if [ -n "$homedir" ]; then
 				echo "export ${_uname}_homedir=\"$homedir\"" >> $tmpf
 			fi

--- a/srcpkgs/xbps-triggers/files/system-accounts
+++ b/srcpkgs/xbps-triggers/files/system-accounts
@@ -86,12 +86,14 @@ run)
 
 			[ "${_uname}" = "${_uid}" ] && _uid=
 
+			eval user_name="\$${_uname}_uname"
 			eval homedir="\$${_uname}_homedir"
 			eval shell="\$${_uname}_shell"
 			eval descr="\$${_uname}_descr"
 			eval groups="\$${_uname}_groups"
 			eval pgroup="\$${_uname}_pgroup"
 
+			[ -n "$user_name" ] && _uname="${user_name}"
 			[ -z "$homedir" ] && homedir="/var/empty"
 			[ -z "$shell" ] && shell="/sbin/nologin"
 			[ -z "$descr" ] && descr="${_uname} unprivileged user"
@@ -151,6 +153,10 @@ run)
 		if [ "$UPDATE" = "no" ]; then
 			for acct in ${system_accounts}; do
 				_uname="${acct%:*}"
+
+				eval user_name="\$${_uname}_uname"
+
+				[ -n "$user_name" ] && _uname="${user_name}"
 
 				comment="$( (getent passwd "${_uname}" | cut -d: -f5 | head -n1) 2>/dev/null )"
 				comment="${comment:-unprivileged user} - for uninstalled package ${PKGNAME}"

--- a/srcpkgs/xbps-triggers/template
+++ b/srcpkgs/xbps-triggers/template
@@ -1,6 +1,6 @@
 # Template file for 'xbps-triggers'
 pkgname=xbps-triggers
-version=0.131
+version=0.132
 revision=1
 bootstrap=yes
 short_desc="XBPS triggers for Void Linux"


### PR DESCRIPTION
Account names may require characters such as dashes, however these characters are not legal as bash variables.

This works around the issue by allowing you to do: system_accounts="myaccount"
gdmgreeter_name="my-account"
gdmgreeter_pgroup="my-account"

A real-world example is present with gdm 49+, which depends on a user named gdm-greeter.
This PR allows for the gdm-greeter account (and successfully loading into gdm 49+) as seen here: https://github.com/oreo639/void-packages/commit/86188bd8d7e09d6af41987b64db8efa989c8b7c8

Let me know if there is a better way to handle this.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
