### PR TITLE
tor: update to 0.4.9.11

### DIFF
--- a/srcpkgs/tor/patches/ppc.patch
+++ b/srcpkgs/tor/patches/ppc.patch
@@ -1,6 +1,6 @@
 --- a/src/lib/sandbox/sandbox.c
 +++ b/src/lib/sandbox/sandbox.c
-@@ -115,6 +115,16 @@
+@@ -119,6 +119,16 @@
  #define REG_SYSCALL 8
  #define M_SYSCALL regs[REG_SYSCALL]
  
@@ -17,7 +17,7 @@
  #endif /* defined(__i386__) || ... */
  
  #ifdef M_SYSCALL
-@@ -1654,7 +1664,15 @@
+@@ -2129,7 +2139,15 @@
  static int
  get_syscall_from_ucontext(const ucontext_t *ctx)
  {

--- a/srcpkgs/tor/template
+++ b/srcpkgs/tor/template
@@ -1,6 +1,6 @@
 # Template file for 'tor'
 pkgname=tor
-version=0.4.9.8
+version=0.4.9.11
 revision=1
 build_style=gnu-configure
 configure_args="--enable-gpl"
@@ -14,7 +14,7 @@ license="BSD-3-Clause, GPL-3.0-only"
 homepage="https://www.torproject.org/"
 changelog="https://gitlab.torproject.org/tpo/core/tor/-/raw/main/ChangeLog"
 distfiles="https://dist.torproject.org/tor-${version}.tar.gz"
-checksum=ac1f394e2dd2ab0877d27d928fd0d9e86662fe3ca6afdffb9fd9b6f0f96d05de
+checksum=2e6c1720118c812acf0079fd47cf91b6bfaba5d766c321c4d3d2a28d6a11a8ed
 
 case "${XBPS_TARGET_MACHINE}" in
 	# Tests just don't work here


### PR DESCRIPTION
Official announcement: [Security Release 0.4.9.11](https://forum.torproject.org/t/security-release-0-4-9-11/21786)

#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, aarch64-glibc
