### PR TITLE
rime-plum: update to 0.2026.5.8, add rime-quick

### DIFF
--- a/srcpkgs/rime-plum/template
+++ b/srcpkgs/rime-plum/template
@@ -1,6 +1,6 @@
 # Template file for 'rime-plum'
 pkgname=rime-plum
-version=0.2024.4.17
+version=0.2026.5.8
 revision=1
 build_style=gnu-makefile
 hostmakedepends="librime"
@@ -12,15 +12,15 @@ homepage="https://rime.im/"
 provides="brise-${version}_${revision}"
 replaces="brise>=0"
 
-_rev=4c28f11f451facef809b380502874a48ba964ddb
-_bopomofo=c7618f4f5728e1634417e9d02ea50d82b71956ab
-_cangjie=0ac8452eeb4abbcd8dd1f9e7314012310743285f
-_essay=0cd115e038b9bdfa4488cd502b5f6887dc1062a9
-_luna_pinyin=0418e912d023c2325598b53b8cdfbefb049d6130
-_prelude=3803f09458072e03b9ed396692ce7e1d35c88c95
+_rev=b1be1969f914cc005add4090631b855db00c2591
+_bopomofo=6085c9a38a4a728047862b33d67eee18aa86f3b9
+_cangjie=52d90a1b1312e74042b38c1cbc8142defbc53171
+_essay=e9b1a374a6ea015fca5bdd04318924b4483ac35a
+_luna_pinyin=56b934b099dfbeab842320f13aa8b461a6ab3e42
+_prelude=082425ea0684bca36474415d4a0e8db9b016487e
 _quick=5dcdb9e353d314239e9c8cddc0f42d52da4837bb
-_stroke=65fdbbf2f9485cc907cb9a6d6b9210938a50f71e
-_terra_pinyin=333ec4128fa1f93924a0707da3c623ccd92a73f0
+_stroke=3a4b0f4013e2b4c14b1e80c92b1d4723eb65f39c
+_terra_pinyin=8a2c895ad7ee8e2b137d91be77f18f86b04d7fc9
 distfiles="
  https://github.com/rime/plum/archive/${_rev}.tar.gz>plum-${_rev}.tar.gz
  https://github.com/rime/rime-bopomofo/archive/$_bopomofo.tar.gz>bopomofo-${_bopomofo}.tar.gz
@@ -32,15 +32,15 @@ distfiles="
  https://github.com/rime/rime-stroke/archive/$_stroke.tar.gz>stroke-${_stroke}.tar.gz
  https://github.com/rime/rime-terra-pinyin/archive/$_terra_pinyin.tar.gz>terra-pinyin-${_terra_pinyin}.tar.gz
 "
-checksum="121d5a405dd1457582609d2a4cc0c6c55f9ada8750e524b5c0b6585dbc5268c8
- 37bc156bca8bca93b001b112ee440fc498207a4f6fbcaa2d2c306cfdd4560577
- 7fea467b08aeb38b0ebc6260a086f11578615549b1ac423bd4a5c6734ccf1ea8
- 43f2664684e0c5deaf2f2f8f5efe86239a48ab7dcbc23d9994c85fe4b68721a3
- ffd1fd5020ce6c95110ce16f82cccb97f44ee274c1d2c24a13601d96cca84cfa
- afa07cd98c540a0ac2d1d6e98ffa776549c535e617d3e41eb6ef80806df806f2
+checksum="4ebc2bec937766184546f9c0598f90a692a2e0ef1a50c0c2e594dbb3e131f61e
+ 5fc0719e8fe9b2eb8aa05c505ffb2b39d972e637951531182dd7d745a83bda51
+ 18d989bf21d0bb86b402f18be4dd060bf2653896c95448afb01d4da2e6be5464
+ 11559224d48709b0d77009a550804bfc2b763cfdf048c8d8fe224b3d36ba441c
+ 876c7ba559794f476abf7195a255aea29000cee281e6f5ec664928dce018bd90
+ 66239ba4745d54471e5ce5540b45e86ec663ff5dba004cb23c95531a3bdec00f
  2f2ae291b1ebd17ad5bfccfabbeb3aba2a466589628f15172da5fc76b24b9f7e
