### PR TITLE
httpstat: update to 1.2.1, adopt

### DIFF
--- a/srcpkgs/httpstat/template
+++ b/srcpkgs/httpstat/template
@@ -1,16 +1,16 @@
 # Template file for 'httpstat'
 pkgname=httpstat
-version=1.1.0
-revision=4
+version=1.2.1
+revision=1
 build_style=go
-go_ldflags="-X=main.version=$version"
+go_ldflags="-X=main.version=${version}"
 go_import_path="github.com/davecheney/httpstat"
 short_desc="It's like curl -v, with colours"
-maintainer="Orphaned <orphan@voidlinux.org>"
+maintainer="elbachir-one <bachiralfa@gmail.com>"
 license="MIT"
 homepage="https://github.com/davecheney/httpstat"
-distfiles="https://github.com/davecheney/httpstat/archive/v${version}.tar.gz"
-checksum=58260ab0a56557d0c2509ea09ee3fe54fe21a49f95d94189efdd64caec84fa67
+distfiles="https://github.com/davecheney/httpstat/archive/refs/tags/v${version}.tar.gz"
+checksum=be3f191a0b07ef3a38b94c0bb9a821b2fc33ea347525a193a167173a2198191c
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)