### PR TITLE
xwud: update to 1.0.8

### DIFF
--- a/srcpkgs/xwud/template
+++ b/srcpkgs/xwud/template
@@ -1,6 +1,6 @@
 # Template file for 'xwud'
 pkgname=xwud
-version=1.0.7
+version=1.0.8
 revision=1
 build_style=gnu-configure
 hostmakedepends="pkg-config"
@@ -10,7 +10,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
 homepage="http://xorg.freedesktop.org"
 distfiles="${XORG_SITE}/app/xwud-${version}.tar.gz"
-checksum=371df65cea6b0ca281f9944337b82bb3bcee624618548e7b7077c2e32574c3e0
+checksum=2c67ddea52cd877b28922bf2781c5935f66abeb947c5a15955e4789e06fc4217
 
 post_install() {
 	vlicense COPYING


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: YES

#### Local build testing
- I built this PR locally for my native architecture: x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl (masterdir)
  - i686 (masterdir)
  - armv6l (cross)
  - armv6l-musl (cross)
  - armv7l (cross)
  - armv7l-musl (cross)

