### PR TITLE
darktable: update to 5.6.0.

### DIFF
--- a/srcpkgs/darktable/template
+++ b/srcpkgs/darktable/template
@@ -1,20 +1,20 @@
 # Template file for 'darktable'
 pkgname=darktable
-version=5.4.0
-revision=2
+version=5.6.0
+revision=1
 # upstream only supports these archs:
 archs="x86_64* aarch64* ppc64le*"
 build_style=cmake
 # this makes sure to use -march=generic and -msse3
 configure_args="-DBINARY_PACKAGE_BUILD=ON -DBUILD_NOISE_TOOLS=ON
- -DRAWSPEED_ENABLE_LTO=ON"
+ -DRAWSPEED_ENABLE_LTO=ON -DUSE_GMIC=OFF"
 hostmakedepends="pkg-config intltool libxslt-devel desktop-file-utils"
 makedepends="gtk+3-devel glib-devel exiv2-devel libxslt-devel
  dbus-glib-devel libcurl-devel libgphoto2-devel libwebp-devel
  lensfun-devel sqlite-devel librsvg-devel lua54-devel json-glib-devel
  libgomp-devel libopenjpeg2-devel libopenexr-devel libgraphicsmagick-devel
  libsecret-devel pugixml-devel libosmgpsmap-devel colord-gtk-devel
- libheif-devel portmidi-devel libjxl-devel $(vopt_if gmic gmic-devel)
+ libheif-devel portmidi-devel libjxl-devel potrace-devel
  $(vopt_if avif libavif-devel) $(vopt_if sdl2 SDL2-devel)"
 depends="adwaita-icon-theme"
 short_desc="Virtual lighttable and darkroom for photographers"
@@ -23,15 +23,10 @@ license="GPL-3.0-or-later"
 homepage="https://www.darktable.org/"
 changelog="https://github.com/darktable-org/darktable/releases"
 distfiles="https://github.com/darktable-org/darktable/releases/download/release-${version}/darktable-${version}.tar.xz"
-checksum=2bf0baea78d27945cf09c33d8804f179e03a83ee19d2e927fd660ea46aca3b16
+checksum=157d6d3847af8afcabe78944454786f73a886e08a504b4bd6114c2065fe006e4
 
-build_options="avif gmic sdl2"
+build_options="avif sdl2"
 build_options_default="avif sdl2"
-
-case "${XBPS_TARGET_MACHINE}" in
-	aarch64) ;;
-	*) build_options_default+=" gmic" ;;
-esac
 
 case "${XBPS_TARGET_MACHINE}" in
 	*-musl) configure_args+=" -DUSE_OPENMP=OFF";;


### PR DESCRIPTION
Drops gmic support for now, cmake isn't able to find it.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
