### PR TITLE
kf6 6.27 and plasma 6 7

### DIFF
--- a/common/build-style/cmake.sh
+++ b/common/build-style/cmake.sh
@@ -63,7 +63,7 @@ _EOF
 		# QT_HOST_PATH isn't enough in my system,
 		# which have binfmts support on and off
 		cmake_args+=" -DQT_HOST_PATH_CMAKE_DIR=/usr/lib/cmake"
-		cmake_args+="  -DKF6_HOST_TOOLING=/usr/lib/cmake"
+		cmake_args+=" -DKF6_HOST_TOOLING=/usr/lib/cmake"
 	fi
 
 	if [[ $build_helper = *"qemu"* ]]; then

--- a/common/hooks/pre-pkg/04-generate-runtime-deps.sh
+++ b/common/hooks/pre-pkg/04-generate-runtime-deps.sh
@@ -93,15 +93,15 @@ hook() {
     depsftmp=$(mktemp) || exit 1
     find ${PKGDESTDIR} -type f -perm -u+w > $depsftmp 2>/dev/null
 
-    for f in ${shlib_requires}; do
-        verify_deps+=" ${f}"
-    done
-
     _shlibtmp=$(mktemp) || exit 1
     parse_shlib_needed 3>&1 >"$_shlibtmp" <"$depsftmp"
     rm -f "$depsftmp"
     verify_deps=$(sort <"$_shlibtmp" | uniq)
     rm -f "$_shlibtmp"
+
+    for f in ${shlib_requires}; do
+        verify_deps+=" ${f}"
+    done
 
     #
     # Add required run time packages by using required shlibs resolved

--- a/common/shlibs
+++ b/common/shlibs
@@ -1987,6 +1987,7 @@ libKF6Syndication.so.6 kf6-syndication-6.19.0_1
 libKF6SyntaxHighlighting.so.6 kf6-syntax-highlighting-6.19.0_1
 libKF6ThreadWeaver.so.6 kf6-threadweaver-6.19.0_1
 # KDE Plasma
+KDE_Plasma.6.7.3 kde-plasma-base-6.7.3_1
 libKQuickImageEditor.so.1 kquickimageeditor-0.6.0_1
 libKNightTime.so.0 knighttime-6.5.1_1
 libklookandfeel.so.6 plasma-workspace-6.5.1_1

--- a/common/shlibs
+++ b/common/shlibs
@@ -1887,6 +1887,7 @@ libqwt-qt5.so.6.3 qwt-6.3.0_1
 libqwt-qt6.so.6.3 qwt-qt6-6.3.0_1
 
 # KDE6 plasma-frameworks
+KDE_Frameworks.6.28.0 kf6-base-6.28.0_1
 libKF6BreezeIcons.so.6 libbreeze-icons-6.19.0_1
 libKF6Attica.so.6 kf6-attica-6.19.0_1
 libKF6Baloo.so.6 kf6-baloo-6.19.0_1

--- a/common/shlibs
+++ b/common/shlibs
@@ -2000,7 +2000,7 @@ libKGlobalAccelD.so.0 kglobalacceld-6.5.1_1
 libKScreenLocker.so.6 kscreenlocker-6.5.1_1
 libKSysGuardFormatter.so.2 libksysguard-6.5.1_1
 libKSysGuardSensorFaces.so.2 libksysguard-6.5.1_1
-libprocesscore.so.10 libksysguard-6.5.1_1
+libprocesscore.so.11 libksysguard-6.7.3_1
 libKSysGuardSystemStats.so.2 libksysguard-6.5.1_1
 libKSysGuardSensors.so.2 libksysguard-6.5.1_1
 libkworkspace6.so.6 kworkspace-6.5.1_1

--- a/srcpkgs/akonadi-calendar/template
+++ b/srcpkgs/akonadi-calendar/template
@@ -3,7 +3,7 @@ pkgname=akonadi-calendar
 version=26.04.1
 revision=1
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="-DBUILD_TESTING=OFF
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins
  -DKDE_INSTALL_QMLDIR=lib/qt6/qml
  -DECM_MKSPECS_INSTALL_DIR=/usr/lib/qt6/mkspecs/modules"

--- a/srcpkgs/akonadi-contacts/template
+++ b/srcpkgs/akonadi-contacts/template
@@ -3,7 +3,7 @@ pkgname=akonadi-contacts
 version=26.04.1
 revision=1
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="-DBUILD_TESTING=OFF
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins
  -DKDE_INSTALL_QMLDIR=lib/qt6/qml
  -DECM_MKSPECS_INSTALL_DIR=/usr/lib/qt6/mkspecs/modules"

--- a/srcpkgs/akonadi-import-wizard/template
+++ b/srcpkgs/akonadi-import-wizard/template
@@ -3,7 +3,7 @@ pkgname=akonadi-import-wizard
 version=26.04.1
 revision=1
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="-DBUILD_TESTING=OFF
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins
  -DKDE_INSTALL_QMLDIR=lib/qt6/qml
  -DECM_MKSPECS_INSTALL_DIR=/usr/lib/qt6/mkspecs/modules"

--- a/srcpkgs/akonadi-mime/template
+++ b/srcpkgs/akonadi-mime/template
@@ -3,7 +3,7 @@ pkgname=akonadi-mime
 version=26.04.1
 revision=1
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="-DBUILD_TESTING=OFF
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins
  -DKDE_INSTALL_QMLDIR=lib/qt6/qml
  -DECM_MKSPECS_INSTALL_DIR=/usr/lib/qt6/mkspecs/modules"

--- a/srcpkgs/akonadi-notes/template
+++ b/srcpkgs/akonadi-notes/template
@@ -3,7 +3,7 @@ pkgname=akonadi-notes
 version=24.08.3
 revision=1
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="-DBUILD_TESTING=OFF
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins
  -DKDE_INSTALL_QMLDIR=lib/qt6/qml
  -DECM_MKSPECS_INSTALL_DIR=/usr/lib/qt6/mkspecs/modules"

--- a/srcpkgs/akonadi-search/template
+++ b/srcpkgs/akonadi-search/template
@@ -4,7 +4,7 @@ version=26.04.1
 revision=1
 build_style=cmake
 build_helper="rust"
-configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="-DBUILD_TESTING=OFF
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins
  -DKDE_INSTALL_QMLDIR=lib/qt6/qml
  -DECM_MKSPECS_INSTALL_DIR=/usr/lib/qt6/mkspecs/modules"

--- a/srcpkgs/akregator/template
+++ b/srcpkgs/akregator/template
@@ -3,7 +3,7 @@ pkgname=akregator
 version=26.04.1
 revision=1
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="-DBUILD_TESTING=OFF
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins
  -DKDE_INSTALL_QMLDIR=lib/qt6/qml
  -DECM_MKSPECS_INSTALL_DIR=/usr/lib/qt6/mkspecs/modules"

--- a/srcpkgs/ark/template
+++ b/srcpkgs/ark/template
@@ -3,7 +3,7 @@ pkgname=ark
 version=26.04.1
 revision=1
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="-DBUILD_TESTING=OFF
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins"
 hostmakedepends="extra-cmake-modules qt6-base gettext
  kf6-kdoctools kf6-kconfig pkg-config python3 kf6-kcoreaddons"

--- a/srcpkgs/audex/template
+++ b/srcpkgs/audex/template
@@ -3,7 +3,7 @@ pkgname=audex
 version=26.04.1
 revision=1
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="-DBUILD_TESTING=OFF
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins -DQT_MAJOR_VERSION=6
  -DKDE_INSTALL_QMLDIR=lib/qt6/qml
  -DECM_MKSPECS_INSTALL_DIR=/usr/lib/qt6/mkspecs/modules"

--- a/srcpkgs/aurorae/template
+++ b/srcpkgs/aurorae/template
@@ -1,12 +1,13 @@
 # Template file for 'aurorae'
+# group=kde-plasma
 pkgname=aurorae
-version=6.6.3
+version=6.7.3
 revision=1
 build_style=cmake
 configure_args="-DKDE_INSTALL_QMLDIR=lib/qt6/qml
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins"
 hostmakedepends="extra-cmake-modules gettext qt6-base qt6-tools
- kf6-kcmutils kf6-kpackage kf6-kconfig"
+ kf6-kcmutils kf6-kpackage kf6-kconfig qt6-declarative-host-tools"
 makedepends="kf6-kconfig-devel kf6-ki18n-devel kf6-kcmutils-devel
  kf6-kpackage-devel kf6-kcoreaddons-devel kf6-kcolorscheme-devel
  kf6-knewstuff-devel kf6-kdecoration-devel kf6-ksvg-devel qt6-tools-devel"
@@ -15,4 +16,8 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.0-or-later"
 homepage="https://invent.kde.org/plasma/aurorae"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=2a196fea76980f20b53bbd94f5ef7a6b5ee08b68ba7a1a5917a780b789c57e91
+checksum=a7953e8c65ca653a01025f76aa06cec13c40999665f79251f006f6f01248ecec
+
+# stage builds
+makedepends+=" kde-plasma-base"
+shlib_requires="KDE_Plasma.${version}"

--- a/srcpkgs/better-blur-dx-x11
+++ b/srcpkgs/better-blur-dx-x11
@@ -1,0 +1,1 @@
+better-blur-dx

--- a/srcpkgs/better-blur-dx/template
+++ b/srcpkgs/better-blur-dx/template
@@ -1,9 +1,9 @@
 # Template file for 'better-blur-dx'
 pkgname=better-blur-dx
-version=2.4.1
+version=2.5.1
 revision=1
 build_style=cmake
-configure_args="-DFORCE_CROSSCOMPILED_TOOLS=ON
+configure_args="
  -DKDE_INSTALL_QMLDIR=lib/qt6/qml -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins"
 hostmakedepends="extra-cmake-modules gettext pkg-config qt6-base qt6-tools
  kf6-kconfig kf6-kcmutils"
@@ -19,4 +19,25 @@ maintainer="Cass Spencer <casscardboard@gmail.com>"
 license="GPL-3.0-or-later"
 homepage="https://github.com/xarblu/kwin-effects-better-blur-dx"
 distfiles="${homepage}/archive/refs/tags/v${version}.tar.gz"
-checksum=e039cdfce81d93761bcf2baeade9d1b2ba83a899ec2954ddf62760a758bf7905
+checksum=42152f040434f0adfef55eab510000a5fc00b0afe1935e0dc6f01c766b4c9dbb
+
+post_configure() {
+	configure_args+=" -DBETTERBLUR_X11=ON"
+	cmake_builddir=build-x11 do_configure
+}
+
+post_build() {
+	cmake_builddir=build-x11 do_build
+}
+
+post_install() {
+	cmake_builddir=build-x11 do_install
+}
+
+better-blur-dx-x11_package() {
+	depends="plasma-desktop>=6.5.0"
+	short_desc+=" - X11 version"
+	pkg_install() {
+		vmove usr/lib/qt6/plugins/kwin-x11
+	}
+}

--- a/srcpkgs/better-blur-dx/template
+++ b/srcpkgs/better-blur-dx/template
@@ -3,7 +3,7 @@ pkgname=better-blur-dx
 version=2.4.1
 revision=1
 build_style=cmake
-configure_args="-DFORCE_CROSSCOMPILED_TOOLS=ON -DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="-DFORCE_CROSSCOMPILED_TOOLS=ON
  -DKDE_INSTALL_QMLDIR=lib/qt6/qml -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins"
 hostmakedepends="extra-cmake-modules gettext pkg-config qt6-base qt6-tools
  kf6-kconfig kf6-kcmutils"

--- a/srcpkgs/bluedevil/template
+++ b/srcpkgs/bluedevil/template
@@ -1,9 +1,10 @@
 # Template file for 'bluedevil'
+# group=kde-plasma
 pkgname=bluedevil
-version=6.6.3
-revision=2
+version=6.7.3
+revision=1
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="-DBUILD_TESTING=OFF
  -DKDE_INSTALL_QMLDIR=lib/qt6/qml -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins"
 hostmakedepends="extra-cmake-modules qt6-base qt6-tools gettext
  qt6-declarative-host-tools kf6-kcmutils kf6-kpackage"
@@ -18,4 +19,8 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later, LGPL-2.1-or-later"
 homepage="https://invent.kde.org/plasma/bluedevil"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=8d8a362b7f0740dba006159ccd2f84c2e32a10cf3f5a1afe3b69db045ec5f358
+checksum=f1c89042b5139a2c6f5c68c574c883fd3fb4259af8c07dac966cfc65e193dcd1
+
+# stage builds
+makedepends+=" kde-plasma-base"
+shlib_requires="KDE_Plasma.${version}"

--- a/srcpkgs/bovo/template
+++ b/srcpkgs/bovo/template
@@ -3,7 +3,6 @@ pkgname=bovo
 version=26.04.1
 revision=1
 build_style=cmake
-configure_args="-DKF6_HOST_TOOLING=/usr/lib/cmake"
 hostmakedepends="extra-cmake-modules gettext kf6-kconfig kf6-kcoreaddons
  kf6-kdoctools qt6-base"
 makedepends="kf6-kcoreaddons-devel kf6-kcrash-devel kf6-kdbusaddons-devel

--- a/srcpkgs/breeze-gtk/template
+++ b/srcpkgs/breeze-gtk/template
@@ -1,6 +1,7 @@
 # Template file for 'breeze-gtk'
+# group=kde-plasma
 pkgname=breeze-gtk
-version=6.6.3
+version=6.7.3
 revision=1
 build_style=cmake
 hostmakedepends="extra-cmake-modules sassc python3 python3-cairo
@@ -11,4 +12,8 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/plasma/breeze-gtk"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=32e2e5947d5d26c1ae2020feca79302d2eea54bce655a6596dd34df5656e5e8d
+checksum=fa93b6819dc5e4acb6e96ec0dbb3d4de7eebff2f1de480be01776a80107a087b
+
+# stage builds
+makedepends+=" kde-plasma-base"
+shlib_requires="KDE_Plasma.${version}"

--- a/srcpkgs/breeze-icons/template
+++ b/srcpkgs/breeze-icons/template
@@ -1,6 +1,7 @@
 # Template file for 'breeze-icons'
+# group=kde-frameworks
 pkgname=breeze-icons
-version=6.25.0
+version=6.28.0
 revision=1
 build_style=cmake
 configure_args="-DINSTALL_HOST_TOOLS=ON"
@@ -12,7 +13,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-3.0-or-later"
 homepage="https://community.kde.org/Frameworks"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname}-${version}.tar.xz"
-checksum=2188492d83ead80cae83cbb0db80cac0b55388ea2e3e02d436354b6ca2559d0c
+checksum=45de8138ead0f3ff24de886fbe61d588ecd7f66dde6f8cf6f2906279254d094d
 nostrip=yes
 
 if [ -z "$CROSS_BUILD" ]; then

--- a/srcpkgs/breeze-qt5/template
+++ b/srcpkgs/breeze-qt5/template
@@ -1,6 +1,7 @@
 # Template file for 'breeze-qt5'
+# group=kde-plasma
 pkgname=breeze-qt5
-version=6.6.3
+version=6.7.3
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF -DBUILD_QT6=OFF -DKF5_HOST_TOOLING=/usr/lib/cmake"
@@ -13,8 +14,12 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later"
 homepage="https://invent.kde.org/plasma/breeze"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname%-qt5}-${version}.tar.xz"
-checksum=31826f094a447873c24b01c67392f96f0135a404cc219c4b969391a22ddd31dd
+checksum=d853fc45a43e64ee6d901860b19e78a50c8a03cfe9127f2a5781d50f13ffe838
 replaces="breeze<6.0.0_1"
+
+# stage builds
+makedepends+=" kde-plasma-base"
+shlib_requires="KDE_Plasma.${version}"
 
 post_install() {
 	rm -rf ${DESTDIR}/usr/share

--- a/srcpkgs/breeze-qt6/template
+++ b/srcpkgs/breeze-qt6/template
@@ -1,6 +1,7 @@
 # Template file for 'breeze-qt6'
+# group=kde-plasma
 pkgname=breeze-qt6
-version=6.6.3
+version=6.7.3
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF -DBUILD_QT5=OFF
@@ -18,5 +19,9 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later"
 homepage="https://invent.kde.org/plasma/breeze"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname%-qt6}-${version}.tar.xz"
-checksum=31826f094a447873c24b01c67392f96f0135a404cc219c4b969391a22ddd31dd
+checksum=d853fc45a43e64ee6d901860b19e78a50c8a03cfe9127f2a5781d50f13ffe838
 replaces="breeze<6.0.0_1 breeze-snow-cursor-theme>=0"
+
+# stage builds
+makedepends+=" kde-plasma-base"
+shlib_requires="KDE_Plasma.${version}"

--- a/srcpkgs/breeze/template
+++ b/srcpkgs/breeze/template
@@ -1,9 +1,10 @@
 # Template file for 'breeze'
+# group=kde-plasma
 pkgname=breeze
-version=6.1.1
+version=6.7.3
 revision=1
 metapackage=yes
-depends="breeze-icons breeze-qt5 breeze-qt6"
+depends="breeze-icons breeze-qt5 breeze-qt6 qqc2-breeze-style"
 short_desc="Breeze visual style for the Plasma Desktop"
 maintainer="John <me@johnnynator.dev>"
 license="Public Domain"

--- a/srcpkgs/calendarsupport/template
+++ b/srcpkgs/calendarsupport/template
@@ -3,7 +3,7 @@ pkgname=calendarsupport
 version=26.04.1
 revision=1
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="-DBUILD_TESTING=OFF
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins
  -DKDE_INSTALL_QMLDIR=lib/qt6/qml
  -DECM_MKSPECS_INSTALL_DIR=/usr/lib/qt6/mkspecs/modules"

--- a/srcpkgs/colord-kde/template
+++ b/srcpkgs/colord-kde/template
@@ -3,7 +3,7 @@ pkgname=colord-kde
 version=26.04.1
 revision=1
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="-DBUILD_TESTING=OFF
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins"
 hostmakedepends="kf6-kcoreaddons-devel extra-cmake-modules gettext
  pkg-config qt6-declarative-host-tools qt6-base-devel kf6-kpackage

--- a/srcpkgs/digikam/template
+++ b/srcpkgs/digikam/template
@@ -3,7 +3,7 @@ pkgname=digikam
 version=9.1.0
 revision=3
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="-DBUILD_TESTING=OFF
  -DENABLE_AKONADICONTACTSUPPORT=ON -DENABLE_KFILEMETADATASUPPORT=ON
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins -DBUILD_WITH_QT6=ON
  -DKDE_INSTALL_QMLDIR=lib/qt6/qml

--- a/srcpkgs/discover/template
+++ b/srcpkgs/discover/template
@@ -1,9 +1,10 @@
 # Template file for 'discover'
+# group=kde-plasma
 pkgname=discover
-version=6.6.5
+version=6.7.3
 revision=1
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake"
+configure_args="-DBUILD_TESTING=OFF"
 hostmakedepends="extra-cmake-modules pkg-config qt6-base-devel qt6-tools
  kf6-kcoreaddons-devel kf6-kdoctools-devel gettext kf6-kconfig-devel
  kf6-kcmutils kf6-kauth-tools kf6-kitemmodels"
@@ -21,4 +22,8 @@ maintainer="1is7ac3 <isaac.qa13@gmail.com>"
 license="GPL-2.0-or-later"
 homepage="https://apps.kde.org/discover"
 distfiles="${KDE_SITE}/plasma/${version}/discover-${version}.tar.xz"
-checksum=0d1471adf4b0b3bf92ac93225e2e4860493677f3fb9a02dbf44b193ae7c15357
+checksum=f28c47569ddffd95c1095ea6c73cfe01a6943bbb3be5d8158d5431c443439f1c
+
+# stage builds
+makedepends+=" kde-plasma-base"
+shlib_requires="KDE_Plasma.${version}"

--- a/srcpkgs/dolphin-plugins/template
+++ b/srcpkgs/dolphin-plugins/template
@@ -3,7 +3,7 @@ pkgname=dolphin-plugins
 version=26.04.1
 revision=1
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="-DBUILD_TESTING=OFF
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins"
 hostmakedepends="extra-cmake-modules gettext qt6-base qt6-tools kf6-kcoreaddons
  kf6-kconfig"

--- a/srcpkgs/dolphin/template
+++ b/srcpkgs/dolphin/template
@@ -3,7 +3,7 @@ pkgname=dolphin
 version=26.04.1
 revision=2
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="-DBUILD_TESTING=OFF
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins"
 hostmakedepends="extra-cmake-modules python3 qt6-tools qt6-base
  gettext kf6-kcoreaddons kf6-kconfig kf6-kdoctools kf6-kcmutils"

--- a/srcpkgs/dragon-player/template
+++ b/srcpkgs/dragon-player/template
@@ -3,7 +3,7 @@ pkgname=dragon-player
 version=26.04.1
 revision=2
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="-DBUILD_TESTING=OFF
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins
  -DKDE_INSTALL_QMLDIR=lib/qt6/qml"
 hostmakedepends="extra-cmake-modules pkg-config qt6-base qt6-tools

--- a/srcpkgs/drawy/template
+++ b/srcpkgs/drawy/template
@@ -3,7 +3,7 @@ pkgname=drawy
 version=1.0.2
 revision=1
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="-DBUILD_TESTING=OFF
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins
  -DKDE_INSTALL_QMLDIR=lib/qt6/qml
  -DECM_MKSPECS_INSTALL_DIR=/usr/lib/qt6/mkspecs/modules"

--- a/srcpkgs/elisa/template
+++ b/srcpkgs/elisa/template
@@ -3,7 +3,7 @@ pkgname=elisa
 version=26.04.1
 revision=2
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="-DBUILD_TESTING=OFF
  -DKDE_INSTALL_QMLDIR=lib/qt6/qml -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins"
 hostmakedepends="extra-cmake-modules kf6-kdoctools gettext qt6-base qt6-tools
  kf6-kpackage kf6-kconfig kf6-kcoreaddons kf6-kcmutils qt6-declarative-host-tools

--- a/srcpkgs/eventviews/template
+++ b/srcpkgs/eventviews/template
@@ -3,7 +3,7 @@ pkgname=eventviews
 version=26.04.1
 revision=1
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="-DBUILD_TESTING=OFF
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins
  -DKDE_INSTALL_QMLDIR=lib/qt6/qml
  -DECM_MKSPECS_INSTALL_DIR=/usr/lib/qt6/mkspecs/modules"

--- a/srcpkgs/extra-cmake-modules/template
+++ b/srcpkgs/extra-cmake-modules/template
@@ -1,6 +1,7 @@
 # Template file for 'extra-cmake-modules'
+# group=kde-frameworks
 pkgname=extra-cmake-modules
-version=6.27.0
+version=6.28.0
 revision=1
 build_style=cmake
 configure_args="-DBUILD_HTML_DOCS=ON -DBUILD_TESTING=ON"
@@ -12,7 +13,7 @@ maintainer="John <me@johnnynator.dev>"
 license="BSD-3-Clause"
 homepage="https://invent.kde.org/frameworks/extra-cmake-modules"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname}-${version}.tar.xz"
