### PR TITLE
lightsoff: update to 50.0

### DIFF
--- a/srcpkgs/lightsoff/template
+++ b/srcpkgs/lightsoff/template
@@ -1,6 +1,6 @@
 # Template file for 'lightsoff'
 pkgname=lightsoff
-version=48.1
+version=50.0
 revision=1
 build_style=meson
 hostmakedepends="gettext glib-devel itstool pkg-config vala"
@@ -8,7 +8,7 @@ makedepends="libadwaita-devel"
 short_desc="GNOME puzzlle game where you turn off lights"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later"
-homepage="https://wiki.gnome.org/Apps/Lightsoff"
-changelog="https://gitlab.gnome.org/GNOME/lightsoff/-/raw/master/NEWS"
-distfiles="${GNOME_SITE}/${pkgname}/${version%%.*}/${pkgname}-${version}.tar.xz"
-checksum=2ec99501713dbcd13c5a565a2e118cc4cc2b502836b387a7736cfba40a8b3989
+homepage="https://gitlab.gnome.org/GNOME/lightsoff"
+changelog="https://gitlab.gnome.org/GNOME/lightsoff/-/blob/main/NEWS"
+distfiles="https://gitlab.gnome.org/GNOME/lightsoff/-/archive/${version}/lightsoff-${version}.tar.gz"
+checksum=4c6aa3cd5049942dda6ad3ac880b3cb10268a23d26b782fe9d3ab64182f8ab5c


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: YES

#### Local build testing
- I built this PR locally for my native architecture: x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl (masterdir)
  - i686 (masterdir)
  - aarch64 (cross)
  - aarch64-musl (cross)
  - armv6l (cross)
  - armv6l-musl (cross)
  - armv7l (cross)
  - armv7l-musl (cross)

