### PR TITLE
drm_info: update to 2.10.0.

### DIFF
--- a/srcpkgs/drm_info/template
+++ b/srcpkgs/drm_info/template
@@ -1,6 +1,6 @@
 # Template file for 'drm_info'
 pkgname=drm_info
-version=2.9.0
+version=2.10.0
 revision=1
 build_style=meson
 hostmakedepends="pkg-config scdoc"
@@ -11,7 +11,14 @@ license="MIT"
 homepage="https://gitlab.freedesktop.org/emersion/drm_info"
 changelog="https://gitlab.freedesktop.org/emersion/drm_info/-/tags"
 distfiles="https://gitlab.freedesktop.org/emersion/drm_info/-/archive/v${version}/drm_info-v${version}.tar.bz2"
-checksum=b684773e3ae48b9f9937b2078221fc4b46590c7c4130a55aa746918a03a0a1a2
+checksum=bec22a3836da30cb00a23fde80b816b7753dbf4103edf5b68fd0dbe37818f842
+
+post_patch() {
+	# pkg-config variables are not sysroot-prefixed, so the
+	# drm_fourcc.h lookup breaks when cross compiling
+	vsed -i meson.build \
+		-e "s|libdrm.get_variable(pkgconfig: 'includedir')|'${XBPS_CROSS_BASE}/usr/include'|"
+}
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures using specific masterdirs:
  - x86_64-musl
  - i686
- I built this PR locally for these architectures (crossbuilds):
  - aarch64
  - aarch64-musl
  - armv7l
  - armv7l-musl
  - armv6l
  - armv6l-musl
  
maintainer ping @RunningDroid 