### PR TITLE
python3-s-tui: update to 1.5.0

### DIFF
--- a/srcpkgs/python3-s-tui/template
+++ b/srcpkgs/python3-s-tui/template
@@ -1,6 +1,6 @@
 # Template file for 'python3-s-tui'
 pkgname=python3-s-tui
-version=1.4.0
+version=1.5.0
 revision=1
 build_style=python3-module
 hostmakedepends="python3-setuptools"
@@ -11,4 +11,4 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-only"
 homepage="https://amanusk.github.io/s-tui"
 distfiles="https://github.com/amanusk/s-tui/archive/v${version}.tar.gz"
-checksum=92ca86bc7b3c95a573678d0d6ac7b88609c5355762d0278a78bbae998a2f4a39
+checksum=d6669cb6e67bb9653751a2b00e7f472816e96acfaf67018980f3c19862e9e40c


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: YES

#### Local build testing
- I built this PR locally for my native architecture: x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl (masterdir)
  - i686 (masterdir)
  - aarch64 (cross)
  - aarch64-musl (cross)
  - armv6l (cross)
  - armv6l-musl (cross)
  - armv7l (cross)
  - armv7l-musl (cross)

