### PR TITLE
mutt: update to 2.4.1

### DIFF
--- a/srcpkgs/mutt/template
+++ b/srcpkgs/mutt/template
@@ -1,6 +1,6 @@
 # Template file for 'mutt'
 pkgname=mutt
-version=2.3.3
+version=2.4.1
 revision=1
 build_style=gnu-configure
 configure_args="--enable-pop --enable-imap --enable-smtp --enable-hcache
@@ -13,13 +13,14 @@ hostmakedepends="perl pkg-config gettext w3m"
 makedepends="gdbm-devel gpgme-devel libidn2-devel openssl-devel gsasl-devel
  ncurses-devel zlib-devel sqlite-devel libunistring-devel libgpg-error-devel"
 depends="mime-types"
+checkdepends="shellcheck"
 short_desc="Mutt Mail Client"
 maintainer="Đoàn Trần Công Danh <congdanhqx@gmail.com>"
 license="GPL-2.0-or-later"
 homepage="http://www.mutt.org"
 changelog="http://mutt.org/relnotes/${version%.*}"
 distfiles="http://ftp.mutt.org/pub/mutt/${pkgname}-${version}.tar.gz"
-checksum=bce753399b28c0efcfa8a446115f0d30d9c27e551ab51b0e53799dd0c373dcc4
+checksum=5624321f0b1cc1eff6cab9ef08f25954ff64c51b33d4bf3b99484cf1edd8cfff
 
 post_install() {
 	# provided by mime-types


### PR DESCRIPTION
- I tested the changes in this PR: **YES**
- I built this PR locally for my native architecture, (aarch64-gnu)

@sgn I could not run the testsuite locally, since this introduces a dependence on `shellcheck`, but I run the program for a while.