### PR TITLE
ngrep: update to 1.49.0, adopt

### DIFF
--- a/srcpkgs/ngrep/template
+++ b/srcpkgs/ngrep/template
@@ -1,22 +1,22 @@
 # Template file for 'ngrep'
 pkgname=ngrep
-version=1.47
+version=1.49.0
 revision=1
 build_style=gnu-configure
-configure_args="--enable-ipv6 --enable-pcre EXTRA_LIBS=-lpcre"
+configure_args="--enable-ipv6 --enable-pcre2 --disable-pcap-restart"
 hostmakedepends="pkg-config"
-makedepends="pcre-devel libpcap-devel"
+makedepends="pcre2-devel libpcap-devel"
 short_desc="Like GNU grep applied to the network layer"
-maintainer="Orphaned <orphan@voidlinux.org>"
+maintainer="Fabian Constantinescu <fabian.constantinescu@protnmail.com>"
 license="MIT"
 homepage="https://github.com/jpr5/ngrep"
-distfiles="https://github.com/jpr5/ngrep/archive/V${version/./_}.tar.gz"
-checksum=dc4dbe20991cc36bac5e97e99475e2a1522fd88c59ee2e08f813432c04c5fff3
+distfiles="https://github.com/jpr5/ngrep/archive/refs/tags/v${version}.tar.gz"
+checksum=6c94b31681316b7469a3ace92d2aeec7c9f490bd6782453dff2ade0e289a3348
 
 if [ "$CROSS_BUILD" ]; then
-	configure_args+=" --with-pcap-includes=$XBPS_CROSS_BASE/usr/include/pcap"
-else
-	configure_args+=" --with-pcap-includes=/usr/include/pcap"
+	configure_args+=" --with-pcap-includes=${XBPS_CROSS_BASE}/usr/include"
+	configure_args+=" --with-pcre2-includes=${XBPS_CROSS_BASE}/usr/include"
+	export NGREP_PCRE2_CONFIG_SCRIPT="${XBPS_CROSS_BASE}/usr/bin/pcre2-config"
 fi
 
 post_install() {

--- a/srcpkgs/ngrep/update
+++ b/srcpkgs/ngrep/update
@@ -1,2 +1,0 @@
-site="https://github.com/jpr5/ngrep/releases"
-pattern="V\K[\d\_]*(?=\.tar\.gz)"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl, -glibc
  - armv7l
  - x86_64-musl
