### PR TITLE
libinput: bump lua54 to lua55

### DIFF
--- a/srcpkgs/libinput/template
+++ b/srcpkgs/libinput/template
@@ -2,12 +2,12 @@
 # keep in sync with libinput-debug-gui
 pkgname=libinput
 version=1.31.3
-revision=1
+revision=2
 build_style=meson
 configure_args="-Db_ndebug=false -Ddebug-gui=false"
 hostmakedepends="pkg-config"
 makedepends="libevdev-devel libwacom-devel mtdev-devel eudev-libudev-devel
- lua54-devel"
+ lua55-devel"
 checkdepends="valgrind check-devel python3-pytest"
 short_desc="Provides handling input devices in Wayland compositors and X"
 maintainer="Orphaned <orphan@voidlinux.org>"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (x86-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86-musl

#### Reasons and the bug this fixes

The motivation is compilation of latest hyprland for Void. Moving to aquamarine 0.14 and hyprland 0.56.2 exposed an issue in libinput when it is compiled against lua54 and the application (in this case hyprland/aquamarine) compiled against lua55. The symbols exposed by libinput are not lua versioned so lua_getfield, for example  is the same no matter lua54 or lua55. This leads to a crash and incompatibility. While it is hyprland exposing this at the moment, i think this will be true for any application built against lua55 trying to use libinput unless updated. Recent introduction of lua55 to void-packages makes this update trivial.

Thanks for the consideration.