### PR TITLE
xfontsel: update to 1.1.2

### DIFF
--- a/srcpkgs/xfontsel/template
+++ b/srcpkgs/xfontsel/template
@@ -1,6 +1,6 @@
 # Template file for 'xfontsel'
 pkgname=xfontsel
-version=1.1.1
+version=1.1.2
 revision=1
 build_style=gnu-configure
 hostmakedepends="pkg-config gettext"
@@ -10,8 +10,8 @@ short_desc="X font selector"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="X11"
 homepage="http://xorg.freedesktop.org"
-distfiles="${XORG_SITE}/app/$pkgname-$version.tar.gz"
-checksum=5a3c037ef28e8d22ccf7ca05894e0fcd86256a48dd56fb6e2838308cef623b7e
+distfiles="${XORG_SITE}/app/xfontsel-$version.tar.gz"
+checksum=6f0545b5d123d2b2f5447fb08f2aed98805b6f9ca00b42054c1ec8f83ee08398
 
 post_install() {
 	vlicense COPYING


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: YES

#### Local build testing
- I built this PR locally for my native architecture: x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl (masterdir)
  - i686 (masterdir)
  - armv6l (cross)
  - armv7l (cross)

