### PR TITLE
gstreamer: update to 1.28.6

### DIFF
--- a/srcpkgs/gst-libav/template
+++ b/srcpkgs/gst-libav/template
@@ -1,6 +1,6 @@
 # Template file for 'gst-libav'
 pkgname=gst-libav
-version=1.28.5
+version=1.28.6
 revision=1
 build_style=meson
 hostmakedepends="pkg-config yasm"
@@ -12,7 +12,7 @@ license="LGPL-2.0-or-later"
 homepage="https://gstreamer.freedesktop.org"
 changelog="https://gstreamer.freedesktop.org/releases/${version%.*}/#${version}"
 distfiles="https://gstreamer.freedesktop.org/src/gst-libav/gst-libav-${version}.tar.xz"
-checksum=452854656056f0b16511a1d9ad4f2679ff5e5a87c89f90cf7ee5dec005ddb1e4
+checksum=71e6eafb4fff2a66d1bb0ba8d078224dfe7e3397307d8c0bba3dc23606e08f51
 
 case "$XBPS_TARGET_MACHINE" in
 	*-musl) # Required by musl for M_SQRT1_2

--- a/srcpkgs/gst-plugins-bad1/template
+++ b/srcpkgs/gst-plugins-bad1/template
@@ -1,6 +1,6 @@
 # Template file for 'gst-plugins-bad1'
 pkgname=gst-plugins-bad1
-version=1.28.5
+version=1.28.6
 revision=1
 build_helper="gir"
 build_style=meson
@@ -11,7 +11,7 @@ configure_args="-Dpackage-origin=https://voidlinux.org -Ddoc=disabled
  -Dmplex=disabled -Dmusepack=disabled -Dopenexr=disabled
  -Dopenmpt=disabled -Dopenni2=disabled -Dsctp=disabled
  -Dsrt=disabled -Dteletext=disabled -Dvoaacenc=disabled -Dvoamrwbenc=disabled
- -Dwildmidi=disabled -Dwpe=disabled -Ddirectfb=disabled
+ -Dwildmidi=disabled -Dwpe=disabled -Ddirectfb=disabled -Dgpl=enabled
  $(vopt_feature gme gme) $(vopt_feature gir introspection) -Dneon=disabled"
 hostmakedepends="automake gettext libtool pkg-config python3 glib-devel
  orc $(vopt_if wayland wayland-devel)"
@@ -36,7 +36,7 @@ license="GPL-2.0-or-later, LGPL-2.1-or-later"
 homepage="https://gstreamer.freedesktop.org"
 changelog="https://gstreamer.freedesktop.org/releases/${version%.*}/#${version}"
 distfiles="https://gstreamer.freedesktop.org/src/gst-plugins-bad/gst-plugins-bad-${version}.tar.xz"
-checksum=d8af55faef2958c1a8663751475ee46f5164877cf4d8c5913ea906ef180aeb71
+checksum=6636f2c2289ceda52c4aba971338c81e2b5780d3381bd3673c1c116ec87587c3
 
 build_options="gir gme libvpl wayland"
 build_options_default="gir wayland"

--- a/srcpkgs/gst-plugins-base1/template
+++ b/srcpkgs/gst-plugins-base1/template
@@ -1,6 +1,6 @@
 # Template file for 'gst-plugins-base1'
 pkgname=gst-plugins-base1
-version=1.28.5
+version=1.28.6
 revision=1
 build_style=meson
 build_helper="gir"
@@ -22,7 +22,7 @@ license="GPL-2.0-or-later, LGPL-2.0-or-later"
 homepage="https://gstreamer.freedesktop.org"
 changelog="https://gstreamer.freedesktop.org/releases/${version%.*}/#${version}"
 distfiles="https://gstreamer.freedesktop.org/src/gst-plugins-base/gst-plugins-base-${version}.tar.xz"
-checksum=776f19228f91fd25bbf54d9850597e158507f594872a52b9b6814e2429b43eaa
+checksum=0ba699c7c6c66f4ba640be78cb38a24715add9683f3e3a199f5369dc5a4f04ac
 
 build_options="cdparanoia gir libvisual sndio wayland"
 build_options_default="cdparanoia gir wayland"

--- a/srcpkgs/gst-plugins-good1/template
+++ b/srcpkgs/gst-plugins-good1/template
@@ -1,6 +1,6 @@
 # Template file for 'gst-plugins-good1'
 pkgname=gst-plugins-good1
-version=1.28.5
+version=1.28.6
 revision=1
 build_style=meson
 build_helper="qmake qmake6"
@@ -27,7 +27,7 @@ license="LGPL-2.1-or-later"
 homepage="https://gstreamer.freedesktop.org"
 changelog="https://gstreamer.freedesktop.org/releases/${version%.*}/#${version}"
 distfiles="https://gstreamer.freedesktop.org/src/gst-plugins-good/gst-plugins-good-${version}.tar.xz"
-checksum=58b45d24a1d77b39d7bb7d9ccc6e2d76bbf28618998c335c163f18e6f94a9324
+checksum=b0c620a4b18b6ee931b4c43bbf1760d308666dc37f730a7e7f1ad327e59ce2df
 
 build_options="gtk3 wayland"
 build_options_default="gtk3 wayland"

--- a/srcpkgs/gst-plugins-ugly1/template
+++ b/srcpkgs/gst-plugins-ugly1/template
@@ -1,6 +1,6 @@
 # Template file for 'gst-plugins-ugly1'
 pkgname=gst-plugins-ugly1
