### PR TITLE
jid: update to 1.1.3

### DIFF
--- a/srcpkgs/jid/template
+++ b/srcpkgs/jid/template
@@ -1,6 +1,6 @@
 # Template file for 'jid'
 pkgname=jid
-version=1.1.2
+version=1.1.3
 revision=1
 build_style=go
 go_import_path="github.com/simeji/jid"
@@ -11,7 +11,7 @@ license="MIT"
 homepage="https://github.com/simeji/jid"
 changelog="https://raw.githubusercontent.com/simeji/jid/refs/heads/master/ChangeLog"
 distfiles="https://github.com/simeji/jid/archive/refs/tags/v${version}.tar.gz"
-checksum=b86b8026e8aa216f31d31d8b9f6548be0533c4b20d555c65066db405075af081
+checksum=5d1092316e13eb3029a76ffd749cf1ad8642511fe3762f00635feea32d24b7d1
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: YES

#### Local build testing
- I built this PR locally for my native architecture: x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl (masterdir)
  - i686 (masterdir)
  - aarch64 (cross)
  - aarch64-musl (cross)
  - armv6l (cross)
  - armv6l-musl (cross)
  - armv7l (cross)
  - armv7l-musl (cross)

