### PR TITLE
libjxl: update to 0.12

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -4485,9 +4485,9 @@ libplayerctl.so.2 playerctl-2.4.1_1
 libwireplumber-0.5.so.0 wireplumber-0.5.2_1
 libjodycode.so.4 libjodycode-4.1.2_1
 libgsoapssl++-2.8.124.so gsoap-2.8.124_1
-libjxl.so.0.11 libjxl-0.11.0_1
-libjxl_cms.so.0.11 libjxl-0.11.0_1
-libjxl_threads.so.0.11 libjxl-0.11.0_1
+libjxl.so.0.12 libjxl-0.12.0_1
+libjxl_cms.so.0.12 libjxl-0.12.0_1
+libjxl_threads.so.0.12 libjxl-0.12.0_1
 libvmaf.so.3 vmaf-3.0.0_1
 liblc3.so.1 liblc3-1.0.3_1
 libmimalloc.so.3 mimalloc-3.3.2_1

--- a/srcpkgs/ImageMagick/template
+++ b/srcpkgs/ImageMagick/template
@@ -2,7 +2,7 @@
 pkgname=ImageMagick
 # Revbump php*-imagick with ImageMagick updates.
 version=7.1.2.25
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--disable-static --enable-opencl --with-modules --with-gslib
  --with-rsvg --with-wmf --with-dejavu-font-dir=/usr/share/fonts/TTF --with-openexr

--- a/srcpkgs/chafa/template
+++ b/srcpkgs/chafa/template
@@ -1,7 +1,7 @@
 # Template file for 'chafa'
 pkgname=chafa
 version=1.18.2
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--enable-man"
 hostmakedepends="docbook-xml docbook-xsl libxslt pkg-config"

--- a/srcpkgs/darktable/template
+++ b/srcpkgs/darktable/template
@@ -1,7 +1,7 @@
 # Template file for 'darktable'
 pkgname=darktable
 version=5.4.0
-revision=1
+revision=2
 # upstream only supports these archs:
 archs="x86_64* aarch64* ppc64le*"
 build_style=cmake

--- a/srcpkgs/digikam/template
+++ b/srcpkgs/digikam/template
@@ -1,7 +1,7 @@
 # Template file for 'digikam'
 pkgname=digikam
 version=9.1.0
-revision=1
+revision=2
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
  -DENABLE_AKONADICONTACTSUPPORT=ON -DENABLE_KFILEMETADATASUPPORT=ON

--- a/srcpkgs/efl/template
+++ b/srcpkgs/efl/template
@@ -1,7 +1,7 @@
 # Template file for 'efl'
 pkgname=efl
 version=1.28.1
-revision=1
+revision=2
 build_style=meson
 configure_args="
  -Dbuild-examples=false

--- a/srcpkgs/ffmpeg6/template
+++ b/srcpkgs/ffmpeg6/template
@@ -2,7 +2,7 @@
 # audacity also needs to be bumped when a new ffmpeg version bumps libavformat's soname!
 pkgname=ffmpeg6
 version=6.1.6
-revision=1
+revision=2
 hostmakedepends="pkg-config perl"
 makedepends="zlib-devel bzip2-devel freetype-devel alsa-lib-devel libXfixes-devel
  libXext-devel libXvMC-devel libxcb-devel lame-devel libtheora-devel

--- a/srcpkgs/gimp/template
+++ b/srcpkgs/gimp/template
@@ -1,7 +1,7 @@
 # Template file for 'gimp'
 pkgname=gimp
 version=3.2.4
-revision=1
+revision=2
 build_style=meson
 build_helper="gir qemu"
 configure_args="-Dcheck-update=no -Drevision=$revision -Denable-default-bin=enabled

--- a/srcpkgs/glycin/template
+++ b/srcpkgs/glycin/template
@@ -1,7 +1,7 @@
 # Template file for 'glycin'
 pkgname=glycin
 version=2.1.5
-revision=1
+revision=2
 build_style=meson
 build_helper="rust gir"
 configure_args="-Dtest_skip_install=true"

--- a/srcpkgs/imlib2/template
+++ b/srcpkgs/imlib2/template
@@ -1,7 +1,7 @@
 # Template file for 'imlib2'
 pkgname=imlib2
 version=1.12.6
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--disable-static --sysconfdir=/etc/imlib2 --enable-visibility-hiding"
 hostmakedepends="pkg-config"

--- a/srcpkgs/kf6-kimageformats/template
+++ b/srcpkgs/kf6-kimageformats/template
@@ -1,7 +1,7 @@
 # Template file for 'kf6-kimageformats'
 pkgname=kf6-kimageformats
 version=6.25.0
-revision=1
+revision=2
 build_style=cmake
 configure_args="-DKIMAGEFORMATS_HEIF=ON -DKDE_INSTALL_QMLDIR=lib/qt6/qml
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins"
@@ -18,7 +18,7 @@ checksum=dfa0e9b16a288a8f94233afcbaffc87c1c5ddc037aca643943aab5a67685f26b
 
 do_check() {
 	cd build
-	exclude="kimageformats-read-xcf|kimageformats-read-psd|kimageformats-read-hej2"
+	exclude="kimageformats-read-xcf|kimageformats-read-psd|kimageformats-read-hej2|kimageformats-write-hej2"
 	case "$XBPS_TARGET_MACHINE" in
 		i686*) exclude+="|kimageformats-write-exr";;
 		*) ;;

