### PR TITLE
notmuch: update to 0.40, add notmuch-git

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -4571,7 +4571,7 @@ libqlementine.so.1 qlementine-1.2.2_1
 libdatovka.so.8 libdatovka-0.7.0_1
 libhyprutils.so.10 hyprutils-0.11.0_1
 libblake3.so.0 libblake3-1.8.2_1
-libsexp.so.1 sfsexp-1.4.1
+libsexp.so.1 sfsexp-1.4.1_1
 libeot.so.0 libeot-0.01_1
 libafflib.so.0 afflib-3.7.22_1
 libsquashfuse.so.0 squashfuse-0.6.1_1

--- a/srcpkgs/notmuch/patches/0008-fix-cross-for-ruby-bindings.patch
+++ b/srcpkgs/notmuch/patches/0008-fix-cross-for-ruby-bindings.patch
@@ -26,11 +26,11 @@ index d914537c..aae1d2fd 100644
 +# Fix makefile definitions for cross compile
 +if ENV['_TARGET_PLATFORM']
 +  system("sed -i 's|^V =.*|V = 1|' Makefile")
-+  system("sed -i 's|^CFLAGS.*|CFLAGS = \$(CCDLFLAGS) $(VOID_TARGET_CFLAGS) \$(ARCH_FLAG)|' Makefile")
-+  system("sed -i 's|^topdir.*|topdir = $(XBPS_CROSS_BASE)/usr/include/ruby-\$(ruby_version)|' Makefile")
-+  system("sed -i 's|^hdrdir.*|hdrdir = $(XBPS_CROSS_BASE)/usr/include/ruby-\$(ruby_version)|' Makefile")
-+  system("sed -i 's|^arch_hdrdir.*|arch_hdrdir = $(XBPS_CROSS_BASE)/usr/include/ruby-\$(ruby_version)/\$(arch)|' Makefile")
-+  system("sed -i 's|^arch =.*|arch = $(_TARGET_PLATFORM)|' Makefile")
++  system("sed -i 's|^CFLAGS.*|CFLAGS = \$(CCDLFLAGS) #{ENV['VOID_TARGET_CFLAGS']} \$(ARCH_FLAG)|' Makefile")
++  system("sed -i 's|^topdir.*|topdir = #{ENV['XBPS_CROSS_BASE']}/usr/include/ruby-\$(ruby_version)|' Makefile")
++  system("sed -i 's|^hdrdir.*|hdrdir = #{ENV['XBPS_CROSS_BASE']}/usr/include/ruby-\$(ruby_version)|' Makefile")
++  system("sed -i 's|^arch_hdrdir.*|arch_hdrdir = #{ENV['XBPS_CROSS_BASE']}/usr/include/ruby-\$(ruby_version)/\$(arch)|' Makefile")
++  system("sed -i 's|^arch =.*|arch = #{ENV['_TARGET_PLATFORM']}|' Makefile")
 +  system("sed -i 's|^dldflags =.*|dldflags = $(LDFLAGS)|' Makefile")
-+  system("sed -i 's|^libdir =.*|libdir = $(exec_prefix)/lib$(XBPS_TARGET_WORDSIZE)|' Makefile")
++  system("sed -i 's|^libdir =.*|libdir = $(exec_prefix)/lib#{ENV['XBPS_TARGET_WORDSIZE']}|' Makefile")
 +end

--- a/srcpkgs/notmuch/patches/0008-fix-cross-for-ruby-bindings.patch
+++ b/srcpkgs/notmuch/patches/0008-fix-cross-for-ruby-bindings.patch
@@ -1,8 +1,8 @@
 diff --git a/bindings/ruby/extconf.rb b/bindings/ruby/extconf.rb
-index d914537c..aae1d2fd 100644
+index ba97670f..07d9fa56 100644
 --- a/bindings/ruby/extconf.rb
 +++ b/bindings/ruby/extconf.rb
-@@ -18,9 +18,31 @@ if not ENV['LIBNOTMUCH']
+@@ -12,8 +12,30 @@ if not ENV['LIBNOTMUCH']
    exit 1
  end
  
@@ -16,8 +16,7 @@ index d914537c..aae1d2fd 100644
 +  RbConfig::MAKEFILE_CONFIG['LDFLAGS'] = ENV['LDFLAGS'] if ENV['LDFLAGS']
 +end
 +
