### PR TITLE
python3-auditok: update to 0.5.0

### DIFF
--- a/srcpkgs/python3-auditok/template
+++ b/srcpkgs/python3-auditok/template
@@ -1,18 +1,19 @@
 # Template file for 'python3-auditok'
 pkgname=python3-auditok
-version=0.4.2
+version=0.5.0
 revision=1
 build_style=python3-pep517
 hostmakedepends="python3-setuptools_scm"
 depends="python3-numpy python3-matplotlib python3-tqdm python3-sounddevice
- ffmpeg6"
+ python3-webrtcvad ffmpeg6"
+checkdepends="python3-pytest python3-pytest-cov $depends"
 short_desc="Audio activity detection and segmentation tool"
 maintainer="Mateusz Sylwestrzak <slymattz@gmail.com>"
 license="MIT"
 homepage="https://github.com/amsehili/auditok"
 changelog="https://raw.githubusercontent.com/amsehili/auditok/main/CHANGELOG"
-distfiles="${PYPI_SITE}/a/auditok/auditok-${version}.tar.gz"
-checksum=52985096cbd3c15d650e71cb252b385875c9031da40ca8584b99fcdd9e26eaa5
+distfiles="https://github.com/amsehili/auditok/archive/refs/tags/v${version}.tar.gz"
+checksum=4870fff3a2e3264bee2452944c82651113eb668735d2d8fb8f8ae0435f449c34
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

**Other notable changes:**
Switch to the GH tarball as it contains the necessary data required to perform tests (PyPi tarball does not include this data). 

Add python3-webrtcvad as a runtime dependency to enable the optional WebRTCVADValidator functionality introduced upstream. Use the currently packaged python3-webrtcvad instead of upstream's webrtcvad-wheels package.
https://github.com/amsehili/auditok/commit/f9763752c180d87b1396756e8edf83cca339af1b

#### Local build testing
- I built this PR locally for my native architecture: x86_64-glibc
