### PR TITLE
New package: ntfsprogs-plus-1.0.0

### DIFF
--- a/srcpkgs/ntfsprogs-plus-devel
+++ b/srcpkgs/ntfsprogs-plus-devel
@@ -1,0 +1,1 @@
+ntfsprogs-plus

--- a/srcpkgs/ntfsprogs-plus/template
+++ b/srcpkgs/ntfsprogs-plus/template
@@ -1,0 +1,29 @@
+# Template file for 'ntfsprogs-plus'
+pkgname=ntfsprogs-plus
+version=1.0.0
+revision=1
+build_style=gnu-configure
+configure_args="--exec-prefix=/usr --disable-static --enable-posix-acls
+ --enable-xattr-mappings --sbin=/usr/bin --includedir=/usr/include/ntfsprogs-plus"
+hostmakedepends="automake libtool pkg-config libgcrypt-devel"
+makedepends="libuuid-devel"
+short_desc="NTFS filesystem utilities"
+maintainer="Nafis <mnabid.25@outlook.com>"
+license="GPL-2.0-or-later, LGPL-2.0-or-later"
+homepage="https://github.com/ntfsprogs-plus/ntfsprogs-plus"
+distfiles="${homepage}/archive/refs/tags/${version}.tar.gz>${pkgname}-${version}.tar.gz"
+checksum=3e3d9d2f3620cdebb128fb8dbc116f2c2a035f18000e3f01af204694ef8c7778
+conflicts="ntfs-3g"
+
+pre_configure() {
+	./autogen.sh
+}
+
+ntfsprogs-plus-devel_package() {
+	depends="${sourcepkg}>=${version}_${revision}"
+	short_desc+=" - development files"
+	pkg_install() {
+		vmove usr/include
+		vmove "usr/lib/*.so"
+	}
+}


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

NTFS filesystem userspace utilities, [supplements the new NTFS driver in Linux 7.x](https://www.kernel.org/doc/html/next/filesystems/ntfs.html#utilities-support).
Homepage: https://github.com/ntfsprogs-plus/ntfsprogs-plus

#### Testing the changes
- I tested the changes in this PR: **YES**


#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**


<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, `x86_64-glibc`
<!--
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
