### PR TITLE
kapow: update to 1.7.1

### DIFF
--- a/srcpkgs/kapow/template
+++ b/srcpkgs/kapow/template
@@ -1,6 +1,6 @@
 # Template file for 'kapow'
 pkgname=kapow
-version=1.7.0
+version=1.7.1
 revision=1
 build_style=cmake
 hostmakedepends="qt6-tools qt6-base gettext"
@@ -10,5 +10,5 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-3.0-or-later"
 homepage="https://gottcode.org/kapow/"
 changelog="https://raw.githubusercontent.com/gottcode/kapow/refs/heads/main/ChangeLog"
-distfiles="https://gottcode.org/${pkgname}/${pkgname}-${version}.tar.bz2"
-checksum=ff86ff05c5b753cdf8c31c1e70fe37b251b53544a4a59a52bb2ef1c9d63af94c
+distfiles="https://gottcode.org/kapow/kapow-${version}.tar.bz2"
+checksum=10609c452b70e7317a27c02172fabee6ee941a7e23a8cc7e0d3daa5b0dfb1733


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: YES

#### Local build testing
- I built this PR locally for my native architecture: x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl (masterdir)
  - i686 (masterdir)
  - aarch64 (cross)
  - aarch64-musl (cross)
  - armv6l (cross)
  - armv6l-musl (cross)
  - armv7l (cross)
  - armv7l-musl (cross)
