### PR TITLE
patchelf: update to 0.19.1

### DIFF
--- a/srcpkgs/patchelf/template
+++ b/srcpkgs/patchelf/template
@@ -1,11 +1,12 @@
 # Template file for 'patchelf'
 pkgname=patchelf
-version=0.18.0
+version=0.19.1
 revision=1
 build_style=gnu-configure
 short_desc="Utility for modifing existing ELF executables and libraries"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-3.0-or-later"
 homepage="https://github.com/NixOS/patchelf"
+changelog="https://raw.githubusercontent.com/NixOS/patchelf/refs/heads/master/ChangeLog.md"
 distfiles="${homepage}/releases/download/${version}/patchelf-${version}.tar.bz2"
-checksum=1952b2a782ba576279c211ee942e341748fdb44997f704dd53def46cd055470b
+checksum=2cce01de93653829f6ab68a20c2ec275e1c00a946110704a27e928d2e6e88716


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: YES

#### Local build testing
- I built this PR locally for my native architecture: x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl (masterdir)
  - i686 (masterdir)
  - aarch64 (cross)
  - aarch64-musl (cross)
  - armv6l (cross)
  - armv6l-musl (cross)
  - armv7l (cross)
  - armv7l-musl (cross)

