### PR TITLE
anki: update to 26.08.1, adopt.

### DIFF
--- a/srcpkgs/anki/template
+++ b/srcpkgs/anki/template
@@ -1,9 +1,9 @@
 # Template file for 'anki'
 pkgname=anki
-version=26.05
+version=26.08.1
 revision=1
-_anki_core_i18n_commit=af7c60d7f1aa1b831eb3b893558e4c625309ac2b
-_anki_desktop_ftl_commit=3a35d0aba2b1d04a69ddb471fb4d62645f6763d3
+_anki_core_i18n_commit=63e6bbbac72036efbc5af5d4981c5f8df82b0d5f
+_anki_desktop_ftl_commit=e3200e9d730630d03cfdc5fc7511ebb2a6fc575f
 build_helper="rust"
 # Leaving out the texlive optional dependency.
 # Its use case is niche, is a large package, and increases install time significantly.
@@ -22,7 +22,7 @@ depends="lame mpv python3 python3-BeautifulSoup4 python3-decorator
  python3-pysocks python3-requests python3-send2trash python3-truststore
  python3-typing_extensions python3-waitress qt6-multimedia qt6-svg"
 short_desc="Spaced repetition flashcard program"
-maintainer="Orphaned <orphan@voidlinux.org>"
+maintainer="Aryo Nazaradeh <aryo.nazaradeh@gmail.com>"
 license="AGPL-3.0-or-later"
 homepage="https://apps.ankiweb.net"
 changelog="https://github.com/ankitects/anki/releases"
@@ -30,9 +30,9 @@ distfiles="
  https://github.com/ankitects/anki/archive/refs/tags/${version}.tar.gz
  https://github.com/ankitects/anki-core-i18n/archive/${_anki_core_i18n_commit}.tar.gz>anki-core-i18n-${_anki_core_i18n_commit}.tar.gz
  https://github.com/ankitects/anki-desktop-ftl/archive/${_anki_desktop_ftl_commit}.tar.gz>anki-desktop-ftl-${_anki_desktop_ftl_commit}.tar.gz"
-checksum="1890f30f04996f87fee2449bd5903156f3e28ea715c0bd307f075777047df101
- 4900cc528c810b2849561afdd8d6a23653f92fb06562efd07b053bcde8f9fc13
- 346ef7dc2ab336d645ed8b4e2a47c7546f3b1f1e059a62f2d73d17a0b958c58f"
+checksum="28ef4b0d0addc9de43e2075ca020308e42e9676f0750dba6fa51946b1b274fef
+ 16942b3ed939035d5d6e51306f624d40ccdb8e22db122e3106a7be6db609698d
+ 03efa95828f1c03e80c93e16099a40c3d2b6e75608c8c44f662668c1374e2421"
 
 skip_extraction="
  anki-core-i18n-${_anki_core_i18n_commit}.tar.gz
@@ -134,11 +134,11 @@ do_install() {
 		python3 -m installer --destdir="${DESTDIR}" "${file}"
 	done
 
-	vinstall qt/launcher/lin/anki.desktop 644 usr/share/applications
-	vinstall qt/launcher/lin/anki.png 644 usr/share/pixmaps
-	vinstall qt/launcher/lin/anki.xpm 644 usr/share/pixmaps
-	vinstall qt/launcher/lin/anki.xml 644 usr/share/mime/packages
-	vman qt/launcher/lin/anki.1
+	vinstall qt/installer/linux-template/'{{ cookiecutter.format }}'/'{{ cookiecutter.app_name }}'/anki.desktop 644 usr/share/applications
+	vinstall qt/installer/linux-template/'{{ cookiecutter.format }}'/'{{ cookiecutter.app_name }}'/anki.png 644 usr/share/pixmaps
+	vinstall qt/installer/linux-template/'{{ cookiecutter.format }}'/'{{ cookiecutter.app_name }}'/anki.xpm 644 usr/share/pixmaps
+	vinstall qt/installer/linux-template/'{{ cookiecutter.format }}'/'{{ cookiecutter.app_name }}'/anki.xml 644 usr/share/mime/packages
+	vman qt/installer/linux-template/'{{ cookiecutter.format }}'/'{{ cookiecutter.app_name }}'/anki.1
 }
 
 post_install() {


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**
- Launched and used the app.

#### Local build testing
- I built this PR locally for my native architecture, (x86)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl

#### Notes
- Installation process changed as of commit https://github.com/ankitects/anki/commit/0d7b3fdd (Anki 26.08): Now using Briefcase, hence the changes in the `do_install()` function.
- Updated commits for the two additional distfiles to the recommended commits which I found here: https://github.com/ankitects/anki/tree/26.08.1/ftl
- This would be my first package adoption. With a lot of help from maintainers, I previously updated this package template to the version that is currently live on the repos (#61528). Before that, it was 6 years out of date, and others had given up on updating it during this period. In total I've had 4 PRs merged, each for different package updates, which hopefully is not too few. I promise to keep an eye on this package!