### PR TITLE
bitwise: update to 0.60

### DIFF
--- a/srcpkgs/bitwise/template
+++ b/srcpkgs/bitwise/template
@@ -1,6 +1,6 @@
 # Template file for 'bitwise'
 pkgname=bitwise
-version=0.50
+version=0.60
 revision=1
 build_style=gnu-configure
 makedepends="ncurses-devel readline-devel"
@@ -10,4 +10,4 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-3.0-only"
 homepage="https://github.com/mellowcandle/bitwise"
 distfiles="${homepage}/releases/download/v${version}/bitwise-v${version}.tar.gz"
-checksum=806271fa5bf31de0600315e8720004a8f529954480e991ca84a9868dc1cae97e
+checksum=0455a0eb67f3a33b727b94400d2cc826d11ed680aa5c96971fccbd5e20c2bfbd


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: YES

#### Local build testing
- I built this PR locally for my native architecture: x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl (masterdir)
  - i686 (masterdir)
  - aarch64 (cross)
  - aarch64-musl (cross)
  - armv6l (cross)
  - armv6l-musl (cross)
  - armv7l (cross)
  - armv7l-musl (cross)
