### PR TITLE
mutt: update to 2.4.1

### DIFF
--- a/srcpkgs/mutt/template
+++ b/srcpkgs/mutt/template
@@ -1,6 +1,6 @@
 # Template file for 'mutt'
 pkgname=mutt
-version=2.3.3
+version=2.4.1
 revision=1
 build_style=gnu-configure
 configure_args="--enable-pop --enable-imap --enable-smtp --enable-hcache
@@ -19,7 +19,8 @@ license="GPL-2.0-or-later"
 homepage="http://www.mutt.org"
 changelog="http://mutt.org/relnotes/${version%.*}"
 distfiles="http://ftp.mutt.org/pub/mutt/${pkgname}-${version}.tar.gz"
-checksum=bce753399b28c0efcfa8a446115f0d30d9c27e551ab51b0e53799dd0c373dcc4
+checksum=5624321f0b1cc1eff6cab9ef08f25954ff64c51b33d4bf3b99484cf1edd8cfff
+make_check=no # no meaningful tests
 
 post_install() {
 	# provided by mime-types


### PR DESCRIPTION
- I tested the changes in this PR: **YES**
- I built this PR locally for my native architecture, (aarch64-gnu)

Disable checks: they now require shellcheck, and I believe they are not meant to test the actual build artifact.