### PR TITLE
lightdm : add patch to use pam_limits

### DIFF
--- a/srcpkgs/lightdm/patches/pam-limits.patch
+++ b/srcpkgs/lightdm/patches/pam-limits.patch
@@ -1,0 +1,31 @@
+Loading pam_limits.so is needed to have limits apply to sessions started with lightdm
+
+--- a/data/pam/lightdm
++++ b/data/pam/lightdm
+@@ -18,3 +18,6 @@ password  required pam_unix.so
+ # Setup session
+ session   required pam_unix.so
+ session   optional pam_systemd.so
++
++# Load limits
++session   optional pam_limits.so
+
+--- a/data/pam/lightdm-autologin
++++ b/data/pam/lightdm-autologin
+@@ -20,3 +20,6 @@ password  required pam_deny.so
+ # Setup session
+ session   required pam_unix.so
+ session   optional pam_systemd.so
++
++# Load limits
++session   optional pam_limits.so
+
+--- a/data/pam/lightdm-greeter
++++ b/data/pam/lightdm-greeter
+@@ -15,3 +15,6 @@ password  required pam_deny.so
+ # Setup session
+ session   required pam_unix.so
+ session   optional pam_systemd.so
++
++# Load limits
++session   optional pam_limits.so

--- a/srcpkgs/lightdm/patches/pam-turnstile-elogind.patch
+++ b/srcpkgs/lightdm/patches/pam-turnstile-elogind.patch
@@ -1,11 +1,9 @@
 1. pam_systemd doesn't exist on void, use pam_elogind instead and make pam_systemd optional
 2. pam_turnstile allows turnstile to integrate with lightdm
 
-See also: https://github.com/chimera-linux/cports/blob/master/main/gdm/patches/pam.patch
-
 --- a/data/pam/lightdm
 +++ b/data/pam/lightdm
-@@ -17,4 +17,6 @@
+@@ -17,7 +17,9 @@ password  required pam_unix.so
  
  # Setup session
  session   required pam_unix.so
@@ -13,9 +11,13 @@ See also: https://github.com/chimera-linux/cports/blob/master/main/gdm/patches/p
 +-session   optional pam_turnstile.so
 +-session   optional pam_elogind.so
 +-session   optional pam_systemd.so
+ 
+ # Load limits
+ session   optional pam_limits.so
+
 --- a/data/pam/lightdm-autologin
 +++ b/data/pam/lightdm-autologin
-@@ -19,4 +19,6 @@
+@@ -19,7 +19,9 @@ password  required pam_deny.so
  
  # Setup session
  session   required pam_unix.so
@@ -23,9 +25,13 @@ See also: https://github.com/chimera-linux/cports/blob/master/main/gdm/patches/p
 +-session   optional pam_turnstile.so
 +-session   optional pam_elogind.so
 +-session   optional pam_systemd.so
+ 
+ # Load limits
+ session   optional pam_limits.so
+
 --- a/data/pam/lightdm-greeter
 +++ b/data/pam/lightdm-greeter
-@@ -14,4 +14,6 @@
+@@ -14,7 +14,9 @@ password  required pam_deny.so
  
  # Setup session
  session   required pam_unix.so
@@ -33,3 +39,6 @@ See also: https://github.com/chimera-linux/cports/blob/master/main/gdm/patches/p
 +-session   optional pam_turnstile.so
 +-session   optional pam_elogind.so
 +-session   optional pam_systemd.so
+ 
+ # Load limits
+ session   optional pam_limits.so

--- a/srcpkgs/lightdm/template
+++ b/srcpkgs/lightdm/template
@@ -1,7 +1,7 @@
 # Template file for 'lightdm'
 pkgname=lightdm
 version=1.32.0
-revision=8
+revision=9
 build_style=gnu-configure
 build_helper="gir"
 configure_args="--sbindir=/usr/bin --with-greeter-session=lightdm-gtk-greeter


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)

I must admit i am not well versed with display managers or pam, but it is as far as i could understand « the » fix for limits not working properly when logging in with lightdm. After some looking up online, i found a few reddit threads [ultimately linking back to this one](https://www.reddit.com/r/voidlinux/comments/b69zc1/how_to_esync_on_void_linux/) sharing this fix.

As far as i could gather, this isn’t a problem of upstream because systemd does *something* that makes this unnecessary/instills the limits even without this ? And that it supports systemd first/only, hence the patch here rather than upstream.