### PR TITLE
New package: rtk-0.45.0

### DIFF
--- a/srcpkgs/rtk/template
+++ b/srcpkgs/rtk/template
@@ -1,0 +1,12 @@
+# Template file for 'rtk'
+pkgname=rtk
+version=0.45.0
+revision=1
+build_style=cargo
+makedepends="sqlite-devel"
+short_desc="CLI proxy for reducing LLM token consumption"
+maintainer="Emil Miler <em@0x45.cz>"
+license="Apache-2.0"
+homepage="https://www.rtk-ai.app/"
+distfiles="https://github.com/rtk-ai/rtk/archive/refs/tags/v${version}.tar.gz"
+checksum=0459f63cb79f610751974ba20732e273d45ddbb4cd0c0795768b62b868891ad9


### PR DESCRIPTION
CLI proxy that reduces LLM token consumption by 60-90% on common dev commands.

https://www.rtk-ai.app/

#### Testing the changes
- I tested the changes in this PR: **YES**
 
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
