### PR TITLE
mpvqt: rebuild for Qt 6.11.1, fix segfault on wayland

### DIFF
--- a/srcpkgs/mpvqt/template
+++ b/srcpkgs/mpvqt/template
@@ -1,7 +1,7 @@
 # Template file for 'mpvqt'
 pkgname=mpvqt
 version=1.2.0
-revision=1
+revision=2
 build_style=cmake
 hostmakedepends="extra-cmake-modules qt6-base"
 makedepends="mpv-devel qt6-declarative-devel"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

Without the rebuild haruna segfaults with the following output on wayland (xwayland works, though):
```
$ haruna 
ATTENTION: default value of option vblank_mode overridden by environment.
unknown() : Native interface revision mismatch (requested 1 / available 2) for interface QWaylandApplication

[1]    26255 segmentation fault  haruna
```

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->


#### Local build testing
- I built this PR locally for my native architecture: x86_64-glibc
