### PR TITLE
sops: update to 3.13.2.

### DIFF
--- a/srcpkgs/sops/template
+++ b/srcpkgs/sops/template
@@ -1,6 +1,6 @@
 # Template file for 'sops'
 pkgname=sops
-version=3.13.1
+version=3.13.2
 revision=1
 build_style=go
 go_import_path="github.com/getsops/sops/v3"
@@ -11,5 +11,5 @@ license="MPL-2.0"
 homepage="https://github.com/getsops/sops"
 changelog="https://raw.githubusercontent.com/getsops/sops/main/CHANGELOG.rst"
 distfiles="https://github.com/getsops/sops/archive/refs/tags/v${version}.tar.gz"
-checksum=60408fa04a024328e6142c7dc67d08810a470aaa440b9f6cb7b3a358359636e9
+checksum=79560b53814e20031d094a293d6c169314eaaf97efd6e95a6d765e61e881db2c
 make_check=no # tests require a running docker daemon


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

Template-only version/checksum bump. Checksum verified by downloading the GitHub source tarball for v3.13.2. Full native package build not run on this host (not a Void builder).
