### PR TITLE
mandrel: update to 25.0.4.1; openjdk25: update to 25.0.4.1+1

### DIFF
--- a/srcpkgs/mandrel/patches/mx-extract-python-3.14.patch
+++ b/srcpkgs/mandrel/patches/mx-extract-python-3.14.patch
@@ -1,0 +1,13 @@
+diff --git a/src/mx/_impl/mx.py b/src/mx/_impl/mx.py
+index 60e14f6d..ce796dac 100755
+--- a/mx/src/mx/_impl/mx.py
++++ b/mx/src/mx/_impl/mx.py
+@@ -8444,6 +8444,10 @@ class TarExtractor(Extractor):
+         return ar.getnames()
+ 
+     def _extractall(self, ar, dst):
++        # Force the filter to 'fully_trusted' when available
++        if hasattr(tarfile, 'fully_trusted_filter'):
++            return ar.extractall(dst, filter=tarfile.fully_trusted_filter)
++
+         return ar.extractall(dst)

--- a/srcpkgs/mandrel/template
+++ b/srcpkgs/mandrel/template
@@ -1,9 +1,9 @@
 # Template file for 'mandrel'
 pkgname=mandrel
-version=23.1.8.0
+version=25.0.4.0
 revision=1
-_java_ver=21
-_mx_ver=6.53.2
+_java_ver=25
+_mx_ver=7.85.1
 archs="aarch64* x86_64*"  # upstream supported archs
 hostmakedepends="openjdk${_java_ver} openjdk${_java_ver}-jmods
  openjdk${_java_ver}-src openjdk${_java_ver}-static-libs python3"
@@ -15,11 +15,16 @@ homepage="https://github.com/graalvm/mandrel"
 distfiles="https://github.com/graalvm/mandrel-packaging/archive/refs/tags/mandrel-${version}-Final.tar.gz>packaging-${version}.tar.gz
  https://github.com/graalvm/mandrel/archive/refs/tags/mandrel-${version}-Final.tar.gz
  https://github.com/graalvm/mx/archive/refs/tags/${_mx_ver}.tar.gz"
-checksum="22ed7c881299c50c915ea6b7545134048f4ecf232c86c7dd260ee759df0dafa5
- ae7f53c476a5f763ca3027f81e70aa170c8fb69a67cf1299083cfaeedd412ded
- 567c95449922b448d78daade5ba7bd91729a75367b69806f1bd590988a1ef717"
+checksum="7739e5218729819b3d57449e766d5222a99ceca218c5b98d9751ad85f07a4d5b
+ e6d178da534fb48611bb0b0ed6206b9386e5c482cd8e6c588b351c0541fedd33
+ 475ca3716610e3e98eb4ec4ef0dd9d2a45a089b3344460e802a107ae99cc1f0c"
 shlib_provides="libawt.so libawt_xawt.so libjava.so libjli.so libjvm.so libjawt.so"
 nocross=yes
+skip_extraction="${_mx_ver}.tar.gz"
+
+post_extract() {
+	vsrcextract -C mx ${_mx_ver}.tar.gz
+}
 
 # XXX: only static builds with native-image work
 # (else TEXTREL issues)
@@ -29,7 +34,7 @@ do_build() {
 	export PATH=/usr/libexec/chroot-git:$PATH
 	. /etc/profile.d/jdk.sh
 	$JAVA_HOME/bin/java -ea build.java \
-		--mx-home $PWD/../mx-* \
+		--mx-home $PWD/../mx \
 		--mandrel-repo $PWD/../mandrel-mandrel-* \
 		--verbose
 }

--- a/srcpkgs/openjdk25/template
+++ b/srcpkgs/openjdk25/template
@@ -1,6 +1,6 @@
 # Template file for 'openjdk25'
 pkgname=openjdk25
-version=25.0.3+0
+version=25.0.5+2
 revision=1
 _gtest_ver=1.14.0
 _java_ver="${version%%.*}"
@@ -43,7 +43,7 @@ license="GPL-2.0-only WITH Classpath-exception-2.0"
 homepage="http://openjdk.java.net/"
 distfiles="https://github.com/openjdk/jdk${_java_ver}u/archive/jdk-${version}.tar.gz
  https://github.com/google/googletest/archive/refs/tags/v${_gtest_ver}.tar.gz"
-checksum="e571ba045ef06ca7e5cc7c6539509dd04012fdaad258c4466744600409845f34
+checksum="aecbf31a39e25ac219905c68d95910c3cbf7f3bfacac6f9713be0e46c6b349aa
  8ad598c73ad796e0d8280b082cebd82a630d73e73cd3c70057938a6501bba5d7"
 alternatives="jdk:/usr/lib/jvm/default-jdk:/${_jdk_home}"
 provides="java-environment-${version}_1"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture: **x86_64**

The `mx` patch comes prescribed from the maintainers of GraalVM: https://github.com/oracle/graal/issues/13277#issuecomment-4182735778

Had to bump `openjdk25` to pass mandrel's minimum JDK version assertion.