### PR TITLE
incus: update to 7.3.0

### DIFF
--- a/srcpkgs/incus/template
+++ b/srcpkgs/incus/template
@@ -1,10 +1,10 @@
 # Template file for 'incus'
 pkgname=incus
-version=6.22.0
+version=7.3.0
 revision=1
 build_style=go
 build_helper=qemu
-go_import_path=github.com/lxc/incus/v6
+go_import_path=github.com/lxc/incus/v7
 go_build_tags="libsqlite3"
 go_package="${go_import_path}/cmd/..."
 make_check_args="-skip TestConvertNetworkConfig"
@@ -18,7 +18,7 @@ maintainer="dkwo <npiazza@disroot.org>"
 license="Apache-2.0"
 homepage="https://linuxcontainers.org/incus"
 distfiles="https://github.com/lxc/incus/archive/refs/tags/v${version}.tar.gz"
-checksum=5e8a8526e0f2f9b4062a9e40c09e335986ea24981b706487988ca06a7b323a52
+checksum=d140be0c9944f930ca46b92b8f660b00dbc8de58aebf235680c92fd6f5db0398
 system_groups="_incus-admin _incus"
 make_dirs="
  /var/lib/incus 0755 root root
@@ -43,7 +43,7 @@ post_install() {
 	# avoid conflict with lxd, lxd-lts
 	mv ${DESTDIR}/usr/bin/{fuidshift,fuidshift-incus}
 	# upstream recommends these should be kept to root only
-	for _tool in fuidshift-incus lxd-to-incus; do
+	for _tool in fuidshift-incus; do
 		chmod 700 ${DESTDIR}/usr/bin/${_tool}
 	done
 
@@ -67,7 +67,7 @@ incus-client_package() {
 incus-tools_package() {
 	short_desc+=" - tools"
 	pkg_install() {
-		for _tool in fuidshift-incus lxc-to-incus lxd-to-incus \
+		for _tool in fuidshift-incus lxc-to-incus \
 		incus-benchmark incus-migrate incus-simplestreams \
 		generate-config generate-database; do
 			vmove usr/bin/${_tool}


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES** (using it for the past week to setup two different clusters with IncusOS as well as work with LXC and OCI containers locally along with skopeo)

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)

#### Notes
~~This in an LTS version, the latest is [7.2.0](https://github.com/lxc/incus/releases/tag/v7.2.0)~~