### PR TITLE
blocky: update to 0.33.0

### DIFF
--- a/srcpkgs/blocky/template
+++ b/srcpkgs/blocky/template
@@ -1,6 +1,6 @@
 # Template file for 'blocky'
 pkgname=blocky
-version=0.32.0
+version=0.33.0
 revision=1
 build_style=go
 go_import_path=github.com/0xERR0R/blocky
@@ -11,7 +11,7 @@ license="Apache-2.0"
 homepage="https://0xerr0r.github.io/blocky/latest"
 changelog="https://github.com/0xERR0R/blocky/releases"
 distfiles="https://github.com/0xERR0R/blocky/archive/v${version}.tar.gz"
-checksum=9328c83aaecc858e4597a9eea36b1c3c01aec8ab4ef0d61c137748f701599531
+checksum=b51b5a23727c1f74f976204524c77d571329439eb88c9a718b92916c16c93ca7
 # test requires existing docker socket
 make_check=extended
 


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-musl