### PR TITLE
python3-protobuf: update to 7.35.1.

### DIFF
--- a/srcpkgs/python3-protobuf/template
+++ b/srcpkgs/python3-protobuf/template
@@ -1,7 +1,7 @@
 # Template file for 'python3-protobuf'
 pkgname=python3-protobuf
-version=5.29.4
-revision=2
+version=7.35.1
+revision=1
 build_style=python3-module
 hostmakedepends="python3-setuptools python3-wheel protobuf"
 makedepends="python3-devel protobuf-devel"
@@ -12,7 +12,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="BSD-3-Clause"
 homepage="https://developers.google.com/protocol-buffers/"
 distfiles="${PYPI_SITE}/p/protobuf/protobuf-${version}.tar.gz"
-checksum=4f1dfcd7997b31ef8f53ec82781ff434a28bf71d9102ddde14d076adcfc78c99
+checksum=ce115a26fe0c39a2c29973d914d327e516a6455464489fe3cd1e51a1b354f81a
 
 post_install() {
 	sed -n 1,29p google/protobuf/__init__.py >LICENSE


### PR DESCRIPTION
#### Important notes
- Closes #62030 
- The `anki` package is currently unfunctional. Anki will not run due to `python3-protobuf` being outdated.
- I believe the issue started when the `protobuf` package (separate from `python3-protobuf`) was updated from 25.2 to 35.1, which updated protoc to 7.35.1. Anki uses the system protoc when building, so newer Anki packages contained protobuf code generated for 7.35.1. However, python3-protobuf remained at 5.29.4, causing a runtime major-version mismatch. Updating python3-protobuf to 7.35.1 brings the compiler and Python runtime back into alignment, which thus also solves the Anki bug.

#### Testing the changes
- I tested the changes in this PR: **YES**
- Tested by running Anki, which uses this package as a runtime dependency.

#### Local build testing
- I built this PR locally for my native architecture, (x86)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
