### PR TITLE
sfeed: update to 2.4

### DIFF
--- a/srcpkgs/sfeed/template
+++ b/srcpkgs/sfeed/template
@@ -1,6 +1,6 @@
 # Template file for 'sfeed'
 pkgname=sfeed
-version=2.2
+version=2.4
 revision=1
 build_style=gnu-makefile
 make_install_args="MANPREFIX=/usr/share/man"
@@ -11,7 +11,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="ISC"
 homepage="https://git.codemadness.org/sfeed"
 distfiles="https://codemadness.org/releases/sfeed/sfeed-${version}.tar.gz"
-checksum=4270389c3cfa474caa3892271c3171a751490328cc52e502d8435de3c2e41cc5
+checksum=f9503fe9205a8136f76a9b753c6007abad33e2a516807e416a986723db06e879
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: YES

#### Local build testing
- I built this PR locally for my native architecture: x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl (masterdir)
  - i686 (masterdir)
  - aarch64 (cross)
  - aarch64-musl (cross)
  - armv6l (cross)
  - armv6l-musl (cross)
  - armv7l (cross)
  - armv7l-musl (cross)

