### PR TITLE
frp: Align service scripts to template file's config path

### DIFF
--- a/srcpkgs/frp/files/frpc/run
+++ b/srcpkgs/frp/files/frpc/run
@@ -1,3 +1,3 @@
 #!/bin/sh
 exec 2>&1
-exec /usr/bin/frpc -c /etc/frp/frpc.ini
+exec /usr/bin/frpc -c /etc/frp/frpc.toml

--- a/srcpkgs/frp/files/frps/run
+++ b/srcpkgs/frp/files/frps/run
@@ -1,3 +1,3 @@
 #!/bin/sh
 exec 2>&1
-exec /usr/bin/frps -c /etc/frp/frps.ini
+exec /usr/bin/frps -c /etc/frp/frps.toml

--- a/srcpkgs/frp/template
+++ b/srcpkgs/frp/template
@@ -1,7 +1,7 @@
 # Template file for 'frp'
 pkgname=frp
 version=0.65.0
-revision=1
+revision=2
 build_style=go
 go_import_path=github.com/fatedier/frp
 go_package="${go_import_path}/cmd/frpc ${go_import_path}/cmd/frps"


### PR DESCRIPTION
https://github.com/void-linux/void-packages/pull/55858 is a previous PR with the same change, but the PR owner closed it, and the package's maintainer, @Anachron, mentioned intent to apply this fix.
(Apologies to said maintainer for the ping, intended as a gentle reminder as they stated not getting a notification in the last PR.)

The package `template` is untouched, this PR simply has the service files use the same config files as the `template` refers to.

Original config file location is deprecated as well, besides not being installed by the `template` already.

#### Testing the changes
- I tested the changes in this PR: **briefly**
  - local Void install on `aarch64-musl` works (hardware: a Raspberry Pi 4), as in:
  "I changed my local service file by hand and this quick fix works on a fresh package install"
  - (`xbps-src` is missing in the static download of `xbps`, so I can't rebuild the package elsewhere, but the `template`'s unchanged anyway!)
