### PR TITLE
x264: rebuild against noexecstack fix

### DIFF
--- a/srcpkgs/x264/template
+++ b/srcpkgs/x264/template
@@ -1,11 +1,12 @@
 # Template file for 'x264'
 pkgname=x264
 version=20250402.165
-revision=1
+revision=2
 _commit=b35605ace3ddf7c1a5d67a2eb553f034aef41d55
 build_style=configure
 configure_args="--prefix=/usr --enable-static --enable-shared
- --host=$XBPS_CROSS_TRIPLET --sysroot=$XBPS_CROSS_BASE"
+ --host=$XBPS_CROSS_TRIPLET --sysroot=$XBPS_CROSS_BASE
+ --extra-ldflags=-Wl,-z,noexecstack"
 hostmakedepends="nasm perl"
 short_desc="Free library for encoding H264/AVC video streams"
 maintainer="Orphaned <orphan@voidlinux.org>"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l

Fixes #61164 