### PR TITLE
New Package: coremark

### DIFF
--- a/srcpkgs/coremark/template
+++ b/srcpkgs/coremark/template
@@ -1,0 +1,23 @@
+# Template file for 'coremark'
+pkgname=coremark
+version=1.01
+revision=1
+archs="x86_64*" # Upstream port limited to Linux x86_64
+build_style=gnu-makefile
+make_use_env=yes # Upstream uses nonstandard env vars in makefile
+make_build_target=compile
+short_desc="Simple industry-standard benchmark to test a processor core"
+maintainer="Dakota Richline <drichline@protonmail.com>"
+license="Apache-2.0"
+homepage=https://www.eembc.org/coremark/
+distfiles="https://github.com/eembc/coremark/archive/refs/tags/v${version}.tar.gz"
+checksum=99c5a6d63af85a281b4e4d6ccb522c446653c435dfec9455ad73ef9e71f28bde
+make_check=no # CoreMark's check target requires coremark.md5, which is not included in the release tarball
+
+do_install() {
+	vbin coremark.exe coremark
+}
+
+post_install() {
+	vdoc README.md # Usage information
+}


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES** (glibc and musl)
 
#### Package

Coremark is apparently the industry standard for benchmarking single core cpu/microcontroller performance. This version compiled using the default makefile target is a useful quick reference on Void systems that's compliant with the Coremark benchmarking standards. (changes to the benchmark are directly compiled in using env vars).

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl (crossbuild; test ran in podman)