### PR TITLE
python3-pikepdf: update to 10.10.0

### DIFF
--- a/srcpkgs/python3-pikepdf/template
+++ b/srcpkgs/python3-pikepdf/template
@@ -1,23 +1,22 @@
 # Template file for 'python3-pikepdf'
 pkgname=python3-pikepdf
-version=10.9.1
+version=10.10.0
 revision=1
 build_style=python3-pep517
-hostmakedepends="python3-pybind11 python3-wheel python3-scikit-build-core
- ninja python3-nanobind"
-makedepends="libqpdf-devel python3-pybind11"
-depends="jbig2dec python3-deprecated python3-lxml python3-packaging
- python3-Pillow python3-setuptools"
-checkdepends="poppler python3-dateutil python3-hypothesis python3-numpy
- python3-psutil python3-pytest python3-pytest-timeout python3-pytest-xdist
- $depends"
+hostmakedepends="ninja python3-scikit-build-core python3-nanobind"
+makedepends="libqpdf-devel python3-devel"
+depends="python3-lxml python3-packaging python3-Pillow"
+checkdepends="$depends python3-pytest python3-pytest-cov python3-pytest-timeout python3-pytest-xdist
+ python3-dateutil python3-numpy python3-psutil python3-nanobind python3-hypothesis python3-attrs"
 short_desc="Python library for reading and writing PDF files"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="MPL-2.0"
 homepage="https://github.com/pikepdf/pikepdf"
-changelog="https://raw.githubusercontent.com/pikepdf/pikepdf/master/docs/releasenotes/version${version%%.*}.rst"
+changelog="https://raw.githubusercontent.com/pikepdf/pikepdf/main/docs/releasenotes/version${version%%.*}.md"
 distfiles="${PYPI_SITE}/p/pikepdf/pikepdf-${version}.tar.gz"
-checksum=410fcf32bc9c8a0a96d94bbd6268ba7585333b1423b93a5fa2ef3c05f4eba3da
+checksum=9f134806b2fe608ccb21379a664ddcefeac3f6944100d343b350299d3c69754e
+
+export CMAKE_ARGS="-DPython_INCLUDE_DIR:PATH=${XBPS_CROSS_BASE}/${py3_inc}"
 
 if [ "$XBPS_BUILD_ENVIRONMENT" = "void-packages-ci" ]; then
 	make_check_args="-k not((test_save_to_dev_null)or(test_repr_stream))"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

I took the liberty of cleaning up dependencies to reflect the current requirements in pyproject.toml.
Changelog led to 404 so I edited it, too.

#### Local build testing
- I built this PR locally for my native architecture: x86_64-glibc
