### PR TITLE
nomacs: update to 3.22.1

### DIFF
--- a/srcpkgs/nomacs/template
+++ b/srcpkgs/nomacs/template
@@ -1,31 +1,18 @@
 # Template file for 'nomacs'
 pkgname=nomacs
-version=3.17.2287
-revision=5
-_plugins_ver=3.17.2285
+version=3.22.1
+revision=1
 build_wrksrc=ImageLounge
 build_style=cmake
 configure_args="-DCMAKE_BUILD_TYPE=None -DENABLE_TRANSLATIONS=1
- -DUSE_SYSTEM_QUAZIP=1"
-hostmakedepends="pkg-config qt5-qmake qt5-host-tools quazip-devel"
-makedepends="qt5-tools-devel qt5-svg-devel exiv2-devel libopencv-devel
- libraw-devel quazip-devel"
+ -DENABLE_QUAZIP=1 -DUSE_SYSTEM_QUAZIP=1"
+hostmakedepends="pkg-config qt6-base qt6-declarative-host-tools quazip-qt6-devel bzip2-devel"
+makedepends="qt6-tools-devel qt6-svg-devel qt6-qt5compat-devel quazip-qt6-devel exiv2-devel libopencv-devel
+ libraw-devel"
+depends="qt6-imageformats kf6-kimageformats"
 short_desc="Simple yet powerful Qt imageviewer"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-3.0-or-later"
 homepage="https://github.com/nomacs/nomacs"
-distfiles="https://github.com/nomacs/nomacs/archive/${version}.tar.gz
- https://github.com/novomesk/nomacs-plugins/archive/refs/tags/${_plugins_ver}.tar.gz>plugins.tar.gz"
-checksum="6905ea615358f84a0c83d5b1b7077871dea0526ec667500a1951448cb845a92c
- 946b2d754be9ecca5cb155f7ecc5dcafb164f6c3dcc7bf5c3c0610d3b47774aa"
-skip_extraction="plugins.tar.gz"
-
-post_extract() {
-	cd ${build_wrksrc}
-	vsrcextract -C plugins "plugins.tar.gz"
-}
-
-post_patch() {
-	# XXX: remove this when updating, it no longer requires git as of 3.17.2295
-	vsed -i -e "s/import subprocess/return '${version}'/" ../scripts/versionupdate.py
-}
+distfiles="https://github.com/nomacs/nomacs/archive/${version}.tar.gz"
+checksum=c9607a110288172897995f682d3d9d6e759903540a0e1a9856f856a45ffb7ec7


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)

Note:

Moved to qt6 as per https://github.com/nomacs/nomacs notes, also qt6-imageformats and kf6-kimageformats added as dependencies as per the same notes.
Nomacs plugins don't seem to be updated anymore, maybe because additional image formats are now pulled from qt6/kf6?