### PR TITLE
lightdm-slick-greeter: update to 2.2.6, changed maintainer

### DIFF
--- a/srcpkgs/lightdm-slick-greeter/template
+++ b/srcpkgs/lightdm-slick-greeter/template
@@ -1,6 +1,6 @@
 # Template file for 'lightdm-slick-greeter'
 pkgname=lightdm-slick-greeter
-version=2.0.9
+version=2.2.6
 revision=1
 build_style=meson
 hostmakedepends="pkg-config gettext vala"
@@ -9,11 +9,11 @@ makedepends="gtk+3-devel lightdm-devel libcanberra-devel ayatana-ido-devel
 depends="hicolor-icon-theme"
 conf_files="/etc/lightdm/slick-greeter.conf"
 short_desc="Light Display Manager GTK+ Greeter from Linux Mint"
-maintainer="Emil Tomczyk <emru@emru.xyz>"
+maintainer="Fabian Constantinescu <fabian.constantinescu@protonmail.com>"
 license="GPL-3.0-only"
 homepage="https://github.com/linuxmint/slick-greeter"
 distfiles="https://github.com/linuxmint/slick-greeter/archive/refs/tags/${version}.tar.gz"
-checksum=fa0146862ac0967a1a333f9b553d60a5c625c99b903d01aefe9b87bfdb111c29
+checksum=f967bde54b174180330e3ddc925377317ae14fe1b53cadf9b4cf11fdcb953379
 provides="lightdm-greeter-1_0"
 
 post_install() {


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-glibc
  - armv7l