### PR TITLE
orc: update to 0.4.42.

### DIFF
--- a/srcpkgs/orc/template
+++ b/srcpkgs/orc/template
@@ -1,25 +1,17 @@
 # Template file for 'orc'
 pkgname=orc
-version=0.4.41
-revision=2
+version=0.4.42
+revision=1
 build_style=meson
-build_helper="gir"
-configure_args="-Dexamples=disabled -Dtests=disabled
- $(vopt_feature gtk_doc gtk_doc)"
-hostmakedepends="pkg-config $(vopt_if gtk_doc gtk-doc)"
-short_desc="Oild Runtime Compiler"
+configure_args="-Dexamples=disabled -Dtests=disabled -Dhotdoc=disabled"
+hostmakedepends="pkg-config"
+short_desc="Oil Runtime Compiler"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="BSD-2-Clause"
-homepage="https://cgit.freedesktop.org/gstreamer/orc"
+homepage="https://gitlab.freedesktop.org/gstreamer/orc"
 changelog="https://gitlab.freedesktop.org/gstreamer/orc/-/raw/main/RELEASE"
 distfiles="http://gstreamer.freedesktop.org/src/orc/orc-${version}.tar.xz"
-checksum=cb1bfd4f655289cd39bc04642d597be9de5427623f0861c1fc19c08d98467fa2
-
-build_options="gtk_doc"
-
-if [ -z "$CROSS_BUILD" ]; then
-	build_options_default+=" gtk_doc"
-fi
+checksum=7ec912ab59af3cc97874c456a56a8ae1eec520c385ec447e8a102b2bd122c90c
 
 post_install() {
 	vlicense COPYING
@@ -32,8 +24,5 @@ orc-devel_package() {
 		vmove usr/include
 		vmove usr/lib/pkgconfig
 		vmove "usr/lib/*.so"
-		if [ "$build_option_gtk_doc" ]; then
-			vmove usr/share/gtk-doc
-		fi
 	}
 }


### PR DESCRIPTION
Update orc from 0.4.41 to 0.4.42.

Changes:
- Update version and checksum
- Remove gtk-doc build option (replaced by hotdoc upstream, not packaged in Void)
- Remove gobject-introspection build helper (removed upstream)
- Fix homepage URL (cgit -> gitlab)
- Fix typo in short_desc ("Oild" -> "Oil")