### PR TITLE
sof-tools: update to 2.15

### DIFF
--- a/srcpkgs/sof-tools/patches/fix-musl-uint.patch
+++ b/srcpkgs/sof-tools/patches/fix-musl-uint.patch
@@ -1,0 +1,24 @@
+musl <stdlib.h> does not include <sys/types.h>, patch submitted upstream
+
+fix a format string in ctl.c on 32-bit archs where size_t is unsigned int instead of long
+--- a/tools/probes/probes_demux.c
++++ b/tools/probes/probes_demux.c
+@@ -15,6 +15,7 @@
+ #include <stdlib.h>
+ #include <string.h>
+ #include <unistd.h>
++#include <sys/types.h>
+ 
+ #include <ipc/probe_dma_frame.h>
+ 
+--- a/tools/ctl/ctl.c
++++ b/tools/ctl/ctl.c
+@@ -503,7 +503,7 @@ static int ctl_set_get(struct ctl_data *ctl_data)
+ 		ref_size = ctl_data->buffer[BUFFER_SIZE_OFFSET] + BUFFER_TLV_HEADER_BYTES;
+ 		if (read_size != ref_size) {
+ 			fprintf(stderr,
+-				"Error: Blob TLV header size %u (plus %lu) does not match with read bytes count %zu.\n",
++				"Error: Blob TLV header size %u (plus %zu) does not match with read bytes count %zu.\n",
+ 				ctl_data->buffer[BUFFER_SIZE_OFFSET], BUFFER_TLV_HEADER_BYTES,
+ 				read_size);
+ 			return -EINVAL;

--- a/srcpkgs/sof-tools/template
+++ b/srcpkgs/sof-tools/template
@@ -1,9 +1,7 @@
 # Template file for 'sof-tools'
 pkgname=sof-tools
-version=2.2.1
+version=2.14.3
 revision=1
-# https://github.com/thesofproject/sof/issues/4902
-archs="x86_64"
 build_wrksrc="tools"
 build_style=cmake
 hostmakedepends="alsa-utils m4"
@@ -13,7 +11,7 @@ maintainer="cinerea0 <cinerea0@protonmail.com>"
 license="BSD-3-Clause"
 homepage="https://thesofproject.github.io/latest/index.html"
 distfiles="https://github.com/thesofproject/sof/archive/refs/tags/v${version}.tar.gz"
-checksum=72e096cc69ca0f1782bd0757c1ac7ae27de3f16228cf8dfb75069b129465ed73
+checksum=8797b05369aef589237a523a9e2c7d8a80e3e1ab7c41fb46a34626047a337494
 
 post_install() {
 	vlicense ../LICENCE


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, X86_64-glibc
- I built this PR locally for these architectures X86:
  - aarch64-musl crossbuild

Included patch to fix musl build. Submitted upstream. Closes https://github.com/void-linux/void-packages/pull/37712 and https://github.com/void-linux/void-packages/issues/38951
