### PR TITLE
New package: freetube-0.23.15

### DIFF
--- a/srcpkgs/freetube/files/freetube.desktop
+++ b/srcpkgs/freetube/files/freetube.desktop
@@ -1,0 +1,11 @@
+[Desktop Entry]
+Name=FreeTube
+GenericName=YouTube Player
+Comment=An open source desktop YouTube player built with privacy in mind
+Exec=freetube %U
+Terminal=false
+Type=Application
+Icon=freetube
+MimeType=x-scheme-handler/freetube;
+Categories=Network;
+StartupWMClass=FreeTube

--- a/srcpkgs/freetube/files/freetube.sh
+++ b/srcpkgs/freetube/files/freetube.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec electron35 /usr/lib/freetube "$@"

--- a/srcpkgs/freetube/template
+++ b/srcpkgs/freetube/template
@@ -1,0 +1,37 @@
+# Template file for 'freetube'
+pkgname=freetube
+version=0.23.15
+revision=1
+archs="x86_64* aarch64*"
+hostmakedepends="nodejs yarn git"
+depends="electron35"
+short_desc="Open source desktop YouTube player built with privacy in mind"
+maintainer="devopnem <devopenm@proton.me>"
+license="AGPL-3.0-or-later"
+homepage="https://freetubeapp.io"
+distfiles="https://github.com/FreeTubeApp/FreeTube/archive/v${version}-beta.tar.gz"
+checksum=72ba2fd551ac2271a70ea2ba60722288e043cef8616c34925dbf8a03c5a6d55f
+nocross="electron"
+
+do_build() {
+	export ELECTRON_SKIP_BINARY_DOWNLOAD=1
+
+	yarn install --frozen-lockfile --ignore-scripts
+
+	node _scripts/patchShaka.mjs || :
+
+	yarn run pack
+}
+
+do_install() {
+	vlicense LICENSE
+
+	vmkdir usr/lib/freetube
+	vcopy dist usr/lib/freetube
+	vinstall package.json 644 usr/lib/freetube
+
+	vbin ${FILESDIR}/freetube.sh freetube
+	vinstall ${FILESDIR}/freetube.desktop 644 usr/share/applications
+
+	install -Dm644 _icons/icon.svg ${DESTDIR}/usr/share/pixmaps/freetube.svg
+}

--- a/srcpkgs/freetube/update
+++ b/srcpkgs/freetube/update
@@ -1,0 +1,3 @@
+pkgname=FreeTube
+site=https://github.com/FreeTubeApp/FreeTube/releases
+pattern='\bv\K[\d.]+(?=-beta)'


### PR DESCRIPTION
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-musl)

### Version note
Latest upstream (v0.24.x) requires Electron ≥41; Void ships `electron35`. Version 0.23.15 is the newest release compatible with Electron 34/35.