### PR TITLE
libebml: update to 1.4.7, adopt; libmatroska: update to 1.7.2

### DIFF
--- a/srcpkgs/libebml/template
+++ b/srcpkgs/libebml/template
@@ -1,16 +1,17 @@
 # Template file for 'libebml'
 pkgname=libebml
-version=1.4.5
+version=1.4.7
 revision=1
 build_style=cmake
 configure_args="-DBUILD_SHARED_LIBS=ON"
+makedepends="utfcpp"
 short_desc="Extensible Binary Meta Language library"
-maintainer="Orphaned <orphan@voidlinux.org>"
+maintainer="Matthias von Faber <mvf@gmx.eu>"
 license="LGPL-2.1-or-later"
 homepage="https://matroska-org.github.io/libebml/"
 changelog="https://github.com/Matroska-Org/libebml/raw/master/NEWS.md"
 distfiles="https://dl.matroska.org/downloads/libebml/libebml-${version}.tar.xz"
-checksum=4971640b0592da29c2d426f303e137a9b0b3d07e1b81d069c1e56a2f49ab221b
+checksum=5b08214f929ee54c6187c370f84235fc9d0f2a2258c4d320d68eae6e2bdfd3f7
 
 libebml-devel_package() {
 	depends="libebml>=${version}_${revision}"

--- a/srcpkgs/libmatroska/template
+++ b/srcpkgs/libmatroska/template
@@ -1,6 +1,6 @@
 # Template file for 'libmatroska'
 pkgname=libmatroska
-version=1.7.1
+version=1.7.2
 revision=1
 build_style=cmake
 configure_args="-DBUILD_SHARED_LIBS=ON"
@@ -11,7 +11,7 @@ license="LGPL-2.1-or-later"
 homepage="https://www.matroska.org/downloads/libraries.html"
 changelog="https://raw.githubusercontent.com/Matroska-Org/libmatroska/master/NEWS.md"
 distfiles="https://github.com/Matroska-Org/libmatroska/archive/refs/tags/release-${version}.tar.gz"
-checksum=64763443947833e6c17f1f555f4bb0df6c9f91881810d9d5e0f0bad3622d308b
+checksum=ef1104f1d77971ac95a33ae6184656fc5ddb51232ca542c31c31daaa493fe204
 
 libmatroska-devel_package() {
 	depends="${makedepends} ${sourcepkg}>=${version}_${revision}"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

---

Tested on `x86_64` (glibc):

- `vlc` and the `mkvtoolnix` utilities still working
- `gerbera` starts but I didn't test it further
- `mplayer` has a bogus `makedepends=libmatroska-devel` but, like `mpv`, ships its own EBML/Matroska implementation and is not affected by this change.

One PR since these libs kinda belong together.

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
