### PR TITLE
xdg-dbus-proxy: update to 0.1.8

### DIFF
--- a/srcpkgs/xdg-dbus-proxy/template
+++ b/srcpkgs/xdg-dbus-proxy/template
@@ -1,6 +1,6 @@
 # Template file for 'xdg-dbus-proxy'
 pkgname=xdg-dbus-proxy
-version=0.1.7
+version=0.1.8
 revision=1
 build_style=meson
 hostmakedepends="libxslt pkg-config docbook-xsl"
@@ -12,5 +12,5 @@ license="GPL-3.0-or-later"
 homepage="https://github.com/flatpak/xdg-dbus-proxy"
 changelog="https://raw.githubusercontent.com/flatpak/xdg-dbus-proxy/main/NEWS"
 distfiles="https://github.com/flatpak/xdg-dbus-proxy/releases/download/${version}/${pkgname}-${version}.tar.xz"
-checksum=3ad3d27ba574e178acb5e4d438ba36ace25e3564f899c36f31c56f82c7adbbe7
+checksum=b6630bd24f8161b0e2546d2acbb014a3b3249f5c0d75f2a863ade898b9034d3d
 make_check_pre=dbus-run-session


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**
- I'm not using any flatpak

#### Local build testing
- I built this PR locally for my native architecture, **x86_64-glibc**
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl
 
[Changelog](https://raw.githubusercontent.com/flatpak/xdg-dbus-proxy/refs/heads/main/NEWS)
