### PR TITLE
libXres: update to 1.2.3

### DIFF
--- a/srcpkgs/libXres/template
+++ b/srcpkgs/libXres/template
@@ -1,6 +1,6 @@
 # Template file for 'libXres'
 pkgname=libXres
-version=1.2.2
+version=1.2.3
 revision=1
 build_style=gnu-configure
 configure_args="--enable-malloc0returnsnull"
@@ -10,8 +10,8 @@ short_desc="X Resource Information Extension Library"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
 homepage="https://gitlab.freedesktop.org/xorg/lib/libxres"
-distfiles="${XORG_SITE}/lib/${pkgname}-${version}.tar.xz"
-checksum=9a7446f3484b9b7538ac5ee30d2c1ce9e5b7fbbaf1440e02f6cca186a1fa745f
+distfiles="${XORG_SITE}/lib/libXres-${version}.tar.xz"
+checksum=d2de8f5401d6c86a8992791654547eb8def585dfdc0c08cc16e24ef6aeeb69dc
 
 post_install() {
 	vlicense COPYING
@@ -25,6 +25,6 @@ libXres-devel_package() {
 		vmove "usr/lib/*.a"
 		vmove "usr/lib/*.so"
 		vmove usr/lib/pkgconfig
-		vmove usr/share
+		vmove usr/share/man/man3
 	}
 }


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: YES

#### Local build testing
- I built this PR locally for my native architecture: x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl (masterdir)
  - i686 (masterdir)
  - aarch64 (cross)
  - aarch64-musl (cross)
  - armv6l (cross)
  - armv6l-musl (cross)
  - armv7l (cross)
  - armv7l-musl (cross)
