### PR TITLE
New package: uosc-ziggy-5.13.0

### DIFF
--- a/srcpkgs/uosc-ziggy/template
+++ b/srcpkgs/uosc-ziggy/template
@@ -1,0 +1,25 @@
+# Template file for 'uosc-ziggy'
+pkgname=uosc-ziggy
+version=5.13.0
+revision=1
+build_style=go
+go_mod_mode=off
+go_import_path="github.com/tomasklaen/uosc"
+go_package="./src/ziggy"
+depends="uosc"
+short_desc="Uosc's utility binary"
+maintainer="dogknowsnx <dogknowsnx@tutamail.com>"
+license="LGPL-2.1-or-later"
+homepage="https://github.com/tomasklaen/uosc"
+changelog="https://github.com/tomasklaen/uosc/releases"
+distfiles="https://github.com/tomasklaen/uosc/archive/refs/tags/${version}.tar.gz"
+checksum=18fb38bd7d3ff3ca03f394b4d57daaa5a3f68051dcc31fdbfff3fbc874468913
+
+nopie_files="/usr/bin/ziggy"
+ignore_elf_files="/usr/share/mpv/scripts/uosc/bin/ziggy-linux"
+
+post_install() {
+	vmkdir usr/share/mpv/scripts/uosc/bin
+	mv ${DESTDIR}/usr/bin/ziggy \
+		${DESTDIR}/usr/share/mpv/scripts/uosc/bin/ziggy-linux
+}

--- a/srcpkgs/uosc/files/README.voidlinux
+++ b/srcpkgs/uosc/files/README.voidlinux
@@ -3,3 +3,7 @@ Enable the 'uosc' UI for 'mpv' by issuing:
   $ mkdir -p ~/.config/mpv/scripts
   $ ln -s /usr/share/mpv/fonts ~/.config/mpv/
   $ ln -s /usr/share/mpv/scripts/uosc ~/.config/mpv/scripts/
+
+The optional utility binary is provided by 'uosc-ziggy':
+
+  # xbps-install -S uosc-ziggy

--- a/srcpkgs/uosc/template
+++ b/srcpkgs/uosc/template
@@ -1,7 +1,7 @@
 # Template file for 'uosc'
 pkgname=uosc
 version=5.13.0
-revision=1
+revision=2
 conf_files="/etc/mpv/script-opts/uosc.conf"
 depends="mpv"
 short_desc="Feature-rich minimalist proximity-based UI for MPV player"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

#### Local build testing
- I built this PR locally for my native architecture, **x86_64-glibc**
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl

Notes:

- The binary basically enables support for subtitle downloads
- I'v got a working template which would add this as a subpackage of `uosc`, but decided against it - 1) because the binary rarely gets updated (last time was about 2 years ago) yet is much larger than `uosc` itself, since it requires the `go`-build style, and 2) [its future is somewhat unclear](https://github.com/tomasklaen/uosc/issues/1107#issuecomment-2899436925) - so in case this binary should stop working, I don't want it to block updates for `uosc` and rather have it removed again.
- EDIT: fwiw, this package builds successfully w/ [go-1.27.0](https://github.com/void-linux/void-packages/pull/62134)

I don't have a strong opinion about merging this - especially given the above, but maybe some users may want the feature(s) provided by the binary, so here it is for completeness' sake.
