### PR TITLE
libdeflate: update to 1.26

### DIFF
--- a/srcpkgs/libdeflate/template
+++ b/srcpkgs/libdeflate/template
@@ -1,6 +1,6 @@
 # Template file for 'libdeflate'
 pkgname=libdeflate
-version=1.25
+version=1.26
 revision=1
 build_style=cmake
 configure_args="-DLIBDEFLATE_USE_SHARED_LIB=ON"
@@ -11,7 +11,7 @@ license="MIT"
 homepage="https://github.com/ebiggers/libdeflate"
 changelog="https://raw.githubusercontent.com/ebiggers/libdeflate/master/NEWS.md"
 distfiles="https://github.com/ebiggers/libdeflate/archive/refs/tags/v${version}.tar.gz"
-checksum=d11473c1ad4c57d874695e8026865e38b47116bbcb872bfc622ec8f37a86017d
+checksum=bba03fffc5538576213675ce6968fcff6ce2e67d82e4d5febea2d05f9f13cf85
 
 post_install() {
 	vlicense COPYING
@@ -24,7 +24,7 @@ libdeflate-devel_package() {
 		vmove usr/include
 		vmove "usr/lib/*.a"
 		vmove "usr/lib/*.so"
-		vmove "/usr/lib/pkgconfig"
-		vmove "/usr/lib/cmake"
+		vmove usr/lib/pkgconfig
+		vmove usr/lib/cmake
 	}
 }


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, **x86_64-glibc**
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl

[Changelog](https://raw.githubusercontent.com/ebiggers/libdeflate/master/NEWS.md)

cc @mobinmob 