### PR TITLE
lazygit: update to 0.63.1.

### DIFF
--- a/srcpkgs/lazygit/template
+++ b/srcpkgs/lazygit/template
@@ -1,6 +1,6 @@
 # Template file for 'lazygit'
 pkgname=lazygit
-version=0.63.0
+version=0.63.1
 revision=1
 build_style=go
 go_import_path=github.com/jesseduffield/lazygit
@@ -13,7 +13,7 @@ license="MIT"
 homepage="https://github.com/jesseduffield/lazygit"
 changelog="https://github.com/jesseduffield/lazygit/releases"
 distfiles="https://github.com/jesseduffield/lazygit/archive/refs/tags/v${version}.tar.gz"
-checksum=56f028ad7700cbe4474e5fb09a617649a82d0963820d38757f61a93b31832610
+checksum=227ff262138440ff68e893f6c95c4e586e954c46913106d84fff78d220e18b6c
 make_check_pre="env PATH=/usr/libexec/chroot-git:${PATH}"
 
 post_install() {


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

Template-only version/checksum bump. Checksum verified by downloading the GitHub source tarball for v0.63.1. Full native package build not run on this host (not a Void builder).
