### PR TITLE
rust-sccache: update to 0.17.0.

### DIFF
--- a/srcpkgs/rust-sccache/template
+++ b/srcpkgs/rust-sccache/template
@@ -1,6 +1,6 @@
 # Template file for 'rust-sccache'
 pkgname=rust-sccache
-version=0.10.0
+version=0.17.0
 revision=1
 build_style=cargo
 make_check_args="-- --skip test_s3_invalid_args --skip test_sccache_command
@@ -14,7 +14,7 @@ license="Apache-2.0"
 homepage="https://crates.io/crates/sccache"
 changelog="https://github.com/mozilla/sccache/releases"
 distfiles="https://static.crates.io/crates/sccache/sccache-${version}.crate"
-checksum=77727cb9a7b4e5cbc718811053088235d19e442079f43c01b77c8adfe818b40f
+checksum=191bf7f2451d7dbfd7d50e2822b831a1b1058d7dfa17fa370306d905f8b4d4cf
 
 case "$XBPS_TARGET_MACHINE" in
 	x86_64*|i686*|arm*|aarch64*) ;;


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64
  - armv6l
