### PR TITLE
x265: update gst-plugins-bad1 and baresip

### DIFF
--- a/srcpkgs/baresip/template
+++ b/srcpkgs/baresip/template
@@ -8,7 +8,7 @@ makedepends="libgsm-devel libpng-devel openssl-devel libsndfile-devel
  opus-devel re-devel spandsp-devel speex-devel speexdsp-devel
  tiff-devel twolame-devel cairo-devel gst-plugins-base1-devel jack-devel
  gstreamer1-devel gtk+3-devel mpg123-devel SDL2-devel ffmpeg6-devel libvpx-devel
- libX11-devel v4l-utils-devel x265-devel libXext-devel webrtc-audio-processing-devel
+ libX11-devel v4l-utils-devel libXext-devel webrtc-audio-processing-devel
  fdk-aac-devel libmosquitto-devel codec2-devel"
 # sndio-devel Currently not hooked up in their cmake build system
 short_desc="Modular SIP User-Agent with audio and video support"

--- a/srcpkgs/gst-plugins-bad1/template
+++ b/srcpkgs/gst-plugins-bad1/template
@@ -1,7 +1,7 @@
 # Template file for 'gst-plugins-bad1'
 pkgname=gst-plugins-bad1
 version=1.28.5
-revision=1
+revision=2
 build_helper="gir"
 build_style=meson
 configure_args="-Dpackage-origin=https://voidlinux.org -Ddoc=disabled
@@ -11,7 +11,7 @@ configure_args="-Dpackage-origin=https://voidlinux.org -Ddoc=disabled
  -Dmplex=disabled -Dmusepack=disabled -Dopenexr=disabled
  -Dopenmpt=disabled -Dopenni2=disabled -Dsctp=disabled
  -Dsrt=disabled -Dteletext=disabled -Dvoaacenc=disabled -Dvoamrwbenc=disabled
- -Dwildmidi=disabled -Dwpe=disabled -Ddirectfb=disabled
+ -Dwildmidi=disabled -Dwpe=disabled -Ddirectfb=disabled -Dgpl=enabled
  $(vopt_feature gme gme) $(vopt_feature gir introspection) -Dneon=disabled"
 hostmakedepends="automake gettext libtool pkg-config python3 glib-devel
  orc $(vopt_if wayland wayland-devel)"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly** (ffmpeg8)

#### Local build testing
- I built this PR locally for my native architecture, **x86_64**

#### Comments

baresip - does not appear to use x265, and relies on ffmpeg (avcodec).

gst-plugins-bad1 - not sure how licensing works, but 265 hasn't been used forever it would seem. `-Dgpl=enabled` is required, which also installs `libdca faad2 libdvdnav` on my system, as well as `/usr/lib/gstreamer-1.0/libgstx265.so`

If the license stuff matters, ig just remove x265 from gst?

@Duncaen 