### PR TITLE
opera: update to 134.0.5954.46.

### DIFF
--- a/srcpkgs/opera/template
+++ b/srcpkgs/opera/template
@@ -1,6 +1,6 @@
 # Template file for 'opera'
 pkgname=opera
-version=133.0.5932.60
+version=134.0.5954.46
 revision=1
 archs="x86_64 aarch64"
 create_wrksrc=yes
@@ -15,11 +15,11 @@ nostrip=yes
 case "$XBPS_TARGET_MACHINE" in
 x86_64*)
 	distfiles="https://rpm.opera.com/rpm/opera_stable-${version}-linux-release-x64-signed.rpm"
-	checksum=2b57ea17b801c3ac9360b7ddb25303860bc7be1fde9f43ac39de5f296e27d131
+	checksum=f038613774aa589ac90e278cc16f335c8c4f59dfd9b15fcf261bcea78b727229
 	;;
 aarch64*)
 	distfiles="https://rpm.opera.com/rpm/opera_stable-${version}-linux-release-arm64-signed.rpm"
-	checksum=e842f59f4d74fa8b164aad8894824be7567cf7569bfd13f161ebb1293a51353d
+	checksum=428f30af93ef4a6cf513e2852523ef995972e3c0ded9c0dd8bbb1dca69b775fe
 	;;
 *)
 	broken="No distfiles available for this target"

--- a/srcpkgs/opera/update
+++ b/srcpkgs/opera/update
@@ -1,1 +1,1 @@
-pattern="opera-stable_\K\d+\.\d+\.\d+\.\d+(?=_amd64\.deb)"
+pattern="opera_stable-\K[\d.]+(?=.+\.rpm)"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **NO**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, `x86_64-glibc`
<!--
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
