### PR TITLE
libxmp: update to 4.7.2

### DIFF
--- a/srcpkgs/libxmp/template
+++ b/srcpkgs/libxmp/template
@@ -1,14 +1,15 @@
 # Template file for 'libxmp'
 pkgname=libxmp
-version=4.6.3
+version=4.7.2
 revision=1
 build_style=gnu-configure
 short_desc="Library that renders module files to PCM data"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
 homepage="http://xmp.sourceforge.net"
-distfiles="${SOURCEFORGE_SITE}/xmp/${pkgname}/${version}/${pkgname}-${version}.tar.gz"
-checksum=b189a2ff3f3eef0008512e0fb27c2cdc27480bc1066b82590a84d02548fab96d
+changelog="https://sourceforge.net/p/xmp/libxmp/ci/libxmp-${version}/tree/docs/Changelog"
+distfiles="${SOURCEFORGE_SITE}/xmp/libxmp/${version}/libxmp-${version}.tar.gz"
+checksum=510a96eefd79e4558fb1fa41fb5494870328776b3f77563f94f61f241f64bde1
 
 libxmp-devel_package() {
 	depends="${sourcepkg}>=${version}_${revision}"
@@ -17,6 +18,7 @@ libxmp-devel_package() {
 		vmove usr/include
 		vmove usr/lib/pkgconfig
 		vmove usr/lib/*.so
+		vman docs/libxmp.3
 	}
 }
 


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: YES

#### Local build testing
- I built this PR locally for my native architecture: x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl (masterdir)
  - i686 (masterdir)
  - aarch64 (cross)
  - aarch64-musl (cross)
  - armv6l (cross)
  - armv6l-musl (cross)
  - armv7l (cross)
  - armv7l-musl (cross)
