### PR TITLE
dbeaver: update to 26.1.3.

### DIFF
--- a/srcpkgs/dbeaver/template
+++ b/srcpkgs/dbeaver/template
@@ -1,6 +1,6 @@
 # Template file for 'dbeaver'
 pkgname=dbeaver
-version=26.1.0
+version=26.1.3
 revision=1
 _version=${version//./_}
 # the build downloads binaries linked to glibc
@@ -16,9 +16,9 @@ changelog="https://dbeaver.io/news/"
 distfiles="https://github.com/dbeaver/dbeaver/archive/${version}.tar.gz
  https://github.com/dbeaver/dbeaver-common/archive/refs/heads/release_${_version}.tar.gz>dbeaver-common-${version}.tar.gz
  https://github.com/dbeaver/dbeaver-jdbc-libsql/archive/refs/heads/release_${_version}.tar.gz>dbeaver-jdbc-libsql-${version}.tar.gz"
-checksum="44bd31ac58a21b82d897e81d3bef5ef542558c460dd8f31863079be759c5f1da
- 356cdf56c2768b4e22e78892d37f912466fcc0b2b5b74382d401af154ccc0ab9
- 087ecdaf417948f5f1291cc77940abf8abf00c8580bf8b489480b485bc8e4a34"
+checksum="df7be19894e575039d649cb680b24dab4e3f1c4e19739717cb61a5ee8a1fafca
+ bdc191282dad9a45e88f598e70bf046fee04350a52470525e39bdbee25a22ad8
+ ef7ac9d5285c1837970d54573aef42274547ef865d64b4a5fa29f16dc82d1a2e"
 nopie=true
 
 post_extract() {


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-libc)