### PR TITLE
coredns: update to 1.14.7

### DIFF
--- a/srcpkgs/coredns/template
+++ b/srcpkgs/coredns/template
@@ -1,9 +1,10 @@
 # Template file for 'coredns'
 pkgname=coredns
-version=1.10.1
-revision=4
+version=1.14.7
+revision=1
 build_style=go
 go_import_path=github.com/coredns/coredns
+go_build_tags=grpcnotrace
 hostmakedepends="mmark"
 short_desc="CoreDNS is a DNS server that chains plugins"
 maintainer="Orphaned <orphan@voidlinux.org>"
@@ -11,13 +12,24 @@ license="Apache-2.0"
 homepage="https://coredns.io"
 changelog="https://github.com/coredns/coredns/releases"
 distfiles="https://github.com/coredns/coredns/archive/v${version}.tar.gz"
-checksum=f47186452e5f2925e2c71135669afd9e03b9b55831417d33d612ef2fa69924a7
+checksum=c3ecdf3ebaba0c453e3dc62643548dbece09999d589513f25ca00ca4eca89423
 make_dirs="/etc/coredns 0750 root root"
 conf_files="/etc/coredns/Corefile"
 
 # Update this on each version bump.
-_git_commit=055b2c31a9cf28321734e5f71613ea080d216cd3
+_git_commit=424d125775cd70fa90dfc80bf0e52cc9a9aeb574
 go_ldflags="-X github.com/coredns/coredns/coremain.GitCommit=${_git_commit}"
+
+do_check() {
+	# trace plugin tests pull in DataDog/dd-trace-go/v2/ddtrace/tracer and DataDog/datadog-go/v5/statsd
+	# which panics on 32 bit systems. https://github.com/DataDog/datadog-go/pull/315
+	local ignore="github.com/coredns/coredns/test$"
+	if [ "$XBPS_TARGET_MACHINE" = "i686" ]; then
+		ignore="${ignore}|github.com/coredns/coredns/plugin/trace$"
+	fi
+	go test -p "$XBPS_MAKEJOBS" -tags "${go_build_tags}" -ldflags "${go_ldflags}" \
+		$(go list ./... | grep -vE "$ignore")
+}
 
 post_build() {
 	make -f Makefile.doc MMARK="$(command -v mmark) -man" man/coredns.1 man/corefile.5 plugins


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, X86_64-glibc
- I built this PR locally for these architectures crossbuilds:
  - aarch64-glibc
  - i686

