### PR TITLE
Manual: improve documentation on checksum

### DIFF
--- a/Manual.md
+++ b/Manual.md
@@ -545,7 +545,7 @@ on the fly on the server, like e.g. snapshot tarballs from any of the
 `https://*.googlesource.com/` sites, the checksum of the `archive contents`
 can be specified by prepending a commercial at (@).
 For tarballs you can find the contents checksum by using the command
-`tar xf <tarball.ext> --to-stdout | sha256sum`.
+`tar xf <tarball.ext> --to-stdout | xbps-digest`.
 
 - `wrksrc` The directory name where the package sources are extracted, set to `${pkgname}-${version}`.
 

--- a/Manual.md
+++ b/Manual.md
@@ -536,7 +536,8 @@ Example:
 
 - `checksum` The `sha256` digests matching `${distfiles}`. Multiple files can be
 separated by blanks. Please note that the order must be the same than
-was used in `${distfiles}`. Example: `checksum="kkas00xjkjas"`
+was used in `${distfiles}`.
+Example: `checksum=ee43eb65b005b1adf2914a8e462466d0cc4b4b639bf7ba1e62741f2ab2a6fb0f`.
 
 If a distfile changes its checksum for every download because it is packaged
 on the fly on the server, like e.g. snapshot tarballs from any of the

--- a/Manual.md
+++ b/Manual.md
@@ -536,7 +536,8 @@ Example:
 
 - `checksum` The `sha256` digests matching `${distfiles}`. Multiple files can be
 separated by blanks. Please note that the order must be the same than
-was used in `${distfiles}`.
+was used in `${distfiles}`. You can manually generate the checksum using
+`xbps-digest <distfile>`.
 Example: `checksum=ee43eb65b005b1adf2914a8e462466d0cc4b4b639bf7ba1e62741f2ab2a6fb0f`.
 
 If a distfile changes its checksum for every download because it is packaged

--- a/Manual.md
+++ b/Manual.md
@@ -512,7 +512,7 @@ can be separated by whitespaces. The files must end in `.tar.lzma`, `.tar.xz`,
 `.txz`, `.tar.bz2`, `.tbz`, `.tar.gz`, `.tgz`, `.gz`, `.bz2`, `.tar` or
 `.zip`. To define a target filename, append `>filename` to the URL.
 Example:
-	distfiles="http://foo.org/foo-1.0.tar.gz http://foo.org/bar-1.0.tar.gz>bar.tar.gz"
+`distfiles="http://foo.org/foo-1.0.tar.gz http://foo.org/bar-1.0.tar.gz>bar.tar.gz"`.
 
   To avoid repetition, several variables for common hosting sites
   exist:


### PR DESCRIPTION
This is a proposal, because I'm not sure if all changes are desired. I committed in small chunks so parts can be dropped easily. I can squash everything if that is preferred.

I tried to find how to generate a checksum and couldn't find it. It says "sha256", but I find a command builds more confidence for newbies. I first selected the wrong command when skimming the docs and used `tar xf <tarball.ext> --to-stdout | sha256sum`.

Also I changed `sha256sum` to `xbps-digest`, which is what `xbps-src` uses internally.

Thanks