### PR TITLE
dbeaver: update to 26.1.4.

### DIFF
--- a/srcpkgs/dbeaver/patches/force-jdk25.patch
+++ b/srcpkgs/dbeaver/patches/force-jdk25.patch
@@ -5,7 +5,7 @@
 
      <launcherArgs>
 -        <programArgs></programArgs>
-+        <programArgs>-vm /usr/lib/jvm/openjdk21/bin</programArgs>
++        <programArgs>-vm /usr/lib/jvm/openjdk25/bin</programArgs>
          <programArgsMac>-vm ../Eclipse/jre/Contents/Home/lib/libjli.dylib</programArgsMac>
 
          <vmArgs>

--- a/srcpkgs/dbeaver/template
+++ b/srcpkgs/dbeaver/template
@@ -1,13 +1,13 @@
 # Template file for 'dbeaver'
 pkgname=dbeaver
-version=26.1.3
+version=26.1.4
 revision=1
 _version=${version//./_}
 # the build downloads binaries linked to glibc
 archs="x86_64 aarch64"
 build_wrksrc="dbeaver"
-hostmakedepends="apache-maven openjdk21"
-depends="openjdk21"
+hostmakedepends="apache-maven openjdk25"
+depends="openjdk25"
 short_desc="Free Universal Database Tool"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="Apache-2.0"
@@ -16,9 +16,9 @@ changelog="https://dbeaver.io/news/"
 distfiles="https://github.com/dbeaver/dbeaver/archive/${version}.tar.gz
  https://github.com/dbeaver/dbeaver-common/archive/refs/heads/release_${_version}.tar.gz>dbeaver-common-${version}.tar.gz
  https://github.com/dbeaver/dbeaver-jdbc-libsql/archive/refs/heads/release_${_version}.tar.gz>dbeaver-jdbc-libsql-${version}.tar.gz"
-checksum="df7be19894e575039d649cb680b24dab4e3f1c4e19739717cb61a5ee8a1fafca
- bdc191282dad9a45e88f598e70bf046fee04350a52470525e39bdbee25a22ad8
- ef7ac9d5285c1837970d54573aef42274547ef865d64b4a5fa29f16dc82d1a2e"
+checksum="584e0e30b832e66e98a81ef648c989907a96fe65e03e8999b4906c375c18c482
+ 2dae4380cd14d0186253807ae269d886ef3c89a64a326ac812fb62faeb1c8da0
+ 9619a107c9fc959afb1e5c0ff14de730a9d9f937cdcea9a63a490b5c5df436a3"
 nopie=true
 
 post_extract() {


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc

updated openjdk to version 25 as in #61355