### PR TITLE
supersonic-desktop: update to 0.22.1.

### DIFF
--- a/srcpkgs/supersonic-desktop/template
+++ b/srcpkgs/supersonic-desktop/template
@@ -1,18 +1,18 @@
 # Template file for 'supersonic-desktop'
 pkgname=supersonic-desktop
-version=0.21.0
+version=0.22.1
 revision=1
 build_style=go
-go_import_path="github.com/dweymouth/supersonic"
+go_import_path="github.com/supersonic-app/supersonic"
 hostmakedepends="pkg-config"
 makedepends="mpv-devel libXcursor-devel libXxf86vm-devel"
 short_desc="Lightweight cross-platform desktop client for self-hosted music servers"
 maintainer="Hendrik Boll <fanyx@posteo.net>"
 license="GPL-3.0-or-later"
-homepage="https://github.com/dweymouth/supersonic"
-changelog="https://raw.githubusercontent.com/dweymouth/supersonic/refs/heads/main/CHANGELOG.md"
-distfiles="https://github.com/dweymouth/supersonic/archive/v${version}.tar.gz"
-checksum=b532e5fb0c2e03949a704ac12576713a85eb1890012befd2f2479caa35723804
+homepage="https://github.com/supersonic-app/supersonic"
+changelog="https://raw.githubusercontent.com/supersonic-app/supersonic/refs/heads/main/CHANGELOG.md"
+distfiles="https://github.com/supersonic-app/supersonic/archive/v${version}.tar.gz"
+checksum=7d4d6012d7354373b69609ce55acd7933406363ba13802f756a2713b19f9c599
 
 post_install() {
 	mv "${DESTDIR}/usr/bin/supersonic" "${DESTDIR}/usr/bin/supersonic-desktop"


### PR DESCRIPTION
## TODO

waiting for 0.22.1 release

- [x] [32-bit builds seem to be broken due to fyne-2.8, both Intel and ARM affected, only ARM reported](https://github.com/fyne-io/fyne/issues/6400)

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
