### PR TITLE
New package: qfind-0.2.0

### DIFF
--- a/srcpkgs/qfind/template
+++ b/srcpkgs/qfind/template
@@ -1,0 +1,22 @@
+# Template file for 'qfind'
+pkgname=qfind
+version=0.2.0
+revision=1
+build_style="cargo"
+hostmakedepends="pkg-config"
+short_desc="Instant filename search"
+maintainer="ihateemoji <ihateemoji.dev@gmail.com>"
+license="MIT"
+homepage="https://github.com/DerpcatMusic/qfind"
+distfiles="https://github.com/DerpcatMusic/qfind/archive/refs/tags/v${version}.tar.gz"
+checksum="6906c6e6f78d65fc6e98b692257b94584e5a7f889db48e386ce335bda0acb3a6"
+
+do_build() {
+	cargo build --release -p qfind -p qfind-tui --target "${RUST_TARGET}"
+}
+
+do_install() {
+	vbin target/${RUST_TARGET}/release/qfind
+	vbin target/${RUST_TARGET}/release/qfind-tui
+	vlicense LICENSE
+}


### PR DESCRIPTION
Qfind is a recently released, neat, quick file-name search tool -> https://github.com/DerpcatMusic/qfind
I have found it quite useful on multiple occasions, so I thought I would contribute my personal xbps template to the void-packages repository. 

- I tested the changes in this PR: YES

- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): YES

- I built this PR locally for my native architecture, (x86_64)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl (cross-build)
  - aarch64 (cross-build)
  - i686 (cross-build)