### PR TITLE
rustnet: update to 1.5.0

### DIFF
--- a/srcpkgs/rustnet/template
+++ b/srcpkgs/rustnet/template
@@ -1,6 +1,6 @@
 # Template file for 'rustnet'
 pkgname=rustnet
-version=1.4.0
+version=1.5.0
 revision=1
 archs="x86_64* aarch64*"
 build_style=cargo
@@ -13,7 +13,7 @@ license="Apache-2.0"
 homepage="https://github.com/domcyrus/rustnet"
 changelog="https://raw.githubusercontent.com/domcyrus/rustnet/refs/heads/main/CHANGELOG.md"
 distfiles="https://github.com/domcyrus/rustnet/archive/refs/tags/v${version}.tar.gz"
-checksum=846f89a9c6cb5a2de6b9d42cf5a8a435e343906cbe9083776ddcc7fdbbb8857b
+checksum=f6425992dc5a8a700323c1231d1833a135cd93424d86cfaa788eed6cb700fe33
 
 _setup_env() {
 	# workaround the cc-rs mixing CFLAGS for host and target.


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, (x64 glibc)