### PR TITLE
media-downloader: update to 5.6.2

### DIFF
--- a/srcpkgs/media-downloader/template
+++ b/srcpkgs/media-downloader/template
@@ -1,14 +1,15 @@
 # Template file for 'media-downloader'
 pkgname=media-downloader
-version=5.6.1
+version=5.6.2
 revision=1
 build_style=cmake
 hostmakedepends="qt6-base qt6-tools"
 makedepends="qt6-base-devel"
+depends="qt6-plugin-tls-openssl"
 short_desc="Qt/C++ frontend to youtube-dl"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="https://github.com/mhogomchungu/media-downloader"
 changelog="https://github.com/mhogomchungu/media-downloader/raw/main/changelog"
 distfiles="https://github.com/mhogomchungu/media-downloader/archive/refs/tags/${version}.tar.gz"
-checksum=a381d2942311d4efd0d2d8f2970fcc987dabe1d36c0d3b17b0d6c47d15ab1f02
+checksum=14938de750dc89489dfaedfe906147f794f27a2758a956a178cfecfec24bd647


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)

Note: I added `qt6-plugin-tls-openssl` as a dependency as I noticed on a different system that `media-downloader` couldn't fetch anything (and was displaying some tls error message) unless this packages was installed.
On the main system that dependency apparently was already installed through a different package as an dependency, like `qt6-webengine` which by itself was probably needed by `falkon` or such. That's why I never noticed this missing dependency before.