### PR TITLE
z3: fix empty libz3.so on musl targets and revbump llvm

### DIFF
--- a/srcpkgs/llvm/template
+++ b/srcpkgs/llvm/template
@@ -1,7 +1,7 @@
 # Template file for 'llvm'
 pkgname=llvm
 version=21
-revision=3
+revision=4
 metapackage=yes
 depends="llvm${version}"
 short_desc="LLVM meta package"

--- a/srcpkgs/llvm18/template
+++ b/srcpkgs/llvm18/template
@@ -1,7 +1,7 @@
 # Template file for 'llvm18'.
 pkgname=llvm18
 version=18.1.8
-revision=6
+revision=7
 build_wrksrc=llvm
 build_style=cmake
 configure_args="

--- a/srcpkgs/llvm19/template
+++ b/srcpkgs/llvm19/template
@@ -1,7 +1,7 @@
 # Template file for 'llvm19'
 pkgname=llvm19
 version=19.1.4
-revision=8
+revision=9
 build_wrksrc=llvm
 build_style=cmake
 _llvm_prefix=lib/llvm/19

--- a/srcpkgs/llvm21/template
+++ b/srcpkgs/llvm21/template
@@ -1,7 +1,7 @@
 # Template file for 'llvm21'
 pkgname=llvm21
 version=21.1.7
-revision=1
+revision=2
 build_wrksrc=llvm
 build_style=cmake
 _major="${version%%.*}"

--- a/srcpkgs/llvm22/template
+++ b/srcpkgs/llvm22/template
@@ -1,7 +1,7 @@
 # Template file for 'llvm22'
 pkgname=llvm22
 version=22.1.4
-revision=1
+revision=2
 build_wrksrc=llvm
 build_style=cmake
 _major="${version%%.*}"

--- a/srcpkgs/z3/template
+++ b/srcpkgs/z3/template
@@ -1,7 +1,7 @@
 # Template file for 'z3'
 pkgname=z3
 version=4.16.0
-revision=1
+revision=2
 build_style=configure
 configure_args="--prefix=/usr -g --python $(vopt_if ocaml --ml)"
 make_build_args="-C build all examples"
@@ -53,7 +53,7 @@ z3-ocaml_package() {
 libz3_package() {
 	short_desc+=" - runtime library"
 	pkg_install() {
-		vmove usr/lib/libz3.so
+		vmove "usr/lib/libz3.so*"
 	}
 }
 


### PR DESCRIPTION
The current `libz3` package on `aarch64-musl` contains a literal 0-byte empty `libz3.so` file

This completely breaks the LLVM toolchain on `aarch64-musl` as `libLLVM.so` attempts to load the empty library and crashes with `symbol not found`

Revbumping `z3` and the `llvm*` suite forces a rebuild to generate the proper 29MB shared library and relink the dependents. I've tested a local `xbps-src` native build of this exact tree on `aarch64-musl` and confirmed it generates the library properly

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
