### PR TITLE
complexity: update to 1.13

### DIFF
--- a/srcpkgs/complexity/template
+++ b/srcpkgs/complexity/template
@@ -1,7 +1,7 @@
 # Template file for 'complexity'
 pkgname=complexity
-version=1.10
-revision=2
+version=1.13
+revision=1
 build_style=gnu-configure
 hostmakedepends="autogen"
 makedepends="autogen"
@@ -10,4 +10,9 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-3.0-or-later"
 homepage="http://www.gnu.org/software/complexity/"
 distfiles="${GNU_SITE}/${pkgname}/${pkgname}-${version}.tar.xz"
-checksum=6d378a3ef9d68938ada2610ce32f63292677d3b5c427983e8d72702167a22053
+checksum=80a625a87ee7c17fed02fb39482a7946fc757f10d8a4ffddc5372b4c4b739e67
+
+pre_configure() {
+	cd src
+	autogen opts.def
+}


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: YES

Added a pre_configure function:
[https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=complexity](url)

#### Local build testing
- I built this PR locally for my native architecture: x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl (masterdir)
  - i686 (masterdir)
  - aarch64 (cross)
  - aarch64-musl (cross)
  - armv6l (cross)
  - armv6l-musl (cross)
  - armv7l (cross)
  - armv7l-musl (cross)
