### PR TITLE
dbeaver: update to 26.1.5, adopt.

### DIFF
--- a/srcpkgs/dbeaver/template
+++ b/srcpkgs/dbeaver/template
@@ -1,6 +1,6 @@
 # Template file for 'dbeaver'
 pkgname=dbeaver
-version=26.1.4
+version=26.1.5
 revision=1
 _version=${version//./_}
 # the build downloads binaries linked to glibc
@@ -9,16 +9,16 @@ build_wrksrc="dbeaver"
 hostmakedepends="apache-maven openjdk25"
 depends="openjdk25"
 short_desc="Free Universal Database Tool"
-maintainer="Orphaned <orphan@voidlinux.org>"
+maintainer="Arjan Mossel <arjanmossel@gmail.com>"
 license="Apache-2.0"
 homepage="https://dbeaver.io"
 changelog="https://dbeaver.io/news/"
 distfiles="https://github.com/dbeaver/dbeaver/archive/${version}.tar.gz
  https://github.com/dbeaver/dbeaver-common/archive/refs/heads/release_${_version}.tar.gz>dbeaver-common-${version}.tar.gz
  https://github.com/dbeaver/dbeaver-jdbc-libsql/archive/refs/heads/release_${_version}.tar.gz>dbeaver-jdbc-libsql-${version}.tar.gz"
-checksum="584e0e30b832e66e98a81ef648c989907a96fe65e03e8999b4906c375c18c482
- 2dae4380cd14d0186253807ae269d886ef3c89a64a326ac812fb62faeb1c8da0
- 9619a107c9fc959afb1e5c0ff14de730a9d9f937cdcea9a63a490b5c5df436a3"
+checksum="ed5f852893ed9e4821bf7837a641e7f66a9fd77215fb9e957480a4630beff6e1
+ f93e443d1668298d921a9b7babaa574e2c03bb95708671f844cb3fbd37d65812
+ 18dfe8cf99020939e3b252e9650e80e1a6d242fa1092e5a7afab2e1dbc4b3590"
 nopie=true
 
 post_extract() {


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc