### PR TITLE
Signal-Desktop: update to 8.19.0.

### DIFF
--- a/srcpkgs/Signal-Desktop/template
+++ b/srcpkgs/Signal-Desktop/template
@@ -1,6 +1,6 @@
 # Template file for 'Signal-Desktop'
 pkgname=Signal-Desktop
-version=8.18.0
+version=8.19.0
 revision=1
 # *-musl could potentially work based on the Alpine port:
 # https://git.alpinelinux.org/aports/tree/testing/signal-desktop
@@ -13,7 +13,7 @@ maintainer="dkwo <npiazza@disroot.org>"
 license="AGPL-3.0-only"
 homepage="https://github.com/signalapp/Signal-Desktop"
 distfiles="https://github.com/signalapp/Signal-Desktop/archive/v${version}.tar.gz"
-checksum=61a93b2b5b74e696de74efe59d408b9ab8c026a826321379ce96a9b68172bc72
+checksum=06f226862e072ffcfc122ea00ae124ab7de8b7eea040484003fc1ef185fcb7f6
 nostrip_files="signal-desktop"
 nocross="gyp -> aarch64-linux-gnu-gcc: error: unrecognized command-line option '-m64'"
 


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc

