### PR TITLE
libXinerama: update to 1.1.6

### DIFF
--- a/srcpkgs/libXinerama/template
+++ b/srcpkgs/libXinerama/template
@@ -1,6 +1,6 @@
 # Template file for 'libXinerama'
 pkgname=libXinerama
-version=1.1.5
+version=1.1.6
 revision=1
 build_style=gnu-configure
 configure_args="--enable-malloc0returnsnull"
@@ -9,9 +9,9 @@ makedepends="xorgproto libXext-devel"
 short_desc="X PanoramiX extension library"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
-homepage="$XORG_SITE"
-distfiles="${XORG_SITE}/lib/${pkgname}-${version}.tar.xz"
-checksum=5094d1f0fcc1828cb1696d0d39d9e866ae32520c54d01f618f1a3c1e30c2085c
+homepage="https://www.x.org/"
+distfiles="${XORG_SITE}/lib/libXinerama-${version}.tar.xz"
+checksum=d00fc1599c303dc5cbc122b8068bdc7405d6fcb19060f4597fc51bd3a8be51d7
 
 post_install() {
 	vlicense COPYING


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: YES

#### Local build testing
- I built this PR locally for my native architecture: x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl (masterdir)
  - i686 (masterdir)
  - armv6l (cross)
  - armv6l-musl (cross)
  - armv7l (cross)
  - armv7l-musl (cross)

