### PR TITLE
skim: update to 5.6.6

### DIFF
--- a/srcpkgs/skim/template
+++ b/srcpkgs/skim/template
@@ -1,20 +1,30 @@
 # Template file for 'skim'
 pkgname=skim
-version=0.20.5
+version=5.6.6
 revision=1
 build_style=cargo
-make_install_args="--path skim"
+checkdepends="zellij"
 short_desc="Fuzzy Finder in rust"
 maintainer="Saksham <voidisnull@duck.com>"
 license="MIT"
 homepage="https://github.com/skim-rs/skim"
 changelog="https://raw.githubusercontent.com/skim-rs/skim/master/CHANGELOG.md"
 distfiles="https://github.com/skim-rs/skim/archive/refs/tags/v${version}.tar.gz"
-checksum=c9b367bd37daa38b95a5da1e8f967279f4127168a38986b2f7d33a4b5fd413c2
+checksum=4f988bf6da4a5e1f71e296d7f96047db2d24253a06a5597b179206f7ecd034d7
 
 if [ "$XBPS_WORDSIZE" = 32 ]; then
 	make_check=no  # disable tests on 32bit due to register exhaustion
 fi
+
+# tests spawn zellij sessions with 20 second timeout, inconsistent failures
+make_check_args="-- --test-threads=1"
+
+pre_check() {
+	# tests hardcode ./target/release/sk, we build with --target
+	ln -sf ../${RUST_TARGET}/release/sk target/release/sk
+	# zellij tests require TERM to be set
+	export TERM=xterm
+}
 
 post_install() {
 	vbin bin/sk-tmux


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, X86_64-glibc
- I built this PR locally for these architectures:
  - aarch64 crossbuild
