### PR TITLE
New package: python3-internetarchive-5.11.0

### DIFF
--- a/srcpkgs/python3-internetarchive/template
+++ b/srcpkgs/python3-internetarchive/template
@@ -1,0 +1,19 @@
+# Template file for 'python3-internetarchive'
+pkgname=python3-internetarchive
+version=5.11.0
+revision=1
+build_style=python3-pep517
+hostmakedepends="python3-setuptools_scm"
+depends="python3-jsonpatch python3-requests python3-tqdm python3-urllib3"
+checkdepends="$depends python3-pytest python3-responses"
+short_desc="Python and command-line interface to archive.org"
+maintainer="Mateusz Sylwestrzak <slymattz@gmail.com>"
+license="AGPL-3.0-only"
+homepage="https://github.com/jjjake/internetarchive"
+changelog="https://github.com/jjjake/internetarchive/releases"
+distfiles="https://github.com/jjjake/internetarchive/archive/refs/tags/v${version}.tar.gz"
+checksum=aae08851984b47ba604d4dc2d1e85388b50057f1a79c816ba4dfea75cf5e7241
+
+post_install() {
+	vlicense LICENSE
+}


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

Decided to use the `python3-` prefix because the package provides an importable Python module in addition to a command-line interface.

#### Local build testing
- I built this PR locally for my native architecture: x86_64-glibc
