### PR TITLE
libpisp: update to 1.6.0.

### DIFF
--- a/srcpkgs/libpisp/template
+++ b/srcpkgs/libpisp/template
@@ -1,7 +1,8 @@
 # Template file for 'libpisp'
 pkgname=libpisp
-version=1.5.0
+version=1.6.0
 revision=1
+archs="aarch64* armv*"
 build_style=meson
 hostmakedepends="pkg-config"
 makedepends="json-c++"
@@ -10,7 +11,7 @@ maintainer="Rutpiv <roger_freitas@live.com>"
 license="BSD-2-Clause"
 homepage="https://github.com/raspberrypi/libpisp"
 distfiles="https://github.com/raspberrypi/libpisp/archive/v${version}.tar.gz"
-checksum=c38c450ce96724c8dd8389ca57faceaae5e5a3db72d594558901352a2bc89e79
+checksum=a48550ef89da1abc7c586fe54c5a03e236aaea6d5f62987c54061e40804673dc
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for these architectures (crossbuilds):
  - aarch64
  - aarch64-musl
  - armv7l
  - armv7l-musl
  - armv6l
  - armv6l-musl
  
---

Restricts archs to "aarch64* armv*". I added this package originally without an archs restriction, which was a mistake: PiSP is Raspberry Pi ISP hardware, and libpisp's only consumer in the repo, libcamera, already gates its libpisp-devel dependency to aarch64*/armv* (its rpi/pisp pipeline handler is ARM-only). The library compiles on x86 but has no build-time consumer and no runtime hardware there, so building it for those arches never made sense. This corrects that.

1.6.0 also adds an optional GStreamer plugin (`pispconvert`), gated behind the `gstreamer` meson feature and disabled by default. This template keeps it disabled: the plugin references `GST_VIDEO_FORMAT_NV12_128C8` and `GST_VIDEO_FORMAT_NV12_10LE32_128C8`, which are not present in any released GStreamer (absent through the current `main`), so it fails to compile against Void's gstreamer. Those formats come from gstreamer MR !9247 (https://gitlab.freedesktop.org/gstreamer/gstreamer/-/merge_requests/9247), which is still under active review and not yet merged. Carrying it as a downstream patch is not worth it while it keeps moving, so the plugin stays off until the formats land in a gstreamer release.