### PR TITLE
glslang: update to 16.5.0; shaderc: update to 2026.3.

### DIFF
--- a/srcpkgs/glslang/template
+++ b/srcpkgs/glslang/template
@@ -1,37 +1,39 @@
 # Template file for 'glslang'
-# Libraries are unversioned, beware of ABI breakage (rebuild shaderc on updates)
+# Rebuild shaderc on SONAME changes
 pkgname=glslang
-version=16.3.0
+version=16.5.0
 revision=1
 build_style=cmake
-hostmakedepends="python3 bison gtest-devel"
+hostmakedepends="python3"
 makedepends="SPIRV-Tools-devel"
 short_desc="Khronos reference front-end for GLSL, ESSL, and sample SPIR-V generator"
 maintainer="Orphaned <orphan@voidlinux.org>"
-license="BSD-3-Clause"
+license="BSD-3-Clause, BSD-2-Clause, MIT, Apache-2.0, GPL-3.0-or-later WITH Bison-exception-2.2, custom:NVIDIA"
 homepage="https://github.com/KhronosGroup/glslang"
 distfiles="https://github.com/KhronosGroup/glslang/archive/${version}.tar.gz"
-checksum=efff5a15258dce1ca2d323bf64c974f5fca03778174615dbc30c8d36db645bf5
+checksum=01af17195fbeb59e39e31e9506de35bb39dfd35807ea0c9a1a99d7d1183ddd45
+
+CFLAGS="-DNDEBUG"
+CXXFLAGS="-DNDEBUG"
 
 if [ "$CROSS_BUILD" ]; then
-	export cmake_crossopts="-DCMAKE_SYSTEM_NAME=Linux -DCMAKE_HOST_SYSTEM_NAME=Linux"
+	cmake_crossopts="-DCMAKE_SYSTEM_NAME=Linux -DCMAKE_HOST_SYSTEM_NAME=Linux"
 fi
 
 do_configure() {
 	cmake -B build-shared -G Ninja \
 		-DCMAKE_INSTALL_PREFIX=/usr \
 		-DCMAKE_INSTALL_LIBDIR=lib \
-		-DCMAKE_BUILD_TYPE=Release \
+		-DCMAKE_BUILD_TYPE=None \
 		-DBUILD_EXTERNAL=OFF \
 		-DBUILD_SHARED_LIBS=ON \
 		-DALLOW_EXTERNAL_SPIRV_TOOLS=YES \
 		$cmake_crossopts
 
-
 	cmake -B build-static -G Ninja \
 		-DCMAKE_INSTALL_PREFIX=/usr \
 		-DCMAKE_INSTALL_LIBDIR=lib \
-		-DCMAKE_BUILD_TYPE=Release \
+		-DCMAKE_BUILD_TYPE=None \
 		-DBUILD_EXTERNAL=OFF \
 		-DBUILD_SHARED_LIBS=OFF \
 		-DALLOW_EXTERNAL_SPIRV_TOOLS=YES \
@@ -53,12 +55,11 @@ pre_check() {
 }
 
 post_install() {
-	sed -n '2,32p' < glslang/GenericCodeGen/CodeGen.cpp > LICENSE
-	vlicense LICENSE
+	vlicense LICENSE.txt
 }
 
 glslang-devel_package() {
-	depends="glslang-${version}_${revision}"
+	depends="glslang>=${version}_${revision}"
 	short_desc+=" - development files"
 	pkg_install() {
 		vmove usr/include

--- a/srcpkgs/shaderc/template
+++ b/srcpkgs/shaderc/template
@@ -1,9 +1,10 @@
 # Template file for 'shaderc'
 pkgname=shaderc
-version=2026.2
+version=2026.3
 revision=1
 build_style=cmake
-configure_args="-DSHADERC_SKIP_TESTS=ON"
+configure_args="-DSHADERC_SKIP_TESTS=ON -DSHADERC_SKIP_EXAMPLES=ON
+ -DSHADERC_SKIP_COPYRIGHT_CHECK=ON"
 hostmakedepends="python3"
 makedepends="SPIRV-Tools-devel glslang-devel SPIRV-Headers"
 short_desc="Collection of tools, libraries and tests for shader compilation"
@@ -11,19 +12,17 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="Apache-2.0"
 homepage="https://github.com/google/shaderc"
 distfiles="https://github.com/google/shaderc/archive/v${version}.tar.gz"
-checksum=f924178e75e3293082481b25ed64d5e48a795b479dac3bd3c83d23070855df42
+checksum=ee493ccf1b3038b4ef2fe024664c5eb2dc4bcc1f6b05b33e3909de0e19c81024
 
 CXXFLAGS="-I${XBPS_CROSS_BASE}/usr/include/glslang"
 LDFLAGS="-Wl,--no-undefined"
 
 pre_configure() {
 	# Unbundle glslang, SPIRV-Headers, SPIRV-Tools
-	# also remove examples
-	sed -i -e '/add_subdirectory(third_party)/d' \
-		   -e '/add_subdirectory(examples)/d' CMakeLists.txt
+	vsed -i CMakeLists.txt -e '/add_subdirectory(third_party)/d'
 
 	# Disable git versioning
-	sed -i -e '/build-version/d' glslc/CMakeLists.txt
+	vsed -i glslc/CMakeLists.txt -e '/build-version/d'
 
 	# Create our own build-version.inc since we disabled git versioning
 	# need to keep this in sync with glslang and SPIRV-Tools versions


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures using specific masterdirs:
  - x86_64-musl
  - i686
- I built this PR locally for these architectures (crossbuilds):
  - aarch64
  - aarch64-musl
  - armv7l
  - armv7l-musl
  - armv6l
  - armv6l-musl
  
---

Besides the version bumps, both templates carry cleanup found while reviewing the build logs.

`glslang`: the devel dep now uses `>=`, the exact version made the 32bit runtime deps hook print a parse error. Removed `bison` (grammar ships pregenerated) and `gtest-devel` (only reached via `ALLOW_EXTERNAL_GTEST`, whose golden output tests fail against system SPIRV-Tools). Declared the full license composition and installed upstream LICENSE.txt via `vlicense` instead of extracting one header from CodeGen.cpp. Switched Release to None with explicit `-DNDEBUG` to honor xbps CFLAGS, upstream defaults to Debug when unset. Updated the stale header comment.

`shaderc`: switched to `vsed`, replaced the dead examples sed with `-DSHADERC_SKIP_EXAMPLES=ON` and added `-DSHADERC_SKIP_COPYRIGHT_CHECK=ON` to drop the upstream lint target.