### PR TITLE
obs: update to 32.2.1 with RNNoise, browser-bin and shaderfilter

### DIFF
--- a/srcpkgs/obs-plugin-browser-bin/template
+++ b/srcpkgs/obs-plugin-browser-bin/template
@@ -1,6 +1,6 @@
 # Template file for 'obs-plugin-browser-bin'
 pkgname=obs-plugin-browser-bin
-version=32.1.0 # This is actually the version of obs to extract the plugin from
+version=32.2.1 # This is actually the version of obs to extract the plugin from
 revision=1
 archs="x86_64"
 short_desc="CEF-based OBS Studio browser plugin"
@@ -8,7 +8,7 @@ maintainer="Michael Aldridge <maldridge@voidlinux.org>"
 license="GPL-2.0-only"
 homepage="https://obsproject.com/kb/browser-source"
 distfiles="https://github.com/obsproject/obs-studio/releases/download/$version/OBS-Studio-$version-Ubuntu-24.04-x86_64.deb"
-checksum=89fa7657c56ffcc302ba75956eef1e7efaedd0e66ae2e2bd79170604d6c68800
+checksum=f3ce385c9157a33db7219953dc672ae566aefe4d1ac1417fff1e2114de3316b5
 
 do_install() {
 	vinstall local/lib/x86_64-linux-gnu/obs-plugins/obs-browser.so 0644 usr/lib/obs-plugins/

--- a/srcpkgs/obs-shaderfilter/template
+++ b/srcpkgs/obs-shaderfilter/template
@@ -11,9 +11,9 @@ distfiles="https://github.com/nleseul/obs-shaderfilter/archive/refs/tags/v${vers
 checksum=533631b9909967baa9d9e92a959314ba8b368723f700f8ac659fa1bd64902130
 
 do_build() {
-	gcc -c src/obs-shaderfilter.c -I${XBPS_CROSS_BASE}/usr/include/obs \
+	${CC} ${CFLAGS} -c src/obs-shaderfilter.c -I${XBPS_CROSS_BASE}/usr/include/obs \
 		-I${XBPS_CROSS_BASE}/usr/include -fPIC -O2
-	gcc -shared -o obs-shaderfilter.so obs-shaderfilter.o \
+	${CC} ${LDFLAGS} -shared -o obs-shaderfilter.so obs-shaderfilter.o \
 		-L${XBPS_CROSS_BASE}/usr/lib -lobs -lobs-frontend-api
 }
 

--- a/srcpkgs/obs-shaderfilter/template
+++ b/srcpkgs/obs-shaderfilter/template
@@ -1,0 +1,26 @@
+# Template file for 'obs-shaderfilter'
+pkgname=obs-shaderfilter
+version=0.9
+revision=1
+makedepends="obs-devel simde"
+short_desc="OBS Studio filter for applying an arbitrary shader to a source"
+maintainer="Rodrigo Amaru Graeff <rodrigo@delphus.org>"
+license="Unlicense"
+homepage="https://github.com/nleseul/obs-shaderfilter"
+distfiles="https://github.com/nleseul/obs-shaderfilter/archive/refs/tags/v${version}-beta.tar.gz"
+checksum=533631b9909967baa9d9e92a959314ba8b368723f700f8ac659fa1bd64902130
+
+do_build() {
+	gcc -c src/obs-shaderfilter.c -I${XBPS_CROSS_BASE}/usr/include/obs \
+		-I${XBPS_CROSS_BASE}/usr/include -fPIC -O2
+	gcc -shared -o obs-shaderfilter.so obs-shaderfilter.o \
+		-L${XBPS_CROSS_BASE}/usr/lib -lobs -lobs-frontend-api
+}
+
+do_install() {
+	vinstall obs-shaderfilter.so 0644 usr/lib/obs-plugins/
+	vmkdir usr/share/obs/obs-plugins/obs-shaderfilter
+	cp -R data/* ${DESTDIR}/usr/share/obs/obs-plugins/obs-shaderfilter/
+	vdoc README.md
+	vlicense LICENSE
+}

--- a/srcpkgs/obs/template
+++ b/srcpkgs/obs/template
@@ -1,11 +1,11 @@
 # Template file for 'obs'
 pkgname=obs
-version=32.1.2
-revision=2
+version=32.2.1
+revision=1
 archs="i686* x86_64* ppc64le* aarch64* riscv64*"
 build_style=cmake
 configure_args="-DOBS_VERSION_OVERRIDE=${version} -DENABLE_JACK=ON
- -DCMAKE_INSTALL_DATAROOTDIR=share -DENABLE_RNNOISE=OFF
+ -DCMAKE_INSTALL_DATAROOTDIR=share -DENABLE_RNNOISE=ON
  -DENABLE_VST=OFF -DENABLE_AJA=OFF
  -DENABLE_SCRIPTING_LUA=$(vopt_if luajit 'ON' 'OFF')
  -DENABLE_NVENC=$(vopt_if nvenc 'ON' 'OFF')
@@ -19,7 +19,7 @@ makedepends="$(vopt_if luajit LuaJIT-devel) fdk-aac-devel
  jansson-devel wayland-devel pipewire-devel libxkbcommon-devel
  pciutils-devel librist-devel srt-devel libdatachannel-devel
  libvpl-devel uthash qt6-base-private-devel json-c++ extra-cmake-modules
- simde $(vopt_if nvenc nv-codec-headers)"
+ simde rnnoise-devel $(vopt_if nvenc nv-codec-headers)"
 depends="xset xdg-desktop-portal"
 short_desc="Open Broadcaster Software"
 maintainer="lemmi <lemmi@nerd2nerd.org>"
@@ -27,7 +27,7 @@ license="GPL-2.0-or-later"
 homepage="https://obsproject.com"
 changelog="https://github.com/obsproject/obs-studio/releases"
 distfiles="https://github.com/obsproject/obs-studio/archive/refs/tags/$version.tar.gz"
-checksum=b4a59410cddb46d0e31df1ee13b8ec66f30862d7e980c1a8c4e3b5d16fae6053
+checksum=db034bc3d2c137ec7f1809cbef4fc90c8948652b90a860078410482457d8a574
 
 build_options="luajit qsv nvenc"
 case $XBPS_TARGET_MACHINE in

--- a/srcpkgs/websocketpp/template
+++ b/srcpkgs/websocketpp/template
@@ -1,14 +1,17 @@
 # Template file for 'websocketpp'
 pkgname=websocketpp
 version=0.8.2
-revision=1
+revision=2
 build_style=cmake
 short_desc="C++/Boost Asio based websocket client/server library"
 maintainer="Duncaen <duncaen@voidlinux.org>"
 license="BSD-3-Clause"
 homepage="https://www.zaphoyd.com/websocketpp"
-distfiles="https://github.com/zaphoyd/websocketpp/archive/${version}.tar.gz"
-checksum=6ce889d85ecdc2d8fa07408d6787e7352510750daa66b5ad44aacb47bea76755
+# fork com fixes de compatibilidade com asio novo (PR #1168, commit 363ec802)
+# o upstream 0.8.2 usa io_service/expires_from_now, removidos no asio >= 1.28
+distfiles="https://github.com/amini-allight/websocketpp/archive/363ec80247782e4b933f93079f02a0835de28570.tar.gz"
+checksum=b6a291d938037860be33f6e52f22037cad8dffc6578ff55cc4dbaed3e7c75865
+wrksrc="websocketpp-363ec80247782e4b933f93079f02a0835de28570"
 
 post_install() {
 	vlicense COPYING

--- a/srcpkgs/websocketpp/template
+++ b/srcpkgs/websocketpp/template
@@ -9,9 +9,8 @@ license="BSD-3-Clause"
 homepage="https://www.zaphoyd.com/websocketpp"
 # fork com fixes de compatibilidade com asio novo (PR #1168, commit 363ec802)
 # o upstream 0.8.2 usa io_service/expires_from_now, removidos no asio >= 1.28
-distfiles="https://github.com/amini-allight/websocketpp/archive/363ec80247782e4b933f93079f02a0835de28570.tar.gz"
+distfiles="https://github.com/amini-allight/websocketpp/archive/363ec80247782e4b933f93079f02a0835de28570.tar.gz>websocketpp-${version}.tar.gz"
 checksum=b6a291d938037860be33f6e52f22037cad8dffc6578ff55cc4dbaed3e7c75865
-wrksrc="websocketpp-363ec80247782e4b933f93079f02a0835de28570"
 
 post_install() {
 	vlicense COPYING


### PR DESCRIPTION
Update OBS Studio to 32.2.1 with the full dependency chain merged together:

- **websocketpp**: use amini-allight fork with asio compatibility fixes (PR #1168) — upstream 0.8.2 uses io_service/expires_from_now removed in asio >= 1.28, breaks obs 32.2.1 build
- **obs**: update to 32.2.1, enable RNNoise noise suppression, add rnnoise-devel to makedepends
- **obs-plugin-browser-bin**: update to 32.2.1
- **obs-shaderfilter**: new package, version 0.9 (denoise video shader)

As requested by maintainer review — merged into one PR since they should be merged together.