### PR TITLE
new packages: add Asahi Linux's muvm, including FEX, libkrun, and fixing other packages

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -2813,7 +2813,7 @@ libsignon-qt6.so.1 signond-8.61_2
 libsignon-plugins-common.so.1 signond-8.61_2
 libsignon-extension.so.1 signond-8.61_2
 libj4status-plugin.so.0 j4status-0.1_1
-libvirglrenderer.so.1 virglrenderer-0.5.0_1
+libvirglrenderer.so.1 virglrenderer-0.5.0_2
 libglpk.so.40 glpk-4.60_1
 libipmimonitoring.so.6 freeipmi-1.5.7_1
 libipmiconsole.so.2 freeipmi-1.5.1_1
@@ -4601,3 +4601,4 @@ libigloo.so.0 libigloo-0.9.5_1
 libfyaml.so.0 libfyaml-0.9.6_1
 libcpptrace.so.1 cpptrace-1.0.4_1
 libcgif.so.0 cgif-0.5.3_1
+libkrun.so.0 libkrun-1.19.3_1

--- a/srcpkgs/FEX/template
+++ b/srcpkgs/FEX/template
@@ -1,0 +1,26 @@
+# Template file for 'FEX'
+pkgname=FEX
+version=2605
+revision=1
+archs="aarch64"
+build_style=cmake
+make_cmd="ninja"
+configure_args="-DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_INSTALL_PREFIX=/usr
+ -DCMAKE_BUILD_TYPE=Release -DUSE_LINKER=lld -DENABLE_LTO=True -DBUILD_TESTING=False -DENABLE_ASSERTIONS=False -G Ninja"
+hostmakedepends="git pkgconf clang cmake lld llvm21-devel openssl-devel nasm
+	python3-setuptools squashfs-tools squashfuse erofs-utils qt6-declarative qt6-declarative-devel"
+short_desc="Fast usermode x86 and x86-64 emulator for ARM64 Linux"
+maintainer="Kira T. Patton <roundduckkira@protonmail.com>"
+license="MIT"
+homepage="https://fex-emu.com"
+changelog="https://github.com/FEX-Emu/FEX/releases/tag/FEX-${version}"
+distfiles="https://github.com/FEX-Emu/FEX.git"
+do_fetch() {
+	git clone --branch "FEX-${version}" --recurse-submodules ${distfiles} ${wrksrc}
+}
+do_extract() {
+	cd ${wrksrc}
+}
+post_install() {
+	vlicense ${wrksrc}/LICENSE
+}

--- a/srcpkgs/libkrun/template
+++ b/srcpkgs/libkrun/template
@@ -1,0 +1,16 @@
+# Template file for 'libkrun'
+pkgname=libkrun
+version=1.19.3
+revision=1
+build_style=gnu-makefile
+make_build_args="GPU=1 BLK=1 NET=1"
+make_install_args="GPU=1 BLK=1 NET=1"
+hostmakedepends="clang21-devel clang21-headers pkg-config libclang patchelf rust cargo virglrenderer-devel libkrunfw"
+depends="libkrunfw"
+short_desc="Dynamic library providing Virtualization-based process isolation"
+maintainer="Kira T. Patton <roundduckkira@protonmail.com>"
+license="Apache-2.0"
+homepage="https://github.com/libkrun/libkrun/"
+changelog="https://github.com/libkrun/libkrun/releases/tag/v${version}"
+distfiles="https://github.com/libkrun/libkrun/archive/refs/tags/v${version}.tar.gz"
+checksum=955b0d948f1d1cf315c55ea92b55d5251928e6ec6f6aa6697cea95afccd4d2b0

