### PR TITLE
stress-ng: Build with GPU support

### DIFF
--- a/srcpkgs/stress-ng/template
+++ b/srcpkgs/stress-ng/template
@@ -1,9 +1,10 @@
 # Template file for 'stress-ng'
 pkgname=stress-ng
 version=0.22.00
-revision=1
+revision=2
 build_style=gnu-makefile
 make_use_env=1
+makedepends="libgbm-devel libglvnd-devel"
 short_desc="Load and stress a computer system"
 maintainer="Leah Neukirchen <leah@vuxu.org>"
 license="GPL-2.0-or-later"


### PR DESCRIPTION
Not sure if it's intentional that it's built without GPU support currently, but it's useful for thermal performance tests of GPUs. It just needs libgbm and libglvnd.

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)