### PR TITLE
librime: update to 1.17.0.

### DIFF
--- a/srcpkgs/librime/template
+++ b/srcpkgs/librime/template
@@ -1,6 +1,6 @@
 # Template file for 'librime'
 pkgname=librime
-version=1.15.0
+version=1.17.0
 revision=1
 build_style=cmake
 configure_args="-DENABLE_LOGGING=OFF -DBUILD_TEST=ON"
@@ -13,7 +13,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="BSD-3-Clause"
 homepage="https://github.com/rime/librime"
 distfiles="https://github.com/rime/librime/archive/${version}.tar.gz"
-checksum=a6283cb6a9fa9445dbd7fac58f614884edd662486fa79809ca63686c8f59c6da
+checksum=a60274da5d8b8a7187e6c7e9ba5023334ed7bdd182535e93c4e96de8cf188377
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc

Superseded https://github.com/void-linux/void-packages/pull/58154 now that rime-plum is packaged.
