### PR TITLE
tombi: update to 1.2.0.

### DIFF
--- a/srcpkgs/tombi/template
+++ b/srcpkgs/tombi/template
@@ -1,6 +1,6 @@
 # Template file for 'tombi'
 pkgname=tombi
-version=1.1.5
+version=1.2.0
 revision=1
 build_style=cargo
 build_wrksrc="rust/tombi-cli"
@@ -11,9 +11,10 @@ license="MIT"
 homepage="https://tombi-toml.github.io/tombi/"
 changelog="https://github.com/tombi-toml/tombi/releases"
 distfiles="https://github.com/tombi-toml/tombi/archive/refs/tags/v${version}.tar.gz"
-checksum=3868abbbe9a8acd58ad970d0b038b45d1acf4c13f564583bf683e2eb577ce9d3
+checksum=207dd1e3febd28a970f99da140f375d60fd838d0017e0f641648b6b5b77cbc3f
 
 export __TOMBI_VERSION=${version}
+export __TOMBI_TARGET_TRIPLE=${XBPS_RUST_TARGET}
 
 post_patch() {
 	# build.rs only tries to set the version to the commit hash


### PR DESCRIPTION

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
