### PR TITLE
Croc: update to 10.4.4

### DIFF
--- a/srcpkgs/croc/template
+++ b/srcpkgs/croc/template
@@ -1,6 +1,6 @@
 # Template file for 'croc'
 pkgname=croc
-version=10.2.4
+version=10.4.4
 revision=1
 build_style=go
 go_import_path=github.com/schollz/croc/v${version%%.*}
@@ -9,7 +9,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
 homepage="https://github.com/schollz/croc"
 distfiles="https://github.com/schollz/croc/archive/refs/tags/v${version}.tar.gz"
-checksum=c259c07b9da3ea39726b0c5e3f78ae66e858e1379bdb11bef93d31298e68f5fe
+checksum=33e9160829705942178a017ce055196c4a66c9ef5cdfe8029e840be835e756d4
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

Bumps croc from 10.2.4 to 10.4.4. Only the version and checksum changed in the template.

Upstream release: https://github.com/schollz/croc/releases/tag/v10.4.4

First time contributing here. I am thinking about switching to Void as my main
distro and running a few tests (qemu vm btw), so happy to fix anything I got wrong.

#### OS Info
tested in:
<img width="553" height="73" alt="image" src="https://github.com/user-attachments/assets/bca6b860-f6a9-4fee-b526-b570e61cf6fd" />

