### PR TITLE
KDE Gear: fix build due to missing KF6I18n check

### DIFF
--- a/srcpkgs/akonadi-import-wizard/patches/find-ki18n.patch
+++ b/srcpkgs/akonadi-import-wizard/patches/find-ki18n.patch
@@ -1,0 +1,22 @@
+From 5a8e55ca18fde080a31eb67f93bd5943a6b4aa0e Mon Sep 17 00:00:00 2001
+From: Laurent Montel <montel@kde.org>
+Date: Sun, 12 Jul 2026 07:32:02 +0200
+Subject: [PATCH] Add missing find_package(KF6I18n
+
+---
+ CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index bd269284..0096298b 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -126,7 +126,7 @@ find_package(KF6Crash ${KF_MIN_VERSION} REQUIRED)
+ find_package(KF6KIO ${KF_MIN_VERSION} REQUIRED)
+ find_package(KF6Archive ${KF_MIN_VERSION} REQUIRED)
+ find_package(KF6IconThemes ${KF_MIN_VERSION} CONFIG REQUIRED)
+-
++find_package(KF6I18n ${KF_MIN_VERSION} CONFIG REQUIRED)
+ find_package(KF6DocTools ${KF_MIN_VERSION})
+ set_package_properties(
+     KF6DocTools

--- a/srcpkgs/akonadi-import-wizard/template
+++ b/srcpkgs/akonadi-import-wizard/template
@@ -2,7 +2,7 @@
 # group=kde-gear
 pkgname=akonadi-import-wizard
 version=26.04.3
-revision=1
+revision=2
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins

--- a/srcpkgs/kaddressbook/patches/find-ki18n.patch
+++ b/srcpkgs/kaddressbook/patches/find-ki18n.patch
@@ -1,0 +1,26 @@
+From 14804f1e8755a0998c83167735914b25828ab200 Mon Sep 17 00:00:00 2001
+From: "Friedrich W. H. Kossebau" <kossebau@kde.org>
+Date: Sat, 11 Jul 2026 10:45:58 +0000
+Subject: [PATCH] Explicitely check KF6I18n dependency ourselves, using it
+ directly
+
+CMake macros are used and explicit lingage, so better to not rely on others to check the dep for us.
+---
+ CMakeLists.txt | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 381da324..503b8241 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -135,6 +135,7 @@ find_package(KF6KCMUtils ${KF_MIN_VERSION} CONFIG REQUIRED)
+ find_package(KF6Crash ${KF_MIN_VERSION} REQUIRED)
+ find_package(KF6IconThemes ${KF_MIN_VERSION} CONFIG REQUIRED)
+ find_package(KF6ColorScheme ${KF_MIN_VERSION} CONFIG REQUIRED)
++find_package(KF6I18n ${KF_MIN_VERSION} CONFIG REQUIRED)
+ find_package(KF6DocTools ${KF_MIN_VERSION})
+ set_package_properties(
+     KF6DocTools
+-- 
+GitLab
+

--- a/srcpkgs/kaddressbook/template
+++ b/srcpkgs/kaddressbook/template
@@ -2,7 +2,7 @@
 # group=kde-gear
 pkgname=kaddressbook
 version=26.04.3
-revision=1
+revision=2
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins

--- a/srcpkgs/pim-data-exporter/patches/find-ki18n.patch
+++ b/srcpkgs/pim-data-exporter/patches/find-ki18n.patch
@@ -1,0 +1,24 @@
+From 8a5bfd6646ddd34236c2a150fc4e830fa9c4e598 Mon Sep 17 00:00:00 2001
+From: Laurent Montel <montel@kde.org>
+Date: Sat, 11 Jul 2026 07:17:46 +0200
+Subject: [PATCH] Add find_package(KF6I18n...)
+
+---
+ CMakeLists.txt | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 953443ba..5b32db22 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -148,6 +148,7 @@ find_package(KF6WidgetsAddons ${KF_MIN_VERSION} REQUIRED)
+ find_package(KF6XmlGui ${KF_MIN_VERSION} REQUIRED)
+ find_package(KF6StatusNotifierItem ${KF_MIN_VERSION} REQUIRED)
+ find_package(KF6IconThemes ${KF_MIN_VERSION} QUIET)
++find_package(KF6I18n ${KF_MIN_VERSION} CONFIG REQUIRED)
+ 
+ find_package(KF6DocTools ${KF_MIN_VERSION})
+ set_package_properties(
+-- 
+GitLab
+

--- a/srcpkgs/pim-data-exporter/template
+++ b/srcpkgs/pim-data-exporter/template
@@ -2,7 +2,7 @@
 # group=kde-gear
 pkgname=pim-data-exporter
 version=26.04.3
-revision=1
+revision=2
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF
  -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

Buildbot is failing after merging #60475. I'll add other packages if they have similar issues.

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, `x86_64-glibc`
<!--
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
 
CC @classabbyamp 