### PR TITLE
calibre: update to 9.13.0

### DIFF
--- a/srcpkgs/calibre/patches/0001-Disable-piper.patch
+++ b/srcpkgs/calibre/patches/0001-Disable-piper.patch
@@ -1,4 +1,4 @@
-From ef8fbea5ff37a4145bdbed91fdc8a6bdfdfc81ea Mon Sep 17 00:00:00 2001
+From e39b17a2aa56a4369843d90848494b6661495f45 Mon Sep 17 00:00:00 2001
 From: Patrick Poitras <patrick@pfpoitras.com>
 Date: Wed, 6 May 2026 19:14:43 -0700
 Subject: [PATCH] Disable piper
@@ -7,16 +7,16 @@ Subject: [PATCH] Disable piper
  setup/build.py                 | 8 ++++++++
  setup/commands.py              | 5 -----
  setup/resources.py             | 2 +-
- src/calibre/gui2/tts/types.py  | 5 +++--
+ src/calibre/gui2/tts/types.py  | 6 +++---
  src/calibre/test_build.py      | 3 ++-
  src/calibre/utils/run_tests.py | 5 +++--
- 6 files changed, 17 insertions(+), 11 deletions(-)
+ 6 files changed, 17 insertions(+), 12 deletions(-)
 
 diff --git a/setup/build.py b/setup/build.py
-index 956ad7504f..54a5f1236a 100644
+index 486249dd1f..920e90b37a 100644
 --- a/setup/build.py
 +++ b/setup/build.py
-@@ -444,6 +444,14 @@ def run(self, opts):
+@@ -470,6 +470,14 @@ def run(self, opts):
                  continue
              if not is_ext_allowed(self.compiling_for, ext):
                  continue
@@ -32,10 +32,10 @@ index 956ad7504f..54a5f1236a 100644
                  if ext.optional:
                      self.warn(ext.error)
 diff --git a/setup/commands.py b/setup/commands.py
-index faba5b437a..96e5682ce6 100644
+index 72ebca92ae..436c798d8d 100644
 --- a/setup/commands.py
 +++ b/setup/commands.py
-@@ -31,7 +31,6 @@
+@@ -33,7 +33,6 @@
      'manual',
      'mathjax',
      'osx',
@@ -43,7 +43,7 @@ index faba5b437a..96e5682ce6 100644
      'pot',
      'publish',
      'publish_betas',
-@@ -95,10 +94,6 @@
+@@ -98,10 +97,6 @@
  
  hyphenation = Hyphenation()
  
@@ -55,12 +55,12 @@ index faba5b437a..96e5682ce6 100644
  
  liberation_fonts = LiberationFonts()
 diff --git a/setup/resources.py b/setup/resources.py
-index fbd918c5df..64a60bd0bf 100644
+index bccb1626b5..e591588e70 100644
 --- a/setup/resources.py
 +++ b/setup/resources.py
-@@ -104,7 +104,7 @@ def run(self, opts):
- class Resources(Command):  # {{{
+@@ -116,7 +116,7 @@ def run(self, opts):
  
+ class Resources(Command):  # {{{
      description = 'Compile various needed calibre resources'
 -    sub_commands = ['liberation_fonts', 'mathjax', 'rapydscript', 'hyphenation', 'piper_voices']
 +    sub_commands = ['liberation_fonts', 'mathjax', 'rapydscript', 'hyphenation']
@@ -68,14 +68,15 @@ index fbd918c5df..64a60bd0bf 100644
      def run(self, opts):
          from calibre.utils.serialize import msgpack_dumps
 diff --git a/src/calibre/gui2/tts/types.py b/src/calibre/gui2/tts/types.py
-index a9ef058ae4..0db9b3dcc3 100644
+index b847d00243..3067a02404 100644
 --- a/src/calibre/gui2/tts/types.py
 +++ b/src/calibre/gui2/tts/types.py
