### PR TITLE
rio: update to 0.5.5

### DIFF
--- a/srcpkgs/rio/template
+++ b/srcpkgs/rio/template
@@ -1,6 +1,6 @@
 # Template file for 'rio'
 pkgname=rio
-version=0.4.12
+version=0.5.5
 revision=1
 build_style=cargo
 build_wrksrc="frontends/rioterm"
@@ -13,7 +13,7 @@ license="MIT"
 homepage="https://rioterm.com/"
 changelog="https://rioterm.com/changelog"
 distfiles="https://github.com/raphamorim/rio/archive/refs/tags/v${version}.tar.gz"
-checksum=0e58095ce82f086b2c392eae6c3fb7129d2b74950d397cf313607c1a66973057
+checksum=3e67926c14f54e3f3359a6461a17cb3a58400cf57b491d2fda974d6821e47d51
 
 case "${XBPS_TARGET_MACHINE}" in
 	i686*)


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x64-glibc)
- I built this PR locally for these architectures:
  - armv6l