### PR TITLE
luajit: update to 2.1.1785192264

### DIFF
--- a/srcpkgs/LuaJIT/template
+++ b/srcpkgs/LuaJIT/template
@@ -1,9 +1,9 @@
 # Template file for 'LuaJIT'
 pkgname=LuaJIT
 # the minor version is the contents of the .relver file in the source tarball
-version=2.1.1783773675
+version=2.1.1785192264
 revision=1
-_commit=3c4f9fe2052b8d08a917ac0d5f38563f0297b5a3
+_commit=faaf663340347a78b22ed94c63c24fe090bd9784
 build_style=gnu-makefile
 hostmakedepends="lua52-BitOp"
 short_desc="Just-In-Time Compiler for Lua"
@@ -11,7 +11,7 @@ maintainer="Daniel Martinez <danielmartinez@cock.li>"
 license="MIT"
 homepage="https://www.luajit.org"
 distfiles="https://github.com/LuaJIT/LuaJIT/archive/${_commit}.tar.gz"
-checksum=295f9e6722a2200aaf41297b28f73d337ac12236cdf1788981e46bd0afd466ff
+checksum=d8d51b50a6b6046848be6632aef06305b4d9326a79e9ddd4f2e0705f1fc3f750
 
 _host_cc="cc"
 if [ -n "$CROSS_BUILD" ]; then


### PR DESCRIPTION
Previously LuaJIT crashed on i686 machines that have no SSE3. The bug was fixed upstream in https://github.com/LuaJIT/LuaJIT/commit/faaf663340347a78b22ed94c63c24fe090bd9784, which is the current head of the (moving) `v2.1` tag.

The bug was observed as a crash at launch of the neovim 0.12.4 package, which uses LuaJIT. After updating LuaJIT, LuaJIT and neovim work as expected.

#### Testing the changes
- I tested the changes in this PR: **YES**
  - I build the updated LuaJIT and tested that the crash is gone with LuaJIT and neovim.
  - I build-tested (`-Q`) `libluv` which is a rev-dep of LuaJIT.

#### Local build testing
- I built this PR locally for my native architecture, (i686-glibc)
