### PR TITLE
d2: update source repository

### DIFF
--- a/srcpkgs/d2/template
+++ b/srcpkgs/d2/template
@@ -10,6 +10,6 @@ maintainer="Toyam Cox <Vaelatern@voidlinux.org>"
 license="MPL-2.0"
 homepage="https://d2lang.com/"
 changelog="https://d2lang.com/releases/intro/"
-distfiles="https://github.com/terrastruct/d2/archive/refs/tags/v${version}.tar.gz"
+distfiles="https://github.com/d2lang/d2/archive/refs/tags/v${version}.tar.gz"
 checksum=b784d6472d53fdaaa7ecc9bdbe23456e2b4a90e18736828028b3f951537e56a1
 make_check=no # tests require playwright + chromium


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

D2's source repository moved from the Terrastruct GitHub organization to `d2lang`. This updates only the active source archive URL; the package version, revision, checksum, and Go import path stay unchanged.

Validation:

- Downloaded `v0.7.1` from the new URL and verified SHA-256 `b784d6472d53fdaaa7ecc9bdbe23456e2b4a90e18736828028b3f951537e56a1`, matching the existing template checksum.
- Ran `git diff --check`.
- Could not run an `xbps-src` build because the required XBPS toolchain is unavailable on this macOS host.

AI usage disclosure: OpenAI Codex was used to locate the active package URL, apply this mechanical replacement, run the validation above, and draft the commit and pull request text.
