### PR TITLE
Node 24.18.0

### DIFF
--- a/srcpkgs/libuv/patches/disable-fs-chown.patch
+++ b/srcpkgs/libuv/patches/disable-fs-chown.patch
@@ -1,20 +1,20 @@
---- a/test/test-list.h	2021-03-02 21:59:17.718832425 +1100
-+++ b/test/test-list.h	2021-03-02 21:59:41.809157112 +1100
-@@ -367,7 +367,7 @@
+--- a/test/test-list.h	2026-07-23 17:58:08.555904735 +0200
++++ b/test/test-list.h	2026-03-06 21:05:38.000000000 +0100
+@@ -379,7 +379,7 @@
  #ifdef _WIN32
- TEST_DECLARE   (fs_unlink_archive_readonly)
+ TEST_FS_DECLARE   (fs_unlink_archive_readonly)
  #endif
--TEST_DECLARE   (fs_chown)
-+/* TEST_DECLARE   (fs_chown) */
- TEST_DECLARE   (fs_link)
- TEST_DECLARE   (fs_readlink)
- TEST_DECLARE   (fs_realpath)
-@@ -1070,7 +1070,7 @@
+-TEST_FS_DECLARE   (fs_chown)
++/* TEST_FS_DECLARE   (fs_chown) */
+ TEST_FS_DECLARE   (fs_link)
+ TEST_FS_DECLARE   (fs_readlink)
+ TEST_FS_DECLARE   (fs_realpath)
+@@ -1107,7 +1107,7 @@
  #ifdef _WIN32
-   TEST_ENTRY  (fs_unlink_archive_readonly)
+   TEST_FS_ENTRY  (fs_unlink_archive_readonly)
  #endif
--  TEST_ENTRY  (fs_chown)
-+  /* TEST_ENTRY  (fs_chown) */
-   TEST_ENTRY  (fs_link)
-   TEST_ENTRY  (fs_utime)
-   TEST_ENTRY  (fs_utime_round)
+-  TEST_FS_ENTRY  (fs_chown)
++  /* TEST_FS_ENTRY  (fs_chown) */
+   TEST_FS_ENTRY  (fs_link)
+   TEST_FS_ENTRY  (fs_utime)
+   TEST_FS_ENTRY  (fs_utime_round)

--- a/srcpkgs/libuv/patches/disable-setuid-test.patch
+++ b/srcpkgs/libuv/patches/disable-setuid-test.patch
@@ -1,6 +1,6 @@
---- a/test/test-list.h	2021-03-02 21:59:17.718832425 +1100
-+++ b/test/test-list.h	2021-03-02 22:05:18.359833402 +1100
-@@ -325,8 +325,8 @@
+--- a/test/test-list.h	2026-07-23 17:55:55.423878627 +0200
++++ b/test/test-list.h	2026-03-06 21:05:38.000000000 +0100
+@@ -335,8 +335,8 @@
  TEST_DECLARE   (spawn_and_ping)
  TEST_DECLARE   (spawn_preserve_env)
  TEST_DECLARE   (spawn_same_stdout_stderr)
@@ -11,7 +11,7 @@
  TEST_DECLARE   (spawn_stdout_to_file)
  TEST_DECLARE   (spawn_stdout_and_stderr_to_file)
  TEST_DECLARE   (spawn_stdout_and_stderr_to_file2)
-@@ -513,7 +513,7 @@
+@@ -533,7 +533,7 @@
  TEST_DECLARE   (win32_signum_number)
  #else
  TEST_DECLARE   (emfile)
@@ -20,7 +20,7 @@
  TEST_DECLARE   (we_get_signal)
  TEST_DECLARE   (we_get_signals)
  TEST_DECLARE   (we_get_signal_one_shot)
-@@ -990,8 +990,8 @@
+@@ -1024,8 +1024,8 @@
    TEST_ENTRY  (spawn_and_ping)
    TEST_ENTRY  (spawn_preserve_env)
    TEST_ENTRY  (spawn_same_stdout_stderr)
@@ -31,7 +31,7 @@
    TEST_ENTRY  (spawn_stdout_to_file)
    TEST_ENTRY  (spawn_stdout_and_stderr_to_file)
    TEST_ENTRY  (spawn_stdout_and_stderr_to_file2)
-@@ -1035,7 +1035,7 @@
+@@ -1070,7 +1070,7 @@
    TEST_ENTRY  (win32_signum_number)
  #else
    TEST_ENTRY  (emfile)

--- a/srcpkgs/libuv/template
+++ b/srcpkgs/libuv/template
@@ -1,6 +1,6 @@
 # Template file for 'libuv'
 pkgname=libuv
-version=1.51.0
+version=1.52.1
 revision=1
 build_style=gnu-configure
 hostmakedepends="pkg-config"
@@ -10,7 +10,7 @@ license="MIT, BSD-2-Clause, ISC"
 homepage="https://libuv.org/"
 changelog="https://raw.githubusercontent.com/libuv/libuv/v1.x/ChangeLog"
 distfiles="https://dist.libuv.org/dist/v${version}/libuv-v${version}-dist.tar.gz"
-checksum=2ceca1a7577633cf92794db5bf5512370f6cd45a5746d6e14f8c20aeab0a547b
+checksum=c5f14915e2fa7b83b6111c3bc477920559499e10d95f852707420c8725b82d6a
 
 LDFLAGS="-pthread"
 

--- a/srcpkgs/nodejs/template
+++ b/srcpkgs/nodejs/template
@@ -1,7 +1,7 @@
 # Template file for 'nodejs'
 pkgname=nodejs
-version=24.14.1
-revision=2
+version=24.18.0
+revision=1
 build_style=configure
 configure_args="
  --prefix=/usr
@@ -43,7 +43,7 @@ license="MIT"
 homepage="https://nodejs.org/"
 changelog="https://raw.githubusercontent.com/nodejs/node/main/doc/changelogs/CHANGELOG_V${version%%.*}.md"
 distfiles="https://nodejs.org/dist/v${version}/node-v${version}.tar.xz"
-checksum=7822507713f202cf2a551899d250259643f477b671706db421a6fb55c4aa0991
+checksum=e94afde24db08e0c564ee7110a2d5aab51ee0059382c9fd8233c54eec47b28f9
 python_version=3
 
 build_options="ssl libuv icu nghttp2 cares brotli"


### PR DESCRIPTION
- I tested the changes in this PR: YES
- I built this PR locally for my native architecture, (aarch64-gnu)

[ci skip]