### PR TITLE
FeatherPad: update to 1.6.4

### DIFF
--- a/srcpkgs/FeatherPad/template
+++ b/srcpkgs/FeatherPad/template
@@ -1,6 +1,6 @@
 # Template file for 'FeatherPad'
 pkgname=FeatherPad
-version=1.6.3
+version=1.6.4
 revision=1
 build_style=cmake
 hostmakedepends="qt6-tools qt6-base-devel pkg-config"
@@ -11,4 +11,4 @@ license="GPL-3.0-or-later"
 homepage="https://github.com/tsujan/FeatherPad"
 changelog="https://github.com/tsujan/FeatherPad/raw/master/ChangeLog"
 distfiles="https://github.com/tsujan/FeatherPad/archive/V${version}.tar.gz"
-checksum=e1eab693d8806855dce0f8a2078aed8a05fb9c1825ad3308468cd9fc797f3e09
+checksum=1442f14aefdb0de26822562d69c446b0e2b4e607597925a2e0c2c7b063e1654e


### PR DESCRIPTION

#### Testing the changes
- I tested the changes in this PR: YES

#### Local build testing
- I built this PR locally for my native architecture x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl (cross)
  - i686 (cross)
  - armv6l (cross)
  - armv7l (cross)

