### PR TITLE
New package: krecorder-26.04.3

### DIFF
--- a/srcpkgs/krecorder/template
+++ b/srcpkgs/krecorder/template
@@ -1,0 +1,20 @@
+# Template file for 'krecorder'
+# group=kde-gear
+pkgname=krecorder
+version=26.04.3
+revision=1
+build_style=cmake
+configure_args="-DBUILD_TESTING=OFF"
+hostmakedepends="extra-cmake-modules gettext kf6-kconfig qt6-base
+ qt6-declarative-host-tools qt6-tools"
+makedepends="kf6-kconfig-devel kf6-kcoreaddons-devel kf6-ki18n-devel
+ kf6-kirigami-devel kirigami-addons-devel qt6-base-devel
+ qt6-declarative-devel qt6-multimedia-devel qt6-svg-devel"
+depends="kirigami-addons"
+short_desc="Convergent audio recording application for Plasma"
+maintainer="Nafis <mnabid.25@outlook.com>"
+license="GPL-3.0-or-later"
+homepage="https://apps.kde.org/krecorder/"
+changelog="https://kde.org/announcements/changelogs/gear/${version}/#krecorder"
+distfiles="${KDE_SITE}/release-service/${version}/src/krecorder-${version}.tar.xz"
+checksum=af7a5e67773006e252616ca165405654d649089787bc646b493f91ad2580a260


### PR DESCRIPTION
A convergent audio recording application for Plasma.
https://apps.kde.org/krecorder/

#### Testing the changes
- I tested the changes in this PR: **briefly**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, `x86_64-glibc`
- I built this PR locally for these architectures:
  - `armv7l-musl` (crossbuild)
