### PR TITLE
typos: update to 1.48.0.

### DIFF
--- a/srcpkgs/typos/template
+++ b/srcpkgs/typos/template
@@ -1,6 +1,6 @@
 # Template file for 'typos'
 pkgname=typos
-version=1.46.0
+version=1.48.0
 revision=1
 build_style=cargo
 make_install_args="--path crates/typos-cli"
@@ -10,7 +10,7 @@ license="Apache-2.0 OR MIT"
 homepage="https://github.com/crate-ci/typos"
 changelog="https://raw.githubusercontent.com/crate-ci/typos/refs/heads/master/CHANGELOG.md"
 distfiles="https://github.com/crate-ci/typos/archive/refs/tags/v${version}.tar.gz"
-checksum=268459bd3b03d4e6c398280ade11d5280850fdb392ed50d3c67e41ddfa083dbc
+checksum=11b662d163b258244f7f27ea1d0f39a17d1032fdc983d527f290dcad8253d355
 
 post_install() {
 	vlicense LICENSE-MIT


### PR DESCRIPTION

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
