### PR TITLE
mitmproxy: update to 12.2.3

### DIFF
--- a/srcpkgs/mitmproxy/template
+++ b/srcpkgs/mitmproxy/template
@@ -1,13 +1,13 @@
 # Template file for 'mitmproxy'
 pkgname=mitmproxy
-version=11.1.3
-revision=2
+version=12.2.3
+revision=1
 build_style=python3-pep517
 hostmakedepends="python3-setuptools"
 depends="python3-aioquic python3-Brotli python3-Flask python3-argon2 python3-asgiref
- python3-certifi python3-cryptography python3-h11 python3-h2 python3-hyperframe
+ python3-bcrypt python3-certifi python3-cryptography python3-h11 python3-h2 python3-hyperframe
  python3-kaitaistruct python3-ldap3 python3-mitmproxy-rs python3-msgpack python3-openssl
- python3-parsing python3-passlib python3-publicsuffix2 python3-pyperclip python3-ruamel.yaml
+ python3-parsing python3-publicsuffix2 python3-pyperclip python3-ruamel.yaml
  python3-sortedcontainers python3-tornado python3-urwid python3-wsproto python3-zstandard"
 checkdepends="${depends} python3-hypothesis python3-parver
  python3-pytest-asyncio python3-pytest-cov python3-pytest-timeout python3-requests"
@@ -17,7 +17,7 @@ license="MIT"
 homepage="https://mitmproxy.org"
 changelog="https://raw.githubusercontent.com/mitmproxy/mitmproxy/main/CHANGELOG.md"
 distfiles="https://github.com/mitmproxy/mitmproxy/archive/refs/tags/v${version}.tar.gz"
-checksum=bb4f6fc8e9ac64b4c725811983e3e3ff6b2b18b2a992d80d816811709e9efde5
+checksum=39073f414cdb9a0bf438b875da0e79bb306bcb7d1331b580763886f509f78c1b
 
 _skip="(test_get_version)" # This test fails without a git repository
 _skip+="or(test_wireguard)" # Tries to execute a helper binary compiled for glibc

--- a/srcpkgs/python3-bcrypt/template
+++ b/srcpkgs/python3-bcrypt/template
@@ -1,7 +1,7 @@
 # Template file for 'python3-bcrypt'
 pkgname=python3-bcrypt
-version=4.1.2
-revision=3
+version=5.0.0
+revision=1
 build_style=python3-pep517
 build_helper="rust"
 hostmakedepends="python3-setuptools-rust python3-wheel python3-cffi cargo"
@@ -12,6 +12,6 @@ short_desc="Modern password hashing for software and servers"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="Apache-2.0"
 homepage="https://github.com/pyca/bcrypt"
-changelog="https://github.com/pyca/bcrypt/blob/main/README.rst#changelog"
+changelog="https://raw.githubusercontent.com/pyca/bcrypt/refs/heads/main/CHANGELOG.rst"
 distfiles="${PYPI_SITE}/b/bcrypt/bcrypt-${version}.tar.gz"
-checksum=33313a1200a3ae90b75587ceac502b048b840fc69e7f7a0905b5f87fac7a1258
+checksum=f748f7c2d6fd375cc93d3fba7ef4a9e3a092421b8dbf34d8d4dc06be9492dfdd

--- a/srcpkgs/python3-mitmproxy-linux/patches/use-stable-rust.patch
+++ b/srcpkgs/python3-mitmproxy-linux/patches/use-stable-rust.patch
@@ -1,0 +1,9 @@
+--- a/mitmproxy-linux/build.rs
++++ b/mitmproxy-linux/build.rs
+@@ -31,5 +31,5 @@ fn main() -> anyhow::Result<()> {
+             .as_str(),
+         ..Default::default()
+     };
+-    aya_build::build_ebpf([ebpf_package], Toolchain::default())
++    aya_build::build_ebpf([ebpf_package], Toolchain::Custom("stable"))
+ }

