### PR TITLE
libXrandr: update to 1.5.5

### DIFF
--- a/srcpkgs/libXrandr/template
+++ b/srcpkgs/libXrandr/template
@@ -1,6 +1,6 @@
 # Template file for 'libXrandr'
 pkgname=libXrandr
-version=1.5.4
+version=1.5.5
 revision=1
 build_style=gnu-configure
 configure_args="--enable-malloc0returnsnull"
@@ -11,7 +11,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
 homepage="https://www.x.org/"
 distfiles="${XORG_SITE}/lib/libXrandr-${version}.tar.xz"
-checksum=1ad5b065375f4a85915aa60611cc6407c060492a214d7f9daf214be752c3b4d3
+checksum=72b922c2e765434e9e9f0960148070bd4504b288263e2868a4ccce1b7cf2767a
 
 post_install() {
 	vlicense COPYING


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: YES

#### Local build testing
- I built this PR locally for my native architecture: x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl (masterdir)
  - i686 (masterdir)
  - armv6l (cross)
  - armv6l-musl (cross)
  - armv7l (cross)
  - armv7l-musl (cross)

