### PR TITLE
nomad: update to 2.0.6

### DIFF
--- a/srcpkgs/nomad/template
+++ b/srcpkgs/nomad/template
@@ -1,11 +1,11 @@
 # Template file for 'nomad'
 pkgname=nomad
-version=1.11.0
+version=2.0.5
 revision=1
 build_style=go
 go_import_path="github.com/hashicorp/nomad"
-go_build_tags="ui release"
-_git_commit=9103d938133311b2da905858801f0e111a2df0a1
+go_build_tags="ui release hashicorpmetrics"
+_git_commit=5c8612bba6eb8e44cc3fc434125cb1b13463c309
 go_ldflags="-X ${go_import_path}/version.GitCommit=${_git_commit}"
 depends="cni-plugins dmidecode"
 short_desc="Cluster scheduler designed to easily integrate into existing workflows"
@@ -13,7 +13,9 @@ maintainer="Michael Aldridge <maldridge@voidlinux.org>"
 license="BUSL-1.1"
 homepage="https://www.nomadproject.io/"
 distfiles="https://github.com/hashicorp/nomad/archive/v${version}.tar.gz"
-checksum=f7eec04e71cf93c7df74ae2c9b0e76c8cdaa0f3084c493458c02f3b72817f287
+checksum=952eac52c3dc92c129feb756d0cabac7c3275ef7771436d60fc1c56a45c781c8
+# integration tests, requires pre-existing nomad binary
+make_check=no
 make_dirs="/etc/nomad.d 0755 root root
  /var/lib/nomad 0755 root root"
 repository=nonfree

--- a/srcpkgs/nomad/template
+++ b/srcpkgs/nomad/template
@@ -1,11 +1,11 @@
 # Template file for 'nomad'
 pkgname=nomad
-version=1.11.0
+version=2.0.6
 revision=1
 build_style=go
 go_import_path="github.com/hashicorp/nomad"
-go_build_tags="ui release"
-_git_commit=9103d938133311b2da905858801f0e111a2df0a1
+go_build_tags="ui release hashicorpmetrics"
+_git_commit=f74ce32f7004446a41fe1bfd508a997f8b88ad6e
 go_ldflags="-X ${go_import_path}/version.GitCommit=${_git_commit}"
 depends="cni-plugins dmidecode"
 short_desc="Cluster scheduler designed to easily integrate into existing workflows"
@@ -13,7 +13,9 @@ maintainer="Michael Aldridge <maldridge@voidlinux.org>"
 license="BUSL-1.1"
 homepage="https://www.nomadproject.io/"
 distfiles="https://github.com/hashicorp/nomad/archive/v${version}.tar.gz"
-checksum=f7eec04e71cf93c7df74ae2c9b0e76c8cdaa0f3084c493458c02f3b72817f287
+checksum=0d577cf89a26c38782267abda1dde43cd762fa55ae2a79577c2a1f6e93486ba1
+# integration tests, requires pre-existing nomad binary
+make_check=no
 make_dirs="/etc/nomad.d 0755 root root
  /var/lib/nomad 0755 root root"
 repository=nonfree


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, X86_64-glibc
