### PR TITLE
ImageMagick: revbump avif support

### DIFF
--- a/srcpkgs/ImageMagick/template
+++ b/srcpkgs/ImageMagick/template
@@ -2,7 +2,7 @@
 pkgname=ImageMagick
 # Revbump php*-imagick with ImageMagick updates.
 version=7.1.2.25
-revision=2
+revision=3
 build_style=gnu-configure
 configure_args="--disable-static --enable-opencl --with-modules --with-gslib
  --with-rsvg --with-wmf --with-dejavu-font-dir=/usr/share/fonts/TTF --with-openexr
@@ -11,7 +11,7 @@ hostmakedepends="automake libtool pkg-config autoconf"
 makedepends="djvulibre-devel fftw-devel ghostscript-devel glib-devel lcms2-devel
  libXt-devel libgomp-devel libltdl-devel librsvg-devel libwebp-devel libwmf-devel
  ocl-icd-devel pango-devel libopenjpeg2-devel graphviz-devel liblqr-devel
- libraqm-devel libopenexr-devel libheif-devel libjxl-devel"
+ libraqm-devel libopenexr-devel libheif-devel libjxl-devel libavif-devel"
 checkdepends="ttf-opensans"
 short_desc="Create, edit, compose, or convert bitmap images"
 maintainer="Orphaned <orphan@voidlinux.org>"


### PR DESCRIPTION
Without converting avif issues
magick: no decode delegate for this image format

magick -list format | grep -i HEIC
     AVCI  HEIC      rw+   AVC Image File Format (1.23.0)
     AVIF  HEIC      rw+   AV1 Image File Format (1.23.0)
     HEIC  HEIC      rw+   High Efficiency Image Format (1.23.0)
     HEIF  HEIC      rw+   High Efficiency Image Format (1.23.0)

magick  -list format | grep AVIF
     AVIF  HEIC      rw+   AV1 Image File Format (1.23.0)

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
