### PR TITLE
update flit_core, add flit, update python3-packaging, etc

### DIFF
--- a/common/build-helper/python3.sh
+++ b/common/build-helper/python3.sh
@@ -8,7 +8,7 @@ if [ -n "$CROSS_BUILD" ]; then
 	export CXX="${XBPS_CROSS_TRIPLET}-g++ -pthread $CXXFLAGS $LDFLAGS"
 	export LDSHARED="${CC} -shared $LDFLAGS"
 	export PYTHON_CONFIG="${XBPS_CROSS_BASE}/usr/bin/python3-config"
-	export PYTHONPATH="${XBPS_CROSS_BASE}/${py3_lib}"
+	export PYTHONPATH="${XBPS_CROSS_BASE}/${py3_lib}:${PYTHONPATH}"
 	for f in ${XBPS_CROSS_BASE}/${py3_lib}/_sysconfigdata_*; do
 		[ -f "$f" ] || continue
 		f=${f##*/}

--- a/common/environment/build-style/python3-pep517.sh
+++ b/common/environment/build-style/python3-pep517.sh
@@ -1,6 +1,7 @@
 lib32disabled=yes
-hostmakedepends+=" python3-build python3-installer"
+hostmakedepends+=" python3-build python3-installer-bootstrap"
 if [ -z "$nopyprovides" ] || [ -z "$noverifypydeps" ]; then
 	hostmakedepends+=" python3-packaging-bootstrap"
 fi
 build_helper+=" python3"
+export PYTHONPATH="${PYTHONPATH}:/${py3_sitelib}-bootstrap"

--- a/srcpkgs/flit/template
+++ b/srcpkgs/flit/template
@@ -1,0 +1,22 @@
+# Template file for 'flit'
+pkgname=flit
+version=4.0.2
+revision=1
+build_style=python3-pep517
+# these tests try to use system pip
+make_check_args="-k not((test_install_data_dir)or(test_install_module_pep621)or(test_symlink_data_dir)or(test_symlink_module_pep621))"
+hostmakedepends="python3-flit_core python3-installer"
+depends="python3-flit_core python3-requests python3-docutils python3-tomli-w
+ python3-pip"
+checkdepends="$depends python3-pytest python3-testpath python3-responses"
+short_desc="Simplified packaging of Python modules"
+maintainer="classabbyamp <void@placeviolette.net>"
+license="BSD-3-Clause"
+homepage="https://flit.pypa.io"
+changelog="https://flit.pypa.io/en/stable/history.html"
+distfiles="${PYPI_SITE}/f/flit/flit-${version}.tar.gz"
+checksum=232bc4317279e8952eca9fb3f5e000d8395d693b39c105b99f619ce461e1da85
+
+post_install() {
+	vlicense LICENSE
+}

--- a/srcpkgs/img2pdf/patches/allow-flit-versions.patch
+++ b/srcpkgs/img2pdf/patches/allow-flit-versions.patch
@@ -1,0 +1,9 @@
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -1,5 +1,5 @@
+ [build-system]
+-requires = ["flit_core >=3.2,<4"]
++requires = ['flit_core']
+ build-backend = "flit_core.buildapi"
+ 
+ [project]

--- a/srcpkgs/python3-Flask/patches/allow-flit-versions.patch
+++ b/srcpkgs/python3-Flask/patches/allow-flit-versions.patch
@@ -1,0 +1,11 @@
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -84,7 +84,7 @@
+ flask = "flask.cli:main"
+ 
+ [build-system]
+-requires = ["flit_core<4"]
++requires = ['flit_core']
+ build-backend = "flit_core.buildapi"
+ 
+ [tool.flit.module]

--- a/srcpkgs/python3-Jinja2/patches/allow-flit-versions.patch
+++ b/srcpkgs/python3-Jinja2/patches/allow-flit-versions.patch
@@ -1,0 +1,11 @@
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -33,7 +33,7 @@
+ jinja2 = "jinja2.ext:babel_extract[i18n]"
+ 
+ [build-system]
+-requires = ["flit_core<4"]
++requires = ['flit_core']
+ build-backend = "flit_core.buildapi"
+ 
+ [tool.flit.module]

--- a/srcpkgs/python3-MyST-Parser/patches/allow-flit-versions.patch
+++ b/srcpkgs/python3-MyST-Parser/patches/allow-flit-versions.patch
@@ -1,0 +1,9 @@
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -1,5 +1,5 @@
+ [build-system]
+-requires = ["flit_core >=3.4,<4"]
++requires = ['flit_core']
+ build-backend = "flit_core.buildapi"
+ 
+ [project]

--- a/srcpkgs/python3-MyST-Parser/template
+++ b/srcpkgs/python3-MyST-Parser/template
@@ -1,9 +1,11 @@
 # Template file for 'python3-MyST-Parser'
 pkgname=python3-MyST-Parser
 version=3.0.1
-revision=3
+revision=4
 build_style=python3-pep517
 hostmakedepends="python3-flit_core"
+depends="python3-Jinja2 python3-Sphinx python3-docutils python3-markdown-it
+ python3-mdit-py-plugins python3-yaml"
 short_desc="Sphinx and Docutils extension to parse MyST"
 maintainer="Daniel Martinez <danielmartinez@cock.li>"
 license="MIT"

--- a/srcpkgs/python3-WeasyPrint/patches/allow-flit-versions.patch
+++ b/srcpkgs/python3-WeasyPrint/patches/allow-flit-versions.patch
@@ -1,0 +1,9 @@
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -1,5 +1,5 @@
+ [build-system]
+-requires = ['flit_core >=3.2,<4']
++requires = ['flit_core']
+ build-backend = 'flit_core.buildapi'
+ 
+ [project]

--- a/srcpkgs/python3-Werkzeug/patches/allow-flit-versions.patch
+++ b/srcpkgs/python3-Werkzeug/patches/allow-flit-versions.patch
@@ -1,0 +1,11 @@
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -36,7 +36,7 @@
+ watchdog = ["watchdog>=2.3"]
+ 
+ [build-system]
+-requires = ["flit_core<4"]
++requires = ['flit_core']
+ build-backend = "flit_core.buildapi"
+ 
+ [tool.flit.module]

--- a/srcpkgs/python3-aiosqlite/patches/allow-flit-versions.patch
+++ b/srcpkgs/python3-aiosqlite/patches/allow-flit-versions.patch
@@ -1,0 +1,9 @@
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -1,5 +1,5 @@
+ [build-system]
+-requires = ["flit_core >=3.8,<4"]
++requires = ['flit_core']
+ build-backend = "flit_core.buildapi"
+ 
+ [project]

--- a/srcpkgs/python3-blessed/patches/allow-flit-versions.patch
+++ b/srcpkgs/python3-blessed/patches/allow-flit-versions.patch
@@ -1,0 +1,9 @@
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -1,5 +1,5 @@
+ [build-system]
+-requires = ['flit_core >=3.11,<4']
++requires = ['flit_core']
+ build-backend = 'flit_core.buildapi'
+ 
+ [tool.flit.sdist]

--- a/srcpkgs/python3-blinker/patches/allow-flit-versions.patch
+++ b/srcpkgs/python3-blinker/patches/allow-flit-versions.patch
@@ -1,0 +1,11 @@
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -20,7 +20,7 @@
+ Chat = "https://discord.gg/pallets"
+ 
+ [build-system]
+-requires = ["flit_core<4"]
++requires = ['flit_core']
+ build-backend = "flit_core.buildapi"
+ 
+ [tool.flit.sdist]

--- a/srcpkgs/python3-build/template
+++ b/srcpkgs/python3-build/template
@@ -5,9 +5,9 @@ revision=1
 # This package is used by the python3-pep517 build style; using that style here
 # would create a build cycle
 build_style=python3-module
-_depends="python3-packaging python3-pyproject-hooks"
-hostmakedepends="python3-flit_core python3-installer $_depends"
-depends="$_depends"
+hostmakedepends="python3-flit_core-bootstrap python3-installer-bootstrap
+ python3-packaging-bootstrap python3-pyproject-hooks"
+depends="python3-packaging python3-pyproject-hooks"
 short_desc="Simple, correct PEP 517 build frontend"
 maintainer="Andrew J. Hesford <ajh@sideband.org>"
 license="MIT"
@@ -24,11 +24,11 @@ do_build() {
 		pypath="${pypath}:${PYTHONPATH}"
 	fi
 
-	PYTHONPATH="${pypath}" python3 -m build --no-isolation --wheel .
+	PYTHONPATH="${pypath}:/${py3_sitelib}-bootstrap" python3 -m build --no-isolation --wheel .
 }
 
 do_install() {
-	python3 -m installer --destdir "${DESTDIR}" \
+	PYTHONPATH="${PYTHONPATH}:/${py3_sitelib}-bootstrap" python3 -m installer --destdir "${DESTDIR}" \
 		"dist/build-${version}-py3-none-any.whl"
 	vlicense LICENSE
 }

--- a/srcpkgs/python3-cairocffi/patches/allow-flit-versions.patch
+++ b/srcpkgs/python3-cairocffi/patches/allow-flit-versions.patch
@@ -1,0 +1,9 @@
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -1,5 +1,5 @@
+ [build-system]
+-requires = ['flit_core >=3.2,<4']
++requires = ['flit_core']
+ build-backend = 'flit_core.buildapi'
+ 
+ [project]

--- a/srcpkgs/python3-click/patches/allow-flit-versions.patch
+++ b/srcpkgs/python3-click/patches/allow-flit-versions.patch
@@ -1,0 +1,11 @@
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -58,7 +58,7 @@
+ ]
+ 
+ [build-system]
+-requires = ["flit_core>=3.11,<4"]
++requires = ['flit_core']
+ build-backend = "flit_core.buildapi"
+ 
+ [tool.flit.module]

