### PR TITLE
gitea: update to 1.26.4

### DIFF
--- a/srcpkgs/gitea/template
+++ b/srcpkgs/gitea/template
@@ -1,6 +1,6 @@
 # Template file for 'gitea'
 pkgname=gitea
-version=1.26.2
+version=1.26.4
 revision=1
 build_style=go
 go_import_path=code.gitea.io/gitea
@@ -29,7 +29,7 @@ license="MIT"
 homepage="https://gitea.io"
 changelog="https://raw.githubusercontent.com/go-gitea/gitea/main/CHANGELOG.md"
 distfiles="https://dl.gitea.io/gitea/${version}/gitea-src-${version}.tar.gz"
-checksum=ce1462ad93dcbf3221a452457008b8159cbab3d0c93958179b88649df1e401cf
+checksum=197d679d8c774e05915c67da67d1cbae9fb055c1dbb802f0c59603a44fcadd98
 
 system_accounts="_gitea"
 _gitea_homedir="/var/lib/gitea"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture:
  - x86_64-glibc
  - aarch64-glibc
- I built this PR locally for these architectures:
  - armv6l (cross-build)
  - armv6l-musl (cross-build)
  - armv7l (cross-build)
  - armv7l-musl (cross-build)

