### PR TITLE
portage: update to 3.0.77

### DIFF
--- a/srcpkgs/portage/template
+++ b/srcpkgs/portage/template
@@ -1,10 +1,10 @@
 # Template file for 'portage'
 pkgname=portage
-version=3.0.44
-revision=4
-build_style=python3-module
-make_install_args="--sbindir=/usr/bin"
-hostmakedepends="python3 python3-setuptools"
+version=3.0.77
+revision=1
+build_style=meson
+hostmakedepends="meson ninja pkg-config"
+makedepends="python3-devel"
 depends="python3 rsync xmlto eselect tar zstd"
 checkdepends="tar zstd gnupg"
 short_desc="Gentoo's package management system"
@@ -13,7 +13,7 @@ license="GPL-2.0-only"
 homepage="https://wiki.gentoo.org/wiki/Portage"
 changelog="https://gitweb.gentoo.org/proj/portage.git/plain/NEWS"
 distfiles="https://github.com/gentoo/portage/archive/portage-${version}.tar.gz"
-checksum=c7171aae7a6d6228b3ecc37819ce4d5c7652a9f47dde4db21d5ce4437d0ae19a
+checksum=cf3fdb81dfc0522689c29180a7a78649e4b86a62bd5513ae291ab9f4bd07d059
 # unshare cannot be used in CI
 # https://bugs.gentoo.org/show_bug.cgi?id=680456
 # https://forums.gentoo.org/viewtopic-t-1113256-start-0.html


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-glibc
  - x86_64-musl
  - armv7l

Fixes: #61520 