### PR TITLE
udiskie: update to 2.7.0, adopt.

### DIFF
--- a/srcpkgs/udiskie/template
+++ b/srcpkgs/udiskie/template
@@ -1,19 +1,18 @@
 # Template file for 'udiskie'
 pkgname=udiskie
-version=2.6.2
+version=2.7.0
 revision=1
 build_style=python3-pep517
 hostmakedepends="gettext asciidoc python3-setuptools"
-depends="gtk+3 libnotify python3-docopt python3-gobject python3-keyutils
- python3-yaml udisks2"
+depends="gtk+3 libkeyutils libnotify python3-docopt python3-gobject python3-yaml udisks2"
 checkdepends="${depends} python3-pytest"
 short_desc="Removable disk automounter using udisks"
-maintainer="Orphaned <orphan@voidlinux.org>"
+maintainer="Rutpiv <roger_freitas@live.com>"
 license="MIT"
 homepage="https://github.com/coldfix/udiskie"
 changelog="https://raw.githubusercontent.com/coldfix/udiskie/master/CHANGES.rst"
 distfiles="https://github.com/coldfix/udiskie/archive/refs/tags/v${version}.tar.gz"
-checksum=9d758efd4e3706ce824e693708cce1e0a840dae9aa5b130e3592d3588da8279c
+checksum=eb8c173e84050db01556aad68e75cfb45fee57d880b368a395459ee5e815ce8b
 make_check=ci-skip # privilege issue with keyring in container
 
 post_build() {


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture (x86_64)
- I built this PR locally for these architectures using specific masterdirs:
  - x86_64-musl
  - i686
- I built this PR locally for these architectures (crossbuilds):
  - aarch64
  - aarch64-musl
  - armv7l
  - armv7l-musl
  - armv6l
  - armv6l-musl
  
---

Adopting this package, having handled its updates in #53711, #57660, #58848 and #59392.