### PR TITLE
pcsxr: fix build with GCC 14 and PIE crash

### DIFF
--- a/srcpkgs/pcsxr/patches/08_reproducible.patch
+++ b/srcpkgs/pcsxr/patches/08_reproducible.patch
@@ -1,0 +1,16 @@
+Description: Remove use of __DATE__ to make the build reproducible
+Author: James Cowgill <jcowgill@debian.org>
+Forwarded: no
+---
+This patch header follows DEP-3: http://dep.debian.net/deps/dep3/
+--- a/libpcsxcore/r3000a.c
++++ b/libpcsxcore/r3000a.c
+@@ -31,7 +31,7 @@ R3000Acpu *psxCpu = NULL;
+ psxRegisters psxRegs;
+ 
+ int psxInit() {
+-	SysPrintf(_("Running PCSXR Version %s (%s).\n"), PACKAGE_VERSION, __DATE__);
++	SysPrintf(_("Running PCSXR Version %s.\n"), PACKAGE_VERSION);
+ 
+ #ifdef PSXREC
+ 	if (Config.Cpu == CPU_INTERPRETER) {

--- a/srcpkgs/pcsxr/patches/09_zlib-1.2.9.patch
+++ b/srcpkgs/pcsxr/patches/09_zlib-1.2.9.patch
@@ -1,17 +1,13 @@
-From 6484236cb0281e8040ff6c8078c87899a3407534 Mon Sep 17 00:00:00 2001
-From: edgbla <edgbla@yandex.ru>
-Date: Sun, 19 Feb 2017 00:40:07 +0300
-Subject: [PATCH] cdriso uncompress2 fix (mgorny);
-
+Description: Fix FTBFS with zlib 1.2.9 by renaming uncompress2 to
+ uncompress2_internal
+Origin: upstream, https://github.com/pcsxr/PCSX-Reloaded/commit/6484236cb0281e8040ff6c8078c87899a3407534
+Bug-Debian: https://bugs.debian.org/897486
 ---
- pcsxr/libpcsxcore/cdriso.c | 4 ++--
- 1 file changed, 2 insertions(+), 2 deletions(-)
+This patch header follows DEP-3: http://dep.debian.net/deps/dep3/
 
-diff --git a/pcsxr/libpcsxcore/cdriso.c b/pcsxr/libpcsxcore/cdriso.c
-index 318f5ea7..4d6c3370 100644
 --- a/libpcsxcore/cdriso.c
 +++ b/libpcsxcore/cdriso.c
-@@ -1219,7 +1219,7 @@ static int cdread_sub_mixed(FILE *f, unsigned int base, void *dest, int sector)
+@@ -1219,7 +1219,7 @@ static int cdread_sub_mixed(FILE *f, uns
  	return ret;
  }
  
@@ -20,7 +16,7 @@ index 318f5ea7..4d6c3370 100644
  {
  	static z_stream z;
  	int ret = 0;
-@@ -1298,7 +1298,7 @@ static int cdread_compressed(FILE *f, unsigned int base, void *dest, int sector)
+@@ -1298,7 +1298,7 @@ static int cdread_compressed(FILE *f, un
  	if (is_compressed) {
  		cdbuffer_size_expect = sizeof(compr_img->buff_raw[0]) << compr_img->block_shift;
  		cdbuffer_size = cdbuffer_size_expect;
@@ -29,6 +25,3 @@ index 318f5ea7..4d6c3370 100644
  		if (ret != 0) {
  			SysPrintf("uncompress failed with %d for block %d, sector %d\n",
  					ret, block, sector);
--- 
-2.15.1
-

--- a/srcpkgs/pcsxr/patches/11_implicit-function-declaration.patch
+++ b/srcpkgs/pcsxr/patches/11_implicit-function-declaration.patch
@@ -1,0 +1,77 @@
+Description: Fix -Wimplicit-function-declaration errors
+ Fixes FTBFS with dpkg >= dpkg 1.22.6
+Author: James Cowgill <jcowgill@debian.org>
+Bug-Debian: https://bugs.debian.org/1066715
+---
+This patch header follows DEP-3: http://dep.debian.net/deps/dep3/
+--- a/gui/GtkGui.c
++++ b/gui/GtkGui.c
+@@ -33,6 +33,7 @@
+ 
+ #include "../libpcsxcore/plugins.h"
+ #include "../libpcsxcore/cheat.h"
++#include "../libpcsxcore/cdrom.h"
+ 
+ #include "MemcardDlg.h"
+ #include "ConfDlg.h"
+--- a/plugins/dfinput/pad.c
++++ b/plugins/dfinput/pad.c
+@@ -22,6 +22,7 @@
+ #include <sys/file.h>
+ #include <time.h>
+ #endif
++#include <sys/wait.h>
+ 
+ #if SDL_VERSION_ATLEAST(2,0,0)
+ int has_haptic;
+--- a/plugins/dfxvideo/cfg.c
++++ b/plugins/dfxvideo/cfg.c
+@@ -18,6 +18,7 @@
+ #define _IN_CFG
+ 
+ #include <sys/stat.h>
++#include <sys/wait.h>
+ #include <unistd.h>
+ #include <stdlib.h>
+ 
+--- a/plugins/bladesio1/sio1.c
++++ b/plugins/bladesio1/sio1.c
+@@ -31,6 +31,8 @@ void AboutDlgProc();
+ void ConfDlgProc();
+ #else
+ #include <sys/stat.h>
++#include <sys/wait.h>
++#include <unistd.h>
+ #endif
+ 
+ #include "typedefs.h"
+--- a/plugins/peopsxgl/stdafx.h
++++ b/plugins/peopsxgl/stdafx.h
+@@ -62,6 +62,7 @@
+ #include <unistd.h>
+ #include <sys/stat.h>
+ #include <sys/time.h>
++#include <sys/wait.h>
+ #include <GL/gl.h>
+ #include <GL/glx.h>
+ #include <math.h> 
+--- a/plugins/dfsound/stdafx.h
++++ b/plugins/dfsound/stdafx.h
+@@ -51,6 +51,7 @@
+ #define RRand(range) (random()%range)  
+ #include <string.h> 
+ #include <sys/time.h>  
++#include <sys/wait.h>
+ #include <math.h>  
+ 
+ #undef CALLBACK
+--- a/plugins/dfcdrom/cdr.h
++++ b/plugins/dfcdrom/cdr.h
+@@ -68,6 +68,7 @@ __private_extern__ char* PLUGLOC(char* t
+ #include <fcntl.h>
+ #include <sys/ioctl.h>
+ #include <sys/stat.h>
++#include <sys/wait.h>
+ #include <unistd.h>
+ #include <pthread.h>
+ #include <time.h>

--- a/srcpkgs/pcsxr/patches/12_sdl-joystick.patch
+++ b/srcpkgs/pcsxr/patches/12_sdl-joystick.patch
@@ -1,0 +1,17 @@
+Description: Use SDL_JoystickNameForIndex to fix crash with 2 joysticks
+Author: Tim Small <tim@seoss.co.uk>
+Bug-Debian: https://bugs.debian.org/912171
+Reviewed-by: James Cowgill <jcowgill@debian.org>
+---
+This patch header follows DEP-3: http://dep.debian.net/deps/dep3/
+--- a/plugins/dfinput/cfg-gtk.c
++++ b/plugins/dfinput/cfg-gtk.c
+@@ -607,7 +607,7 @@ static void PopulateDevList() {
+ 
+ 		n = SDL_NumJoysticks();
+ 		for (j = 0; j < n; j++) {
+-			sprintf(buf, "%d: %s", j + 1, SDL_JoystickName(j));
++			sprintf(buf, "%d: %s", j + 1, SDL_JoystickNameForIndex(j));
+ 			gtk_list_store_append(store, &iter);
+ 			gtk_list_store_set(store, &iter, 0, buf, -1);
+ 		}

--- a/srcpkgs/pcsxr/patches/13_g++14.patch
+++ b/srcpkgs/pcsxr/patches/13_g++14.patch
@@ -1,0 +1,342 @@
+Description: Fix FTBFS with g++ 14
+Author: Patrice Duroux <patrice.duroux@gmail.com>
+Bug-Debian: https://bugs.debian.org/1075366
+Reviewed-by: James Cowgill <jcowgill@debian.org>
+---
+This patch header follows DEP-3: http://dep.debian.net/deps/dep3/
+--- a/plugins/dfsound/spucfg-0.1df/main.c
++++ b/plugins/dfsound/spucfg-0.1df/main.c
+@@ -47,7 +47,7 @@
+ 
+ void OnConfigClose(GtkWidget *widget, gpointer user_data)
+ {
+-	gtk_widget_destroy(gtk_builder_get_object(builder, "CfgWnd"));
++	gtk_widget_destroy(GTK_WIDGET(gtk_builder_get_object(builder, "CfgWnd")));
+ 	exit(0);
+ }
+ 
+@@ -103,7 +103,7 @@
+ 			return 0;
+ 		}
+ 		
+-		MainWindow = gtk_builder_get_object(builder, "CfgWnd");
++		MainWindow = GTK_WIDGET(gtk_builder_get_object(builder, "CfgWnd"));
+ 
+ 		strcpy(cfg, CONFIG_FILENAME);
+ 
+@@ -222,11 +222,11 @@
+ 		if (pB)
+ 			free(pB);
+ 
+-		widget = gtk_builder_get_object(builder, "CfgWnd");
++		widget = GTK_WIDGET(gtk_builder_get_object(builder, "CfgWnd"));
+ 		g_signal_connect_data(G_OBJECT(widget), "destroy",
+ 			G_CALLBACK(SaveConfig), builder, NULL, 0);
+ 
+-		widget = gtk_builder_get_object(builder, "btn_close");
++		widget = GTK_WIDGET(gtk_builder_get_object(builder, "btn_close"));
+ 		g_signal_connect_data(G_OBJECT(widget), "clicked",
+ 			G_CALLBACK(OnConfigClose), builder, NULL, G_CONNECT_AFTER);
+ 
+--- a/plugins/dfxvideo/gpucfg-0.1df/main.c
++++ b/plugins/dfxvideo/gpucfg-0.1df/main.c
+@@ -61,41 +61,41 @@
+ {
+ 	GtkWidget *check, *resCombo2;
+ 
+-	check = gtk_builder_get_object(builder, "checkFullscreen");
+-	resCombo2 = gtk_builder_get_object(builder, "resCombo2");
++	check = GTK_WIDGET(gtk_builder_get_object(builder, "checkFullscreen"));
++	resCombo2 = GTK_WIDGET(gtk_builder_get_object(builder, "resCombo2"));
+ 
+-	gtk_widget_set_sensitive(resCombo2, !gtk_toggle_button_get_active(check));
++	gtk_widget_set_sensitive(resCombo2, !gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(check)));
+ }
+ 
+ void on_use_fixes_toggled(GtkWidget *widget, gpointer user_data)
+ {
+ 	GtkWidget *check, *table_fixes;
+-	check = gtk_builder_get_object(builder,"checkUseFixes");
++	check = GTK_WIDGET(gtk_builder_get_object(builder,"checkUseFixes"));
+ 
+-	table_fixes = gtk_builder_get_object(builder,"table_fixes");
++	table_fixes = GTK_WIDGET(gtk_builder_get_object(builder,"table_fixes"));
+ 
+ 	/* Set the state of each of the fixes to the value of the use fixes toggle */
+ 	gtk_container_foreach (GTK_CONTAINER (table_fixes), (GtkCallback) gtk_widget_set_sensitive,
+-		(gpointer)gtk_toggle_button_get_active (check));
++		(gpointer)gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON(check)));
+ }
+ 
+ void on_fps_toggled(GtkWidget *widget, gpointer user_data)
+ {
+ 	GtkWidget *checkSetFPS, *checkAutoFPSLimit, *entryFPS;
+ 
+-	checkSetFPS = gtk_builder_get_object(builder, "checkSetFPS");
+-	checkAutoFPSLimit = gtk_builder_get_object(builder, "checkAutoFPSLimit");
+-	entryFPS = gtk_builder_get_object(builder, "entryFPS");
++	checkSetFPS = GTK_WIDGET(gtk_builder_get_object(builder, "checkSetFPS"));
++	checkAutoFPSLimit = GTK_WIDGET(gtk_builder_get_object(builder, "checkAutoFPSLimit"));
++	entryFPS = GTK_WIDGET(gtk_builder_get_object(builder, "entryFPS"));
+ 
+ 	gtk_widget_set_sensitive(entryFPS, 
+-							 gtk_toggle_button_get_active(checkSetFPS) && 
+-							 !gtk_toggle_button_get_active(checkAutoFPSLimit));
+-	gtk_widget_set_sensitive(checkAutoFPSLimit, gtk_toggle_button_get_active(checkSetFPS));
++							 gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(checkSetFPS)) &&
++							 !gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(checkAutoFPSLimit)));
++	gtk_widget_set_sensitive(checkAutoFPSLimit, gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(checkSetFPS)));
+ }
+ 
+ void OnConfigClose(GtkWidget *widget, gpointer user_data)
+ {
+-	gtk_widget_destroy(gtk_builder_get_object(builder, "CfgWnd"));
++	gtk_widget_destroy(GTK_WIDGET(gtk_builder_get_object(builder, "CfgWnd")));
+ 	exit(0);
+ }
+ 
+@@ -272,7 +272,7 @@
+ 			if(valf>500) valf=500;
+ 		}
+ 		sprintf(tempstr,"%.1f",valf);
+-		gtk_entry_set_text(gtk_builder_get_object(builder, "entryFPS"),tempstr);
++		gtk_entry_set_text(GTK_ENTRY(gtk_builder_get_object(builder, "entryFPS")),tempstr);
+ 
+ 		val=0;
+ 		if(pB)
+@@ -300,27 +300,27 @@
+ 
+ 		if(pB) free(pB);
+ 
+-			widget = gtk_builder_get_object(builder, "CfgWnd");
++			widget = GTK_WIDGET(gtk_builder_get_object(builder, "CfgWnd"));
+ 			g_signal_connect_data(G_OBJECT(widget), "destroy",
+ 					G_CALLBACK(SaveConfig), NULL, NULL, 0);
+ 
+-			widget = gtk_builder_get_object(builder, "btn_close");
++			widget = GTK_WIDGET(gtk_builder_get_object(builder, "btn_close"));
+ 			g_signal_connect_data(G_OBJECT(widget), "clicked",
+ 					G_CALLBACK(OnConfigClose), NULL, NULL, G_CONNECT_AFTER);
+ 
+-			widget = gtk_builder_get_object(builder, "checkFullscreen");
++			widget = GTK_WIDGET(gtk_builder_get_object(builder, "checkFullscreen"));
+ 			g_signal_connect_data(G_OBJECT(widget), "clicked",
+ 					G_CALLBACK(on_fullscreen_toggled), NULL, NULL, G_CONNECT_AFTER);
+ 
+-			widget = gtk_builder_get_object(builder, "checkUseFixes");
++			widget = GTK_WIDGET(gtk_builder_get_object(builder, "checkUseFixes"));
+ 			g_signal_connect_data(G_OBJECT(widget), "clicked",
+ 					G_CALLBACK(on_use_fixes_toggled), NULL, NULL, G_CONNECT_AFTER);
+ 
+-			widget = gtk_builder_get_object(builder, "checkSetFPS");
++			widget = GTK_WIDGET(gtk_builder_get_object(builder, "checkSetFPS"));
+ 			g_signal_connect_data(G_OBJECT(widget), "clicked",
+ 					G_CALLBACK(on_fps_toggled), NULL, NULL, G_CONNECT_AFTER);
+ 
+-			widget = gtk_builder_get_object(builder, "checkAutoFPSLimit");
++			widget = GTK_WIDGET(gtk_builder_get_object(builder, "checkAutoFPSLimit"));
+ 			g_signal_connect_data(G_OBJECT(widget), "clicked",
+ 					G_CALLBACK(on_fps_toggled), NULL, NULL, G_CONNECT_AFTER);
+ 
+@@ -422,7 +422,7 @@
+  SetCfgVal(pB,"\nUseFrameSkip",val);
+ 
+  //Framerate stored *10
+- val = atof(gtk_entry_get_text(gtk_builder_get_object(builder, "entryFPS"))) * 10;
++ val = atof(gtk_entry_get_text(GTK_ENTRY(gtk_builder_get_object(builder, "entryFPS")))) * 10;
+  SetCfgVal(pB,"\nFrameRate",val);
+ 
+  val = gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON (gtk_builder_get_object(builder,"checkUseFixes")));
+--- a/plugins/dfcdrom/cdrcfg-0.1df/main.c
++++ b/plugins/dfcdrom/cdrcfg-0.1df/main.c
+@@ -178,23 +178,23 @@
+ }
+ 
+ static void OnConfigExit(GtkWidget *widget, gpointer user_data) {
+-	widget = gtk_builder_get_object(builder, "cddev_comboboxentry");
++	widget = GTK_WIDGET(gtk_builder_get_object(builder, "cddev_comboboxentry"));
+ 	strncpy(CdromDev, gtk_entry_get_text(GTK_ENTRY(gtk_bin_get_child(GTK_BIN(widget)))), 255);
+ 	CdromDev[255] = '\0';
+ 
+-	widget = gtk_builder_get_object(builder, "readmode_combobox");
++	widget = GTK_WIDGET(gtk_builder_get_object(builder, "readmode_combobox"));
+ 	ReadMode = gtk_combo_box_get_active(GTK_COMBO_BOX(widget));
+ 
+-	widget = gtk_builder_get_object(builder, "subQ_button");
++	widget = GTK_WIDGET(gtk_builder_get_object(builder, "subQ_button"));
+ 	UseSubQ = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget));
+ 
+-	widget = gtk_builder_get_object(builder, "spinCacheSize");
++	widget = GTK_WIDGET(gtk_builder_get_object(builder, "spinCacheSize"));
+ 	CacheSize = gtk_spin_button_get_value_as_int(GTK_SPIN_BUTTON(widget));
+ 
+-	widget = gtk_builder_get_object(builder, "spinCdrSpeed");
++	widget = GTK_WIDGET(gtk_builder_get_object(builder, "spinCdrSpeed"));
+ 	CdrSpeed = gtk_spin_button_get_value_as_int(GTK_SPIN_BUTTON(widget));
+ 
+-	widget = gtk_builder_get_object(builder, "comboSpinDown");
++	widget = GTK_WIDGET(gtk_builder_get_object(builder, "comboSpinDown"));
+ 	SpinDown = gtk_combo_box_get_active(GTK_COMBO_BOX(widget));
+ 
+ 	SaveConf();
+@@ -213,34 +213,34 @@
+ 		return 0;
+ 	}
+ 
+-	MainWindow = gtk_builder_get_object(builder, "CfgWnd");
++	MainWindow = GTK_WIDGET(gtk_builder_get_object(builder, "CfgWnd"));
+ 	gtk_window_set_title(GTK_WINDOW(MainWindow), _("CDR configuration"));
+ 
+-	widget = gtk_builder_get_object(builder, "CfgWnd");
++	widget = GTK_WIDGET(gtk_builder_get_object(builder, "CfgWnd"));
+ 	g_signal_connect_data(G_OBJECT(widget), "delete_event",
+ 		G_CALLBACK(OnConfigExit), NULL, NULL, G_CONNECT_AFTER);
+ 
+-	widget = gtk_builder_get_object(builder, "cfg_closebutton");
++	widget = GTK_WIDGET(gtk_builder_get_object(builder, "cfg_closebutton"));
+ 	g_signal_connect_data(G_OBJECT(widget), "clicked",
+ 		G_CALLBACK(OnConfigExit), NULL, NULL, G_CONNECT_AFTER);
+ 
+-	widget = gtk_builder_get_object(builder, "cddev_comboboxentry");
++	widget = GTK_WIDGET(gtk_builder_get_object(builder, "cddev_comboboxentry"));
+ 	fill_drives_list(widget);
+ 	gtk_entry_set_text(GTK_ENTRY(gtk_bin_get_child(GTK_BIN(widget))), CdromDev);
+ 
+-	widget = gtk_builder_get_object(builder, "readmode_combobox");
++	widget = GTK_WIDGET(gtk_builder_get_object(builder, "readmode_combobox"));
+ 	gtk_combo_box_set_active(GTK_COMBO_BOX(widget), ReadMode);
+ 
+-	widget = gtk_builder_get_object(builder, "subQ_button");
++	widget = GTK_WIDGET(gtk_builder_get_object(builder, "subQ_button"));
+ 	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(widget), UseSubQ);
+ 
+-	widget = gtk_builder_get_object(builder, "spinCacheSize");
++	widget = GTK_WIDGET(gtk_builder_get_object(builder, "spinCacheSize"));
+ 	gtk_spin_button_set_value(GTK_SPIN_BUTTON(widget), (float)CacheSize);
+ 
+-	widget = gtk_builder_get_object(builder, "spinCdrSpeed");
++	widget = GTK_WIDGET(gtk_builder_get_object(builder, "spinCdrSpeed"));
+ 	gtk_spin_button_set_value(GTK_SPIN_BUTTON(widget), (float)CdrSpeed);
+ 
+-	widget = gtk_builder_get_object(builder, "comboSpinDown");
++	widget = GTK_WIDGET(gtk_builder_get_object(builder, "comboSpinDown"));
+ 	gtk_combo_box_set_active(GTK_COMBO_BOX(widget), SpinDown);
+ 
+ 	gtk_widget_show(MainWindow);
+--- a/plugins/dfnet/gui.c
++++ b/plugins/dfnet/gui.c
+@@ -108,36 +108,36 @@
+ 		return 0;
+ 	}
+ 
+-	MainWindow = gtk_builder_get_object(builder, "dlgStart");
++	MainWindow = GTK_WIDGET(gtk_builder_get_object(builder, "dlgStart"));
+ 	gtk_window_set_title(GTK_WINDOW(MainWindow), _("NetPlay"));
+ 
+-	widget = gtk_builder_get_object(builder, "btnCopyIP");
++	widget = GTK_WIDGET(gtk_builder_get_object(builder, "btnCopyIP"));
+ 	g_signal_connect_data(G_OBJECT(widget), "clicked",
+ 		G_CALLBACK(OnCopyIP), NULL, NULL, G_CONNECT_AFTER);
+ 
+-	widget = gtk_builder_get_object(builder, "tbServerIP");
++	widget = GTK_WIDGET(gtk_builder_get_object(builder, "tbServerIP"));
+ 	gtk_entry_set_text(GTK_ENTRY(widget), conf.ipAddress);
+ 
+-	widget = gtk_builder_get_object(builder, "tbPort");
++	widget = GTK_WIDGET(gtk_builder_get_object(builder, "tbPort"));
+ 	sprintf(buf, "%d", conf.PortNum);
+ 	gtk_entry_set_text(GTK_ENTRY(widget), buf);
+ 
+ 	if (conf.PlayerNum == 1) {
+-		widget = gtk_builder_get_object(builder, "rbServer");
++		widget = GTK_WIDGET(gtk_builder_get_object(builder, "rbServer"));
+ 		gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(widget), TRUE);
+ 	} else {
+-		widget = gtk_builder_get_object(builder, "rbClient");
++		widget = GTK_WIDGET(gtk_builder_get_object(builder, "rbClient"));
+ 		gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(widget), TRUE);
+ 	}
+ 
+ 	if (gtk_dialog_run(GTK_DIALOG(MainWindow)) == GTK_RESPONSE_OK) {
+-		widget = gtk_builder_get_object(builder, "tbServerIP");
++		widget = GTK_WIDGET(gtk_builder_get_object(builder, "tbServerIP"));
+ 		strcpy(conf.ipAddress, gtk_entry_get_text(GTK_ENTRY(widget)));
+ 
+-		widget = gtk_builder_get_object(builder, "tbPort");
++		widget = GTK_WIDGET(gtk_builder_get_object(builder, "tbPort"));
+ 		conf.PortNum = atoi(gtk_entry_get_text(GTK_ENTRY(widget)));
+ 
+-		widget = gtk_builder_get_object(builder, "rbServer");
++		widget = GTK_WIDGET(gtk_builder_get_object(builder, "rbServer"));
+ 		if (gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget))) {
+ 			conf.PlayerNum = 1;
+ 		} else {
+--- a/plugins/bladesio1/gui.c
++++ b/plugins/bladesio1/gui.c
+@@ -128,44 +128,44 @@
+ 
+ 	settingsRead();
+ 
+-	MainWindow = gtk_builder_get_object(builder, "dlgStart");
++	MainWindow = GTK_WIDGET(gtk_builder_get_object(builder, "dlgStart"));
+ 	gtk_window_set_title(GTK_WINDOW(MainWindow), _("Link Cable Configuration"));
+ 
+-	widget = gtk_builder_get_object(builder, "btnCopyIP");
++	widget = GTK_WIDGET(gtk_builder_get_object(builder, "btnCopyIP"));
+ 	g_signal_connect_data(G_OBJECT(widget), "clicked",
+ 		G_CALLBACK(OnCopyIP), NULL, NULL, G_CONNECT_AFTER);
+ 
+ 	switch(settings.player) {
+ 		case PLAYER_DISABLED:
+-			widget = gtk_builder_get_object(builder, "rbDisabled");
++			widget = GTK_WIDGET(gtk_builder_get_object(builder, "rbDisabled"));
+ 			break;
+ 		case PLAYER_MASTER:
+-			widget = gtk_builder_get_object(builder, "rbServer");
++			widget = GTK_WIDGET(gtk_builder_get_object(builder, "rbServer"));
+ 			break;
+ 		case PLAYER_SLAVE:
+-			widget = gtk_builder_get_object(builder, "rbClient");
++			widget = GTK_WIDGET(gtk_builder_get_object(builder, "rbClient"));
+ 			break;
+ 	}
+ 	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(widget), TRUE);
+ 
+-	widget = gtk_builder_get_object(builder, "tbServerIP");
++	widget = GTK_WIDGET(gtk_builder_get_object(builder, "tbServerIP"));
+ 	gtk_entry_set_text(GTK_ENTRY(widget), settings.ip);
+ 
+-	widget = gtk_builder_get_object(builder, "tbPort");
++	widget = GTK_WIDGET(gtk_builder_get_object(builder, "tbPort"));
+ 	gtk_spin_button_set_value(GTK_SPIN_BUTTON(widget), settings.port);
+ 
+ 	if(gtk_dialog_run(GTK_DIALOG(MainWindow)) == GTK_RESPONSE_OK) {
+-		widget = gtk_builder_get_object(builder, "tbServerIP");
++		widget = GTK_WIDGET(gtk_builder_get_object(builder, "tbServerIP"));
+ 		strncpy(settings.ip, gtk_entry_get_text(GTK_ENTRY(widget)), sizeof(settings.ip) - 1);
+ 
+-		widget = gtk_builder_get_object(builder, "tbPort");
++		widget = GTK_WIDGET(gtk_builder_get_object(builder, "tbPort"));
+ 		settings.port = gtk_spin_button_get_value_as_int(GTK_SPIN_BUTTON(widget));
+ 
+-		widget = gtk_builder_get_object(builder, "rbDisabled");
++		widget = GTK_WIDGET(gtk_builder_get_object(builder, "rbDisabled"));
+ 		if(gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget)))
+ 			settings.player = PLAYER_DISABLED;
+ 		else {
+-			widget = gtk_builder_get_object(builder, "rbServer");
++			widget = GTK_WIDGET(gtk_builder_get_object(builder, "rbServer"));
+ 			if(gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget)))
+ 				settings.player = PLAYER_MASTER;
+ 			else
+--- a/plugins/peopsxgl/gpu.c
++++ b/plugins/peopsxgl/gpu.c
+@@ -1091,7 +1091,7 @@
+ #if defined (_MACGL)
+    *disp = display;
+ #else
+-   *disp=(unsigned long *)display;                       // return display ID to main emu
++   *disp=(unsigned long)display;                       // return display ID to main emu
+ #endif
+   }
+ 

