### PR TITLE
New package: wolfetch-0.5.4

### DIFF
--- a/srcpkgs/wolfetch/template
+++ b/srcpkgs/wolfetch/template
@@ -1,0 +1,21 @@
+# Template file for 'wolfetch'
+pkgname=wolfetch
+version=0.5.4
+revision=1
+build_style=cargo
+short_desc="Tiny and fast system fetch for Linux and BSD"
+maintainer="wolfetch contributors <noreply@example.invalid>"
+license="GPL-3.0-only"
+homepage="https://github.com/TrueWulf/wolfetch"
+distfiles="https://github.com/TrueWulf/wolfetch/archive/refs/tags/v${version}.tar.gz"
+checksum=53aa76bb286a78a9c2697bf753c677ae24baa414063ee3eb2777bc69d66bdc69
+
+post_install() {
+	vlicense LICENSE
+	vdoc README.md
+	vman man/wolfetch.1
+	vman man/wolfetch.5
+	vcompletion completions/wolfetch.bash bash
+	vcompletion completions/wolfetch.fish fish
+	vcompletion completions/_wolfetch zsh
+}


### PR DESCRIPTION
Add wolfetch 0.5.4, a tiny system fetch written in Rust.

- Source release: https://github.com/TrueWulf/wolfetch/releases/tag/v0.5.4
- License: GPL-3.0-only
- Builds with the Cargo build style.
- Installs wolfetch, wfetch, man pages, and shell completions.

Local source archive SHA-256: 53aa76bb286a78a9c2697bf753c677ae24baa414063ee3eb2777bc69d66bdc69