### PR TITLE
containerd: update to 2.3.2

### DIFF
--- a/srcpkgs/containerd/patches/Fix-TestCgroupNamespace-failure-on-cgroups-v1-hosts.patch
+++ b/srcpkgs/containerd/patches/Fix-TestCgroupNamespace-failure-on-cgroups-v1-hosts.patch
@@ -1,0 +1,80 @@
+From 970b5d46bc30b5aafe16c4fbb245500f885cc9cd Mon Sep 17 00:00:00 2001
+From: Arjun Yogidas <arjunry@amazon.com>
+Date: Thu, 16 Apr 2026 18:24:24 +0000
+Subject: [PATCH] Fix TestCgroupNamespace failure on cgroups v1 hosts
+
+Signed-off-by: Arjun Yogidas <arjunry@amazon.com>
+---
+ .../cri/server/container_create_linux_test.go | 31 +++++++++++++++++--
+ 1 file changed, 28 insertions(+), 3 deletions(-)
+
+diff --git a/internal/cri/server/container_create_linux_test.go b/internal/cri/server/container_create_linux_test.go
+index 8151be9a4..f376ee045 100644
+--- a/internal/cri/server/container_create_linux_test.go
++++ b/internal/cri/server/container_create_linux_test.go
+@@ -487,6 +487,8 @@ func TestPrivilegedBindMount(t *testing.T) {
+ 	}
+ }
+ 
++// TestCgroupNamespace verifies that a cgroup namespace is only assigned to
++// non-privileged containers on cgroupv2 hosts.
+ func TestCgroupNamespace(t *testing.T) {
+ 	testPid := uint32(1234)
+ 	c := newTestCRIService()
+@@ -498,27 +500,50 @@ func TestCgroupNamespace(t *testing.T) {
+ 	tests := []struct {
+ 		desc                  string
+ 		privileged            bool
++		requireCgroupV2       bool
+ 		expectCgroupNamespace bool
+ 	}{
+ 		{
+-			desc:                  "non-privileged container should get cgroup namespace",
++			desc:                  "cgroupv2: non-privileged container should get cgroup namespace",
+ 			privileged:            false,
++			requireCgroupV2:       true,
+ 			expectCgroupNamespace: true,
+ 		},
+ 		{
+-			desc:                  "privileged container should not get cgroup namespace",
++			desc:                  "cgroupv2: privileged container should not get cgroup namespace",
+ 			privileged:            true,
++			requireCgroupV2:       true,
++			expectCgroupNamespace: false,
++		},
++		{
++			desc:                  "cgroupv1: non-privileged container should not get cgroup namespace",
++			privileged:            false,
++			requireCgroupV2:       false,
++			expectCgroupNamespace: false,
++		},
++		{
++			desc:                  "cgroupv1: privileged container should not get cgroup namespace",
++			privileged:            true,
++			requireCgroupV2:       false,
+ 			expectCgroupNamespace: false,
+ 		},
+ 	}
+ 
+ 	for _, tt := range tests {
+ 		t.Run(tt.desc, func(t *testing.T) {
++			// Skip if the host's cgroup mode doesn't match what the test case requires.
++			if tt.requireCgroupV2 && !isUnifiedCgroupsMode() {
++				t.Skip("requires cgroups v2")
++			}
++			if !tt.requireCgroupV2 && isUnifiedCgroupsMode() {
++				t.Skip("requires cgroups v1")
++			}
++
+ 			containerConfig.Linux.SecurityContext.Privileged = tt.privileged
+ 			sandboxConfig.Linux.SecurityContext.Privileged = tt.privileged
+ 
+ 			spec, err := c.buildContainerSpec(currentPlatform, t.Name(), testSandboxID, testPid, "", testContainerName, testImageName, containerConfig, sandboxConfig, imageConfig, nil, ociRuntime, nil)
+-			assert.NoError(t, err)
++			require.NoError(t, err)
+ 
+ 			hasCgroupNS := false
+ 			for _, ns := range spec.Linux.Namespaces {
+-- 
+2.54.0.windows.1
+

--- a/srcpkgs/containerd/template
+++ b/srcpkgs/containerd/template
@@ -1,6 +1,6 @@
 # Template file for 'containerd'
 pkgname=containerd
-version=2.2.0
+version=2.3.2
 revision=1
 build_style=go
 build_helper="qemu"
@@ -21,7 +21,7 @@ maintainer="Orphan <orphan@voidlinux.org>"
 license="Apache-2.0"
 homepage="https://github.com/containerd/containerd"
 distfiles="https://github.com/containerd/containerd/archive/v${version}.tar.gz"
-checksum=86e7a268fc73f5332522baef86082c1d6c17986e2957a9ad842ead35d1080fca
+checksum=1a215ae4acb184192668b21f8b8375ceb6e86f8832a97fe6f7ab53ad79bb2cee
 make_dirs="/var/lib/containerd 0755 root root"
 
 # Cross builds fail with -fuse-ld=gold


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86-64)
- I'm using this version on my homelab environment for several days and didn't notice any issues