### PR TITLE
clevis: update to 23

### DIFF
--- a/srcpkgs/clevis/patches/0001-dracut-avoid-requiring-systemd-reply-password-at-bui.patch
+++ b/srcpkgs/clevis/patches/0001-dracut-avoid-requiring-systemd-reply-password-at-bui.patch
@@ -1,0 +1,29 @@
+From 55dd24711be711763b5eca2dcaa23d0c17bbe6cc Mon Sep 17 00:00:00 2001
+From: Owen Xie <15828145+nfusionz@users.noreply.github.com>
+Date: Sun, 31 May 2026 04:20:11 -0400
+Subject: [PATCH 1/2] dracut: avoid requiring systemd-reply-password at build
+ time
+
+Fixes dracut module issue in non-systemd environments where
+systemd-reply-password.path() is called when it doesn't exist,
+causing an error. The path isn't used for the non-systemd flow.
+---
+ src/luks/dracut/clevis/meson.build | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/luks/dracut/clevis/meson.build b/src/luks/dracut/clevis/meson.build
+index f37cc3c..e6230f3 100644
+--- a/src/luks/dracut/clevis/meson.build
++++ b/src/luks/dracut/clevis/meson.build
+@@ -5,7 +5,7 @@ if dracut.found()
+ 
+   dracut_data = configuration_data()
+   dracut_data.merge_from(data)
+-  dracut_data.set('SYSTEMD_REPLY_PASS', sd_reply_pass.path())
++  dracut_data.set('SYSTEMD_REPLY_PASS', sd_reply_pass.found() ? sd_reply_pass.path() : '')
+ 
+   configure_file(
+     input: 'module-setup.sh.in',
+-- 
+2.54.0
+

--- a/srcpkgs/clevis/patches/0002-dracut-include-chmod-for-password-unlocker.patch
+++ b/srcpkgs/clevis/patches/0002-dracut-include-chmod-for-password-unlocker.patch
@@ -1,0 +1,26 @@
+From a575ea0337878708766cd074a14ea5d8be32d360 Mon Sep 17 00:00:00 2001
+From: Owen Xie <15828145+nfusionz@users.noreply.github.com>
+Date: Sun, 31 May 2026 18:43:31 -0400
+Subject: [PATCH 2/2] dracut: include chmod for password unlocker
+
+Fixes issue in non-systemd environments that may not
+have chmod included in the init environment already.
+---
+ src/luks/dracut/clevis/module-setup.sh.in | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/luks/dracut/clevis/module-setup.sh.in b/src/luks/dracut/clevis/module-setup.sh.in
+index 32fac41..cb0bd22 100755
+--- a/src/luks/dracut/clevis/module-setup.sh.in
++++ b/src/luks/dracut/clevis/module-setup.sh.in
+@@ -52,6 +52,7 @@ install() {
+         inst_script "$moddir"/clevis-password-unlocker-prepare /bin/clevis-password-unlocker-prepare
+         inst_multiple \
+             clevis-luks-unlock \
++            chmod \
+             blkid
+     fi
+ 
+-- 
+2.54.0
+

--- a/srcpkgs/clevis/patches/0003-tests-avoid-assert-in-token-to-jwe-test.patch
+++ b/srcpkgs/clevis/patches/0003-tests-avoid-assert-in-token-to-jwe-test.patch
@@ -1,0 +1,100 @@
+tests: avoid assert in token-to-jwe test
+
+Void builds with b_ndebug=true by default, which defines NDEBUG. This causes
+assert() expressions to be compiled out, leaving variables used only by those
+checks unused. Since clevis builds with -Werror, test-token-to-jwe then fails
+to compile.
+
+Replace assert() with an explicit CHECK() helper so the test remains active
+with NDEBUG defined.
+
+--- a/src/luks/udisks2/test-token-to-jwe.c	2026-05-13 21:45:35.000000000 +0700
++++ b/src/luks/udisks2/test-token-to-jwe.c	2026-06-30 12:26:23.264129600 +0700
+@@ -19,11 +19,17 @@
+ 
+ #include "token-to-jwe.h"
+ 
+-#include <assert.h>
+ #include <stdio.h>
+ #include <stdlib.h>
+ #include <string.h>
+ 
++#define CHECK(expr) do { \
++    if (!(expr)) { \
++        fprintf(stderr, "%s:%d: check failed: %s\n", __FILE__, __LINE__, #expr); \
++        abort(); \
++    } \
++} while (0)
++
+ static const char valid_token[] =
+     "{"
+     "  \"type\": \"clevis\","
+@@ -51,8 +57,8 @@
+         "."
+         "6L9KBrn6-R1---wTikJTrA";
+ 
+-    assert(token_to_jwe(valid_token, &pkt));
+-    assert(strcmp(pkt.data, expected) == 0);
++    CHECK(token_to_jwe(valid_token, &pkt));
++    CHECK(strcmp(pkt.data, expected) == 0);
+     fprintf(stderr, "test_basic_conversion: PASS\n");
+ }
+ 
+@@ -61,8 +67,8 @@
+ {
+     pkt_t pkt = {};
+ 
+-    assert(token_to_jwe(valid_token, &pkt));
+-    assert(pkt.used == (ssize_t) strlen(pkt.data));
++    CHECK(token_to_jwe(valid_token, &pkt));
++    CHECK(pkt.used == (ssize_t) strlen(pkt.data));
+     fprintf(stderr, "test_used_equals_strlen: PASS\n");
+ }
+ 
+@@ -71,11 +77,11 @@
+ {
+     pkt_t pkt = {};
+ 
+-    assert(!token_to_jwe(NULL, &pkt));
+-    assert(!token_to_jwe("not json", &pkt));
+-    assert(!token_to_jwe("{}", &pkt));
+-    assert(!token_to_jwe("{\"jwe\":{}}", &pkt));
+-    assert(!token_to_jwe("{\"jwe\":{\"protected\":\"a\"}}", &pkt));
++    CHECK(!token_to_jwe(NULL, &pkt));
++    CHECK(!token_to_jwe("not json", &pkt));
++    CHECK(!token_to_jwe("{}", &pkt));
++    CHECK(!token_to_jwe("{\"jwe\":{}}", &pkt));
++    CHECK(!token_to_jwe("{\"jwe\":{\"protected\":\"a\"}}", &pkt));
+     fprintf(stderr, "test_invalid_json: PASS\n");
+ }
+ 
+@@ -92,10 +98,10 @@
+         "}}";
+     pkt_t pkt = {};
+ 
+-    assert(token_to_jwe(json, &pkt));
+-    assert(strcmp(pkt.data, "....") == 0);
+-    assert(pkt.used == 4);
+-    assert(pkt.used == (ssize_t) strlen(pkt.data));
++    CHECK(token_to_jwe(json, &pkt));
++    CHECK(strcmp(pkt.data, "....") == 0);
++    CHECK(pkt.used == 4);
++    CHECK(pkt.used == (ssize_t) strlen(pkt.data));
+     fprintf(stderr, "test_empty_components: PASS\n");
+ }
+ 
+@@ -112,10 +118,10 @@
+         "}}";
+     pkt_t pkt = {};
+ 
+-    assert(token_to_jwe(json, &pkt));
+-    assert(strcmp(pkt.data, "a.b.c.d.e") == 0);
+-    assert(pkt.used == 9);
+-    assert(pkt.used == (ssize_t) strlen(pkt.data));
++    CHECK(token_to_jwe(json, &pkt));
++    CHECK(strcmp(pkt.data, "a.b.c.d.e") == 0);
++    CHECK(pkt.used == 9);
++    CHECK(pkt.used == (ssize_t) strlen(pkt.data));
+     fprintf(stderr, "test_single_char_components: PASS\n");
+ }
+ 

