### PR TITLE
android-udev-rules: update to 20260423

### DIFF
--- a/srcpkgs/android-udev-rules/template
+++ b/srcpkgs/android-udev-rules/template
@@ -1,6 +1,6 @@
 # Template file for 'android-udev-rules'
 pkgname=android-udev-rules
-version=20250525
+version=20260423
 revision=1
 short_desc="Android udev rules list aimed to be the most comprehensive on the net"
 maintainer="Orphaned <orphan@voidlinux.org>"
@@ -8,7 +8,7 @@ license="GPL-3.0-or-later"
 homepage="https://github.com/M0Rf30/android-udev-rules"
 changelog="https://github.com/M0Rf30/android-udev-rules/releases"
 distfiles="https://github.com/M0Rf30/android-udev-rules/archive/${version}.tar.gz"
-checksum=582bf8daa23f318047e77ece4c101c8696fd9151c459f695dca56cf4a40a72a2
+checksum=d5cfdbd2bc19dc560424c807298c6822daf4ed1cf8389373dfe029b5dfc7b1a2
 system_groups="adbusers"
 
 do_install() {


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc