### PR TITLE
just: update to 1.58.0

### DIFF
--- a/srcpkgs/just/template
+++ b/srcpkgs/just/template
@@ -1,6 +1,6 @@
 # Template file for 'just'
 pkgname=just
-version=1.51.0
+version=1.58.0
 revision=1
 build_style=cargo
 build_helper=qemu
@@ -12,7 +12,7 @@ license="CC0-1.0"
 homepage="https://github.com/casey/just"
 changelog="https://raw.githubusercontent.com/casey/just/master/CHANGELOG.md"
 distfiles="https://github.com/casey/just/archive/refs/tags/${version}.tar.gz"
-checksum=ed424dcf55ec08e22a0c58f6cfb7333573775d69dac3802bf0c1d96f7557089d
+checksum=c8a36e6e9397f2fdfcb0cc246fcdb790b52a784f3c8cabc0d8baeb031852a148
 
 # Fix failing test
 pre_check() {


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture: x86_64-libc