-version=1.28.5
+version=1.28.6
 revision=1
 build_style=meson
 configure_args=" -Dsidplay=disabled -Dgpl=enabled -Dx264=enabled
@@ -17,4 +17,4 @@ license="LGPL-2.1-or-later, GPL-2.0-or-later"
 homepage="https://gstreamer.freedesktop.org"
 changelog="https://gstreamer.freedesktop.org/releases/${version%.*}/#${version}"
 distfiles="https://gstreamer.freedesktop.org/src/gst-plugins-ugly/gst-plugins-ugly-${version}.tar.xz"
-checksum=0ef4cf9c3c9a5e776a6ca8d190a31863391b681980252143b822b29aa831e120
+checksum=ee279da13a740fd7f060d631a673223fa3bcc8c33d350c8d0264bd332a24ecd8

--- a/srcpkgs/gst-rtsp-server/template
+++ b/srcpkgs/gst-rtsp-server/template
@@ -1,6 +1,6 @@
 # Template file for 'gst-rtsp-server'
 pkgname=gst-rtsp-server
-version=1.28.5
+version=1.28.6
 revision=1
 build_style=meson
 build_helper=gir
@@ -14,7 +14,7 @@ license="LGPL-2.1-or-later"
 homepage="https://gstreamer.freedesktop.org"
 changelog="https://gstreamer.freedesktop.org/releases/${version%.*}/#${version}"
 distfiles="https://gstreamer.freedesktop.org/src/gst-rtsp-server/gst-rtsp-server-${version}.tar.xz"
-checksum=7e19fddeb1261bebc3ec397857fedd5c77129b66ab52788fdadad05117566225
+checksum=0cb725b1351f75e88803c55dddea1f27be09523ddcd7f29ab18270e182a2a463
 
 gst-rtsp-server-devel_package() {
 	depends="${sourcepkg}>=${version}_${revision} gst-plugins-base1-devel"

--- a/srcpkgs/gst1-editing-services/template
+++ b/srcpkgs/gst1-editing-services/template
@@ -1,6 +1,6 @@
 # Template file for 'gst1-editing-services'
 pkgname=gst1-editing-services
-version=1.28.5
+version=1.28.6
 revision=1
 build_style=meson
 build_helper="gir"
@@ -14,7 +14,7 @@ license="LGPL-2.0-or-later"
 homepage="https://gstreamer.freedesktop.org"
 changelog="https://gstreamer.freedesktop.org/releases/${version%.*}/#${version}"
 distfiles="https://gstreamer.freedesktop.org/src/gst-editing-services/gst-editing-services-${version}.tar.xz"
-checksum=d02f9df7dd74f2a50243a6fa5e327cfbbd5c12129ce7b6e73d70c08532491a88
+checksum=3d151e5097d686c5890ae76f14c57ee19538fd61c6cf637171f90b309cafd53c
 
 build_options="gir"
 

--- a/srcpkgs/gst1-python3/template
+++ b/srcpkgs/gst1-python3/template
@@ -1,6 +1,6 @@
 # Template file for 'gst1-python3'
 pkgname=gst1-python3
-version=1.28.5
+version=1.28.6
 revision=1
 build_style=meson
 hostmakedepends="pkg-config python3 python3-packaging-bootstrap"
@@ -13,5 +13,5 @@ license="LGPL-2.1-or-later"
 homepage="https://gstreamer.freedesktop.org"
 changelog="https://gstreamer.freedesktop.org/releases/${version%.*}/#${version}"
 distfiles="https://gstreamer.freedesktop.org/src/gst-python/gst-python-${version}.tar.xz"
-checksum=0ac461b5700b9766998aa686439064caf58ca4fdaf848dfd477b5a7700b176cc
+checksum=34d58440c53b5495a123d0a4b7b7abbc6e9792a5b21954db86a0791b16f6e012
 make_check=no # Upstream didn't adjust checks to match their API changes

--- a/srcpkgs/gstreamer1/template
+++ b/srcpkgs/gstreamer1/template
@@ -1,6 +1,6 @@
 # Template file for 'gstreamer1'
 pkgname=gstreamer1
-version=1.28.5
+version=1.28.6
 revision=1
 build_style=meson
 build_helper="gir"
@@ -17,7 +17,7 @@ license="LGPL-2.0-or-later"
 homepage="https://gstreamer.freedesktop.org"
 changelog="https://gstreamer.freedesktop.org/releases/${version%.*}/#${version}"
 distfiles="https://gstreamer.freedesktop.org/src/gstreamer/gstreamer-${version}.tar.xz"
-checksum=a5a9f783809b17a8eb774f4a7695b2cb8cba6b15520129906f87eaf30e7f8469
+checksum=62b6b9f0ad3147a6dd6420ac64a91180b14e990695bddd353b96041611d052ca
 
 pre_check() {
 	# gst_gstdatetime is known to fail according to LFS


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture (x86_64)
- I built this PR locally for these architectures using specific masterdirs:
  - x86_64-musl
  - i686
- I built this PR locally for these architectures (crossbuilds):
  - aarch64
  - aarch64-musl
  - armv7l
  - armv7l-musl
  - armv6l
  - armv6l-musl
  
---
Tested on x86_64. All plugins load without errors, audio/video pipelines, VA-API hardware decoding (vah264dec/vah265dec), gst-libav, gst1-python3, GES, and RTSP elements all working correctly.