### PR TITLE
deja-dup: update to 50.1

### DIFF
--- a/srcpkgs/deja-dup/template
+++ b/srcpkgs/deja-dup/template
@@ -1,6 +1,6 @@
 # Template file for 'deja-dup'
 pkgname=deja-dup
-version=50.0
+version=50.1
 revision=1
 build_style=meson
 configure_args="-Dpackagekit=disabled"
@@ -13,7 +13,7 @@ license="GPL-3.0-or-later"
 homepage="https://gitlab.gnome.org/World/deja-dup"
 changelog="https://gitlab.gnome.org/World/deja-dup/-/raw/main/NEWS.md"
 distfiles="https://gitlab.gnome.org/World/deja-dup/-/archive/${version}/deja-dup-${version}.tar.gz"
-checksum=7f1efb56aab43b622f9e23acad5c2433b94ca2edab0cce458e4475e199311b42
+checksum=997c506c0630b67148a334bf22b9f398bedaf085c32c4c3d5d7f1b3a84d19152
 
 # TODO: fix tests
 make_check=no


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - i686
