### PR TITLE
scenefx: update to 0.5

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -4533,7 +4533,7 @@ libopenrazer.so.0 libopenrazer-0.2.0_1
 libstaroffice-0.0.so.0 libstaroffice-0.0.7_1
 libbox2d.so.2 box2d-2.4.1_1
 libhwy.so.1 highway-1.2.0_1
-libscenefx-0.4.so scenefx-0.4.1_1
+libscenefx-0.5.so scenefx-0.5_1
 libnng.so.1 nng-1.5.2_1
 libsentry.so sentry-native-0.7.7_1
 libjose.so.0 libjose-14_1

--- a/srcpkgs/mangowc/template
+++ b/srcpkgs/mangowc/template
@@ -1,11 +1,12 @@
 # Template file for 'mangowc'
 pkgname=mangowc
-version=0.14.4
+version=0.16.1
 revision=1
 conf_files="/etc/mango/config.conf"
 build_style=meson
 hostmakedepends="pkg-config wayland-devel"
-makedepends="cJSON-devel wlroots0.19-devel pcre2-devel scenefx-devel"
+makedepends="cJSON-devel wlroots0.20-devel pcre2-devel scenefx-devel
+ libinput-devel pango-devel"
 depends="$(vopt_if xwayland xorg-server-xwayland)"
 short_desc="Dwl-based wayland compositor using scenefx"
 maintainer="Emil Miler <em@0x45.cz>"
@@ -13,7 +14,7 @@ license="GPL-3.0-or-later"
 homepage="https://github.com/mangowm/mango"
 changelog="https://github.com/mangowm/mango/releases"
 distfiles="https://github.com/mangowm/mango/archive/refs/tags/${version}.tar.gz"
-checksum=e37e732ff3b0db309fc616cec5ed9699e972f2969f82c1bbc3c5a298168401f8
+checksum=fe3d34e5731983083a83cc2b4ce0f61b538d2fe7f84e7a85aae5ec427d863c10
 
 build_options="xwayland"
 desc_option_xwayland="Enable Xwayland support"

--- a/srcpkgs/scenefx/template
+++ b/srcpkgs/scenefx/template
@@ -1,18 +1,18 @@
 # Template file for 'scenefx'
 pkgname=scenefx
-version=0.4.1
+version=0.5
 revision=1
 build_style=meson
 configure_args="-Dwerror=false -Db_ndebug=false"
 hostmakedepends="pkg-config wayland-devel scdoc"
-makedepends="wlroots0.19-devel"
+makedepends="wlroots0.20-devel"
 short_desc="Drop-in replacement for the wlroots scene API"
 maintainer="Christopher K. 'Shmish' Schmitt <me@shmish.dev>"
 license="MIT"
 homepage="https://github.com/wlrfx/scenefx"
 changelog="https://github.com/wlrfx/scenefx/releases/"
 distfiles="https://github.com/wlrfx/scenefx/archive/refs/tags/${version}.tar.gz"
-checksum=fa23f6ff509168d4a5eb0c5a7ef3b8cf3d39e3fba18320c28256e6c91c85d9ff
+checksum=0fa8ecca0e310f813efd052624c5ed7d9153d6a0fdead5cc957d34c07f9a86c6
 
 post_install() {
 	vlicense LICENSE

--- a/srcpkgs/swayfx/template
+++ b/srcpkgs/swayfx/template
@@ -1,12 +1,12 @@
 # Template file for 'swayfx'
 pkgname=swayfx
-version=0.5.3
-revision=2
+version=0.6
+revision=1
 build_style=meson
 configure_args="-Dwerror=false -Db_ndebug=false"
 conf_files="/etc/sway/config"
 hostmakedepends="pkg-config wayland-devel scdoc"
-makedepends="wlroots0.19-devel pcre2-devel json-c-devel pango-devel cairo-devel
+makedepends="wlroots0.20-devel pcre2-devel json-c-devel pango-devel cairo-devel
  gdk-pixbuf-devel libevdev-devel scenefx-devel"
 depends="libcap-progs swaybg xorg-server-xwayland libxkbcommon>=1.5.0_1
  virtual?font:sans-serif"
@@ -16,7 +16,7 @@ license="MIT"
 homepage="https://github.com/WillPower3309/swayfx"
 changelog="https://github.com/WillPower3309/swayfx/releases"
 distfiles="https://github.com/WillPower3309/swayfx/archive/refs/tags/${version}.tar.gz"
-checksum=e6345e198f128520cf422b458ac8ad9759c3a6c8f633d7b722655309f8a14b9e
+checksum=854f9d1468b8706718210e026d0bb0ddbc8370f750345fbbdd163f130c1b922d
 conflicts="sway>=0"
 provides="sway-${version}_1"
 replaces="sway>=0"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc

Note that swayfx is also a reverse dependency of scenefx and the latest upstream release still depends on scenefx-0.4 / wlroots-0.19.  We need to wait for upstream swayfx before merging.
