### PR TITLE
metalog: update to 20260221, adopt.

### DIFF
--- a/srcpkgs/metalog/template
+++ b/srcpkgs/metalog/template
@@ -1,18 +1,18 @@
 # Template file for 'metalog'
 pkgname=metalog
-version=20260105
+version=20260221
 revision=1
 build_style=gnu-configure
 conf_files="/etc/metalog.conf"
 hostmakedepends="autoconf autoconf-archive automake pkg-config"
 makedepends="pcre2-devel"
 short_desc="Modern replacement for syslogd and klogd"
-maintainer="Orphaned <orphan@voidlinux.org>"
+maintainer="Leanhduc <0353618151hao@gmail.com>"
 license="GPL-2.0-only"
 homepage="https://github.com/hvisage/metalog"
 changelog="https://github.com/hvisage/metalog/blob/master/NEWS"
 distfiles="https://github.com/hvisage/metalog/archive/${version}.tar.gz"
-checksum=58ee4f423d51eccdd4b404c7c6e3b62b334d7be6e1a052bca1b0efb2501f69cc
+checksum=74758d711cf264aa8eb78caf4887998cb7bea0876c34d8ec19bd59fb8991349f
 
 pre_configure() {
 	./autogen.sh


### PR DESCRIPTION
Testing the changes
- I tested the changes in this PR: **YES**

Local build testing
- I built this PR locally for my native architecture: x86_64