### PR TITLE
cava: update to 1.0.0.

### DIFF
--- a/srcpkgs/cava/template
+++ b/srcpkgs/cava/template
@@ -1,6 +1,6 @@
 # Template file for 'cava'
 pkgname=cava
-version=0.10.7
+version=1.0.0
 revision=1
 build_style=gnu-configure
 hostmakedepends="autoconf-archive automake libtool pkg-config"
@@ -13,7 +13,7 @@ license="MIT"
 homepage="https://github.com/karlstav/cava"
 changelog="https://github.com/karlstav/cava/releases"
 distfiles="https://github.com/karlstav/cava/archive/refs/tags/${version}.tar.gz"
-checksum=43f994f7e609fab843af868d8a7bc21471ac62c5a4724ef97693201eac42e70a
+checksum=2866cea11d0bd38406924ab2b47d5577f14909a7321ee928b6836391f375af7e
 build_options="alsa jack pipewire pulseaudio sndio"
 build_options_default="alsa jack pipewire pulseaudio sndio"
 replaces="xava>=0 cava-gui>=0"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86)
- I installed, ran, and used this package.
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64 (crossbuild)
