### PR TITLE
OpenCL-CLHPP: update to 2026.05.29.

### DIFF
--- a/srcpkgs/OpenCL-CLHPP/template
+++ b/srcpkgs/OpenCL-CLHPP/template
@@ -1,6 +1,6 @@
 # Template file for 'OpenCL-CLHPP'
 pkgname=OpenCL-CLHPP
-version=2025.07.22
+version=2026.05.29
 revision=1
 build_style=cmake
 configure_args="-DBUILD_EXAMPLES=OFF -DBUILD_TESTING=OFF -DBUILD_DOCS=ON"
@@ -12,7 +12,7 @@ maintainer="Daniel Martinez <danielmartinez@cock.li>"
 license="Apache-2.0"
 homepage="https://github.com/KhronosGroup/OpenCL-CLHPP"
 distfiles="https://github.com/KhronosGroup/OpenCL-CLHPP/archive/refs/tags/v${version}.tar.gz"
-checksum=c1031afde6e9eb042e6fcfbc17078f4b437a7e8d55482a1ca6e0fa762d262a89
+checksum=fafb4fd202d113992c009d46e6358e70076167e62a5baeb377fe813033a2655e
 
 post_install() {
 	ninja -C ${cmake_builddir} docs


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture (x86_64)
- I built this PR locally for these architectures using specific masterdirs:
  - x86_64-musl
  - i686
- I built this PR locally for these architectures (crossbuilds):
  - aarch64
  - aarch64-musl
  - armv7l
  - armv7l-musl
  - armv6l
  - armv6l-musl