### PR TITLE
android-tools: update to 36.0.1

### DIFF
--- a/srcpkgs/android-tools/template
+++ b/srcpkgs/android-tools/template
@@ -1,11 +1,9 @@
 # Template file for 'android-tools'
 pkgname=android-tools
-version=35.0.2
-revision=2
+version=36.0.1
+revision=1
 archs="armv* aarch64* x86_64* i686* ppc64le* riscv64*"
 build_style=cmake
-# requires new changes in libusb that have not been released yet
-configure_args="-DANDROID_TOOLS_USE_BUNDLED_LIBUSB=ON"
 hostmakedepends="perl go protobuf pkg-config samurai"
 makedepends="gtest-devel zlib-devel libusb-devel pcre2-devel fmt-devel
  liblz4-devel libzstd-devel protobuf-devel brotli-devel abseil-cpp-devel"
@@ -15,7 +13,7 @@ maintainer="John <me@johnnynator.dev>"
 license="Apache-2.0, ISC, GPL-2.0-only, MIT"
 homepage="https://developer.android.com/tools/help/adb.html"
 distfiles="https://github.com/nmeum/android-tools/releases/download/${version}/android-tools-${version}.tar.xz"
-checksum=d2c3222280315f36d8bfa5c02d7632b47e365bfe2e77e99a3564fb6576f04097
+checksum=38e8a84b739480141de0836bf6d581b3339ac7d53d0f7ce8c044a3368c8c2f8f
 
 case "${XBPS_TARGET_MACHINE}" in
 	i686*) CFLAGS="-msse2" CXXFLAGS="-msse2";;


### PR DESCRIPTION
Revert some changes from 98f4f5a9791364ed07ba0901a64c5c74bee9c292 commit because this release can be used with system provided libusb library.

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
