### PR TITLE
goldendict-ng: update to 26.6.2

### DIFF
--- a/srcpkgs/goldendict-ng/template
+++ b/srcpkgs/goldendict-ng/template
@@ -1,6 +1,6 @@
 # Template file for 'goldendict-ng'
 pkgname=goldendict-ng
-version=26.6.1
+version=26.6.2
 revision=1
 build_style=cmake
 configure_args="-DUSE_ALTERNATIVE_NAME=ON -DWITH_TTS=OFF"
@@ -15,7 +15,7 @@ maintainer="Mateusz Sylwestrzak <slymattz@gmail.com>"
 license="GPL-3.0-or-later"
 homepage="https://xiaoyifang.github.io/goldendict-ng/"
 distfiles="https://github.com/xiaoyifang/goldendict-ng/archive/refs/tags/v${version}.tar.gz"
-checksum=583134f54158c2700aad3faaf1f1e636e7861efe348f332f47c57f1bcf798dfc
+checksum=61f592dffe3d5e9cf9c50188799374a66cc460ec7aff3be067cd4c79f19e1a27
 
 if [ "$XBPS_WORDSIZE$XBPS_WORDSIZE" != "64$XBPS_TARGET_WORDSIZE" ]; then
 	broken="Qt6 WebEngine"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture: x86_64-glibc
