### PR TITLE
New package: egl-wayland2-1.0.1

### DIFF
--- a/srcpkgs/egl-wayland2/template
+++ b/srcpkgs/egl-wayland2/template
@@ -1,0 +1,16 @@
+# Template file for 'egl-wayland2'
+pkgname=egl-wayland2
+version=1.0.1
+revision=1
+build_style=meson
+hostmakedepends="pkg-config"
+makedepends="wayland-devel wayland-protocols libdrm-devel MesaLib-devel
+			libglvnd-devel eglexternalplatform"
+depends="nvidia>=560"
+short_desc="NVIDIA Wayland EGL External Platform library, Version 2"
+maintainer="Joshua Kloepfer <joshua.kloepfer@gmail.com>"
+license="Apache-2.0"
+homepage="https://github.com/NVIDIA/egl-wayland2"
+changelog="https://github.com/NVIDIA/egl-wayland2/releases"
+distfiles="https://github.com/NVIDIA/egl-wayland2/archive/refs/tags/v${version}.tar.gz"
+checksum=1d8f154e69b3055cb20f5eddda0fa438aea292e6ef835b129cd2efaae5eb95fc

--- a/srcpkgs/egl-wayland2/template
+++ b/srcpkgs/egl-wayland2/template
@@ -1,0 +1,15 @@
+# Template file for 'egl-wayland2'
+pkgname=egl-wayland2
+version=1.0.1
+revision=1
+build_style=meson
+hostmakedepends="pkg-config wayland-devel"
+makedepends="wayland-devel wayland-protocols libdrm-devel MesaLib-devel
+ libglvnd-devel eglexternalplatform"
+short_desc="NVIDIA Wayland EGL External Platform library, Version 2"
+maintainer="Joshua Kloepfer <joshua.kloepfer@gmail.com>"
+license="Apache-2.0"
+homepage="https://github.com/NVIDIA/egl-wayland2"
+changelog="https://github.com/NVIDIA/egl-wayland2/releases"
+distfiles="https://github.com/NVIDIA/egl-wayland2/archive/refs/tags/v${version}.tar.gz"
+checksum=1d8f154e69b3055cb20f5eddda0fa438aea292e6ef835b129cd2efaae5eb95fc

--- a/srcpkgs/eglexternalplatform/template
+++ b/srcpkgs/eglexternalplatform/template
@@ -1,0 +1,16 @@
+# Template file for 'eglexternalplatform'
+pkgname=eglexternalplatform
+version=1.2.1
+revision=1
+build_style=meson
+hostmakedepends="pkg-config"
+short_desc="EGL External Platform interface headers"
+maintainer="Joshua Kloepfer<joshua.kloepfer@gmail.com>"
+license="MIT"
+homepage="https://github.com/NVIDIA/eglexternalplatform"
+distfiles="https://github.com/NVIDIA/eglexternalplatform/archive/refs/tags/${version}.tar.gz"
+checksum=5089ceb054ca50c85837f015756a3d0f2f75cf2a98c9e5fbcbcfb8206137f76e
+
+post_install() {
+	vlicense COPYING
+}


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc

#### Rationale
- Nvidia said swapping to egl wayland 2 fixes a file descriptor leak noted here: https://forums.developer.nvidia.com/t/fd-leak-with-explicit-sync-and-kde-plasma/317293/40
- Testing on my system showed that it did get rid of the bug and made my system perform much better