### PR TITLE
lms: fix crash on startup due to boost::asio ABI mismatch

### DIFF
--- a/srcpkgs/lms/template
+++ b/srcpkgs/lms/template
@@ -1,7 +1,7 @@
 # Template file for 'lms'
 pkgname=lms
 version=3.76.0
-revision=3
+revision=4
 build_style=cmake
 configure_args="-DLMS_IMAGE_BACKEND=graphicsmagick"
 hostmakedepends="pkg-config"
@@ -15,6 +15,13 @@ license="GPL-3.0-or-later"
 homepage="https://github.com/epoupon/lms"
 distfiles="https://github.com/epoupon/lms/archive/refs/tags/v${version}.tar.gz "
 checksum=3c8cd0cc29bb406deab6f7937df6c78d4d9398ccf56f108eaeb589532c397ed7
+
+# lms (C++20) and libwthttp (wt, C++14) each compile the header-only boost::asio
+# but share one epoll_reactor at runtime, so their reactor layouts must match.
+# Under C++20 asio uses atomic_slim_mutex (via BOOST_ASIO_HAS_STD_ATOMIC_WAIT)
+# and under C++14 posix_mutex; the mismatch segfaults in object_pool::alloc at
+# startup.  Force posix_mutex to match libwthttp.
+CXXFLAGS+=" -DBOOST_ASIO_DISABLE_STD_ATOMIC_WAIT"
 
 system_accounts="_lms"
 _lms_homedir="/var/lms"


### PR DESCRIPTION
lms would crash in x86_64-musl after updating every package to their latest versions.

lms and libwthttp (from wt) each compile their own copy of the header-only boost::asio, but share one epoll_reactor at runtime via asio's service registry.  Their reactor layouts must therefore match.

asio's reactor layout depends on BOOST_ASIO_HAS_STD_ATOMIC_WAIT (C++20 std::atomic::wait): lms is C++20, so asio uses atomic_slim_mutex (152-byte reactor, free_list_ at +0x90); wt is C++14, so libwthttp uses posix_mutex (232-byte reactor, free_list_ at +0xe0).

The mismatch makes libwthttp read registered_descriptors_ past lms's allocation and SIGSEGV in object_pool::alloc during Server::start (addTcpListener) on every startup.

Force the posix_mutex path with BOOST_ASIO_DISABLE_STD_ATOMIC_WAIT so lms's reactor ABI matches libwthttp.  Verified on x86_64-musl: lms now starts and serves on :5082 without crashing.

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-musl)
