### PR TITLE
stepmania: fix build with GCC 14 and binutils >= 2.41

### DIFF
--- a/srcpkgs/stepmania/patches/ffmpeg-binutils-2.41.patch
+++ b/srcpkgs/stepmania/patches/ffmpeg-binutils-2.41.patch
@@ -1,0 +1,76 @@
+From effadce6c756247ea8bae32dc13bb3e6f464f0eb Mon Sep 17 00:00:00 2001
+From: =?utf8?q?R=C3=A9mi=20Denis-Courmont?= <remi@remlab.net>
+Date: Sun, 16 Jul 2023 18:18:02 +0300
+Subject: [PATCH] avcodec/x86/mathops: clip constants used with shift
+ instructions within inline assembly
+
+Fixes assembling with binutil as >= 2.41
+
+Signed-off-by: James Almer <jamrial@gmail.com>
+---
+ libavcodec/x86/mathops.h | 26 +++++++++++++++++++++++---
+ 1 file changed, 23 insertions(+), 3 deletions(-)
+
+diff --git a/extern/ffmpeg-linux-2.1.3/libavcodec/x86/mathops.h b/extern/ffmpeg-linux-2.1.3/libavcodec/x86/mathops.h
+index 6298f5ed19..ca7e2dffc1 100644
+--- a/extern/ffmpeg-linux-2.1.3/libavcodec/x86/mathops.h
++++ b/extern/ffmpeg-linux-2.1.3/libavcodec/x86/mathops.h
+@@ -35,12 +35,20 @@
+ static av_always_inline av_const int MULL(int a, int b, unsigned shift)
+ {
+     int rt, dummy;
++    if (__builtin_constant_p(shift))
+     __asm__ (
+         "imull %3               \n\t"
+         "shrdl %4, %%edx, %%eax \n\t"
+         :"=a"(rt), "=d"(dummy)
+-        :"a"(a), "rm"(b), "ci"((uint8_t)shift)
++        :"a"(a), "rm"(b), "i"(shift & 0x1F)
+     );
++    else
++        __asm__ (
++            "imull %3               \n\t"
++            "shrdl %4, %%edx, %%eax \n\t"
++            :"=a"(rt), "=d"(dummy)
++            :"a"(a), "rm"(b), "c"((uint8_t)shift)
++        );
+     return rt;
+ }
+ 
+@@ -113,19 +121,31 @@ __asm__ volatile(\
+ // avoid +32 for shift optimization (gcc should do that ...)
+ #define NEG_SSR32 NEG_SSR32
+ static inline  int32_t NEG_SSR32( int32_t a, int8_t s){
++    if (__builtin_constant_p(s))
+     __asm__ ("sarl %1, %0\n\t"
+          : "+r" (a)
+-         : "ic" ((uint8_t)(-s))
++         : "i" (-s & 0x1F)
+     );
++    else
++        __asm__ ("sarl %1, %0\n\t"
++               : "+r" (a)
++               : "c" ((uint8_t)(-s))
++        );
+     return a;
+ }
+ 
+ #define NEG_USR32 NEG_USR32
+ static inline uint32_t NEG_USR32(uint32_t a, int8_t s){
++    if (__builtin_constant_p(s))
+     __asm__ ("shrl %1, %0\n\t"
+          : "+r" (a)
+-         : "ic" ((uint8_t)(-s))
++         : "i" (-s & 0x1F)
+     );
++    else
++        __asm__ ("shrl %1, %0\n\t"
++               : "+r" (a)
++               : "c" ((uint8_t)(-s))
++        );
+     return a;
+ }
+ 
+-- 
+2.25.1
+

--- a/srcpkgs/stepmania/template
+++ b/srcpkgs/stepmania/template
@@ -4,13 +4,17 @@ version=5.0.12
 revision=4
 # see CMake/SetupFfmpeg.cmake in the source code
 _ffmpeg_ver=2.1.3
+# Upstream has stated that only x86 hardware can meet the performance
+# constraints and that musl is not supported due to interop issues
+# with Windows
+archs="i686 x86_64"
 build_wrksrc="${pkgname}-${version}"
 build_style=cmake
 make_cmd=make
 cmake_builddir="Build"
 hostmakedepends="nasm yasm pkg-config"
 makedepends="libmad-devel libvorbis-devel pcre-devel libjpeg-turbo-devel
-alsa-lib-devel libXrandr-devel libva-devel glew-devel"
+ alsa-lib-devel libXrandr-devel libva-devel glew-devel"
 short_desc="Advanced rhythm game"
 maintainer="Michael Aldridge <maldridge@voidlinux.org>"
 license="MIT"
@@ -21,15 +25,19 @@ checksum="df79bcadd69d4ed60cf560d45386ec275181343495ffd744c3ff8f73c83d4755
  cfafef9c9fb2581ac234fc11da97c677e5a911db4e16b341ab724b7e6aa03b62"
 patch_args="-Np1 --directory=${build_wrksrc}"
 
-# Upstream has stated that only x86 hardware can meed the performance
-# constraints and that musl is not supported due to interop issues
-# with Windows
-archs="i686 x86_64"
-
 export CMAKE_GENERATOR="Unix Makefiles"
 
 post_extract() {
 	mv FFmpeg-n${_ffmpeg_ver} ${build_wrksrc}/extern/ffmpeg-linux-${_ffmpeg_ver}
+}
+
+post_patch() {
+	# ffmpeg's configure ignores $CFLAGS; GCC 14 promoted several
+	# warnings (implicit-int, implicit-function-declaration,
+	# int-conversion, incompatible-pointer-types) to errors that the
+	# vendored ffmpeg 2.1.3 trips, so downgrade them via -fpermissive
+	vsed -i CMake/SetupFfmpeg.cmake \
+		-e 's|--extra-cflags=-w|--extra-cflags=-w -fpermissive|'
 }
 
 post_install() {


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture (x86_64)
- I built this PR locally for these architectures using specific masterdirs:
  - i686
 
---

Fixes the stepmania build, broken by GCC 14 and binutils >= 2.41. The failures predate the nasm update and were discovered while validating dependent packages in #57682.

Two changes to the vendored ffmpeg:
* Backport of upstream FFmpeg commit [effadce6c756](https://github.com/FFmpeg/FFmpeg/commit/effadce6c756247ea8bae32dc13bb3e6f464f0eb) (binutils >= 2.41 inline asm fix), adapted only in the file paths to match the vendored tree; the code changes are identical to upstream.
* `-fpermissive` passed via the configure hook for legacy code already silenced with `-w` upstream. The vendored ffmpeg ignores `$CFLAGS` from the environment, so the flag is injected through `--extra-cflags`.