### PR TITLE
libXpm: update to 3.5.19

### DIFF
--- a/srcpkgs/libXpm/template
+++ b/srcpkgs/libXpm/template
@@ -1,6 +1,6 @@
 # Template file for 'libXpm'
 pkgname=libXpm
-version=3.5.17
+version=3.5.19
 revision=1
 build_style=gnu-configure
 hostmakedepends="gettext pkg-config"
@@ -8,9 +8,9 @@ makedepends="xorgproto libSM-devel libXext-devel libXt-devel"
 short_desc="X PixMap Library from modular Xorg X11"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
-homepage="${XORG_SITE}"
-distfiles="${XORG_SITE}/lib/${pkgname}-${version}.tar.xz"
-checksum=64b31f81019e7d388c822b0b28af8d51c4622b83f1f0cb6fa3fc95e271226e43
+homepage="https://www.x.org/"
+distfiles="${XORG_SITE}/lib/libXpm-${version}.tar.xz"
+checksum=ad3576d689221a39dc728f0e0dc02ca7bb6a0d724c9a77fd1bfa1e9af83be900
 
 post_install() {
 	vlicense COPYING
@@ -25,5 +25,6 @@ libXpm-devel_package() {
 		vmove "usr/lib/*.a"
 		vmove "usr/lib/*.so"
 		vmove usr/lib/pkgconfig
+		vmove usr/share/man/man3
 	}
 }


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: YES

#### Local build testing
- I built this PR locally for my native architecture: x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl (masterdir)
  - i686 (masterdir)
  - aarch64 (cross)
  - aarch64-musl (cross)
  - armv6l (cross)
  - armv6l-musl (cross)
  - armv7l (cross)
  - armv7l-musl (cross)
