### PR TITLE
python3-btrfsutil: update to 7.1.

### DIFF
--- a/srcpkgs/python3-btrfsutil/template
+++ b/srcpkgs/python3-btrfsutil/template
@@ -1,6 +1,6 @@
 # Template file for 'python3-btrfsutil'
 pkgname=python3-btrfsutil
-version=7.0
+version=7.1
 revision=1
 build_style=python3-module
 hostmakedepends="python3-setuptools"
@@ -10,4 +10,4 @@ maintainer="Yushi <git@yushi.one>"
 license="GPL-2.0-only"
 homepage="https://pypi.org/project/btrfsutil/"
 distfiles="${PYPI_SITE}/b/btrfsutil/btrfsutil-${version}.tar.gz"
-checksum=8aa72188ca61c926de9b17f3c0777b6bcc2796297810f9e9ddfacb45aaf40643
+checksum=8fc597319a15da9028a4878b3ea147318ddf810dd640ee9ebf15b1d084d79250


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
#### Local build testing
- I built this PR locally for my native architecture, (aarch64-glibc)

