### PR TITLE
setxkbmap: update to 1.3.5

### DIFF
--- a/srcpkgs/setxkbmap/template
+++ b/srcpkgs/setxkbmap/template
@@ -1,6 +1,6 @@
 # Template file for 'setxkbmap'
 pkgname=setxkbmap
-version=1.3.4
+version=1.3.5
 revision=1
 build_style=gnu-configure
 hostmakedepends="pkg-config"
@@ -10,7 +10,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
 homepage="https://gitlab.freedesktop.org/xorg/app/setxkbmap"
 distfiles="${XORG_SITE}/app/setxkbmap-${version}.tar.xz"
-checksum=be8d8554d40e981d1b93b5ff82497c9ad2259f59f675b38f1b5e84624c07fade
+checksum=360193cecc93f906d8383a8fb5c1f3a7eed35e6ced0e118a64ee56ae13c88cac
 
 post_install() {
 	vlicense COPYING


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: YES

#### Local build testing
- I built this PR locally for my native architecture: x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl (masterdir)
  - i686 (masterdir)
  - aarch64 (cross)
  - aarch64-musl (cross)
  - armv6l (cross)
  - armv6l-musl (cross)
  - armv7l (cross)
  - armv7l-musl (cross)