- $LOCAL_LIBS += ENV['LIBNOTMUCH']
- $LIBS += " -ltalloc"
+ $LOCAL_LIBS = ENV['LIBNOTMUCH']
  
  # Create Makefile
  dir_config('notmuch')

--- a/srcpkgs/notmuch/template
+++ b/srcpkgs/notmuch/template
@@ -1,7 +1,7 @@
 # Template file for 'notmuch'
 pkgname=notmuch
-version=0.39
-revision=5
+version=0.40
+revision=1
 build_style=configure
 build_helper=python3
 configure_args="--prefix=/usr
@@ -21,7 +21,7 @@ license="GPL-3.0-or-later"
 homepage="https://notmuchmail.org"
 distfiles="https://notmuchmail.org/releases/notmuch-${version}.tar.xz
  https://notmuchmail.org/releases/test-databases/database-v1.tar.xz"
-checksum="b88bb02a76c46bad8d313fd2bb4f8e39298b51f66fcbeb304d9f80c3eef704e3
+checksum="4b4314bbf1c2029fdf793637e6c7bb15c1b1730d22be9aa04803c98c5bbc446f
  4299e051b10e1fa7b33ea2862790a09ebfe96859681804e5251e130f800e69d2"
 skip_extraction="database-v1.tar.xz"
 replaces="notmuch-emacs>=0"

--- a/srcpkgs/notmuch/template
+++ b/srcpkgs/notmuch/template
@@ -121,14 +121,6 @@ python3-notmuch2_package() {
 notmuch-ruby_package() {
 	short_desc+=" - Ruby bindings"
 	pkg_install() {
-		if [ "$CROSS_BUILD" ]; then
-			_TARGET_PLATFORM="$(ruby -r \
-				$(find ${XBPS_CROSS_BASE}/usr/lib/ruby -iname rbconfig.rb) \
-				-e 'puts RbConfig::CONFIG["arch"]' 2>/dev/null)"
-			VOID_TARGET_CFLAGS="$CFLAGS"
-			export _TARGET_PLATFORM XBPS_CROSS_BASE VOID_TARGET_CFLAGS \
-			       XBPS_TARGET_WORDSIZE
-		fi
 		make DESTDIR=${PKGDESTDIR} -C bindings/ruby install
 	}
 }

--- a/srcpkgs/notmuch/template
+++ b/srcpkgs/notmuch/template
@@ -1,7 +1,7 @@
 # Template file for 'notmuch'
 pkgname=notmuch
 version=0.39
-revision=4
+revision=5
 build_style=configure
 build_helper=python3
 configure_args="--prefix=/usr
@@ -11,10 +11,10 @@ hostmakedepends="perl pkg-config python3-Sphinx python3-devel texinfo
  desktop-file-utils emacs gnupg python3-setuptools python3-cffi
  python3-build python3-installer doxygen ruby-devel"
 makedepends="bash-completion gmime3-devel talloc-devel xapian-core-devel
- python3-cffi ruby-devel"
+ python3-cffi ruby-devel sfsexp-devel"
 depends="gmime3>=3.2.7"
 checkdepends="python3-pytest mdocml dtach gdb tar xz xapian-core
- openssl"
+ openssl git"
 short_desc="Thread-based email index, search, and tagging"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-3.0-or-later"
@@ -40,7 +40,7 @@ do_build() {
 		export _TARGET_PLATFORM XBPS_CROSS_BASE VOID_TARGET_CFLAGS \
 		       XBPS_TARGET_WORDSIZE
 	fi
-	make ${makejobs}
+	make ${makejobs} all notmuch-git
 	make -C contrib/notmuch-mutt
 	cd ${wrksrc}/bindings/python-cffi
 	python -m build --wheel --skip-dependency-check --no-isolation
@@ -69,6 +69,8 @@ do_check() {
 do_install() {
 	make DESTDIR=${DESTDIR} install
 	rm -f ${DESTDIR}/usr/share/applications/mimeinfo.cache
+	vbin notmuch-git
+	ln -s notmuch-git "$PKGDESTDIR"/usr/bin/nmbug
 }
 
 libnotmuch_package() {


### PR DESCRIPTION
- **sfsexp: fix shlib** -- this library is a new dependency of notmuch-git/notmuch
- **notmuch: build with sexp, add notmuch-git subpkg**
- **notmuch: clean up notmuch-ruby cross**
- **notmuch: update to 0.40**

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Notes
- Recreating #56742 which was previously reviewed by @sgn.

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
