### PR TITLE
New package: kubectx-0.11.0

### DIFF
--- a/srcpkgs/kubectx/template
+++ b/srcpkgs/kubectx/template
@@ -1,0 +1,36 @@
+# Template file for 'kubectx'
+pkgname=kubectx
+version=0.11.0
+revision=1
+build_style=go
+go_import_path="github.com/ahmetb/${pkgname}"
+go_package="./cmd/kubectx ./cmd/kubens"
+go_ldflags="-X main.version=v${version}"
+short_desc="Faster way to switch between clusters in kubectl"
+maintainer="al20ov <nicolas.antauf@gmail.com>"
+license="Apache-2.0"
+homepage="https://kubectx.dev"
+changelog="https://github.com/ahmetb/kubectx/releases"
+distfiles="https://github.com/ahmetb/kubectx/archive/refs/tags/v${version}.tar.gz"
+checksum=1c8eb6b30c0067f89e5b2f9480865b0e3229a221fadddb644ce192d663c63907
+
+post_install() {
+	vcompletion completion/$pkgname.bash bash
+	vcompletion completion/$pkgname.fish fish
+	vcompletion completion/_$pkgname.zsh zsh
+
+	vcompletion completion/kubens.bash bash kubens
+	vcompletion completion/kubens.fish fish kubens
+	vcompletion completion/_kubens.zsh zsh kubens
+}
+
+kubens_package() {
+	short_desc="Faster way to switch between namespaces in kubectl"
+	pkg_install() {
+		vmove usr/bin/kubens
+
+		vmove usr/share/bash-completion/completions/kubens
+		vmove usr/share/fish/vendor_completions.d/kubens.fish
+		vmove usr/share/zsh/site-functions/_kubens
+	}
+}

--- a/srcpkgs/kubens
+++ b/srcpkgs/kubens
@@ -1,0 +1,1 @@
+kubectx


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl (cross-built)
  - i686

Tested on my work laptop where I have to frequently switch between kubectl contexts, clean up contexts for deleted clusters, etc... It also has an interactive mode if fzf is installed.
And `kubens` gets compiled too so I thought I would make it a subpackage.