### PR TITLE
jjui: update to 0.10.9

### DIFF
--- a/srcpkgs/jjui/template
+++ b/srcpkgs/jjui/template
@@ -1,6 +1,6 @@
 # Template file for 'jjui'
 pkgname=jjui
-version=0.9.12
+version=0.10.9
 revision=1
 build_style=go
 go_import_path="github.com/idursun/jjui"
@@ -11,7 +11,7 @@ license="MIT"
 homepage="https://idursun.github.io/jjui/"
 changelog="https://github.com/idursun/jjui/releases"
 distfiles="https://github.com/idursun/jjui/archive/refs/tags/v${version}.tar.gz"
-checksum=214a7f620e035bdcdfe0f9f8ac56b532bcd11a91bb7b06c515b8bf005af03ebd
+checksum=1e6f74b3e00bb652f533331a15e4e0b9d6139a0db6f3f0f1e5b348ce547f72d0
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: YES


#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64
  - armv6l

