### PR TITLE
wpa_supplicant: enable Suite-B 192 support

### DIFF
--- a/srcpkgs/wpa_supplicant/files/config
+++ b/srcpkgs/wpa_supplicant/files/config
@@ -686,3 +686,6 @@ CONFIG_WEP=y
 
 # Wi-Fi Aware unsynchronized service discovery (NAN USD)
 #CONFIG_NAN_USD=y
+
+CONFIG_SUITEB=y
+CONFIG_SUITEB192=y

--- a/srcpkgs/wpa_supplicant/template
+++ b/srcpkgs/wpa_supplicant/template
@@ -1,7 +1,7 @@
 # Template file for 'wpa_supplicant'
 pkgname=wpa_supplicant
 version=2.12
-revision=1
+revision=2
 build_wrksrc="${pkgname}"
 build_style=gnu-makefile
 make_build_args="V=1 BINDIR=/usr/bin"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-musl, x86_64-glibc, aarch64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
