### PR TITLE
winegui: update to 4.1.0

### DIFF
--- a/srcpkgs/winegui/template
+++ b/srcpkgs/winegui/template
@@ -1,18 +1,19 @@
 # Template file for 'winegui'
 pkgname=winegui
-version=2.8.1
-revision=2
+version=4.1.0
+revision=1
 archs="i686* x86_64*"
 build_style=cmake
+configure_args="-DCHECK_FOR_UPDATE=OFF"
 hostmakedepends="pkg-config"
-makedepends="gtkmm-devel"
-depends="wine wget unzip 7zip cabextract zenity"
+makedepends="gtkmm4-devel json-c++"
+depends="wine wget unzip 7zip cabextract zenity tar xz"
 short_desc="User-friendly WINE manager"
 maintainer="Melroy van den Berg <melroy@melroy.org>"
 license="AGPL-3.0-only"
 homepage="https://gitlab.melroy.org/melroy/winegui"
-distfiles="https://winegui.melroy.org/downloads/WineGUI-Source-v${version}.tar.gz"
-checksum=61b732379875c70e4d47f214409854fae6ff943a38207feabfa94ceabaa4a275
+distfiles="https://github.com/winegui/WineGUI/releases/download/v${version}/WineGUI-Source-v${version}.tar.gz"
+checksum=d248d9d61ec9a3474a08ab40548031d93bf19147c9a281a98ddf30f406f65dff
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES** 🥳 

(moved to github.com for package retrieval, moved to GTK4 now, additional configure flags to avoid internal version checks by WineGUI, add new build dependency, plus two new runtime dependencies)

<img width="1318" height="899" alt="image" src="https://github.com/user-attachments/assets/cc04ba9f-f805-4b91-b100-4cfb8b14ef18" />


#### Local build testing
- I built this PR locally for my native architecture, **x86_64-glibc**