--- a/srcpkgs/clevis/template
+++ b/srcpkgs/clevis/template
@@ -1,7 +1,7 @@
 # Template file for 'clevis'
 pkgname=clevis
-version=20
-revision=2
+version=23
+revision=1
 build_style=meson
 hostmakedepends="asciidoc bash-completion cryptsetup curl jq keyutils pkg-config tpm2-tools"
 makedepends="bash-completion cryptsetup-devel dracut jansson-devel
@@ -11,8 +11,8 @@ short_desc="Pluggable framework for automated decryption"
 maintainer="Johannes Heimansberg <git@jhe.dedyn.io>"
 license="GPL-3.0-or-later WITH custom:OpenSSL-Exception"
 homepage="https://github.com/latchset/clevis"
-distfiles="https://github.com/latchset/clevis/archive/v$version/clevis-$version.tar.gz"
-checksum=67eb9cbbb9c90f9802cae76503f74f23d0046ee6570553407035e9fae3b4b4dd
+distfiles="https://github.com/latchset/clevis/archive/v${version}/clevis-${version}.tar.gz"
+checksum=a8a09f148d54d91aa0d21c5fa508dd1446c2a200be7679fbf6e7d19196aec164
 make_check="ci-skip" # LUKS tests fail in CI pipeline
 
 post_install() {


### PR DESCRIPTION
#### Testing the changes

- I tested the changes in this PR: **YES**

#### Local build testing

- I built this PR locally for my native architecture, x86_64-glibc

Additional testing:

- Updated `clevis` to 23.
- Applied upstream dracut fixes from latchset/clevis#561:
  - avoid requiring `systemd-reply-password` at build time on non-systemd systems
  - include `chmod` in the dracut module for the password unlocker scripts
- ~~Set `b_ndebug=false` because Clevis 23's `test-token-to-jwe` uses `assert()`. With Void's default `b_ndebug=true`, `NDEBUG` is defined, the assertions are compiled out, and the test fails to build under `-Werror` due to unused variables.~~
- Added a patch for `test-token-to-jwe` to avoid using `assert()`. With Void's default `b_ndebug=true`, `NDEBUG is defined`, so `assert()` is compiled out and the test fails to build under `-Werror` due to unused variables. The patch uses an explicit `CHECK()` helper instead.
- Tested on Void Linux x86_64 with runit, dracut, and a TPM2-bound LUKS root volume.
- Confirmed Clevis 23 builds successfully.
- Confirmed TPM2-bound LUKS auto-unlock works after regenerating the initramfs with dracut.
- Confirmed the previous early-boot `chmod: command not found` warning is gone.
