### PR TITLE
openvpn: update to 2.7.5

### DIFF
--- a/srcpkgs/openvpn/template
+++ b/srcpkgs/openvpn/template
@@ -1,6 +1,6 @@
 # Template file for 'openvpn'
 pkgname=openvpn
-version=2.7.4
+version=2.7.5
 revision=1
 build_style=gnu-configure
 configure_args="$(vopt_enable pkcs11) --disable-systemd
@@ -16,7 +16,7 @@ license="GPL-2.0-only"
 homepage="https://www.openvpn.net"
 changelog="https://raw.githubusercontent.com/OpenVPN/openvpn/release/${version%.*}/Changes.rst"
 distfiles="https://build.openvpn.net/downloads/releases/openvpn-${version}.tar.gz"
-checksum=18db05f3d5eee3663db1914590044e5f96ff5cd47b6e7846c6a350806c23dbce
+checksum=c6864b3c7d4e059c7d6ce22d1b5fa646c8b379a06af872eeb9792b6083a44ac4
 # t_net.sh fails on CI.
 make_check=ci-skip
 


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **yes**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl (cross)
  - aarch64 (cross)
  - i686 (cross)
  - armv7l-musl (cross)
  - armv7l (cross)
  - armv6l-musl (cross)
  - armv6l (cross)