### PR TITLE
uthash: update to 2.4.0

### DIFF
--- a/srcpkgs/uthash/template
+++ b/srcpkgs/uthash/template
@@ -1,14 +1,14 @@
 # Template file for 'uthash'
 pkgname=uthash
-version=2.3.0
+version=2.4.0
 revision=1
 short_desc="Hash table for C structures"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="BSD-2-Clause"
-homepage="http://troydhanson.github.com/uthash/"
+homepage="https://troydhanson.github.io/uthash/"
 changelog="https://raw.githubusercontent.com/troydhanson/uthash/master/doc/ChangeLog.txt"
 distfiles="https://github.com/troydhanson/uthash/archive/v${version}.tar.gz"
-checksum=e10382ab75518bad8319eb922ad04f907cb20cccb451a3aa980c9d005e661acc
+checksum=387ba027946d7c64e9aa19cc53b2edcd714f8f9dca9fa8e3aaef17e0e8e3d736
 
 do_install() {
 	vmkdir usr/include


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR:  YES

#### Local build testing
- I built this PR locally for my native architecture:  x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl (masterdir)
  - i686 (masterdir)
  - aarch64 (cross)
  - aarch64-musl (cross)
  - armv6l (cross)
  - armv6l-musl (cross)
  - armv7l (cross)
  - armv7l-musl (cross)
