### PR TITLE
rpi-imager: update to 2.0.10.

### DIFF
--- a/srcpkgs/rpi-imager/patches/devendor-and-lrelease.patch
+++ b/srcpkgs/rpi-imager/patches/devendor-and-lrelease.patch
@@ -1,0 +1,90 @@
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -155,26 +155,26 @@ set(BUILD_TESTING OFF CACHE BOOL "" FORCE)
+ set(BUILD_STATIC_LIBS ON)
+ set(BUILD_SHARED_LIBS OFF)
+ 
+-include(FetchContent)
++find_package(PkgConfig REQUIRED)
+ 
+ # Bundled liblzma
+-include(dependencies/xz.cmake)
++pkg_check_modules(LibLZMA REQUIRED IMPORTED_TARGET liblzma)
+ 
+ # Bundled zstd
+-include(dependencies/zstd.cmake)
++pkg_check_modules(ZSTD REQUIRED IMPORTED_TARGET libzstd)
+ 
+ # Remote nghttp2
+-include(dependencies/nghttp2.cmake)
++pkg_check_modules(NGHTTP2 REQUIRED IMPORTED_TARGET libnghttp2)
+ 
+ # Bundled yescrypt
+ include(dependencies/yescrypt.cmake)
+ 
+ 
+ # Bundled zlib
+-include(dependencies/zlib.cmake)
++pkg_check_modules(ZLIB REQUIRED IMPORTED_TARGET zlib)
+ 
+ # Bundled libarchive
+-include(dependencies/libarchive.cmake)
++pkg_check_modules(LibArchive REQUIRED IMPORTED_TARGET libarchive)
+ 
+ # libcurl
+ if(APPLE)
+@@ -188,12 +188,12 @@ if(APPLE)
+     # Note: No need to find OpenSSL on macOS - we use native Security.framework
+     # for RSA operations and CommonCrypto for hashing
+ else()
+-    include(dependencies/curl.cmake)
++    pkg_check_modules(CURL REQUIRED IMPORTED_TARGET libcurl)
+ endif()
+ 
+ 
+ # Bundled libusb (for rpiboot Compute Module support)
+-include(dependencies/libusb.cmake)
++pkg_check_modules(LIBUSB REQUIRED IMPORTED_TARGET libusb-1.0)
+ 
+ # Add dependencies
+ if (APPLE)
+@@ -301,6 +301,13 @@ if(${QT}WinExtras_FOUND)
+     set(EXTRALIBS ${EXTRALIBS} ${QT}::WinExtras)
+ endif()
+ 
++# when cross-compiling, use host's lrelease instead of cross one
++if(CMAKE_CROSSCOMPILING AND TARGET Qt6::lrelease)
++  set_target_properties(Qt6::lrelease PROPERTIES
++    IMPORTED_LOCATION "/usr/lib64/qt6/bin/lrelease"
++    IMPORTED_LOCATION_NONE "/usr/lib64/qt6/bin/lrelease")
++endif()
++
+ # Find all translation files automatically
+ file(GLOB TRANSLATIONS CONFIGURE_DEPENDS "i18n/*.ts")
+ 
+@@ -535,12 +542,12 @@ else()
+     include(linux/PlatformPackaging.cmake)
+ endif()
+ 
+-add_dependencies(${PROJECT_NAME} zlibstatic yescrypt usb-1.0-static)
+-include_directories(${CURL_INCLUDE_DIR} ${LibArchive_INCLUDE_DIR} ${LIBLZMA_INCLUDE_DIRS} ${LIBDRM_INCLUDE_DIRS} ${ZLIB_INCLUDE_DIRS} ${ZSTD_INCLUDE_DIR} ${YESCRYPT_INCLUDE_DIR} ${LIBUSB_INCLUDE_DIR})
++add_dependencies(${PROJECT_NAME} yescrypt)
++include_directories(${LIBDRM_INCLUDE_DIRS} ${YESCRYPT_INCLUDE_DIR})
+ 
+ # Link different Qt components based on build type
+ # rpiboot link libraries (libusb)
+-set(RPIBOOT_LIBS ${LIBUSB_LIBRARIES})
++set(RPIBOOT_LIBS PkgConfig::LIBUSB)
+ 
+ if(BUILD_CLI_ONLY)
+     # CLI-only build: link Core, Network and essential libraries
+@@ -549,7 +556,7 @@ else()
+     # Regular GUI build: link all GUI components
+     # Add DBus on Linux for suspend inhibitor and native file dialogs (portals)
+     if(UNIX AND NOT APPLE)
+-        target_link_libraries(${PROJECT_NAME} PRIVATE ${QT}::Core ${QT}::Gui ${QT}::Quick ${QT}::Svg ${QT}::Network ${QT}::DBus ${CURL_LIBRARIES} ${LibArchive_LIBRARIES} ${ZSTD_LIBRARIES} ${LIBLZMA_LIBRARIES} ${ZLIB_LIBRARIES} ${YESCRYPT_LIBRARIES} ${LIBDRM_LIBRARIES} ${ATOMIC_LIBRARY} ${RPIBOOT_LIBS} ${EXTRALIBS})
++        target_link_libraries(${PROJECT_NAME} PRIVATE ${QT}::Core ${QT}::Gui ${QT}::Quick ${QT}::Svg ${QT}::Network ${QT}::DBus PkgConfig::CURL PkgConfig::LibArchive PkgConfig::ZSTD PkgConfig::LibLZMA PkgConfig::ZLIB ${YESCRYPT_LIBRARIES} ${LIBDRM_LIBRARIES} ${ATOMIC_LIBRARY} ${RPIBOOT_LIBS} ${EXTRALIBS})
+     else()
+         target_link_libraries(${PROJECT_NAME} PRIVATE ${QT}::Core ${QT}::Gui ${QT}::Quick ${QT}::Svg ${QT}::Network ${CURL_LIBRARIES} ${LibArchive_LIBRARIES} ${ZSTD_LIBRARIES} ${LIBLZMA_LIBRARIES} ${ZLIB_LIBRARIES} ${YESCRYPT_LIBRARIES} ${LIBDRM_LIBRARIES} ${ATOMIC_LIBRARY} ${RPIBOOT_LIBS} ${EXTRALIBS})
+     endif()