--- a/srcpkgs/python3-cssselect2/patches/allow-flit-versions.patch
+++ b/srcpkgs/python3-cssselect2/patches/allow-flit-versions.patch
@@ -1,0 +1,9 @@
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -1,5 +1,5 @@
+ [build-system]
+-requires = ['flit_core >=3.2,<4']
++requires = ['flit_core']
+ build-backend = 'flit_core.buildapi'
+ 
+ [project]

--- a/srcpkgs/python3-docutils/patches/allow-flit-versions.patch
+++ b/srcpkgs/python3-docutils/patches/allow-flit-versions.patch
@@ -1,0 +1,11 @@
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -3,7 +3,7 @@
+ # Use flit as a build backend (https://flit.pypa.io/)
+ # Build with (https://build.pypa.io/)
+ [build-system]
+-requires = ["flit_core>=3.11,<4"]
++requires = ['flit_core']
+ build-backend = "flit_core.buildapi"
+ 
+ # Project metadata

--- a/srcpkgs/python3-entrypoints/patches/allow-flit-versions.patch
+++ b/srcpkgs/python3-entrypoints/patches/allow-flit-versions.patch
@@ -1,0 +1,48 @@
+From 1333ae592d0261e6a014ef4c0fb25086ab0919dc Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Micha=C5=82=20G=C3=B3rny?= <mgorny@gentoo.org>
+Date: Wed, 5 Aug 2026 20:24:55 +0200
+Subject: [PATCH] Use the PEP 621 project metadata to support flit-core>=5
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Signed-off-by: Michał Górny <mgorny@gentoo.org>
+---
+ pyproject.toml | 22 ++++++++++++----------
+ 1 file changed, 12 insertions(+), 10 deletions(-)
+
+diff --git a/pyproject.toml b/pyproject.toml
+index 1279b10..810224a 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -1,18 +1,20 @@
+ [build-system]
+-requires = ["flit_core  >=2,<4"]
++requires = ["flit_core >=2,<5"]
+ build-backend = "flit_core.buildapi"
+ 
+-[tool.flit.metadata]
+-module = "entrypoints"
+-author = "Thomas Kluyver"
+-author-email = "thomas@kluyver.me.uk"
+-home-page = "https://github.com/takluyver/entrypoints"
+-description-file = "README.rst"
++[project]
++name = "entrypoints"
++authors = [
++    { name = "Thomas Kluyver", email = "thomas@kluyver.me.uk" },
++]
++readme = "README.rst"
++license = "MIT"
++requires-python = ">=3.6"
++dynamic = ["version", "description"]
+ classifiers = [
+-    "License :: OSI Approved :: MIT License",
+     "Programming Language :: Python :: 3"
+ ]
+-requires-python = ">=3.6"
+ 
+-[tool.flit.metadata.urls]
++[project.urls]
++Homepage = "https://github.com/takluyver/entrypoints"
+ Documentation = "https://entrypoints.readthedocs.io/en/latest/"

