### PR TITLE
New package: umu-launcher-1.4.4

### DIFF
--- a/srcpkgs/umu-launcher/template
+++ b/srcpkgs/umu-launcher/template
@@ -1,0 +1,41 @@
+# Template file for 'umu-launcher'
+pkgname=umu-launcher
+version=1.4.4
+revision=1
+archs="x86_64 i686 aarch64"
+hostmakedepends="cargo git hatchling python3-build python3-installer python3-pip python3-wheel scdoc"
+makedepends="python3-pyzstd python3-urllib3 rust-std"
+depends="bash curl desktop-file-utils hicolor-icon-theme diffutils python3 python3-pyzstd python3-urllib3 python3-xlib"
+short_desc="Unified launcher for Windows games on Linux"
+maintainer="Naiko <glclaritas@gmail.com>"
+license="GPL-3.0-only"
+homepage="https://github.com/Open-Wine-Components/umu-launcher"
+distfiles="https://github.com/Open-Wine-Components/umu-launcher/archive/${version}.tar.gz"
+checksum=19767e226b0b937b1dcdcd00282eb31d1a7bb42ee01d54f6dae78e44ab8e3284
+
+do_configure() {
+	./configure.sh --prefix=/usr --use-system-pyzstd --use-system-urllib
+}
+
+do_build() {
+	if [ "$CROSS_BUILD" ]; then
+		export CARGO_BUILD_TARGET="${RUST_TARGET}"
+		local target_env=$(echo "${RUST_TARGET}" | tr '[:lower:]-' '[:upper:]_')
+		export "CARGO_TARGET_${target_env}_LINKER"="${XBPS_CROSS_TRIPLET}-gcc"
+
+		export PYO3_CROSS="1"
+		export PYO3_CROSS_PYTHON_VERSION="$(python3 -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')"
+		export PYO3_CROSS_LIB_DIR="${XBPS_CROSS_BASE}/usr/lib"
+	fi
+	make
+}
+
+post_build() {
+	if [ "$CROSS_BUILD" ]; then
+		mv -f "builddir/${RUST_TARGET}/release/libumu_delta.so" builddir/release/
+	fi
+}
+
+do_install() {
+	make DESTDIR=${DESTDIR} install
+}


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
- I built this PR locally for my native architecture, (x86_64-glibc, i686-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64(cross)

When using proton inside lutris, umu-launcher is needed and although lutris can pull its own umu-launcher copy, umu-launcher in PATH seem to be used over the one lutris pulled.

for this template, I was building just for my system arch x86_64 and using for months.  
the other day, I saw package request for umu-launcher in issues section - #61613 . so I adjusted for aarch64 cross build. 