-@@ -236,8 +236,9 @@ def qt_engine_metadata(name: str, human_name: str, desc: str, allows_choosing_au
+@@ -264,9 +264,9 @@ def qt_engine_metadata(
              continue
  
      try:
 -        import calibre_extensions.piper as check_that_piper_imports
+-
 -        del check_that_piper_imports
 +        # import calibre_extensions.piper as check_that_piper_imports
 +        # del check_that_piper_imports
@@ -84,10 +85,10 @@ index a9ef058ae4..0db9b3dcc3 100644
          pass
      else:
 diff --git a/src/calibre/test_build.py b/src/calibre/test_build.py
-index b60e2f1cd6..bfbed35e56 100644
+index 30d34fe690..6868947bd3 100644
 --- a/src/calibre/test_build.py
 +++ b/src/calibre/test_build.py
-@@ -158,7 +158,8 @@ def test_plugins(self):
+@@ -172,7 +172,8 @@ def test_plugins(self):
                      # Just check that the DLL can be loaded
                      ctypes.CDLL(os.path.join(plugins_loc, name + ('.dylib' if ismacos else '.so')))
                  continue
@@ -98,11 +99,11 @@ index b60e2f1cd6..bfbed35e56 100644
      def test_lxml(self):
          from calibre.utils.cleantext import test_clean_xml_chars
 diff --git a/src/calibre/utils/run_tests.py b/src/calibre/utils/run_tests.py
-index 19853589ff..7e880dff58 100644
+index e42782699c..54f31c7985 100644
 --- a/src/calibre/utils/run_tests.py
 +++ b/src/calibre/utils/run_tests.py
-@@ -190,8 +190,9 @@ def test_import_of_all_python_modules(self):
-                 'calibre.utils.linux_trash', 'calibre.utils.open_with.linux',
+@@ -565,8 +565,9 @@ def test_import_of_all_python_modules(self):
+                 'calibre.utils.open_with.linux',
                  'calibre.gui2.linux_file_dialogs',
              }
 -        if 'SKIP_SPEECH_TESTS' in os.environ:
@@ -114,5 +115,5 @@ index 19853589ff..7e880dff58 100644
              exclude_modules.add('calibre.devices.usbms.hal')
          d = os.path.dirname
 -- 
-2.54.0
+2.55.0
 

--- a/srcpkgs/calibre/template
+++ b/srcpkgs/calibre/template
@@ -1,7 +1,7 @@
 # Template file for 'calibre'
 pkgname=calibre
-version=9.10.0
-revision=2
+version=9.13.0
+revision=1
 build_helper=python3
 pycompile_dirs="/usr/lib/calibre/"
 hostmakedepends="pkg-config cmake python3-BeautifulSoup4 python3-Pillow
@@ -39,7 +39,7 @@ license="GPL-3.0-only"
 homepage="https://calibre-ebook.com"
 changelog="https://raw.githubusercontent.com/kovidgoyal/calibre/master/Changelog.txt"
 distfiles="https://download.calibre-ebook.com/${version}/calibre-${version}.tar.xz"
-checksum=53b8a277c766e6c3fb5dfb26fa29119f4a129bf8f9a954b4235a963c8a30c301
+checksum=38d7d88d7abcbc62c6fe3575483fb5493ce962d261a978a1a4db4d58bc4b3793
 python_version=3
 lib32disabled=yes
 nocross="python3 setup.py gui"
@@ -188,6 +188,9 @@ do_check() {
 	# test_websocket_basic fails
     # test_tzdata fails because we don't specifically
     #    use pip-packaged version of tzdata
+    # test_feedparser fails because only the test relies on a split-out version
+    #    of sgmllib that we don't have packaged. This split-out package is quite
+    #    new so I expect the core code will eventually use it. 
 	python3 setup.py test \
 		--exclude-test-name unrar \
 		--exclude-test-name qt \
@@ -196,7 +199,8 @@ do_check() {
 		--exclude-test-name test_recipe_browser_webengine \
 		--exclude-test-name test_piper \
 		--exclude-test-name test_websocket_basic \
-		--exclude-test-name test_tzdata
+		--exclude-test-name test_tzdata \
+		--exclude-test-name test_feedparser
 }
 
 do_install() {


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)

Two changes other than version bump:

1. Rebased the patch that disables piper because of whitespace changes upstream
2. Added disabled test that uses a newly split-off "feedparser-sgmllib". The test is the only thing that uses that package. I think it's a partially-carried-through migration at this time.