### PR TITLE
xrefresh: update to 1.1.1

### DIFF
--- a/srcpkgs/xrefresh/template
+++ b/srcpkgs/xrefresh/template
@@ -1,6 +1,6 @@
 # Template file for 'xrefresh'
 pkgname=xrefresh
-version=1.1.0
+version=1.1.1
 revision=1
 build_style=gnu-configure
 hostmakedepends="pkg-config"
@@ -10,7 +10,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
 homepage="https://gitlab.freedesktop.org/xorg/app/xrefresh"
 distfiles="${XORG_SITE}/app/xrefresh-${version}.tar.gz"
-checksum=cbf0d3ed80f03188841a96ceb20e615b40a006e3928be2e179d9d5a0ded639b2
+checksum=59b685a378e55da7b554199f41b4f5a423ed1d86b4d2dfa2290751aa71b4e2ea
 
 post_install() {
 	vlicense COPYING


### PR DESCRIPTION

#### Testing the changes
- I tested the changes in this PR: YES

#### Local build testing
- I built this PR locally for my native architecture x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl (cross)
  - i686 (cross)
  - armv6l (cross)
  - armv7l (cross)

