### PR TITLE
biblioteq: update to 2026.06.25.

### DIFF
--- a/srcpkgs/biblioteq/patches/support-etc-configuration.patch
+++ b/srcpkgs/biblioteq/patches/support-etc-configuration.patch
@@ -2,7 +2,7 @@ Add /usr/lib/BiblioteQ search path to the launcher script.
 
 --- a/biblioteq.sh
 +++ b/biblioteq.sh
-@@ -48,6 +48,16 @@ then
+@@ -46,6 +46,16 @@
      exit $?
  fi
  

--- a/srcpkgs/biblioteq/template
+++ b/srcpkgs/biblioteq/template
@@ -1,19 +1,19 @@
 # Template file for 'biblioteq'
 pkgname=biblioteq
-version=2026.06.07
+version=2026.06.25
 revision=1
 build_style=qmake
 build_helper=qmake6
 hostmakedepends="qt6-tools qt6-base"
-makedepends="libpqxx-devel qt6-base-devel poppler-cpp-devel poppler-qt6-devel
- sqlite-devel yaz-devel"
+makedepends="libpqxx-devel qt6-base-devel qt6-multimedia-devel poppler-cpp-devel
+ poppler-qt6-devel sqlite-devel yaz-devel"
 depends="qt6-plugin-sqlite"
 short_desc="Professional cataloging and library management suite"
 maintainer="Rutpiv <roger_freitas@live.com>"
 license="BSD-3-Clause"
 homepage="https://textbrowser.github.io/biblioteq/"
 distfiles="https://github.com/textbrowser/biblioteq/archive/${version}.tar.gz"
-checksum=073e19dea154e1440a0bd93c35f8b8e7903187d83a7fd03944da17335e1f6012
+checksum=4a748144f4555697a129d028bf3fc9a55d76a46cdace2c6ebe0a1b41c6091388
 conf_files="/etc/biblioteq.conf"
 
 # Set the appropriate build helper and dependencies based on architecture


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures using specific masterdirs:
  - x86_64-musl
  - i686
- I built this PR locally for these architectures (crossbuilds):
  - aarch64
  - aarch64-musl
  - armv7l
  - armv7l-musl
  - armv6l
  - armv6l-musl
 
---

Add `qt6-multimedia-devel` to makedepends. Upstream gates audio
feedback in the batch activities browser behind `qtHaveModule(multimedia)`,
which was previously not discovered. This enables `BIBLIOTEQ_AUDIO_SUPPORTED`
and adds a runtime dependency on `qt6-multimedia`.

Rename `support-etc-configuration.patch.patch` to drop the doubled
extension and correct the hunk header.