### PR TITLE
New package: ferrisfetch-0.1.0

### DIFF
--- a/srcpkgs/ferrisfetch/template
+++ b/srcpkgs/ferrisfetch/template
@@ -1,0 +1,20 @@
+# Template file for 'ferrisfetch'
+pkgname=ferrisfetch
+version=0.1.0
+revision=1
+build_style=cargo
+short_desc="Fast, lightweight Linux system information fetch tool written in Rust"
+maintainer="Kushagra Kumar <kkushagra86@gmail.com>"
+license="MIT"
+homepage="https://github.com/kk376/ferrisfetch"
+changelog="https://raw.githubusercontent.com/kk376/ferrisfetch/main/CHANGELOG.md"
+distfiles="https://github.com/kk376/ferrisfetch/archive/refs/tags/v${version}.tar.gz"
+checksum=6e2fbf052988cb945c436087f42dcf9ebd8885d3cd19638b58221e7d41eca9df
+
+post_install() {
+	vlicense LICENSE
+	vdoc README.md
+	vcompletion completions/ferrisfetch.bash bash
+	vcompletion completions/_ferrisfetch zsh
+	vcompletion completions/ferrisfetch.fish fish
+}


### PR DESCRIPTION
#### Package Information
- **Package name:** ferrisfetch
- **Version:** 0.1.0
- **Upstream URL:** https://github.com/Kk376/ferrisfetch
- **License:** MIT
- **Short description:** Fast, lightweight Linux and Android system information fetch CLI written in Rust

#### Testing
- [x] Package template conforms to Void Linux Manual
- [x] Includes bash, zsh, and fish completions