### PR TITLE
rosegarden: update to 26.06

### DIFF
--- a/srcpkgs/rosegarden/template
+++ b/srcpkgs/rosegarden/template
@@ -1,9 +1,9 @@
 # Template file for 'rosegarden'
 pkgname=rosegarden
-version=25.12
+version=26.06
 revision=1
 build_style=cmake
-configure_args="-DUSE_QT6=ON -DQT_HOST_PATH=/usr/lib"
+configure_args="-DUSE_QT6=ON -DQT_HOST_PATH=/usr/lib -DBUILD_TESTING=ON"
 hostmakedepends="pkg-config qt6-base qt6-tools shared-mime-info"
 makedepends="alsa-lib-devel dssi-devel fftw-devel jack-devel ladspa-sdk liblo-devel
  liblrdf-devel libsamplerate-devel libSM-devel libsndfile-devel lilv-devel qt6-base-devel
@@ -15,4 +15,4 @@ license="GPL-2.0-or-later"
 homepage="http://rosegardenmusic.com/"
 changelog="https://raw.githubusercontent.com/tedfelix/rosegarden-official/master/CHANGELOG"
 distfiles="${SOURCEFORGE_SITE}/rosegarden/rosegarden/${version/*.*.*/${version%.*}}/rosegarden-${version}.tar.xz"
-checksum=970bcd4cc33e4a7d7b3d1cc6d8c09bffbaa5f00a487b965c12f6e8dca8cafa6d
+checksum=75d9f01c6aa46d1a08c1ac29ee375e4aab1dcdb670fb7230a9e69c09458d3bd9


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64 (cross)
  - armv7l-musl (cross)
  - x86_64-musl
  - i686
