### PR TITLE
xpr: update to 1.2.1

### DIFF
--- a/srcpkgs/xpr/template
+++ b/srcpkgs/xpr/template
@@ -1,6 +1,6 @@
 # Template file for 'xpr'
 pkgname=xpr
-version=1.2.0
+version=1.2.1
 revision=1
 build_style=gnu-configure
 hostmakedepends="pkg-config"
@@ -9,8 +9,8 @@ short_desc="Print an X window dump"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
 homepage="http://xorg.freedesktop.org"
-distfiles="${XORG_SITE}/app/$pkgname-$version.tar.xz"
-checksum=8b9402f8331309f0a9d8143d4d6129c4a7479ff9449616849b9f1e2a5835cec3
+distfiles="${XORG_SITE}/app/xpr-$version.tar.xz"
+checksum=0a5b947cd5e3990c9fcd04fdf92603241de4a55a29b89d4e8a0e473320b778ba
 
 post_install() {
 	vlicense COPYING


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: YES

#### Local build testing
- I built this PR locally for my native architecture: x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl (masterdir)
  - i686 (masterdir)
  - aarch64 (cross)
  - aarch64-musl (cross)
  - armv6l (cross)
  - armv6l-musl (cross)
  - armv7l (cross)
  - armv7l-musl (cross)

