### PR TITLE
urlscan: update to 1.1.2

### DIFF
--- a/srcpkgs/urlscan/template
+++ b/srcpkgs/urlscan/template
@@ -1,6 +1,6 @@
 # Template file for 'urlscan'
 pkgname=urlscan
-version=1.0.9
+version=1.1.2
 revision=1
 build_style=python3-pep517
 hostmakedepends="hatchling hatch-vcs"
@@ -11,4 +11,4 @@ license="GPL-2.0-or-later"
 homepage="https://github.com/firecat53/urlscan"
 changelog="https://github.com/firecat53/urlscan/releases"
 distfiles="${PYPI_SITE}/u/urlscan/urlscan-${version}.tar.gz"
-checksum=067087895077762807ff028ed332e4e1ab6e1a7c249188dc846f6d160afba7ff
+checksum=e4f01037dcb84f0cc5733b9423732ebf368cb9b4c9714bdaf7dd336d883a78b2


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: YES

#### Local build testing
- I built this PR locally for my native architecture: x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl (masterdir)
  - i686 (masterdir)
  - aarch64 (cross)
  - aarch64-musl (cross)
  - armv6l (cross)
  - armv6l-musl (cross)
  - armv7l (cross)
  - armv7l-musl (cross)

