### PR TITLE
rustnet: update to 1.6.0

### DIFF
--- a/srcpkgs/rustnet/template
+++ b/srcpkgs/rustnet/template
@@ -1,6 +1,6 @@
 # Template file for 'rustnet'
 pkgname=rustnet
-version=1.5.0
+version=1.6.0
 revision=1
 archs="x86_64* aarch64*"
 build_style=cargo
@@ -13,7 +13,7 @@ license="Apache-2.0"
 homepage="https://github.com/domcyrus/rustnet"
 changelog="https://raw.githubusercontent.com/domcyrus/rustnet/refs/heads/main/CHANGELOG.md"
 distfiles="https://github.com/domcyrus/rustnet/archive/refs/tags/v${version}.tar.gz"
-checksum=f6425992dc5a8a700323c1231d1833a135cd93424d86cfaa788eed6cb700fe33
+checksum=245fc7074d5f142fbf1c798233be86b715b4f2ce3b3cfec10fabdcbbc9345ddb
 
 _setup_env() {
 	# workaround the cc-rs mixing CFLAGS for host and target.


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, (x64 glibc)
- Crossbuild: aarch64 aarch64-musl