### PR TITLE
efitools: enable man pages.

### DIFF
--- a/srcpkgs/efitools/patches/05-makefile-remove-useless-problematic-target.patch
+++ b/srcpkgs/efitools/patches/05-makefile-remove-useless-problematic-target.patch
@@ -8,18 +8,18 @@ index 7d471da..30e236b 100644
  	KeyTool.efi HashTool.efi SetNull.efi ShimReplace.efi
  BINARIES = cert-to-efi-sig-list sig-list-to-certs sign-efi-sig-list \
  	hash-to-efi-sig-list efi-readvar efi-updatevar cert-to-efi-hash-list \
-@@ -27,20 +27,14 @@ include Make.rules
+@@ -27,20 +27,16 @@ include Make.rules
  
  EFISIGNED = $(patsubst %.efi,%-signed.efi,$(EFIFILES))
  
 -all: $(EFISIGNED) $(BINARIES) $(MANPAGES) noPK.auth $(KEYAUTH) \
 -	$(KEYUPDATEAUTH) $(KEYBLACKLISTAUTH) $(KEYHASHBLACKLISTAUTH)
 -
-+all: $(EFIFILES) $(BINARIES)
++all: $(EFIFILES) $(BINARIES) $(MANPAGES)
  
  install: all
--	$(INSTALL) -m 755 -d $(MANDIR)
--	$(INSTALL) -m 644 $(MANPAGES) $(MANDIR)
+ 	$(INSTALL) -m 755 -d $(MANDIR)
+ 	$(INSTALL) -m 644 $(MANPAGES) $(MANDIR)
  	$(INSTALL) -m 755 -d $(EFIDIR)
  	$(INSTALL) -m 755 $(EFIFILES) $(EFIDIR)
  	$(INSTALL) -m 755 -d $(BINDIR)

--- a/srcpkgs/efitools/patches/help2man-cross-compile.patch
+++ b/srcpkgs/efitools/patches/help2man-cross-compile.patch
@@ -1,0 +1,18 @@
+diff --git a/Make.rules b/Make.rules
+index 903a5a4..4a400d5 100644
+--- a/Make.rules
++++ b/Make.rules
+@@ -132,4 +132,12 @@ getvar = $(shell if [ "$(1)" = "PK" -o "$(1)" = "KEK" ]; then echo $(1); else ec
+ 	ar rcv $@ $^
+ 
+ doc/%.1: doc/%.1.in %
+-	$(HELP2MAN) --no-info -i $< -o $@ ./$*
++	mkdir -p help2man-cross-shims
++	printf '#!/bin/sh\ncase "$$1" in\n\t--version) printf "$* %%s\\n" ' > help2man-cross-shims/$*
++	sed -nE 's/^#define VERSION ("[^"]+")$$/\1/p' include/version.h >> help2man-cross-shims/$*
++	printf '\t\t;;\n\t--help) cat <<"EOT"\n' >> help2man-cross-shims/$*
++	grep -Eazo 'Usage: %s.*$$' $* | head -c -1 | sed -E 's/%s/$*/' >> help2man-cross-shims/$*
++	grep -Eazo '[[:print:][:space:]]*Options:.*' $* | head -c -1 >> help2man-cross-shims/$*
++	printf 'EOT\n\t\t;;\nesac\n' >> help2man-cross-shims/$*
++	chmod +x help2man-cross-shims/$*
++	$(HELP2MAN) --no-info -i $< -o $@ help2man-cross-shims/$*

--- a/srcpkgs/efitools/template
+++ b/srcpkgs/efitools/template
@@ -1,10 +1,10 @@
 # Template file for 'efitools'
 pkgname=efitools
 version=1.9.2
-revision=6
+revision=7
 archs="x86_64* i686* arm* aarch64*"
 build_style=gnu-makefile
-hostmakedepends="perl-File-Slurp"
+hostmakedepends="perl-File-Slurp help2man"
 makedepends="gnu-efi-libs openssl-devel"
 short_desc="Tools to manipulate EFI secure boot platforms"
 maintainer="Doan Tran Cong Danh <congdanhqx@gmail.com>"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I **cross**built this PR locally for armv6l-musl

In #38282 @sgn said,

> Feel free to re-open if you can cross-compile.

So, here's a version with working cross-compilation setup. The resultant man pages are byte-for-byte identical to ones using the upstream help2man set up, except that the footer of sig-list-to-certs(1) is correct (since my shim does not incorrectly print the usage when run with `--version`).