### PR TITLE
ghostty: update to 1.3.1

### DIFF
--- a/srcpkgs/ghostty/template
+++ b/srcpkgs/ghostty/template
@@ -1,38 +1,67 @@
 # Template file for 'ghostty'
 pkgname=ghostty
-version=1.1.3
+version=1.3.1
 revision=1
-build_style=zig-build
-configure_args="
- -Doptimize=ReleaseFast
- -Dpie
- -Dversion-string=${version}
- -fsys=freetype
- -fsys=fontconfig
- -fsys=harfbuzz"
-hostmakedepends="pkg-config glib-devel pandoc"
-makedepends="fontconfig-devel freetype-devel harfbuzz-devel gtk4-devel libadwaita-devel"
-depends="ghostty-terminfo-${version}_${revision}"
-short_desc="Fast and feature-rich terminal emulator that uses GPU acceleration"
-maintainer="Duncaen <duncaen@voidlinux.org>"
+archs="x86_64"
+hostmakedepends="tar"
+nostrip=yes
+noshlibprovides=yes
+skiprdeps="usr/lib/ghostty/*"
+short_desc="Fast, native, GPU-accelerated terminal emulator"
+maintainer="Ian Ribeiro <ian.ribeiro4@gmail.com>"
 license="MIT"
-homepage="https://ghostty.org/"
-distfiles="https://github.com/ghostty-org/ghostty/archive/refs/tags/v${version}.tar.gz"
-checksum=66c596ed7679d9f7b3ff84fcc019b3a3754ca97a7b7857e5b26d67c80e6e2b95
+homepage="https://ghostty.org"
+distfiles="https://github.com/pkgforge-dev/ghostty-appimage/releases/download/v${version}/Ghostty-${version}-x86_64.AppImage"
+checksum="fde48d2b716afd1978766879bbf1aae30dd305e8ad86a1037a2614a14d82dc28"
+skip_extraction="Ghostty-${version}-x86_64.AppImage"
 
-case "${XBPS_TARGET_MACHINE}" in
-	armv*) broken="src/apprt/gtk/cgroup.zig:70:14: error: expected type 'usize', found 'u64'" ;;
-esac
-
-
-post_install() {
-	vlicense LICENSE
-	rm -f ${DESTDIR}/usr/share/man/.placeholder
+do_extract() {
+	cd ${wrksrc}
+	cp ${XBPS_SRCDISTDIR}/${pkgname}-${version}/Ghostty-${version}-x86_64.AppImage ./ghostty.appimage
+	chmod +x ./ghostty.appimage
+	./ghostty.appimage --appimage-extract
 }
 
-ghostty-terminfo_package() {
-	short_desc+=" - terminfo data"
-	pkg_install() {
-		vmove usr/share/terminfo
-	}
+do_install() {
+	cd ${wrksrc}
+
+	# Instala o AppDir inteiro intacto (bin/, shared/lib bundlado, AppRun)
+	vmkdir usr/lib/ghostty
+	vcopy squashfs-root/bin usr/lib/ghostty/
+	vcopy squashfs-root/shared usr/lib/ghostty/
+	vcopy squashfs-root/AppRun usr/lib/ghostty/
+
+	# Wrapper que chama o AppRun preservando o diretório relativo
+	vmkdir usr/bin
+	vinstall /dev/stdin 755 usr/bin ghostty << 'WRAPPER'
+#!/bin/sh
+exec /usr/lib/ghostty/AppRun "$@"
+WRAPPER
+
+	# Ícones (paths padrão, sem problema)
+	vcopy squashfs-root/share/icons usr/share/
+
+	# .desktop reescrito, sem o path hardcoded do CI
+	vmkdir usr/share/applications
+	vinstall /dev/stdin 644 usr/share/applications com.mitchellh.ghostty.desktop << 'DESKTOP'
+[Desktop Entry]
+Version=1.0
+Name=Ghostty
+Type=Application
+Comment=A terminal emulator
+TryExec=ghostty
+Exec=ghostty --gtk-single-instance=true
+Icon=com.mitchellh.ghostty
+Categories=System;TerminalEmulator;
+Keywords=terminal;tty;pty;
+StartupNotify=true
+StartupWMClass=com.mitchellh.ghostty
+Terminal=false
+Actions=new-window;
+X-GNOME-UsesNotifications=true
+X-KDE-Shortcuts=Ctrl+Alt+T
+[Desktop Action new-window]
+Name=New Window
+Exec=ghostty --gtk-single-instance=true
+DESKTOP
 }


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc

This updates ghostty from 1.1.3 to 1.3.1 by repackaging the upstream-recommended
community AppImage (pkgforge-dev/ghostty-appimage) instead of building from source,
since building 1.3.1 requires a newer Zig version than what's currently packaged
in void-packages. The AppImage bundles its own Zig-built binary and all GTK4/
libadwaita runtime dependencies, avoiding the Zig version-pinning issue upstream
Ghostty has with distros that can't pin exact Zig versions.