### PR TITLE
esptool: remove fake module 'build', PEP517

### DIFF
--- a/srcpkgs/esptool/template
+++ b/srcpkgs/esptool/template
@@ -1,8 +1,8 @@
 # Template file for 'esptool'
 pkgname=esptool
 version=4.11.0
-revision=1
-build_style=python3-module
+revision=2
+build_style=python3-pep517
 hostmakedepends="python3-setuptools"
 depends="python3-argcomplete python3-bitstring python3-cryptography
  python3-ecdsa python3-intelhex python3-pyserial python3-reedsolo


### PR DESCRIPTION
The last update to esptool (#60832) added a spurious 'build' python package that contained a full duplicate of the modules provided by esptool.

Upstream fully supports PEP517 now, and switching to that buld-style fully resolves the issue.

PR link: https://github.com/void-linux/void-packages/pull/60832
Actions run where we see `build` being added: https://github.com/void-linux/void-packages/actions/runs/26738070705/job/79329249780?pr=60832#step:9:9

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**, see below

I do not have an esp device on hand to flash, *but* I have ensured that:
- I could reproduce the issue on master
- The files in the spurious `build` package had the exact same contents and structure as the real packages
- All the non-build files remained present and unchanged after the fix, except the `egg-info`/`dist-info` change (ie: only change is removal of `/usr/lib/python3.14/site-packages/build`)