### PR TITLE
gopls: update to 0.23.0.

### DIFF
--- a/srcpkgs/gopls/template
+++ b/srcpkgs/gopls/template
@@ -1,6 +1,6 @@
 # Template file for 'gopls'
 pkgname=gopls
-version=0.21.1
+version=0.23.0
 revision=1
 build_wrksrc=gopls
 build_style=go
@@ -10,8 +10,9 @@ short_desc="Official language server for the Go language"
 maintainer="Bnyro <bnyro@tutanota.com>"
 license="BSD-3-Clause"
 homepage="https://github.com/golang/tools/tree/master/gopls"
+changelog="https://go.dev/gopls/release/v${version}.md"
 distfiles="https://github.com/golang/tools/archive/refs/tags/gopls/v${version}.tar.gz"
-checksum=af211e00c3ffe44fdf2dd3efd557e580791e09f8dbb4284c917bd120bc3c8f9c
+checksum=1ba41875b918db73c6a409ad8f552b85f72dfeea43ffb541b798322ff6b4152b
 
 post_install() {
 	vlicense ../LICENSE


### PR DESCRIPTION
0.21.0 doesn't like the new `new(expr)` language change. update to 0.23.0 fixes this.

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
