### PR TITLE
chrpath: update to 0.18

### DIFF
--- a/srcpkgs/chrpath/template
+++ b/srcpkgs/chrpath/template
@@ -1,14 +1,20 @@
 # Template file for 'chrpath'
 pkgname=chrpath
-version=0.16
-revision=3
+version=0.18
+revision=1
 build_style="gnu-configure"
+hostmakedepends="automake"
 short_desc="Change or delete the rpath or runpath in ELF files"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="https://directory.fsf.org/project/chrpath/"
-distfiles="${DEBIAN_SITE}/main/c/chrpath/chrpath_${version}.orig.tar.gz"
-checksum=bb0d4c54bac2990e1bdf8132f2c9477ae752859d523e141e72b3b11a12c26e7b
+changelog="https://codeberg.org/pere/chrpath/src/tag/release-0.18/NEWS"
+distfiles="https://codeberg.org/pere/chrpath/archive/release-${version}.tar.gz"
+checksum=83441d1347a09a249c9f7efeac319454e17334d72e2983f18c812c7032cfef54
+
+pre_configure() {
+	autoreconf -vi
+}
 
 post_install() {
 	rm -r ${DESTDIR}/usr/doc


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: YES

Since the last update the project migrated to codeberg so I updated distfiles and added the changelog as well as a pre_configure function which requires automake.

#### Local build testing
- I built this PR locally for my native architecture: x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl (masterdir)
  - i686 (masterdir)
  - aarch64 (cross)
  - aarch64-musl (cross)
  - armv6l (cross)
  - armv6l-musl (cross)
  - armv7l (cross)
  - armv7l-musl (cross)

