### PR TITLE
python3-aioquic: update to 1.3.0

### DIFF
--- a/srcpkgs/python3-aioquic/template
+++ b/srcpkgs/python3-aioquic/template
@@ -1,7 +1,7 @@
 # Template file for 'python3-aioquic'
 pkgname=python3-aioquic
-version=1.2.0
-revision=2
+version=1.3.0
+revision=1
 build_style=python3-pep517
 make_check_args="-k not(test_verify_subject_no_subjaltname)"
 hostmakedepends="python3-setuptools python3-wheel"
@@ -15,7 +15,7 @@ license="BSD-3-Clause"
 homepage="https://github.com/aiortc/aioquic"
 changelog="https://aioquic.readthedocs.io/en/stable/changelog.html"
 distfiles="${PYPI_SITE}/a/aioquic/aioquic-${version}.tar.gz"
-checksum=f91263bb3f71948c5c8915b4d50ee370004f20a416f67fab3dcc90556c7e7199
+checksum=28d070b2183e3e79afa9d4e7bd558960d0d53aeb98bc0cf0a358b279ba797c92
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
Testing the changes
- I tested the changes in this PR: **YES**

Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-glibc (crossbuild)
  - i686-glibc (crossbuild)

