### PR TITLE
New package: yggdrasil-ng-0.3.0

### DIFF
--- a/srcpkgs/yggdrasil-ng/files/yggdrasil-ng/run
+++ b/srcpkgs/yggdrasil-ng/files/yggdrasil-ng/run
@@ -1,0 +1,8 @@
+#!/bin/sh
+exec 2>&1
+modprobe tun
+[ -r ./conf ] && . ./conf
+exec setpriv --ambient-caps +net_admin,+net_raw \
+	--inh-caps +net_admin,+net_raw \
+	--bounding-set -all,+net_admin,+net_raw \
+	yggdrasil-ng ${OPTS:- --autoconf}

--- a/srcpkgs/yggdrasil-ng/template
+++ b/srcpkgs/yggdrasil-ng/template
@@ -1,0 +1,17 @@
+# Template file for 'yggdrasil-ng'
+pkgname=yggdrasil-ng
+version=0.3.0
+revision=1
+build_style=cargo
+make_install_args="--path crates/yggdrasil"
+short_desc="Rust rewrite of the Yggdrasil encrypted IPv6 overlay network"
+maintainer="John Mitrich <johnmitrich@gmail.com>"
+license="MPL-2.0"
+homepage="https://github.com/Revertron/Yggdrasil-ng"
+distfiles="https://github.com/Revertron/Yggdrasil-ng/archive/v${version}.tar.gz"
+checksum=be136c7478bf245bc434ddde1e9750968ad5f7d716750fbe66949a98e9fc7fb5
+
+post_install() {
+	vsv yggdrasil-ng
+	mv ${DESTDIR}/usr/bin/yggdrasil ${DESTDIR}/usr/bin/yggdrasil-ng
+}


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

Rust rewrite of the Yggdrasil network (upstream: github.com/Revertron/Yggdrasil-ng).
Single binary (daemon + control commands), installed as /usr/bin/yggdrasil-ng
to not clash with the original Go implementation. Ships a runit service that
uses /etc/yggdrasil-ng.toml if present, otherwise runs with --autoconf.

Tested locally: x86_64 native build with tests (all suites pass), cross-builds
for i686, aarch64, armv7l, armv6l. Runtime-tested: daemon starts, allocates
IPv6 address/subnet, TCP listener works.