### PR TITLE
xtermcontrol: update to 3.11

### DIFF
--- a/srcpkgs/xtermcontrol/template
+++ b/srcpkgs/xtermcontrol/template
@@ -1,6 +1,6 @@
 # Template file for 'xtermcontrol'
 pkgname=xtermcontrol
-version=3.10
+version=3.11
 revision=1
 build_style=gnu-configure
 short_desc="Enables dynamic control of xterm properties"
@@ -9,4 +9,4 @@ license="LGPL-2.1-or-later"
 homepage="https://thrysoee.dk/xtermcontrol"
 changelog="https://raw.githubusercontent.com/JessThrysoee/xtermcontrol/master/ChangeLog"
 distfiles="https://thrysoee.dk/xtermcontrol/xtermcontrol-${version}.tar.gz"
-checksum=3eb97b1d9d8aae1bad4fe2c41ca3a3dbb10d2d67e6ca4599aa1f631a40503dee
+checksum=49ea6d3eda0dbcf875363763cefe1818ce6786b9910255ea641d9786bdafd44c


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: YES

#### Local build testing
- I built this PR locally for my native architecture: x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl (masterdir)
  - i686 (masterdir)
  - aarch64 (cross)
  - aarch64-musl (cross)
  - armv6l (cross)
  - armv6l-musl (cross)
  - armv7l (cross)
  - armv7l-musl (cross)
