### PR TITLE
lightdm-slick-greeter: update to 2.2.7

### DIFF
--- a/srcpkgs/lightdm-slick-greeter/template
+++ b/srcpkgs/lightdm-slick-greeter/template
@@ -1,19 +1,19 @@
 # Template file for 'lightdm-slick-greeter'
 pkgname=lightdm-slick-greeter
-version=2.2.6
+version=2.2.7
 revision=1
 build_style=meson
 hostmakedepends="pkg-config gettext vala libvala"
 makedepends="gtk+3-devel lightdm-devel libcanberra-devel ayatana-ido-devel
  xapp-devel"
-depends="hicolor-icon-theme"
+depends="hicolor-icon-theme numlockx"
 conf_files="/etc/lightdm/slick-greeter.conf"
 short_desc="Light Display Manager GTK+ Greeter from Linux Mint"
 maintainer="Fabian Constantinescu <fabian.constantinescu@protonmail.com>"
 license="GPL-3.0-only"
 homepage="https://github.com/linuxmint/slick-greeter"
 distfiles="https://github.com/linuxmint/slick-greeter/archive/refs/tags/${version}.tar.gz"
-checksum=f967bde54b174180330e3ddc925377317ae14fe1b53cadf9b4cf11fdcb953379
+checksum=f685da6ca9d97329b4b200077d12db0ad4f9964d4515479e6c00bba721ab0626
 provides="lightdm-greeter-1_0"
 
 post_install() {


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - armv7l
