### PR TITLE
keymapper: update to 5.7.1.

### DIFF
--- a/srcpkgs/keymapper/template
+++ b/srcpkgs/keymapper/template
@@ -1,6 +1,6 @@
 # Template file for 'keymapper'
 pkgname=keymapper
-version=5.6.0
+version=5.7.1
 revision=1
 build_style=cmake
 configure_args="-DVERSION=${version}"
@@ -12,7 +12,7 @@ license="GPL-3.0-only"
 homepage="https://github.com/houmain/keymapper"
 changelog="https://raw.githubusercontent.com/houmain/keymapper/main/CHANGELOG.md"
 distfiles="https://github.com/houmain/keymapper/archive/refs/tags/${version}.tar.gz"
-checksum=a12c2f540f50cbf8605403e18bb1fcf07bc9eee30519f5a1e4839aa06881a02c
+checksum=912041946525431a5db188c0e8827028039185895580f348a0f904918b7cc469
 
 post_install() {
 	vsv keymapperd


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl (cross)
  - armv7l (cross)
  - armv6l-musl (cross)
