### PR TITLE
New package: jellyfin-tui-1.5.2

### DIFF
--- a/srcpkgs/jellyfin-tui/template
+++ b/srcpkgs/jellyfin-tui/template
@@ -1,0 +1,19 @@
+# Template file for 'jellyfin-tui'
+pkgname=jellyfin-tui
+version=1.5.2
+revision=1
+build_style=cargo
+hostmakedepends="pkg-config sqlite-devel"
+makedepends="openssl-devel sqlite-devel mpv-devel"
+short_desc="TUI streaming client for the Jellyfin media server"
+maintainer="xJayMorex <github@johntaylor.hu>"
+license="GPL-3.0-or-later"
+homepage="https://github.com/dhonus/jellyfin-tui"
+changelog="https://github.com/dhonus/jellyfin-tui/releases"
+distfiles="https://github.com/dhonus/jellyfin-tui/archive/refs/tags/v${version}.tar.gz"
+checksum=6d419fb912c2fd7151eb2585dfaf9fdc8b4cdd89e921501212bbc20d56c0953a
+make_check=no # no tests
+
+if [ "$XBPS_TARGET_WORDSIZE" -eq 32 ]; then
+	broken="overflow in libmpv2-sys bindings"
+fi


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64
- I built this PR locally for these architectures:
  - x86_64-musl
  - aarch64 (crossbuild)
