### PR TITLE
xrestop: update to 0.6

### DIFF
--- a/srcpkgs/xrestop/template
+++ b/srcpkgs/xrestop/template
@@ -1,12 +1,13 @@
 # Template file for 'xrestop'
 pkgname=xrestop
-version=0.4
+version=0.6
 revision=1
 build_style=gnu-configure
+hostmakedepends="pkg-config"
 makedepends="libXres-devel ncurses-devel"
 short_desc="Top-like X Server resource usage monitor that uses the XRes extension"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="https://www.freedesktop.org/wiki/Software/xrestop/"
-distfiles="https://downloads.yoctoproject.org/releases/${pkgname}/${pkgname}-${version}.tar.gz"
-checksum=67c2fc94a7ecedbaae0d1837e82e93d1d98f4a6d759828860e552119af3ce257
+distfiles="${XORG_SITE}/app/xrestop-${version}.tar.gz"
+checksum=c4a212808be703b4929b01fa57efc46e6b662b958dc33c044efeab38065cd5dd


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: YES

#### Local build testing
- I built this PR locally for my native architecture x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl (cross)
  - i686 (cross)
  - armv6l (cross)
  - armv7l (cross)

The build would fail during the configure stage so I added the hostmakedepends variable and assigned "pkg-config" to it.

I updated the url in the distfiles variable since the latest release the original url offers is version 0.4.
