### PR TITLE
krusader: add kde-cli-tools dependency

### DIFF
--- a/srcpkgs/krusader/template
+++ b/srcpkgs/krusader/template
@@ -1,7 +1,7 @@
 # Template file for 'krusader'
 pkgname=krusader
 version=2.9.0
-revision=1
+revision=2
 build_style=cmake
 configure_args="-DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins"
 hostmakedepends="extra-cmake-modules gettext pkg-config qt6-base
@@ -14,6 +14,7 @@ makedepends="qt6-base-devel qt6-qt5compat-devel
  kf6-kparts-devel kf6-solid-devel kf6-ktextwidgets-devel kf6-kwallet-devel
  kf6-kwidgetsaddons-devel kf6-kwindowsystem-devel kf6-kxmlgui-devel
  kf6-kguiaddons-devel kf6-kstatusnotifieritem-devel"
+depends="kde-cli-tools" # keditfiletype
 short_desc="Twin-panel (commander-style) file manager"
 maintainer="Piotr Wójcik <chocimier@tlen.pl>"
 license="GPL-2.0-or-later"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64

If you change the default application used to open a file then krusader fails and tells the user that it cannot execute the binary keditfiletype.
keditfiletype is provided by kde-cli-tools.
This is only a runtime dependency.,

More info at https://www.reddit.com/r/voidlinux/comments/1up58te/should_krusader_depend_on_kdeclitools/