### PR TITLE
python3-uvicorn: update to 0.51.0

### DIFF
--- a/srcpkgs/python3-uvicorn/template
+++ b/srcpkgs/python3-uvicorn/template
@@ -1,6 +1,6 @@
 # Template file for 'python3-uvicorn'
 pkgname=python3-uvicorn
-version=0.47.0
+version=0.51.0
 revision=1
 build_style=python3-pep517
 hostmakedepends="hatchling"
@@ -11,7 +11,7 @@ license="BSD-3-Clause"
 homepage="https://uvicorn.dev/"
 changelog="https://raw.githubusercontent.com/Kludex/uvicorn/refs/heads/main/docs/release-notes.md"
 distfiles="${PYPI_SITE}/u/uvicorn/uvicorn-${version}.tar.gz"
-checksum=7c9a0ea1a9414106bbab7324609c162d8fa0cdcdcb703060987269d77c7bb533
+checksum=f6f4b69b657c312f516dd2d268ab9ae6f254b11e4bac504f37b2ab58b24dd0b0
 
 post_install() {
 	vlicense LICENSE.md


### PR DESCRIPTION
- I tested the changes in this PR: **NO**
- I built this PR locally for my native architecture, (x86_64-glibc)