### PR TITLE
biblioteq: update to 2026.07.31.

### DIFF
--- a/srcpkgs/biblioteq/patches/support-etc-configuration.patch
+++ b/srcpkgs/biblioteq/patches/support-etc-configuration.patch
@@ -2,20 +2,21 @@ Add /usr/lib/BiblioteQ search path to the launcher script.
 
 --- a/biblioteq.sh
 +++ b/biblioteq.sh
-@@ -46,6 +46,16 @@
+@@ -50,6 +50,17 @@
      exit $?
  fi
  
-+if [ -r /usr/lib/BiblioteQ/BiblioteQ ] &&
++if [ -f /usr/lib/BiblioteQ/BiblioteQ ] && \
++   [ -r /usr/lib/BiblioteQ/BiblioteQ ] && \
 +   [ -x /usr/lib/BiblioteQ/BiblioteQ ]
 +then
-+    echo "Launching an official BiblioteQ."
++    echo "Launching an official BiblioteQ (/usr/lib/BiblioteQ)."
 +    set_qt_qpa_platformtheme "/usr/lib/BiblioteQ/BiblioteQ"
 +    /usr/lib/BiblioteQ/BiblioteQ \
 +	--configuration-file /etc/biblioteq.conf "$@"
 +    exit $?
 +fi
 +
- if [ -r /usr/local/biblioteq/BiblioteQ ] &&
+ if [ -f /usr/local/biblioteq/BiblioteQ ] && \
+    [ -r /usr/local/biblioteq/BiblioteQ ] && \
     [ -x /usr/local/biblioteq/BiblioteQ ]
- then

--- a/srcpkgs/biblioteq/template
+++ b/srcpkgs/biblioteq/template
@@ -1,6 +1,6 @@
 # Template file for 'biblioteq'
 pkgname=biblioteq
-version=2026.07.05
+version=2026.07.31
 revision=1
 build_style=qmake
 build_helper=qmake6
@@ -13,7 +13,7 @@ maintainer="Rutpiv <roger_freitas@live.com>"
 license="BSD-3-Clause"
 homepage="https://textbrowser.github.io/biblioteq/"
 distfiles="https://github.com/textbrowser/biblioteq/archive/${version}.tar.gz"
-checksum=07a126c0b22bad6f4335bc5f26bdaca0017d4b633921def60982ad983cc5c46d
+checksum=e7d30ff0895567877d800bfb6206cd338fffccbfb177a5c38641bb36d29b7d59
 conf_files="/etc/biblioteq.conf"
 
 # Set the appropriate build helper and dependencies based on architecture


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures using specific masterdirs:
  - x86_64-musl
  - i686
- I built this PR locally for these architectures (crossbuilds):
  - aarch64
  - aarch64-musl
  - armv7l
  - armv7l-musl
  - armv6l
  - armv6l-musl