### PR TITLE
goldendict-ng: update to 26.8.0

### DIFF
--- a/srcpkgs/goldendict-ng/template
+++ b/srcpkgs/goldendict-ng/template
@@ -1,6 +1,6 @@
 # Template file for 'goldendict-ng'
 pkgname=goldendict-ng
-version=26.6.2
+version=26.8.0
 revision=1
 build_style=cmake
 configure_args="-DUSE_ALTERNATIVE_NAME=ON -DWITH_TTS=OFF"
@@ -14,8 +14,9 @@ short_desc="Feature-rich dictionary lookup program (goldendict fork)"
 maintainer="Mateusz Sylwestrzak <slymattz@gmail.com>"
 license="GPL-3.0-or-later"
 homepage="https://xiaoyifang.github.io/goldendict-ng/"
+changelog="https://github.com/xiaoyifang/goldendict-ng/releases"
 distfiles="https://github.com/xiaoyifang/goldendict-ng/archive/refs/tags/v${version}.tar.gz"
-checksum=61f592dffe3d5e9cf9c50188799374a66cc460ec7aff3be067cd4c79f19e1a27
+checksum=181534c827ca7939cb310df2013b084e4274b64f621821a4f825219f2dc888e3
 
 if [ "$XBPS_WORDSIZE$XBPS_WORDSIZE" != "64$XBPS_TARGET_WORDSIZE" ]; then
 	broken="Qt6 WebEngine"


### PR DESCRIPTION

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture: x86_64-glibc
