### PR TITLE
ada: update to 4.0.0

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -466,7 +466,7 @@ libparted.so.2 libparted-3.1_1
 libparted-fs-resize.so.0 libparted-3.1_1
 libntfs-3g.so.89 ntfs-3g-2021.8.22_1
 libruby.so.3.4 ruby-3.4.5_1
-libada.so.3 ada-3.1.0_1
+libada.so.4 ada-4.0.0_1
 librw.so.0 rankwidth-0.9_1
 libxenctrl.so.4.19 xen-libs-4.19.0_1
 libxenfsimage.so.4.19 xen-libs-4.19.0_1

--- a/srcpkgs/ada/template
+++ b/srcpkgs/ada/template
@@ -1,6 +1,6 @@
 # Template file for 'ada'
 pkgname=ada
-version=3.4.4
+version=4.0.0
 revision=1
 build_style=cmake
 configure_args="-DBUILD_SHARED_LIBS=ON"
@@ -9,7 +9,7 @@ maintainer="John <me@johnnynator.dev>"
 license="MIT OR Apache-2.0"
 homepage="https://www.ada-url.com/"
 distfiles="https://github.com/ada-url/ada/archive/refs/tags/v${version}.tar.gz"
-checksum=77bc5bbc383ed098cc60266ad6ee912de2431bb62d89248c0e17c4e712dcdaf9
+checksum=6d6c7ef7dd2e329320d34eb2ab29ccdc879ee3935af9dfb894a6640e58dc381d
 
 post_install() {
 	vlicense LICENSE-APACHE

--- a/srcpkgs/nodejs/template
+++ b/srcpkgs/nodejs/template
@@ -1,7 +1,7 @@
 # Template file for 'nodejs'
 pkgname=nodejs
 version=24.18.0
-revision=1
+revision=2
 build_style=configure
 configure_args="
  --prefix=/usr

--- a/srcpkgs/telegram-desktop/template
+++ b/srcpkgs/telegram-desktop/template
@@ -1,7 +1,7 @@
 # Template file for 'telegram-desktop'
 pkgname=telegram-desktop
 version=7.0.4
-revision=1
+revision=2
 build_style=cmake
 build_helper="qemu gir"
 configure_args="-DTDESKTOP_API_ID=209235

--- a/srcpkgs/telegram-desktop/template
+++ b/srcpkgs/telegram-desktop/template
@@ -1,7 +1,7 @@
 # Template file for 'telegram-desktop'
 pkgname=telegram-desktop
-version=7.0.4
-revision=2
+version=7.0.9
+revision=1
 build_style=cmake
 build_helper="qemu gir"
 configure_args="-DTDESKTOP_API_ID=209235
@@ -29,7 +29,7 @@ license="GPL-3.0-or-later, OpenSSL"
 homepage="https://desktop.telegram.org/"
 changelog="https://github.com/telegramdesktop/tdesktop/blob/v${version}/changelog.txt"
 distfiles="https://github.com/telegramdesktop/tdesktop/releases/download/v${version}/tdesktop-${version}-full.tar.gz"
-checksum=9b805d85cc9d36b4a8e3cab78d8f4137fa82ec70d5c6dbfef4beb4f449e14eb9
+checksum=b906980ba9dad0c82ad53d5a17ece95c1cab35e655ef981abe63cf157344ca6b
 
 case $XBPS_TARGET_MACHINE in
 	armv6*) configure_args+=" -DDESKTOP_APP_DISABLE_SCUDO=true";; # Requires armv6k+ due to yield


### PR DESCRIPTION
- **nodejs: rebuild for ada-4.0.0**
- **ada: update to 4.0.0.**
- **telegram-desktop: rebuild for ada-4.0.0**
- **telegram-desktop: update to 7.0.9.**

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**, ada-4.0.0 breaks nodejs?

```
=== release test-whatwg-url-custom-parsing ===                                
Path: parallel/test-whatwg-url-custom-parsing
node:assert:152
  throw new AssertionError(obj);
  ^

AssertionError [ERR_ASSERTION]: Missing expected exception.
    at Object.<anonymous> (/builddir/nodejs-24.18.0/test/parallel/test-whatwg-url-custom-parsing.js:54:10)
    at Module._compile (node:internal/modules/cjs/loader:1871:14)
    at Object..js (node:internal/modules/cjs/loader:2002:10)
    at Module.load (node:internal/modules/cjs/loader:1594:32)
    at Module._load (node:internal/modules/cjs/loader:1396:12)
    at wrapModuleLoad (node:internal/modules/cjs/loader:255:19)
    at Module.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:154:5)
    at node:internal/main/run_main_module:33:47 {
  generatedMessage: false,
  code: 'ERR_ASSERTION',
  actual: undefined,
  expected: [Function (anonymous)],
  operator: 'throws',
  diff: 'simple'
}

Node.js v24.18.0
Command: out/Release/node /builddir/nodejs-24.18.0/test/parallel/test-whatwg-url-custom-parsing.js
```

[ci skip][skip ci][skip skip][ci ci]
