### PR TITLE
squid: update to 7.6

### DIFF
--- a/srcpkgs/squid/template
+++ b/srcpkgs/squid/template
@@ -1,6 +1,6 @@
 # Template file for 'squid'
 pkgname=squid
-version=6.7
+version=7.6
 revision=1
 build_style=gnu-configure
 configure_args="
@@ -39,7 +39,6 @@ configure_args="
  --with-build-environment=default"
 conf_files="/etc/squid/squid.conf
  /etc/squid/errorpage.css
- /etc/squid/cachemgr.conf
  /etc/squid/mime.conf"
 make_dirs="/var/log/squid 750 squid squid
  /var/cache/squid 750 squid squid"
@@ -52,9 +51,9 @@ short_desc="Caching proxy for the Web"
 maintainer="Toyam Cox <Vaelatern@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="http://www.squid-cache.org/"
-changelog="http://www.squid-cache.org/Versions/v${version%%.*}/changesets/"
-distfiles="http://www.squid-cache.org/Versions/v${version%%.*}/squid-${version}.tar.xz"
-checksum=e14daa4eae41925d1ae3f08e64439a6aaa3011bdced686628b8de697d5ab8428
+changelog="https://github.com/squid-cache/squid/releases"
+distfiles="https://github.com/squid-cache/squid/releases/download/SQUID_7_6/squid-${version}.tar.gz"
+checksum=57a385d0435768da1f6a469a251f3c951bb79f0ea6d3f04c569d5a50c20e678a
 system_accounts="squid"
 # squid-conf-tests requires a squid user in the system
 make_check=no


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, X86_64-glibc
- I built this PR locally for these architectures
  - aarch64 crossbuild
  - i686 crossbuild