### PR TITLE
opentofu: update to 1.12.6.

### DIFF
--- a/srcpkgs/opentofu/patches/go-version.patch
+++ b/srcpkgs/opentofu/patches/go-version.patch
@@ -1,0 +1,12 @@
+diff --git a/go.mod b/go.mod
+index 934ae7eff3..5103b1c93f 100644
+--- a/go.mod
++++ b/go.mod
+@@ -1,6 +1,6 @@
+ module github.com/opentofu/opentofu
+ 
+-go 1.26.6
++go 1.26
+ 
+ // At the time of adding this configuration, the new Go feature introduced here https://github.com/golang/go/issues/67061,
+ // was having a good amount of issues linked to, affecting AWS Firewall, GCP various services and a lot more.

--- a/srcpkgs/opentofu/template
+++ b/srcpkgs/opentofu/template
@@ -1,15 +1,15 @@
 # Template file for 'opentofu'
 pkgname=opentofu
-version=1.12.2
+version=1.12.6
 revision=1
 build_style=go
-go_import_path="github.com/opentofu/$pkgname"
+go_import_path="github.com/opentofu/${pkgname}"
 go_package="${go_import_path}/cmd/tofu"
 go_ldflags="-X ${go_import_path}/version.dev=no"
 short_desc="Tool for building and changing infrastructure, from community"
-maintainer="Emil Tomczyk <emru@emru.xyz>"
+maintainer="al20ov <nicolas.antauf@gmail.com>"
 license="MPL-2.0"
 homepage="https://opentofu.org/"
 changelog="https://github.com/opentofu/opentofu/releases"
-distfiles="https://github.com/opentofu/opentofu/archive/v$version.tar.gz"
-checksum=f1e13ed2c1552ea7828156a10588a544d8b6b0d2c25f801a07fdf666734604fd
+distfiles="https://github.com/opentofu/opentofu/archive/v${version}.tar.gz"
+checksum=d6b49908a66ad277d7de33e9a218ae11b956cd094e39c82300b9b75cac2479ba


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - i686-glibc
  - aarch64-musl (cross built)

CC @Emru1