### PR TITLE
udevil: add runit service for devmon

### DIFF
--- a/srcpkgs/udevil/files/devmon/run
+++ b/srcpkgs/udevil/files/devmon/run
@@ -1,0 +1,4 @@
+#!/bin/sh
+exec 2>&1
+[ -r conf ] && . ./conf
+exec devmon ${OPTS}

--- a/srcpkgs/udevil/template
+++ b/srcpkgs/udevil/template
@@ -1,7 +1,7 @@
 # Template file for 'udevil'
 pkgname=udevil
 version=0.4.4
-revision=5
+revision=6
 build_style=gnu-configure
 configure_args="--disable-systemd"
 conf_files="/etc/udevil/udevil.conf"
@@ -16,4 +16,8 @@ checksum=ad2fd8375bd62622718a04235e9772119459089938dbb78e657955e595822b7c
 
 post_patch() {
 	vsed -i -e '/DATADIRNAME=/s/=.*/=share/' configure
+}
+
+post_install() {
+	vsv devmon
 }


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**. I installed the new build, enabled the service and tested my e-reader automounted.

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->

devmon ships with udevil and is actually the main reason I wanted to install the package to begin with.