### PR TITLE
gitlab-runner: update to 19.2.2

### DIFF
--- a/srcpkgs/gitlab-runner/template
+++ b/srcpkgs/gitlab-runner/template
@@ -1,7 +1,7 @@
 # Template file for 'gitlab-runner'
 pkgname=gitlab-runner
-version=16.1.0
-revision=3
+version=19.2.2
+revision=1
 build_style=go
 go_import_path=gitlab.com/gitlab-org/gitlab-runner
 short_desc="Official GitLab CI runner written in Go"
@@ -10,8 +10,10 @@ license="MIT"
 homepage="https://docs.gitlab.com/runner/"
 changelog="https://gitlab.com/gitlab-org/gitlab-runner/-/raw/main/CHANGELOG.md"
 distfiles="https://gitlab.com/gitlab-org/gitlab-runner/-/archive/v${version}/gitlab-runner-v${version}.tar.gz"
-checksum=c3d6889ad861a9547cfe0453a36de8c770791633905724acd6f0372e2d9a9e0f
+checksum=093d8e33789357f3ec3a930340dd9496a964163d51e01a479b114b675dec1040
 
+# integration tests rely on running inside gitlab ci
+make_check=no
 post_install() {
 	vsv gitlab-runner
 	vlicense ${wrksrc}/LICENSE


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, X86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64 crossbuild
