### PR TITLE
docker-credential-pass: update to 0.9.8

### DIFF
--- a/srcpkgs/docker-credential-pass/template
+++ b/srcpkgs/docker-credential-pass/template
@@ -1,17 +1,21 @@
 # Template file for 'docker-credential-pass'
 pkgname=docker-credential-pass
-version=0.6.4
-revision=6
+version=0.9.8
+revision=1
 build_style=go
 go_import_path="github.com/docker/docker-credential-helpers"
 go_package="${go_import_path}/pass/cmd"
+make_check_target="${go_import_path}/pass ${go_import_path}/pass/cmd ${go_import_path}/client ${go_import_path}/credentials ${go_import_path}/registryurl"
+# tests require gpg keypair to interact with
+make_check_args="-skip TestPassHelper$|TestPassHelperCheckInit|TestPassHelperList|TestPassHelperWithEmptyServer"
 depends="pass gnupg>=2"
+checkdepends="pass gnupg"
 short_desc="Use native stores to keep Docker credentials safe"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
 homepage="https://github.com/docker/docker-credential-helpers"
 distfiles="https://github.com/docker/docker-credential-helpers/archive/v${version}.tar.gz"
-checksum=b97d27cefb2de7a18079aad31c9aef8e3b8a38313182b73aaf8b83701275ac83
+checksum=7954c8bcb271021a7b3a8a992a5eb2828af3b5668659582112f2dd672c5242ba
 
 post_install() {
 	mv ${DESTDIR}/usr/bin/cmd ${DESTDIR}/usr/bin/docker-credential-pass


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**
- 
#### Local build testing
- I built this PR locally for my native architecture, X86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64 crossbuild
  - i686 crossbuild