- b0dfbb9b43cabf7e6d970ec345808c3197d507cbafdb80e3fb8f366ba70f05fd
- 5f94ac60a156ee45c7a01598af3a1bdc7b829e2c1d75da590a9ae024bb3c49dd"
+ 14995408f49a8389bbcc50b8865ec8d1d90c26517cdb33f69b4a69b8a5d2ddb8
+ 7507d3f00d0219f49e538653af1c8462345d0b2e691616145072e5c34584e621"
 
 skip_extraction="
  bopomofo-${_bopomofo}.tar.gz

--- a/srcpkgs/rime-plum/template
+++ b/srcpkgs/rime-plum/template
@@ -18,6 +18,7 @@ _cangjie=0ac8452eeb4abbcd8dd1f9e7314012310743285f
 _essay=0cd115e038b9bdfa4488cd502b5f6887dc1062a9
 _luna_pinyin=0418e912d023c2325598b53b8cdfbefb049d6130
 _prelude=3803f09458072e03b9ed396692ce7e1d35c88c95
+_quick=5dcdb9e353d314239e9c8cddc0f42d52da4837bb
 _stroke=65fdbbf2f9485cc907cb9a6d6b9210938a50f71e
 _terra_pinyin=333ec4128fa1f93924a0707da3c623ccd92a73f0
 distfiles="
@@ -27,6 +28,7 @@ distfiles="
  https://github.com/rime/rime-essay/archive/$_essay.tar.gz>essay-${_essay}.tar.gz
  https://github.com/rime/rime-luna-pinyin/archive/$_luna_pinyin.tar.gz>luna-pinyin-${_luna_pinyin}.tar.gz
  https://github.com/rime/rime-prelude/archive/$_prelude.tar.gz>prelude-${_prelude}.tar.gz
+ https://github.com/rime/rime-quick/archive/$_quick.tar.gz>quick-${_quick}.tar.gz
  https://github.com/rime/rime-stroke/archive/$_stroke.tar.gz>stroke-${_stroke}.tar.gz
  https://github.com/rime/rime-terra-pinyin/archive/$_terra_pinyin.tar.gz>terra-pinyin-${_terra_pinyin}.tar.gz
 "
@@ -36,6 +38,7 @@ checksum="121d5a405dd1457582609d2a4cc0c6c55f9ada8750e524b5c0b6585dbc5268c8
  43f2664684e0c5deaf2f2f8f5efe86239a48ab7dcbc23d9994c85fe4b68721a3
  ffd1fd5020ce6c95110ce16f82cccb97f44ee274c1d2c24a13601d96cca84cfa
  afa07cd98c540a0ac2d1d6e98ffa776549c535e617d3e41eb6ef80806df806f2
+ 2f2ae291b1ebd17ad5bfccfabbeb3aba2a466589628f15172da5fc76b24b9f7e
  b0dfbb9b43cabf7e6d970ec345808c3197d507cbafdb80e3fb8f366ba70f05fd
  5f94ac60a156ee45c7a01598af3a1bdc7b829e2c1d75da590a9ae024bb3c49dd"
 
@@ -45,6 +48,7 @@ skip_extraction="
  essay-${_essay}.tar.gz
  luna-pinyin-${_luna_pinyin}.tar.gz
  prelude-${_prelude}.tar.gz
+ quick-${_quick}.tar.gz
  stroke-${_stroke}.tar.gz
  terra-pinyin-${_terra_pinyin}.tar.gz
 "


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
#### Local build testing
- I built this PR locally for my native architecture, (aarch64-glibc)


This PR updates all the components of `rime-plum` to the latest commit (as of 11 Aug 2026) and add [`rime-quick`](https://github.com/rime/rime-quick).

cc: @sgn 