### PR TITLE
R fixes / updates

### DIFF
--- a/srcpkgs/R-cran-cpp11/template
+++ b/srcpkgs/R-cran-cpp11/template
@@ -1,13 +1,13 @@
 # Template file for 'R-cran-cpp11'
 pkgname=R-cran-cpp11
-version=0.5.2
+version=0.5.5
 revision=1
 build_style=R-cran
 short_desc="Header only, C++11 interface to R's C interface"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
 homepage="https://github.com/r-lib/cpp11"
-checksum=0e8ac07f9d599b82e7a811f9d084e5125ae787b1ba04e5ba57f79e2642af091b
+checksum=72486beb0605c1229bf3d422cd536224af8dc09bd389a3116f62f4c7705c62f4
 
 post_install() {
 	vlicense LICENSE

--- a/srcpkgs/R-cran-rlang/template
+++ b/srcpkgs/R-cran-rlang/template
@@ -1,10 +1,10 @@
 # Template file for 'R-cran-rlang'
 pkgname=R-cran-rlang
-version=1.2.0
+version=1.3.0
 revision=1
 build_style=R-cran
 short_desc="Functions for Base Types and Core R and 'Tidyverse' Features"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-3.0-or-later"
 homepage="https://rlang.r-lib.org/"
-checksum=8f808ad4f6c1ba37d81b6a4a2cdb4a7d4d30d5bee4ba3e9924352d85a3874357
+checksum=80aa537d49e72265f443a15e8936128af583caa5e572086518b503cbf064279c

--- a/srcpkgs/R-cran-svglite/template
+++ b/srcpkgs/R-cran-svglite/template
@@ -1,7 +1,7 @@
 # Template file for 'R-cran-svglite'
 pkgname=R-cran-svglite
 version=2.2.1
-revision=1
+revision=2
 build_style=R-cran
 makedepends="R-cran-systemfonts R-cran-cpp11 libpng-devel R-cran-textshaping"
 depends="R-cran-systemfonts R-cran-cpp11 R-cran-textshaping"

--- a/srcpkgs/R-cran-vctrs/template
+++ b/srcpkgs/R-cran-vctrs/template
@@ -1,6 +1,6 @@
 # Template file for 'R-cran-vctrs'
 pkgname=R-cran-vctrs
-version=0.6.5
+version=0.7.3
 revision=1
 build_style=R-cran
 makedepends="R-cran-ellipsis R-cran-digest R-cran-glue R-cran-rlang R-cran-cli
@@ -11,4 +11,4 @@ short_desc="Vector Helpers"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-3.0-only"
 homepage="https://github.com/r-lib/vctrs"
-checksum=43167d2248fd699594044b5c8f1dbb7ed163f2d64761e08ba805b04e7ec8e402
+checksum=b45078413e06ac624dddb7221a3a43908b405c8abec09822cb86638d30b0435b


### PR DESCRIPTION
Noticed some errors with my R scripts after a recent update, these updates seem to get my stuff working again.

- **R-cran-cpp11: update to 0.5.5.**
- **R-cran-rlang: update to 1.3.0.**
- **R-cran-svglite: bump to rebuild.**
- **R-cran-vctrs: update to 0.7.3.**

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, x86-64-glibc
