### PR TITLE
New package: ft2-clone-2.22_1

### DIFF
--- a/srcpkgs/ft2-clone/files/templatify-build-date.patch
+++ b/srcpkgs/ft2-clone/files/templatify-build-date.patch
@@ -1,0 +1,22 @@
+--- a/src/ft2_about.c
++++ b/src/ft2_about.c
+@@ -433,7 +433,8 @@ void initAboutScreen(void)
+ 	for (int32_t i = 0; i < SINUS_PHASES; i++)
+ 		sin16[i] = (int16_t)round(32767.0 * sin(i * PI * 2.0 / SINUS_PHASES));
+ 
+-	sprintf(customText3, "v%s (%s)", PROG_VER_STR, __DATE__);
++	sprintf(customText3, "v%s (%s)", PROG_VER_STR, PROG_VER_DATE);
++
+ 	customText0X = (SCREEN_W    - textWidth(customText0)) / 2;
+ 	customText1X = (SCREEN_W    - textWidth(customText1)) / 2;
+ 	customText2X = (SCREEN_W-8) - textWidth(customText2);
+--- a/src/ft2_header.h
++++ b/src/ft2_header.h
+@@ -13,6 +13,7 @@
+ #include "ft2_replayer.h"
+ 
+ #define PROG_VER_STR "@PKGVER@"
++#define PROG_VER_DATE "@DATE@"
+ 
+ // do NOT change these! It will only mess things up...
+ 

--- a/srcpkgs/ft2-clone/template
+++ b/srcpkgs/ft2-clone/template
@@ -1,0 +1,46 @@
+# Template file for 'ft2-clone'
+pkgname=ft2-clone
+version=2.22
+revision=1
+build_style=cmake
+configure_args="-W no-author -DCMAKE_BUILD_TYPE=None"
+hostmakedepends="cmake ninja libicns gendesk"
+makedepends="SDL2-devel alsa-lib-devel"
+depends="hicolor-icon-theme SDL2"
+short_desc="Portable Fasttracker II clone"
+maintainer="tema5002 <tema5002@tuta.io>"
+license="BSD-3-Clause AND MIT AND CC-BY-NC-SA-4.0"
+homepage="https://16-bits.org/ft2.php"
+distfiles="https://github.com/8bitbubsy/ft2-clone/archive/refs/tags/v${version}.tar.gz"
+checksum="c4488c081997284cf0879a8f95bb0a834ead5913880443d76b2247a933ba1727"
+
+pre_configure() {
+	cp ${FILESDIR}/templatify-build-date.patch .
+	sed -e "s/@PKGVER@/${version}/" -i templatify-build-date.patch
+	patch -p1 < templatify-build-date.patch
+
+	local commit_date="19 July 2026"
+	sed -e "s/@DATE@/${commit_date}/" -i src/ft2_header.h
+
+	icns2png -x release/macos/ft2-clone-macos.app/Contents/Resources/ft2-clone-macos.icns
+
+	gendesk -n \
+		--exec ${pkgname} \
+		--name 'Fasttracker II Clone' \
+		--pkgname ${pkgname} \
+		--pkgdesc "${short_desc}" \
+		--icon ${pkgname} \
+		--genericname 'Music Tracker'
+}
+
+do_install() {
+	DESTDIR="${DESTDIR}" cmake --install build
+
+	vinstall ft2-clone-macos_512x512x32.png 644 usr/share/icons/hicolor/512x512/apps "${pkgname}.png"
+	vinstall ft2-clone.desktop 644 usr/share/applications "${pkgname}.desktop"
+	vdoc README.md
+
+	for f in LICENSE*; do
+		vlicense "$f"
+	done
+}


### PR DESCRIPTION
Adds ft2-clone, a portable, highly accurate clone of Fasttracker II (the classic MS-DOS tracker) for Linux/macOS/Windows, built on SDL2. Upstream: https://github.com/8bitbubsy/ft2-clone

#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)

<img width="1623" height="950" alt="image" src="https://github.com/user-attachments/assets/43bf963e-f3cd-4d5d-a55d-ccea524fd8e3" />

