### PR TITLE
nfs-utils: update to 2.9.2, rpcbind: update to 1.2.9

### DIFF
--- a/srcpkgs/nfs-utils/patches/musl-includes.patch
+++ b/srcpkgs/nfs-utils/patches/musl-includes.patch
@@ -10,21 +10,14 @@ missing include for basename(3)
  
  #include <netlink/genl/family.h>
 
-strerror() is declared in <string.h>. Without this header, the
-function is implicitly declared as returning int instead of char *.
-
-This causes a type mismatch when passing its return value to "%s"
-format specifiers, leading to build failures on musl.
-
-Add the missing include to provide the correct prototype.
- 
---- a/support/nfs/fh_key_file.c 2026-04-04 11:27:07.000000000 +0200
-+++ b/support/nfs/fh_key_file.c 2026-04-08 14:41:46.500051425 +0200
-@@ -26,6 +26,7 @@
- #include <sys/types.h>
+fixes getport.c:459:41: error: implicit declaration of function 'offsetof' on musl
+--- a/support/nfs/getport.c
++++ b/support/nfs/getport.c
+@@ -31,6 +31,7 @@
  #include <unistd.h>
+ #include <fcntl.h>
  #include <errno.h>
-+#include <string.h>
- #include <uuid/uuid.h>
++#include <stddef.h>
  
- #include "nfslib.h" 
+ #include <sys/socket.h>
+ #include <netinet/in.h>

--- a/srcpkgs/nfs-utils/template
+++ b/srcpkgs/nfs-utils/template
@@ -1,6 +1,6 @@
 # Template file for 'nfs-utils'
 pkgname=nfs-utils
-version=2.9.1
+version=2.9.2
 revision=1
 build_style=gnu-configure
 configure_args="--with-statduser=nobody --enable-gss --enable-nfsv4
@@ -14,7 +14,7 @@ license="GPL-2.0-or-later"
 homepage="https://www.linux-nfs.org/"
 changelog="https://www.kernel.org/pub/linux/utils/nfs-utils/${version}/${version}-Changelog"
 distfiles="${KERNEL_SITE}/utils/${pkgname}/${version}/${pkgname}-${version}.tar.xz"
-checksum=302846343bf509f8f884c23bdbd0fe853b7f7cbb6572060a9082279d13b21a2c
+checksum=e1dd8a9c95af15492065942cc3b52b1339ffd586baa2280ed86c9d3dc4097e8c
 replaces="rpcgen>=0"
 
 hostmakedepends="pkg-config libtirpc-devel rpcsvc-proto mit-krb5-devel"

--- a/srcpkgs/rpcbind/template
+++ b/srcpkgs/rpcbind/template
@@ -1,6 +1,6 @@
 # Template file for 'rpcbind'
 pkgname=rpcbind
-version=1.2.8
+version=1.2.9
 revision=1
 build_style=gnu-configure
 configure_args="--enable-warmstarts --with-statedir=/run --with-rpcuser=rpc
@@ -12,7 +12,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="BSD-3-Clause"
 homepage="https://rpcbind.sourceforge.net"
 distfiles="${SOURCEFORGE_SITE}/${pkgname}/${pkgname}-${version}.tar.bz2"
-checksum=964132c389918e8964d7334936b6dd10ef025b300c6b29e693ba0f29550e3de5
+checksum=ce5f1a87c566ef0b2897a28f50a75c1dc23fec413a46a7f4183423b6b6aa991b
 system_accounts="rpc"
 
 post_install() {


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**. I will continue testing over the next few days and change this to **YES** if everything works correctly.
- Tested NFSv4 on both the server and client sides.
- Additional testers are welcome.

As for the musl-includes.patch:
`#include <string.h>` in `support/nfs/fh_key_file.c` has been merged upstream.
`#include <stddef.h>`in `support/nfs/getport.c` was necessary to fix compilation errors on musl.


#### Local build testing
- I built this PR locally for my native architecture: x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl
