### PR TITLE
fastfetch: add appimage install count support

### DIFF
--- a/srcpkgs/fastfetch/template
+++ b/srcpkgs/fastfetch/template
@@ -1,7 +1,7 @@
 # Template file for 'fastfetch'
 pkgname=fastfetch
 version=2.67.1
-revision=1
+revision=2
 build_style=cmake
 configure_args="-DENABLE_SYSTEM_YYJSON=ON -DBUILD_FLASHFETCH=OFF -DINSTALL_LICENSE=OFF
  -DENABLE_QUICKJS=OFF"
@@ -34,7 +34,7 @@ pre_configure() {
 	mkdir -p build && cd build
 	configure_args+="$(CMAKE_GENERATOR="Ninja" cmake -L ${wrksrc}/${build_wrksrc} | \
 		grep -oE 'PACKAGES_DISABLE_[a-zA-Z0-9]+' | \
-		grep -viE 'xbps|flatpak|nix|guix' | xargs printf ' -D%s=ON')"
+		grep -viE 'xbps|flatpak|nix|guix|appimage' | xargs printf ' -D%s=ON')"
 }
 
 post_install() {


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES** - i built and installed fastfetch with this change running it works and makes the appimage counter that upstream has visible when running it (plus using strace to confirm).

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- cross built for armv6l per CONTRIBUTING.md to test

The pre_configure() hack that disables irrelevant package manager checks (added because upstream probes every manager by default) currently excludes appimage along with the distro specific package managers its meant to target.

Since AppImage isnt a distro-specific package manger (support added upstream in [fastfetch-cli/fastfetch#2179](https://github.com/fastfetch-cli/fastfetch/issues/2179)), I think it shouldnt be disabled by default here, where xbps/flatpak/nix/guix are already exempted. This adds appimage to that exemption list so fastfetch can counts AppImages under ~/AppImages and ~/Applications, matching behavior on other distros.

Just noting that I've not made a PR before ever so I hope I have not done anything too wrong. Please let me know if you need anything else! (just to be safe, i did use Claude when troubleshooting why fastfetch wasnt picking up appimages when it was doing so on other distros, and help me with the initial narrative description which i worked off of to finalise myself, I did the changes and made this PR myself too)