### PR TITLE
mdbook-mermaid: update to 0.17.0.

### DIFF
--- a/srcpkgs/mdbook-mermaid/template
+++ b/srcpkgs/mdbook-mermaid/template
@@ -1,6 +1,6 @@
 # Template file for 'mdbook-mermaid'
 pkgname=mdbook-mermaid
-version=0.14.0
+version=0.17.0
 revision=1
 build_style=cargo
 short_desc="Preprocessor for mdbook to add mermaid support"
@@ -9,7 +9,7 @@ license="MPL-2.0"
 homepage="https://github.com/badboy/mdbook-mermaid"
 changelog="https://raw.githubusercontent.com/badboy/mdbook-mermaid/main/CHANGELOG.md"
 distfiles="https://github.com/badboy/mdbook-mermaid/archive/refs/tags/v${version}.tar.gz"
-checksum=79c000c81b9c9c6f0b10d14d8ca3a53a6db62fdd0ac128ce4842158f0e04de98
+checksum=ed155c57d4356b90c26806a8699a1287712831e45c0cc6e5eb7ed4cc7fd4ada7
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc

The current `mdbook-mermaid` version is not compatible with `mdbook-0.5`, so without this bump the package is effectively useless.