### PR TITLE
common/shlibs: add libLLVMSPIRVLib.so.22.1 entry

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -965,6 +965,7 @@ libLLVM.so.22.1 libllvm22-22.1.1_1
 libLLVMSPIRVLib.so.18.1 SPIRV-LLVM-Translator-18.1.2_1
 libLLVMSPIRVLib.so.19.1 SPIRV-LLVM-Translator19-19.1.1_1
 libLLVMSPIRVLib.so.21.1 SPIRV-LLVM-Translator21-21.1.1_1
+libLLVMSPIRVLib.so.22.1 SPIRV-LLVM-Translator22-22.1.1_1
 libomp.so.5 libomp-17.0.6_1
 libomptarget.so.18.1 libomp-18.1.8_1
 libisofs.so.6 libisofs-0.6.24_1


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

---

`SPIRV-LLVM-Translator22` has installed `libLLVMSPIRVLib.so.22.1` since it was added, but the soname was never registered in
`common/shlibs`. Building the package on an otherwise unmodified tree
reports:

    => SPIRV-LLVM-Translator22-22.1.2_1: running pre-pkg hook: 99-pkglint ...
    => SPIRV-LLVM-Translator22-22.1.2_1: libLLVMSPIRVLib.so.22.1 not found in common/shlibs.

The version is `22.1.1_1`, the version that introduced the soname, per the entries for 19 and 21.

No consumer links against this soname today, so nothing needs a revbump.