### PR TITLE
New package: python3-unrpa-2.3.0

### DIFF
--- a/srcpkgs/python3-unrpa/template
+++ b/srcpkgs/python3-unrpa/template
@@ -1,0 +1,13 @@
+# Template file for 'python3-unrpa'
+pkgname=python3-unrpa
+version=2.3.0
+revision=1
+build_style=python3-module
+hostmakedepends="python3-setuptools"
+depends="python3"
+short_desc="Extract files from the RPA archive format (from Ren'Py visual novels)"
+maintainer="Gareth Latty <gareth@lattyware.co.uk>"
+license="GPL-3.0-or-later"
+homepage="https://github.com/Lattyware/unrpa"
+distfiles="https://github.com/Lattyware/unrpa/archive/refs/tags/${version}.tar.gz"
+checksum=e30684de7098fa7fc657d0cfd9d7d0e2a7fe96f31a964f5ac5f81418a5b4cb7d


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

This package is for decompressing .rpa renpy archive files.

#### Testing the changes
- I tested the changes in this PR: YES

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): YES

#### Local build testing
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-glibc
  - x86_64-glibc

