### PR TITLE
ergo: update to 2.19.0.

### DIFF
--- a/srcpkgs/ergo/template
+++ b/srcpkgs/ergo/template
@@ -1,6 +1,6 @@
 # Template file for 'ergo'
 pkgname=ergo
-version=2.18.0
+version=2.19.0
 revision=1
 build_style=go
 go_import_path="github.com/ergochat/ergo"
@@ -12,7 +12,8 @@ license="MIT"
 homepage="https://ergo.chat/"
 changelog="https://raw.githubusercontent.com/ergochat/ergo/master/CHANGELOG.md"
 distfiles="https://github.com/ergochat/ergo/archive/v${version}.tar.gz"
-checksum=5dafcdc9b1eaed0273d54dc274a050d983f79057fbc529af0c52704b1a540680
+checksum=37abcccd951fb9b672efffaa90e021d5f7d8b6a300137e2d89d708986e041927
+conf_files="/etc/ergo.conf"
 system_accounts="_ergo"
 _ergo_homedir="/var/lib/ergo"
 make_dirs="/var/lib/ergo 0755 _ergo _ergo"
@@ -21,7 +22,7 @@ replaces="oragono>=0"
 post_install() {
 	vlicense LICENSE
 
-	vsconf default.yaml ergo.conf
+	vconf default.yaml ergo.conf
 
 	vinstall ergo.motd 644 usr/share/${pkgname} default.motd
 


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->
Also tweaked the package template to put the config file where it should be by default as per the service

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc