### PR TITLE
common/shlibs: remove stale libLLVMSPIRVLib.so.18.1 entry

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -962,7 +962,6 @@ libLLVM.so.18.1 libllvm18-18.1.8_1
 libLLVM.so.19.1 libllvm19-19.1.0_1
 libLLVM.so.21.1 libllvm21-21.1.4_1
 libLLVM.so.22.1 libllvm22-22.1.1_1
-libLLVMSPIRVLib.so.18.1 SPIRV-LLVM-Translator-18.1.2_1
 libLLVMSPIRVLib.so.19.1 SPIRV-LLVM-Translator19-19.1.1_1
 libLLVMSPIRVLib.so.21.1 SPIRV-LLVM-Translator21-21.1.1_1
 libomp.so.5 libomp-17.0.6_1


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

---

The standalone `SPIRV-LLVM-Translator` template was removed in 8b716a2, when the package became a metapackage subpackage of `llvm`. The entry mapping `libLLVMSPIRVLib.so.18.1` to `SPIRV-LLVM-Translator-18.1.2_1` still remains, a pkgname that is now a metapackage depending on `SPIRV-LLVM-Translator${version}`, so it cannot provide the specified soname. No srcpkg in the tree installs `libLLVMSPIRVLib.so.18.1`.

Adding a `SPIRV-LLVM-Translator18` package to pair with the `llvm18` still in the tree would be the other way to make this soname valid again, but it would have no consumer; `mesa` is the only consumer in the tree and it uses `SPIRV-LLVM-Translator21`. Either way the line as written today is wrong.