--- a/srcpkgs/python3-entrypoints/template
+++ b/srcpkgs/python3-entrypoints/template
@@ -13,9 +13,6 @@ homepage="https://github.com/takluyver/entrypoints"
 distfiles="https://github.com/takluyver/entrypoints/archive/${version}.tar.gz"
 checksum=d2197a94aa73e70a7f60600e654ac9918ca2a0ee5480eb875296c42220a02272
 
-pre_build() {
-	vsed -i "s|@VERSION@|${version}|" setup.py
-}
 post_install() {
 	vinstall entrypoints.py 644 usr/lib/python${py3_ver}/site-packages
 	vlicense LICENSE

--- a/srcpkgs/python3-flit_core-bootstrap/template
+++ b/srcpkgs/python3-flit_core-bootstrap/template
@@ -1,7 +1,7 @@
 # Template file for 'python3-flit_core-bootstrap'
 pkgname=python3-flit_core-bootstrap
-version=3.12.0
-revision=2
+version=4.0.2
+revision=1
 # This package is required by python3-build and python3-installer, used by the
 # python3-pep517 style; so using that style here would create a cycle
 hostmakedepends="python3"
@@ -12,7 +12,7 @@ license="BSD-3-Clause"
 homepage="https://flit.pypa.io/"
 changelog="https://flit.pypa.io/en/stable/history.html"
 distfiles="${PYPI_SITE}/f/flit_core/flit_core-${version}.tar.gz"
-checksum=18f63100d6f94385c6ed57a72073443e1a71a4acb4339491615d0f16d6ff01b2
+checksum=b6929defd93884b584d7c87829e0e7b5c26ed6be17b0b873979019314aa841c8
 make_check=no # bootstrap
 repository=bootstrap
 nopyprovides=yes

--- a/srcpkgs/python3-flit_core/template
+++ b/srcpkgs/python3-flit_core/template
@@ -1,10 +1,9 @@
 # Template file for 'python3-flit_core'
 pkgname=python3-flit_core
-version=3.12.0
-revision=2
-# This package is required by python3-build and python3-installer, used by the
-# python3-pep517 style; so using that style here would create a cycle
-hostmakedepends="python3"
+version=4.0.2
+revision=1
+build_style=python3-pep517
+hostmakedepends="python3-flit_core-bootstrap"
 depends="python3"
 checkdepends="python3-pytest python3-testpath $depends"
 short_desc="Simplified packaging of Python modules - PEP 517 build backend"
@@ -13,19 +12,8 @@ license="BSD-3-Clause"
 homepage="https://flit.pypa.io/"
 changelog="https://flit.pypa.io/en/stable/history.html"
 distfiles="${PYPI_SITE}/f/flit_core/flit_core-${version}.tar.gz"
-checksum=18f63100d6f94385c6ed57a72073443e1a71a4acb4339491615d0f16d6ff01b2
+checksum=b6929defd93884b584d7c87829e0e7b5c26ed6be17b0b873979019314aa841c8
 
-do_build() {
-	python3 -m flit_core.wheel
-}
-
-do_check() {
-	python3 -m pytest tests_core
-}
-
-do_install() {
-	python3 bootstrap_install.py --install-root "${DESTDIR}" \
-		"dist/flit_core-${version}-py3-none-any.whl"
-
+post_install() {
 	vlicense LICENSE
 }

--- a/srcpkgs/python3-idna/patches/allow-flit-versions.patch
+++ b/srcpkgs/python3-idna/patches/allow-flit-versions.patch
@@ -1,0 +1,9 @@
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -1,5 +1,5 @@
+ [build-system]
+-requires = ["flit_core >=3.11,<4"]
++requires = ['flit_core']
+ build-backend = "flit_core.buildapi"
+ 
+ [project]

--- a/srcpkgs/python3-installer/patches/allow-flit-versions.patch
+++ b/srcpkgs/python3-installer/patches/allow-flit-versions.patch
@@ -1,0 +1,11 @@
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -1,7 +1,7 @@
+ [build-system]
+ build-backend = "flit_core.buildapi"
+ requires = [
+-    "flit_core<4,>=3.11",
++    'flit_core',
+ ]
+ 
+ [project]

--- a/srcpkgs/python3-installer/template
+++ b/srcpkgs/python3-installer/template
@@ -2,10 +2,8 @@
 pkgname=python3-installer
 version=1.0.1
 revision=1
-# This package is used by the python3-pep517 build style; using that style here
-# would create a build cycle
-build_style=python3-module
-hostmakedepends="python3-flit_core"
+build_style=python3-pep517
+hostmakedepends="python3-flit_core-bootstrap"
 depends="python3"
 checkdepends="python3-pytest-xdist"
 short_desc="Low-level library for installing from a Python wheel"
@@ -15,22 +13,6 @@ homepage="https://installer.readthedocs.io/"
 distfiles="https://github.com/pypa/installer/archive/${version}.tar.gz"
 checksum=391b8068eb6b5629496a71e33b948b10c31bea77a12d302034323406ee03ffd1
 
-do_build() {
-	python3 -m flit_core.wheel
-}
-
-do_check() {
-	PYTHONPATH=src python3 -m pytest -n $XBPS_MAKEJOBS
-}
-
-do_install() {
-	local pypath="./src"
-	if [ -n "${PYTHONPATH}" ]; then
-		pypath="${pypath}:${PYTHONPATH}"
-	fi
-
-	PYTHONPATH="${pypath}" python3 -m installer --destdir "${DESTDIR}" \
-		"dist/installer-${version}-py3-none-any.whl"
-
+post_install() {
 	vlicense LICENSE
 }

--- a/srcpkgs/python3-ipython-pygments-lexers/patches/allow-flit-versions.patch
+++ b/srcpkgs/python3-ipython-pygments-lexers/patches/allow-flit-versions.patch
@@ -1,0 +1,9 @@
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -1,5 +1,5 @@
+ [build-system]
+-requires = ["flit_core >=3.2,<4"]
++requires = ['flit_core']
+ build-backend = "flit_core.buildapi"
+ 
+ [project]

--- a/srcpkgs/python3-itsdangerous/patches/allow-flit-versions.patch
+++ b/srcpkgs/python3-itsdangerous/patches/allow-flit-versions.patch
@@ -1,0 +1,11 @@
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -23,7 +23,7 @@
+ Chat = "https://discord.gg/pallets"
+ 
+ [build-system]
+-requires = ["flit_core<4"]
++requires = ['flit_core']
+ build-backend = "flit_core.buildapi"
+ 
+ [tool.flit.module]

--- a/srcpkgs/python3-jeepney/patches/allow-flit-versions.patch
+++ b/srcpkgs/python3-jeepney/patches/allow-flit-versions.patch
@@ -1,0 +1,9 @@
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -1,5 +1,5 @@
+ [build-system]
+-requires = ["flit_core >=3.11,<4"]
++requires = ['flit_core']
+ build-backend = "flit_core.buildapi"
+ 
+ [project]

--- a/srcpkgs/python3-loguru/patches/allow-flit-versions.patch
+++ b/srcpkgs/python3-loguru/patches/allow-flit-versions.patch
@@ -1,0 +1,10 @@
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -1,6 +1,6 @@
+ [build-system]
+ build-backend = "flit_core.buildapi"
+-requires = ["flit_core>=3,<4"]
++requires = ['flit_core']
+ 
+ [project]
+ authors = [{ name = "Delgan", email = "delgan.py@gmail.com" }]

--- a/srcpkgs/python3-lsprotocol/patches/allow-flit-versions.patch
+++ b/srcpkgs/python3-lsprotocol/patches/allow-flit-versions.patch
@@ -1,0 +1,9 @@
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -1,5 +1,5 @@
+ [build-system]
+-requires = ["flit_core >=3.2,<4"]
++requires = ['flit_core']
+ build-backend = "flit_core.buildapi"
+ 
+ [project]

--- a/srcpkgs/python3-markdown-it/patches/allow-flit-versions.patch
+++ b/srcpkgs/python3-markdown-it/patches/allow-flit-versions.patch
@@ -1,0 +1,9 @@
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -1,5 +1,5 @@
+ [build-system]
+-requires = ["flit_core >=3.4,<4"]
++requires = ['flit_core']
+ build-backend = "flit_core.buildapi"
+ 
+ [project]

--- a/srcpkgs/python3-mdit-py-plugins/patches/allow-flit-versions.patch
+++ b/srcpkgs/python3-mdit-py-plugins/patches/allow-flit-versions.patch
@@ -1,0 +1,9 @@
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -1,5 +1,5 @@
+ [build-system]
+-requires = ["flit_core >=3.4,<4"]
++requires = ['flit_core']
+ build-backend = "flit_core.buildapi"
+ 
+ [project]

--- a/srcpkgs/python3-mdit-py-plugins/template
+++ b/srcpkgs/python3-mdit-py-plugins/template
@@ -1,9 +1,10 @@
 # Template file for 'python3-mdit-py-plugins'
 pkgname=python3-mdit-py-plugins
 version=0.4.1
-revision=3
+revision=4
 build_style=python3-pep517
 hostmakedepends="python3-flit_core"
+depends="python3-markdown-it"
 short_desc="Markdown-It-Py Plugin Extensions"
 maintainer="Daniel Martinez <danielmartinez@cock.li>"
 license="MIT"

--- a/srcpkgs/python3-mdurl/patches/allow-flit-versions.patch
+++ b/srcpkgs/python3-mdurl/patches/allow-flit-versions.patch
@@ -1,0 +1,9 @@
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -1,5 +1,5 @@
+ [build-system]
+-requires = ["flit_core>=3.2.0,<4"]
++requires = ['flit_core']
+ build-backend = "flit_core.buildapi"
+ 
+ [project]

--- a/srcpkgs/python3-mediafile/template
+++ b/srcpkgs/python3-mediafile/template
@@ -1,9 +1,9 @@
 # Template file for 'python3-mediafile'
 pkgname=python3-mediafile
-version=0.13.0
-revision=2
+version=0.17.0
+revision=1
 build_style=python3-pep517
-hostmakedepends="python3-flit_core"
+hostmakedepends="python3-poetry-core"
 depends="python3-mutagen python3-six python3-filetype"
 checkdepends="${depends} python3-pytest"
 short_desc="Read and write audio files' tags in Python"
@@ -11,7 +11,8 @@ maintainer="Joel Beckmeyer <joel@beckmeyer.us>"
 license="MIT"
 homepage="https://github.com/beetbox/mediafile"
 distfiles="${PYPI_SITE}/m/mediafile/mediafile-${version}.tar.gz"
-checksum=de71063e1bffe9733d6ccad526ea7dac8a9ce760105827f81ab0cb034c729a6d
+checksum=80c9003fd25d7096a7237e3b58e6ff018ef67f9c39900feafacabac1742c7d3a
+make_check=no # no tests
 
 post_install() {
 	vlicense LICENSE

--- a/srcpkgs/python3-more-itertools/patches/allow-flit-versions.patch
+++ b/srcpkgs/python3-more-itertools/patches/allow-flit-versions.patch
@@ -1,0 +1,9 @@
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -1,5 +1,5 @@
+ [build-system]
+-requires = ["flit_core >=3.12,<4"]
++requires = ['flit_core']
+ build-backend = "flit_core.buildapi"
+ 
+ [project]

--- a/srcpkgs/python3-mypy_extensions/patches/allow-flit-versions.patch
+++ b/srcpkgs/python3-mypy_extensions/patches/allow-flit-versions.patch
@@ -1,0 +1,9 @@
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -1,5 +1,5 @@
+ [build-system]
+-requires      = ["flit_core>=3.11,<4"]
++requires      = ['flit_core']
+ build-backend = "flit_core.buildapi"
+ 
+ [project]

--- a/srcpkgs/python3-nkdfu/patches/allow-flit-versions.patch
+++ b/srcpkgs/python3-nkdfu/patches/allow-flit-versions.patch
@@ -1,0 +1,54 @@
+From b68013ed349a625887b5c022bb18245ee20f1292 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Miro=20Hron=C4=8Dok?= <miro@hroncok.cz>
+Date: Thu, 20 Aug 2026 11:42:09 +0200
+Subject: [PATCH] Update project metadata to support flit-core version 4+
+
+---
+ pyproject.toml | 22 +++++++++++-----------
+ 1 file changed, 11 insertions(+), 11 deletions(-)
+
+diff --git a/pyproject.toml b/pyproject.toml
+index bfef87d..7509e74 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -1,29 +1,29 @@
+ [build-system]
+-requires = ["flit_core"]
++requires = ["flit_core>=3.11,<5"]
+ build-backend = "flit_core.buildapi"
+ 
+-[tool.flit.metadata]
+-module = "nkdfu"
+-dist-name = "nkdfu"
+-author = "Nitrokey"
+-author-email = "pypi@nitrokey.com"
+-home-page = "https://github.com/Nitrokey/nkdfu"
++[project]
++name = "nkdfu"
++dynamic = ["version", "description"]
++authors = [{ name = "Nitrokey", email = "pypi@nitrokey.com" }]
++urls.Homepage = "https://github.com/Nitrokey/nkdfu"
+ requires-python = ">=3.6"
+-description-file = "README.md"
+-requires = [
++readme = "README.md"
++dependencies = [
+   "fire",
+   "tqdm",
+   "intelhex >= 2.3.0",
+   "libusb1 >= 1.9.3",
+ ]
+ classifiers=[
+-    "License :: OSI Approved :: GNU General Public License v2 (GPLv2)",
+     "Intended Audience :: Developers",
+     "Intended Audience :: End Users/Desktop",
+     "Programming Language :: Python :: 3 :: Only",
+     "Programming Language :: Python :: 3.6",
+     "Programming Language :: Python :: 3.7",
+ ]
++license = "GPL-2.0-only"
++license-files = ["LICENSE"]
+ 
+-[tool.flit.scripts]
++[project.scripts]
+ nkdfu = "nkdfu.dfu_flash:cli"

--- a/srcpkgs/python3-ordered_set/patches/allow-flit-versions.patch
+++ b/srcpkgs/python3-ordered_set/patches/allow-flit-versions.patch
@@ -1,0 +1,9 @@
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -1,5 +1,5 @@
+ [build-system]
+-requires = ["flit_core >=3.2,<4"]
++requires = ['flit_core']
+ build-backend = "flit_core.buildapi"
+ 
+ [project]

--- a/srcpkgs/python3-packaging-bootstrap/template
+++ b/srcpkgs/python3-packaging-bootstrap/template
@@ -1,6 +1,6 @@
 # Template file for 'python3-packaging-bootstrap'
 pkgname=python3-packaging-bootstrap
-version=26.2
+version=26.3
 revision=1
 # This package is required by python3-build, used by the python3-pep517 style;
 # using that style here would create a cycle
@@ -11,8 +11,9 @@ short_desc="Core utilities for Python 3 packages (for xbps-src use)"
 maintainer="Andrew J. Hesford <ajh@sideband.org>"
 license="Apache-2.0, BSD-2-Clause"
 homepage="https://github.com/pypa/packaging"
+changelog="https://github.com/pypa/packaging/raw/refs/heads/main/CHANGELOG.rst"
 distfiles="${PYPI_SITE}/p/packaging/packaging-${version}.tar.gz"
-checksum=ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661
+checksum=94edc256424af38762eb31306eed28beb9f0efc50a8837492c9d6fd6004aed79
 make_check=no # provides no tests, bootstrap
 repository=bootstrap
 nopyprovides=yes

--- a/srcpkgs/python3-packaging/template
+++ b/srcpkgs/python3-packaging/template
@@ -1,27 +1,28 @@
 # Template file for 'python3-packaging'
 pkgname=python3-packaging
-version=26.2
+version=26.3
 revision=1
 # This package is required by python3-build, used by the python3-pep517 style;
 # using that style here would create a cycle
 build_style=python3-module
-hostmakedepends="python3-flit_core python3-installer"
+hostmakedepends="python3-flit_core-bootstrap python3-installer-bootstrap"
 depends="python3-parsing"
 checkdepends="python3-pytest"
 short_desc="Core utilities for Python packages (Python3)"
 maintainer="Andrew J. Hesford <ajh@sideband.org>"
 license="Apache-2.0, BSD-2-Clause"
 homepage="https://github.com/pypa/packaging"
+changelog="https://github.com/pypa/packaging/raw/refs/heads/main/CHANGELOG.rst"
 distfiles="${PYPI_SITE}/p/packaging/packaging-${version}.tar.gz"
-checksum=ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661
+checksum=94edc256424af38762eb31306eed28beb9f0efc50a8837492c9d6fd6004aed79
 make_check=no # provides no tests
 
 do_build() {
-	python3 -m flit_core.wheel
+	PYTHONPATH="${PYTHONPATH}:/${py3_sitelib}-bootstrap" python3 -m flit_core.wheel
 }
 
 do_install() {
-	python3 -m installer --destdir "${DESTDIR}" \
+	PYTHONPATH="${PYTHONPATH}:/${py3_sitelib}-bootstrap" python3 -m installer --destdir "${DESTDIR}" \
 		"dist/packaging-${version}-py3-none-any.whl"
 	vlicense LICENSE
 }

--- a/srcpkgs/python3-parsing/template
+++ b/srcpkgs/python3-parsing/template
@@ -11,7 +11,7 @@ make_check_args="
  --ignore=tests/test_diagram.py
  --deselect=tests/test_examples.py::TestExamples::test_range_check
 "
-hostmakedepends="python3-flit_core python3-installer"
+hostmakedepends="python3-flit_core-bootstrap python3-installer-bootstrap"
 depends="python3"
 checkdepends="python3-pytest-xdist"
 short_desc="Python parsing module"
@@ -23,11 +23,11 @@ distfiles="${PYPI_SITE}/p/pyparsing/pyparsing-${version}.tar.gz"
 checksum=c777f4d763f140633dcb6d8a3eda953bf7a214dc4eff598413c070bcdc117cbc
 
 do_build() {
-	python3 -m flit_core.wheel
+	PYTHONPATH="${PYTHONPATH}:/${py3_sitelib}-bootstrap" python3 -m flit_core.wheel
 }
 
 do_install() {
-	python3 -m installer --destdir "${DESTDIR}" \
+	PYTHONPATH="${PYTHONPATH}:/${py3_sitelib}-bootstrap" python3 -m installer --destdir "${DESTDIR}" \
 		"dist/pyparsing-${version}-py3-none-any.whl"
 
 	vlicense LICENSE

--- a/srcpkgs/python3-pep440/patches/allow-flit-versions.patch
+++ b/srcpkgs/python3-pep440/patches/allow-flit-versions.patch
@@ -1,0 +1,9 @@
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -1,5 +1,5 @@
+ [build-system]
+-requires = ["flit_core >=3.4,<4"]
++requires = ['flit_core']
+ build-backend = "flit_core.buildapi"
+ 
+ [project]

--- a/srcpkgs/python3-pip/patches/allow-flit-versions.patch
+++ b/srcpkgs/python3-pip/patches/allow-flit-versions.patch
@@ -1,0 +1,86 @@
+From 09a03f6cfaeecae8bf5774ae371d37c4369e2da4 Mon Sep 17 00:00:00 2001
+From: Damian Shaw <damian.peter.shaw@gmail.com>
+Date: Sat, 15 Aug 2026 13:36:05 -0400
+Subject: [PATCH] Allow flit-core 4 to build pip
+
+---
+ build-project/pylock.toml    | 16 ++++++++--------
+ build-project/pyproject.toml |  2 +-
+ pyproject.toml               |  6 +++---
+ 3 files changed, 12 insertions(+), 12 deletions(-)
+
+diff --git a/build-project/pylock.toml b/build-project/pylock.toml
+index 45d0422bc6..220c63cfee 100644
+--- a/build-project/pylock.toml
++++ b/build-project/pylock.toml
+@@ -14,25 +14,25 @@ sha256 = "13f3eecb844759ab66efec90ca17639bbf14dc06cb2fdf37a9010322d9c50a6f"
+ 
+ [[packages]]
+ name = "flit-core"
+-version = "3.12.0"
++version = "4.0.2"
+ 
+ [[packages.wheels]]
+-name = "flit_core-3.12.0-py3-none-any.whl"
+-url = "https://files.pythonhosted.org/packages/f2/65/b6ba90634c984a4fcc02c7e3afe523fef500c4980fec67cc27536ee50acf/flit_core-3.12.0-py3-none-any.whl"
++name = "flit_core-4.0.2-py3-none-any.whl"
++url = "https://files.pythonhosted.org/packages/40/79/099ca4ec8c22b6462577ef933f90eed4c47cdcf6473d2cfcad275c3ce232/flit_core-4.0.2-py3-none-any.whl"
+ 
+ [packages.wheels.hashes]
+-sha256 = "e7a0304069ea895172e3c7bb703292e992c5d1555dd1233ab7b5621b5b69e62c"
++sha256 = "8d80717e28d982b41594ed5b14d4e89fbc5bad55473fde27994a3101db18a94e"
+ 
+ [[packages]]
+ name = "packaging"
+-version = "26.2"
++version = "26.3"
+ 
+ [[packages.wheels]]
+-name = "packaging-26.2-py3-none-any.whl"
+-url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl"
++name = "packaging-26.3-py3-none-any.whl"
++url = "https://files.pythonhosted.org/packages/63/34/ba1c580383c9eada3711951fef0795c80b829a078d72188184bcab9dd527/packaging-26.3-py3-none-any.whl"
+ 
+ [packages.wheels.hashes]
+-sha256 = "5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e"
++sha256 = "d7193f7c8e4e93f444fde0262bf90af30e16fa0ad0ad44cb553c87339b23cd1c"
+ 
+ [[packages]]
+ name = "pyproject-hooks"
+diff --git a/build-project/pyproject.toml b/build-project/pyproject.toml
+index 6dc112d878..bfa0ffd568 100644
+--- a/build-project/pyproject.toml
++++ b/build-project/pyproject.toml
+@@ -1,2 +1,2 @@
+ [dependency-groups]
+-build = ["build", "flit-core"]
++build = ["build", "flit-core >=3.11,<5"]
+diff --git a/pyproject.toml b/pyproject.toml
+index 48f64c8018..fe6b39913d 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -45,13 +45,13 @@ Source = "https://github.com/pypa/pip"
+ Changelog = "https://pip.pypa.io/en/stable/news/"
+ 
+ [build-system]
+-requires = ["flit-core >=3.11,<4"]
++requires = ["flit-core >=3.11,<5"]
+ build-backend = "flit_core.buildapi"
+ 
+ [dependency-groups]
+ test = [
+     "cryptography",
+-    "flit-core >= 3.11, < 4",
++    "flit-core >= 3.11, < 5",
+     "freezegun",
+     "installer",
+     # pytest-subket requires 7.0+
+@@ -69,7 +69,7 @@ test = [
+ ]
+ 
+ test-common-wheels = [
+-    "flit-core >= 3.11, < 4",
++    "flit-core >= 3.11, < 5",
+     # We pin setuptools<80 because our test suite currently
+     # depends on setup.py develop to generate egg-link files.
+     "setuptools >= 70.1.0, <80",

--- a/srcpkgs/python3-puccinialin/patches/allow-flit-versions.patch
+++ b/srcpkgs/python3-puccinialin/patches/allow-flit-versions.patch
@@ -1,0 +1,11 @@
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -23,7 +23,7 @@
+ repository = "https://github.com/konstin/puccinialin"
+ 
+ [build-system]
+-requires = ["flit_core>=3.2,<4"]
++requires = ['flit_core']
+ build-backend = "flit_core.buildapi"
+ 
+ [tool.ruff]

--- a/srcpkgs/python3-pydyf/patches/allow-flit-versions.patch
+++ b/srcpkgs/python3-pydyf/patches/allow-flit-versions.patch
@@ -1,0 +1,9 @@
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -1,5 +1,5 @@
+ [build-system]
+-requires = ['flit_core >=3.2,<4']
++requires = ['flit_core']
+ build-backend = 'flit_core.buildapi'
+ 
+ [project]

--- a/srcpkgs/python3-pypdf/patches/allow-flit-versions.patch
+++ b/srcpkgs/python3-pypdf/patches/allow-flit-versions.patch
@@ -1,0 +1,9 @@
+--- a/pypdf-3.17.4/pyproject.toml
++++ b/pypdf-3.17.4/pyproject.toml
+@@ -1,5 +1,5 @@
+ [build-system]
+-requires = ["flit_core >=3.9,<4"]
++requires = ['flit_core']
+ build-backend = "flit_core.buildapi"
+ 
+ [project]

--- a/srcpkgs/python3-pyproject-hooks/template
+++ b/srcpkgs/python3-pyproject-hooks/template
@@ -5,7 +5,7 @@ revision=3
 # This package is required by python3-build, used by the python3-pep517 style;
 # using that style here would create a cycle
 build_style=python3-module
-hostmakedepends="python3-flit_core python3-installer"
+hostmakedepends="python3-flit_core-bootstrap python3-installer-bootstrap"
 depends="python3"
 checkdepends="python3-pytest-xdist python3-testpath
  python3-setuptools python3-flit_core python3-pip"
@@ -17,7 +17,7 @@ distfiles="https://github.com/pypa/pyproject-hooks/archive/v${version}.tar.gz"
 checksum=d993cda99f6c41c2679a0cd5528fc15608cc114df26553deb41db62185c11206
 
 do_build() {
-	python3 -m flit_core.wheel
+	PYTHONPATH="${PYTHONPATH}:/${py3_sitelib}-bootstrap" python3 -m flit_core.wheel
 }
 
 do_check() {
@@ -26,7 +26,7 @@ do_check() {
 }
 
 do_install() {
-	python3 -m installer --destdir "${DESTDIR}" \
+	PYTHONPATH="${PYTHONPATH}:/${py3_sitelib}-bootstrap" python3 -m installer --destdir "${DESTDIR}" \
 		"dist/pyproject_hooks-${version}-py3-none-any.whl"
 	vlicense LICENSE
 }

--- a/srcpkgs/python3-pytest-import-check/patches/allow-flit-versions.patch
+++ b/srcpkgs/python3-pytest-import-check/patches/allow-flit-versions.patch
@@ -1,0 +1,9 @@
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -1,5 +1,5 @@
+ [build-system]
+-requires = ["flit_core >=3.7,<4"]
++requires = ['flit_core']
+ build-backend = "flit_core.buildapi"
+ 
+ [project]

--- a/srcpkgs/python3-quart/patches/allow-flit-versions.patch
+++ b/srcpkgs/python3-quart/patches/allow-flit-versions.patch
@@ -1,0 +1,11 @@
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -81,7 +81,7 @@
+ ]
+ 
+ [build-system]
+-requires = ["flit-core<4"]
++requires = ["flit-core"]
+ build-backend = "flit_core.buildapi"
+ 
+ [tool.flit.module]

--- a/srcpkgs/python3-roman-numerals/patches/allow-flit-versions.patch
+++ b/srcpkgs/python3-roman-numerals/patches/allow-flit-versions.patch
@@ -1,0 +1,11 @@
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -3,7 +3,7 @@
+ # Use flit as a build backend (https://flit.pypa.io/)
+ # Build with (https://build.pypa.io/)
+ [build-system]
+-requires = ["flit_core>=3.12,<4"]
++requires = ['flit_core']
+ build-backend = "flit_core.buildapi"
+ 
+ # Project metadata

--- a/srcpkgs/python3-roman-numerals/template
+++ b/srcpkgs/python3-roman-numerals/template
@@ -1,6 +1,6 @@
 # Template file for 'python3-roman-numerals'
 pkgname=python3-roman-numerals
-version=3.1.0
+version=4.1.0
 revision=1
 build_style=python3-pep517
 hostmakedepends="python3-flit_core"
@@ -11,8 +11,8 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="0BSD OR CC0-1.0"
 homepage="https://pypi.org/project/roman-numerals/"
 changelog="https://github.com/AA-Turner/roman-numerals/blob/master/CHANGES.rst"
-distfiles="${PYPI_SITE}/r/roman-numerals/roman_numerals-${version}.tar.gz"
-checksum=384e36fc1e8d4bd361bdb3672841faae7a345b3f708aae9895d074c878332551
+distfiles="${PYPI_SITE}/r/roman_numerals/roman_numerals-${version}.tar.gz"
+checksum=1af8b147eb1405d5839e78aeb93131690495fe9da5c91856cb33ad55a7f1e5b2
 replaces="python3-roman-numerals-py>=0"
 
 post_install() {

--- a/srcpkgs/python3-seaborn/patches/allow-flit-versions.patch
+++ b/srcpkgs/python3-seaborn/patches/allow-flit-versions.patch
@@ -1,0 +1,9 @@
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -1,5 +1,5 @@
+ [build-system]
+-requires = ["flit_core >=3.2,<4"]
++requires = ['flit_core']
+ build-backend = "flit_core.buildapi"
+ 
+ [project]

--- a/srcpkgs/python3-snakeoil/patches/allow-flit-versions.patch
+++ b/srcpkgs/python3-snakeoil/patches/allow-flit-versions.patch
@@ -1,0 +1,9 @@
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -1,5 +1,5 @@
+ [build-system]
+-requires = ["flit_core >=3.8,<4"]
++requires = ['flit_core']
+ build-backend = "flit_core.buildapi"
+ 
+ [project]

--- a/srcpkgs/python3-socksio/patches/allow-flit-versions.patch
+++ b/srcpkgs/python3-socksio/patches/allow-flit-versions.patch
@@ -1,9 +1,70 @@
+From b326406915fd98a8185c1c160165c5b8963b30c1 Mon Sep 17 00:00:00 2001
+From: Theodore Ni <3806110+tjni@users.noreply.github.com>
+Date: Thu, 29 Feb 2024 19:06:33 -0800
+Subject: [PATCH] Unpin flit-core dependency
+
+---
+ pyproject.toml | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/pyproject.toml b/pyproject.toml
+index 2d6c5a3..60c63ea 100644
 --- a/pyproject.toml
 +++ b/pyproject.toml
 @@ -1,5 +1,5 @@
  [build-system]
 -requires = ["flit_core >=2,<3"]
-+requires = ["flit_core"]
++requires = ["flit_core >=2"]
  build-backend = "flit_core.buildapi"
  
  [tool.flit.metadata]
+
+From 61bd9df09c3da182f3d73cbff8e6479292ab7687 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Micha=C5=82=20G=C3=B3rny?= <mgorny@gentoo.org>
+Date: Tue, 18 Aug 2026 15:05:44 +0200
+Subject: [PATCH] Use PEP 621 metadata to fix building with flit-core >=5
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Signed-off-by: Michał Górny <mgorny@gentoo.org>
+Co-authored-by: Seth Larson <sethmichaellarson@gmail.com>
+---
+ pyproject.toml           | 18 +++++++++++-------
+
+diff --git a/pyproject.toml b/pyproject.toml
+index 60c63ea..8b3d77d 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -2,13 +2,14 @@
+ requires = ["flit_core >=2"]
+ build-backend = "flit_core.buildapi"
+ 
+-[tool.flit.metadata]
+-module = "socksio"
+-author = "Seth Michael Larson"
+-author-email = "sethmichaellarson@gmail.com"
+-home-page = "https://github.com/sethmlarson/socksio"
+-requires-python=">=3.6"
+-description-file="README.md"
++[project]
++name = "socksio"
++authors = [
++    { name = "Seth Michael Larson", email = "sethmichaellarson@gmail.com" },
++]
++readme = "README.md"
++requires-python = ">=3.6"
++dynamic = ["version", "description"]
+ classifiers = [
+     "License :: OSI Approved :: MIT License",
+     "Programming Language :: Python :: 3.6",
+@@ -20,6 +21,9 @@ classifiers = [
+     "Topic :: Internet :: Proxy Servers",
+ ]
+ 
++[project.urls]
++Homepage = "https://github.com/sethmlarson/socksio"
++
+ [tool.isort]
+ combine_as_imports = true
+ force_grid_wrap = 0

--- a/srcpkgs/python3-sphinx-inline-tabs/patches/allow-flit-versions.patch
+++ b/srcpkgs/python3-sphinx-inline-tabs/patches/allow-flit-versions.patch
@@ -1,0 +1,9 @@
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -1,5 +1,5 @@
+ [build-system]
+-requires = ["flit_core>=3.11,<4"]
++requires = ['flit_core']
+ build-backend = "flit_core.buildapi"
+ 
+ [project]

--- a/srcpkgs/python3-testpath/patches/allow-flit-versions.patch
+++ b/srcpkgs/python3-testpath/patches/allow-flit-versions.patch
@@ -1,0 +1,9 @@
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -1,5 +1,5 @@
+ [build-system]
+-requires = ["flit_core >=3.2.0,<4"]
++requires = ['flit_core']
+ build-backend = "flit_core.buildapi"
+ 
+ [project]

--- a/srcpkgs/python3-threadpoolctl/patches/allow-flit-versions.patch
+++ b/srcpkgs/python3-threadpoolctl/patches/allow-flit-versions.patch
@@ -1,0 +1,50 @@
+From dba704bc7c1eb34695965bec04b33f955167a74f Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Lo=C3=AFc=20Est=C3=A8ve?= <loic.esteve@ymail.com>
+Date: Tue, 11 Aug 2026 13:20:57 +0200
+Subject: [PATCH] Use PEP 621 metadata to fix building with flit-core>=4 (#226)
+
+---
+ pyproject.toml | 19 +++++++++----------
+ 1 file changed, 9 insertions(+), 10 deletions(-)
+
+diff --git a/pyproject.toml b/pyproject.toml
+index c0ea1696..f7a95ccd 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -1,20 +1,16 @@
+ [build-system]
+-requires = ["flit_core >=2,<4"]
++requires = ["flit_core >=3.2,<5"]
+ build-backend = "flit_core.buildapi"
+ 
+-# TODO: replace the following section by the standard [project] section to be able
+-# to use flit v4.
+-[tool.flit.metadata]
+-module = "threadpoolctl"
+-author = "Thomas Moreau"
+-author-email = "thomas.moreau.2010@gmail.com"
+-home-page = "https://github.com/joblib/threadpoolctl"
+-description-file = "README.md"
++[project]
++name = "threadpoolctl"
++authors = [{name = "Thomas Moreau", email = "thomas.moreau.2010@gmail.com"}]
++readme = "README.md"
+ requires-python = ">=3.9"
+ license = "BSD-3-Clause"
++dynamic = ["version", "description"]
+ classifiers = [
+     "Intended Audience :: Developers",
+-    "License :: OSI Approved :: BSD License",
+     "Programming Language :: Python :: 3",
+     "Programming Language :: Python :: 3.9",
+     "Programming Language :: Python :: 3.10",
+@@ -24,6 +20,9 @@ classifiers = [
+     "Topic :: Software Development :: Libraries :: Python Modules",
+ ]
+ 
++[project.urls]
++homepage = "https://github.com/joblib/threadpoolctl"
++
+ [tool.black]
+ line-length = 88
+ target_version = ['py39', 'py310', 'py311', 'py312', 'py313']

--- a/srcpkgs/python3-tinycss2/patches/allow-flit-versions.patch
+++ b/srcpkgs/python3-tinycss2/patches/allow-flit-versions.patch
@@ -1,0 +1,9 @@
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -1,5 +1,5 @@
+ [build-system]
+-requires = ['flit_core >=3.2,<4']
++requires = ['flit_core']
+ build-backend = 'flit_core.buildapi'
+ 
+ [project]

--- a/srcpkgs/python3-tinyhtml5/patches/allow-flit-versions.patch
+++ b/srcpkgs/python3-tinyhtml5/patches/allow-flit-versions.patch
@@ -1,0 +1,9 @@
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -1,5 +1,5 @@
+ [build-system]
+-requires = ['flit_core >=3.2,<4']
++requires = ['flit_core']
+ build-backend = 'flit_core.buildapi'
+ 
+ [project]

--- a/srcpkgs/python3-tomli-w/patches/allow-flit-versions.patch
+++ b/srcpkgs/python3-tomli-w/patches/allow-flit-versions.patch
@@ -1,0 +1,9 @@
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -1,5 +1,5 @@
+ [build-system]
+-requires = ["flit_core>=3.2.0,<4"]
++requires = ['flit_core']
+ build-backend = "flit_core.buildapi"
+ 
+ [project]

--- a/srcpkgs/python3-tomli/patches/allow-flit-versions.patch
+++ b/srcpkgs/python3-tomli/patches/allow-flit-versions.patch
@@ -1,0 +1,9 @@
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -1,5 +1,5 @@
+ [build-system]
+-requires = ["flit_core>=3.12,<4"]
++requires = ['flit_core']
+ build-backend = "flit_core.buildapi"
+ 
+ [project]

--- a/srcpkgs/python3-truststore/patches/allow-flit-versions.patch
+++ b/srcpkgs/python3-truststore/patches/allow-flit-versions.patch
@@ -1,0 +1,9 @@
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -1,5 +1,5 @@
+ [build-system]
+-requires = ["flit_core >=3.11,<4"]
++requires = ['flit_core']
+ build-backend = "flit_core.buildapi"
+ 
+ [project]

--- a/srcpkgs/python3-typing_extensions/patches/allow-flit-versions.patch
+++ b/srcpkgs/python3-typing_extensions/patches/allow-flit-versions.patch
@@ -1,0 +1,10 @@
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -1,6 +1,6 @@
+ # Build system requirements.
+ [build-system]
+-requires = ["flit_core >=3.11,<4"]
++requires = ['flit_core']
+ build-backend = "flit_core.buildapi"
+ 
+ # Project metadata


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**
- ran `xbps-cycles.py` and built with `xbps-src -N` to confirm there are no cycles

---

- updates `python3-flit_core` to 4.0.2. this is a minor breaking change, but I have verified/patched all reverse dependencies to be compatible
- adds the command-line tool `python3-flit`
- updates `python3-packaging`
- use the `-bootstrap` version of some packages to solve cycles and allow the pep517 build style to work automatically with these bootstrap packages
- update a couple packages to fix flit compatibility
- add a few missing dependencies found when testing