### PR TITLE
pastebinit: update to 1.8.0

### DIFF
--- a/srcpkgs/pastebinit/template
+++ b/srcpkgs/pastebinit/template
@@ -1,15 +1,15 @@
 # Template file for 'pastebinit'
 pkgname=pastebinit
-version=1.6.2
+version=1.8.0
 revision=1
 hostmakedepends="asciidoc gettext"
 depends="python3-distro"
 short_desc="Pastebin command-line client"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later"
-homepage="https://phab.lubuntu.me/source/pastebinit/"
-distfiles="$DEBIAN_SITE/main/p/$pkgname/${pkgname}_$version.orig.tar.gz"
-checksum=b7f63207bfb66eca0e77052283815346d3ad9de2b30aa9f68b74521f0b54940a
+homepage="https://github.com/pastebinit/pastebinit/"
+distfiles="https://github.com/pastebinit/pastebinit/archive/refs/tags/${version}.tar.gz"
+checksum=fc8ed4323ddfb130c17380af8f4970ac9c1648563fb1ab4efd307e87eb2c41e7
 
 do_build() {
 	a2x -f manpage pastebinit.xml


### PR DESCRIPTION

The original url listed as the homepage is no longer accessible so I updated it to their github repo which debian also links to as the homepage: [https://packages.debian.org/forky/pastebinit](url)

The original url in distfiles still works but it seemed to make sense to also change it to their github repo.


#### Testing the changes
- I tested the changes in this PR: YES

#### Local build testing
- I built this PR locally for my native architecture: x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl (masterdir)
  - i686 (masterdir)
  - aarch64 (cross)
  - aarch64-musl (cross)
  - armv6l (cross)
  - armv6l-musl (cross)
  - armv7l (cross)
  - armv7l-musl (cross)