--- a/srcpkgs/libkrunfw/template
+++ b/srcpkgs/libkrunfw/template
@@ -1,0 +1,15 @@
+# Template file for 'libkrunfw'
+pkgname=libkrunfw
+version=5.5.0
+revision=1
+build_style=gnu-makefile
+hostmakedepends="tar xz bc elfutils-devel flex gmp-devel kmod libmpc-devel \
+ pkg-config cpio openssl-devel perl pahole python3 zstd \
+ curl python3-pyelftools"
+short_desc="Dynamic library bundling the guest payload consumed by libkrun"
+maintainer="Kira T. Patton <roundduckkira@protonmail.com>"
+license="GPL-2.0-only"
+homepage="https://github.com/libkrun/libkrunfw/"
+changelog="https://github.com/libkrun/libkrunfw/releases/tag/v${version}"
+distfiles="https://github.com/libkrun/libkrunfw/archive/refs/tags/v${version}.tar.gz"
+checksum=b0cbf1450269c80aea1dccbf440011deb2762a098b338c234079a6ef06456ead

--- a/srcpkgs/libkrunfw/template
+++ b/srcpkgs/libkrunfw/template
@@ -3,7 +3,7 @@ pkgname=libkrunfw
 version=5.5.0
 revision=1
 build_style=gnu-makefile
-hostmakedepends="tar xz bc elfutils-devel linux6.18-headers flex gmp-devel kmod libmpc-devel \
+hostmakedepends="tar xz bc elfutils-devel flex gmp-devel kmod libmpc-devel \
  pkg-config cpio openssl-devel perl pahole python3 zstd \
  curl python3-pyelftools"
 short_desc="Dynamic library bundling the guest payload consumed by libkrun"

--- a/srcpkgs/libkrunfw/template
+++ b/srcpkgs/libkrunfw/template
@@ -3,7 +3,7 @@ pkgname=libkrunfw
 version=5.5.0
 revision=1
 build_style=gnu-makefile
-hostmakedepends="tar xz bc elfutils-devel flex gmp-devel kmod libmpc-devel \
+hostmakedepends="tar xz bc elfutils-devel linux6.18-headers flex gmp-devel kmod libmpc-devel \
  pkg-config cpio openssl-devel perl pahole python3 zstd \
  curl python3-pyelftools"
 short_desc="Dynamic library bundling the guest payload consumed by libkrun"

--- a/srcpkgs/libkrunfw/template
+++ b/srcpkgs/libkrunfw/template
@@ -2,14 +2,40 @@
 pkgname=libkrunfw
 version=5.5.0
 revision=1
+_kernel_version=6.12.91
 build_style=gnu-makefile
-hostmakedepends="tar xz bc elfutils-devel linux6.18-headers flex gmp-devel kmod libmpc-devel \
- pkg-config cpio openssl-devel perl pahole python3 zstd \
- curl python3-pyelftools"
+hostmakedepends="python3-pyelftools tar xz bc cpio flex perl elfutils-devel"
 short_desc="Dynamic library bundling the guest payload consumed by libkrun"
 maintainer="Kira T. Patton <roundduckkira@protonmail.com>"
-license="GPL-2.0-only"
+license="GPL-2.0-only AND LGPL-2.1-only"
 homepage="https://github.com/libkrun/libkrunfw/"
 changelog="https://github.com/libkrun/libkrunfw/releases/tag/v${version}"
-distfiles="https://github.com/libkrun/libkrunfw/archive/refs/tags/v${version}.tar.gz"
-checksum=b0cbf1450269c80aea1dccbf440011deb2762a098b338c234079a6ef06456ead
+distfiles="https://github.com/containers/libkrunfw/archive/refs/tags/v${version}.tar.gz
+ ${KERNEL_SITE}/kernel/v${_kernel_version%%.*}.x/linux-${_kernel_version}.tar.xz"
+checksum="b0cbf1450269c80aea1dccbf440011deb2762a098b338c234079a6ef06456ead
+ 0ff2ab9e169f9f1948557471fbb450d3018f8c5b77caf288e1a3982582597969"
+
+skip_extraction="linux-${_kernel_version}.tar.xz"
+
+
+do_build() {
+	local _arch _cross
+
+	case "$XBPS_TARGET_MACHINE" in
+		x86_64*) _arch=x86_64;;
+		aarch64*) _arch=arm64 ;;
+	esac
+
+	if [ "$CROSS_BUILD" ]; then
+		_cross="CROSS_COMPILE=${XBPS_CROSS_TRIPLET}-"
+	fi
+
+	export LDFLAGS=
+
+	make ARCH=$_arch ${_cross} ${makejobs}
+}
+
+post_extract() {
+	mkdir tarballs
+	vsrccopy linux-${_kernel_version}.tar.xz tarballs
+}

