### PR TITLE
libgbinder: update to 1.1.51.

### DIFF
--- a/srcpkgs/libgbinder/template
+++ b/srcpkgs/libgbinder/template
@@ -1,6 +1,6 @@
 # Template file for 'libgbinder'
 pkgname=libgbinder
-version=1.1.50
+version=1.1.51
 revision=1
 build_style=gnu-makefile
 make_use_env=1
@@ -16,7 +16,7 @@ license="BSD-3-Clause"
 homepage="https://github.com/mer-hybris/libgbinder"
 changelog="https://raw.githubusercontent.com/mer-hybris/libgbinder/master/debian/changelog"
 distfiles="https://github.com/mer-hybris/libgbinder/archive/refs/tags/${version}.tar.gz"
-checksum=eabf5b715b933665edefca87425908fb2d23a938de2b0eeb8fd7cb9a3d668f46
+checksum=e0980ca929d9b3c6992236866ef938671e52b4e5deef6fccd2636c2ffc9f4309
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture (x86_64)
- I built this PR locally for these architectures using specific masterdirs:
  - x86_64-musl
  - i686
- I built this PR locally for these architectures (crossbuilds):
  - aarch64
  - aarch64-musl
  - armv7l
  - armv7l-musl
  - armv6l
  - armv6l-musl