### PR TITLE
DirectXShaderCompiler: update to version 1.9.2607

### DIFF
--- a/srcpkgs/DirectXShaderCompiler/template
+++ b/srcpkgs/DirectXShaderCompiler/template
@@ -1,26 +1,26 @@
 # Template file for 'DirectXShaderCompiler'
 pkgname=DirectXShaderCompiler
-version=1.8.2502
+version=1.9.2607
 revision=1
 archs="x86_64* i686*"
 build_style=cmake
-configure_args="-C ../cmake/caches/PredefinedParams.cmake"
+configure_args="-C ../cmake/caches/PredefinedParams.cmake -DLLVM_INCLUDE_TESTS=OFF -DCLANG_INCLUDE_TESTS=FALSE -DHLSL_INCLUDE_TESTS=FALSE"
 hostmakedepends="python3 git"
 makedepends="libxml2-devel"
-short_desc="DirectX Shader Compiler based on LLVM/Clang. "
+short_desc="DirectX Shader Compiler based on LLVM/Clang"
 maintainer="John <me@johnnynator.dev>"
-license="LLVM"
+license="NCSA"
 homepage="https://github.com/microsoft/DirectXShaderCompiler"
-_SPIRV_Headers_commit=3f17b2af6784bfa2c5aa5dbb8e0e74a607dd8b3b
-_SPIRV_Tools_commit=4d2f0b40bfe290dea6c6904dafdf7fd8328ba346
+_SPIRV_Headers_commit=29981f65241605e08b0ede4cfeb999fe3b723c6a
+_SPIRV_Tools_commit=b707790a898e44038547df54580022fc1cf89c3d
 _DirectX_Headers_commit=980971e835876dc0cde415e8f9bc646e64667bf7
 distfiles="https://github.com/microsoft/DirectXShaderCompiler/archive/refs/tags/v${version}.tar.gz
  https://github.com/KhronosGroup/SPIRV-Headers/archive/${_SPIRV_Headers_commit}.tar.gz
  https://github.com/KhronosGroup/SPIRV-Tools/archive/${_SPIRV_Tools_commit}.tar.gz
  https://github.com/microsoft/DirectX-Headers/archive/${_DirectX_Headers_commit}.tar.gz"
-checksum="1318cbe4860d5ee82b447b12391ee7a8d881fbb286914075a099415b741e0c13
- 2301e11e5c77213258d6863bf4e6c607a8c6431fa8336e98ac6a2131bd6284f8
- 41481a45441d92b2404aa06bdecbb0302f22636335be4e19023632c83fa89aa1
+checksum="4ed223c7b4c61effa86aeb550e91f51451f479c5bd8820926fed9af452b3dbd5
+ 232899f1ad4104fb5bc377b94596c7621575eee62ad9a9e8f929b63a7dd8a7ad
+ 05d8af89737bde57571c48dbd36714c9f520a69623e14de72c3be6b600e277d6
  b5a4b6d8806ff7f29f19879f83d015dbe8740676d4ca0b48647a789cc7773c4e"
 
 skip_extraction="
@@ -32,7 +32,7 @@ skip_extraction="
 if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
 	# Tests on musl would require some patching to be done
 	# Also some fun with Mutexes. so mt is disabled for now
-	configure_args+=" -DLLVM_INCLUDE_TESTS=OFF -DCLANG_INCLUDE_TESTS=FALSE -DHLSL_INCLUDE_TESTS=FALSE -DLLVM_ENABLE_THREADS=OFF"
+	configure_args+=" -DLLVM_ENABLE_THREADS=OFF"
 fi
 nocross="fun with cmake and bunlded llvm"
 


### PR DESCRIPTION
disable testing for x86_64 and musl (the build process tries downloading older versions of dxc for tests). I also updated the license to "NCSA" which should be the SPDX id for the LLVM license?

@Johnnynator: you're listed as maintainer for this package and i see that you're still active so i didn't update the maintainer in the template file.

#### Testing the changes
- I tested the changes in this PR: **YES** (built and verified locally, but dxc test suite has been disabled due to dxc download failures)

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
