### PR TITLE
SDL2_net: update to 2.4.0.

### DIFF
--- a/srcpkgs/SDL2_net/template
+++ b/srcpkgs/SDL2_net/template
@@ -1,20 +1,21 @@
 # Template file for 'SDL2_net'
 pkgname=SDL2_net
-version=2.0.1
-revision=3
-build_style=gnu-configure
-configure_args="--disable-static"
+version=2.4.0
+revision=1
+build_style=cmake
+configure_args="-DSDL2NET_SAMPLES=OFF"
 hostmakedepends="pkg-config"
 makedepends="SDL2-devel"
-short_desc="SDL2 networking module"
+short_desc="Networking library (SDL 2.x)"
 maintainer="Orphaned <orphan@voidlinux.org>"
-license="BSD-3-Clause"
-homepage="https://www.libsdl.org/projects/SDL_net/"
+license="Zlib"
+homepage="https://github.com/libsdl-org/SDL_net"
+changelog="https://github.com/libsdl-org/SDL_net/raw/SDL2/CHANGES.txt"
 distfiles="https://www.libsdl.org/projects/SDL_net/release/${pkgname}-${version}.tar.gz"
-checksum=15ce8a7e5a23dafe8177c8df6e6c79b6749a03fff1e8196742d3571657609d21
+checksum=9cbca2527feb3f1a622d48ba65cc7dee9b1e3f2c55ceafb7d7720bb058aafb30
 
 post_install() {
-	vlicense COPYING.txt
+	vlicense LICENSE.txt
 }
 
 SDL2_net-devel_package() {
@@ -22,6 +23,7 @@ SDL2_net-devel_package() {
 	short_desc+=" - development files"
 	pkg_install() {
 		vmove usr/include
+		vmove usr/lib/cmake
 		vmove usr/lib/pkgconfig
 		vmove "usr/lib/*.so"
 	}


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture (x86_64)
- I built this PR locally for these architectures using specific masterdirs:
  - x86_64-musl
  - i686
- I built this PR locally for these architectures (crossbuilds):
  - aarch64
  - aarch64-musl
  - armv7l
  - armv7l-musl
  - armv6l
  - armv6l-musl

---

Upstream migrated from autotools to CMake as of 2.2.0, so this switches build_style to cmake and drops the stale autotools configure_args. Samples build by default but upstream installs none of them, so -DSDL2NET_SAMPLES=OFF
skips the throwaway executables.

Part of the SDL_net work promised in #61117.