### PR TITLE
obs: update to 32.2.1, enable RNNoise noise suppression

### DIFF
--- a/srcpkgs/obs/template
+++ b/srcpkgs/obs/template
@@ -1,11 +1,11 @@
 # Template file for 'obs'
 pkgname=obs
-version=32.1.2
-revision=2
+version=32.2.1
+revision=1
 archs="i686* x86_64* ppc64le* aarch64* riscv64*"
 build_style=cmake
 configure_args="-DOBS_VERSION_OVERRIDE=${version} -DENABLE_JACK=ON
- -DCMAKE_INSTALL_DATAROOTDIR=share -DENABLE_RNNOISE=OFF
+ -DCMAKE_INSTALL_DATAROOTDIR=share -DENABLE_RNNOISE=ON
  -DENABLE_VST=OFF -DENABLE_AJA=OFF
  -DENABLE_SCRIPTING_LUA=$(vopt_if luajit 'ON' 'OFF')
  -DENABLE_NVENC=$(vopt_if nvenc 'ON' 'OFF')
@@ -19,7 +19,7 @@ makedepends="$(vopt_if luajit LuaJIT-devel) fdk-aac-devel
  jansson-devel wayland-devel pipewire-devel libxkbcommon-devel
  pciutils-devel librist-devel srt-devel libdatachannel-devel
  libvpl-devel uthash qt6-base-private-devel json-c++ extra-cmake-modules
- simde $(vopt_if nvenc nv-codec-headers)"
+ simde rnnoise-devel $(vopt_if nvenc nv-codec-headers)"
 depends="xset xdg-desktop-portal"
 short_desc="Open Broadcaster Software"
 maintainer="lemmi <lemmi@nerd2nerd.org>"
@@ -27,7 +27,7 @@ license="GPL-2.0-or-later"
 homepage="https://obsproject.com"
 changelog="https://github.com/obsproject/obs-studio/releases"
 distfiles="https://github.com/obsproject/obs-studio/archive/refs/tags/$version.tar.gz"
-checksum=b4a59410cddb46d0e31df1ee13b8ec66f30862d7e980c1a8c4e3b5d16fae6053
+checksum=db034bc3d2c137ec7f1809cbef4fc90c8948652b90a860078410482457d8a574
 
 build_options="luajit qsv nvenc"
 case $XBPS_TARGET_MACHINE in


### PR DESCRIPTION
Update obs-studio to 32.2.1 and re-enable the native RNNoise filter.

**Update 32.2.1:** dependency chain unchanged (same makedepends as 32.1.2, verified locally). Build tested on x86_64.

**RNNoise:** the rnnoise 0.2 update (2025-12-17) fixed the GCC 14 build breakage (calloc-transposed-args, upstream obsproject/obs-studio#10665) that caused -DENABLE_RNNOISE=OFF to be set in the first place. Re-enable the native RNNoise noise suppression filter and add rnnoise-devel to makedepends.

- [x] I tested the changes in this PR: **YES** (built and ran 32.2.1 with RNNoise filter active)