### PR TITLE
obs-plugin-browser-bin: update to 32.2.1

### DIFF
--- a/srcpkgs/obs-plugin-browser-bin/template
+++ b/srcpkgs/obs-plugin-browser-bin/template
@@ -1,6 +1,6 @@
 # Template file for 'obs-plugin-browser-bin'
 pkgname=obs-plugin-browser-bin
-version=32.1.0 # This is actually the version of obs to extract the plugin from
+version=32.2.1 # This is actually the version of obs to extract the plugin from
 revision=1
 archs="x86_64"
 short_desc="CEF-based OBS Studio browser plugin"
@@ -8,7 +8,7 @@ maintainer="Michael Aldridge <maldridge@voidlinux.org>"
 license="GPL-2.0-only"
 homepage="https://obsproject.com/kb/browser-source"
 distfiles="https://github.com/obsproject/obs-studio/releases/download/$version/OBS-Studio-$version-Ubuntu-24.04-x86_64.deb"
-checksum=89fa7657c56ffcc302ba75956eef1e7efaedd0e66ae2e2bd79170604d6c68800
+checksum=f3ce385c9157a33db7219953dc672ae566aefe4d1ac1417fff1e2114de3316b5
 
 do_install() {
 	vinstall local/lib/x86_64-linux-gnu/obs-plugins/obs-browser.so 0644 usr/lib/obs-plugins/


### PR DESCRIPTION
Update obs-plugin-browser-bin to extract the browser plugin from the official OBS Studio 32.2.1 .deb.

The .deb structure is unchanged (usr/local/lib/x86_64-linux-gnu/obs-plugins/). Companion to the obs 32.2.1 update (PR #61820) so the plugin ABI matches the base obs version.

- [x] I tested the changes in this PR: **YES** (browser source loads with CEF 127.0.6533, verified in OBS 32.2.1)