### PR TITLE
wayland: update to 1.26.0

### DIFF
--- a/srcpkgs/wayland/template
+++ b/srcpkgs/wayland/template
@@ -1,6 +1,6 @@
 # Template file for 'wayland'
 pkgname=wayland
-version=1.25.0
+version=1.26.0
 revision=1
 build_style=meson
 # "Tests must not be built with NDEBUG defined, they rely on assert()."
@@ -13,7 +13,7 @@ maintainer="Érico Nogueira <ericonr@disroot.org>"
 license="MIT"
 homepage="https://wayland.freedesktop.org/"
 distfiles="https://gitlab.freedesktop.org/wayland/wayland/-/releases/${version}/downloads/wayland-${version}.tar.xz"
-checksum=c065f040afdff3177680600f249727e41a1afc22fccf27222f15f5306faa1f03
+checksum=64176eaa46e4969903e286f8e5ef8331affc17fdf03ac9b58381d2b23162b7a3
 
 if [ "$XBPS_CHECK_PKGS" ]; then
 	configure_args+=" -Dtests=true"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**|**in progress**

```
[*] Waybar-0.15.0_3          Polybar-like Wayland Bar for Sway and Wlroots based compositors
[*] bemenu-0.6.23_1          Dynamic menu library and client program inspired by dmenu
[*] cliphist-0.7.0_1         Wayland clipboard manager
[*] firefox-152.0.6_1        Mozilla Firefox web browser
[*] foot-1.27.0_1            Fast, lightweight and minimalistic Wayland terminal emulator
[*] foot-terminfo-1.27.0_1   Fast, lightweight and minimalistic Wayland terminal emulator - terminfo data
[*] gtk-layer-shell-0.10.1_1 Library to create panels and other desktop components for Wayland
[*] imv-5.0.1_2              Image viewer for X11/Wayland
[*] labwc-0.20.1_1           Wayland window-stacking compositor
[*] libdecor-0.2.5_1         Client-side decorations library for Wayland client
[*] libinput-1.31.3_1        Provides handling input devices in Wayland compositors and X
[*] swaybg-1.2.2_1           Wallpaper tool for Wayland compositors
[*] swayidle-1.9.0_1         Idle management daemon for Wayland
[*] swayimg-5.4_1            Image viewer for Sway/Wayland
[*] swaylock-1.8.5_1         Screen locker for Wayland
[*] wayfire-0.10.1_1         3D wayland compositor
[*] wayland-1.26.0_0         Core Wayland window system code and protocol
[*] wl-clipboard-2.3.0_1     Wayland clipboard utilities
[*] wlroots0.19-0.19.3_1     Modular Wayland compositor library 0.19
[*] wlroots0.20-0.20.2_1     Modular Wayland compositor library 0.20
[*] wlsunset-0.4.0_1         Day/night gamma adjustments for Wayland compositors
[*] wob-0.16_1               Lightweight overlay volume/backlight/progress/anything bar for Wayland
[*] wtype-0.4_1              Wayland version of xdotool
```

#### Local build testing
- I built this PR locally for my native architecture, **x86_64-glibc**
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl
 
Changes: [wayland 1.25.91](https://lore.freedesktop.org/wayland-devel/-Ppab1BlrXbXvKwok-5WA3ohwqMovJGchqsCmF7qFdoDznIykeyly1AyQQMub66aLExGGDZNNHSG6h5MQpY2EzFc0c_32wItTwTFDdtAZnA=@emersion.fr/T/#u) [wayland 1.26.0](https://lore.freedesktop.org/wayland-devel/5On45eE2mxDczYfK0kAKrM_Bf7fI0NV07MXCBmsfDLplHSIU3cn-8JoaUj6zURfuWVB7pHDaBIPSXKenUGUdQeAZ51wpzMtGf_W-BdLgNC0=@emersion.fr/T/#u)

cc @ericonr 
