### PR TITLE
perl-Syntax-Keyword-Try & perl-XS-Parse-Keyword: rebuild

### DIFF
--- a/srcpkgs/perl-Syntax-Keyword-Try/template
+++ b/srcpkgs/perl-Syntax-Keyword-Try/template
@@ -1,7 +1,7 @@
 # Template file for 'perl-Syntax-Keyword-Try'
 pkgname=perl-Syntax-Keyword-Try
 version=0.31
-revision=1
+revision=2
 build_style=perl-ModuleBuild
 hostmakedepends="perl perl-Module-Build perl-XS-Parse-Keyword"
 makedepends="perl"

--- a/srcpkgs/perl-XS-Parse-Keyword/template
+++ b/srcpkgs/perl-XS-Parse-Keyword/template
@@ -1,7 +1,7 @@
 # Template file for 'perl-XS-Parse-Keyword'
 pkgname=perl-XS-Parse-Keyword
 version=0.49
-revision=1
+revision=2
 build_style=perl-ModuleBuild
 hostmakedepends="perl perl-ExtUtils-CChecker perl-Module-Build"
 makedepends="perl perl-File-ShareDir"


### PR DESCRIPTION
These rebuilds do not appear to be included during the mass update to perl 5.42. Reads like this is my source of failure in https://github.com/void-linux/void-packages/pull/61993