### PR TITLE
New package: moraine-0.2.2

### DIFF
--- a/srcpkgs/moraine/template
+++ b/srcpkgs/moraine/template
@@ -1,0 +1,36 @@
+# Template file for 'moraine'
+pkgname=moraine
+version=0.2.2
+revision=1
+build_style=cargo
+configure_args="--features gui"
+hostmakedepends="pkg-config"
+makedepends="gtk4-devel"
+depends="rsync openssh"
+short_desc="Snapshot-based backup over SSH/rsync and rclone (CLI + GTK app)"
+maintainer="Jonaz Thern <info@thern.io>"
+license="MIT"
+homepage="https://github.com/TheJonaz/moraine-backup"
+changelog="https://github.com/TheJonaz/moraine-backup/raw/main/CHANGELOG.md"
+distfiles="https://github.com/TheJonaz/moraine-backup/archive/refs/tags/v${version}.tar.gz"
+checksum=4af5288f7c3d72e96f56e383018dcb23bb6ec29a4c53d58bdaffc3d43ad92c87
+
+post_install() {
+	# desktop entry + icons
+	vinstall assets/moraine-gui.desktop 644 usr/share/applications
+	vinstall assets/moraine.svg 644 usr/share/icons/hicolor/scalable/apps
+	vinstall assets/moraine-256.png 644 usr/share/icons/hicolor/256x256/apps moraine.png
+	vinstall assets/moraine-128.png 644 usr/share/icons/hicolor/128x128/apps moraine.png
+
+	# runtime assets the GUI loads from $XDG_DATA_DIRS/moraine/assets
+	vinstall assets/hero-bg.png 644 usr/share/moraine/assets
+	vinstall assets/moraine-64.png 644 usr/share/moraine/assets
+	vinstall assets/moraine-256.png 644 usr/share/moraine/assets
+
+	vman man/moraine.1
+	vman man/moraine-gui.1
+	vlicense LICENSE
+}
+
+# optional runtime backend:
+#   rclone  — cloud/SFTP/FTP/SMB/WebDAV/S3 targets


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **NO**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

---

**moraine** is a snapshot backup tool written in Rust — hard-linked snapshots over SSH/rsync, plus an rclone backend for cloud/SFTP/FTP/SMB/WebDAV/S3. It ships both the `moraine` CLI and the `moraine-gui` GTK 4 desktop app (`build_style=cargo`, `--features gui`).

**Transparency:** this was prepared from a non-Void environment, so I could **not** run `./xbps-src pkg moraine` or `xlint template` locally — relying on CI here. The template builds from the v0.2.2 release tarball and its `checksum` was verified against the downloaded asset. Homepage: https://github.com/TheJonaz/moraine-backup (MIT).
