### PR TITLE
go-size-analyzer: update to 1.13.0.

### DIFF
--- a/srcpkgs/go-size-analyzer/template
+++ b/srcpkgs/go-size-analyzer/template
@@ -1,6 +1,6 @@
 # Template file for 'go-size-analyzer'
 pkgname=go-size-analyzer
-version=1.11.0
+version=1.13.0
 revision=1
 build_style=go
 go_import_path="github.com/Zxilly/go-size-analyzer"
@@ -12,7 +12,12 @@ maintainer="Bnyro <bnyro@tutanota.com>"
 license="AGPL-3.0-only"
 homepage="https://github.com/Zxilly/go-size-analyzer"
 distfiles="https://github.com/Zxilly/go-size-analyzer/archive/refs/tags/v${version}.tar.gz"
-checksum=0e1734c90e6ff1a45b079e4c4eb2c7bc1bfe9a85c9d9110133aeb39323f6ee36
+checksum=160415a10eaa2c1151dda1e8913d5d1ccf912cd7c18e35a673b88ac72667e507
+make_check=no # requires binary files to analyze them
+
+pre_build() {
+	export GOEXPERIMENT=jsonv2
+}
 
 post_install() {
 	# avoid name clash with 'gwenhywfar' package


### PR DESCRIPTION

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
