### PR TITLE
mise: update to 2026.7.3.

### DIFF
--- a/srcpkgs/mise/template
+++ b/srcpkgs/mise/template
@@ -1,6 +1,6 @@
 # Template file for 'mise'
 pkgname=mise
-version=2026.6.0
+version=2026.7.3
 revision=1
 build_style=cargo
 hostmakedepends="pkg-config"
@@ -13,7 +13,7 @@ license="MIT"
 homepage="https://github.com/jdx/mise"
 changelog="https://github.com/jdx/mise/releases"
 distfiles="https://github.com/jdx/mise/archive/v${version}.tar.gz>${pkgname}-${version}.tar.gz"
-checksum=e85144f94a49b9e01af3e90f0f3bec4648531ef501703841fb618fecda8d705c
+checksum=05a81b2e03465417cac0b588c3d9b9ed2933c823519f71e1e6238fd9c00b929d
 
 case "$XBPS_TARGET_MACHINE" in
 	i686*) broken="runs out of memory" ;;


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86-glibc)


