### PR TITLE
steam-udev-rules: update to 20260625

### DIFF
--- a/srcpkgs/steam-udev-rules/template
+++ b/srcpkgs/steam-udev-rules/template
@@ -1,15 +1,15 @@
 # Template file for 'steam-udev-rules'
 pkgname=steam-udev-rules
 reverts="1.0.0.78_2 1.0.0.78_3"
-version=1.0.0.61+20230830
+version=1.0.0.61+20260625
 revision=1
-_commit=13443480a64fe8f10676606bd57da6de89f8ccb1
+_commit=22ec85e5ff5ea2e15c56d71a41bcbef46356cd60
 short_desc="Udev rules for gaming peripherals for Steam and SteamVR"
 maintainer="classabbyamp <void@placeviolette.net>"
 license="MIT"
 homepage="https://github.com/ValveSoftware/steam-devices"
 distfiles="https://github.com/ValveSoftware/steam-devices/archive/${_commit}.tar.gz"
-checksum=2e508acb093d1428f32c3f6b0bc836cc4a20ceef4afc92b6cdb7cf631400fd36
+checksum=ca8d13d1ad744c495a10be95ab75deff27045208c5e22d799642863c1a65d0a1
 
 post_patch() {
 	# support access via input group or logind uaccess


### PR DESCRIPTION
This adds support for 2026 steam controller.

#### Testing the changes
- I tested the changes in this PR: **YES**