### PR TITLE
rockpro64-uboot: update to 2026.07

### DIFF
--- a/srcpkgs/atf-rk3399-bl31/template
+++ b/srcpkgs/atf-rk3399-bl31/template
@@ -1,6 +1,6 @@
 # Template file for 'atf-rk3399-bl31'
 pkgname=atf-rk3399-bl31
-version=2.7
+version=2.14.6
 revision=1
 archs="aarch64*"
 hostmakedepends="cross-arm-none-eabi"
@@ -8,20 +8,16 @@ short_desc="ARM Trusted Firmware for Rockchip rk3399 boards (ARMv8, bl31 option)
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="BSD-3-Clause"
 homepage="https://developer.trustedfirmware.org/dashboard/view/6/"
-distfiles="https://git.trustedfirmware.org/TF-A/trusted-firmware-a.git/snapshot/trusted-firmware-a-${version}.tar.gz"
-checksum=53422dc649153838e03820330ba17cb10afe3e330ecde0db11e4d5f1361a33e6
+distfiles="https://github.com/TrustedFirmware-A/trusted-firmware-a/archive/refs/tags/lts-v${version}.tar.gz"
+checksum=833bad7e99b5ac6bc5437a0b34c5847ef494ee0f3f3212e453704827aac91358
 nostrip=yes
-
-post_patch() {
-	# Adjust the baud rate to match uboot and the kernel for the PBP
-	vsed -i -e 's/\(RK3399_BAUDRATE\s*\)115200/\11500000/' \
-		plat/rockchip/rk3399/rk3399_def.h
-}
 
 do_build() {
 	unset CFLAGS CXXFLAGS CPPFLAGS LDFLAGS
 	if [ "$CROSS_BUILD" ]; then
 		export CROSS_COMPILE=${XBPS_CROSS_TRIPLET}-
+		export ARCH=${XBPS_TARGET_MACHINE}
+		export AS=${XBPS_CROSS_TRIPLET}-gcc
 	fi
 	make ${makejobs} PLAT=rk3399 bl31
 }

--- a/srcpkgs/atf-rk3399-bl31/update
+++ b/srcpkgs/atf-rk3399-bl31/update
@@ -1,2 +1,1 @@
-site=https://git.trustedfirmware.org/TF-A/trusted-firmware-a.git/refs/
-pattern="tag/\?h=v\K[\d\.]+"
+pattern="lts-v\K[\d\.]+"

--- a/srcpkgs/rockpro64-uboot/template
+++ b/srcpkgs/rockpro64-uboot/template
@@ -1,6 +1,6 @@
 # Template file for 'rockpro64-uboot'
 pkgname=rockpro64-uboot
-version=2026.04
+version=2026.07
 revision=1
 archs="aarch64*"
 hostmakedepends="bison flex bc dtc which python3 swig python3-devel python3-setuptools python3-pyelftools openssl-devel libuuid-devel gnutls-devel ncurses-libtinfo-devel"
@@ -11,7 +11,7 @@ maintainer="Tim Sandquist <tim.sandquist@gmail.com>"
 license="GPL-2.0-or-later, BSD-3-Clause"
 homepage="https://www.denx.de/wiki/U-Boot/"
 distfiles="https://ftp.denx.de/pub/u-boot/u-boot-${version}.tar.bz2"
-checksum=ac7c04b8b7004923b00a4e5d6699c5df4d21233bac9fda690d8cfbc209fff2fd
+checksum=78e8bfc382fe388f9b55aa1daf8c563522a037779b5d4c349d1415e381f1243e
 
 do_configure() {
 	unset CFLAGS CXXFLAGS CPPFLAGS LDFLAGS


### PR DESCRIPTION
atf-rk3399-bl31 was updated to 2.14.5 as well

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
#### Local build testing
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-glibc
