### PR TITLE
xdg-user-dirs: enable translation targets

### DIFF
--- a/srcpkgs/xdg-user-dirs/template
+++ b/srcpkgs/xdg-user-dirs/template
@@ -1,9 +1,9 @@
 # Template file for 'xdg-user-dirs'
 pkgname=xdg-user-dirs
 version=0.20
-revision=1
+revision=2
 build_style=meson
-hostmakedepends="libxslt docbook-xsl"
+hostmakedepends="libxslt docbook-xsl gettext"
 conf_files="
 	/etc/xdg/user-dirs.conf
 	/etc/xdg/user-dirs.defaults"


### PR DESCRIPTION
closes #62104

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)