### PR TITLE
obs-shaderfilter: new package, version 0.9

### DIFF
--- a/srcpkgs/obs-shaderfilter/template
+++ b/srcpkgs/obs-shaderfilter/template
@@ -1,0 +1,26 @@
+# Template file for 'obs-shaderfilter'
+pkgname=obs-shaderfilter
+version=0.9
+revision=1
+makedepends="obs-devel simde"
+short_desc="OBS Studio filter for applying an arbitrary shader to a source"
+maintainer="Rodrigo Amaru Graeff <rodrigo@delphus.org>"
+license="Unlicense"
+homepage="https://github.com/nleseul/obs-shaderfilter"
+distfiles="https://github.com/nleseul/obs-shaderfilter/archive/refs/tags/v${version}-beta.tar.gz"
+checksum=533631b9909967baa9d9e92a959314ba8b368723f700f8ac659fa1bd64902130
+
+do_build() {
+	gcc -c src/obs-shaderfilter.c -I${XBPS_CROSS_BASE}/usr/include/obs \
+		-I${XBPS_CROSS_BASE}/usr/include -fPIC -O2
+	gcc -shared -o obs-shaderfilter.so obs-shaderfilter.o \
+		-L${XBPS_CROSS_BASE}/usr/lib -lobs -lobs-frontend-api
+}
+
+do_install() {
+	vinstall obs-shaderfilter.so 0644 usr/lib/obs-plugins/
+	vmkdir usr/share/obs/obs-plugins/obs-shaderfilter
+	cp -R data/* ${DESTDIR}/usr/share/obs/obs-plugins/obs-shaderfilter/
+	vdoc README.md
+	vlicense LICENSE
+}


### PR DESCRIPTION
#### New package
- `obs-shaderfilter`: OBS Studio filter for applying an arbitrary shader to a source (https://github.com/nleseul/obs-shaderfilter)

Tested with OBS 32.2.1 (libobs.so.30): plugin loads and the "User-defined shader" filter creates and renders correctly, including a custom bilateral denoise shader.

#### Build notes
- `makedepends`: `obs-devel simde` (simde needed for the sse-intrin headers pulled by obs-devel)
- Distfile: `v${version}-beta.tar.gz` tag (only release tag upstream)
- License: Unlicense