### PR TITLE
vimb: update to 4.0.0

### DIFF
--- a/srcpkgs/vimb/template
+++ b/srcpkgs/vimb/template
@@ -1,16 +1,16 @@
 # Template file for 'vimb'
 pkgname=vimb
-version=3.7.1
+version=4.0.0
 revision=1
 build_style=gnu-makefile
 make_build_target=RUNPREFIX=/usr
 make_use_env=yes
 hostmakedepends="pkg-config"
-makedepends="libwebkit2gtk41-devel libglib-devel libsoup3-devel"
+makedepends="libwebkitgtk60-devel libglib-devel libsoup3-devel"
 short_desc="Fast and lightweight web browser based on WebKit/GTK+"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-3.0-or-later"
 homepage="https://fanglingsu.github.io/vimb/"
 changelog="https://raw.githubusercontent.com/fanglingsu/vimb/master/CHANGELOG.md"
 distfiles="https://github.com/fanglingsu/vimb/archive/refs/tags/${version}.tar.gz"
-checksum=42eb74a4f319a1574a27377d7adb1f08f49e2c353a1d7037dc39d85b510aab69
+checksum=4ae8c296430f023d6b556f8dd7a21d0df30aa4e3c6f5402510cc0cfe747c13bd


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: YES

#### Local build testing
- I built this PR locally for my native architecture: x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl (masterdir)
  - i686 (masterdir)
  - aarch64 (cross)
  - aarch64-musl (cross)
  - armv6l (cross)
  - armv6l-musl (cross)
  - armv7l (cross)
  - armv7l-musl (cross)