--- a/srcpkgs/mesa/template
+++ b/srcpkgs/mesa/template
@@ -1,7 +1,7 @@
 # Template file for 'mesa'
 pkgname=mesa
 version=26.1.4
-revision=1
+revision=2
 build_style=meson
 build_helper="qemu"
 _llvmver=21
@@ -162,13 +162,14 @@ case "$XBPS_TARGET_MACHINE" in
 		;;
 esac
 
-# x86 additionally gets intel, vmware and gallium nine
+# x86 additionally gets intel, vmware, asahi native-context (for Apple Silicon FEX support) and gallium nine
 # aarch64 also gets vmware for VMware Fusion on Apple Silicon
 # arm gets its own drivers (for mali, tegra etc.)
 case "$XBPS_TARGET_MACHINE" in
 	i686*|x86_64*)
 		_have_intel=yes
 		_have_vmware=yes
+		_have_nativeContext=yes
 		;;
 	aarch64*)
 		_have_arm=yes
@@ -244,6 +245,14 @@ if [ "$_have_arm" ]; then
 	subpackages+=" mesa-kmsro-dri mesa-v3d-dri mesa-vc4-dri"
 	subpackages+=" mesa-etnaviv-dri mesa-freedreno-dri"
 	subpackages+=" mesa-lima-dri mesa-panfrost-dri"
+fi
+
+# native context Asahi support for a future FEX Void RootFS for Asahi Linux
+if [ "$_have_nativeContext" ]; then
+	_have_vulkan=yes
+	_have_opencl=yes
+	_gallium_drivers+=",asahi"
+	_vulkan_drivers+=",asahi"
 fi
 
 if [ "$_have_virgl" ]; then

--- a/srcpkgs/muvm/template
+++ b/srcpkgs/muvm/template
@@ -1,0 +1,19 @@
+# Template file for 'muvm'
+pkgname=muvm
+version=0.6.0
+revision=1
+archs="aarch64"
+build_style=cargo
+make_install_args="--path crates/muvm"
+hostmakedepends="libkrun pkg-config llvm21-devel eudev-libudev-devel"
+depends="FEX"
+short_desc="Run x86 programs from ARM64 in a microVM"
+maintainer="Kira T. Patton <roundduckkira@protonmail.com>"
+license="MIT"
+homepage="https://github.com/AsahiLinux/muvm"
+changelog="https://github.com/AsahiLinux/muvm/releases/tag/muvm-${version}"
+distfiles="https://github.com/AsahiLinux/muvm/archive/refs/tags/muvm-${version}.tar.gz"
+checksum=7e7f10bced9f99ee7d9c4def71cb785b5f648f100971fb32868dbb7f87ab1839
+post_install() {
+	vlicense ${wrksrc}/crates/muvm/LICENSE
+}

--- a/srcpkgs/virglrenderer/template
+++ b/srcpkgs/virglrenderer/template
@@ -1,8 +1,9 @@
 # Template file for 'virglrenderer'
 pkgname=virglrenderer
 version=1.3.0
-revision=1
+revision=2
 build_style=meson
+configure_args="-D venus=true -D drm-renderers=asahi"
 hostmakedepends="pkg-config python3-yaml"
 makedepends="libepoxy-devel MesaLib-devel"
 short_desc="Virgl GL renderer library"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
#### Local build testing
- I built this PR locally for my native architecture, (aarch64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl (DOES NOT WORK due to glibc dependency in FEX)
  
  #61287 This is a rebase and resubmit of this pull request to fix linting issues and clean up the git history. Here is a screenshot of it being tested, now finally supporting venus hardware acceleration, so hopefully soon mesa's package will be changed (probably by me) to allow a FEX RootFS to be made with Asahi drivers.
<img width="1920" height="1080" alt="Screenshot_20260704_041333" src="https://github.com/user-attachments/assets/043b47bc-6bfc-4c2f-957a-346602a22655" />