--- a/srcpkgs/rpi-imager/patches/musl.patch
+++ b/srcpkgs/rpi-imager/patches/musl.patch
@@ -1,0 +1,11 @@
+--- a/src/linux/platformquirks_linux.cpp
++++ b/src/linux/platformquirks_linux.cpp
+@@ -73,7 +73,7 @@ namespace {
+         char buf[4096];
+         struct iovec iov = { buf, sizeof(buf) };
+         struct sockaddr_nl sa;
+-        struct msghdr msg = { &sa, sizeof(sa), &iov, 1, nullptr, 0, 0 };
++        struct msghdr msg = { .msg_name = &sa, .msg_namelen = sizeof(sa), .msg_iov = &iov, .msg_iovlen = 1, .msg_control = nullptr, .msg_controllen = 0, .msg_flags = 0 };
+         
+         // Use poll() instead of select() - no fd number limitations
+         struct pollfd fds[2];

--- a/srcpkgs/rpi-imager/template
+++ b/srcpkgs/rpi-imager/template
@@ -1,20 +1,21 @@
 # Template file for 'rpi-imager'
 pkgname=rpi-imager
-version=1.8.5
+version=2.0.10
 revision=1
 build_wrksrc=src
 build_style=cmake
 configure_args="-DENABLE_TELEMETRY=OFF -DENABLE_CHECK_VERSION=OFF"
-hostmakedepends="qt5-host-tools qt5-qmake"
-makedepends="qt5-devel qt5-declarative-devel qt5-svg-devel qt5-tools-devel
- libcurl-devel libarchive-devel gnutls-devel"
-depends="qt5-quickcontrols2 qt5-svg util-linux"
+hostmakedepends="pkg-config qt6-tools qt6-declarative-host-tools"
+makedepends="liblzma-devel libzstd-devel nghttp2-devel zlib-devel
+ libarchive-devel libcurl-devel libusb-devel gnutls-devel libudev-devel
+ liburing-devel qt6-tools-devel qt6-declarative-devel qt6-svg-devel"
+depends="util-linux"
 short_desc="Raspberry Pi Imaging Utility"
 maintainer="Adam Gausmann <adam@gaussian.dev>"
 license="Apache-2.0"
 homepage="https://github.com/raspberrypi/rpi-imager"
 distfiles="https://github.com/raspberrypi/rpi-imager/archive/v${version}.tar.gz"
-checksum=443e2ca2132067cc67038c82d890f70fd744da2503588852f014435dd11fb786
+checksum=9d2569e9b7adafa6aaecca169b2bb1f877d6f7fd7b3f02fdb549a36a2865b160
 
 pre_configure() {
 	ln -sf /bin/true $XBPS_WRAPPERDIR/lsblk


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures:
  - i686
  - aarch64-musl (crossbuilt)

Version 2.xx went from QT5 to QT6.

The devendor-and-lrelease patch is a combination of a de-vendor patch ([Alpine](https://gitlab.alpinelinux.org/alpine/aports/-/blob/master/testing/rpi-imager/devendor.patch), [Arch](https://gitlab.archlinux.org/archlinux/packaging/packages/rpi-imager/-/blob/main/remove-vendoring.patch), https://github.com/raspberrypi/rpi-imager/issues/924) and a patch that forces the use of the host's lrelease during cross-builds to avoid the need for a qemu build_helper, also found in the FreeCAD template.

And musl.patch is just the last part from [Alpine's compatibility patch](https://gitlab.alpinelinux.org/alpine/aports/-/blob/master/testing/rpi-imager/alpine.patch)