### PR TITLE
uv: update to 0.11.29.

### DIFF
--- a/srcpkgs/uv/template
+++ b/srcpkgs/uv/template
@@ -1,6 +1,6 @@
 # Template file for 'uv'
 pkgname=uv
-version=0.11.28
+version=0.11.29
 revision=1
 build_style=python3-pep517
 build_helper="rust qemu"
@@ -13,7 +13,7 @@ license="Apache-2.0 OR MIT"
 homepage="https://github.com/astral-sh/uv"
 changelog="https://github.com/astral-sh/uv/raw/main/CHANGELOG.md"
 distfiles="https://github.com/astral-sh/uv/releases/download/${version}/source.tar.gz>uv-${version}.tar.gz"
-checksum=3a3444224a4a017cd94f4a8471abbd03647d42c2b9a1b9f78102bccab344af67
+checksum=990adcf5c9add5b35e84f4a6e64c41803421c17d77932485ce8f7e468007f8e5
 
 case "$XBPS_TARGET_MACHINE" in
 	i686*)


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

Template-only version/checksum bump. Checksum verified by downloading astral-sh/uv 0.11.29 source.tar.gz. Full native package build not run on this host (not a Void builder).
