### PR TITLE
dbeaver: update to 26.1.1

### DIFF
--- a/srcpkgs/dbeaver/patches/force-jdk25.patch
+++ b/srcpkgs/dbeaver/patches/force-jdk25.patch
@@ -5,7 +5,7 @@
 
      <launcherArgs>
 -        <programArgs></programArgs>
-+        <programArgs>-vm /usr/lib/jvm/openjdk21/bin</programArgs>
++        <programArgs>-vm /usr/lib/jvm/openjdk25/bin</programArgs>
          <programArgsMac>-vm ../Eclipse/jre/Contents/Home/lib/libjli.dylib</programArgsMac>
 
          <vmArgs>

--- a/srcpkgs/dbeaver/template
+++ b/srcpkgs/dbeaver/template
@@ -1,13 +1,13 @@
 # Template file for 'dbeaver'
 pkgname=dbeaver
-version=26.1.0
+version=26.1.1
 revision=1
 _version=${version//./_}
 # the build downloads binaries linked to glibc
 archs="x86_64 aarch64"
 build_wrksrc="dbeaver"
-hostmakedepends="apache-maven openjdk21"
-depends="openjdk21"
+hostmakedepends="apache-maven openjdk25"
+depends="openjdk25"
 short_desc="Free Universal Database Tool"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="Apache-2.0"
@@ -16,9 +16,9 @@ changelog="https://dbeaver.io/news/"
 distfiles="https://github.com/dbeaver/dbeaver/archive/${version}.tar.gz
  https://github.com/dbeaver/dbeaver-common/archive/refs/heads/release_${_version}.tar.gz>dbeaver-common-${version}.tar.gz
  https://github.com/dbeaver/dbeaver-jdbc-libsql/archive/refs/heads/release_${_version}.tar.gz>dbeaver-jdbc-libsql-${version}.tar.gz"
-checksum="44bd31ac58a21b82d897e81d3bef5ef542558c460dd8f31863079be759c5f1da
- 356cdf56c2768b4e22e78892d37f912466fcc0b2b5b74382d401af154ccc0ab9
- 087ecdaf417948f5f1291cc77940abf8abf00c8580bf8b489480b485bc8e4a34"
+checksum="8affa472ecd8f9b1515779d4c60cae9401cf08980186cb96ca51f30f8fe69c86
+ 415e8bbe629a97551fdcbc635796ade958f8b6b70e8e4291b78c919c4bf96d4f
+ 1124f0fffa7b85d95445535f5a0d27775be42ddc1aa010dbb67b477bdfaba50e"
 nopie=true
 
 post_extract() {


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc

updated openjdk to version 25 (it is LTS and GA since Sept 2025)
verified locally with a few databases, no issues
