### PR TITLE
opera: update to 133.0.5932.60, add aarch64 build

### DIFF
--- a/srcpkgs/opera/template
+++ b/srcpkgs/opera/template
@@ -1,31 +1,47 @@
 # Template file for 'opera'
 pkgname=opera
-version=132.0.5905.22
+version=133.0.5932.60
 revision=1
-archs="x86_64"
+archs="x86_64 aarch64"
 create_wrksrc=yes
 depends="ffmpeg6 desktop-file-utils hicolor-icon-theme libcanberra-gtk3 gsettings-desktop-schemas"
 short_desc="Fast, secure, easy to use browser"
 maintainer="mobinmob <mobinmob@disroot.org>"
 license="custom:Proprietary"
 homepage="https://www.opera.com/computer"
-distfiles="https://get.geo.opera.com/pub/opera/desktop/${version}/linux/opera-stable_${version}_amd64.rpm"
-checksum=2b000108393fdf603f7aa1277304fe6c63546a15db18df07359486c5acf2f077
 repository="nonfree"
 nostrip=yes
 
+case "$XBPS_TARGET_MACHINE" in
+x86_64*)
+	distfiles="https://rpm.opera.com/rpm/opera_stable-${version}-linux-release-x64-signed.rpm"
+	checksum=2b57ea17b801c3ac9360b7ddb25303860bc7be1fde9f43ac39de5f296e27d131
+	;;
+aarch64*)
+	distfiles="https://rpm.opera.com/rpm/opera_stable-${version}-linux-release-arm64-signed.rpm"
+	checksum=e842f59f4d74fa8b164aad8894824be7567cf7569bfd13f161ebb1293a51353d
+	;;
+*)
+	broken="No distfiles available for this target"
+	;;
+esac
+
 do_install() {
-	# Create necessary dirs
 	vmkdir usr/bin
 	vmkdir usr/lib
 
 	# Copy files
-	vcopy usr/lib64/opera-stable usr/lib/
+	case "$XBPS_TARGET_MACHINE" in
+		x86_64*) _libdir="usr/lib64/opera-stable" ;;
+		aarch64*) _libdir="usr/aarch64/opera-stable" ;;
+	esac
+
+	vcopy "${_libdir}" usr/lib/
 	vcopy usr/share usr/share/
 
 	# Link executable in path
 	ln -s ../lib/opera-stable/opera "${DESTDIR}/usr/bin/opera"
 
 	# Install 3rd-party licenses
-	vlicense usr/lib64/opera-stable/opera_autoupdate.licenses
+	vlicense "${_libdir}/opera_autoupdate.licenses"
 }


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **NO**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, `x86_64-glibc`
- I built this PR locally for these architectures:
  - `aarch64` (cross)