### PR TITLE
povray: -fno-fast-math

### DIFF
--- a/srcpkgs/povray/template
+++ b/srcpkgs/povray/template
@@ -22,7 +22,7 @@ nocross="Builds fail on ARM architectures
  Logs are at https://travis-ci.org/void-linux/void-packages/builds/412583835."
 LDFLAGS+=" -Wl,-z,stack-size=1048576"
 CFLAGS="-D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64"
-CXXFLAGS="-D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64"
+CXXFLAGS="-D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -fno-fast-math"
 
 pre_configure() {
 	cd $wrksrc/unix


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)

this fixes https://github.com/void-linux/void-packages/issues/55478. povray no longer intersects 0 rays with -fno-fast-math
