### PR TITLE
xmp: update to 4.3.1

### DIFF
--- a/srcpkgs/xmp/template
+++ b/srcpkgs/xmp/template
@@ -1,7 +1,7 @@
 # Template file for 'xmp'
 pkgname=xmp
-version=4.1.0
-revision=2
+version=4.3.1
+revision=1
 build_style=gnu-configure
 conf_files="/etc/xmp/xmp.conf /etc/xmp/modules.conf"
 hostmakedepends="pkg-config"
@@ -10,5 +10,6 @@ short_desc="Extended module player"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-only"
 homepage="http://xmp.sourceforge.net"
-distfiles="${SOURCEFORGE_SITE}/${pkgname}/${pkgname}/${version}/${pkgname}-${version}.tar.gz"
-checksum=1dbd61074783545ac7bef5b5daa772fd2110764cb70f937af8c3fad30f73289e
+changelog="https://sourceforge.net/p/xmp/xmp-cli/ci/xmp-4.3.1/tree/Changelog"
+distfiles="${SOURCEFORGE_SITE}/xmp/xmp/${version}/xmp-${version}.tar.gz"
+checksum=cbfdab11233708c4de6ab965f64d96d4cb5b9d8e14d2d23df3b1b896386f870f


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: YES

#### Local build testing
- I built this PR locally for my native architecture: x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl (masterdir)
  - i686 (masterdir)
  - aarch64 (cross)
  - aarch64-musl (cross)
  - armv6l (cross)
  - armv6l-musl (cross)
  - armv7l (cross)
  - armv7l-musl (cross)
