### PR TITLE
dooble: update to 2026.08.21

### DIFF
--- a/srcpkgs/dooble/template
+++ b/srcpkgs/dooble/template
@@ -1,21 +1,21 @@
 # Template file for 'dooble'
 pkgname=dooble
-version=2025.11.25
-revision=2
+version=2026.08.21
+revision=1
 archs="x86_64* aarch64*"
 build_style=qmake
 configure_args="dooble.pro"
 hostmakedepends="qt6-base qt6-webengine
  qt6-plugin-tls-qcertonly qt6-plugin-tls-openssl"
 makedepends="qt6-charts-private-devel qt6-webengine-devel qt6-webchannel-devel
- qt6-location-devel"
-depends="qt6-plugin-sqlite libreoffice-qtwebengine-dict"
+ qt6-location-devel gpgme-devel"
+depends="qt6-plugin-sqlite hunspell-qtwebengine-dict"
 short_desc="Dooble, the scientific browser. Minimal, cute, and unusually stable"
 maintainer="Eloi Torrents <eloitor@duck.com>"
 license="BSD-3-Clause"
 homepage="https://textbrowser.github.io/dooble/"
 distfiles="https://github.com/textbrowser/dooble/archive/refs/tags/${version}.tar.gz"
-checksum=213b75a0ae17a64c826f48cb9e2e4fe51fbb033cf43bcbc275681f0f4c611fea
+checksum=0c35db368b252775ecd885597234b8a632523db23b0b474ac18d3e51a4623f68
 
 post_patch() {
 	vsed -i -e 's/Wzero-as-null-pointer-constant/Wno-zero-as-null-pointer-constant/' \


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64
  - x86_64-musl
