### PR TITLE
tuigreet: update to 0.11.1.

### DIFF
--- a/srcpkgs/tuigreet/template
+++ b/srcpkgs/tuigreet/template
@@ -1,17 +1,18 @@
 # Template file for 'tuigreet'
 pkgname=tuigreet
-version=0.9.1
+version=0.11.1
 revision=1
 build_style=cargo
+make_install_args="--path crates/tuigreet"
 hostmakedepends="scdoc"
 depends="greetd"
 short_desc="Graphical console greeter for greetd"
 maintainer="rslabbert <rslabbert@fastmail.com>"
 license="GPL-3.0-or-later"
-homepage="https://github.com/apognu/tuigreet"
-changelog="https://github.com/apognu/tuigreet/releases"
-distfiles="https://github.com/apognu/tuigreet/archive/refs/tags/${version}.tar.gz"
-checksum=14fd1fadeb84040eb31901da2b53a48aa55b0fdaccb36d96fa52ce2d2113667f
+homepage="https://github.com/tuigreet/tuigreet"
+changelog="https://github.com/tuigreet/tuigreet/releases"
+distfiles="https://github.com/tuigreet/tuigreet/archive/refs/tags/${version}.tar.gz"
+checksum=7d643ba224c40c6a63f9462a826630543071aea08e732ccd2e880bcd80d939e8
 tags="greeter"
 make_dirs="/var/cache/tuigreet 0755 _greeter _greeter"
 


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures:
  - aarch64-musl (cross-built)
  - i686

@rslabbert @cinerea0

`tuigreet` itself was moved to its own crate in a subdirectory.