### PR TITLE
[WIP] python3 aiohttp

### DIFF
--- a/srcpkgs/python3-aiodns/template
+++ b/srcpkgs/python3-aiodns/template
@@ -1,16 +1,17 @@
 # Template file for 'python3-aiodns'
 pkgname=python3-aiodns
-version=2.0.0
-revision=7
-build_style=python3-module
-hostmakedepends="python3-setuptools"
+version=4.0.4
+revision=1
+build_style=python3-pep517
+hostmakedepends="python3-setuptools python3-pycares"
 depends="python3-pycares"
+checkdepends="${depends} python3-pytest python3-pytest-asyncio python3-pytest-cov python3-uvloop"
 short_desc="Asynchronous Python DNS library using asyncio"
 maintainer="Franklin Delehelle <franklin.delehelle@odena.eu>"
 license="MIT"
 homepage="https://github.com/saghul/aiodns"
-distfiles="${PYPI_SITE}/a/aiodns/aiodns-${version}.tar.gz"
-checksum=815fdef4607474295d68da46978a54481dd1e7be153c7d60f9e72773cd38d77d
+distfiles="https://github.com/aio-libs/aiodns/archive/refs/tags/v4.0.4.tar.gz"
+checksum=c3928cf575ec8e707264eb8ffd4ad22c20c8398c62422cc7e4c94f9c827acf0e
 
 post_install() {
 	vlicense LICENSE

--- a/srcpkgs/python3-aiodns/template
+++ b/srcpkgs/python3-aiodns/template
@@ -1,16 +1,18 @@
 # Template file for 'python3-aiodns'
 pkgname=python3-aiodns
-version=2.0.0
-revision=7
-build_style=python3-module
-hostmakedepends="python3-setuptools"
+version=4.0.4
+revision=1
+build_style=python3-pep517
+hostmakedepends="python3-setuptools python3-pycares"
 depends="python3-pycares"
+checkdepends="${depends} python3-pytest python3-pytest-asyncio python3-pytest-cov python3-uvloop"
 short_desc="Asynchronous Python DNS library using asyncio"
 maintainer="Franklin Delehelle <franklin.delehelle@odena.eu>"
 license="MIT"
 homepage="https://github.com/saghul/aiodns"
-distfiles="${PYPI_SITE}/a/aiodns/aiodns-${version}.tar.gz"
-checksum=815fdef4607474295d68da46978a54481dd1e7be153c7d60f9e72773cd38d77d
+changelog="https://github.com/aio-libs/aiodns/blob/master/ChangeLog"
+distfiles="https://github.com/aio-libs/aiodns/archive/refs/tags/v${version}.tar.gz"
+checksum=c3928cf575ec8e707264eb8ffd4ad22c20c8398c62422cc7e4c94f9c827acf0e
 
 post_install() {
 	vlicense LICENSE

--- a/srcpkgs/python3-aiohttp/template
+++ b/srcpkgs/python3-aiohttp/template
@@ -1,16 +1,31 @@
 # Template file for 'python3-aiohttp'
 pkgname=python3-aiohttp
-version=3.14.1
+version=3.14.3
 revision=1
 build_style=python3-pep517
+make_check_args="--deselect=tests/test_http_parser.py::test_http_response_parser_bad_chunked_strict_c
+ --deselect=tests/test_http_parser.py::test_http_response_parser_bad_chunked_strict_py
+ --deselect=tests/test_http_parser.py::test_http_response_parser_strict_headers
+ --deselect=tests/test_http_parser.py::test_http_response_parser_strict_obs_line_folding
+ --deselect=tests/test_proxy_functional.py::test_uvloop_secure_https_proxy
+ --deselect='tests/test_client_functional.py::test_invalid_idna[pyloop]'
+ --deselect=tests/test_circular_imports.py::test_no_warnings
+ --ignore=tests/autobahn/test_autobahn.py
+ --ignore=tests/test_benchmarks_client.py
+ --ignore=tests/test_benchmarks_client_request.py
+ --ignore=tests/test_benchmarks_client_ws.py
+ --ignore=tests/test_benchmarks_cookiejar.py
+ --ignore=tests/test_benchmarks_http_websocket.py
+ --ignore=tests/test_benchmarks_http_writer.py
+ -n auto
+ -W ignore::DeprecationWarning"
 hostmakedepends="python3-pkgconfig python3-setuptools python3-wheel"
 makedepends="python3-devel"
-depends="python3-aiohappyeyeballs python3-aiosignal python3-attrs python3-frozenlist python3-multidict
- python3-propcache python3-yarl"
+depends="python3-aiohappyeyeballs python3-aiosignal python3-attrs python3-frozenlist python3-multidict python3-propcache python3-yarl python3-packaging"
+checkdepends="${depends} python3-pytest python3-pytest-timeout python3-coverage python3-freezegun python3-gunicorn python3-pytest-mock python3-re-assert python3-Brotli python3-pytest-xdist python3-aiodns python3-time-machine python3-trustme python3-uvloop python3-zlib-ng python3-isal"
 short_desc="HTTP client/server for asyncio (PEP-3156)"
 maintainer="Michael Aldridge <maldridge@voidlinux.org>"
 license="Apache-2.0"
 homepage="https://aiohttp.readthedocs.io/"
 distfiles="${PYPI_SITE}/a/aiohttp/aiohttp-${version}.tar.gz"
-checksum=307f2cff90a764d329e77040603fa032db89c5c24fdad50c4c15334cba744035
-make_check=no # Depends on proxy.py and re_assert
+checksum=9491196535a88924a60afd5b5f434b5b203b6cc616250878dbdb223a8f7844bc

--- a/srcpkgs/python3-gunicorn/template
+++ b/srcpkgs/python3-gunicorn/template
@@ -1,0 +1,24 @@
+# Template file for 'python3-gunicorn'
+pkgname=python3-gunicorn
+version=26.0.0
+revision=1
+build_style=python3-pep517
+hostmakedepends="python3-setuptools"
+depends="python3-gevent python3-tornado python3-setproctitle python3-h2 python3-packaging python3-gunicorn_h1c"
+checkdepends="${depends} python3-pytest python3-pytest-asyncio python3-uvloop python3-coverage python3-pytest-cov"
+short_desc="WSGI HTTP Server for UNIX, fast clients and sleepy applications"
+maintainer="Jason Elswick <jason@jasondavid.us>"
+license="MIT"
+homepage="https://github.com/benoitc/gunicorn"
+distfiles="https://github.com/benoitc/gunicorn/archive/refs/tags/${version}.tar.gz"
+checksum=f027ccd517acc218e55a365bae4d52d04af92b45d1b511676fa74d321049383a
+
+do_check() {
+	python -m venv --system-site-packages test-env
+	test-env/bin/python -m installer dist/*.whl
+	test-env/bin/python -m pytest
+}
+
+post_install() {
+	vlicense LICENSE
+}

--- a/srcpkgs/python3-gunicorn_h1c/patches/correct-sse4.2-flags.patch
+++ b/srcpkgs/python3-gunicorn_h1c/patches/correct-sse4.2-flags.patch
@@ -1,0 +1,15 @@
+--- a/setup.py
++++ b/setup.py
+@@ -10,11 +10,8 @@ extra_compile_args = ["-O3"]
+ 
+ # Platform-specific SIMD flags
+-if platform.machine() in ("x86_64", "AMD64", "i686", "i386"):
++if os.environ.get("GUNICORN_H1C_SSE42") == "1":
+     # x86: Enable SSE4.2 for fast string operations
+     extra_compile_args.append("-msse4.2")
+-elif platform.machine() in ("arm64", "aarch64"):
+-    # ARM64: NEON is enabled by default on aarch64
+-    pass
+ 
+ # Base path for sources
+

--- a/srcpkgs/python3-gunicorn_h1c/template
+++ b/srcpkgs/python3-gunicorn_h1c/template
@@ -1,0 +1,19 @@
+# Template file for 'python3-gunicorn_h1c'
+pkgname=python3-gunicorn_h1c
+version=0.6.5
+revision=1
+build_style=python3-pep517
+hostmakedepends="python3-setuptools python3-wheel"
+makedepends="python3-devel"
+checkdepends="python3-pytest python3-pytest-benchmark"
+short_desc="HTTP/1.1 Gunicorn parser using picohttpparser with SIMD optimizations"
+maintainer="Jason Elswick <jason@jasondavid.us>"
+license="MIT"
+homepage="https://github.com/benoitc/gunicorn_h1c"
+changelog="https://github.com/benoitc/gunicorn_h1c/blob/main/CHANGELOG.md"
+distfiles="https://github.com/benoitc/gunicorn_h1c/archive/refs/tags/v${version}.tar.gz"
+checksum=0579c77498060d77661dd8b878769c458ee08d530d901c054778b8b34de8cb32
+
+post_install() {
+	vlicense LICENSE
+}

--- a/srcpkgs/python3-gunicorn_h1c/template
+++ b/srcpkgs/python3-gunicorn_h1c/template
@@ -1,0 +1,26 @@
+# Template file for 'python3-gunicorn_h1c'
+pkgname=python3-gunicorn_h1c
+version=0.6.9
+revision=1
+build_style=python3-pep517
+hostmakedepends="python3-setuptools python3-wheel"
+makedepends="python3-devel"
+checkdepends="python3-pytest python3-pytest-benchmark"
+short_desc="HTTP/1.1 Gunicorn parser using picohttpparser with SIMD optimizations"
+maintainer="Jason Elswick <jason@jasondavid.us>"
+license="MIT"
+homepage="https://github.com/benoitc/gunicorn_h1c"
+changelog="https://github.com/benoitc/gunicorn_h1c/blob/main/CHANGELOG.md"
+distfiles="https://github.com/benoitc/gunicorn_h1c/archive/refs/tags/v${version}.tar.gz"
+checksum=1e4de3f26e6765cb76f9ac05204a6bfa28827c93f90a5a7ad90cc1adad69de70
+
+pre_build() {
+	case "$XBPS_TARGET_MACHINE" in
+		x86_64|i686) export GUNICORN_H1C_SSE42=1 ;;
+		*) export GUNICORN_H1C_SSE42=0 ;;
+	esac
+}
+
+post_install() {
+	vlicense LICENSE
+}

--- a/srcpkgs/python3-isal/template
+++ b/srcpkgs/python3-isal/template
@@ -1,0 +1,15 @@
+# Template file for 'python3-isal'
+pkgname=python3-isal
+version=1.8.0
+revision=1
+build_style=python3-pep517
+hostmakedepends="python3-setuptools python3-setuptools_scm nasm"
+makedepends="python3-devel"
+short_desc="Faster zlib gzip (de)compression python bindings for isa-l library"
+maintainer="Jason Elswick <jason@jasondavid.us>"
+license="PSF-2.0"
+homepage="https://github.com/pycompression/python-isal"
+changelog="https://github.com/pycompression/python-isal/blob/develop/CHANGELOG.rst"
+distfiles="${PYPI_SITE}/i/isal/isal-${version}.tar.gz"
+checksum=124233e9a31a62030a07aafd48c26689561926f4e10417ed3ea46c211218f2b4
+make_check=no # ModuleNotFoundError: No module named 'test'

--- a/srcpkgs/python3-pycares/template
+++ b/srcpkgs/python3-pycares/template
@@ -1,18 +1,24 @@
 # Template file for 'python3-pycares'
 pkgname=python3-pycares
-version=3.1.1
-revision=8
-build_style=python3-module
-# using bundled c-ares which is patched for TTL support
-hostmakedepends="python3-setuptools python3-cffi"
-makedepends="python3-devel"
+version=5.0.1
+revision=1
+build_style=python3-pep517
+make_check_args="--deselect tests/test_all.py::DNSTest::test_gethostbyaddr --deselect tests/test_all.py::DNSTest::test_gethostbyaddr6 --deselect tests/test_all.py::DNSTest::test_getnameinfo --deselect tests/test_all.py::DNSTest::test_query_txt_chunked --deselect tests/test_all.py::DNSTest::test_getaddrinfo2 --deselect tests/test_all.py::DNSTest::test_getaddrinfo4 --deselect tests/test_all.py::DNSTest::test_getaddrinfo5 --deselect tests/test_all.py::DNSTest::test_query_a_rotate"
+hostmakedepends="python3-setuptools python3-wheel python3-cffi cmake"
+makedepends="python3-devel c-ares-devel"
 depends="python3-cffi"
+checkdepends="${depends} python3-pytest python3-idna"
 short_desc="Python interface for c-ares"
-maintainer="Orphaned <orphan@voidlinux.org>"
+maintainer="Jason Elswick <jason@jasondavid.us>"
 license="MIT"
 homepage="https://github.com/saghul/pycares"
-distfiles="${PYPI_SITE}/p/pycares/pycares-${version}.tar.gz"
-checksum=18dfd4fd300f570d6c4536c1d987b7b7673b2a9d14346592c5d6ed716df0d104
+changelog="https://github.com/saghul/pycares/blob/master/ChangeLog"
+distfiles="https://github.com/saghul/pycares/archive/refs/tags/v${version}.tar.gz"
+checksum=6b80a9824a15eff719d8dca261a90e86e60c57d01dbb941aabbcb4a505152308
+
+pre_build() {
+	export PYCARES_USE_SYSTEM_LIB=1
+}
 
 post_install() {
 	vlicense LICENSE

--- a/srcpkgs/python3-zlib-ng/template
+++ b/srcpkgs/python3-zlib-ng/template
@@ -1,0 +1,15 @@
+# Template file for 'python3-zlib-ng'
+pkgname=python3-zlib-ng
+version=1.0.0
+revision=1
+build_style=python3-pep517
+hostmakedepends="python3-setuptools python3-setuptools_scm"
+makedepends="python3-devel"
+short_desc="Replacement for Python's zlib and gzip modules using zlib-ng"
+maintainer="Jason Elswick <jason@jasondavid.us>"
+license="PSF-2.0"
+homepage="https://github.com/pycompression/python-zlib-ng"
+changelog="https://github.com/pycompression/python-zlib-ng/blob/develop/CHANGELOG.rst"
+distfiles="${PYPI_SITE}/z/zlib-ng/zlib_ng-${version}.tar.gz"
+checksum=c753cea73f9e803c246e9bf01a59eb652897ed8a19334ada0f968394c7f61650
+make_check=no # ModuleNotFoundError: No module named 'test'


### PR DESCRIPTION
- **New package: python3-isal-1.8.0**
- **New package: python3-zlib-ng-1.0.0**
- **New package: python3-gunicorn_h1c-0.6.9**
- **New package: python3-gunicorn-26.0.0**
- **python3-pycares: update to 5.0.1, adopt.**
- **python3-aiodns: update to 4.0.4.**
- **python3-aiohttp: update to 3.14.3, add tests.**

#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-libc

The other packages are for the aiohttp testing. It looked like aiodns and pycares were very much behind too.
