### PR TITLE
acl: update to 2.4.0

### DIFF
--- a/srcpkgs/acl/template
+++ b/srcpkgs/acl/template
@@ -1,18 +1,17 @@
 # Template file for 'acl'
 pkgname=acl
-version=2.3.2
+version=2.4.0
 revision=1
 bootstrap=yes
 build_style=gnu-configure
-configure_args="--libdir=/usr/lib${XBPS_TARGET_WORDSIZE}
- --libexecdir=/usr/lib${XBPS_TARGET_WORDSIZE}"
 makedepends="attr-devel"
+checkdepends="perl"
 short_desc="Access Control List filesystem support"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="LGPL-2.1-or-later"
 homepage="https://savannah.nongnu.org/projects/acl"
 distfiles="${NONGNU_SITE}/acl/acl-${version}.tar.gz"
-checksum=5f2bdbad629707aa7d85c623f994aa8a1d2dec55a73de5205bac0bf6058a2f7c
+checksum=73c853c3d44e1f693e5a96a986f1bd19d3d0dac2c7d453e796177774bc4e5f6a
 
 if [ -z "$CHROOT_READY" ]; then
 	CFLAGS+=" -I${XBPS_MASTERDIR}/usr/include"


### PR DESCRIPTION
## acl: update to 2.4.0

This update fixes two security vulnerabilities in acl < 2.4.0:

- **CVE-2026-54369** (CVSS 8.4 HIGH): Symlink traversal privilege escalation via libacl pathname-based functions (acl_get_file, acl_set_file, acl_extended_file, acl_delete_def_file). Attackers who control any component of a pathname processed by a privileged caller can redirect ACL read or write operations to arbitrary files.

- **CVE-2026-54370** (CVSS 7.2 MEDIUM-HIGH): TOCTOU race condition vulnerability allowing local attackers to escalate privileges by replacing a pathname component with a symlink between an lstat() check and subsequent operations in getfacl, setfacl, or chacl.

### Changes in 2.4.0

- Harden setfacl, getfacl, and chacl against malicious input
- Add new API functions: `acl_get_file_at()`, `acl_set_file_at()`, `acl_delete_def_file_at()` for safer operations using file descriptors
- Remove libacl dependency on libattr
- Reject invalid numeric UIDs and GIDs in libacl
- Fix NULL pointer dereferences and memory corruption
- Fix setfacl --restore for pathnames beginning with whitespace
- Prevent setfacl --restore --test from changing file permissions
- Fix memory wasting loop when user does not exist
- Improve errno handling in acl permission functions
- Internalize walk_tree API and replace with hardened version
- Comprehensive test suite improvements
- Documentation updates and translation updates

### Testing

Built and tested locally on x86_64:
- Package builds successfully
- getfacl, setfacl, chacl all work correctly
- libacl.so.1.2.2400 installed and functional
- ACL operations verified (setfacl/getfacl on test files)

This is a security-critical update affecting a core system library.