### PR TITLE
vala-panel-appmenu: fix appmenu-gtk-module gschema package split

### DIFF
--- a/srcpkgs/vala-panel-appmenu/template
+++ b/srcpkgs/vala-panel-appmenu/template
@@ -1,7 +1,7 @@
 # Template file for 'vala-panel-appmenu'
 pkgname=vala-panel-appmenu
 version=25.04
-revision=1
+revision=2
 build_style=meson
 build_helper="gir"
 configure_args="-Dxfce=enabled -Dmate=disabled -Dbudgie=disabled
@@ -27,7 +27,6 @@ appmenu-glib-translator_package() {
 	pkg_install() {
 		vmove usr/lib/libappmenu-glib-translator*.so.*
 		vmove usr/share/gir-1.0
-		vmove usr/share/glib-2.0
 		vmove usr/share/vala
 	}
 }
@@ -58,6 +57,7 @@ appmenu-gtk3-module_package() {
 	depends="vala-panel-appmenu-registrar-${version}_${revision}"
 	pkg_install() {
 		vmove usr/lib/gtk-3.0
+		vmove usr/share/glib-2.0/schemas/org.appmenu.gtk-module.gschema.xml
 		vmove "usr/lib/libappmenu-gtk3*.so.*"
 		vmove etc/X11/xinit/xinitrc.d/80-appmenu-gtk-module.sh
 	}


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl
