### PR TITLE
vokoscreenNG: rebuild to fix Qt6 issue

### DIFF
--- a/srcpkgs/vokoscreenNG/template
+++ b/srcpkgs/vokoscreenNG/template
@@ -1,7 +1,7 @@
 # Template file for 'vokoscreenNG'
 pkgname=vokoscreenNG
 version=4.9.0
-revision=1
+revision=2
 build_style=qmake
 build_wrksrc="src"
 hostmakedepends="pkg-config qt6-base-devel qt6-tools-devel"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)

Fixes a Qt6 issue similar to the issue reported half a year ago in https://github.com/void-linux/void-packages/issues/58131.