### PR TITLE
libXi: update to 1.8.3

### DIFF
--- a/srcpkgs/libXi/template
+++ b/srcpkgs/libXi/template
@@ -1,7 +1,7 @@
 # Template file for 'libXi'
 pkgname=libXi
-version=1.8.2
-revision=2
+version=1.8.3
+revision=1
 build_style=gnu-configure
 configure_args="--enable-malloc0returnsnull"
 hostmakedepends="pkg-config xmlto"
@@ -10,8 +10,8 @@ short_desc="X Input extension library"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
 homepage="https://gitlab.freedesktop.org/xorg/lib/libxi"
-distfiles="${XORG_SITE}/lib/${pkgname}-${version}.tar.xz"
-checksum=d0e0555e53d6e2114eabfa44226ba162d2708501a25e18d99cfb35c094c6c104
+distfiles="${XORG_SITE}/lib/libXi-${version}.tar.xz"
+checksum=7ad60056f01af4f786cfe93b3a7707447711626fc8da2637bec71a90409babe5
 
 post_install() {
 	vlicense COPYING


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: YES

#### Local build testing
- I built this PR locally for my native architecture: x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl (masterdir)
  - i686 (masterdir)
  - aarch64 (cross)
  - aarch64-musl (cross)
  - armv6l (cross)
  - armv6l-musl (cross)
  - armv7l (cross)
  - armv7l-musl (cross)

