### PR TITLE
python3-peewee: update to 4.2.6.

### DIFF
--- a/srcpkgs/python3-peewee/template
+++ b/srcpkgs/python3-peewee/template
@@ -1,6 +1,6 @@
 # Template file for 'python3-peewee'
 pkgname=python3-peewee
-version=4.2.3
+version=4.2.6
 revision=1
 build_style=python3-pep517
 hostmakedepends="python3-setuptools python3-wheel python3-Cython"
@@ -12,7 +12,7 @@ license="MIT"
 homepage="https://github.com/coleifer/peewee"
 changelog="https://raw.githubusercontent.com/coleifer/peewee/master/CHANGELOG.md"
 distfiles="https://github.com/coleifer/peewee/archive/${version}.tar.gz"
-checksum=de5e67a6dfda5ba337a60a703bb0db7385fd96a4c478207329cb2a322e017c69
+checksum=65a301bf2bfb3407cff9ff0d39f021bb16e862b9f5d08efa813bf3c5db7265e2
 
 do_check() {
 	python -m unittest discover -v


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-libc
