### PR TITLE
checkbashisms: update to 2.26.10

### DIFF
--- a/srcpkgs/checkbashisms/template
+++ b/srcpkgs/checkbashisms/template
@@ -1,6 +1,6 @@
 # Template file for 'checkbashisms'
 pkgname=checkbashisms
-version=2.26.9
+version=2.26.10
 revision=1
 depends="perl"
 checkdepends="shunit2 perl"
@@ -10,7 +10,7 @@ license="GPL-2.0-or-later"
 homepage="https://tracker.debian.org/pkg/devscripts"
 changelog="https://tracker.debian.org/media/packages/d/devscripts/changelog-${version}"
 distfiles="${DEBIAN_SITE}/main/d/devscripts/devscripts_${version}.tar.xz"
-checksum=61429335d33a3e744966185bda49e7a354705c0e59600f17d50c1e656d39066e
+checksum=c5778b09ada6f8a084f97828721ced03d2fc03a07244911c9e072ccdb9b9400e
 
 pre_install() {
 	vsed -i "s|###VERSION###|${version}|" scripts/checkbashisms.pl


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **yes**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl (cross)
  - aarch64 (cross)
  - i686 (cross)
  - armv7l-musl (cross)
  - armv7l (cross)
  - armv6l-musl (cross)
  - armv6l (cross)