### PR TITLE
libgbinder: update to 1.1.50.

### DIFF
--- a/srcpkgs/libgbinder/template
+++ b/srcpkgs/libgbinder/template
@@ -1,6 +1,6 @@
 # Template file for 'libgbinder'
 pkgname=libgbinder
-version=1.1.48
+version=1.1.50
 revision=1
 build_style=gnu-makefile
 make_use_env=1
@@ -8,7 +8,7 @@ make_build_args="KEEP_SYMBOLS=1"
 make_build_target="release pkgconfig"
 make_install_target="install-dev"
 make_check_target="test"
-hostmakedepends="pkg-config bison flex"
+hostmakedepends="pkg-config"
 makedepends="libglibutil-devel"
 short_desc="GLib-style interface to binder (Android IPC mechanism)"
 maintainer="Rutpiv <roger_freitas@live.com>"
@@ -16,7 +16,7 @@ license="BSD-3-Clause"
 homepage="https://github.com/mer-hybris/libgbinder"
 changelog="https://raw.githubusercontent.com/mer-hybris/libgbinder/master/debian/changelog"
 distfiles="https://github.com/mer-hybris/libgbinder/archive/refs/tags/${version}.tar.gz"
-checksum=471db8bc927d77f4b5f56b5a98ae5564f594a407f6e07202e064adc8023f1c59
+checksum=eabf5b715b933665edefca87425908fb2d23a938de2b0eeb8fd7cb9a3d668f46
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture (x86_64)
- I built this PR locally for these architectures using specific masterdirs:
  - x86_64-musl
  - i686
- I built this PR locally for these architectures (crossbuilds):
  - aarch64
  - aarch64-musl
  - armv7l
  - armv7l-musl
  - armv6l
  - armv6l-musl
 
---

Drops `bison` and `flex` from `hostmakedepends`. They are unused: the only lexer/parser (`cmdline.l`/`cmdline.y`) lives under test/binder-call, which is built by neither the `release pkgconfig` build target nor the `make -C unit test` check target. A local build confirms only pkg-config is pulled in as a host dependency.