### PR TITLE
marisa: update to 0.3.1.

### DIFF
--- a/srcpkgs/marisa/template
+++ b/srcpkgs/marisa/template
@@ -1,22 +1,19 @@
 # Template file for 'marisa'
 pkgname=marisa
-version=0.2.6
+version=0.3.1
 revision=1
-build_style=gnu-configure
-hostmakedepends="autoconf automake libtool"
+build_style=cmake
+configure_args="-DBUILD_SHARED_LIBS=ON -DENABLE_NATIVE_CODE=OFF -DBUILD_TESTING=OFF"
+hostmakedepends="pkg-config"
 short_desc="Matching Algorithm with Recursively Implemented StorAge"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="BSD-2-Clause, LGPL-2.1-or-later"
 homepage="https://github.com/s-yata/marisa-trie"
-distfiles=https://github.com/s-yata/marisa-trie/files/4832504/marisa-$version.tar.gz
-checksum=1063a27c789e75afa2ee6f1716cc6a5486631dcfcb7f4d56d6485d2462e566de
-
-case "$XBPS_TARGET_MACHINE" in
-	x86_64*) configure_args+=" --enable-popcnt --enable-sse2";;
-esac
+distfiles="https://github.com/s-yata/marisa-trie/archive/refs/tags/v${version}.tar.gz"
+checksum=986ed5e2967435e3a3932a8c95980993ae5a196111e377721f0849cad4e807f3
 
 pre_configure() {
-	autoreconf -fi
+	vsed -i 's/CONFIGURATIONS Release//g' CMakeLists.txt
 }
 
 post_install() {
@@ -29,7 +26,7 @@ marisa-devel_package() {
 	pkg_install() {
 		vmove usr/include
 		vmove usr/lib/pkgconfig
-		vmove "usr/lib/*.a"
+		vmove usr/lib/cmake
 		vmove "usr/lib/*.so"
 	}
 }


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64
- I built this PR locally for these architectures:
  - i686 (crossbuild)
  - aarch64 (crossbuild)

### Reason for this update

The previous template for `marisa` (0.2.6) explicitly hardcoded `--enable-popcnt` in its configure arguments for `x86_64`. This caused an `Illegal instruction` crash on older x86_64 CPUs that lack native SSE4.2 `POPCNT` support (such as the Intel Core 2 Duo P8600).

This PR updates `marisa` to `0.3.1`, which migrates the build system from Autotools to CMake. By adopting the new version and keeping `-DENABLE_NATIVE_CODE=OFF`, the problematic hardcoded `popcnt` flag is safely dropped..