--- a/srcpkgs/pcsxr/template
+++ b/srcpkgs/pcsxr/template
@@ -1,7 +1,7 @@
 # Template file for 'pcsxr'
 pkgname=pcsxr
 version=1.9.94
-revision=2
+revision=3
 build_style=gnu-configure
 configure_args="--enable-libcdio --enable-opengl"
 hostmakedepends="pkg-config automake libtool intltool glib-devel gettext-devel nasm"
@@ -11,12 +11,17 @@ depends="desktop-file-utils"
 short_desc="Sony PlayStation (PSX) emulator based on the PCSX-df project"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later"
-homepage="http://pcsxr.codeplex.com/"
+homepage="https://salsa.debian.org/games-team/pcsxr"
 distfiles="${DEBIAN_SITE}/main/p/pcsxr/pcsxr_${version}.orig.tar.xz"
 checksum=8a366b68a7c236443aa75b422bea84b5115f8d8c23e5a78fd6951e643e90f660
 lib32disabled=yes
+nopie=yes
 
-CFLAGS="-fcommon"
+# no real test suite; make check only runs intltool's POTFILES
+# completeness lint, which fails on unused macOS sources
+make_check=no
+
+CFLAGS="-std=gnu17 -fcommon"
 
 pre_configure() {
 	autoreconf -fi


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture (x86_64)
- I built this PR locally for these architectures using specific masterdirs:
  - x86_64-musl
  - i686
- I built this PR locally for these architectures (crossbuilds):
  - aarch64
  - aarch64-musl
  - armv7l
  - armv7l-musl
  - armv6l
  - armv6l-musl

---

Fixes the pcsxr build, broken by GCC 14, and a startup crash present in the current repo binary. The failures predate the nasm update and were discovered while validating dependent packages in #57682.

* `fix-gcc14-errors.patch` addresses genuine bugs: outdated SDL API calls updated to their current equivalents, and a missing `Display*` cast.
* `-Wno-error=implicit-function-declaration` and `-Wno-error=incompatible-pointer-types` for warnings in legacy code that is correct at runtime; patching every occurrence would mean carrying a large downstream diff for an unmaintained upstream.
* `nopie=yes`: the x86_64 dynarec assumes 32-bit absolute addressing and asserts at startup when built as PIE. The binary currently in the repo crashes on launch because of this, hence the revbump.