### PR TITLE
qbe: update to 1.3.

### DIFF
--- a/srcpkgs/qbe/template
+++ b/srcpkgs/qbe/template
@@ -1,6 +1,6 @@
 # Template file for 'qbe'
 pkgname=qbe
-version=1.2
+version=1.3
 revision=1
 build_style=gnu-makefile
 make_use_env=yes
@@ -9,7 +9,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
 homepage="https://c9x.me/compile/"
 distfiles="https://c9x.me/compile/release/qbe-${version}.tar.xz"
-checksum=a6d50eb952525a234bf76ba151861f73b7a382ac952d985f2b9af1df5368225d
+checksum=d587905d620dc5e1d2bfa7c2cc642b9b837aa89a3188c6e37b53d756cf66e320
 
 # Currently only riscv64, aarch64 and x86_64 targets are supported and the checks
 # test the compiled binaries.


### PR DESCRIPTION

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl
  - aarch64 (crossbuild)
  - aarch64-musl (crossbuild)
  - armv7l (crossbuild)
  - armv7l-musl (crossbuild)
  - armv6l (crossbuild)
  - armv6l-musl (crossbuild)
  - riscv64 (crossbuild)
  - riscv64-musl (crossbuild)