-checksum=f3b5af578017a6a0f127fb1c31609db2e4f016e99b900d5a11f6ffb6c55006a3
+checksum=a32e24b267e8528d0253bc8df18bdc00e676560a43b796533e1b1406f4eef4db
 python_version=3
 
 do_check() {

--- a/srcpkgs/fcitx5-configtool/template
+++ b/srcpkgs/fcitx5-configtool/template
@@ -4,7 +4,7 @@ version=5.1.13
 revision=1
 build_style=cmake
 configure_args="-DENABLE_KCM=ON -DENABLE_CONFIG_QT=ON -DENABLE_TEST=ON
- -DKF6_HOST_TOOLING=/usr/lib/cmake -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins"
+ -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins"
 hostmakedepends="cldr-emoji-annotation pkg-config gettext doxygen
  extra-cmake-modules glib-devel qt6-base xkeyboard-config iso-codes
  AppStream kf6-kcoreaddons kf6-kpackage kf6-kcmutils"

--- a/srcpkgs/ffmpegthumbs/template
+++ b/srcpkgs/ffmpegthumbs/template
@@ -3,7 +3,7 @@ pkgname=ffmpegthumbs
 version=26.04.1
 revision=1
 build_style=cmake
-configure_args="-DQT_MAJOR_VERSION=6 -DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="-DQT_MAJOR_VERSION=6
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins"
 hostmakedepends="extra-cmake-modules pkg-config gettext qt6-base
  kf6-kconfig"

--- a/srcpkgs/filelight/template
+++ b/srcpkgs/filelight/template
@@ -3,7 +3,7 @@ pkgname=filelight
 version=26.04.1
 revision=1
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="-DBUILD_TESTING=OFF
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins"
 hostmakedepends="extra-cmake-modules gettext kf6-kcoreaddons kf6-kdoctools
  kf6-kpackage qt6-base qt6-tools kf6-kconfig qt6-declarative-host-tools"

--- a/srcpkgs/flatpak-kcm/template
+++ b/srcpkgs/flatpak-kcm/template
@@ -1,9 +1,10 @@
 # Template file for 'flatpak-kcm'
+# group=kde-plasma
 pkgname=flatpak-kcm
-version=6.6.3
+version=6.7.3
 revision=1
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="-DBUILD_TESTING=OFF
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins"
 hostmakedepends="extra-cmake-modules pkg-config qt6-base gettext
  kf6-kconfig kf6-kcmutils kf6-kpackage"
@@ -16,4 +17,8 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later, LGPL-2.1-or-later"
 homepage="https://invent.kde.org/plasma/flatpak-kcm"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=946bb718adae43a5ac7598199eda087a74dcec4cc8d78ecc45aabad2c16a6189
+checksum=003766fec79807f86dc3d504bf888da9d371ebb8dd0ae9280df9b38ed053fed2
+
+# stage builds
+makedepends+=" kde-plasma-base"
+shlib_requires="KDE_Plasma.${version}"

--- a/srcpkgs/gwenview/template
+++ b/srcpkgs/gwenview/template
@@ -3,7 +3,7 @@ pkgname=gwenview
 version=26.04.3
 revision=1
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="-DBUILD_TESTING=OFF
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins"
 hostmakedepends="extra-cmake-modules pkg-config gettext qt6-base
  qt6-tools python3 kf6-kdoctools kf6-kconfig kf6-kcoreaddons

--- a/srcpkgs/haruna/template
+++ b/srcpkgs/haruna/template
@@ -3,7 +3,7 @@ pkgname=haruna
 version=1.8.1
 revision=3
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="-DBUILD_TESTING=OFF
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins
  -DKDE_INSTALL_QMLDIR=lib/qt6/qml"
 hostmakedepends="extra-cmake-modules gettext pkg-config qt6-base qt6-tools"

--- a/srcpkgs/incidenceeditor/template
+++ b/srcpkgs/incidenceeditor/template
@@ -3,7 +3,7 @@ pkgname=incidenceeditor
 version=26.04.1
 revision=1
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="-DBUILD_TESTING=OFF
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins
  -DKDE_INSTALL_QMLDIR=lib/qt6/qml
  -DECM_MKSPECS_INSTALL_DIR=/usr/lib/qt6/mkspecs/modules"

--- a/srcpkgs/juk/template
+++ b/srcpkgs/juk/template
@@ -3,7 +3,7 @@ pkgname=juk
 version=26.04.1
 revision=1
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="-DBUILD_TESTING=OFF
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins"
 hostmakedepends="extra-cmake-modules pkg-config qt6-base qt6-tools
  kf6-kcoreaddons kf6-kdoctools gettext kf6-kconfig"

--- a/srcpkgs/k3b/template
+++ b/srcpkgs/k3b/template
@@ -3,7 +3,7 @@ pkgname=k3b
 version=26.04.1
 revision=1
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="-DBUILD_TESTING=OFF
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins -DQT_MAJOR_VERSION=6
  -DKDE_INSTALL_QMLDIR=lib/qt6/qml
  -DECM_MKSPECS_INSTALL_DIR=/usr/lib/qt6/mkspecs/modules"

--- a/srcpkgs/kactivitymanagerd/template
+++ b/srcpkgs/kactivitymanagerd/template
@@ -1,7 +1,8 @@
 # Template file for 'kactivitymanagerd'
+# group=kde-plasma
 pkgname=kactivitymanagerd
-version=6.6.3
-revision=2
+version=6.7.3
+revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins"
 hostmakedepends="extra-cmake-modules gettext qt6-base qt6-tools kf6-kconfig"
@@ -12,4 +13,8 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later"
 homepage="https://invent.kde.org/plasma/kactivitymanagerd"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=858bea71cc64bb2922ef06d5c125b5addaea2d8c095bf3dc8875a25f5b8c3341
+checksum=5336d9addebc89e85d3b613ff1136c7c842f74ca986dd1d46c0a2f7733dc095a
+
+# stage builds
+makedepends+=" kde-plasma-base"
+shlib_requires="KDE_Plasma.${version}"

--- a/srcpkgs/kaddressbook/template
+++ b/srcpkgs/kaddressbook/template
@@ -3,7 +3,7 @@ pkgname=kaddressbook
 version=26.04.1
 revision=1
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="-DBUILD_TESTING=OFF
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins
  -DKDE_INSTALL_QMLDIR=lib/qt6/qml
  -DECM_MKSPECS_INSTALL_DIR=/usr/lib/qt6/mkspecs/modules"

--- a/srcpkgs/kalarm/template
+++ b/srcpkgs/kalarm/template
@@ -3,7 +3,7 @@ pkgname=kalarm
 version=26.04.1
 revision=1
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="-DBUILD_TESTING=OFF
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins
  -DKDE_INSTALL_QMLDIR=lib/qt6/qml
  -DECM_MKSPECS_INSTALL_DIR=/usr/lib/qt6/mkspecs/modules"

--- a/srcpkgs/kamera/template
+++ b/srcpkgs/kamera/template
@@ -3,7 +3,7 @@ pkgname=kamera
 version=26.04.1
 revision=1
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="-DBUILD_TESTING=OFF
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins
  -DKDE_INSTALL_QMLDIR=lib/qt6/qml
  -DECM_MKSPECS_INSTALL_DIR=/usr/lib/qt6/mkspecs/modules"

--- a/srcpkgs/kamoso/template
+++ b/srcpkgs/kamoso/template
@@ -3,7 +3,7 @@ pkgname=kamoso
 version=26.04.1
 revision=1
 build_style=cmake
-configure_args="-DKF6_HOST_TOOLING=/usr/lib/cmake -DKDE_INSTALL_QMLDIR=lib/qt6/qml"
+configure_args="-DKDE_INSTALL_QMLDIR=lib/qt6/qml"
 hostmakedepends="boost extra-cmake-modules gettext pkg-config python3 qt6-tools qt6-base
  kf6-kconfig kf6-kdoctools"
 makedepends="gst-plugins-base1-devel gst-plugins-bad1-devel gstreamer1-devel

--- a/srcpkgs/kapman/template
+++ b/srcpkgs/kapman/template
@@ -3,7 +3,7 @@ pkgname=kapman
 version=26.04.1
 revision=1
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="-DBUILD_TESTING=OFF
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins
  -DKDE_INSTALL_QMLDIR=lib/qt6/qml
  -DECM_MKSPECS_INSTALL_DIR=/usr/lib/qt6/mkspecs/modules"

--- a/srcpkgs/kasts/template
+++ b/srcpkgs/kasts/template
@@ -3,7 +3,7 @@ pkgname=kasts
 version=26.04.1
 revision=2
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="-DBUILD_TESTING=OFF
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins
  -DKDE_INSTALL_QMLDIR=lib/qt6/qml
  -DECM_MKSPECS_INSTALL_DIR=/usr/lib/qt6/mkspecs/modules"

--- a/srcpkgs/kate/template
+++ b/srcpkgs/kate/template
@@ -3,7 +3,7 @@ pkgname=kate
 version=26.04.1
 revision=2
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="-DBUILD_TESTING=OFF
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins"
 hostmakedepends="extra-cmake-modules pkg-config gettext qt6-tools qt6-base
  kf6-kconfig kf6-kdoctools"

--- a/srcpkgs/kblocks/template
+++ b/srcpkgs/kblocks/template
@@ -3,7 +3,7 @@ pkgname=kblocks
 version=26.04.1
 revision=1
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="-DBUILD_TESTING=OFF
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins
  -DKDE_INSTALL_QMLDIR=lib/qt6/qml
  -DECM_MKSPECS_INSTALL_DIR=/usr/lib/qt6/mkspecs/modules"

--- a/srcpkgs/kbounce/template
+++ b/srcpkgs/kbounce/template
@@ -3,7 +3,7 @@ pkgname=kbounce
 version=26.04.1
 revision=1
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="-DBUILD_TESTING=OFF
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins
  -DKDE_INSTALL_QMLDIR=lib/qt6/qml
  -DECM_MKSPECS_INSTALL_DIR=/usr/lib/qt6/mkspecs/modules"

--- a/srcpkgs/kbreakout/template
+++ b/srcpkgs/kbreakout/template
@@ -3,7 +3,7 @@ pkgname=kbreakout
 version=26.04.1
 revision=1
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="-DBUILD_TESTING=OFF
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins
  -DKDE_INSTALL_QMLDIR=lib/qt6/qml
  -DECM_MKSPECS_INSTALL_DIR=/usr/lib/qt6/mkspecs/modules"

--- a/srcpkgs/kcachegrind/template
+++ b/srcpkgs/kcachegrind/template
@@ -3,7 +3,7 @@ pkgname=kcachegrind
 version=26.04.1
 revision=1
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="-DBUILD_TESTING=OFF
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins"
 hostmakedepends="extra-cmake-modules gettext kf6-kcoreaddons kf6-kdoctools kf6-kconfig
  pkg-config qt6-tools qt6-base"

--- a/srcpkgs/kcalc/template
+++ b/srcpkgs/kcalc/template
@@ -3,7 +3,7 @@ pkgname=kcalc
 version=26.04.1
 revision=1
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="-DBUILD_TESTING=OFF
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins
  -DKDE_INSTALL_QMLDIR=lib/qt6/qml
  -DECM_MKSPECS_INSTALL_DIR=/usr/lib/qt6/mkspecs/modules"

--- a/srcpkgs/kcalutils/template
+++ b/srcpkgs/kcalutils/template
@@ -3,7 +3,7 @@ pkgname=kcalutils
 version=26.04.1
 revision=1
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="-DBUILD_TESTING=OFF
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins
  -DKDE_INSTALL_QMLDIR=lib/qt6/qml
  -DECM_MKSPECS_INSTALL_DIR=/usr/lib/qt6/mkspecs/modules"

--- a/srcpkgs/kcharselect/template
+++ b/srcpkgs/kcharselect/template
@@ -3,7 +3,7 @@ pkgname=kcharselect
 version=26.04.1
 revision=1
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="-DBUILD_TESTING=OFF
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins"
 hostmakedepends="extra-cmake-modules kf6-kcoreaddons gettext qt6-base qt6-tools
  kf6-kconfig kf6-kdoctools python3"

--- a/srcpkgs/kclock/template
+++ b/srcpkgs/kclock/template
@@ -3,7 +3,7 @@ pkgname=kclock
 version=26.04.1
 revision=2
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="-DBUILD_TESTING=OFF
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins
  -DKDE_INSTALL_QMLDIR=lib/qt6/qml"
 hostmakedepends="extra-cmake-modules gettext pkg-config qt6-base qt6-tools"

--- a/srcpkgs/kcm-wacomtablet/template
+++ b/srcpkgs/kcm-wacomtablet/template
@@ -1,10 +1,10 @@
 # Template file for 'kcm-wacomtablet'
+# group=kde-plasma
 pkgname=kcm-wacomtablet
-version=6.6.3
-revision=2
+version=6.7.3
+revision=1
 build_style=cmake
-configure_args="-DKF6_HOST_TOOLING=/usr/lib/cmake
- -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins"
+configure_args="-DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins"
 hostmakedepends="pkg-config gettext extra-cmake-modules qt6-base qt6-tools
  kf6-kwindowsystem kf6-kcmutils kf6-kpackage kf6-kconfig kf6-kdoctools"
 makedepends="qt6-declarative-devel plasma-workspace-devel libwacom-devel
@@ -22,7 +22,11 @@ maintainer="Piraty <mail@piraty.dev>"
 license="GPL-2.0-or-later"
 homepage="https://invent.kde.org/plasma/wacomtablet"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname#kcm-}-${version}.tar.xz"
-checksum=74e9c6dafa85258c99323dd5338653a899037b333f5ac91c0df4c42340ea7ab3
+checksum=c8faf17d762a5541edf1f2aaa18f71217050bd70f36b9fa710df05192ee15ef2
+
+# stage builds
+makedepends+=" kde-plasma-base"
+shlib_requires="KDE_Plasma.${version}"
 
 do_check() {
 	cd build

--- a/srcpkgs/kcolorchooser/template
+++ b/srcpkgs/kcolorchooser/template
@@ -3,7 +3,7 @@ pkgname=kcolorchooser
 version=26.04.1
 revision=1
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="-DBUILD_TESTING=OFF
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins"
 hostmakedepends="extra-cmake-modules kf6-kcoreaddons gettext qt6-tools qt6-base
  kf6-kcoreaddons kf6-kconfig"

--- a/srcpkgs/kcron/template
+++ b/srcpkgs/kcron/template
@@ -3,7 +3,7 @@ pkgname=kcron
 version=26.04.1
 revision=1
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="-DBUILD_TESTING=OFF
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins"
 hostmakedepends="extra-cmake-modules gettext kf6-kcoreaddons kf6-kdoctools
  kf6-kauth-tools pkg-config qt6-base kf6-kcmutils"

--- a/srcpkgs/kde-cli-tools/template
+++ b/srcpkgs/kde-cli-tools/template
@@ -1,9 +1,10 @@
 # Template file for 'kde-cli-tools'
+# group=kde-plasma
 pkgname=kde-cli-tools
-version=6.6.3
-revision=2
+version=6.7.3
+revision=1
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="-DBUILD_TESTING=OFF
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins"
 hostmakedepends="extra-cmake-modules qt6-base qt6-tools gettext
  kf6-kwindowsystem kf6-kconfig kf6-kcmutils kf6-kdoctools"
@@ -18,7 +19,11 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later, GPL-2.0-or-later"
 homepage="https://invent.kde.org/plasma/kde-cli-tools"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=b51294a62d0dd3bc0232a3b9b0314405717aa5081fafa48445b5c66b1899def6
+checksum=f2ef2df829b56365e864eecc8d5040d9b2583adb8fe673234f83f581d89089f1
+
+# stage builds
+makedepends+=" kde-plasma-base"
+shlib_requires="KDE_Plasma.${version}"
 
 post_install() {
 	ln -sf ../libexec/kf6/kdesu ${DESTDIR}/usr/bin

--- a/srcpkgs/kde-gtk-config/template
+++ b/srcpkgs/kde-gtk-config/template
@@ -1,6 +1,7 @@
 # Template file for 'kde-gtk-config'
+# group=kde-plasma
 pkgname=kde-gtk-config
-version=6.6.3
+version=6.7.3
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF
@@ -17,7 +18,11 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later, LGPL-2.1-or-later"
 homepage="https://invent.kde.org/plasma/kde-gtk-config"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=4b5a88620cea11c6c29e33646e0893ab2bc825c1d6480c83e60572a153e34103
+checksum=c07671efa879888e81bddae411bcb25a81ee38453b4ee2c685e5864fa329d614
+
+# stage builds
+makedepends+=" kde-plasma-base"
+shlib_requires="KDE_Plasma.${version}"
 
 kde-gtk-config5_package() {
 	short_desc+=" - (Dummy transitional package)"

--- a/srcpkgs/kde-plasma-base/template
+++ b/srcpkgs/kde-plasma-base/template
@@ -1,0 +1,11 @@
+# Template file for 'kde-plasma-base'
+# group=kde-plasma
+pkgname=kde-plasma-base
+version=6.7.3
+revision=1
+metapackage=yes
+short_desc="KDE Plasma base package"
+maintainer="John <me@johnnynator.dev>"
+license="Public Domain"
+homepage="https://kde.org/plasma-desktop/"
+shlib_provides="KDE_Plasma.${version}"

--- a/srcpkgs/kde-plasma/template
+++ b/srcpkgs/kde-plasma/template
@@ -1,6 +1,7 @@
 # Template file for 'kde-plasma'
+# group=kde-plasma
 pkgname=kde-plasma
-version=6.5.2
+version=6.7.3
 revision=1
 metapackage=yes
 depends="bluedevil>=${version}
@@ -32,6 +33,7 @@ short_desc="KDE Plasma Desktop meta-package for Void Linux"
 maintainer="John <me@johnnynator.dev>"
 license="Public Domain"
 homepage="https://kde.org/plasma-desktop"
+replaces="kde5>=0"
 
 kde5_package() {
 	metapackage=yes

--- a/srcpkgs/kdeconnect/template
+++ b/srcpkgs/kdeconnect/template
@@ -5,7 +5,7 @@ revision=2
 build_style=cmake
 configure_args="-DWaylandScanner_EXECUTABLE=/usr/bin/wayland-scanner
  -DKDE_INSTALL_QMLDIR=lib/qt6/qml -DBLUETOOTH_ENABLED=ON
- -DKF6_HOST_TOOLING=/usr/lib/cmake -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins"
+ -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins"
 hostmakedepends="extra-cmake-modules qt6-tools
  pkg-config wayland-devel qt6-base python3 kf6-kdoctools kf6-kpackage kf6-kconfig
  kf6-kpackage kf6-kcoreaddons gettext qt6-declarative-host-tools

--- a/srcpkgs/kdenlive/template
+++ b/srcpkgs/kdenlive/template
@@ -3,7 +3,7 @@ pkgname=kdenlive
 version=26.04.1
 revision=2
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="-DBUILD_TESTING=OFF
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins -DFETCH_OTIO=OFF
  -DKDE_INSTALL_QMLDIR=lib/qt6/qml"
 hostmakedepends="

--- a/srcpkgs/kdepim-addons/template
+++ b/srcpkgs/kdepim-addons/template
@@ -3,7 +3,7 @@ pkgname=kdepim-addons
 version=26.04.1
 revision=1
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="-DBUILD_TESTING=OFF
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins
  -DKDE_INSTALL_QMLDIR=lib/qt6/qml
  -DECM_MKSPECS_INSTALL_DIR=/usr/lib/qt6/mkspecs/modules"

--- a/srcpkgs/kdepim-runtime/template
+++ b/srcpkgs/kdepim-runtime/template
@@ -4,7 +4,7 @@ version=26.04.1
 revision=1
 build_style=cmake
 # XXX KolabLibraries, Kolabxml
-configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="-DBUILD_TESTING=OFF
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins
  -DKDE_INSTALL_QMLDIR=lib/qt6/qml
  -DECM_MKSPECS_INSTALL_DIR=/usr/lib/qt6/mkspecs/modules"

--- a/srcpkgs/kdeplasma-addons/template
+++ b/srcpkgs/kdeplasma-addons/template
@@ -1,12 +1,15 @@
 # Template file for 'kdeplasma-addons'
+# group=kde-plasma
 pkgname=kdeplasma-addons
-version=6.6.3
-revision=2
+version=6.7.3
+revision=1
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
+build_helper="rust"
+configure_args="-DBUILD_TESTING=OFF
  -DKDE_INSTALL_QMLDIR=lib/qt6/qml -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins"
 hostmakedepends="extra-cmake-modules qt6-base qt6-tools pkg-config gettext
- qt6-declarative-host-tools kf6-kcmutils kf6-kpackage kf6-kauth-tools"
+ qt6-declarative-host-tools kf6-kcmutils kf6-kpackage kf6-kauth-tools corrosion
+ cargo"
 makedepends="kf6-kdeclarative-devel kf6-kholidays-devel kf6-krunner-devel
  libplasma-devel qt6-declarative-private-devel kf6-kglobalaccel-devel
  kf6-kconfig-devel kf6-kcoreaddons-devel kf6-kdbusaddons-devel
@@ -19,7 +22,7 @@ makedepends="kf6-kdeclarative-devel kf6-kholidays-devel kf6-krunner-devel
  kf6-kconfig-devel kf6-kcoreaddons-devel kf6-kglobalaccel-devel
  kf6-ki18n-devel kf6-kjobwidgets-devel kf6-ksvg-devel
  kf6-kitemmodels-devel kf6-purpose-devel kf6-kirigami-devel
- kf6-kdbusaddons-devel"
+ kf6-kdbusaddons-devel rust-std"
 depends="qt6-plugin-networkinformation qt6-location kf6-kirigami kf6-purpose
  kf6-kitemmodels"
 short_desc="Various Plasma addons"
@@ -27,7 +30,11 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later, LGPL-2.1-or-later"
 homepage="https://invent.kde.org/plasma/kdeplasma-addons"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=e9c99ea5283d708fe06257f277313fdfa19bccfaf81482a28a50fce0bfff2947
+checksum=7a86994afe91f54fc5624cc5f3e92064c2b4d790047e657c9303bf01b4966ca8
+
+# stage builds
+makedepends+=" kde-plasma-base"
+shlib_requires="KDE_Plasma.${version}"
 
 if [ "$XBPS_WORDSIZE$XBPS_WORDSIZE" = "64$XBPS_TARGET_WORDSIZE" ]; then
 	makedepends+=" qt6-webengine-devel"

--- a/srcpkgs/kdevelop/template
+++ b/srcpkgs/kdevelop/template
@@ -4,7 +4,7 @@ version=26.04.1
 revision=1
 _llvmver=21
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="-DBUILD_TESTING=OFF
  -DClang_DIR=${XBPS_CROSS_BASE}/usr/lib/llvm/${_llvmver}/lib/cmake/clang
  -DCMAKE_C_STANDARD=11" # Required for static_assert
 hostmakedepends="extra-cmake-modules qt6-base qt6-tools shared-mime-info

--- a/srcpkgs/kdiagram6/template
+++ b/srcpkgs/kdiagram6/template
@@ -3,7 +3,7 @@ pkgname=kdiagram6
 version=3.0.1
 revision=1
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="-DBUILD_TESTING=OFF
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins
  -DKDE_INSTALL_QMLDIR=lib/qt6/qml
  -DECM_MKSPECS_INSTALL_DIR=/usr/lib/qt6/mkspecs/modules"

--- a/srcpkgs/kdialog/template
+++ b/srcpkgs/kdialog/template
@@ -3,7 +3,7 @@ pkgname=kdialog
 version=26.04.1
 revision=1
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="-DBUILD_TESTING=OFF
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins"
 hostmakedepends="extra-cmake-modules kf6-kcoreaddons python3 kf6-kconfig
  qt6-base qt6-tools gettext"

--- a/srcpkgs/kdiamond/template
+++ b/srcpkgs/kdiamond/template
@@ -3,7 +3,7 @@ pkgname=kdiamond
 version=26.04.1
 revision=1
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="-DBUILD_TESTING=OFF
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins
  -DKDE_INSTALL_QMLDIR=lib/qt6/qml
  -DECM_MKSPECS_INSTALL_DIR=/usr/lib/qt6/mkspecs/modules"

--- a/srcpkgs/kdiff3/template
+++ b/srcpkgs/kdiff3/template
@@ -3,7 +3,7 @@ pkgname=kdiff3
 version=1.12.3
 revision=2
 build_style=cmake
-configure_args="-DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins"
 hostmakedepends="extra-cmake-modules gettext kf6-kcoreaddons kf6-kdoctools
  kf6-kconfig qt6-base"

--- a/srcpkgs/keditbookmarks/template
+++ b/srcpkgs/keditbookmarks/template
@@ -3,7 +3,7 @@ pkgname=keditbookmarks
 version=26.04.1
 revision=1
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="-DBUILD_TESTING=OFF
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins
  -DKDE_INSTALL_QMLDIR=lib/qt6/qml
  -DECM_MKSPECS_INSTALL_DIR=/usr/lib/qt6/mkspecs/modules"

--- a/srcpkgs/kf6-akonadi/template
+++ b/srcpkgs/kf6-akonadi/template
@@ -4,7 +4,7 @@ version=26.04.1
 revision=2
 build_style=cmake
 build_helper="qemu"
-configure_args="-DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins
  -DKDE_INSTALL_QMLDIR=lib/qt6/qml"
 hostmakedepends="extra-cmake-modules qt6-base qt6-tools python3

--- a/srcpkgs/kf6-attica/template
+++ b/srcpkgs/kf6-attica/template
@@ -1,6 +1,7 @@
 # Template file for 'kf6-attica'
+# group=kde-frameworks
 pkgname=kf6-attica
-version=6.25.0
+version=6.28.0
 revision=1
 build_style=cmake
 hostmakedepends="extra-cmake-modules qt6-tools qt6-base"
@@ -10,8 +11,11 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/attica"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=fa39cc74cd34ffd4beb906099a5f42e4180432b5839a75a4b251c0ae2fb01ab1
+checksum=652e28562ed6798f834843b45f5cd3ea5833f0ee3c2607cfe3d021b57c6e7618
 
+# stage builds
+makedepends+=" kf6-base"
+shlib_requires="KDE_Frameworks.${version}"
 
 do_check() {
 	cd build

--- a/srcpkgs/kf6-baloo/template
+++ b/srcpkgs/kf6-baloo/template
@@ -1,9 +1,10 @@
 # Template file for 'kf6-baloo'
+# group=kde-frameworks
 pkgname=kf6-baloo
-version=6.25.0
+version=6.28.0
 revision=1
 build_style=cmake
-configure_args="-DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="
  -DKDE_INSTALL_QMLDIR=lib/qt6/qml
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins"
 hostmakedepends="extra-cmake-modules qt6-tools qt6-base
@@ -16,7 +17,11 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/baloo"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=d7746f5742d96f85c11b64a1aae8a6af1f20e55b815f81da8a4e6c3c5172a2d9
+checksum=9cc6ac9ab0605eab7f337b7ea1803348da4a71173b722d5047748c557ba22c0f
+
+# stage builds
+makedepends+=" kf6-base"
+shlib_requires="KDE_Frameworks.${version}"
 
 do_check() {
 	cd build

--- a/srcpkgs/kf6-base/template
+++ b/srcpkgs/kf6-base/template
@@ -1,0 +1,11 @@
+# Template file for 'kf6-base'
+# group=kde-frameworks
+pkgname=kf6-base
+version=6.28.0
+revision=1
+metapackage=yes
+short_desc="KDE Frameworks base package"
+maintainer="John <me@johnnynator.dev>"
+license="Public Domain"
+homepage="https://develop.kde.org/products/frameworks/"
+shlib_provides="KDE_Frameworks.${version}"

--- a/srcpkgs/kf6-bluez-qt/template
+++ b/srcpkgs/kf6-bluez-qt/template
@@ -1,7 +1,8 @@
 # Template file for 'kf6-bluez-qt'
+# group=kde-frameworks
 pkgname=kf6-bluez-qt
-version=6.25.0
-revision=2
+version=6.28.0
+revision=1
 build_style=cmake
 configure_args="-DKDE_INSTALL_QMLDIR=lib/qt6/qml"
 hostmakedepends="extra-cmake-modules qt6-tools qt6-base
@@ -13,7 +14,11 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/bluez-qt"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=e728c968d633cfd5921dd5cf5b424a33f17a7682d1c780437e15710aa3ff2101
+checksum=ae4410142170e84df104ef9723c7307de1d5ab68b2874c4ccdb0af99e00ae806
+
+# stage builds
+makedepends+=" kf6-base"
+shlib_requires="KDE_Frameworks.${version}"
 
 do_check() {
 	cd build

--- a/srcpkgs/kf6-frameworkintegration/template
+++ b/srcpkgs/kf6-frameworkintegration/template
@@ -1,6 +1,7 @@
 # Template file for 'kf6-frameworkintegration'
+# group=kde-frameworks
 pkgname=kf6-frameworkintegration
-version=6.25.0
+version=6.28.0
 revision=1
 build_style=cmake
 configure_args="-DKDE_INSTALL_QMLDIR=lib/qt6/qml
@@ -16,7 +17,11 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/frameworkintegration"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=eb8d55bd04cb023ea0480cf82c396d63b4a14ae7e5f60963a00a0d58f47a8022
+checksum=7fdc1db8a5b4c41c7b7487e5e45bc68b0c56a45f182a6362d8bd55ae5f5cc474
+
+# stage builds
+makedepends+=" kf6-base"
+shlib_requires="KDE_Frameworks.${version}"
 
 kf6-frameworkintegration-devel_package() {
 	depends="${sourcepkg}>=${version}_${revision}

--- a/srcpkgs/kf6-kaccounts-integration/template
+++ b/srcpkgs/kf6-kaccounts-integration/template
@@ -3,7 +3,7 @@ pkgname=kf6-kaccounts-integration
 version=26.04.1
 revision=1
 build_style=cmake
-configure_args="-DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="
  -DKDE_INSTALL_QMLDIR=lib/qt6/qml
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins"
 hostmakedepends="extra-cmake-modules pkg-config qt6-base gettext

--- a/srcpkgs/kf6-karchive/template
+++ b/srcpkgs/kf6-karchive/template
@@ -1,6 +1,7 @@
 # Template file for 'kf6-karchive'
+# group=kde-frameworks
 pkgname=kf6-karchive
-version=6.25.0
+version=6.28.0
 revision=1
 build_style=cmake
 hostmakedepends="extra-cmake-modules qt6-tools qt6-base
@@ -12,7 +13,11 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/karchive"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=123a268352ab63d548ba5e3c3e8fbf1d737025e4c5189821cf10e3328ab4de15
+checksum=ff36137e6b171906b4bde4006558739c5d7771dc30b9a037b65e62b2674a1b13
+
+# stage builds
+makedepends+=" kf6-base"
+shlib_requires="KDE_Frameworks.${version}"
 
 kf6-karchive-devel_package() {
 	depends="$makedepends ${sourcepkg}>=${version}_${revision}"

--- a/srcpkgs/kf6-kauth/template
+++ b/srcpkgs/kf6-kauth/template
@@ -1,6 +1,7 @@
 # Template file for 'kf6-kauth'
+# group=kde-frameworks
 pkgname=kf6-kauth
-version=6.25.0
+version=6.28.0
 revision=1
 build_style=cmake
 configure_args="-DKDE_INSTALL_QMLDIR=lib/qt6/qml
@@ -13,7 +14,11 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/kauth"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=e1a9b20a1b8718a0a0ead943e6ae999692fe7efe6b5bd513fdb5ba1849e4bdf0
+checksum=fb4d90ee46a2f6202e53cdd5af8f77069c380955e3f340881f2f36ec8312079b
+
+# stage builds
+makedepends+=" kf6-base"
+shlib_requires="KDE_Frameworks.${version}"
 subpackages="kf6-kauth-tools kf6-kauth-devel"
 
 do_check() {

--- a/srcpkgs/kf6-kbookmarks/template
+++ b/srcpkgs/kf6-kbookmarks/template
@@ -1,6 +1,7 @@
 # Template file for 'kf6-kbookmarks'
+# group=kde-frameworks
 pkgname=kf6-kbookmarks
-version=6.25.0
+version=6.28.0
 revision=1
 build_style=cmake
 hostmakedepends="extra-cmake-modules qt6-tools qt6-base kf6-kconfig"
@@ -11,7 +12,11 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/kbookmarks"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=5c4a8c1f8499f6ff1cdd035b56f6fe321244913b1894a8c6001c3acf082c5bd6
+checksum=d7f4048860ef00bc5d135e284dc6b1307d03199c2c13020994b17e38e3741f5c
+
+# stage builds
+makedepends+=" kf6-base"
+shlib_requires="KDE_Frameworks.${version}"
 
 kf6-kbookmarks-devel_package() {
 	depends="${sourcepkg}>=${version}_${revision}

--- a/srcpkgs/kf6-kcalendarcore/template
+++ b/srcpkgs/kf6-kcalendarcore/template
@@ -1,18 +1,39 @@
 # Template file for 'kf6-kcalendarcore'
+# group=kde-frameworks
 pkgname=kf6-kcalendarcore
-version=6.25.0
+version=6.28.0
 revision=1
 build_style=cmake
-configure_args="-DKDE_INSTALL_QMLDIR=lib/qt6/qml"
-hostmakedepends="extra-cmake-modules qt6-tools qt6-base qt6-declarative-host-tools"
-makedepends="qt6-base-devel libical-devel qt6-declarative-devel"
+_llvmver=21
+configure_args="-DKDE_INSTALL_QMLDIR=lib/qt6/qml $(vopt_bool python BUILD_PYTHON_BINDINGS)"
+hostmakedepends="extra-cmake-modules qt6-tools qt6-base qt6-declarative-host-tools
+ $(vopt_if python "python3-build python3-setuptools shiboken6 llvm${_llvmver}")"
+makedepends="qt6-base-devel libical-devel qt6-declarative-devel
+ $(vopt_if python 'libshiboken6-devel libpyside6-devel python3-devel')"
 checkdepends="perl"
 short_desc="Library for Interfacing with Calendars"
 maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/kcalendarcore"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=d6a19c3ec0cdfc6979bfde08ce7c62db8c52dd9dff4a13e4da8978e00480dfeb
+checksum=c0c8272729cc9cc7006f87b64f80feb03750acb6bbd208ae94c2bad77fc444be
+
+# stage builds
+makedepends+=" kf6-base"
+shlib_requires="KDE_Frameworks.${version}"
+
+build_options="python"
+build_options_default="python"
+
+if [ "$CROSS_BUILD" ]; then
+	configure_args+=" -DECM_SHIBOKEN_ARCH=$XBPS_CROSS_RUST_TARGET"
+	configure_args+=" -DSYSROOT_INCLUDE_DIRS=$XBPS_CROSS_BASE/usr/include"
+fi
+export LLVM_INSTALL_DIR=/usr/lib/llvm/${_llvmver}
+
+case "$XBPS_TARGET_MACHINE" in
+	arm*) configure_args+=" -DSHIBOKEN_GENERATOR_EXTRA_FLAGS=--clang-option=-mfloat-abi=hard" ;;
+esac
 
 do_check() {
 	cd build

--- a/srcpkgs/kf6-kcmutils/template
+++ b/srcpkgs/kf6-kcmutils/template
@@ -1,10 +1,11 @@
 # Template file for 'kf6-kcmutils'
+# group=kde-frameworks
 pkgname=kf6-kcmutils
-version=6.25.0
-revision=2
+version=6.28.0
+revision=1
 build_style=cmake
 build_helper=qemu
-configure_args="-DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="
  -DKDE_INSTALL_QMLDIR=lib/qt6/qml"
 hostmakedepends="extra-cmake-modules gettext qt6-tools qt6-base
  qt6-declarative-host-tools kf6-kconfig"
@@ -16,7 +17,11 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/kcmutils"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=cc7c01e948d7040e9e002ea5379ce8c05f2a85f28cdd4431aee106bdf0661c3d
+checksum=9afe5ca9d1c4bd06479b2619326ec6f1e3c3998859dceaae3da9a4b7318d5a21
+
+# stage builds
+makedepends+=" kf6-base"
+shlib_requires="KDE_Frameworks.${version}"
 
 kf6-kcmutils-devel_package() {
 	depends="${sourcepkg}>=${version}_${revision}

--- a/srcpkgs/kf6-kcodecs/template
+++ b/srcpkgs/kf6-kcodecs/template
@@ -1,6 +1,7 @@
 # Template file for 'kf6-kcodecs'
+# group=kde-frameworks
 pkgname=kf6-kcodecs
-version=6.25.0
+version=6.28.0
 revision=1
 build_style=cmake
 hostmakedepends="extra-cmake-modules qt6-tools qt6-base
@@ -11,7 +12,11 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/kcodecs"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=5051fe783803d94444a231c79635b96f1266594942b836f59ae8460497c788c5
+checksum=b0a9ae34b389c6460adad5323d21bb9e43638acb58da9685f8dc8d821c38a4d8
+
+# stage builds
+makedepends+=" kf6-base"
+shlib_requires="KDE_Frameworks.${version}"
 
 kf6-kcodecs-devel_package() {
 	depends="$makedepends ${sourcepkg}>=${version}_${revision}"

--- a/srcpkgs/kf6-kcolorscheme/template
+++ b/srcpkgs/kf6-kcolorscheme/template
@@ -1,7 +1,8 @@
 # Template file for 'kf6-kcolorscheme'
+# group=kde-frameworks
 pkgname=kf6-kcolorscheme
-version=6.25.0
-revision=2
+version=6.28.0
+revision=1
 build_style=cmake
 hostmakedepends="extra-cmake-modules qt6-tools qt6-base
  kf6-kconfig gettext"
@@ -14,7 +15,11 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/kcolorscheme"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=95a8a37817765f910c59b269a9958557505b99ff698fd6d220bcb166d5e302f5
+checksum=129c98fd9ba3428cafbd7263557a9ea47c0d4f157b8a5f56b209a95dc9815e6a
+
+# stage builds
+makedepends+=" kf6-base"
+shlib_requires="KDE_Frameworks.${version}"
 
 kf6-kcolorscheme-devel_package() {
 	depends="${sourcepkg}>=${version}_${revision}

--- a/srcpkgs/kf6-kcompletion/template
+++ b/srcpkgs/kf6-kcompletion/template
@@ -1,6 +1,7 @@
 # Template file for 'kf6-kcompletion'
+# group=kde-frameworks
 pkgname=kf6-kcompletion
-version=6.25.0
+version=6.28.0
 revision=1
 build_style=cmake
 hostmakedepends="extra-cmake-modules qt6-tools qt6-base kf6-kconfig"
@@ -10,7 +11,11 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/kcompletion"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=e4138d525eb9e27a9222d655e412c0de8b4bd7b34289d1c7ca5a808e20b53238
+checksum=8aa9cbc36139adfa8e3b2c744cc94714afe154d21cef8a3a2d5f4d311be7cc3c
+
+# stage builds
+makedepends+=" kf6-base"
+shlib_requires="KDE_Frameworks.${version}"
 
 kf6-kcompletion-devel_package() {
 	depends="$makedepends ${sourcepkg}>=${version}_${revision}"

--- a/srcpkgs/kf6-kconfig/template
+++ b/srcpkgs/kf6-kconfig/template
@@ -1,10 +1,12 @@
 # Template file for 'kf6-kconfig'
+# group=kde-frameworks
 pkgname=kf6-kconfig
-version=6.25.0
-revision=2
+version=6.28.0
+revision=1
 build_style=cmake
 configure_args="-DKDE_INSTALL_QMLDIR=lib/qt6/qml
- -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins"
+ -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins
+ -DKDE_INSTALL_QTMETATYPESDIR=lib/qt6/metatypes"
 hostmakedepends="extra-cmake-modules qt6-base qt6-tools
  qt6-declarative-host-tools"
 makedepends="qt6-declarative-devel qt6-base-private-devel"
@@ -13,7 +15,11 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/kconfig"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=8c675c9d35a866fbf1b564354a589019b429cca949f7ba3ba0adb9f2fa15959c
+checksum=24e26e516b7904a26661eab7d2064bee1ac57165571e85b4da6020fd36f14322
+
+# stage builds
+makedepends+=" kf6-base"
+shlib_requires="KDE_Frameworks.${version}"
 
 do_check() {
 	cd build

--- a/srcpkgs/kf6-kconfigwidgets/template
+++ b/srcpkgs/kf6-kconfigwidgets/template
@@ -1,9 +1,10 @@
 # Template file for 'kf6-kconfigwidgets'
+# group=kde-frameworks
 pkgname=kf6-kconfigwidgets
-version=6.25.0
-revision=2
+version=6.28.0
+revision=1
 build_style=cmake
-configure_args="-DKF6_HOST_TOOLING=/usr/lib/cmake"
+configure_args=""
 hostmakedepends="extra-cmake-modules qt6-tools qt6-base
  gettext kf6-kconfig-devel"
 makedepends="kf6-kcodecs-devel kf6-kcolorscheme-devel kf6-kconfig-devel
@@ -13,7 +14,11 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/kconfigwidgets"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=c45ee1f4b2ede987efc8deac48710d87d9d37bb8355f0d7e130d557dfb2029a2
+checksum=f795386fb06b8922325075a8fa9f817c3d25e04bbfdcf60b13ad714c7c54e987
+
+# stage builds
+makedepends+=" kf6-base"
+shlib_requires="KDE_Frameworks.${version}"
 
 do_check() {
 	cd build

--- a/srcpkgs/kf6-kcontacts/template
+++ b/srcpkgs/kf6-kcontacts/template
@@ -1,6 +1,7 @@
 # Template file for 'kf6-kcontacts'
+# group=kde-frameworks
 pkgname=kf6-kcontacts
-version=6.25.0
+version=6.28.0
 revision=1
 build_style=cmake
 configure_args="-DKDE_INSTALL_QMLDIR=lib/qt6/qml"
@@ -13,7 +14,11 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/kcontacts"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=386826b3886d6b32a4583e638493ccd3cfb37722faaf318742d70d6bf0e3f0a7
+checksum=389d6128f18bee9113844615f535eeb870605f6fce968ca5c18d85a22478b8a2
+
+# stage builds
+makedepends+=" kf6-base"
+shlib_requires="KDE_Frameworks.${version}"
 
 do_check() {
 	cd build

--- a/srcpkgs/kf6-kcoreaddons/template
+++ b/srcpkgs/kf6-kcoreaddons/template
@@ -1,11 +1,13 @@
 # Template file for 'kf6-kcoreaddons'
+# group=kde-frameworks
 pkgname=kf6-kcoreaddons
-version=6.25.0
-revision=2
+version=6.28.0
+revision=1
 build_style=cmake
 _llvmver=21
 configure_args="-DKDE_INSTALL_QMLDIR=lib/qt6/qml
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins
+ -DKDE_INSTALL_QTMETATYPESDIR=lib/qt6/metatypes
  $(vopt_bool python BUILD_PYTHON_BINDINGS)"
 hostmakedepends="extra-cmake-modules qt6-tools qt6-base
  qt6-declarative-host-tools
@@ -16,9 +18,12 @@ short_desc="KCoreAddons"
 maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/kcoreaddons"
-#changelog=""
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=e7f0825576dc44af0c7194538e48114aa240f8fd3402f27047771f009e161a7e
+checksum=a713febee2f43bc31986d6c27d846ccab556fc7bc7c1919c3a662495720b431a
+
+# stage builds
+makedepends+=" kf6-base"
+shlib_requires="KDE_Frameworks.${version}"
 
 build_options="python"
 build_options_default="python"

--- a/srcpkgs/kf6-kcrash/template
+++ b/srcpkgs/kf6-kcrash/template
@@ -1,16 +1,21 @@
 # Template file for 'kf6-kcrash'
+# group=kde-frameworks
 pkgname=kf6-kcrash
-version=6.25.0
+version=6.28.0
 revision=1
 build_style=cmake
-hostmakedepends="extra-cmake-modules qt6-tools qt6-base "
+hostmakedepends="extra-cmake-modules qt6-tools qt6-base"
 makedepends="kf6-kcoreaddons-devel"
 short_desc="KDE Graceful handling of application crashes"
 maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/kcrash"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=b1b952c500787e760c0fca3ce20c6ed8cf488ed106e0e72bc604509df84d8fd7
+checksum=ddcc14c0c40e24f4c0dc04246b87d11b650e6fd8be2cb00e4f2cc2ee9e605702
+
+# stage builds
+makedepends+=" kf6-base"
+shlib_requires="KDE_Frameworks.${version}"
 
 kf6-kcrash-devel_package() {
 	depends="$makedepends ${sourcepkg}>=${version}_${revision}"

--- a/srcpkgs/kf6-kdav/template
+++ b/srcpkgs/kf6-kdav/template
@@ -1,6 +1,7 @@
 # Template file for 'kf6-kdav'
+# group=kde-frameworks
 pkgname=kf6-kdav
-version=6.25.0
+version=6.28.0
 revision=1
 build_style=cmake
 hostmakedepends="extra-cmake-modules qt6-tools qt6-base
@@ -11,7 +12,11 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/kdav"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=a16c4cc1b21cdf2739e1ba20b77a5212b9daabc7e395259771dd077f5200f14b
+checksum=ebc481902d89c427da7bad85debb375cb00d92c1d881ba330bd9f1ab8cb37f92
+
+# stage builds
+makedepends+=" kf6-base"
+shlib_requires="KDE_Frameworks.${version}"
 replaces="kdav>=0"
 
 kf6-kdav-devel_package() {

--- a/srcpkgs/kf6-kdbusaddons/template
+++ b/srcpkgs/kf6-kdbusaddons/template
@@ -1,7 +1,8 @@
 # Template file for 'kf6-kdbusaddons'
+# group=kde-frameworks
 pkgname=kf6-kdbusaddons
-version=6.25.0
-revision=2
+version=6.28.0
+revision=1
 build_style=cmake
 hostmakedepends="extra-cmake-modules qt6-tools qt6-base "
 makedepends="qt6-base-private-devel"
@@ -11,8 +12,12 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/kdbusaddons"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=b872463ff1874beeff86cf951e510488e959d595ca3d2839fb8e9639fbffb0e2
+checksum=94ff8745ce65507986a05bffbab905bfd894936e8f53b4b6e2d9b3a96cb2d6f4
 make_check_pre="dbus-run-session"
+
+# stage builds
+makedepends+=" kf6-base"
+shlib_requires="KDE_Frameworks.${version}"
 
 kf6-kdbusaddons-devel_package() {
 	depends="qt6-base-devel ${sourcepkg}>=${version}_${revision}"

--- a/srcpkgs/kf6-kdeclarative/template
+++ b/srcpkgs/kf6-kdeclarative/template
@@ -1,7 +1,8 @@
 # Template file for 'kf6-kdeclarative'
+# group=kde-frameworks
 pkgname=kf6-kdeclarative
-version=6.25.0
-revision=2
+version=6.28.0
+revision=1
 build_style=cmake
 configure_args="-DKDE_INSTALL_QMLDIR=lib/qt6/qml"
 hostmakedepends="extra-cmake-modules qt6-tools qt6-base
@@ -14,7 +15,11 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/kdeclarative"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=7692ccdffd55826976e916927b59aeb2d24a77b16af967fb265e9fe0cde387fa
+checksum=988638fdf810d97d14144c2129655d9d0600006d7dcb06787b04c12d5269c969
+
+# stage builds
+makedepends+=" kf6-base"
+shlib_requires="KDE_Frameworks.${version}"
 
 kf6-kdeclarative-devel_package() {
 	depends="${sourcepkg}>=${version}_${revision} kf6-kconfig-devel

--- a/srcpkgs/kf6-kdecoration/template
+++ b/srcpkgs/kf6-kdecoration/template
@@ -1,6 +1,7 @@
 # Template file for 'kf6-kdecoration'
+# group=kde-plasma
 pkgname=kf6-kdecoration
-version=6.6.3
+version=6.7.3
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF"
@@ -11,7 +12,11 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/plasma/kdecoration"
 distfiles="${KDE_SITE}/plasma/${version}/kdecoration-${version}.tar.xz"
-checksum=0760e182234d79b3a693d12920284c9b864c437f797dbcd526188d761b7de3e9
+checksum=69690713d2216323dae96d61d74e087bd9e5e5b3effcf1c54f7a3e823672d0e7
+
+# stage builds
+makedepends+=" kde-plasma-base"
+shlib_requires="KDE_Plasma.${version}"
 
 kf6-kdecoration-devel_package() {
 	conflicts="kdecoration-devel>=0"

--- a/srcpkgs/kf6-kded/template
+++ b/srcpkgs/kf6-kded/template
@@ -1,9 +1,10 @@
 # Template file for 'kf6-kded'
+# group=kde-frameworks
 pkgname=kf6-kded
-version=6.25.0
+version=6.28.0
 revision=1
 build_style=cmake
-configure_args="-DKF6_HOST_TOOLING=/usr/lib/cmake"
+configure_args=""
 hostmakedepends="extra-cmake-modules qt6-tools qt6-base
  kf6-kdoctools kf6-kconfig"
 makedepends="kf6-kconfig-devel kf6-kcoreaddons-devel kf6-kcrash-devel
@@ -13,7 +14,11 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/kded"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=030cc827c37b490a2181e120cd831b73c9a7683a87cf55d0d5b334059f78c590
+checksum=31ba5c920b199dd13fff634001d22c993df3d639a8df989e0a55ec1d13a8279f
+
+# stage builds
+makedepends+=" kf6-base"
+shlib_requires="KDE_Frameworks.${version}"
 
 kf6-kded-devel_package() {
 	depends="$makedepends ${sourcepkg}>=${version}_${revision}"

--- a/srcpkgs/kf6-kdesu/template
+++ b/srcpkgs/kf6-kdesu/template
@@ -1,7 +1,8 @@
 # Template file for 'kf6-kdesu'
+# group=kde-frameworks
 pkgname=kf6-kdesu
-version=6.25.0
-revision=2
+version=6.28.0
+revision=1
 build_style=cmake
 hostmakedepends="extra-cmake-modules qt6-tools qt6-base
  gettext kf6-kconfig"
@@ -12,7 +13,11 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/kdesu"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=09ad4bf5fe7abae40884f8b645b22948cd00f418c7d643a0b5d505a02ef6f634
+checksum=9af5746db7e25e2aac69c19a9cc9758fc7e7b4cbbcf2b6b6a6c93bd7c642e80f
+
+# stage builds
+makedepends+=" kf6-base"
+shlib_requires="KDE_Frameworks.${version}"
 
 kf6-kdesu-devel_package() {
 	depends="${sourcepkg}>=${version}_${revision} kf6-kpty-devel qt6-base-devel"

--- a/srcpkgs/kf6-kdnssd/template
+++ b/srcpkgs/kf6-kdnssd/template
@@ -1,6 +1,7 @@
 # Template file for 'kf6-kdnssd'
+# group=kde-frameworks
 pkgname=kf6-kdnssd
-version=6.25.0
+version=6.28.0
 revision=1
 build_style=cmake
 hostmakedepends="extra-cmake-modules qt6-tools qt6-base "
@@ -10,7 +11,11 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/kdnssd"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=865175616c5169d25f0783798e0a7918a418180c33828e461c1608e6121d3634
+checksum=f4fe731aad56ae010c2b42f2bd56d4499339bb0839ae2251035132f1a3708df2
+
+# stage builds
+makedepends+=" kf6-base"
+shlib_requires="KDE_Frameworks.${version}"
 
 kf6-kdnssd-devel_package() {
 	depends="$makedepends ${sourcepkg}>=${version}_${revision}"

--- a/srcpkgs/kf6-kdoctools/template
+++ b/srcpkgs/kf6-kdoctools/template
@@ -1,6 +1,7 @@
 # Template file for 'kf6-kdoctools'
+# group=kde-frameworks
 pkgname=kf6-kdoctools
-version=6.25.0
+version=6.28.0
 revision=1
 build_style=cmake
 build_helper=qemu
@@ -13,7 +14,11 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/kdoctools"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=2c5866257edda20f33c35f64a8bcab08de3dddb4e751bbbc2e09e941df979918
+checksum=024914031fba7a9b79982d02736b21399d9a0d09ad81323d58e17d6b2216c7b0
+
+# stage builds
+makedepends+=" kf6-base"
+shlib_requires="KDE_Frameworks.${version}"
 
 post_patch() {
 	vsed -i -e '

--- a/srcpkgs/kf6-kfilemetadata/template
+++ b/srcpkgs/kf6-kfilemetadata/template
@@ -1,6 +1,7 @@
 # Template file for 'kf6-kfilemetadata'
+# group=kde-frameworks
 pkgname=kf6-kfilemetadata
-version=6.25.0
+version=6.28.0
 revision=1
 build_style=cmake
 configure_args="-DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins"
@@ -14,7 +15,11 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/kfilemetadata"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=78b3516ab3038fec122f86c1370f4c7d8857ddea9e907263242affae1dd1f738
+checksum=015be4aa6986642d3f13903b47c1aae7183d3218888dc4353afe1b1e9dd64c1e
+
+# stage builds
+makedepends+=" kf6-base"
+shlib_requires="KDE_Frameworks.${version}"
 
 do_check() {
 	cd build

--- a/srcpkgs/kf6-kglobalaccel/template
+++ b/srcpkgs/kf6-kglobalaccel/template
@@ -1,7 +1,8 @@
 # Template file for 'kf6-kglobalaccel'
+# group=kde-frameworks
 pkgname=kf6-kglobalaccel
-version=6.25.0
-revision=2
+version=6.28.0
+revision=1
 build_style=cmake
 hostmakedepends="extra-cmake-modules qt6-tools qt6-base "
 makedepends="qt6-base-private-devel qt6-declarative-devel"
@@ -10,7 +11,11 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/kglobalaccel"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=81f9842f13db8e2d4384c0f02650cd076441d2fba9540820901fffe1d2f4897f
+checksum=b40c195ba7e6674898a64f4e3e25e0235dd79682f39395409469274acb580ac0
+
+# stage builds
+makedepends+=" kf6-base"
+shlib_requires="KDE_Frameworks.${version}"
 
 kf6-kglobalaccel-devel_package() {
 	depends="${sourcepkg}>=${version}_${revision} qt6-base-devel"

--- a/srcpkgs/kf6-kguiaddons/template
+++ b/srcpkgs/kf6-kguiaddons/template
@@ -1,10 +1,13 @@
 # Template file for 'kf6-kguiaddons'
+# group=kde-frameworks
 pkgname=kf6-kguiaddons
-version=6.25.0
-revision=2
+version=6.28.0
+revision=1
 build_style=cmake
 _llvmver=21
 configure_args="-DKDE_INSTALL_QMLDIR=lib/qt6/qml
+ -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins
+ -DKDE_INSTALL_QTMETATYPESDIR=lib/qt6/metatypes
  $(vopt_bool python BUILD_PYTHON_BINDINGS)"
 hostmakedepends="extra-cmake-modules qt6-tools qt6-base
  $(vopt_if python "shiboken6 python3-build python3-setuptools llvm${_llvmver}")
@@ -18,7 +21,11 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/kguiaddons"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=38850963cb91978d08e781d81b147c7b66f78f4204ad820631e42ab1ef5ef76b
+checksum=f46aeca80707e774fcffe8aa82e464a81056ce84f613347a5c9cc24c1c9a8432
+
+# stage builds
+makedepends+=" kf6-base"
+shlib_requires="KDE_Frameworks.${version}"
 
 build_options="python"
 build_options_default="python"

--- a/srcpkgs/kf6-kholidays/template
+++ b/srcpkgs/kf6-kholidays/template
@@ -1,6 +1,7 @@
 # Template file for 'kf6-kholidays'
+# group=kde-frameworks
 pkgname=kf6-kholidays
-version=6.25.0
+version=6.28.0
 revision=1
 build_style=cmake
 configure_args="-DKDE_INSTALL_QMLDIR=lib/qt6/qml
@@ -13,7 +14,11 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/kholidays"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=13c345422f802bd157aaea18b2ccb5270eb5e3de44915bcce70f1a4234e1497b
+checksum=6960e2040c148d878466f40c1c3bdcfa8c84fff456f4c8ce7456065bd0745d6c
+
+# stage builds
+makedepends+=" kf6-base"
+shlib_requires="KDE_Frameworks.${version}"
 
 kf6-kholidays-devel_package() {
 	depends="$makedepends ${sourcepkg}>=${version}_${revision}"

--- a/srcpkgs/kf6-ki18n/template
+++ b/srcpkgs/kf6-ki18n/template
@@ -1,6 +1,7 @@
 # Template file for 'kf6-ki18n'
+# group=kde-frameworks
 pkgname=kf6-ki18n
-version=6.25.0
+version=6.28.0
 revision=1
 build_style=cmake
 configure_args="-DKDE_INSTALL_QMLDIR=lib/qt6/qml
@@ -14,7 +15,11 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/ki18n"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=7fbac8bc88f5cb1af00f6a667381c4bcebba6f417dc6a3c7eef8bded6c9161de
+checksum=820ce5858c6db732d68da53572a0e7db8353e4372d2122debcfb0f9ff10b85db
+
+# stage builds
+makedepends+=" kf6-base"
+shlib_requires="KDE_Frameworks.${version}"
 
 do_check() {
 	cd build

--- a/srcpkgs/kf6-kiconthemes/template
+++ b/srcpkgs/kf6-kiconthemes/template
@@ -1,7 +1,8 @@
 # Template file for 'kf6-kiconthemes'
+# group=kde-frameworks
 pkgname=kf6-kiconthemes
-version=6.25.0
-revision=2
+version=6.28.0
+revision=1
 build_style=cmake
 configure_args="-DKDE_INSTALL_QMLDIR=lib/qt6/qml
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins"
@@ -15,7 +16,11 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/kiconthemes"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=f68f0d810a53ec589fbbc0b05d3754e2bd26e0b7c3ceb3938698b08702ae10d5
+checksum=edf83069f25f8edf759d07502a6f8302c8c064cd562651deedefe6393fefcace
+
+# stage builds
+makedepends+=" kf6-base"
+shlib_requires="KDE_Frameworks.${version}"
 
 kf6-kiconthemes-devel_package() {
 	depends="${sourcepkg}>=${version}_${revision} qt6-base-devel

--- a/srcpkgs/kf6-kidletime/template
+++ b/srcpkgs/kf6-kidletime/template
@@ -1,7 +1,8 @@
 # Template file for 'kf6-kidletime'
+# group=kde-frameworks
 pkgname=kf6-kidletime
-version=6.25.0
-revision=2
+version=6.28.0
+revision=1
 build_style=cmake
 configure_args="-DKDE_INSTALL_QMLDIR=lib/qt6/qml
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins"
@@ -14,7 +15,11 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/kidletime"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=64e83d46a15b444017c6341e479e229bbd6cbb8320ef1359773737cee89dd7ca
+checksum=0ada459a4ccdf75d17329bfa4ee42c2c6e7b3ead1ec4b427f82bed063b970ff5
+
+# stage builds
+makedepends+=" kf6-base"
+shlib_requires="KDE_Frameworks.${version}"
 
 kf6-kidletime-devel_package() {
 	depends="${sourcepkg}>=${version}_${revision} qt6-base-devel"

--- a/srcpkgs/kf6-kimageformats/template
+++ b/srcpkgs/kf6-kimageformats/template
@@ -1,7 +1,8 @@
 # Template file for 'kf6-kimageformats'
+# group=kde-frameworks
 pkgname=kf6-kimageformats
-version=6.25.0
-revision=2
+version=6.28.0
+revision=1
 build_style=cmake
 configure_args="-DKIMAGEFORMATS_HEIF=ON -DKDE_INSTALL_QMLDIR=lib/qt6/qml
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins"
@@ -14,7 +15,11 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/kimageformats"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=dfa0e9b16a288a8f94233afcbaffc87c1c5ddc037aca643943aab5a67685f26b
+checksum=91808c6de080ab5b506721c1f78ad5772bcb1f70bba7262c275ccd98de8b6b38
+
+# stage builds
+makedepends+=" kf6-base"
+shlib_requires="KDE_Frameworks.${version}"
 
 do_check() {
 	cd build

--- a/srcpkgs/kf6-kio/template
+++ b/srcpkgs/kf6-kio/template
@@ -1,10 +1,10 @@
 # Template file for 'kf6-kio'
+# group=kde-frameworks
 pkgname=kf6-kio
-version=6.25.0
-revision=2
+version=6.28.0
+revision=1
 build_style=cmake
 configure_args="-DKDE_INSTALL_QMLDIR=lib/qt6/qml
- -DKF6_HOST_TOOLING=/usr/lib/cmake
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins"
 hostmakedepends="extra-cmake-modules qt6-tools qt6-base
  gettext kf6-kdoctools kf6-kconfig kf6-kauth-tools"
@@ -20,7 +20,11 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/kio"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=bf71b2227016df6566665cead6cb468726d7cc708059e812daee7ea54f405378
+checksum=158f47746806c3dd87a09091eaa46ffee286cd658f9e26b4422656b66176627a
+
+# stage builds
+makedepends+=" kf6-base"
+shlib_requires="KDE_Frameworks.${version}"
 
 do_check() {
 	cd build

--- a/srcpkgs/kf6-kirigami/template
+++ b/srcpkgs/kf6-kirigami/template
@@ -1,10 +1,12 @@
 # Template file for 'kf6-kirigami'
+# group=kde-frameworks
 pkgname=kf6-kirigami
-version=6.25.0
-revision=2
+version=6.28.0
+revision=1
 build_style=cmake
 configure_args="-DKDE_INSTALL_QMLDIR=lib/qt6/qml
- -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins"
+ -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins
+ -DKDE_INSTALL_QTMETATYPESDIR=lib/qt6/metatypes"
 hostmakedepends="extra-cmake-modules qt6-tools qt6-base qt6-shadertools
  qt6-declarative-host-tools"
 makedepends="qt6-declarative-private-devel qt6-shadertools-devel qt6-svg-devel
@@ -14,7 +16,11 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/kirigami"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=da7f3b733557b19975bb6b122e05d2f4d9214a70a81e2bb6e71c65761a3c6b43
+checksum=30fc6bd928a7124ace334944c8b45748603d37e45464db874903d7eb91f41d36
+
+# stage builds
+makedepends+=" kf6-base"
+shlib_requires="KDE_Frameworks.${version}"
 
 kf6-kirigami-devel_package() {
 	depends="${sourcepkg}>=${version}_${revision} qt6-base-devel

--- a/srcpkgs/kf6-kitemmodels/template
+++ b/srcpkgs/kf6-kitemmodels/template
@@ -1,6 +1,7 @@
 # Template file for 'kf6-kitemmodels'
+# group=kde-frameworks
 pkgname=kf6-kitemmodels
-version=6.25.0
+version=6.28.0
 revision=1
 build_style=cmake
 configure_args="-DKDE_INSTALL_QMLDIR=lib/qt6/qml
@@ -13,7 +14,11 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/kitemmodels"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=ab78119a00b84eac65ffc986df30fbf9b1b8d00635e8fc626372e84580d158ca
+checksum=e03c5dbfc97fa298de9be58bfeb686518a52ae1236389fbc2436ff84165e7e2b
+
+# stage builds
+makedepends+=" kf6-base"
+shlib_requires="KDE_Frameworks.${version}"
 
 kf6-kitemmodels-devel_package() {
 	depends="$makedepends ${sourcepkg}>=${version}_${revision}"

--- a/srcpkgs/kf6-kitemviews/template
+++ b/srcpkgs/kf6-kitemviews/template
@@ -1,6 +1,7 @@
 # Template file for 'kf6-kitemviews'
+# group=kde-frameworks
 pkgname=kf6-kitemviews
-version=6.25.0
+version=6.28.0
 revision=1
 build_style=cmake
 configure_args="-DBUILD_DESIGNERPLUGIN=ON -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins"
@@ -11,7 +12,11 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/kitemviews"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=b57f38d6fd184a4b260d0b35d76f6c0fb96bdd80475e3ca7d4151023730e5d3d
+checksum=2b474a0a0ca1d59111ab864d4f05100e0056b5204d52dfbab6776ca0fbfdd402
+
+# stage builds
+makedepends+=" kf6-base"
+shlib_requires="KDE_Frameworks.${version}"
 
 kf6-kitemviews-devel_package() {
 	depends="$makedepends ${sourcepkg}>=${version}_${revision}"

--- a/srcpkgs/kf6-kjobwidgets/template
+++ b/srcpkgs/kf6-kjobwidgets/template
@@ -1,7 +1,8 @@
 # Template file for 'kf6-kjobwidgets'
+# group=kde-frameworks
 pkgname=kf6-kjobwidgets
-version=6.25.0
-revision=2
+version=6.28.0
+revision=1
 build_style=cmake
 _llvmver=21
 configure_args="$(vopt_bool python BUILD_PYTHON_BINDINGS)"
@@ -15,7 +16,11 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/kjobwidgets"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=756bdc0a1c89a8e732ea7299bd325c38b81604da76b4cf361ccfc8b40a6e781e
+checksum=a13fcc9c861a90a540e5f93028fa7fae48f4c8643dadd287f3d54f5f24fab3da
+
+# stage builds
+makedepends+=" kf6-base"
+shlib_requires="KDE_Frameworks.${version}"
 
 build_options="python"
 build_options_default="python"

--- a/srcpkgs/kf6-knewstuff/template
+++ b/srcpkgs/kf6-knewstuff/template
@@ -1,7 +1,8 @@
 # Template file for 'kf6-knewstuff'
+# group=kde-frameworks
 pkgname=kf6-knewstuff
-version=6.25.0
-revision=2
+version=6.28.0
+revision=1
 build_style=cmake
 configure_args="-DKDE_INSTALL_QMLDIR=lib/qt6/qml
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins"
@@ -15,7 +16,11 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/knewstuff"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=8c31ef25a7d7389473d12245ae564ad888467b8ef910ac212e16e9334540cd08
+checksum=dc479d74def4e2d3e96f320f19285dcf88ec3ec6d39229f14ecb362983e305bd
+
+# stage builds
+makedepends+=" kf6-base"
+shlib_requires="KDE_Frameworks.${version}"
 
 kf6-knewstuff-devel_package() {
 	depends="${sourcepkg}>=${version}_${revision} qt6-base-devel

--- a/srcpkgs/kf6-knotifications/template
+++ b/srcpkgs/kf6-knotifications/template
@@ -1,7 +1,8 @@
 # Template file for 'kf6-knotifications'
+# group=kde-frameworks
 pkgname=kf6-knotifications
-version=6.25.0
-revision=2
+version=6.28.0
+revision=1
 build_style=cmake
 _llvmver=21
 configure_args="-DKDE_INSTALL_QMLDIR=lib/qt6/qml
@@ -18,7 +19,11 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/knotifications"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=0884add69f26a455cb8b6327bf89dc7ad3a0e4397c43c202fcf7ff73204ec695
+checksum=e5d3b284ccc907f190d3ab10995a0ae7fa0f505088acc69edc7adfcc6a8140d6
+
+# stage builds
+makedepends+=" kf6-base"
+shlib_requires="KDE_Frameworks.${version}"
 
 build_options="python"
 build_options_default="python"

--- a/srcpkgs/kf6-knotifyconfig/template
+++ b/srcpkgs/kf6-knotifyconfig/template
@@ -1,6 +1,7 @@
 # Template file for 'kf6-knotifyconfig'
+# group=kde-frameworks
 pkgname=kf6-knotifyconfig
-version=6.25.0
+version=6.28.0
 revision=1
 build_style=cmake
 hostmakedepends="extra-cmake-modules qt6-tools qt6-base
@@ -13,7 +14,11 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/knotifyconfig"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=8dc37406d8f13193216201752ece968cbd38da5a76780ad78575d11b47b440ea
+checksum=142cb399c5b55ed0d85f752f8fbb3db3f5930cbfa09737fdb17af6c2dfa073f6
+
+# stage builds
+makedepends+=" kf6-base"
+shlib_requires="KDE_Frameworks.${version}"
 
 kf6-knotifyconfig-devel_package() {
 	depends="${sourcepkg}>=${version}_${revision} qt6-base-devel"

--- a/srcpkgs/kf6-kpackage/template
+++ b/srcpkgs/kf6-kpackage/template
@@ -1,6 +1,7 @@
 # Template file for 'kf6-kpackage'
+# group=kde-frameworks
 pkgname=kf6-kpackage
-version=6.25.0
+version=6.28.0
 revision=1
 build_style=cmake
 hostmakedepends="extra-cmake-modules qt6-tools qt6-base kf6-kdoctools
@@ -12,7 +13,11 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/kpackage"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=bd465c0f1c11ec4c6767c985ebd144cc1efd6b6f249e7d19bf2cc04b956a663e
+checksum=2d04bcbc3492229cfc240884b04e7b220fa2022019c8f9d87f9f7814ea94c382
+
+# stage builds
+makedepends+=" kf6-base"
+shlib_requires="KDE_Frameworks.${version}"
 
 kf6-kpackage-devel_package() {
 	depends="$makedepends ${sourcepkg}>=${version}_${revision}"

--- a/srcpkgs/kf6-kparts/template
+++ b/srcpkgs/kf6-kparts/template
@@ -1,6 +1,7 @@
 # Template file for 'kf6-kparts'
+# group=kde-frameworks
 pkgname=kf6-kparts
-version=6.25.0
+version=6.28.0
 revision=1
 build_style=cmake
 hostmakedepends="extra-cmake-modules qt6-tools qt6-base
@@ -12,7 +13,11 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/kparts"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=f0d6346e3127d1e44506733113be467d8b50cb82731d300a57990dd09baaedf1
+checksum=fbdbab6dfdc16be97440a6e8032f30d1571eb72489c3d36801df6fb419dd4563
+
+# stage builds
+makedepends+=" kf6-base"
+shlib_requires="KDE_Frameworks.${version}"
 
 kf6-kparts-devel_package() {
 	depends="$makedepends ${sourcepkg}>=${version}_${revision}"

--- a/srcpkgs/kf6-kpeople/template
+++ b/srcpkgs/kf6-kpeople/template
@@ -1,6 +1,7 @@
 # Template file for 'kf6-kpeople'
+# group=kde-frameworks
 pkgname=kf6-kpeople
-version=6.25.0
+version=6.28.0
 revision=1
 build_style=cmake
 configure_args="-DKDE_INSTALL_QMLDIR=lib/qt6/qml
@@ -14,7 +15,11 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/kpeople"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=8bece583572330449dfa735b589b1df276759dbbb3a1f3a4d134c5677e2bf558
+checksum=a5bcf11a6cbca46d4bf83399fe9c0c3c9aaf228be81b05ba966a4ba51256fd0a
+
+# stage builds
+makedepends+=" kf6-base"
+shlib_requires="KDE_Frameworks.${version}"
 
 do_check() {
 	cd build

--- a/srcpkgs/kf6-kplotting/template
+++ b/srcpkgs/kf6-kplotting/template
@@ -1,6 +1,7 @@
 # Template file for 'kf6-kplotting'
+# group=kde-frameworks
 pkgname=kf6-kplotting
-version=6.25.0
+version=6.28.0
 revision=1
 build_style=cmake
 hostmakedepends="extra-cmake-modules qt6-tools qt6-base "
@@ -10,7 +11,11 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/kplotting"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=9fbd4775c9b1f56a24d90ee47cd0ad57c816fbbf60e3aaeba6e2b631f7b3fc9b
+checksum=bd350755be56da3d3ff4c65d9f62859782c9c1d75311a4830b3683f6ccb1c431
+
+# stage builds
+makedepends+=" kf6-base"
+shlib_requires="KDE_Frameworks.${version}"
 
 kf6-kplotting-devel_package() {
 	depends="$makedepends ${sourcepkg}>=${version}_${revision}"

--- a/srcpkgs/kf6-kpty/template
+++ b/srcpkgs/kf6-kpty/template
@@ -1,6 +1,7 @@
 # Template file for 'kf6-kpty'
+# group=kde-frameworks
 pkgname=kf6-kpty
-version=6.25.0
+version=6.28.0
 revision=1
 build_style=cmake
 configure_args="-DUTEMPTER_EXECUTABLE=/usr/lib/utempter/utempter"
@@ -12,7 +13,11 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/kpty"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=eb4deb424bdf20328dac0a12fdaab715dbf800e1cd08a4188cc2d3075543709f
+checksum=5a08d641e43fa8fd071d759d84e930251aa111973b362edce14d49032aa731d1
+
+# stage builds
+makedepends+=" kf6-base"
+shlib_requires="KDE_Frameworks.${version}"
 
 kf6-kpty-devel_package() {
 	depends="$makedepends ${sourcepkg}>=${version}_${revision}"

--- a/srcpkgs/kf6-kquickcharts/template
+++ b/srcpkgs/kf6-kquickcharts/template
@@ -1,7 +1,8 @@
 # Template file for 'kf6-kquickcharts'
+# group=kde-frameworks
 pkgname=kf6-kquickcharts
-version=6.25.0
-revision=2
+version=6.28.0
+revision=1
 build_style=cmake
 configure_args="-DKDE_INSTALL_QMLDIR=lib/qt6/qml
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins"
@@ -13,7 +14,11 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/kquickcharts"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=146598a1e107e8480631b3001fd39d264e81dd5af6a315dec71524465d099244
+checksum=c5d361d90861b4cd3db861568da5279ae2b1cb953e874126c15abbd7138378e5
+
+# stage builds
+makedepends+=" kf6-base"
+shlib_requires="KDE_Frameworks.${version}"
 
 kf6-kquickcharts-devel_package() {
 	depends="${sourcepkg}>=${version}_${revision} qt6-base-devel"

--- a/srcpkgs/kf6-krunner/template
+++ b/srcpkgs/kf6-krunner/template
@@ -1,8 +1,11 @@
 # Template file for 'kf6-krunner'
+# group=kde-frameworks
 pkgname=kf6-krunner
-version=6.25.0
+version=6.28.0
 revision=1
 build_style=cmake
+configure_args="-DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins
+ -DKDE_INSTALL_QTMETATYPESDIR=lib/qt6/metatypes"
 hostmakedepends="extra-cmake-modules qt6-tools qt6-base
  kf6-kconfig gettext"
 makedepends="kf6-kconfig-devel kf6-kcoreaddons-devel kf6-ki18n-devel
@@ -13,7 +16,11 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/krunner"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=a2cf0c9ae296868250b15b8446d657063a95c70d9d182b007814fb59efa50419
+checksum=c4c1fccbe6e04acc8d5891df4eca20a4b6be24c032a10e92839a41c1bb847cc4
+
+# stage builds
+makedepends+=" kf6-base"
+shlib_requires="KDE_Frameworks.${version}"
 
 do_check() {
 	cd build

--- a/srcpkgs/kf6-kservice/template
+++ b/srcpkgs/kf6-kservice/template
@@ -1,9 +1,9 @@
 # Template file for 'kf6-kservice'
+# group=kde-frameworks
 pkgname=kf6-kservice
-version=6.25.0
+version=6.28.0
 revision=1
 build_style=cmake
-configure_args="-DKF6_HOST_TOOLING=/usr/lib/cmake"
 hostmakedepends="extra-cmake-modules qt6-tools qt6-base
  gettext kf6-kdoctools kf6-kconfig"
 makedepends="kf6-kconfig-devel kf6-kcoreaddons-devel kf6-ki18n-devel
@@ -13,7 +13,11 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/kservice"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=04fa9f824e50c25b6ad7e29262c6566e0ce11edefb9fede317399a88501e9f74
+checksum=d9151195b748361a12d7aeafd8df531d2f45b55d202d7fa5f47c3a11d59877d6
+
+# stage builds
+makedepends+=" kf6-base"
+shlib_requires="KDE_Frameworks.${version}"
 
 do_check() {
 	cd build

--- a/srcpkgs/kf6-kstatusnotifieritem/template
+++ b/srcpkgs/kf6-kstatusnotifieritem/template
@@ -1,7 +1,8 @@
 # Template file for 'kf6-kstatusnotifieritem'
+# group=kde-frameworks
 pkgname=kf6-kstatusnotifieritem
-version=6.25.0
-revision=2
+version=6.28.0
+revision=1
 build_style=cmake
 _llvmver=21
 configure_args="$(vopt_bool python BUILD_PYTHON_BINDINGS)"
@@ -14,7 +15,11 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/kstatusnotifieritem"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=7a6397f08b15a7d50e407c193f1774b548994f6f9d12327dfbb674270adfc9af
+checksum=595135e16456ed2e86ebdf6919b181426cea2e7449ed7d32905dac52050d22de
+
+# stage builds
+makedepends+=" kf6-base"
+shlib_requires="KDE_Frameworks.${version}"
 
 build_options="python"
 build_options_default="python"

--- a/srcpkgs/kf6-ksvg/template
+++ b/srcpkgs/kf6-ksvg/template
@@ -1,6 +1,7 @@
 # Template file for 'kf6-ksvg'
+# group=kde-frameworks
 pkgname=kf6-ksvg
-version=6.25.0
+version=6.28.0
 revision=1
 build_style=cmake
 configure_args="-DKDE_INSTALL_QMLDIR=lib/qt6/qml
@@ -15,7 +16,11 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/ksvg"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=9c05166e289d39603696944edfbc3b50a1aadcd19e5b602002013c6149a44129
+checksum=d580e6038ab3fb8a8755c953abd27a55894c2ae05e72cdef9bca1cf4e265a325
+
+# stage builds
+makedepends+=" kf6-base"
+shlib_requires="KDE_Frameworks.${version}"
 
 kf6-ksvg-devel_package() {
 	depends="$makedepends ${sourcepkg}>=${version}_${revision}"

--- a/srcpkgs/kf6-ktexteditor/template
+++ b/srcpkgs/kf6-ktexteditor/template
@@ -1,9 +1,10 @@
 # Template file for 'kf6-ktexteditor'
+# group=kde-frameworks
 pkgname=kf6-ktexteditor
-version=6.25.0
+version=6.28.0
 revision=1
 build_style=cmake
-configure_args="-DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="
  -DKDE_INSTALL_QMLDIR=lib/qt6/qml
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins"
 hostmakedepends="extra-cmake-modules qt6-tools qt6-base kf6-kauth-tools
@@ -19,7 +20,11 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/ktexteditor"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=77e815edcdf572397f5eb750d7232b366f6cc6274bb34246ab88f2f2179733b4
+checksum=63b7bbd9325cfda64e2c8f862e2327270ef7a9d1f887b5c6585f372511d33f8d
+
+# stage builds
+makedepends+=" kf6-base"
+shlib_requires="KDE_Frameworks.${version}"
 
 kf6-ktexteditor-devel_package() {
 	depends="$makedepends ${sourcepkg}>=${version}_${revision}"

--- a/srcpkgs/kf6-ktexttemplate/template
+++ b/srcpkgs/kf6-ktexttemplate/template
@@ -1,6 +1,7 @@
 # Template file for 'kf6-ktexttemplate'
+# group=kde-frameworks
 pkgname=kf6-ktexttemplate
-version=6.25.0
+version=6.28.0
 revision=1
 build_style=cmake
 configure_args="-DKDE_INSTALL_QMLDIR=lib/qt6/qml
@@ -13,7 +14,11 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/ktexttemplate"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=4e9f7583b3dcb37980b99fb2ac2de9e95af8b14fe9a166752bcb83c66ce26e25
+checksum=a184163f7d5d2ac4cd4a71d04bee830020332552bfa9eb5159ced57b20edd527
+
+# stage builds
+makedepends+=" kf6-base"
+shlib_requires="KDE_Frameworks.${version}"
 
 kf6-ktexttemplate-devel_package() {
 	depends="$makedepends ${sourcepkg}>=${version}_${revision}"

--- a/srcpkgs/kf6-ktextwidgets/template
+++ b/srcpkgs/kf6-ktextwidgets/template
@@ -1,6 +1,7 @@
 # Template file for 'kf6-ktextwidgets'
+# group=kde-frameworks
 pkgname=kf6-ktextwidgets
-version=6.25.0
+version=6.28.0
 revision=1
 build_style=cmake
 hostmakedepends="extra-cmake-modules qt6-tools qt6-base
@@ -13,7 +14,11 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/ktextwidgets"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=adb35bb19fb27e89b999645f8f9d650d1de3e8ed9bb686120705fdcd1cb0f3de
+checksum=b995613588aa68c20872e2e3c173083d6e8139e91852e0e7a29bd3ae7dee67e9
+
+# stage builds
+makedepends+=" kf6-base"
+shlib_requires="KDE_Frameworks.${version}"
 
 kf6-ktextwidgets-devel_package() {
 	depends="$makedepends ${sourcepkg}>=${version}_${revision}"

--- a/srcpkgs/kf6-kunitconversion/template
+++ b/srcpkgs/kf6-kunitconversion/template
@@ -1,7 +1,8 @@
 # Template file for 'kf6-kunitconversion'
+# group=kde-frameworks
 pkgname=kf6-kunitconversion
-version=6.25.0
-revision=2
+version=6.28.0
+revision=1
 _llvmver=21
 build_style=cmake
 configure_args="$(vopt_bool python BUILD_PYTHON_BINDINGS)"
@@ -14,7 +15,11 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/kunitconversion"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=369ef042de797ea647994c524cc43915b514850026cfddb4b24bc78bdfc3dcc8
+checksum=b3e7dc0ad758a994f5171c6fb9a4bbf59bb51bdf7e0fecf0df6a3b55f2e5bd6b
+
+# stage builds
+makedepends+=" kf6-base"
+shlib_requires="KDE_Frameworks.${version}"
 
 build_options="python"
 build_options_default="python"

--- a/srcpkgs/kf6-kuserfeedback/template
+++ b/srcpkgs/kf6-kuserfeedback/template
@@ -1,6 +1,7 @@
 # Template file for 'kf6-kuserfeedback'
+# group=kde-frameworks
 pkgname=kf6-kuserfeedback
-version=6.25.0
+version=6.28.0
 revision=1
 build_style=cmake
 configure_args="-DKDE_INSTALL_QMLDIR=lib/qt6/qml
@@ -14,7 +15,11 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/kuserfeedback"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=4ce9fd672bed20ce646cd175522d207e0fe753fe42c5cf773c087927c0f30fe3
+checksum=07f279845b3cd6e675513afb81f3c6274b2f6757edc149d163116b3c50dfa0df
+
+# stage builds
+makedepends+=" kf6-base"
+shlib_requires="KDE_Frameworks.${version}"
 
 do_check() {
 	cd build

--- a/srcpkgs/kf6-kwallet/template
+++ b/srcpkgs/kf6-kwallet/template
@@ -1,9 +1,9 @@
 # Template file for 'kf6-kwallet'
+# group=kde-frameworks
 pkgname=kf6-kwallet
-version=6.25.0
+version=6.28.0
 revision=1
 build_style=cmake
-configure_args="-DKF6_HOST_TOOLING=/usr/lib/cmake"
 hostmakedepends="extra-cmake-modules qt6-tools qt6-base
  gettext kf6-kdoctools kf6-kconfig pkg-config"
 makedepends="kf6-kconfig-devel kf6-kcoreaddons-devel kf6-kcrash-devel
@@ -15,7 +15,11 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/kwallet"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=6fe7c8f4c556db4861f0046dfe179c31e7891fb6ecdcfa33692d252bf23d3b11
+checksum=e21130c86ffa0be49065648f4e753d63d3d786fab876f511d9d09da16480f691
+
+# stage builds
+makedepends+=" kf6-base"
+shlib_requires="KDE_Frameworks.${version}"
 
 # https://bugs.kde.org/show_bug.cgi?id=509680 / https://github.com/void-linux/void-packages/issues/57348
 post_install() {

--- a/srcpkgs/kf6-kwayland/template
+++ b/srcpkgs/kf6-kwayland/template
@@ -1,7 +1,8 @@
 # Template file for 'kf6-kwayland'
+# group=kde-plasma
 pkgname=kf6-kwayland
-version=6.6.3
-revision=2
+version=6.7.3
+revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF"
 hostmakedepends="kf6-kcoreaddons pkg-config extra-cmake-modules qt6-tools qt6-base
@@ -13,7 +14,11 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/plasma/kwayland"
 distfiles="${KDE_SITE}/plasma/${version}/kwayland-${version}.tar.xz"
-checksum=55029d00c415b40e077a461541663fbca5c96e6b74e261950f7480ec5abbb555
+checksum=0e331dca128a9e2f0b408e1020e5b613e24d742cc1bfd8bb5f89459fee11c217
+
+# stage builds
+makedepends+=" kde-plasma-base"
+shlib_requires="KDE_Plasma.${version}"
 
 kf6-kwayland-devel_package() {
 	short_desc+=" - development"

--- a/srcpkgs/kf6-kweathercore/template
+++ b/srcpkgs/kf6-kweathercore/template
@@ -3,7 +3,7 @@ pkgname=kf6-kweathercore
 version=26.04.1
 revision=1
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="-DBUILD_TESTING=OFF
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins
  -DKDE_INSTALL_QMLDIR=lib/qt6/qml
  -DECM_MKSPECS_INSTALL_DIR=/usr/lib/qt6/mkspecs/modules"

--- a/srcpkgs/kf6-kwidgetsaddons/template
+++ b/srcpkgs/kf6-kwidgetsaddons/template
@@ -1,7 +1,8 @@
 # Template file for 'kf6-kwidgetsaddons'
+# group=kde-frameworks
 pkgname=kf6-kwidgetsaddons
-version=6.25.0
-revision=2
+version=6.28.0
+revision=1
 _llvmver=21
 build_style=cmake
 configure_args="-DBUILD_DESIGNERPLUGIN=ON -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins
@@ -15,7 +16,11 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/kwidgetsaddons"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=8a9f9cde4427ffec37a0501d337aadae3de39736674f571ff8a13d17d1e6c938
+checksum=6bb6a22e40bc8cfaeda08276b771488294ad417e7802b27bdc455202afdabd7d
+
+# stage builds
+makedepends+=" kf6-base"
+shlib_requires="KDE_Frameworks.${version}"
 
 build_options="python"
 build_options_default="python"

--- a/srcpkgs/kf6-kwindowsystem/template
+++ b/srcpkgs/kf6-kwindowsystem/template
@@ -1,7 +1,8 @@
 # Template file for 'kf6-kwindowsystem'
+# group=kde-frameworks
 pkgname=kf6-kwindowsystem
-version=6.25.0
-revision=2
+version=6.28.0
+revision=1
 build_style=cmake
 configure_args="-DKDE_INSTALL_QMLDIR=lib/qt6/qml
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins"
@@ -14,7 +15,11 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/kwindowsystem"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=b51448a7669efa18190ab7fa8d6f5e0f77d8f9879cf457dadb4629b245a02434
+checksum=5adbdf9c82b1ecbb92bda6498ea1b8f88c08f9ec57dbff70d582e2453bf16b12
+
+# stage builds
+makedepends+=" kf6-base"
+shlib_requires="KDE_Frameworks.${version}"
 
 post_install() {
 	sed -i -e 's:/usr/[a-z0-9-]*/usr/include;::' \

--- a/srcpkgs/kf6-kxmlgui/template
+++ b/srcpkgs/kf6-kxmlgui/template
@@ -1,7 +1,8 @@
 # Template file for 'kf6-kxmlgui'
+# group=kde-frameworks
 pkgname=kf6-kxmlgui
-version=6.25.0
-revision=2
+version=6.28.0
+revision=1
 _llvmver=21
 build_style=cmake
 configure_args="$(vopt_bool python BUILD_PYTHON_BINDINGS)"
@@ -17,7 +18,11 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/kxmlgui"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=02d97c24ec0bc102c299f3429056b45025e24d59ec31464317a3062cc1fc2021
+checksum=e40b86ebb9f1be00255cd4835ab0b0ac8650c47d0eb17a47d9df7d4b5658df58
+
+# stage builds
+makedepends+=" kf6-base"
+shlib_requires="KDE_Frameworks.${version}"
 
 build_options="python"
 build_options_default="python"

--- a/srcpkgs/kf6-modemmanager-qt/template
+++ b/srcpkgs/kf6-modemmanager-qt/template
@@ -1,6 +1,7 @@
 # Template file for 'kf6-modemmanager-qt'
+# group=kde-frameworks
 pkgname=kf6-modemmanager-qt
-version=6.25.0
+version=6.28.0
 revision=1
 build_style=cmake
 hostmakedepends="extra-cmake-modules qt6-tools qt6-base
@@ -12,7 +13,11 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/modemmanager-qt"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=1f1c3ef493445a3f9215462dd86d25e2e4355ffbce9a70016288be04c537b91b
+checksum=742891c3c1dfcd6c9eaa2b1664cfe7e9b311187eec7ecd9d8812829dce8485c9
+
+# stage builds
+makedepends+=" kf6-base"
+shlib_requires="KDE_Frameworks.${version}"
 
 do_check() {
 	cd build

--- a/srcpkgs/kf6-networkmanager-qt/template
+++ b/srcpkgs/kf6-networkmanager-qt/template
@@ -1,6 +1,7 @@
 # Template file for 'kf6-networkmanager-qt'
+# group=kde-frameworks
 pkgname=kf6-networkmanager-qt
-version=6.25.0
+version=6.28.0
 revision=1
 build_style=cmake
 configure_args="-DKDE_INSTALL_QMLDIR=lib/qt6/qml"
@@ -12,7 +13,11 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/networkmanager-qt"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=c3874938892c43ae8d486cd7b71e586f3ad368518cbf80034dcbf97516976756
+checksum=30604204bb00115f515146d05f981aa1f9824e14c0c537a1ec397581ac5d912e
+
+# stage builds
+makedepends+=" kf6-base"
+shlib_requires="KDE_Frameworks.${version}"
 
 do_check() {
 	cd build

--- a/srcpkgs/kf6-prison/template
+++ b/srcpkgs/kf6-prison/template
@@ -1,7 +1,8 @@
 # Template file for 'kf6-prison'
+# group=kde-frameworks
 pkgname=kf6-prison
-version=6.25.0
-revision=2
+version=6.28.0
+revision=1
 build_style=cmake
 configure_args="-DKDE_INSTALL_QMLDIR=lib/qt6/qml"
 hostmakedepends="extra-cmake-modules qt6-tools qt6-base
@@ -13,7 +14,11 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/prison"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=9f4a8fa5732e45142c9ba2e35a38904d44193efc050e1ca20a414445c3a98b34
+checksum=ad24dd64b5150ec9ebc4df9734b4c2a58c27a588eafeb4239cdcef01629fe696
+
+# stage builds
+makedepends+=" kf6-base"
+shlib_requires="KDE_Frameworks.${version}"
 
 kf6-prison-devel_package() {
 	depends="$makedepends ${sourcepkg}>=${version}_${revision}"

--- a/srcpkgs/kf6-purpose/patches/intltool.patch
+++ b/srcpkgs/kf6-purpose/patches/intltool.patch
@@ -1,22 +1,22 @@
 --- a/src/plugins/youtube/CMakeLists.txt
 +++ b/src/plugins/youtube/CMakeLists.txt
-@@ -1,6 +1,7 @@
+@@ -1,7 +1,7 @@
  add_definitions(-DTRANSLATION_DOMAIN=\"purpose6_youtube\")
  
--kaccounts_add_service(${CMAKE_CURRENT_SOURCE_DIR}/google-youtube.service.in)
-+kaccounts_add_service(${CMAKE_CURRENT_SOURCE_DIR}/google-youtube.service.in
-+    NO_INTLTOOL)
+ if (KAccounts6_FOUND)
+-    kaccounts_add_service(${CMAKE_CURRENT_SOURCE_DIR}/google-youtube.service.in)
++	kaccounts_add_service(${CMAKE_CURRENT_SOURCE_DIR}/google-youtube.service.in NO_INTLTOOL)
+ endif()
  
  add_share_plugin(youtubeplugin youtubeplugin.cpp youtubejob.cpp youtubejobcomposite.cpp)
- target_link_libraries(youtubeplugin KF6::WidgetsAddons KF6::KIOCore Qt6::Network KF6::I18n KF6::Purpose KAccounts6)
 --- a/src/plugins/nextcloud/CMakeLists.txt
 +++ b/src/plugins/nextcloud/CMakeLists.txt
-@@ -1,6 +1,7 @@
+@@ -1,7 +1,7 @@
  add_definitions(-DTRANSLATION_DOMAIN=\"purpose6_nextcloud\")
  
--kaccounts_add_service(${CMAKE_CURRENT_SOURCE_DIR}/nextcloud-upload.service.in)
-+kaccounts_add_service(${CMAKE_CURRENT_SOURCE_DIR}/nextcloud-upload.service.in
-+    NO_INTLTOOL)
+ if (KAccounts6_FOUND)
+-    kaccounts_add_service(${CMAKE_CURRENT_SOURCE_DIR}/nextcloud-upload.service.in)
++	kaccounts_add_service(${CMAKE_CURRENT_SOURCE_DIR}/nextcloud-upload.service.in NO_INTLTOOL)
+ endif()
  
  add_share_plugin(nextcloudplugin nextcloudplugin.cpp nextcloudjob.cpp)
- target_link_libraries(nextcloudplugin KF6::KIOCore KF6::I18n KF6::Purpose KAccounts6)

--- a/srcpkgs/kf6-purpose/template
+++ b/srcpkgs/kf6-purpose/template
@@ -1,7 +1,8 @@
 # Template file for 'kf6-purpose'
+# group=kde-frameworks
 pkgname=kf6-purpose
-version=6.25.0
-revision=2
+version=6.28.0
+revision=1
 build_style=cmake
 configure_args="-DKDE_INSTALL_QMLDIR=lib/qt6/qml
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins"
@@ -17,7 +18,11 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/purpose"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=773abfa91f50ce10419373fdb4e7e0b2be009e739f8de2f3450d3ef169b6a23e
+checksum=c2be01e1aaf2ab14ba6f05582d7c4a29e144dd96258d86b208f58c34bfa83672
+
+# stage builds
+makedepends+=" kf6-base"
+shlib_requires="KDE_Frameworks.${version}"
 
 kf6-purpose-devel_package() {
 	depends="${sourcepkg}>=${version}_${revision} kf6-kcoreaddons-devel"

--- a/srcpkgs/kf6-qqc2-desktop-style/template
+++ b/srcpkgs/kf6-qqc2-desktop-style/template
@@ -1,7 +1,8 @@
 # Template file for 'kf6-qqc2-desktop-style'
+# group=kde-frameworks
 pkgname=kf6-qqc2-desktop-style
-version=6.25.0
-revision=2
+version=6.28.0
+revision=1
 build_style=cmake
 configure_args="-DKDE_INSTALL_QMLDIR=lib/qt6/qml
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins"
@@ -14,7 +15,11 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/qqc2-desktop-style"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=c09070e57a196baab50e62aac5e17051666a898d95ac29d8853c6634a02ab9d1
+checksum=8748d01f401cb16a34adbdf568b2bde2cc1820f82c38249fdec11b66d9da97d1
+
+# stage builds
+makedepends+=" kf6-base"
+shlib_requires="KDE_Frameworks.${version}"
 
 do_check() {
 	cd build

--- a/srcpkgs/kf6-solid/template
+++ b/srcpkgs/kf6-solid/template
@@ -1,6 +1,7 @@
 # Template file for 'kf6-solid'
+# group=kde-frameworks
 pkgname=kf6-solid
-version=6.25.0
+version=6.28.0
 revision=1
 build_style=cmake
 hostmakedepends="extra-cmake-modules qt6-tools qt6-base flex pkg-config"
@@ -11,9 +12,12 @@ short_desc="Hardware integration and detection"
 maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/solid"
-#changelog=""
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=8177fa8f139b855856e171426c5f2adb96d727e62e6ec536675da11aa157b33e
+checksum=47fa84db565372584c6ecb03f71a6085f706a1c031ea4f2ffc35808f09a19b3d
+
+# stage builds
+makedepends+=" kf6-base"
+shlib_requires="KDE_Frameworks.${version}"
 
 kf6-solid-devel_package() {
 	depends="qt6-base-devel ${sourcepkg}>=${version}_${revision}"

--- a/srcpkgs/kf6-sonnet/template
+++ b/srcpkgs/kf6-sonnet/template
@@ -1,6 +1,7 @@
 # Template file for 'kf6-sonnet'
+# group=kde-frameworks
 pkgname=kf6-sonnet
-version=6.25.0
+version=6.28.0
 revision=1
 build_style=cmake
 configure_args="-DBUILD_DESIGNERPLUGIN=ON
@@ -14,7 +15,11 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/sonnet"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=510521f1404914943b3141e0b111f2330bbeefdf40405f93c0cf7b84a8c1c589
+checksum=66c6b439950bec7f67b730e6e49d6d30cba21dad115e4a47c4fe46014cc19c3b
+
+# stage builds
+makedepends+=" kf6-base"
+shlib_requires="KDE_Frameworks.${version}"
 
 kf6-sonnet-devel_package() {
 	depends="$makedepends ${sourcepkg}>=${version}_${revision}"

--- a/srcpkgs/kf6-syndication/template
+++ b/srcpkgs/kf6-syndication/template
@@ -1,6 +1,7 @@
 # Template file for 'kf6-syndication'
+# group=kde-frameworks
 pkgname=kf6-syndication
-version=6.25.0
+version=6.28.0
 revision=1
 build_style=cmake
 hostmakedepends="extra-cmake-modules qt6-tools qt6-base"
@@ -10,7 +11,11 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/syndication"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=953f5935b1a0ba7c2c70cc213c0144d9c73855c802a1525be6c086543428f957
+checksum=24db750155b69e3f858997cad0655a2f230f85d587c1063166113bc7690fd7b8
+
+# stage builds
+makedepends+=" kf6-base"
+shlib_requires="KDE_Frameworks.${version}"
 
 kf6-syndication-devel_package() {
 	depends="$makedepends ${sourcepkg}>=${version}_${revision}"

--- a/srcpkgs/kf6-syntax-highlighting/template
+++ b/srcpkgs/kf6-syntax-highlighting/template
@@ -1,6 +1,7 @@
 # Template file for 'kf6-syntax-highlighting'
+# group=kde-frameworks
 pkgname=kf6-syntax-highlighting
-version=6.25.0
+version=6.28.0
 revision=1
 build_style=cmake
 configure_args="
@@ -15,7 +16,11 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/syntax-highlighting"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=8aeee428e82ac96aad01bbd423518705d214e0f3a5ac1fd64389565d08e5d501
+checksum=b9d90a03b4e9a48170a14f7a4a79c44f0aae9f14e1b94b7b1fc75d5c3fb31d3a
+
+# stage builds
+makedepends+=" kf6-base"
+shlib_requires="KDE_Frameworks.${version}"
 
 if [ "$CROSS_BUILD" ]; then
 	hostmakedepends+=" kf6-syntax-highlighting-devel"

--- a/srcpkgs/kf6-threadweaver/template
+++ b/srcpkgs/kf6-threadweaver/template
@@ -1,6 +1,7 @@
 # Template file for 'kf6-threadweaver'
+# group=kde-frameworks
 pkgname=kf6-threadweaver
-version=6.25.0
+version=6.28.0
 revision=1
 build_style=cmake
 hostmakedepends="extra-cmake-modules qt6-tools qt6-base "
@@ -10,7 +11,11 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/frameworks/threadweaver"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/${pkgname#kf6-}-${version}.tar.xz"
-checksum=f74ca31f5559f55870496df5372da09dfb409e197cc6e0f660979b98cd611444
+checksum=ab4a7e1a2ff4ee9e3ebb73097fb93beda6857f08d1c4ab7d15af17c383ffaf7e
+
+# stage builds
+makedepends+=" kf6-base"
+shlib_requires="KDE_Frameworks.${version}"
 
 kf6-threadweaver-devel_package() {
 	depends="$makedepends ${sourcepkg}>=${version}_${revision}"

--- a/srcpkgs/kfind/template
+++ b/srcpkgs/kfind/template
@@ -3,7 +3,7 @@ pkgname=kfind
 version=26.04.1
 revision=1
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="-DBUILD_TESTING=OFF
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins"
 hostmakedepends="extra-cmake-modules gettext kf6-kcoreaddons qt6-base
  kf6-kdoctools kf6-kconfig"

--- a/srcpkgs/kgamma/template
+++ b/srcpkgs/kgamma/template
@@ -1,9 +1,10 @@
 # Template file for 'kgamma'
+# group=kde-plasma
 pkgname=kgamma
-version=6.6.3
+version=6.7.3
 revision=1
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="-DBUILD_TESTING=OFF
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins"
 hostmakedepends="extra-cmake-modules gettext kf6-kcoreaddons
  kf6-kdoctools kf6-kconfig kf6-kcmutils qt6-tools qt6-base"
@@ -14,7 +15,11 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="https://invent.kde.org/plasma/kgamma"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=6c13370802e14595f24f3fd475a50cd27138f9af5fe873df306b90d9ee2956d6
+checksum=1cdf5b63343ea0525a72642dd884978628906155242495209603bd6d76b203a0
+
+# stage builds
+makedepends+=" kde-plasma-base"
+shlib_requires="KDE_Plasma.${version}"
 
 kgamma5_package() {
 	metapackage=yes

--- a/srcpkgs/kget/template
+++ b/srcpkgs/kget/template
@@ -3,7 +3,7 @@ pkgname=kget
 version=26.04.1
 revision=1
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="-DBUILD_TESTING=OFF
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins
  -DKDE_INSTALL_QMLDIR=lib/qt6/qml
  -DECM_MKSPECS_INSTALL_DIR=/usr/lib/qt6/mkspecs/modules"

--- a/srcpkgs/kglobalacceld/template
+++ b/srcpkgs/kglobalacceld/template
@@ -1,7 +1,8 @@
 # Template file for 'kglobalacceld'
+# group=kde-plasma
 pkgname=kglobalacceld
-version=6.6.3
-revision=2
+version=6.7.3
+revision=1
 build_style=cmake
 configure_args="-DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins"
 hostmakedepends="extra-cmake-modules qt6-base qt6-tools kf6-kconfig"
@@ -13,7 +14,11 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-3.0-or-later"
 homepage="https://invent.kde.org/plasma/kglobalacceld"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=bcb5d43146df016fe568401912538de8c70e01c4e6da78740e6f2181a8b29ea7
+checksum=cd940d21bb050d6ee689d5962d31292c52f31cfa9211ea789dbed4ff05022f1d
+
+# stage builds
+makedepends+=" kde-plasma-base"
+shlib_requires="KDE_Plasma.${version}"
 
 do_check() {
 	cd build

--- a/srcpkgs/kgpg/template
+++ b/srcpkgs/kgpg/template
@@ -3,7 +3,7 @@ pkgname=kgpg
 version=26.04.1
 revision=1
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="-DBUILD_TESTING=OFF
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins
  -DKDE_INSTALL_QMLDIR=lib/qt6/qml
  -DECM_MKSPECS_INSTALL_DIR=/usr/lib/qt6/mkspecs/modules"

--- a/srcpkgs/khelpcenter/template
+++ b/srcpkgs/khelpcenter/template
@@ -3,7 +3,7 @@ pkgname=khelpcenter
 version=26.04.1
 revision=1
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake"
+configure_args="-DBUILD_TESTING=OFF"
 hostmakedepends="extra-cmake-modules kf6-kcoreaddons qt6-base qt6-tools
  kf6-kconfig kf6-kdoctools python3 pkg-config gettext"
 makedepends="libxml2-devel qt6-base-devel xapian-core-devel

--- a/srcpkgs/kidentitymanagement/template
+++ b/srcpkgs/kidentitymanagement/template
@@ -3,7 +3,7 @@ pkgname=kidentitymanagement
 version=26.04.1
 revision=2
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="-DBUILD_TESTING=OFF
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins
  -DKDE_INSTALL_QMLDIR=lib/qt6/qml
  -DECM_MKSPECS_INSTALL_DIR=/usr/lib/qt6/mkspecs/modules"

--- a/srcpkgs/kig/template
+++ b/srcpkgs/kig/template
@@ -3,7 +3,7 @@ pkgname=kig
 version=26.04.1
 revision=1
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="-DBUILD_TESTING=OFF
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins
  -DKDE_INSTALL_QMLDIR=lib/qt6/qml
  -DECM_MKSPECS_INSTALL_DIR=/usr/lib/qt6/mkspecs/modules"

--- a/srcpkgs/kile/template
+++ b/srcpkgs/kile/template
@@ -3,7 +3,7 @@ pkgname=kile
 version=2.9.94
 revision=1
 build_style=cmake
-configure_args="-DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins"
 hostmakedepends="extra-cmake-modules gettext kf6-kdoctools kf6-kcoreaddons
  kf6-kconfig qt6-base qt6-tools"

--- a/srcpkgs/kimap/template
+++ b/srcpkgs/kimap/template
@@ -3,7 +3,7 @@ pkgname=kimap
 version=26.04.1
 revision=1
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="-DBUILD_TESTING=OFF
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins
  -DKDE_INSTALL_QMLDIR=lib/qt6/qml
  -DECM_MKSPECS_INSTALL_DIR=/usr/lib/qt6/mkspecs/modules"

--- a/srcpkgs/kinfocenter/template
+++ b/srcpkgs/kinfocenter/template
@@ -1,9 +1,10 @@
 # Template file for 'kinfocenter'
+# group=kde-plasma
 pkgname=kinfocenter
-version=6.6.3
-revision=2
+version=6.7.3
+revision=1
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="-DBUILD_TESTING=OFF
  -DKDE_INSTALL_QMLDIR=lib/qt6/qml -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins"
 hostmakedepends="extra-cmake-modules gettext pkg-config qt6-tools qt6-base
  qt6-concurrent qt6-plugin-odbc qt6-plugin-pgsql qt6-plugin-mysql qt6-plugin-sqlite
@@ -20,4 +21,8 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later, LGPL-2.1-or-later, GFDL-1.2-only"
 homepage="https://invent.kde.org/plasma/kinfocenter"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=610c473bdf55497105a28e5cea67401446d83d1bd1b97ed56c4e07be7da0c813
+checksum=436eb7e95e061ebddb84d0e51b5abf477a5a3b2698462ea247ea6ba633a88655
+
+# stage builds
+makedepends+=" kde-plasma-base"
+shlib_requires="KDE_Plasma.${version}"

--- a/srcpkgs/kio-extras/template
+++ b/srcpkgs/kio-extras/template
@@ -3,7 +3,7 @@ pkgname=kio-extras
 version=26.04.1
 revision=2
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="-DBUILD_TESTING=OFF
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins
  -DWITH_LIBPROXY=ON"
 hostmakedepends="extra-cmake-modules pkg-config gperf qt6-base qt6-tools

--- a/srcpkgs/kio-gdrive/template
+++ b/srcpkgs/kio-gdrive/template
@@ -3,7 +3,7 @@ pkgname=kio-gdrive
 version=26.04.1
 revision=1
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="-DBUILD_TESTING=OFF
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins -DQT_MAJOR_VERSION=6
  -DKDE_INSTALL_QMLDIR=lib/qt6/qml
  -DECM_MKSPECS_INSTALL_DIR=/usr/lib/qt6/mkspecs/modules"

--- a/srcpkgs/kirigami-addons/template
+++ b/srcpkgs/kirigami-addons/template
@@ -1,7 +1,7 @@
 # Template file for 'kirigami-addons'
 pkgname=kirigami-addons
-version=1.11.0
-revision=5
+version=1.12.1
+revision=1
 build_style=cmake
 configure_args="-DKDE_INSTALL_QMLDIR=lib/qt6/qml
  -DBUILD_TESTING=OFF -DBUILD_QCH=ON"
@@ -20,7 +20,7 @@ maintainer="José Santos <agarimos@tutanota.com>"
 license="GPL-3.0-or-later"
 homepage="https://invent.kde.org/libraries/kirigami-addons"
 distfiles="${KDE_SITE}/kirigami-addons/kirigami-addons-${version}.tar.xz"
-checksum=6dcdfa324f710f00887e6321212fc8582a3c4712450d129d91435bb1edd8d523
+checksum=c543a493ce5875f405fb1c9ff6d531060ed082cc6d710e56d46ac42d164207bb
 
 kirigami-addons-devel_package() {
 	depends="qt6-base-devel ${sourcepkg}-${version}_${revision}"

--- a/srcpkgs/kitinerary/template
+++ b/srcpkgs/kitinerary/template
@@ -3,7 +3,7 @@ pkgname=kitinerary
 version=26.04.1
 revision=3
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="-DBUILD_TESTING=OFF
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins
  -DKDE_INSTALL_QMLDIR=lib/qt6/qml
  -DECM_MKSPECS_INSTALL_DIR=/usr/lib/qt6/mkspecs/modules"

--- a/srcpkgs/kldap/template
+++ b/srcpkgs/kldap/template
@@ -3,7 +3,7 @@ pkgname=kldap
 version=26.04.1
 revision=1
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="-DBUILD_TESTING=OFF
  -DKDE_INSTALL_QMLDIR=lib/qt6/qml -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins"
 hostmakedepends="extra-cmake-modules qt6-base python3 kf6-kconfig
  gettext kf6-kcoreaddons kf6-kdoctools"

--- a/srcpkgs/kleopatra/template
+++ b/srcpkgs/kleopatra/template
@@ -3,7 +3,7 @@ pkgname=kleopatra
 version=26.04.1
 revision=1
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="-DBUILD_TESTING=OFF
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins
  -DKDE_INSTALL_QMLDIR=lib/qt6/qml
  -DECM_MKSPECS_INSTALL_DIR=/usr/lib/qt6/mkspecs/modules"

--- a/srcpkgs/klickety/template
+++ b/srcpkgs/klickety/template
@@ -3,7 +3,7 @@ pkgname=klickety
 version=26.04.2
 revision=1
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="-DBUILD_TESTING=OFF
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins
  -DKDE_INSTALL_QMLDIR=lib/qt6/qml
  -DECM_MKSPECS_INSTALL_DIR=/usr/lib/qt6/mkspecs/modules"

--- a/srcpkgs/kmag/template
+++ b/srcpkgs/kmag/template
@@ -3,7 +3,7 @@ pkgname=kmag
 version=26.04.1
 revision=1
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake"
+configure_args="-DBUILD_TESTING=OFF"
 hostmakedepends="extra-cmake-modules gettext kf6-kcoreaddons kf6-kdoctools
  qt6-base kf6-kconfig"
 makedepends="kf6-kparts-devel libqaccessibilityclient-devel qt6-base-devel

--- a/srcpkgs/kmahjongg/template
+++ b/srcpkgs/kmahjongg/template
@@ -3,7 +3,6 @@ pkgname=kmahjongg
 version=26.04.1
 revision=1
 build_style=cmake
-configure_args="-DKF6_HOST_TOOLING=/usr/lib/cmake"
 hostmakedepends="extra-cmake-modules gettext kf6-kconfig kf6-kcoreaddons
  kf6-kdoctools qt6-base"
 makedepends="kf6-kconfig-devel kf6-kcrash-devel kf6-kdbusaddons-devel

--- a/srcpkgs/kmail-account-wizard/template
+++ b/srcpkgs/kmail-account-wizard/template
@@ -3,7 +3,7 @@ pkgname=kmail-account-wizard
 version=26.04.1
 revision=2
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="-DBUILD_TESTING=OFF
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins
  -DKDE_INSTALL_QMLDIR=lib/qt6/qml
  -DECM_MKSPECS_INSTALL_DIR=/usr/lib/qt6/mkspecs/modules"

--- a/srcpkgs/kmail/template
+++ b/srcpkgs/kmail/template
@@ -3,7 +3,7 @@ pkgname=kmail
 version=26.04.1
 revision=1
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="-DBUILD_TESTING=OFF
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins
  -DKDE_INSTALL_QMLDIR=lib/qt6/qml
  -DECM_MKSPECS_INSTALL_DIR=/usr/lib/qt6/mkspecs/modules"

--- a/srcpkgs/kmailtransport/template
+++ b/srcpkgs/kmailtransport/template
@@ -3,7 +3,7 @@ pkgname=kmailtransport
 version=26.04.1
 revision=1
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="-DBUILD_TESTING=OFF
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins
  -DKDE_INSTALL_QMLDIR=lib/qt6/qml
  -DECM_MKSPECS_INSTALL_DIR=/usr/lib/qt6/mkspecs/modules"

--- a/srcpkgs/kmbox/template
+++ b/srcpkgs/kmbox/template
@@ -3,7 +3,7 @@ pkgname=kmbox
 version=26.04.1
 revision=1
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="-DBUILD_TESTING=OFF
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins
  -DKDE_INSTALL_QMLDIR=lib/qt6/qml
  -DECM_MKSPECS_INSTALL_DIR=/usr/lib/qt6/mkspecs/modules"

--- a/srcpkgs/kmenuedit/template
+++ b/srcpkgs/kmenuedit/template
@@ -1,9 +1,9 @@
 # Template file for 'kmenuedit'
+# group=kde-plasma
 pkgname=kmenuedit
-version=6.6.3
+version=6.7.3
 revision=1
 build_style=cmake
-configure_args="-DKF6_HOST_TOOLING=/usr/lib/cmake"
 hostmakedepends="extra-cmake-modules qt6-base qt6-tools gettext
  kf6-kdoctools kf6-kconfig"
 makedepends="kf6-sonnet-devel kf6-kio-devel kf6-ki18n-devel
@@ -14,4 +14,8 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later"
 homepage="https://invent.kde.org/plasma/kmenuedit"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=6030a52204a546423ffac803659a87dced3650dc121d6798caeffb3143c3dc43
+checksum=dd92ee9c3bf3fde6d7bc4990453b9c72238b51b86d510d943d68bb1d1602e2ec
+
+# stage builds
+makedepends+=" kde-plasma-base"
+shlib_requires="KDE_Plasma.${version}"

--- a/srcpkgs/kmime6/template
+++ b/srcpkgs/kmime6/template
@@ -3,7 +3,7 @@ pkgname=kmime6
 version=26.04.1
 revision=1
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="-DBUILD_TESTING=OFF
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins
  -DKDE_INSTALL_QMLDIR=lib/qt6/qml
  -DECM_MKSPECS_INSTALL_DIR=/usr/lib/qt6/mkspecs/modules"

--- a/srcpkgs/kmines/template
+++ b/srcpkgs/kmines/template
@@ -3,7 +3,7 @@ pkgname=kmines
 version=26.04.1
 revision=1
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="-DBUILD_TESTING=OFF
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins
  -DKDE_INSTALL_QMLDIR=lib/qt6/qml
  -DECM_MKSPECS_INSTALL_DIR=/usr/lib/qt6/mkspecs/modules"

--- a/srcpkgs/kmix/template
+++ b/srcpkgs/kmix/template
@@ -4,7 +4,7 @@ version=26.04.1
 revision=1
 build_style=cmake
 configure_args="-DSYSCONF_INSTALL_DIR=/etc
- -DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
+ -DBUILD_TESTING=OFF
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins
  -DKDE_INSTALL_QMLDIR=lib/qt6/qml
  -DECM_MKSPECS_INSTALL_DIR=/usr/lib/qt6/mkspecs/modules"

--- a/srcpkgs/kmplot/template
+++ b/srcpkgs/kmplot/template
@@ -4,7 +4,6 @@ version=26.04.1
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF -DBUILD_WITH_QT6=ON
- -DKF6_HOST_TOOLING=/usr/lib/cmake
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins
  -DKDE_INSTALL_QMLDIR=lib/qt6/qml
  -DECM_MKSPECS_INSTALL_DIR=/usr/lib/qt6/mkspecs/modules"

--- a/srcpkgs/knights/template
+++ b/srcpkgs/knights/template
@@ -3,7 +3,7 @@ pkgname=knights
 version=26.04.1
 revision=1
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="-DBUILD_TESTING=OFF
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins
  -DKDE_INSTALL_QMLDIR=lib/qt6/qml
  -DECM_MKSPECS_INSTALL_DIR=/usr/lib/qt6/mkspecs/modules"

--- a/srcpkgs/knighttime/template
+++ b/srcpkgs/knighttime/template
@@ -1,6 +1,7 @@
 # Template file for 'knighttime'
+# group=kde-plasma
 pkgname=knighttime
-version=6.6.3
+version=6.7.3
 revision=1
 build_style=cmake
 hostmakedepends="qt6-base extra-cmake-modules kf6-kconfig gettext
@@ -13,7 +14,11 @@ maintainer="Đoàn Trần Công Danh <congdanhqx@gmail.com>"
 license="LGPL-2.0-or-later"
 homepage="https://invent.kde.org/plasma/knighttime"
 distfiles="${KDE_SITE}/plasma/${version}/knighttime-${version}.tar.xz"
-checksum=97f612eb6cae0ee39ad3579bb9124d701751c83fd02cd3f5ed120896b1313a21
+checksum=22295cf3640e15eb04d28350934a1d457a4ec578033af8c28948bd10a8c75387
+
+# stage builds
+makedepends+=" kde-plasma-base"
+shlib_requires="KDE_Plasma.${version}"
 
 knighttime-devel_package() {
 	depends="${sourcepkg}>=${version}_${revision}"

--- a/srcpkgs/knotes/template
+++ b/srcpkgs/knotes/template
@@ -3,7 +3,7 @@ pkgname=knotes
 version=24.05.1
 revision=1
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="-DBUILD_TESTING=OFF
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins
  -DKDE_INSTALL_QMLDIR=lib/qt6/qml
  -DECM_MKSPECS_INSTALL_DIR=/usr/lib/qt6/mkspecs/modules"

--- a/srcpkgs/kolourpaint/template
+++ b/srcpkgs/kolourpaint/template
@@ -4,7 +4,7 @@ version=26.04.1
 revision=1
 build_style=cmake
 configure_args="-DQT_MAJOR_VERSION=6 -DBUILD_TESTING=OFF
- -DKF6_HOST_TOOLING=/usr/lib/cmake -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins"
+ -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins"
 hostmakedepends="extra-cmake-modules gettext kf6-kcoreaddons kf6-kdoctools
  qt6-base kf6-kconfig"
 makedepends="qt6-base-devel

--- a/srcpkgs/kompare/template
+++ b/srcpkgs/kompare/template
@@ -3,7 +3,7 @@ pkgname=kompare
 version=26.04.1
 revision=1
 build_style=cmake
-configure_args="-DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins"
 hostmakedepends="extra-cmake-modules gettext qt6-tools qt6-base
  kf6-kconfig kf6-kdoctools"

--- a/srcpkgs/konqueror/template
+++ b/srcpkgs/konqueror/template
@@ -4,7 +4,6 @@ version=26.04.1
 revision=2
 build_style=cmake
 configure_args="-DBUILD_WITH_QT6=ON -DBUILD_TESTING=OFF
- -DKF6_HOST_TOOLING=/usr/lib/cmake
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins
  -DKDE_INSTALL_QMLDIR=lib/qt6/qml
  -DECM_MKSPECS_INSTALL_DIR=/usr/lib/qt6/mkspecs/modules"

--- a/srcpkgs/konquest/template
+++ b/srcpkgs/konquest/template
@@ -3,7 +3,7 @@ pkgname=konquest
 version=26.04.1
 revision=1
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="-DBUILD_TESTING=OFF
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins
  -DKDE_INSTALL_QMLDIR=lib/qt6/qml
  -DECM_MKSPECS_INSTALL_DIR=/usr/lib/qt6/mkspecs/modules"

--- a/srcpkgs/konsole/template
+++ b/srcpkgs/konsole/template
@@ -3,7 +3,7 @@ pkgname=konsole
 version=26.04.1
 revision=1
 build_style=cmake
-configure_args="-DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins"
 hostmakedepends="pkg-config extra-cmake-modules qt6-base qt6-tools gettext
  kf6-kdoctools kf6-kconfig"

--- a/srcpkgs/kontact/template
+++ b/srcpkgs/kontact/template
@@ -3,7 +3,7 @@ pkgname=kontact
 version=26.04.1
 revision=1
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="-DBUILD_TESTING=OFF
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins
  -DKDE_INSTALL_QMLDIR=lib/qt6/qml
  -DECM_MKSPECS_INSTALL_DIR=/usr/lib/qt6/mkspecs/modules"

--- a/srcpkgs/kontactinterface/template
+++ b/srcpkgs/kontactinterface/template
@@ -3,7 +3,7 @@ pkgname=kontactinterface
 version=26.04.1
 revision=2
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="-DBUILD_TESTING=OFF
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins
  -DKDE_INSTALL_QMLDIR=lib/qt6/qml
  -DECM_MKSPECS_INSTALL_DIR=/usr/lib/qt6/mkspecs/modules"

--- a/srcpkgs/konversation/template
+++ b/srcpkgs/konversation/template
@@ -3,7 +3,7 @@ pkgname=konversation
 version=26.04.1
 revision=1
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="-DBUILD_TESTING=OFF
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins"
 hostmakedepends="extra-cmake-modules kf6-kconfig kf6-kdoctools kf6-kcoreaddons
  qt6-tools qt6-base gettext"

--- a/srcpkgs/korganizer/template
+++ b/srcpkgs/korganizer/template
@@ -3,7 +3,7 @@ pkgname=korganizer
 version=26.04.1
 revision=1
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="-DBUILD_TESTING=OFF
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins
  -DKDE_INSTALL_QMLDIR=lib/qt6/qml
  -DECM_MKSPECS_INSTALL_DIR=/usr/lib/qt6/mkspecs/modules"

--- a/srcpkgs/kpat/template
+++ b/srcpkgs/kpat/template
@@ -4,7 +4,7 @@ version=26.04.1
 revision=1
 build_style=cmake
 configure_args="-DWITH_BH_SOLVER=OFF
- -DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
+ -DBUILD_TESTING=OFF
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins
  -DKDE_INSTALL_QMLDIR=lib/qt6/qml
  -DECM_MKSPECS_INSTALL_DIR=/usr/lib/qt6/mkspecs/modules"

--- a/srcpkgs/kpimtextedit/template
+++ b/srcpkgs/kpimtextedit/template
@@ -3,7 +3,7 @@ pkgname=kpimtextedit
 version=26.04.1
 revision=1
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="-DBUILD_TESTING=OFF
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins
  -DKDE_INSTALL_QMLDIR=lib/qt6/qml
  -DECM_MKSPECS_INSTALL_DIR=/usr/lib/qt6/mkspecs/modules"

--- a/srcpkgs/kpipewire/template
+++ b/srcpkgs/kpipewire/template
@@ -1,7 +1,8 @@
 # Template file for 'kpipewire'
+# group=kde-plasma
 pkgname=kpipewire
-version=6.6.3
-revision=2
+version=6.7.3
+revision=1
 build_style=cmake
 configure_args="-DKDE_INSTALL_QMLDIR=lib/qt6/qml"
 hostmakedepends="extra-cmake-modules gettext qt6-base qt6-tools pkg-config
@@ -16,7 +17,11 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-3.0-or-later"
 homepage="https://invent.kde.org/plasma/kpipewire"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=3758393ad2dfd32074a31c705d840d742a074731983b489995829f18636d9e21
+checksum=b622f3d2d8d43af1795103ec7b46b90f11af559245c9f1371fbd5663d0d8ee33
+
+# stage builds
+makedepends+=" kde-plasma-base"
+shlib_requires="KDE_Plasma.${version}"
 
 do_check() {
 	cd build

--- a/srcpkgs/kpkpass/template
+++ b/srcpkgs/kpkpass/template
@@ -3,7 +3,7 @@ pkgname=kpkpass
 version=26.04.1
 revision=1
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="-DBUILD_TESTING=OFF
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins
  -DKDE_INSTALL_QMLDIR=lib/qt6/qml
  -DECM_MKSPECS_INSTALL_DIR=/usr/lib/qt6/mkspecs/modules"

--- a/srcpkgs/kpmcore/template
+++ b/srcpkgs/kpmcore/template
@@ -3,7 +3,7 @@ pkgname=kpmcore
 version=26.04.1
 revision=1
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="-DBUILD_TESTING=OFF
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins"
 hostmakedepends="extra-cmake-modules qt6-base-devel qt6-base pkg-config kf6-kcoreaddons
 gettext kf6-kauth-tools"

--- a/srcpkgs/krdc/template
+++ b/srcpkgs/krdc/template
@@ -3,7 +3,7 @@ pkgname=krdc
 version=26.04.1
 revision=2
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="-DBUILD_TESTING=OFF
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins -DQT_MAJOR_VERSION=6
  -DKDE_INSTALL_QMLDIR=lib/qt6/qml
  -DECM_MKSPECS_INSTALL_DIR=/usr/lib/qt6/mkspecs/modules"

--- a/srcpkgs/krdp/template
+++ b/srcpkgs/krdp/template
@@ -1,9 +1,10 @@
 # Template file for 'krdp'
+# group=kde-plasma
 pkgname=krdp
-version=6.6.3
-revision=2
+version=6.7.3
+revision=1
 build_style=cmake
-configure_args="-DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="
  -DKDE_INSTALL_QMLDIR=lib/qt6/qml
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins"
 hostmakedepends="extra-cmake-modules pkg-config qt6-base gettext qt6-tools freerdp
@@ -12,11 +13,15 @@ makedepends="kf6-kcmutils-devel kf6-kconfig-devel kf6-kcoreaddons-devel
  kf6-ki18n-devel kpipewire-devel kf6-kstatusnotifieritem-devel
  kf6-kdbusaddons-devel kf6-kcrash-devel kf6-kguiaddons-devel pam-devel
  qtkeychain-qt6-devel plasma-wayland-protocols freerdp-devel
- qt6-declarative-devel libxkbcommon-devel
+ qt6-declarative-devel libxkbcommon-devel kirigami-addons-devel
  libxcb-devel pipewire-devel qt6-base-private-devel freerdp"
 short_desc="Plasma rdp server and library"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="LGPL-2.0-or-later"
 homepage="https://invent.kde.org/plasma/krdp"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=ae030e0ae4ed7a617392e6ad50cd99626fa6e402ee3fcaefec327adbfb37f630
+checksum=4d8019b00b20e91e84f34da0d53cbcc2b1ae5a57a1f437a426c6735fcfa414d0
+
+# stage builds
+makedepends+=" kde-plasma-base"
+shlib_requires="KDE_Plasma.${version}"

--- a/srcpkgs/krfb/template
+++ b/srcpkgs/krfb/template
@@ -3,7 +3,7 @@ pkgname=krfb
 version=26.04.1
 revision=2
 build_style=cmake
-configure_args="-DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins"
 hostmakedepends="extra-cmake-modules qt6-base qt6-tools pkg-config gettext
  kf6-kdoctools kf6-kconfig wayland-devel"

--- a/srcpkgs/kruler/template
+++ b/srcpkgs/kruler/template
@@ -3,7 +3,7 @@ pkgname=kruler
 version=26.04.1
 revision=2
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="-DBUILD_TESTING=OFF
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins
  -DKDE_INSTALL_QMLDIR=lib/qt6/qml
  -DECM_MKSPECS_INSTALL_DIR=/usr/lib/qt6/mkspecs/modules"

--- a/srcpkgs/ksanecore6/template
+++ b/srcpkgs/ksanecore6/template
@@ -3,7 +3,7 @@ pkgname=ksanecore6
 version=26.04.1
 revision=1
 build_style=cmake
-configure_args="-DQT_MAJOR_VERSION=6 -DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="-DQT_MAJOR_VERSION=6
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins"
 hostmakedepends="extra-cmake-modules gettext qt6-base"
 makedepends="qt6-base-devel sane-devel kf6-kconfig-devel kf6-ki18n-devel"

--- a/srcpkgs/kscreen/template
+++ b/srcpkgs/kscreen/template
@@ -1,9 +1,10 @@
 # Template file for 'kscreen'
+# group=kde-plasma
 pkgname=kscreen
-version=6.6.3
-revision=2
+version=6.7.3
+revision=1
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="-DBUILD_TESTING=OFF
  -DKDE_INSTALL_QMLDIR=lib/qt6/qml -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins"
 hostmakedepends="extra-cmake-modules qt6-base qt6-tools gettext
  kf6-kcmutils kf6-kpackage pkg-config wayland-devel
@@ -11,11 +12,16 @@ hostmakedepends="extra-cmake-modules qt6-base qt6-tools gettext
 makedepends="kf6-kxmlgui-devel kf6-kcmutils-devel kf6-ksvg-devel
  kf6-kdbusaddons-devel kf6-kcrash-devel
  kf6-kpackage-devel libkf6screen-devel layer-shell-qt-devel libplasma-devel
- qt6-sensors-devel qt6-base-private-devel wayland-protocols"
-depends="hicolor-icon-theme"
+ qt6-sensors-devel qt6-base-private-devel wayland-protocols
+ kf6-kitemmodels-devel plasma5support-devel"
+depends="hicolor-icon-theme kf6-kimageformats"
 short_desc="KDE screen management software"
 maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later, LGPL-2.1-or-later"
 homepage="https://invent.kde.org/plasma/kscreen"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=45f2999182eef89991812cfcf085b368d58052d21c22ab46325998aa51db13d1
+checksum=dfe6a724dd758d5d9512562f59559944c5c94e1d2a259d0fd61d8eb74439f34c
+
+# stage builds
+makedepends+=" kde-plasma-base"
+shlib_requires="KDE_Plasma.${version}"

--- a/srcpkgs/kscreenlocker/template
+++ b/srcpkgs/kscreenlocker/template
@@ -1,9 +1,10 @@
 # Template file for 'kscreenlocker'
+# group=kde-plasma
 pkgname=kscreenlocker
-version=6.6.3
-revision=2
+version=6.7.3
+revision=1
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="-DBUILD_TESTING=OFF
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins"
 hostmakedepends="extra-cmake-modules pkg-config qt6-base qt6-tools gettext
  elogind wayland-devel kf6-kpackage kf6-kcmutils kf6-kconfig"
@@ -32,7 +33,11 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later"
 homepage="https://invent.kde.org/plasma/kscreenlocker"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=f73d79394ecde7c87e76d4daf777bf23cae8c19585f3166ac08a93e3596e22b3
+checksum=76d4bbb1201102e1b5dd34142c55006bf27f3ced39fa64c97a7f44bb1e534dfe
+
+# stage builds
+makedepends+=" kde-plasma-base"
+shlib_requires="KDE_Plasma.${version}"
 
 kscreenlocker-devel_package() {
 	short_desc+=" - development files"

--- a/srcpkgs/ksmtp/template
+++ b/srcpkgs/ksmtp/template
@@ -3,7 +3,7 @@ pkgname=ksmtp
 version=26.04.1
 revision=1
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="-DBUILD_TESTING=OFF
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins
  -DKDE_INSTALL_QMLDIR=lib/qt6/qml
  -DECM_MKSPECS_INSTALL_DIR=/usr/lib/qt6/mkspecs/modules"

--- a/srcpkgs/ksshaskpass/template
+++ b/srcpkgs/ksshaskpass/template
@@ -1,9 +1,10 @@
 # Template file for 'ksshaskpass'
+# group=kde-plasma
 pkgname=ksshaskpass
-version=6.6.3
+version=6.7.3
 revision=1
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake"
+configure_args="-DBUILD_TESTING=OFF"
 hostmakedepends="extra-cmake-modules qt6-base qt6-tools gettext
  kf6-kdoctools"
 makedepends="kf6-kwallet-devel kf6-kdoctools-devel qtkeychain-qt6-devel"
@@ -12,5 +13,9 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later"
 homepage="https://invent.kde.org/plasma/ksshaskpass"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=f19f8a135abe71abeb55b2d01a6fdf207977e5b6ff74ba95a149bb32714118fc
+checksum=d275e6b3427e6f120c97f7a6e64d9d157829976a1241277f13cdef1c7e2b193a
 alternatives="ssh-askpass:/usr/libexec/ssh-askpass:/usr/bin/ksshaskpass"
+
+# stage builds
+makedepends+=" kde-plasma-base"
+shlib_requires="KDE_Plasma.${version}"

--- a/srcpkgs/ksystemlog/template
+++ b/srcpkgs/ksystemlog/template
@@ -3,7 +3,7 @@ pkgname=ksystemlog
 version=26.04.1
 revision=1
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="-DBUILD_TESTING=OFF
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins
  -DKDE_INSTALL_QMLDIR=lib/qt6/qml
  -DECM_MKSPECS_INSTALL_DIR=/usr/lib/qt6/mkspecs/modules"

--- a/srcpkgs/ksystemstats/template
+++ b/srcpkgs/ksystemstats/template
@@ -1,6 +1,7 @@
 # Template file for 'ksystemstats'
+# group=kde-plasma
 pkgname=ksystemstats
-version=6.6.3
+version=6.7.3
 revision=1
 build_style=cmake
 configure_args="-DKDE_INSTALL_QMLDIR=lib/qt6/qml
@@ -13,7 +14,11 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-3.0-only,LGPL-3.0-only"
 homepage="https://invent.kde.org/plasma/ksystemstats"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=d700d628ac0371c9f3730ca11d7bd528ab234a10078e8ce3d77fff47cf8e8bac
+checksum=394a6d342a1f8a2c3d6273fb8604c18220f9135d234bd2e651ef76f99d19c259
+
+# stage builds
+makedepends+=" kde-plasma-base"
+shlib_requires="KDE_Plasma.${version}"
 
 do_check() {
 	cd build

--- a/srcpkgs/kteatime/template
+++ b/srcpkgs/kteatime/template
@@ -3,7 +3,7 @@ pkgname=kteatime
 version=26.04.1
 revision=1
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="-DBUILD_TESTING=OFF
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins
  -DKDE_INSTALL_QMLDIR=lib/qt6/qml
  -DECM_MKSPECS_INSTALL_DIR=/usr/lib/qt6/mkspecs/modules"

--- a/srcpkgs/ktextaddons/template
+++ b/srcpkgs/ktextaddons/template
@@ -3,7 +3,7 @@ pkgname=ktextaddons
 version=2.0.1
 revision=1
 build_style=cmake
-configure_args="-DBUILD_WITH_QT6=ON -DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="-DBUILD_WITH_QT6=ON -DBUILD_TESTING=OFF
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins
  -DKDE_INSTALL_QMLDIR=lib/qt6/qml
  -DECM_MKSPECS_INSTALL_DIR=/usr/lib/qt6/mkspecs/modules"

--- a/srcpkgs/ktnef/template
+++ b/srcpkgs/ktnef/template
@@ -3,7 +3,7 @@ pkgname=ktnef
 version=26.04.1
 revision=1
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="-DBUILD_TESTING=OFF
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins
  -DKDE_INSTALL_QMLDIR=lib/qt6/qml
  -DECM_MKSPECS_INSTALL_DIR=/usr/lib/qt6/mkspecs/modules"

--- a/srcpkgs/ktorrent/template
+++ b/srcpkgs/ktorrent/template
@@ -4,7 +4,6 @@ version=26.04.1
 revision=1
 build_style=cmake
 configure_args="-DWITH_SYSTEM_GEOIP=ON -DBUILD_TESTING=OFF
- -DKF6_HOST_TOOLING=/usr/lib/cmake
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins
  -DKDE_INSTALL_QMLDIR=lib/qt6/qml
  -DECM_MKSPECS_INSTALL_DIR=/usr/lib/qt6/mkspecs/modules"

--- a/srcpkgs/ktuberling/template
+++ b/srcpkgs/ktuberling/template
@@ -3,7 +3,7 @@ pkgname=ktuberling
 version=26.04.1
 revision=1
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="-DBUILD_TESTING=OFF
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins
  -DKDE_INSTALL_QMLDIR=lib/qt6/qml
  -DECM_MKSPECS_INSTALL_DIR=/usr/lib/qt6/mkspecs/modules"

--- a/srcpkgs/kturtle/template
+++ b/srcpkgs/kturtle/template
@@ -3,7 +3,7 @@ pkgname=kturtle
 version=26.04.1
 revision=1
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="-DBUILD_TESTING=OFF
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins
  -DKDE_INSTALL_QMLDIR=lib/qt6/qml
  -DECM_MKSPECS_INSTALL_DIR=/usr/lib/qt6/mkspecs/modules"

--- a/srcpkgs/kunifiedpush/template
+++ b/srcpkgs/kunifiedpush/template
@@ -3,7 +3,7 @@ pkgname=kunifiedpush
 version=26.04.1
 revision=1
 build_style=cmake
-configure_args="-DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="
  -DKDE_INSTALL_QMLDIR=lib/qt6/qml -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins"
 hostmakedepends="extra-cmake-modules qt6-base qt6-tools gettext kf6-kcmutils"
 makedepends="kf6-ki18n-devel kf6-kcoreaddons-devel kf6-solid-devel

--- a/srcpkgs/kwallet-pam/template
+++ b/srcpkgs/kwallet-pam/template
@@ -1,6 +1,7 @@
 # Template file for 'kwallet-pam'
+# group=kde-plasma
 pkgname=kwallet-pam
-version=6.6.3
+version=6.7.3
 revision=1
 build_style=cmake
 hostmakedepends="extra-cmake-modules qt6-base qt6-tools pkg-config"
@@ -11,5 +12,9 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/plasma/kwallet-pam"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=965a008d89a64f8161673c6a32c7f71c28473ee2714856743b949acf18296e16
+checksum=a720a1440edf8734e4b8d4d4d5ea96fc14946c21f38f6a5ca1b738d8a8dc583b
 conflicts="kwallet<=5.115.0_1"
+
+# stage builds
+makedepends+=" kde-plasma-base"
+shlib_requires="KDE_Plasma.${version}"

--- a/srcpkgs/kwalletmanager/template
+++ b/srcpkgs/kwalletmanager/template
@@ -3,7 +3,7 @@ pkgname=kwalletmanager
 version=26.04.1
 revision=1
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="-DBUILD_TESTING=OFF
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins"
 hostmakedepends="extra-cmake-modules gettext kf6-kdoctools pkg-config
  qt6-base qt6-tools kf6-kauth-tools kf6-kconfig kf6-kcmutils"

--- a/srcpkgs/kwayland-integration/template
+++ b/srcpkgs/kwayland-integration/template
@@ -1,6 +1,7 @@
 # Template file for 'kwayland-integration'
+# group=kde-plasma
 pkgname=kwayland-integration
-version=6.6.3
+version=6.7.3
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins"
@@ -14,4 +15,8 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/plasma/kwayland-integration"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=ea4c1424acdf1d437be88a6ff3ee2ed055e620da1b05dec1a534049d111b31ab
+checksum=82e0ac703eee65b3e83b4c6973020cee032b79c2dd41e43cb65f7286d0765962
+
+# stage builds
+makedepends+=" kde-plasma-base"
+shlib_requires="KDE_Plasma.${version}"

--- a/srcpkgs/kweather/template
+++ b/srcpkgs/kweather/template
@@ -3,7 +3,7 @@ pkgname=kweather
 version=26.04.1
 revision=2
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="-DBUILD_TESTING=OFF
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins
  -DKDE_INSTALL_QMLDIR=lib/qt6/qml"
 hostmakedepends="extra-cmake-modules gettext pkg-config python3 qt6-base qt6-tools"

--- a/srcpkgs/kwin-x11/template
+++ b/srcpkgs/kwin-x11/template
@@ -1,11 +1,12 @@
 # Template file for 'kwin-x11'
+# group=kde-plasma
 pkgname=kwin-x11
-version=6.6.3
-revision=2
+version=6.7.3
+revision=1
 build_style=cmake
 build_helper=qemu
 configure_args="-DBUILD_TESTING=OFF -DFORCE_CROSSCOMPILED_TOOLS=ON
- -DKF6_HOST_TOOLING=/usr/lib/cmake -DKDE_INSTALL_QMLDIR=lib/qt6/qml
+ -DKDE_INSTALL_QMLDIR=lib/qt6/qml
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins"
 hostmakedepends="extra-cmake-modules gettext pkg-config libcap-progs
  qt6-base qt6-tools qt6-declarative-host-tools wayland-devel hwids
@@ -35,7 +36,11 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later AND MIT"
 homepage="https://invent.kde.org/plasma/kwin-x11"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=a29fc80038fa4608cd1c9ca56734e874b0ba6ae66a6494a079e7f738ff36cc53
+checksum=a4401360c1ab832b448b362c3309f022b322da4c42bafcec9708128dd229ac71
+
+# stage builds
+makedepends+=" kde-plasma-base"
+shlib_requires="KDE_Plasma.${version}"
 
 kwin-x11-devel_package() {
 	depends="${sourcepkg}>=${version}_${revision}"

--- a/srcpkgs/kwin/template
+++ b/srcpkgs/kwin/template
@@ -1,11 +1,12 @@
 # Template file for 'kwin'
+# group=kde-plasma
 pkgname=kwin
-version=6.6.3
-revision=2
+version=6.7.3
+revision=1
 build_style=cmake
 build_helper=qemu
 configure_args="-DBUILD_TESTING=OFF -DFORCE_CROSSCOMPILED_TOOLS=ON
- -DKF6_HOST_TOOLING=/usr/lib/cmake -DKDE_INSTALL_QMLDIR=lib/qt6/qml
+ -DKDE_INSTALL_QMLDIR=lib/qt6/qml
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins"
 hostmakedepends="extra-cmake-modules gettext pkg-config kf6-kauth-tools
  qt6-base qt6-tools qt6-declarative-host-tools libcap-progs
@@ -35,8 +36,12 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later"
 homepage="https://invent.kde.org/plasma/kwin"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=61a2e0f0b1a34f38b37f8a4ac7f7712c975ec763ff4e24ebb05ec1187e458e0f
+checksum=345b45d400884cc6b00f4b3585cc056aa2780f32afe2df394d20c5a98273c559
 replaces="kwayland-server>=0"
+
+# stage builds
+makedepends+=" kde-plasma-base"
+shlib_requires="KDE_Plasma.${version}"
 
 kwin-devel_package() {
 	short_desc+=" - development"

--- a/srcpkgs/kwrited/template
+++ b/srcpkgs/kwrited/template
@@ -1,6 +1,7 @@
 # Template file for 'kwrited'
+# group=kde-plasma
 pkgname=kwrited
-version=6.6.3
+version=6.7.3
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins"
@@ -11,4 +12,8 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later"
 homepage="https://invent.kde.org/plasma/kwrited"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=7d254573de29330bd47cb332de97a824e0ea23bcabc516cc917ba16823a40c80
+checksum=0e20696353a99c6cc4f188240b1a9b51fd077b0cbb20c9d5123b9a2a8fb7fc2d
+
+# stage builds
+makedepends+=" kde-plasma-base"
+shlib_requires="KDE_Plasma.${version}"

--- a/srcpkgs/layer-shell-qt/template
+++ b/srcpkgs/layer-shell-qt/template
@@ -1,7 +1,8 @@
 # Template file for 'layer-shell-qt'
+# group=kde-plasma
 pkgname=layer-shell-qt
-version=6.6.3
-revision=2
+version=6.7.3
+revision=1
 build_style=cmake
 configure_args="-DKDE_INSTALL_QMLDIR=lib/qt6/qml
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins"
@@ -14,7 +15,11 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-3.0-or-later"
 homepage="https://invent.kde.org/plasma/layer-shell-qt"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=092c02ff70e51a3e2f86d657d3a278a277458b295ada74d08b447a0695ec9b9a
+checksum=51924fa14d05320eacef8defea51895c96117bc89dd709e74536dd8ecdfb4581
+
+# stage builds
+makedepends+=" kde-plasma-base"
+shlib_requires="KDE_Plasma.${version}"
 
 layer-shell-qt-devel_package() {
 	depends="${sourcepkg}>=${version}_${revision} qt6-base-devel"

--- a/srcpkgs/libgravatar/template
+++ b/srcpkgs/libgravatar/template
@@ -3,7 +3,7 @@ pkgname=libgravatar
 version=26.04.1
 revision=1
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="-DBUILD_TESTING=OFF
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins
  -DKDE_INSTALL_QMLDIR=lib/qt6/qml
  -DECM_MKSPECS_INSTALL_DIR=/usr/lib/qt6/mkspecs/modules"

--- a/srcpkgs/libkcddb6/template
+++ b/srcpkgs/libkcddb6/template
@@ -3,7 +3,7 @@ pkgname=libkcddb6
 version=26.04.1
 revision=1
 build_style=cmake
-configure_args="-DKF6_HOST_TOOLING=/usr/lib/cmake -DQT_MAJOR_VERSION=6
+configure_args="-DQT_MAJOR_VERSION=6
  -DECM_MKSPECS_INSTALL_DIR=/usr/lib/qt6/mkspecs/modules
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins"
 hostmakedepends="extra-cmake-modules gettext kf6-kconfig kf6-kcoreaddons

--- a/srcpkgs/libkdegames/template
+++ b/srcpkgs/libkdegames/template
@@ -3,7 +3,7 @@ pkgname=libkdegames
 version=26.04.1
 revision=2
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="-DBUILD_TESTING=OFF
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins
  -DKDE_INSTALL_QMLDIR=lib/qt6/qml
  -DECM_MKSPECS_INSTALL_DIR=/usr/lib/qt6/mkspecs/modules"

--- a/srcpkgs/libkdepim/template
+++ b/srcpkgs/libkdepim/template
@@ -3,7 +3,7 @@ pkgname=libkdepim
 version=26.04.1
 revision=1
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="-DBUILD_TESTING=OFF
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins
  -DKDE_INSTALL_QMLDIR=lib/qt6/qml
  -DECM_MKSPECS_INSTALL_DIR=/usr/lib/qt6/mkspecs/modules"

--- a/srcpkgs/libkf6screen/template
+++ b/srcpkgs/libkf6screen/template
@@ -1,7 +1,8 @@
 # Template file for 'libkf6screen'
+# group=kde-plasma
 pkgname=libkf6screen
-version=6.6.3
-revision=2
+version=6.7.3
+revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins"
@@ -14,7 +15,11 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/plasma/libkscreen"
 distfiles="${KDE_SITE}/plasma/${version}/libkscreen-${version}.tar.xz"
-checksum=408110fc5342a8fe1ff43f026613e0b5ad94e925e85c195a24eac142e74fd179
+checksum=26dfe23f20eaf95b5d4fa2595d55a9c740d1356d5e317b48edeb10975ea6359e
+
+# stage builds
+makedepends+=" kde-plasma-base"
+shlib_requires="KDE_Plasma.${version}"
 
 libkf6screen-devel_package() {
 	short_desc+=" - development"

--- a/srcpkgs/libkgapi/template
+++ b/srcpkgs/libkgapi/template
@@ -3,7 +3,7 @@ pkgname=libkgapi
 version=26.04.1
 revision=1
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="-DBUILD_TESTING=OFF
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins
  -DKDE_INSTALL_QMLDIR=lib/qt6/qml
  -DECM_MKSPECS_INSTALL_DIR=/usr/lib/qt6/mkspecs/modules"

--- a/srcpkgs/libkleo/template
+++ b/srcpkgs/libkleo/template
@@ -3,7 +3,7 @@ pkgname=libkleo
 version=26.04.1
 revision=1
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="-DBUILD_TESTING=OFF
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins
  -DKDE_INSTALL_QMLDIR=lib/qt6/qml
  -DECM_MKSPECS_INSTALL_DIR=/usr/lib/qt6/mkspecs/modules"

--- a/srcpkgs/libkmahjongg/template
+++ b/srcpkgs/libkmahjongg/template
@@ -3,7 +3,7 @@ pkgname=libkmahjongg
 version=26.04.1
 revision=1
 build_style=cmake
-configure_args="-DKF6_HOST_TOOLING=/usr/lib/cmake"
+configure_args=""
 hostmakedepends="extra-cmake-modules gettext kf6-kconfig kf6-kcoreaddons
  qt6-base"
 makedepends="kf6-kcompletion-devel kf6-kconfig-devel kf6-kconfigwidgets-devel

--- a/srcpkgs/libksieve/template
+++ b/srcpkgs/libksieve/template
@@ -3,7 +3,7 @@ pkgname=libksieve
 version=26.04.1
 revision=1
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="-DBUILD_TESTING=OFF
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins
  -DKDE_INSTALL_QMLDIR=lib/qt6/qml
  -DECM_MKSPECS_INSTALL_DIR=/usr/lib/qt6/mkspecs/modules"

--- a/srcpkgs/libksysguard/template
+++ b/srcpkgs/libksysguard/template
@@ -1,9 +1,10 @@
 # Template file for 'libksysguard'
+# group=kde-plasma
 pkgname=libksysguard
-version=6.6.3
-revision=2
+version=6.7.3
+revision=1
 build_style=cmake
-configure_args="-DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="
  -DKDE_INSTALL_QMLDIR=lib/qt6/qml
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins"
 hostmakedepends="extra-cmake-modules gettext pkg-config libcap-progs
@@ -19,7 +20,11 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/plasma/libksysguard"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=f4061299a69dc9e3cf83c0e54c174708d8dc748ae208d30a04b274c552586dbf
+checksum=2059f30d684078704493870a7f5d7aa31bf958c83476778c08bec8630e5bbfcd
+
+# stage builds
+makedepends+=" kde-plasma-base"
+shlib_requires="KDE_Plasma.${version}"
 
 do_check() {
 	cd build

--- a/srcpkgs/libktorrent/template
+++ b/srcpkgs/libktorrent/template
@@ -3,7 +3,7 @@ pkgname=libktorrent
 version=26.04.1
 revision=1
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="-DBUILD_TESTING=OFF
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins
  -DKDE_INSTALL_QMLDIR=lib/qt6/qml
  -DECM_MKSPECS_INSTALL_DIR=/usr/lib/qt6/mkspecs/modules"

--- a/srcpkgs/libplasma/template
+++ b/srcpkgs/libplasma/template
@@ -1,9 +1,10 @@
 # Template file for 'libplasma'
+# group=kde-plasma
 pkgname=libplasma
-version=6.6.3
-revision=2
+version=6.7.3
+revision=1
 build_style=cmake
-configure_args="-DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="
  -DKDE_INSTALL_QMLDIR=lib/qt6/qml
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins"
 hostmakedepends="extra-cmake-modules qt6-base qt6-tools
@@ -23,7 +24,11 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-3.0-or-later"
 homepage="https://invent.kde.org/plasma/libplasma"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=815ca99f55e68727ffed90b2d0a176f6240a2256454b1089a5a7f266a5a3775c
+checksum=9634ea7432d05fc7429a512d3ce5673d8bfff59f9618aa04013ea4f09ab8b010
+
+# stage builds
+makedepends+=" kde-plasma-base"
+shlib_requires="KDE_Plasma.${version}"
 
 do_check() {
 	cd build

--- a/srcpkgs/lokalize/template
+++ b/srcpkgs/lokalize/template
@@ -3,7 +3,7 @@ pkgname=lokalize
 version=26.04.1
 revision=1
 build_style=cmake
-configure_args="-DKF6_HOST_TOOLING=/usr/lib/cmake"
+configure_args=""
 hostmakedepends="extra-cmake-modules gettext pkg-config qt6-tools qt6-base
  kf6-kconfig kf6-kdoctools"
 makedepends="hunspell-devel qt6-base-devel

--- a/srcpkgs/mailcommon/template
+++ b/srcpkgs/mailcommon/template
@@ -3,7 +3,7 @@ pkgname=mailcommon
 version=26.04.1
 revision=1
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="-DBUILD_TESTING=OFF
  -DOPTION_USE_PLASMA_ACTIVITIES=ON
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins
  -DKDE_INSTALL_QMLDIR=lib/qt6/qml

--- a/srcpkgs/mailimporter/template
+++ b/srcpkgs/mailimporter/template
@@ -3,7 +3,7 @@ pkgname=mailimporter
 version=26.04.1
 revision=1
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="-DBUILD_TESTING=OFF
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins
  -DKDE_INSTALL_QMLDIR=lib/qt6/qml
  -DECM_MKSPECS_INSTALL_DIR=/usr/lib/qt6/mkspecs/modules"

--- a/srcpkgs/merkuro/template
+++ b/srcpkgs/merkuro/template
@@ -3,7 +3,7 @@ pkgname=merkuro
 version=26.04.1
 revision=2
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="-DBUILD_TESTING=OFF
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins
  -DKDE_INSTALL_QMLDIR=lib/qt6/qml
  -DECM_MKSPECS_INSTALL_DIR=/usr/lib/qt6/mkspecs/modules"

--- a/srcpkgs/messagelib/template
+++ b/srcpkgs/messagelib/template
@@ -3,7 +3,7 @@ pkgname=messagelib
 version=26.04.1
 revision=1
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="-DBUILD_TESTING=OFF
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins
  -DKDE_INSTALL_QMLDIR=lib/qt6/qml
  -DECM_MKSPECS_INSTALL_DIR=/usr/lib/qt6/mkspecs/modules"

--- a/srcpkgs/milou/template
+++ b/srcpkgs/milou/template
@@ -1,9 +1,10 @@
 # Template file for 'milou'
+# group=kde-plasma
 pkgname=milou
-version=6.6.3
-revision=2
+version=6.7.3
+revision=1
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="-DBUILD_TESTING=OFF
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins
  -DKDE_INSTALL_QMLDIR=lib/qt6/qml"
 hostmakedepends="extra-cmake-modules qt6-base qt6-tools gettext
@@ -16,4 +17,8 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later, LGPL-2.1-or-later"
 homepage="https://invent.kde.org/plasma/milou"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=909834cd7c62de83255a97090c685903ed6245b50be9c15d299703d9b822f9fd
+checksum=20b8d9e040ffbeeebe05b27d89759c8e8c89081aba463e3ae0d3847e60ad4d52
+
+# stage builds
+makedepends+=" kde-plasma-base"
+shlib_requires="KDE_Plasma.${version}"

--- a/srcpkgs/mimetreeparser/template
+++ b/srcpkgs/mimetreeparser/template
@@ -3,7 +3,7 @@ pkgname=mimetreeparser
 version=26.04.1
 revision=2
 build_style=cmake
-configure_args="-DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins
  -DKDE_INSTALL_QMLDIR=lib/qt6/qml
  -DECM_MKSPECS_INSTALL_DIR=/usr/lib/qt6/mkspecs/modules"

--- a/srcpkgs/neochat/template
+++ b/srcpkgs/neochat/template
@@ -3,7 +3,7 @@ pkgname=neochat
 version=26.04.2
 revision=2
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="-DBUILD_TESTING=OFF
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins"
 hostmakedepends="extra-cmake-modules gettext pkg-config qt6-base qt6-tools
  kf6-kcoreaddons kf6-kconfig python3 kf6-kdoctools qt6-declarative-host-tools"

--- a/srcpkgs/ocean-sound-theme/template
+++ b/srcpkgs/ocean-sound-theme/template
@@ -1,6 +1,7 @@
 # Template file for 'ocean-sound-theme'
+# group=kde-plasma
 pkgname=ocean-sound-theme
-version=6.6.3
+version=6.7.3
 revision=1
 build_style=cmake
 hostmakedepends="extra-cmake-modules qt6-base"
@@ -10,4 +11,8 @@ maintainer="Rose <rose@pinkro.se>"
 license="CC-BY-SA-4.0"
 homepage="https://invent.kde.org/plasma/ocean-sound-theme"
 distfiles="${KDE_SITE}/plasma/${version}/ocean-sound-theme-${version}.tar.xz"
-checksum=a879429433796e611206e94aed70c506618ace9bf492a3f2ff9d771087b6f808
+checksum=9ad12fdad851e69f4ff7d966e8b85b93c23cfc7b01f90434914300c60140e971
+
+# stage builds
+makedepends+=" kde-plasma-base"
+shlib_requires="KDE_Plasma.${version}"

--- a/srcpkgs/okular/template
+++ b/srcpkgs/okular/template
@@ -3,7 +3,7 @@ pkgname=okular
 version=26.04.1
 revision=2
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="-DBUILD_TESTING=OFF
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins"
 hostmakedepends="extra-cmake-modules pkg-config qt6-base gettext
  qt6-xml kf6-kcoreaddons kf6-kdoctools kf6-kconfig python3"

--- a/srcpkgs/oxygen-qt5/template
+++ b/srcpkgs/oxygen-qt5/template
@@ -1,6 +1,7 @@
 # Template file for 'oxygen-qt5'
+# group=kde-plasma
 pkgname=oxygen-qt5
-version=6.6.3
+version=6.7.3
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF -DBUILD_QT6=OFF"
@@ -14,7 +15,11 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later, GPL-2.0-or-later"
 homepage="https://invent.kde.org/plasma/oxygen"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname%-qt5}-${version}.tar.xz"
-checksum=2b62011740f28db8975ce37ed733f514e8180ffe4840f81276bd9f9914d7079c
+checksum=d4537dc7d5afa2a754278abef32ceead82da41a8c8ca19e6cbd6f678f49aea9c
+
+# stage builds
+makedepends+=" kde-plasma-base"
+shlib_requires="KDE_Plasma.${version}"
 
 post_install() {
 	rm -rf ${DESTDIR}/usr/share

--- a/srcpkgs/oxygen-qt6/template
+++ b/srcpkgs/oxygen-qt6/template
@@ -1,11 +1,11 @@
 # Template file for 'oxygen-qt6'
+# group=kde-plasma
 pkgname=oxygen-qt6
-version=6.6.3
-revision=2
+version=6.7.3
+revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF -DBUILD_QT5=OFF
- -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins
- -DKF6_HOST_TOOLING=/usr/lib/cmake"
+ -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins"
 hostmakedepends="extra-cmake-modules pkg-config qt6-base qt6-tools gettext
  kf6-kwindowsystem kf6-kcmutils kf6-kpackage"
 makedepends="qt6-base-private-devel qt6-declarative-devel
@@ -27,4 +27,8 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later, GPL-2.0-or-later"
 homepage="https://invent.kde.org/plasma/oxygen"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname%-qt6}-${version}.tar.xz"
-checksum=2b62011740f28db8975ce37ed733f514e8180ffe4840f81276bd9f9914d7079c
+checksum=d4537dc7d5afa2a754278abef32ceead82da41a8c8ca19e6cbd6f678f49aea9c
+
+# stage builds
+makedepends+=" kde-plasma-base"
+shlib_requires="KDE_Plasma.${version}"

--- a/srcpkgs/oxygen-sounds/template
+++ b/srcpkgs/oxygen-sounds/template
@@ -1,6 +1,7 @@
 # Template file for 'oxygen-sounds'
+# group=kde-plasma
 pkgname=oxygen-sounds
-version=6.6.3
+version=6.7.3
 revision=1
 build_style=cmake
 hostmakedepends="extra-cmake-modules"
@@ -9,4 +10,8 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-3.0-or-later"
 homepage="https://invent.kde.org/plasma/oxygen-sounds"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=c53b95557e318f78b26ee5bde1152781f61dfc1a441336dfa32ce8de5aee5be4
+checksum=799a12bc37b630ca0fd65082e2e7d891aff76cfdf81406ff8c76ceb487bcd657
+
+# stage builds
+makedepends+=" kde-plasma-base"
+shlib_requires="KDE_Plasma.${version}"

--- a/srcpkgs/palapeli/template
+++ b/srcpkgs/palapeli/template
@@ -3,7 +3,7 @@ pkgname=palapeli
 version=26.04.1
 revision=1
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="-DBUILD_TESTING=OFF
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins
  -DKDE_INSTALL_QMLDIR=lib/qt6/qml
  -DECM_MKSPECS_INSTALL_DIR=/usr/lib/qt6/mkspecs/modules"

--- a/srcpkgs/partitionmanager/template
+++ b/srcpkgs/partitionmanager/template
@@ -3,7 +3,7 @@ pkgname=partitionmanager
 version=26.04.1
 revision=1
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="-DBUILD_TESTING=OFF
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins"
 hostmakedepends="qt6-base-devel kf6-kdoctools kf6-kconfig qt6-base
  extra-cmake-modules pkg-config gettext kf6-kcoreaddons"

--- a/srcpkgs/picmi/template
+++ b/srcpkgs/picmi/template
@@ -3,7 +3,6 @@ pkgname=picmi
 version=26.04.1
 revision=1
 build_style=cmake
-configure_args="-DKF6_HOST_TOOLING=/usr/lib/cmake"
 hostmakedepends="extra-cmake-modules gettext kf6-kconfig kf6-kcoreaddons
  kf6-kdoctools qt6-base"
 makedepends="kf6-kconfig-devel kf6-kcrash-devel kf6-kdbusaddons-devel

--- a/srcpkgs/pim-data-exporter/template
+++ b/srcpkgs/pim-data-exporter/template
@@ -3,7 +3,7 @@ pkgname=pim-data-exporter
 version=26.04.1
 revision=1
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="-DBUILD_TESTING=OFF
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins
  -DKDE_INSTALL_QMLDIR=lib/qt6/qml
  -DECM_MKSPECS_INSTALL_DIR=/usr/lib/qt6/mkspecs/modules"

--- a/srcpkgs/pimcommon/template
+++ b/srcpkgs/pimcommon/template
@@ -3,7 +3,7 @@ pkgname=pimcommon
 version=26.04.1
 revision=1
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="-DBUILD_TESTING=OFF
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins
  -DKDE_INSTALL_QMLDIR=lib/qt6/qml
  -DECM_MKSPECS_INSTALL_DIR=/usr/lib/qt6/mkspecs/modules"

--- a/srcpkgs/plasma-activities-stats/template
+++ b/srcpkgs/plasma-activities-stats/template
@@ -1,6 +1,7 @@
 # Template file for 'plasma-activities-stats'
+# group=kde-plasma
 pkgname=plasma-activities-stats
-version=6.6.3
+version=6.7.3
 revision=1
 build_style=cmake
 hostmakedepends="extra-cmake-modules qt6-base qt6-tools
@@ -12,7 +13,11 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-3.0-or-later"
 homepage="https://invent.kde.org/plasma/plasma-activities-stats"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=56667b230dc52893c3f08680e37a403d228a50a6a0b06ad081179224a7f16d16
+checksum=448b85d569f3912f8c93c1c412e36551bab7dfe8991baa0c6206c60223e98a08
+
+# stage builds
+makedepends+=" kde-plasma-base"
+shlib_requires="KDE_Plasma.${version}"
 
 plasma-activities-stats-devel_package() {
 	depends="${sourcepkg}>=${version}_${revision}"

--- a/srcpkgs/plasma-activities/template
+++ b/srcpkgs/plasma-activities/template
@@ -1,6 +1,7 @@
 # Template file for 'plasma-activities'
+# group=kde-plasma
 pkgname=plasma-activities
-version=6.6.3
+version=6.7.3
 revision=1
 build_style=cmake
 configure_args="-DKDE_INSTALL_QMLDIR=lib/qt6/qml
@@ -15,7 +16,11 @@ maintainer="John <me@johnnynator.dev>"
 license="(LGPL-2.1-only OR LGPL-3.0-only) AND GPL-2.0-or-later"
 homepage="https://invent.kde.org/plasma/plasma-activities"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=ac15123637ea067ab646cde091d69c84fc24742fd7308e5418bf99298ab9717a
+checksum=3a9fbf0039464270238b84344b1064c57fb11a6aa5d7900f08a0a868063a62ea
+
+# stage builds
+makedepends+=" kde-plasma-base"
+shlib_requires="KDE_Plasma.${version}"
 
 plasma-activities-devel_package() {
 	depends="${sourcepkg}>=${version}_${revision}"

--- a/srcpkgs/plasma-bigscreen/patches/qqc2-style.patch
+++ b/srcpkgs/plasma-bigscreen/patches/qqc2-style.patch
@@ -1,0 +1,68 @@
+From baabf41700f7790f95007cb3c96929f4e041c6ca Mon Sep 17 00:00:00 2001
+From: Devin Lin <espidev@gmail.com>
+Date: Wed, 8 Jul 2026 23:21:20 -0400
+Subject: [PATCH] Properly support using qqc2-desktop-style
+
+Properly support solely using qqc2-desktop-style:
+- I forgot to remove the manual setting of qqc2-breeze-style in the
+settings in https://invent.kde.org/plasma/plasma-bigscreen/-/merge_requests/199, it's now removed
+- Manually add a background to the sidebar component modal background,
+  because qqc2-desktop-style doesn't have one
+- Turn off the automatic scrollbar introduced by qqc2-desktop-style for
+  ScrollView in
+  the search view
+---
+ .../bigscreenplugin/qml/controls/SidebarOverlay.qml      | 9 +++++++++
+ .../package/contents/ui/search/SearchWindow.qml          | 3 +++
+ settingsapp/main.cpp                                     | 1 -
+ 3 files changed, 12 insertions(+), 1 deletion(-)
+
+diff --git a/components/bigscreenplugin/qml/controls/SidebarOverlay.qml b/components/bigscreenplugin/qml/controls/SidebarOverlay.qml
+index 7c0c8dda..a60677f2 100644
+--- a/components/bigscreenplugin/qml/controls/SidebarOverlay.qml
++++ b/components/bigscreenplugin/qml/controls/SidebarOverlay.qml
+@@ -62,6 +62,15 @@ QQC2.Popup {
+         }
+     }
+ 
++    QQC2.Overlay.modal: Rectangle {
++        color: Qt.rgba(0,0,0,0.4)
++        Behavior on opacity {
++            OpacityAnimator {
++                duration: Kirigami.Units.longDuration
++            }
++        }
++    }
++
+     background: Item {
+         Rectangle {
+             id: frame
+diff --git a/containments/homescreen/package/contents/ui/search/SearchWindow.qml b/containments/homescreen/package/contents/ui/search/SearchWindow.qml
+index e9668009..77884663 100644
+--- a/containments/homescreen/package/contents/ui/search/SearchWindow.qml
++++ b/containments/homescreen/package/contents/ui/search/SearchWindow.qml
+@@ -168,6 +168,9 @@ Window {
+                 Layout.maximumWidth: column.columnContentWidth
+                 Layout.alignment: Qt.AlignHCenter
+ 
++                QQC2.ScrollBar.vertical: null
++                QQC2.ScrollBar.horizontal: null
++
+                 SearchListView {
+                     id: listView
+                     anchors.fill: parent
+diff --git a/settingsapp/main.cpp b/settingsapp/main.cpp
+index 24dcdbc9..2e6ed227 100644
+--- a/settingsapp/main.cpp
++++ b/settingsapp/main.cpp
+@@ -22,7 +22,6 @@
+ int main(int argc, char *argv[])
+ {
+     qputenv("PLASMA_PLATFORM", QByteArray("mediacenter"));
+-    qputenv("QT_QUICK_CONTROLS_STYLE", QByteArray("org.kde.breeze"));
+ 
+     QGuiApplication::setAttribute(Qt::AA_ShareOpenGLContexts);
+ 
+-- 
+GitLab
+

--- a/srcpkgs/plasma-bigscreen/patches/uaccess.patch
+++ b/srcpkgs/plasma-bigscreen/patches/uaccess.patch
@@ -1,0 +1,13 @@
+enable uinput via both the input group (as upstream does) and via uaccess
+
+upstream splits this into two rules based on if systemd is available:
+https://invent.kde.org/plasma/plasma-bigscreen/-/merge_requests/192
+(after this release)
+
+--- a/inputhandler/40-uinput.rules
++++ b/inputhandler/40-uinput.rules
+@@ -1,3 +1,3 @@
+ # SPDX-FileCopyrightText: 2026 Bart Ribbers <bribbers@disroot.org>
+ # SPDX-License-Identifier: CC0-1.0
+-SUBSYSTEM=="misc", KERNEL=="uinput", MODE="0660", GROUP="input"
++SUBSYSTEM=="misc", KERNEL=="uinput", MODE="0660", GROUP="input", TAG+="uaccess", OPTIONS+="static_node=uinput"

--- a/srcpkgs/plasma-bigscreen/template
+++ b/srcpkgs/plasma-bigscreen/template
@@ -1,0 +1,31 @@
+# Template file for 'plasma-bigscreen'
+# group=kde-plasma
+pkgname=plasma-bigscreen
+version=6.7.3
+revision=1
+build_style=cmake
+hostmakedepends="extra-cmake-modules qt6-base gettext pkg-config kf6-kpackage
+ kf6-kconfig kf6-kcmutils qt6-declarative-host-tools"
+makedepends="qt6-multimedia-devel qt6-declarative-private-devel qt6-webengine-devel
+ qcoro-qt6-devel plasma-wayland-protocols kf6-bluez-qt-devel kf6-kcmutils-devel
+ kf6-kconfig-devel kf6-kdbusaddons-devel kf6-kglobalaccel-devel kf6-ki18n-devel
+ kf6-kiconthemes-devel kf6-kio-devel kf6-kirigami-devel kf6-knotifications-devel
+ kf6-ksvg-devel kf6-kwindowsystem-devel libkf6screen-devel libplasma-devel
+ plasma-activities-devel plasma-activities-stats-devel plasma-workspace-devel
+ SDL3-devel libcec-devel"
+depends="plasma-nano plasma-nm plasma-pa kdeconnect kde-cli-tools milou kscreen
+ kwin plasma-keyboard"
+short_desc="Plasma shell for TVs"
+maintainer="John <me@johnnynator.dev>"
+license="GPL-2.0-or-later AND CC-BY-SA-4.0"
+homepage="https://plasma-bigscreen.org"
+distfiles="${KDE_SITE}/plasma/${version}/plasma-bigscreen-${version}.tar.xz"
+checksum=db213defa3a3a8271a54da30760c2df012fa6ee9143b90fb2af060ad1fa1ae0e
+
+# stage builds
+makedepends+=" kde-plasma-base"
+shlib_requires="KDE_Plasma.${version}"
+
+if [ "$XBPS_WORDSIZE$XBPS_WORDSIZE" != "64$XBPS_TARGET_WORDSIZE" ]; then
+	broken="no qt6-webengine"
+fi

--- a/srcpkgs/plasma-browser-integration/template
+++ b/srcpkgs/plasma-browser-integration/template
@@ -1,6 +1,7 @@
 # Template file for 'plasma-browser-integration'
+# group=kde-plasma
 pkgname=plasma-browser-integration
-version=6.6.3
+version=6.7.3
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF
@@ -23,4 +24,8 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-3.0-or-later"
 homepage="https://invent.kde.org/plasma/plasma-browser-integration"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=14dfc993fd7dcd77e41f82d386d2a6033e588ee9ceffe01ce32a7a13f53720e4
+checksum=9a97ec66c29b9817e5081259b7a2c8974aebf60f0aa1323f3f7f3fbb247674d2
+
+# stage builds
+makedepends+=" kde-plasma-base"
+shlib_requires="KDE_Plasma.${version}"

--- a/srcpkgs/plasma-desktop/template
+++ b/srcpkgs/plasma-desktop/template
@@ -1,16 +1,15 @@
 # Template file for 'plasma-desktop'
+# group=kde-plasma
 pkgname=plasma-desktop
-version=6.6.3
-revision=2
+version=6.7.3
+revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF
- -DKF6_HOST_TOOLING=/usr/lib/cmake
  -DKDE_INSTALL_QMLDIR=lib/qt6/qml -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins"
 hostmakedepends="extra-cmake-modules pkg-config gettext qt6-base qt6-shadertools
- qt6-tools wayland-protocols plasma-wayland-protocols kf6-kdoctools
- kf6-kconfig kf6-kcmutils kf6-kpackage kf6-kauth-tools wayland-devel
- qt6-declarative-host-tools"
-makedepends="kf6-kauth-devel kf6-kcrash-devel kf6-kdoctools-devel
+ qt6-tools wayland-protocols plasma-wayland-protocols kf6-kdoctools kf6-kauth-tools
+ kf6-kconfig kf6-kcmutils kf6-kpackage wayland-devel qt6-declarative-host-tools"
+makedepends="kf6-kcrash-devel kf6-kdoctools-devel kf6-kauth-devel
  kf6-ki18n-devel kf6-kcmutils-devel kf6-knewstuff-devel
  kf6-kio-devel kf6-knotifications-devel kf6-knotifyconfig-devel
  kf6-attica-devel kf6-krunner-devel kf6-kglobalaccel-devel
@@ -27,8 +26,7 @@ makedepends="kf6-kauth-devel kf6-kcrash-devel kf6-kdoctools-devel
  libksysguard-devel kf6-kded-devel kf6-baloo-devel libX11-devel
  libcanberra-devel eudev-libudev-devel libxcb-devel xcb-util-image-devel
  xorg-server-devel libglib-devel kwin-devel alsa-lib-devel
- kscreenlocker-devel
- libwacom-devel qt6-qt5compat-devel"
+ kscreenlocker-devel libwacom-devel qt6-qt5compat-devel"
 depends="kmenuedit polkit-kde-agent powerdevil systemsettings
  kf6-qqc2-desktop-style plasma5support
  accountsservice ksystemstats xdg-user-dirs noto-fonts-emoji"
@@ -37,6 +35,10 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later, LGPL-2.0-or-later, LGPL-2.1-or-later, GFDL-1.2-or-later"
 homepage="https://invent.kde.org/plasma/plasma-desktop"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=c5c026bb5a4a29aaf79a9bc07e77873c851f625ef5ba94ce0b717da6f18b1a18
+checksum=8c1bb725b42375e8ce217fb0432cad30fcca0cb315d864b318b76b38b5f074c6
 replaces="user-manager>=0"
 python_version=3
+
+# stage builds
+makedepends+=" kde-plasma-base"
+shlib_requires="KDE_Plasma.${version}"

--- a/srcpkgs/plasma-disks/template
+++ b/srcpkgs/plasma-disks/template
@@ -1,6 +1,7 @@
 # Template file for 'plasma-disks'
+# group=kde-plasma
 pkgname=plasma-disks
-version=6.6.3
+version=6.7.3
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF
@@ -18,4 +19,8 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later"
 homepage="https://invent.kde.org/plasma/plasma-disks"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=7e30d2c0813f8a9e0a03740769b6b4e32c52aa43c2e53c3215d27cd019b8f1ed
+checksum=c7a7604581d646b04e2aa4e2ce0e30f7dde204a853dc958ccb392acf89cce259
+
+# stage builds
+makedepends+=" kde-plasma-base"
+shlib_requires="KDE_Plasma.${version}"

--- a/srcpkgs/plasma-firewall/template
+++ b/srcpkgs/plasma-firewall/template
@@ -1,9 +1,10 @@
 # Template file for 'plasma-firewall'
+# group=kde-plasma
 pkgname=plasma-firewall
-version=6.6.3
+version=6.7.3
 revision=1
 build_style=cmake
-configure_args="-DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins"
 hostmakedepends="extra-cmake-modules qt6-base qt6-tools gettext python3
  kf6-kconfig kf6-kauth-tools kf6-kcmutils"
@@ -14,4 +15,8 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-only, GPL-3.0-only"
 homepage="https://invent.kde.org/network/plasma-firewall"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=dca9ac27df7b6dbc28db69440d7cc1c0b92257815c5aa3664540b897566c0e88
+checksum=6c322eb566d36d28c23795d5760865fad8d4141dbe383a8d5edf247ae830f9aa
+
+# stage builds
+makedepends+=" kde-plasma-base"
+shlib_requires="KDE_Plasma.${version}"

--- a/srcpkgs/plasma-integration/template
+++ b/srcpkgs/plasma-integration/template
@@ -1,9 +1,10 @@
 # Template file for 'plasma-integration'
+# group=kde-plasma
 pkgname=plasma-integration
-version=6.6.3
-revision=2
+version=6.7.3
+revision=1
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF -DBUILD_QT5=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="-DBUILD_TESTING=OFF -DBUILD_QT5=OFF
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins"
 hostmakedepends="extra-cmake-modules pkg-config qt6-base qt6-tools gettext
  wayland-devel kf6-kconfig"
@@ -19,4 +20,8 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.0-or-later"
 homepage="https://invent.kde.org/plasma/plasma-integration"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=302c5bca988c8db4763669b2dbbba7576d94733a3c044170213d65cf3b1c3261
+checksum=ab606df87cc34fb8a85ce2c549cc61e126cdf210ac16a1e8594fa363173e89dc
+
+# stage builds
+makedepends+=" kde-plasma-base"
+shlib_requires="KDE_Plasma.${version}"

--- a/srcpkgs/plasma-keyboard/template
+++ b/srcpkgs/plasma-keyboard/template
@@ -1,23 +1,29 @@
 # Template file for 'plasma-keyboard'
+# group=kde-plasma
 pkgname=plasma-keyboard
-version=6.6.3
-revision=2
+version=6.7.3
+revision=1
 build_style=cmake
 configure_args="-DKDE_INSTALL_QMLDIR=lib/qt6/qml
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins"
 hostmakedepends="extra-cmake-modules gettext wayland-devel
  wayland-protocols plasma-wayland-protocols pkg-config
  qt6-declarative-host-tools qt6-base qt6-tools
- kf6-kcmutils kf6-kconfig"
-makedepends="kf6-kcoreaddons-devel kf6-ki18n-devel
+ kf6-kcmutils kf6-kconfig kf6-kpackage"
+makedepends="libplasma-devel kf6-kcoreaddons-devel kf6-ki18n-devel
  kf6-kcmutils-devel kf6-kconfig-devel qt6-virtualkeyboard-devel
- qt6-wayland-private-devel qt6-base-private-devel kf6-kcrash-devel"
+ qt6-wayland-private-devel qt6-base-private-devel kf6-kcrash-devel
+ kf6-kirigami-devel"
 short_desc="Virtual Keyboard for Qt based desktops"
 maintainer="John <me@johnnynator.dev>"
 license="(GPL-2.0-only OR GPL-3.0-only OR custom:LicenseRef-KDE-Accepted-GPL) AND GPL-3.0-or-later AND (LGPL-2.1-only OR LGPL-3.0-only OR custom:LicenseRef-KDE-Accepted-LGPL)"
 homepage="https://invent.kde.org/plasma/plasma-keyboard"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=fd10bafeb13b1065720dbf8ee334354f050979eddec8b2b025f76c6eb1a1193c
+checksum=c371d98c4588db6672a93aa13b53d178f2dc383bdb580c8bed65d1849be7c97e
+
+# stage builds
+makedepends+=" kde-plasma-base"
+shlib_requires="KDE_Plasma.${version}"
 
 post_install() {
 	vlicense LICENSES/LicenseRef-KDE-Accepted-GPL.txt

--- a/srcpkgs/plasma-nano/template
+++ b/srcpkgs/plasma-nano/template
@@ -1,0 +1,22 @@
+# Template file for 'plasma-nano'
+# group=kde-plasma
+pkgname=plasma-nano
+version=6.7.3
+revision=1
+build_style=cmake
+configure_args="-DKDE_INSTALL_QMLDIR=lib/qt6/qml"
+hostmakedepends="extra-cmake-modules qt6-base gettext kf6-kconfig kf6-kpackage
+ qt6-declarative-host-tools"
+makedepends="qt6-base-devel qt6-declarative-private-devel qt6-svg-devel
+ kf6-ki18n-devel kf6-kwindowsystem-devel kf6-kservice-devel kf6-kitemmodels-devel
+ kf6-kirigami-devel kf6-kwayland-devel kf6-kconfig-devel libplasma-devel"
+short_desc="Minimal Plasma shell for embedded devices"
+maintainer="John <me@johnnynator.dev>"
+license="GPL-2.0-or-later AND LGPL-2.0-or-later"
+homepage="https://invent.kde.org/plasma/plasma-nano"
+distfiles="${KDE_SITE}/plasma/${version}/plasma-nano-${version}.tar.xz"
+checksum=cb585738f3bff48e24bc6025bb32e3fc1771ebbfce95459d4308f445302e2201
+
+# stage builds
+makedepends+=" kde-plasma-base"
+shlib_requires="KDE_Plasma.${version}"

--- a/srcpkgs/plasma-nm/template
+++ b/srcpkgs/plasma-nm/template
@@ -1,9 +1,10 @@
 # Template file for 'plasma-nm'
+# group=kde-plasma
 pkgname=plasma-nm
-version=6.6.3
-revision=2
+version=6.7.3
+revision=1
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="-DBUILD_TESTING=OFF
  -DKDE_INSTALL_QMLDIR=lib/qt6/qml -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins
  $(vopt_bool openconnect BUILD_OPENCONNECT)"
 hostmakedepends="extra-cmake-modules mobile-broadband-provider-info pkg-config
@@ -16,15 +17,20 @@ makedepends="plasma-workspace-devel kf6-networkmanager-qt-devel
  kf6-kcompletion-devel kf6-kcoreaddons-devel kf6-kdbusaddons-devel
  kf6-kio-devel kf6-ki18n-devel kf6-knotifications-devel kf6-kservice-devel
  kf6-kwallet-devel kf6-kwidgetsaddons-devel kf6-kwindowsystem-devel kf6-ksvg-devel
- NetworkManager-devel qt6-base-private-devel
- qcoro-qt6-devel $(vopt_if openconnect 'openconnect-devel qt6-webengine-devel')"
-depends="mobile-broadband-provider-info kf6-kirigami kf6-prison"
+ kf6-prison-devel kf6-kquickcharts-devel NetworkManager-devel qt6-base-private-devel
+ qtkeychain-qt6-devel qcoro-qt6-devel
+ $(vopt_if openconnect 'openconnect-devel qt6-webengine-devel')"
+depends="mobile-broadband-provider-info kf6-kirigami kf6-prison kirigami-addons"
 short_desc="NetworkManager Plasma applet"
 maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/plasma/plasma-nm"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=802374c9d9827d227c3f5f44cfb4c7a7e3fe06a5944dbad29f8604fc4e2a9497
+checksum=b438bf11e82b2169fcddb715f324ea2e01693342c6cac6c392240f9c67b09be4
+
+# stage builds
+makedepends+=" kde-plasma-base"
+shlib_requires="KDE_Plasma.${version}"
 
 build_options="openconnect"
 

--- a/srcpkgs/plasma-pa/template
+++ b/srcpkgs/plasma-pa/template
@@ -1,9 +1,10 @@
 # Template file for 'plasma-pa'
+# group=kde-plasma
 pkgname=plasma-pa
-version=6.6.3
-revision=2
+version=6.7.3
+revision=1
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="-DBUILD_TESTING=OFF
  -DKDE_INSTALL_QMLDIR=lib/qt6/qml
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins"
 hostmakedepends="extra-cmake-modules pkg-config qt6-base gettext qt6-tools
@@ -20,4 +21,8 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/plasma/plasma-pa"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=3549a90ba8c321570f81bfd573b8dd9a63ccd32f87d484534733b2b0c838cb4b
+checksum=c97e985d37494c3617afcbe1d43e039de0068ed53e237083f27dc046e20d1665
+
+# stage builds
+makedepends+=" kde-plasma-base"
+shlib_requires="KDE_Plasma.${version}"

--- a/srcpkgs/plasma-sdk/template
+++ b/srcpkgs/plasma-sdk/template
@@ -1,9 +1,10 @@
 # Template file for 'plasma-sdk'
+# group=kde-plasma
 pkgname=plasma-sdk
-version=6.6.3
-revision=2
+version=6.7.3
+revision=1
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="-DBUILD_TESTING=OFF
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins"
 hostmakedepends="extra-cmake-modules qt6-base qt6-tools gettext kf6-kdoctools
  kf6-kconfig kf6-kpackage qt6-declarative-host-tools"
@@ -18,4 +19,8 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later, LGPL-2.1-or-later"
 homepage="https://invent.kde.org/plasma/plasma-sdk"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=4953ef978568947992aae44921302c8de776fa269e1644ea366772ddccc72c42
+checksum=b02dab7c22051b01eff53e0038ef445647161769766265c3b43f8da4cac0de61
+
+# stage builds
+makedepends+=" kde-plasma-base"
+shlib_requires="KDE_Plasma.${version}"

--- a/srcpkgs/plasma-systemmonitor/template
+++ b/srcpkgs/plasma-systemmonitor/template
@@ -1,9 +1,10 @@
 # Template file for 'plasma-systemmonitor'
+# group=kde-plasma
 pkgname=plasma-systemmonitor
-version=6.6.3
-revision=2
+version=6.7.3
+revision=1
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="-DBUILD_TESTING=OFF
  -DKDE_INSTALL_QMLDIR=lib/qt6/qml"
 hostmakedepends="extra-cmake-modules gettext qt6-base qt6-tools kf6-kpackage
  kf6-kconfig kf6-kcoreaddons qt6-declarative-host-tools"
@@ -18,7 +19,11 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-only, GPL-3.0-only, LGPL-2.1-only, LGPL-3.0-only"
 homepage="https://invent.kde.org/plasma/plasma-systemmonitor"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=411bd919fa926bc6d7b44645f546bd48b0b82ae1f3fe97999a0568abd7019c85
+checksum=5c1190c61d20a254ce8f369de55a837df2ee33366e78124b015cbb3d62d1490c
+
+# stage builds
+makedepends+=" kde-plasma-base"
+shlib_requires="KDE_Plasma.${version}"
 
 ksysguard_package() {
 	metapackage=yes

--- a/srcpkgs/plasma-thunderbolt/template
+++ b/srcpkgs/plasma-thunderbolt/template
@@ -1,9 +1,10 @@
 # Template file for 'plasma-thunderbolt'
+# group=kde-plasma
 pkgname=plasma-thunderbolt
-version=6.6.3
+version=6.7.3
 revision=1
 build_style=cmake
-configure_args="-DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins"
 hostmakedepends="extra-cmake-modules gettext qt6-tools qt6-base
  kf6-kconfig kf6-kcmutils"
@@ -15,8 +16,9 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-3.0-or-later"
 homepage="https://invent.kde.org/plasma/plasma-thunderbolt"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=93849d95036f18d83d118320098c6a3de3444cfde1bbfe45b2dd076c01bae502
+checksum=4ce862d02d30a998b362f70d6dd834c07f0ecfc040d334b90bfb9a37674326f2
+make_check=no # Requires running dbus and bolt services
 
-do_check() {
-	: # Requires running dbus and bolt services
-}
+# stage builds
+makedepends+=" kde-plasma-base"
+shlib_requires="KDE_Plasma.${version}"

--- a/srcpkgs/plasma-vault/template
+++ b/srcpkgs/plasma-vault/template
@@ -1,9 +1,10 @@
 # Template file for 'plasma-vault'
+# group=kde-plasma
 pkgname=plasma-vault
-version=6.6.3
+version=6.7.3
 revision=1
 build_style=cmake
-configure_args="-DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins"
 hostmakedepends="extra-cmake-modules qt6-base qt6-tools
  pkg-config gettext kf6-kconfig kf6-kpackage"
@@ -15,4 +16,8 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later, LGPL-2.0-or-later, LGPL-2.1-or-later"
 homepage="https://invent.kde.org/plasma/plasma-vault"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=ff5dd7c32c8f2afd4465fee250265cd041252217080f39832f7793eda9879b4f
+checksum=8c5d91ad776cee1ef1eca2fb39b5da82d129567b46d2494c3171e17a3e923a27
+
+# stage builds
+makedepends+=" kde-plasma-base"
+shlib_requires="KDE_Plasma.${version}"

--- a/srcpkgs/plasma-wayland-protocols/template
+++ b/srcpkgs/plasma-wayland-protocols/template
@@ -1,6 +1,6 @@
 # Template file for 'plasma-wayland-protocols'
 pkgname=plasma-wayland-protocols
-version=1.20.0
+version=1.21.0
 revision=1
 build_style=cmake
 hostmakedepends="extra-cmake-modules wayland-devel"
@@ -10,4 +10,4 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-3.0-or-later"
 homepage="https://invent.kde.org/libraries/plasma-wayland-protocols"
 distfiles="${KDE_SITE}/${pkgname}/${pkgname}-${version}.tar.xz"
-checksum=9818bb1462211ce5982e670abf0d964eb11fe1d0c02a1c26084db30695a79d6a
+checksum=698a7b28b711270314e396e248ae86087cfeaed01372009063995be6e1dc85ba

--- a/srcpkgs/plasma-workspace-wallpapers/template
+++ b/srcpkgs/plasma-workspace-wallpapers/template
@@ -1,6 +1,7 @@
 # Template file for 'plasma-workspace-wallpapers'
+# group=kde-plasma
 pkgname=plasma-workspace-wallpapers
-version=6.6.3
+version=6.7.3
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF"
@@ -10,4 +11,8 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later"
 homepage="https://invent.kde.org/plasma/plasma-workspace-wallpapers"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=73854af7129707a75f8b131edfd42c440410b8f219babb6173314a22cce915dd
+checksum=b8f5db6b254fdd75f9f28d0c6ff0af87dcbc3ec69c1a3881d5bdb70035071551
+
+# stage builds
+makedepends+=" kde-plasma-base"
+shlib_requires="KDE_Plasma.${version}"

--- a/srcpkgs/plasma-workspace/template
+++ b/srcpkgs/plasma-workspace/template
@@ -1,16 +1,17 @@
 # Template file for 'plasma-workspace'
+# group=kde-plasma
 pkgname=plasma-workspace
-version=6.6.3
-revision=2
+version=6.7.3
+revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF -DKDE_INSTALL_QMLDIR=lib/qt6/qml
  -DWaylandScanner_EXECUTABLE=/usr/bin/wayland-scanner
- -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins -DKF6_HOST_TOOLING=/usr/lib/cmake"
+ -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins"
 hostmakedepends="extra-cmake-modules iso-codes pkg-config gettext
  qt6-base qt6-tools SPIRV-Tools qt6-shadertools kf6-kcmutils kf6-kconfig
  qt6-declarative-host-tools kf6-kdoctools kf6-kwindowsystem
  kf6-kpackage kf6-kauth-tools wayland-devel"
-makedepends="qt6-declarative-devel libplasma-devel qt6-base-private-devel
+makedepends="qt6-declarative-private-devel libplasma-devel qt6-base-private-devel
  kf6-krunner-devel kf6-knotifyconfig-devel kf6-kdesu-devel kf6-knewstuff-devel
  kf6-kcmutils-devel kf6-kidletime-devel libksysguard-devel
  kf6-baloo-devel kf6-ktexteditor-devel kwin-devel libxcb-devel libXtst-devel
@@ -33,7 +34,7 @@ makedepends="qt6-declarative-devel libplasma-devel qt6-base-private-devel
  libqalculate-devel kf6-kquickcharts-devel NetworkManager-devel
  libglib-devel fontconfig-devel libxcb-devel xcb-util-devel
  xcb-util-cursor-devel xcb-util-image-devel qt6-shadertools-devel
- qt6-qt5compat-devel qt6-declarative-private-devel"
+ qt6-qt5compat-devel"
 # qt6-tools for qdbus
 depends="kactivitymanagerd kwin iso-codes milou plasma-integration kpipewire
  xorg-server-xwayland qt6-tools kf6-kquickcharts kirigami-addons"
@@ -42,7 +43,11 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later, GFDL-1.2-or-later, LGPL-2.1-or-later"
 homepage="https://invent.kde.org/plasma/plasma-workspace"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=18001465a01ee29292a3c37e62205106ee9f79f18aaa42ae9654d160abf11790
+checksum=438851708a70781ecf3afa0a08488fdc6768b6ed5abca5f202a87e395aa6376f
+
+# stage builds
+makedepends+=" kde-plasma-base"
+shlib_requires="KDE_Plasma.${version}"
 
 if [ "$XBPS_TARGET_LIBC" = "glibc" ]; then
 	makedepends+=" libxcrypt-devel"

--- a/srcpkgs/plasma5support/template
+++ b/srcpkgs/plasma5support/template
@@ -1,7 +1,8 @@
 # Template file for 'plasma5support'
+# group=kde-plasma
 pkgname=plasma5support
-version=6.6.3
-revision=2
+version=6.7.3
+revision=1
 build_style=cmake
 configure_args="-DKDE_INSTALL_QMLDIR=lib/qt6/qml
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins"
@@ -18,7 +19,11 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-3.0-or-later"
 homepage="https://invent.kde.org/plasma/plasma5support"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=7f764826ef8967990eb42da3636bbfdd29c85e3928eeb917b8d8fed4b77f730c
+checksum=fa7ad66a4d32145ee6a91ecd69f19440c554d062afa930e2c8597e32cfc50f7c
+
+# stage builds
+makedepends+=" kde-plasma-base"
+shlib_requires="KDE_Plasma.${version}"
 
 do_check() {
 	cd build

--- a/srcpkgs/plasmatube/template
+++ b/srcpkgs/plasmatube/template
@@ -3,7 +3,7 @@ pkgname=plasmatube
 version=26.04.2
 revision=2
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="-DBUILD_TESTING=OFF
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins
  -DKDE_INSTALL_QMLDIR=lib/qt6/qml"
 hostmakedepends="extra-cmake-modules gettext kf6-kconfig kf6-kcoreaddons

--- a/srcpkgs/polkit-kde-agent/template
+++ b/srcpkgs/polkit-kde-agent/template
@@ -1,6 +1,7 @@
 # Template file for 'polkit-kde-agent'
+# group=kde-plasma
 pkgname=polkit-kde-agent
-version=6.6.3
+version=6.7.3
 revision=1
 build_style=cmake
 hostmakedepends="extra-cmake-modules qt6-base qt6-tools gettext"
@@ -13,4 +14,8 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later"
 homepage="https://commits.kde.org/polkit-kde-agent"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-1-${version}.tar.xz"
-checksum=3189471debe07a3f779efb247a9db1c15618cd70f37fc360e78078f40d5507a4
+checksum=8b78de2016688115995535acd3727e8273e4582c1b5cdc883f43683223970b2a
+
+# stage builds
+makedepends+=" kde-plasma-base"
+shlib_requires="KDE_Plasma.${version}"

--- a/srcpkgs/powerdevil/template
+++ b/srcpkgs/powerdevil/template
@@ -1,9 +1,10 @@
 # Template file for 'powerdevil'
+# group=kde-plasma
 pkgname=powerdevil
-version=6.6.3
-revision=2
+version=6.7.3
+revision=1
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="-DBUILD_TESTING=OFF
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins -DKDE_INSTALL_QMLDIR=lib/qt6/qml"
 hostmakedepends="extra-cmake-modules pkg-config gettext qt6-base qt6-tools
  qt6-declarative-host-tools kf6-kdoctools kf6-kcmutils kf6-kconfig
@@ -22,4 +23,8 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later"
 homepage="https://invent.kde.org/plasma/powerdevil"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=73e9b85dbf9791fcf22c01d67b3cf024e23fea170476f09ff8fd91b4034480e9
+checksum=72e362963d67488cb55b9d6c563a66bbe043553980269f2e2c2b691f023e2f35
+
+# stage builds
+makedepends+=" kde-plasma-base"
+shlib_requires="KDE_Plasma.${version}"

--- a/srcpkgs/print-manager/template
+++ b/srcpkgs/print-manager/template
@@ -1,10 +1,11 @@
 # Template file for 'print-manager'
+# group=kde-plasma
 pkgname=print-manager
 reverts="23.08.5_1 22.12.1_1 22.04.1_1 21.12.3_1 21.12.2_1 21.08.0_1 20.12.2_1"
-version=6.6.3
-revision=2
+version=6.7.3
+revision=1
 build_style=cmake
-configure_args="-DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="
  -DKDE_INSTALL_QMLDIR=lib/qt6/qml
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins"
 hostmakedepends="extra-cmake-modules qt6-base gettext kf6-kconfig
@@ -13,10 +14,16 @@ makedepends="plasma-framework-devel kf6-kcmutils-devel cups-devel
  qt6-declarative-devel kf6-kdbusaddons-devel kf6-kconfigwidgets-devel
  kf6-kcoreaddons-devel kf6-ki18n-devel kf6-kio-devel kf6-knotifications-devel
  kf6-kwidgetsaddons-devel kf6-kwindowsystem-devel system-config-printer
- kf6-kirigami-devel libplasma-devel kf6-kconfig-devel kf6-kpackage-devel"
+ kf6-kirigami-devel libplasma-devel kf6-kconfig-devel kf6-kpackage-devel
+ kirigami-addons-devel kf6-kdeclarative"
+depends="kf6-kdeclarative"
 short_desc="Printing management for KDE Plasma"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="https://invent.kde.org/plasma/print-manager"
 distfiles="${KDE_SITE}/plasma/${version}/print-manager-${version}.tar.xz"
-checksum=686fcff428c2be57114d14c3e74129f3e35e4c457cbcad37219515473c5b621b
+checksum=9de31d9e12324431dcd2efb983016f95e8574a8aa79e6bf761777d666ace17b2
+
+# stage builds
+makedepends+=" kde-plasma-base"
+shlib_requires="KDE_Plasma.${version}"

--- a/srcpkgs/qqc2-breeze-style/template
+++ b/srcpkgs/qqc2-breeze-style/template
@@ -1,0 +1,22 @@
+# Template file for 'qqc2-breeze-style'
+# group=kde-plasma
+pkgname=qqc2-breeze-style
+version=6.7.3
+revision=1
+build_style=cmake
+configure_args="-DKDE_INSTALL_QMLDIR=lib/qt6/qml
+ -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins"
+hostmakedepends="extra-cmake-modules qt6-base kf6-kconfig qt6-declarative-host-tools"
+makedepends="kf6-kconfig-devel kf6-kconfigwidgets-devel kf6-kguiaddons-devel
+ kf6-kiconthemes-devel kf6-kirigami-devel kf6-kquickcharts-devel kf6-kconfig-devel
+ qt6-declarative-private-devel"
+short_desc="Breeze-inspired QQC2 style"
+maintainer="John <me@johnnynator.dev>"
+license="LGPL-2.1-only OR LGPL-3.0-only OR LicenseRef-KDE-Accepted-LGPL"
+homepage="https://invent.kde.org/plasma/qqc2-breeze-style"
+distfiles="${KDE_SITE}/plasma/${version}/qqc2-breeze-style-${version}.tar.xz"
+checksum=e399daf4cee241e4bcaf77b69548f7b9f6b1550cc0f7dc5ce6f2ec4f99d82899
+
+# stage builds
+makedepends+=" kde-plasma-base"
+shlib_requires="KDE_Plasma.${version}"

--- a/srcpkgs/sddm-kcm/template
+++ b/srcpkgs/sddm-kcm/template
@@ -1,9 +1,10 @@
 # Template file for 'sddm-kcm'
+# group=kde-plasma
 pkgname=sddm-kcm
-version=6.6.3
+version=6.7.3
 revision=1
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="-DBUILD_TESTING=OFF
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins"
 hostmakedepends="extra-cmake-modules pkg-config qt6-tools qt6-base gettext
  kf6-kcmutils kf6-kconfig kf6-kauth-tools"
@@ -15,4 +16,8 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later"
 homepage="https://invent.kde.org/plasma/sddm-kcm"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=30e9c85cb3f1cc2f711ed5946e44efd5aea5258c582bbd9d0f107e54841daaaf
+checksum=345acf5cf3cf2b5feb2ee0b31471521e79268491019a6baefb31b23690f62e0f
+
+# stage builds
+makedepends+=" kde-plasma-base"
+shlib_requires="KDE_Plasma.${version}"

--- a/srcpkgs/skanlite/template
+++ b/srcpkgs/skanlite/template
@@ -4,7 +4,7 @@ version=26.04.1
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF -DBUILD_WITH_QT6=ON
- -DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
+ -DBUILD_TESTING=OFF
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins"
 hostmakedepends="extra-cmake-modules gettext kf6-kcoreaddons kf6-kdoctools
  qt6-base kf6-kconfig"

--- a/srcpkgs/skanpage/template
+++ b/srcpkgs/skanpage/template
@@ -3,7 +3,7 @@ pkgname=skanpage
 version=26.04.1
 revision=1
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="-DBUILD_TESTING=OFF
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins"
 hostmakedepends="extra-cmake-modules gettext qt6-base qt6-tools kf6-kcoreaddons kf6-kconfig"
 makedepends="qt6-base-devel qt6-declarative-devel qt6-pdf-devel

--- a/srcpkgs/spectacle/template
+++ b/srcpkgs/spectacle/template
@@ -1,42 +1,30 @@
 # Template file for 'spectacle'
+# group=kde-plasma
 pkgname=spectacle
 reverts="24.12.1_1 24.12.0_1 24.08.1_2 24.08.1_1 24.08.0_1 24.05.0_4 24.05.0_3 24.05.0_2 24.05.0_2 24.05.0_2 24.05.0_1 24.02.2_1 23.08.5_1 23.08.4_1 23.08.3_1 23.08.2_1 23.08.0_1 23.04.2_1 23.04.0_1 22.12.1_1 22.08.2_1 22.08.1_1 22.04.3_1 22.04.1_1 21.12.3_1 21.12.2_1 21.12.1_1 21.12.0_1 21.08.3_1 21.08.2_1 21.08.1_1 21.08.0_1 21.04.3_1 21.04.2_1 21.04.1_1 21.04.0_1 20.12.3_1 20.12.2_1 20.12.1_1 20.12.0_1 20.08.3_1 20.08.2_1 20.08.1_1 20.08.0_1 20.04.3_1 20.04.2_1 20.04.2_1 20.04.1_1 20.04.0_1"
-version=6.6.5
-revision=2
+version=6.7.3
+revision=1
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake"
-hostmakedepends="extra-cmake-modules qt6-tools qt6-base
+configure_args="-DBUILD_TESTING=OFF"
+hostmakedepends="pkg-config extra-cmake-modules qt6-tools qt6-base
  qt6-declarative-host-tools gettext wayland-devel kf6-kdoctools kf6-kconfig
  plasma-wayland-protocols"
 makedepends="qt6-base-private-devel qt6-declarative-devel qt6-multimedia-devel
- kf6-kcoreaddons-devel
- kf6-kwidgetsaddons-devel
- kf6-kdbusaddons-devel
- kf6-knotifications-devel
- kf6-kconfig-devel
- kf6-ki18n-devel
- kf6-kio-devel
- kf6-kwindowsystem-devel
- kf6-kglobalaccel-devel
- kf6-kxmlgui-devel
- kf6-kguiaddons-devel
- kf6-kirigami-devel
- kf6-kstatusnotifieritem-devel
- kf6-prison-devel
- kf6-kcrash-devel
- kquickimageeditor-devel
- wayland-devel
- layer-shell-qt-devel
- kpipewire-devel
- libopencv-devel
- kf6-purpose-devel
- libxcb-devel
- xcb-util-devel
- xcb-util-image-devel
- xcb-util-cursor-devel"
+ kf6-kcoreaddons-devel kf6-kwidgetsaddons-devel kf6-kdbusaddons-devel
+ kf6-knotifications-devel kf6-kconfig-devel kf6-ki18n-devel kf6-kio-devel
+ kf6-kwindowsystem-devel kf6-kglobalaccel-devel kf6-kxmlgui-devel
+ kf6-kguiaddons-devel kf6-kirigami-devel kf6-kstatusnotifieritem-devel
+ kf6-prison-devel kf6-kcrash-devel kquickimageeditor-devel wayland-devel
+ layer-shell-qt-devel kpipewire-devel libopencv-devel kf6-purpose-devel
+ libxcb-devel xcb-util-devel xcb-util-image-devel xcb-util-cursor-devel
+ tesseract-ocr-devel"
 short_desc="KDE screenshot capture utility"
 maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.0-or-later, GPL-2.0-or-later"
 homepage="https://apps.kde.org/spectacle/"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=a37df7731a6bc89bc23ac08ad1f995ce9f1efb330f3ebad9bf926dca6ebb5fc7
+checksum=4f5c87592f35bb1bd58fa8e72829c39049646acc3d2f79451daa340c0dbb1154
+
+# stage builds
+makedepends+=" kde-plasma-base"
+shlib_requires="KDE_Plasma.${version}"

--- a/srcpkgs/svgpart/template
+++ b/srcpkgs/svgpart/template
@@ -3,7 +3,7 @@ pkgname=svgpart
 version=26.04.1
 revision=1
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="-DBUILD_TESTING=OFF
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins
  -DKDE_INSTALL_QMLDIR=lib/qt6/qml
  -DECM_MKSPECS_INSTALL_DIR=/usr/lib/qt6/mkspecs/modules"

--- a/srcpkgs/sweeper/template
+++ b/srcpkgs/sweeper/template
@@ -3,7 +3,7 @@ pkgname=sweeper
 version=26.04.1
 revision=1
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="-DBUILD_TESTING=OFF
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins
  -DKDE_INSTALL_QMLDIR=lib/qt6/qml
  -DECM_MKSPECS_INSTALL_DIR=/usr/lib/qt6/mkspecs/modules"

--- a/srcpkgs/systemsettings/template
+++ b/srcpkgs/systemsettings/template
@@ -1,9 +1,10 @@
 # Template file for 'systemsettings'
+# group=kde-plasma
 pkgname=systemsettings
-version=6.6.3
-revision=2
+version=6.7.3
+revision=1
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="-DBUILD_TESTING=OFF
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins"
 hostmakedepends="python3 qt6-base qt6-tools kf6-kcmutils kf6-kauth-tools
  kf6-kconfig
@@ -23,4 +24,8 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later, GFDL-1.2-only"
 homepage="https://invent.kde.org/plasma/systemsettings"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=99974a1922c9e3b3ce8a8479946e6f48c28f2ea860a3b8763c7bfc35e712e151
+checksum=9729cd487a838c80c8a5adc98b50d84ba4231cb47f55b5efa8972213b88e1640
+
+# stage builds
+makedepends+=" kde-plasma-base"
+shlib_requires="KDE_Plasma.${version}"

--- a/srcpkgs/tellico/template
+++ b/srcpkgs/tellico/template
@@ -3,7 +3,7 @@ pkgname=tellico
 version=4.1.3
 revision=1
 build_style=cmake
-configure_args="$(vopt_bool webcam ENABLE_WEBCAM) -DKF6_HOST_TOOLING=/usr/lib/cmake"
+configure_args="$(vopt_bool webcam ENABLE_WEBCAM) "
 hostmakedepends="extra-cmake-modules qt6-base qt6-tools gettext
  pkg-config kf6-kdoctools kf6-kconfig"
 makedepends="kf6-karchive-devel kf6-kcodecs-devel kf6-sonnet-devel

--- a/srcpkgs/tokodon/template
+++ b/srcpkgs/tokodon/template
@@ -3,7 +3,7 @@ pkgname=tokodon
 version=26.04.2
 revision=2
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="-DBUILD_TESTING=OFF
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins
  -DKDE_INSTALL_QMLDIR=lib/qt6/qml"
 hostmakedepends="extra-cmake-modules gettext kf6-kconfig kf6-kcoreaddons

--- a/srcpkgs/xdg-desktop-portal-kde/template
+++ b/srcpkgs/xdg-desktop-portal-kde/template
@@ -1,7 +1,8 @@
 # Template file for 'xdg-desktop-portal-kde'
+# group=kde-plasma
 pkgname=xdg-desktop-portal-kde
-version=6.6.3
-revision=2
+version=6.7.3
+revision=1
 build_style=cmake
 configure_args="-DWaylandScanner_EXECUTABLE=/usr/bin/wayland-scanner"
 hostmakedepends="extra-cmake-modules qt6-base qt6-tools gettext
@@ -12,7 +13,7 @@ makedepends="qt6-base-devel qt6-declarative-devel
  kf6-kio-devel kf6-kdeclarative-devel kf6-kirigami-devel
  kf6-kstatusnotifieritem-devel libplasma-devel kf6-kwayland-devel
  kf6-kcrash-devel kf6-kiconthemes-devel kf6-kcoreaddons-devel
- kf6-kconfig-devel kf6-ki18n-devel kf6-kguiaddons-devel kf6-kglobalaccel-devel
+ kf6-kconfig-devel kf6-ki18n-devel kf6-kglobalaccel-devel
  qt6-base-private-devel qt6-declarative-devel kf6-kio-devel kf6-knotifications-devel
  kf6-kservice-devel kf6-kwidgetsaddons-devel kf6-kwindowsystem-devel
  libepoxy-devel pipewire-devel libglib-devel"
@@ -23,7 +24,11 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-3.0-or-later"
 homepage="https://invent.kde.org/plasma/xdg-desktop-portal-kde"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=d9b5c39596b4039e517c8a04bb6c2faae7f7c4d99855756fdafb9417fe3ffbfd
+checksum=de9ce7475f3670e5662de8a3ad9002df918ab5ee94b4401e3ccb1d67f46d4919
+
+# stage builds
+makedepends+=" kde-plasma-base"
+shlib_requires="KDE_Plasma.${version}"
 
 do_check() {
 	cd build

--- a/srcpkgs/yakuake/template
+++ b/srcpkgs/yakuake/template
@@ -3,7 +3,7 @@ pkgname=yakuake
 version=26.04.1
 revision=2
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="-DBUILD_TESTING=OFF
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins
  -DKDE_INSTALL_QMLDIR=lib/qt6/qml
  -DECM_MKSPECS_INSTALL_DIR=/usr/lib/qt6/mkspecs/modules"

--- a/srcpkgs/zanshin/template
+++ b/srcpkgs/zanshin/template
@@ -3,7 +3,7 @@ pkgname=zanshin
 version=26.04.1
 revision=1
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF -DKF6_HOST_TOOLING=/usr/lib/cmake
+configure_args="-DBUILD_TESTING=OFF
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins
  -DKDE_INSTALL_QMLDIR=lib/qt6/qml
  -DECM_MKSPECS_INSTALL_DIR=/usr/lib/qt6/mkspecs/modules"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR:
    - [x] x86_64 (tested plasma-desktop and plasma-bigscreen)
    - [x] x86_64-musl
    - [x] i686
    - [ ] aarch64
    - [x] aarch64-musl
    - [x] armv7l
    - [ ] armv7l-musl
    - [ ] armv6l
    - [x] armv6l-musl

[ci skip] [skip ci] [ci-skip] [skip-ci] 

this should fix #59502 for future updates due to the addition of `kf6-base` and `kde-plasma-base`