### PR TITLE
niri: add warning message about GBM interface requirement

### DIFF
--- a/srcpkgs/niri/INSTALL.msg
+++ b/srcpkgs/niri/INSTALL.msg
@@ -1,0 +1,7 @@
+Niri requires a GBM interface (dri_gbm.so).
+A missing GBM interface will result in missing libraries (dri_gbm.so).
+It can be provided by several different packages,
+but xbps cannot express this type of optional dependency.
+Be sure to have one of the following installed;
+- the proprietary Nvidia drivers (nonfree), `nvidia`.
+- the `mesa-dri` package.


### PR DESCRIPTION
Based on #61975. In addition to the documentation, I think it does not hurt to have a secondary reminder when installing software like this that a dependency has to be managed manually.
It would be silly to repeat it for every software that might use GBM, but since niri is a window manager, it will likely be one of the first to be installed.

I have not bumped the revision number, as this is a change purely for the installation process, not functionally for the package.

If this is a good idea, maybe we can do a similar thing for other packages where this is the case too?

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, X86_64

