### PR TITLE
openssl: update to 3.6.4

### DIFF
--- a/srcpkgs/openssl/template
+++ b/srcpkgs/openssl/template
@@ -1,6 +1,6 @@
 # Template file for 'openssl'
 pkgname=openssl
-version=3.6.3
+version=3.6.4
 revision=1
 bootstrap=yes
 build_style=configure
@@ -17,7 +17,7 @@ maintainer="classabbyamp <void@placeviolette.net>"
 license="Apache-2.0"
 homepage="https://openssl-library.org"
 distfiles="https://github.com/openssl/openssl/releases/download/openssl-${version}/openssl-${version}.tar.gz"
-checksum=243a86649cf6f23eeb6a2ff2456e09e5d77dd9018a54d3d96b0c6bdd6ba6c7f1
+checksum=9bffaa1ad1e07b354c21bd3324ec02fa15579f45a7d0494b3e74bc449b7333ef
 conf_files="/etc/ssl/openssl.cnf"
 replaces="libressl>=0"
 


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86-64-glibc)

[Changelog 3.6.4](https://github.com/openssl/openssl/releases/tag/openssl-3.6.4)

cc @classabbyamp
