### PR TITLE
rhash: fix use of SSE4 instructions on i686

### DIFF
--- a/srcpkgs/rhash/template
+++ b/srcpkgs/rhash/template
@@ -1,7 +1,7 @@
 # Template file for 'rhash'
 pkgname=rhash
 version=1.4.6
-revision=1
+revision=2
 build_style=configure
 configure_args="--enable-openssl --prefix=/usr --sysconfdir=/etc"
 make_install_target="install install-lib-headers"
@@ -13,6 +13,14 @@ license="0BSD"
 homepage="https://github.com/rhash/RHash"
 distfiles="https://github.com/rhash/RHash/archive/v${version}.tar.gz"
 checksum=9f6019cfeeae8ace7067ad22da4e4f857bb2cfa6c2deaa2258f55b2227ec937a
+
+case "$XBPS_TARGET_MACHINE" in
+	i686*)
+		# configure.sh does compile checks for SSE4 instructions that are not available on
+		# i686 targets
+		configure_args+=" --disable-shani"
+		;;
+esac
 
 post_extract() {
 	vsed -i -e 's/__GLIBC__/__linux__/' librhash/byte_order.h


### PR DESCRIPTION
On my i686 system this compile test succeeded with `gcc` 14.2.1, so it baked SSE4 intrinsics into the binary:

https://github.com/rhash/RHash/blob/3dbba4baa3cbdc3baf06d3ba086d8094bd98cd88/configure#L771-L791

Even though the compiler may support SSE4, the i686 target does not. We're disabling "sha1 intrinsics" detection for i686 targets with `--disable-shani`:

https://github.com/rhash/RHash/blob/3dbba4baa3cbdc3baf06d3ba086d8094bd98cd88/configure#L169-L171

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (i686-glibc)
- It should not change compilation for other architectures.

Fixes: #59135 