### PR TITLE
tuxedo-yt6801: udpate to 1.31.1.8

### DIFF
--- a/srcpkgs/tuxedo-yt6801/files/dkms.conf
+++ b/srcpkgs/tuxedo-yt6801/files/dkms.conf
@@ -1,0 +1,5 @@
+PACKAGE_NAME="tuxedo-yt6801"
+PACKAGE_VERSION="0.0.0"
+
+DEST_MODULE_LOCATION[0]="/kernel/drivers/net/ethernet/motorcomm"
+BUILT_MODULE_NAME[0]="yt6801"

--- a/srcpkgs/tuxedo-yt6801/template
+++ b/srcpkgs/tuxedo-yt6801/template
@@ -1,23 +1,25 @@
 # Template file for 'tuxedo-yt6801'
 pkgname=tuxedo-yt6801
-version=1.0.30tux5
+version=1.0.31.8
 revision=1
+_ver="${version%.*}-${version##*.}"
 depends="dkms"
 short_desc="Kernel module for Motorcomm YT6801 ethernet controller (DKMS)"
 maintainer="Seth <sutura-git@qkco.es>"
 license="GPL-2.0-or-later"
 homepage="https://gitlab.com/tuxedocomputers/development/packages/tuxedo-yt6801"
 changelog="https://gitlab.com/tuxedocomputers/development/packages/tuxedo-yt6801/-/raw/main/debian/changelog"
-distfiles="https://gitlab.com/tuxedocomputers/development/packages/tuxedo-yt6801/-/archive/v${version}/tuxedo-yt6801-v${version}.tar.gz"
-checksum=3df563a7d5236fd461f385956e12eccd2689058f29e2f52727065ecd2978247b
+distfiles="https://gitlab.com/tuxedocomputers/development/packages/tuxedo-yt6801/-/archive/v${_ver}/tuxedo-yt6801-v${_ver}.tar.gz"
+checksum=5772343153ec62b8f2bec23053db1bf551a59e7c7c0c646a8e9cf5f25de1b615
 
 dkms_modules="tuxedo-yt6801 ${version}"
 
 do_install() {
-	sed "s/#MODULE_VERSION#/${version}/" debian/tuxedo-yt6801.dkms > dkms.conf
 	vmkdir usr/src/${pkgname}-${version}
+	vcopy ${FILESDIR}/dkms.conf usr/src/${pkgname}-${version}
+	vsed -i ${DESTDIR}/usr/src/${pkgname}-${version}/dkms.conf -e "s/0\.0\.0/${version}/"
 	vcopy "src/*.c" usr/src/${pkgname}-${version}
 	vcopy "src/*.h" usr/src/${pkgname}-${version}
-	vcopy dkms.conf usr/src/${pkgname}-${version}
 	vcopy "src/Kbuild" usr/src/${pkgname}-${version}
+	vcopy files/usr/lib/modprobe.d usr/lib
 }


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

@suturar They changed packaging and versioning which I adjusted. I extracted the `dkms.conf` from `package.yml` just like in #61471 and they added a blacklist in `modprobe.d`.

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)
- Built for kernels 5.15, 6.1, 6.3–6.19, 7.0–7.1