### PR TITLE
spotify-adblock: update to 1.1.1

### DIFF
--- a/srcpkgs/spotify-adblock/template
+++ b/srcpkgs/spotify-adblock/template
@@ -1,6 +1,6 @@
 # Template file for 'spotify-adblock'
 pkgname=spotify-adblock
-version=1.0.3
+version=1.1.1
 revision=1
 build_style=cargo
 conf_files="/etc/spotify-adblock/config.toml"
@@ -9,7 +9,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-3.0-or-later"
 homepage="https://github.com/abba23/spotify-adblock"
 distfiles="https://github.com/abba23/spotify-adblock/archive/refs/tags/v${version}.tar.gz"
-checksum=8141c2433dbb6a6c693e95856c0e2e4b22b5a9da81f70589cd07b9e058d8b3c5
+checksum=9c39ad9251503bc45f08a6319b53578f2e7d1ed7ab3187c1f7ed8747f363fe2c
 
 pre_install() {
 	{


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
