### PR TITLE
jpeginfo: update to 1.7.1

### DIFF
--- a/srcpkgs/jpeginfo/template
+++ b/srcpkgs/jpeginfo/template
@@ -1,6 +1,6 @@
 # Template file for 'jpeginfo'
 pkgname=jpeginfo
-version=1.7.0
+version=1.7.1
 revision=1
 build_style=gnu-configure
 makedepends="libjpeg-turbo-devel"
@@ -10,7 +10,7 @@ license="GPL-3.0-or-later"
 homepage="https://github.com/tjko/jpeginfo"
 changelog="https://raw.githubusercontent.com/tjko/jpeginfo/master/README"
 distfiles="https://github.com/tjko/jpeginfo/archive/refs/tags/v${version}.tar.gz"
-checksum=dc985083448d9707d42e49bed826a247c0dbda6913c870e9a5d9bf7c74939659
+checksum=274f6be23fd089bd9e8715b67643a66ca2f63a503028bdea3e571228d50b669e
 
 pre_install() {
 	make_install_args="INSTALL_ROOT=${DESTDIR}"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: YES

#### Local build testing
- I built this PR locally for my native architecture: x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl (masterdir)
  - i686 (masterdir)
  - armv6l (cross)
  - armv6l-musl (cross)
  - armv7l (cross)
  - armv7l-musl (cross)

