### PR TITLE
wpa_supplicant: readd a patch

### DIFF
--- a/srcpkgs/wpa_supplicant/patches/brcmfmac-temporarily-revert-commit.patch
+++ b/srcpkgs/wpa_supplicant/patches/brcmfmac-temporarily-revert-commit.patch
@@ -1,0 +1,47 @@
+From 2514856652f9a393e505d542cb8f039f8bac10f5 Mon Sep 17 00:00:00 2001
+From: Janne Grunau <janne-fdr@jannau.net>
+Date: Sun, 4 Aug 2024 13:24:42 +0200
+Subject: [PATCH 1/1] Revert "Mark authorization completed on driver indication
+ during 4-way HS offload"
+
+This reverts commit 41638606054a09867fe3f9a2b5523aa4678cbfa5.
+---
+ wpa_supplicant/events.c | 25 ++++++++-----------------
+ 1 file changed, 8 insertions(+), 17 deletions(-)
+
+diff --git a/wpa_supplicant/events.c b/wpa_supplicant/events.c
+index 46e7cf1ab..7b3ef7205 100644
+--- a/wpa_supplicant/events.c
++++ b/wpa_supplicant/events.c
+@@ -4925,23 +4925,14 @@
+ 		    wpa_key_mgmt_wpa_psk(wpa_s->key_mgmt)) ||
+ 		   ((wpa_s->drv_flags2 & WPA_DRIVER_FLAGS2_OWE_OFFLOAD_STA) &&
+ 		    wpa_s->key_mgmt == WPA_KEY_MGMT_OWE)) {
+-		if (already_authorized) {
+-			/*
+-			 * We are done; the driver will take care of RSN 4-way
+-			 * handshake.
+-			 */
+-			wpa_supplicant_cancel_auth_timeout(wpa_s);
+-			wpa_supplicant_set_state(wpa_s, WPA_COMPLETED);
+-			eapol_sm_notify_portValid(wpa_s->eapol, true);
+-			eapol_sm_notify_eap_success(wpa_s->eapol, true);
+-		} else {
+-			/* Update port, WPA_COMPLETED state from the
+-			 * EVENT_PORT_AUTHORIZED handler when the driver is done
+-			 * with the 4-way handshake.
+-			 */
+-			wpa_msg(wpa_s, MSG_DEBUG,
+-				"ASSOC INFO: wait for driver port authorized indication");
+-		}
++		/*
++		 * We are done; the driver will take care of RSN 4-way
++		 * handshake.
++		 */
++		wpa_supplicant_cancel_auth_timeout(wpa_s);
++		wpa_supplicant_set_state(wpa_s, WPA_COMPLETED);
++		eapol_sm_notify_portValid(wpa_s->eapol, true);
++		eapol_sm_notify_eap_success(wpa_s->eapol, true);
+ 	} else if ((wpa_s->drv_flags & WPA_DRIVER_FLAGS_4WAY_HANDSHAKE_8021X) &&
+ 		   wpa_key_mgmt_wpa_ieee8021x(wpa_s->key_mgmt)) {
+ 		/*

--- a/srcpkgs/wpa_supplicant/template
+++ b/srcpkgs/wpa_supplicant/template
@@ -1,7 +1,7 @@
 # Template file for 'wpa_supplicant'
 pkgname=wpa_supplicant
 version=2.12
-revision=1
+revision=2
 build_wrksrc="${pkgname}"
 build_style=gnu-makefile
 make_build_args="V=1 BINDIR=/usr/bin"


### PR DESCRIPTION
- I tested the changes in this PR: **YES**
- I built this PR locally for my native architecture, (aarch64-gnu)

Without this patch, wifi connection fails in certain cases (e.g. pixel hotspot to macbook air).
~~Whille at it, also add an unpriviledge user `_wpas`: this does nothing per se, but it makes life easier if you want to run the service unprivileged (otherwise permissions on conf files are rewritten at every update).~~