--- a/srcpkgs/krita/template
+++ b/srcpkgs/krita/template
@@ -1,7 +1,7 @@
 # Template file for 'krita'
 pkgname=krita
 version=5.2.14
-revision=1
+revision=2
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF -DENABLE_UPDATERS=OFF"
 hostmakedepends="extra-cmake-modules gettext pkg-config python3

--- a/srcpkgs/libjxl/template
+++ b/srcpkgs/libjxl/template
@@ -1,8 +1,8 @@
 # Template file for 'libjxl'
 pkgname=libjxl
-version=0.11.2
+version=0.12.0
 revision=1
-_testdata_hash=ff8d743aaba05b3014f17e5475e576242fa979fc
+_testdata_hash=73695d303670c90e4d506ea89d9901b081385089
 build_style=cmake
 configure_args="-DJPEGXL_ENABLE_BENCHMARK=OFF -DJPEGXL_ENABLE_EXAMPLES=OFF
  -DJPEGXL_ENABLE_SJPEG=OFF -DJPEGXL_ENABLE_PLUGINS=ON -DJPEGXL_VERSION=${version}
@@ -18,8 +18,8 @@ homepage="https://jpeg.org/jpegxl/"
 changelog="https://raw.githubusercontent.com/libjxl/libjxl/main/CHANGELOG.md"
 distfiles="https://github.com/libjxl/libjxl/archive/v${version}.tar.gz
  https://github.com/libjxl/testdata/archive/${_testdata_hash}.tar.gz>testdata-${_testdata_hash}.tar.gz"
-checksum="ab38928f7f6248e2a98cc184956021acb927b16a0dee71b4d260dc040a4320ea
- 9c45a108df32a002a69465df896d33acf77d97c88fb59dffa0dff5628370e96f"
+checksum="03e9be69a30be4011f559da75328b6d7cea8ad921fabfbd551ce10bf45cdc992
+ 380a58890e11513d34f1ed1e686e3c2cee97931cc9faaa80b33fd6c8d2640301"
 skip_extraction="testdata-${_testdata_hash}.tar.gz"
 
 if [ -z "$XBPS_CHECK_PKGS" ]; then

--- a/srcpkgs/openimageio/template
+++ b/srcpkgs/openimageio/template
@@ -1,7 +1,7 @@
 # Template file for 'openimageio'
 pkgname=openimageio
 version=3.1.8.0
-revision=1
+revision=2
 build_style=cmake
 build_helper=qemu
 configure_args="-DUSE_QT=0 -DUSE_PYTHON=0 -DOIIO_BUILD_TESTS=0

--- a/srcpkgs/rawtherapee/template
+++ b/srcpkgs/rawtherapee/template
@@ -1,7 +1,7 @@
 # Template file for 'rawtherapee'
 pkgname=rawtherapee
 version=5.12
-revision=1
+revision=2
 build_style=cmake
 configure_args="-DCACHE_NAME_SUFFIX=\"\" -DWITH_LTO=ON -DWITH_SYSTEM_LIBRAW=ON"
 hostmakedepends="pkg-config"

--- a/srcpkgs/swayimg/template
+++ b/srcpkgs/swayimg/template
@@ -1,7 +1,7 @@
 # Template file for 'swayimg'
 pkgname=swayimg
 version=5.4
-revision=1
+revision=2
 build_style=meson
 configure_args="-D version=${version}"
 hostmakedepends="pkg-config wayland-devel"

--- a/srcpkgs/vips/template
+++ b/srcpkgs/vips/template
@@ -1,6 +1,6 @@
 # Template file for 'vips'
 pkgname=vips
-version=8.18.3
+version=8.18.4
 revision=1
 build_style=meson
 build_helper=gir
@@ -19,7 +19,7 @@ license="LGPL-2.1-or-later"
 homepage="https://www.libvips.org/"
 changelog="https://raw.githubusercontent.com/libvips/libvips/master/ChangeLog"
 distfiles="https://github.com/libvips/libvips/archive/refs/tags/v${version}.tar.gz"
-checksum=21aa79be2a83f1f46582c58e0fc7fc2b355e6fbb661091fb963a3b20f494dbaf
+checksum=1e8d2228a4ffae7498e357dcddb3775440afa7b11726841cd511674dced84257
 python_version=3
 
 build_options="gir hdf5"

--- a/srcpkgs/wbg/template
+++ b/srcpkgs/wbg/template
@@ -1,7 +1,7 @@
 # Template file for 'wbg'
 pkgname=wbg
 version=1.3.0
-revision=1
+revision=2
 build_style=meson
 hostmakedepends="pkg-config wayland-devel"
 makedepends="libjpeg-turbo-devel libpng-devel libwebp-devel libjxl-devel pixman-devel
@@ -12,7 +12,7 @@ license="MIT"
 homepage="https://codeberg.org/dnkl/wbg"
 changelog="https://codeberg.org/dnkl/wbg/raw/branch/master/CHANGELOG.md"
 distfiles="https://codeberg.org/dnkl/wbg/archive/${version}.tar.gz"
-checksum=2d5b3109d65602827e7e935e00ee25deae3e89574f8328b28e214cd61f98de07
+checksum=bea54a7d869084fc6c5992825c5cdf3a48f992e23f5a2cf95dfaeb6116cb3d47
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**
  - I've been running my own master branch libjxl and periodically updating it in the past several months. I haven't *thoroughly* tested *every* dependency, but they do all build. most of the changes are fixes and optimizations.

#### Local build testing
- I built this PR locally for my native architecture, `x86_64-glibc`

includes:
- vips 8.18.4