### PR TITLE
New package: awsvpnclient-5.4.0

### DIFF
--- a/srcpkgs/awsvpnclient/INSTALL
+++ b/srcpkgs/awsvpnclient/INSTALL
@@ -1,0 +1,12 @@
+case "${ACTION}" in
+post)
+	# Generate FIPS module integrity config required by the bundled OpenSSL.
+	# fips.so uses musl, so we invoke it via the bundled musl linker.
+	/opt/awsvpnclient/Service/Resources/openvpn/ld-musl-x86_64.so.1 \
+		/opt/awsvpnclient/Service/Resources/openvpn/openssl fipsinstall \
+		-module /opt/awsvpnclient/Service/Resources/openvpn/fips.so \
+		-out /opt/awsvpnclient/Service/Resources/openvpn/fipsmodule.cnf \
+		>/dev/null 2>&1
+	echo "awsvpnclient: enable the service with: ln -s /etc/sv/awsvpnclient /var/service/"
+	;;
+esac

--- a/srcpkgs/awsvpnclient/files/awsvpnclient/run
+++ b/srcpkgs/awsvpnclient/files/awsvpnclient/run
@@ -1,0 +1,3 @@
+#!/bin/sh
+export PATH=/usr/libexec/awsvpnclient:${PATH}
+exec /opt/awsvpnclient/Service/ACVC.GTK.Service 2>&1

--- a/srcpkgs/awsvpnclient/files/resolvectl
+++ b/srcpkgs/awsvpnclient/files/resolvectl
@@ -1,0 +1,27 @@
+#!/bin/sh
+action="${1}"
+shift
+
+case "${action}" in
+	dns)
+		shift # skip interface arg
+		for ns in "$@"; do
+			grep -q "nameserver ${ns}" /etc/resolv.conf 2>/dev/null || \
+				printf 'nameserver %s\n' "${ns}" >> /etc/resolv.conf
+		done
+		;;
+	domain)
+		shift # skip interface arg
+		for d in "$@"; do
+			grep -q "search ${d}" /etc/resolv.conf 2>/dev/null || \
+				printf 'search %s\n' "${d}" >> /etc/resolv.conf
+		done
+		;;
+	revert)
+		[ -f /etc/resolv.conf.awsvpn-bak ] && \
+			cp /etc/resolv.conf.awsvpn-bak /etc/resolv.conf
+		;;
+	status)
+		;;
+esac
+exit 0

--- a/srcpkgs/awsvpnclient/patches/awsvpnclient.desktop.patch
+++ b/srcpkgs/awsvpnclient/patches/awsvpnclient.desktop.patch
@@ -1,0 +1,11 @@
+--- a/usr/share/applications/awsvpnclient.desktop
++++ b/usr/share/applications/awsvpnclient.desktop
+@@ -3,7 +3,7 @@
+ Type=Application
+ Encoding=UTF-8
+ Name=AWS VPN Client
+ Comment=AWS VPN Client
+-Exec="/opt/awsvpnclient/AWS\sVPN\sClient" %u
++Exec="/opt/awsvpnclient/AWS VPN Client" %u
+ Path=/opt/awsvpnclient
+ Icon=acvc-64.png

--- a/srcpkgs/awsvpnclient/template
+++ b/srcpkgs/awsvpnclient/template
@@ -1,0 +1,30 @@
+# Template file for 'awsvpnclient'
+pkgname=awsvpnclient
+version=5.4.0
+revision=1
+archs="x86_64"
+depends="xdg-utils lsof"
+short_desc="Official AWS VPN Client for Linux"
+maintainer="Orphaned <orphan@voidlinux.org>"
+license="custom:awsvpnclient"
+homepage="https://aws.amazon.com/vpn/"
+distfiles="https://d20adtppz83p9s.cloudfront.net/GTK/${version}/awsvpnclient_amd64.deb"
+checksum="7dd9e28962bf64bf94ef41b8e1f68de5e0d0393d71300767698fb336c69276cc"
+nostrip=yes
+restricted=yes
+repository=nonfree
+
+do_install() {
+	vcopy opt /
+	vcopy usr /
+
+	# runit service for the VPN daemon
+	vsv awsvpnclient
+
+	# resolvectl shim — configure-dns calls resolvectl (systemd-resolved) which does not
+	# exist on Void. Installed to libexec; the runit run script prepends it to PATH so
+	# configure-dns finds it without modifying the integrity-checked configure-dns script.
+	vinstall ${FILESDIR}/resolvectl 755 usr/libexec/awsvpnclient
+
+	vlicense "${DESTDIR}/opt/awsvpnclient/Resources/LINUX-LICENSE.txt"
+}


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- Installed the package, started the runit service, launched the GUI, and connected a VPN (DNS via the resolvectl shim)

<!-- No cross builds: upstream only ships an amd64 .deb (archs="x86_64"). -->

AWS VPN Client from the upstream GTK `.deb` (`nonfree`, `restricted=yes`).

Notes from getting it running on Void (`void-base`, x86_64, glibc 2.41, kernel 6.18):

Upstream only publishes `awsvpnclient_amd64.deb`, so this is x86_64 only. Cross builds don't apply.

The `.deb` expects systemd. Void uses runit, so `files/awsvpnclient/run` starts `ACVC.GTK.Service`. The GUI does not connect without that daemon.

`configure-dns` calls `resolvectl` (systemd-resolved), which Void does not have. Patching that script failed with `OvpnResourcesChecksumValidationFailed`. The shim lives in `/usr/libexec/awsvpnclient`, and the run script prepends that dir to `PATH` so the lookup works without touching the checksummed file. libexec keeps it out of `/usr/bin`.

The `.desktop` Exec line ships as `AWS\sVPN\sClient`, which breaks on Void. `patches/awsvpnclient.desktop.patch` fixes the path.

Connect hit `UnableToEnforceFipsException` until `fipsmodule.cnf` was generated with the bundled musl OpenSSL/`fips.so`. The INSTALL hook does that after install.