### PR TITLE
LibreCAD: update to 2.2.1.5

### DIFF
--- a/srcpkgs/LibreCAD/template
+++ b/srcpkgs/LibreCAD/template
@@ -1,6 +1,6 @@
 # Template file for 'LibreCAD'
 pkgname=LibreCAD
-version=2.2.1.2
+version=2.2.1.5
 revision=1
 build_style=qmake
 hostmakedepends="qt5-qmake pkg-config ImageMagick qt5-host-tools"
@@ -10,7 +10,12 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-only"
 homepage="https://librecad.org"
 distfiles="https://github.com/librecad/librecad/archive/refs/tags/v${version}.tar.gz"
-checksum=2b961cb916a7415d97f427f824c1830e06d4832cc376fea38b27cb456ee95a8e
+checksum=703f6e6701b7ee47769b6def271fa025ef32e31ee193e2ba69a2c47fff8da459
+
+if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
+	makedepends+=" libexecinfo-devel"
+	configure_args+=" LIBS+=-lexecinfo"
+fi
 
 if [ -n "$CROSS_BUILD" ]; then
 	configure_args+=" BOOST_DIR=${XBPS_CROSS_BASE}/usr"


### PR DESCRIPTION

#### Testing the changes
- I tested the changes in this PR: briefly

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-musl)

information:
libexecinfo-devel added to makedepends to supply execinfo.h during musl specific compilation