--- a/srcpkgs/python3-mitmproxy-linux/template
+++ b/srcpkgs/python3-mitmproxy-linux/template
@@ -1,0 +1,24 @@
+# Template file for 'python3-mitmproxy-linux'
+pkgname=python3-mitmproxy-linux
+version=0.12.11
+revision=1
+archs="x86_64* aarch64*"
+build_style=python3-pep517
+build_helper="rust"
+hostmakedepends="maturin cargo rust-bpf-linker llvm22-devel rust-src"
+makedepends="rust-std python3-devel"
+depends="python3"
+short_desc="Redirect traffic to mitmproxy via eBPF"
+maintainer="John Mitrich <johnmitrich@gmail.com>"
+license="MIT"
+homepage="https://github.com/mitmproxy/mitmproxy_rs"
+changelog="https://github.com/mitmproxy/mitmproxy_rs/raw/main/CHANGELOG.md"
+distfiles="${PYPI_SITE}/m/mitmproxy_linux/mitmproxy_linux-${version}.tar.gz"
+checksum=3155d4aa6b3e038f97b39ed5aa7b1fc89e5b7d25d119a19581aa472dc606ae5c
+
+export LLVM_SYS_221_PREFIX=/usr/lib/llvm/22
+export RUSTC_BOOTSTRAP=1
+
+post_install() {
+	vlicense LICENSE
+}

--- a/srcpkgs/python3-mitmproxy-rs/template
+++ b/srcpkgs/python3-mitmproxy-rs/template
@@ -1,18 +1,19 @@
 # Template file for 'python3-mitmproxy-rs'
 pkgname=python3-mitmproxy-rs
-version=0.11.1
-revision=2
+version=0.12.11
+revision=1
 build_style=python3-pep517
 build_helper="rust"
 hostmakedepends="maturin cargo"
-makedepends="rust-std python3"
+makedepends="rust-std python3-devel"
+depends="python3 python3-mitmproxy-linux"
 short_desc="Rust bits in mitmproxy"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
 homepage="https://github.com/mitmproxy/mitmproxy_rs"
 changelog="https://github.com/mitmproxy/mitmproxy_rs/raw/main/CHANGELOG.md"
 distfiles="${PYPI_SITE}/m/mitmproxy_rs/mitmproxy_rs-${version}.tar.gz"
-checksum=a77c022bc0563f9d56fa0809a27013ed2fb5d3145c599098cb1175e7326e7829
+checksum=6f5ecf3dd3c21e56191b84fc90364dc4d1dc95c660beedab4c816a0119ecb785
 replaces="python3-mitmproxy_wireguard>=0"
 
 post_install() {

--- a/srcpkgs/rust-bpf-linker/template
+++ b/srcpkgs/rust-bpf-linker/template
@@ -1,0 +1,21 @@
+# Template file for 'rust-bpf-linker'
+pkgname=rust-bpf-linker
+version=0.10.4
+revision=1
+build_style=cargo
+hostmakedepends="cargo llvm22-devel"
+makedepends="rust-std"
+short_desc="BPF static linker"
+maintainer="John Mitrich <johnmitrich@gmail.com>"
+license="Apache-2.0 OR MIT"
+homepage="https://github.com/aya-rs/bpf-linker"
+distfiles="https://github.com/aya-rs/bpf-linker/archive/refs/tags/v${version}.tar.gz"
+checksum=32a5c6b3081386e7dca8765d2c7d23f9f7feed459ad135c914d8bab686168b3d
+# tests require BPF sysroot and nightly Rust
+make_check=no
+
+export LLVM_SYS_221_PREFIX=/usr/lib/llvm/22
+
+post_install() {
+	vlicense LICENSE-MIT
+}


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64
- I built this PR locally for these architectures aarch64

mitmproxy: update to 12.2.3

Updates mitmproxy and its Rust dependencies to versions that support the new
local redirect mode (eBPF-based traffic redirection on Linux).

Packages:

- rust-bpf-linker: BPF static linker from aya-rs, required to link eBPF
  programs during mitmproxy_rs build. Built against LLVM 22.

- python3-mitmproxy-linux: Linux traffic redirector (eBPF-based). Built
  from sdist; patches build.rs to use stable Rust instead of nightly
  (bpfel-unknown-none target has been stable since Rust 1.87).

- python3-bcrypt: updated to 5.0.0 (required by mitmproxy 12.x).

- python3-mitmproxy-rs: updated to 0.12.11.

- mitmproxy: updated to 12.2.3.