### PR TITLE
python3-click-aliases: update to 1.0.7, orphan

### DIFF
--- a/srcpkgs/python3-click-aliases/template
+++ b/srcpkgs/python3-click-aliases/template
@@ -1,16 +1,18 @@
 # Template file for 'python3-click-aliases'
 pkgname=python3-click-aliases
-version=1.0.6
+version=1.0.7
 revision=1
 build_style=python3-pep517
-hostmakedepends="python3-poetry-core python3-wheel"
+hostmakedepends="python3-poetry-core"
 depends="python3-click"
+checkdepends="$depends python3-pytest"
 short_desc="Enable aliases for Click"
-maintainer="Mateusz Sylwestrzak <slymattz@gmail.com>"
+maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
 homepage="https://github.com/click-contrib/click-aliases"
-distfiles="${PYPI_SITE}/c/click_aliases/click_aliases-${version}.tar.gz"
-checksum=9372e58d00aa146f0d235e4e5e8bd280e84fe78e52db5fd80eacb14ecdf2e0d4
+changelog="https://github.com/click-contrib/click-aliases/releases"
+distfiles="https://github.com/click-contrib/click-aliases/archive/refs/tags/v${version}.tar.gz"
+checksum=f25b48309e29c7f4b1baf39b9b92b331e80c44c737548dac4a524f55aa61470d
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**
Tested argument parsing with a small code snippet.

I switched to the GH tarball to enable tests.

I'm orphaning this package due to the fact that it's no longer a dependency of python3-pynitrokey.

#### Local build testing
- I built this PR locally for my native architecture: x86_64-glibc
