### PR TITLE
rio: update to 0.5.24

### DIFF
--- a/srcpkgs/rio/template
+++ b/srcpkgs/rio/template
@@ -1,6 +1,6 @@
 # Template file for 'rio'
 pkgname=rio
-version=0.5.5
+version=0.5.24
 revision=1
 build_style=cargo
 build_wrksrc="frontends/rioterm"
@@ -13,7 +13,7 @@ license="MIT"
 homepage="https://rioterm.com/"
 changelog="https://rioterm.com/changelog"
 distfiles="https://github.com/raphamorim/rio/archive/refs/tags/v${version}.tar.gz"
-checksum=3e67926c14f54e3f3359a6461a17cb3a58400cf57b491d2fda974d6821e47d51
+checksum=f8412e719fda7c5d95bcd00aad38d54596998900ad98077dcfc5c1b7c3c9a496
 
 case "${XBPS_TARGET_MACHINE}" in
 	i686*)


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x64-glibc)
- I built this PR locally for these architectures:
  - armv6l