### PR TITLE
go: update to 1.27.0.

### DIFF
--- a/srcpkgs/go/template
+++ b/srcpkgs/go/template
@@ -1,6 +1,6 @@
 # Template file for 'go'
 pkgname=go
-version=1.26.5
+version=1.27.0
 revision=1
 _bootstrap="1.24.6"
 create_wrksrc=yes
@@ -13,7 +13,7 @@ license="BSD-3-Clause"
 homepage="https://go.dev/"
 changelog="https://go.dev/doc/devel/release.html"
 distfiles="https://go.dev/dl/go${version}.src.tar.gz"
-checksum=495be4bc87176ac567392e5b4116abd98466d33d7b49d41e764ccc6976b2dc42
+checksum=7002403d7cc44529ef6d26f69a44818263395ead7c16c05a5808ae047ebeb0e5
 nostrip=yes
 noverifyrdeps=yes
 # on CI it tries to use `git submodule`, which is not part of chroot-git


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-musl)
- Runtime tested by building a large cgo/c-shared/c-archive project (graphics.gd) with the packaged toolchain and running its full test suite.