### PR TITLE
libcpuid: update to 0.8.1

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -631,7 +631,7 @@ libexempi.so.8 exempi-2.5.0_1
 libatasmart.so.4 libatasmart-0.17_1
 libsgutils2-1.45.so.2 libsgutils-1.45_1
 libcpufreq.so.0 libcpufreq-007_1
-libcpuid.so.17 libcpuid-0.7.0_1
+libcpuid.so.18 libcpuid-0.8.1_1
 libgucharmap_2_90.so.7 gucharmap-3.0.0_1
 libgphoto2.so.6 libgphoto2-2.5.7_1
 libgphoto2_port.so.12 libgphoto2-2.5.7_1

--- a/srcpkgs/CPU-X/template
+++ b/srcpkgs/CPU-X/template
@@ -1,7 +1,7 @@
 # Template file for 'CPU-X'
 pkgname=CPU-X
 version=5.1.0
-revision=3
+revision=4
 archs="x86_64* i686*"
 build_style=cmake
 hostmakedepends="pkg-config nasm gettext"

--- a/srcpkgs/libcpuid/template
+++ b/srcpkgs/libcpuid/template
@@ -1,6 +1,6 @@
 # Template file for 'libcpuid'
 pkgname=libcpuid
-version=0.7.0
+version=0.8.1
 revision=1
 archs="i686* x86_64*"
 build_style=cmake
@@ -12,7 +12,7 @@ license="BSD-2-Clause"
 homepage="https://github.com/anrieff/libcpuid"
 changelog="https://raw.githubusercontent.com/anrieff/libcpuid/master/ChangeLog"
 distfiles="https://github.com/anrieff/libcpuid/archive/v${version}.tar.gz"
-checksum=cfd9e6bcda5da3f602273e55f983bdd747cb93dde0b9ec06560e074939314210
+checksum=81f2f40da5d66b8220476e116cb40bca4e6a62c0d22bdeeb8e3856cf14607007
 
 post_install() {
 	vlicense COPYING

--- a/srcpkgs/nix/template
+++ b/srcpkgs/nix/template
@@ -1,7 +1,7 @@
 # Template file for 'nix'
 pkgname=nix
 version=2.30.5
-revision=3
+revision=4
 build_style=meson
 build_helper=qemu
 # Use /nix/var as suggested by the official Manual.


### PR DESCRIPTION


#### Testing the changes
- I tested the changes in this PR: YES


#### Local build testing
- I built this PR locally for my native architecture x86_64 GLIBC
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - i686 (cross)
  - x86_64-musl (cross)

libcpuid doesn't support ARM without a kernel module and dkms. Since libcpuid had this support since 0.7.0 but was never utilized in the template I figured best to keep it the same.
  