### PR TITLE
tcping: fix musl segmentation fault

### DIFF
--- a/srcpkgs/tcping/patches/freeaddrinfo.patch
+++ b/srcpkgs/tcping/patches/freeaddrinfo.patch
@@ -1,0 +1,34 @@
+From a8e34037b569f7ef470be77a06c01b7beb53ce3e Mon Sep 17 00:00:00 2001
+From: Roberto Ricci <io@r-ricci.it>
+Date: Wed, 9 Aug 2023 12:52:55 +0200
+Subject: [PATCH] tcping_freehostinfo: don't pass NULL to freeaddrinfo()
+
+According to the POSIX man page, "The freeaddrinfo() function shall
+free one or more addrinfo structures". Trying to free zero
+structures is a misuse of the interface.
+tcping segfaults with musl libc if the name does not resolve.
+Fix this by checking if `hi->ai` is NULL before calling freeaddrinfo().
+Checking whether `hi` is NULL is not strictly necessary, but it makes
+the library more robust.
+---
+ tcping.c | 7 +++++--
+ 1 file changed, 5 insertions(+), 2 deletions(-)
+
+diff --git a/tcping.c b/tcping.c
+index 748761d..28af2f9 100644
+--- a/tcping.c
++++ b/tcping.c
+@@ -22,8 +22,11 @@ int tcping_gethostinfo(char *node, char *serv, int ai_family,
+ 
+ void tcping_freehostinfo(struct hostinfo *hi)
+ {
+-    freeaddrinfo(hi->ai);
+-    free(hi);
++    if (hi) {
++        if (hi->ai)
++            freeaddrinfo(hi->ai);
++        free(hi);
++    }
+ }
+ 
+ int tcping_socket(struct hostinfo *host)

--- a/srcpkgs/tcping/template
+++ b/srcpkgs/tcping/template
@@ -1,7 +1,7 @@
 # Template file for 'tcping'
 pkgname=tcping
 version=2.1.0
-revision=1
+revision=2
 build_style=gnu-makefile
 short_desc="Ping over a tcp connection"
 maintainer="Enno Boland <gottox@voidlinux.org>"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
