### PR TITLE
Qtile

### DIFF
--- a/srcpkgs/python3-qtile-extras/template
+++ b/srcpkgs/python3-qtile-extras/template
@@ -1,6 +1,6 @@
 # Template file for 'python3-qtile-extras'
 pkgname=python3-qtile-extras
-version=0.36.0
+version=0.37.0
 revision=1
 build_style=python3-pep517
 hostmakedepends="python3-wheel python3-setuptools python3-setuptools_scm"
@@ -11,7 +11,7 @@ license="MIT"
 homepage="https://github.com/elParaguayo/qtile-extras"
 changelog="https://raw.githubusercontent.com/elParaguayo/qtile-extras/main/CHANGELOG"
 distfiles="${PYPI_SITE}/q/qtile-extras/qtile_extras-${version}.tar.gz"
-checksum=879f38c12e345f7d0f4c160e03bde05bd4226e30b2b8db486e2831835c265e22
+checksum=e21a28380a7da5ba24cb7ae3470573569d72d0e27b55bde0eae4e6d6679138ce
 # Tests require a lot of python modules that are not packaged
 make_check=no
 

--- a/srcpkgs/qtile/files/qtile.desktop
+++ b/srcpkgs/qtile/files/qtile.desktop
@@ -1,0 +1,6 @@
+[Desktop Entry]
+Name=Qtile
+Comment=Qtile Session
+Exec=qtile start
+Type=Application
+Keywords=wm;tiling

--- a/srcpkgs/qtile/template
+++ b/srcpkgs/qtile/template
@@ -1,9 +1,9 @@
 # Template file for 'qtile'
 pkgname=qtile
-version=0.36.0
-revision=2
+version=0.37.0
+revision=1
 build_style=python3-pep517
-_wlroots=0.19
+_wlroots=0.20
 make_build_args="--config-setting backend=wayland"
 hostmakedepends="python3-setuptools python3-setuptools_scm python3-cairocffi
  python3-xcffib python3-wheel pkg-config wayland-devel"
@@ -16,7 +16,7 @@ license="MIT"
 homepage="http://www.qtile.org/"
 changelog="https://raw.githubusercontent.com/qtile/qtile/master/CHANGELOG"
 distfiles="${PYPI_SITE}/q/qtile/qtile-${version}.tar.gz"
-checksum=1337d0d7db44fca99c79647bc5d04e35a9371ba858bd782f2fe29a7d2f5c311e
+checksum=47be6fa48cd286c9438508f78b64263e1ca6db73c07ce85aa2b2d991f3f17ddf
 
 pre_build() {
 	# CFLAGS+=" $($PKG_CONFIG --cflags cairo pixman-1 libdrm wlroots-${_wlroots})"
@@ -29,8 +29,8 @@ pre_build() {
 }
 
 post_install() {
-	vinstall resources/qtile.desktop 644 usr/share/xsessions
-	vinstall resources/qtile-wayland.desktop 644 usr/share/wayland-sessions
+	vinstall ${FILESDIR}/qtile.desktop 644 usr/share/xsessions
+	vinstall ${FILESDIR}/qtile.desktop 644 usr/share/wayland-sessions
 	vlicense LICENSE
 }
 


### PR DESCRIPTION
The upstream desktop file has been replaced with one tailored to systemd so we need to provide one.
Next version of Qtile will also provide a plain desktop file https://github.com/qtile/qtile/pull/6020

Qtile now auto detect backend so no need for separate desktop file for X11 and Wayland.

#### Testing the changes
- I tested the changes in this PR: **YES**, but not Wayland

#### Local build testing
- I built this PR locally for my native architecture, (x86-64-LIBC)