### PR TITLE
libvips: update to 8.18.5.

### DIFF
--- a/srcpkgs/vips/template
+++ b/srcpkgs/vips/template
@@ -1,6 +1,6 @@
 # Template file for 'vips'
 pkgname=vips
-version=8.18.4
+version=8.18.5
 revision=1
 build_style=meson
 build_helper=gir
@@ -19,7 +19,7 @@ license="LGPL-2.1-or-later"
 homepage="https://www.libvips.org/"
 changelog="https://raw.githubusercontent.com/libvips/libvips/master/ChangeLog"
 distfiles="https://github.com/libvips/libvips/archive/refs/tags/v${version}.tar.gz"
-checksum=1e8d2228a4ffae7498e357dcddb3775440afa7b11726841cd511674dced84257
+checksum=95e51e4dc890eac8c9fd1d2ded62930bd59825b017558efa52858790779c90a6
 python_version=3
 
 build_options="gir hdf5"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, `x86_64-glibc`
