### PR TITLE
fsearch: update to 0.3.1

### DIFF
--- a/srcpkgs/fsearch/patches/query.patch
+++ b/srcpkgs/fsearch/patches/query.patch
@@ -1,46 +1,25 @@
---- a/src/fsearch_time_utils.c
-+++ b/src/fsearch_time_utils.c
-@@ -377,7 +377,7 @@ parse_implicit_date_time_constants(const
- }
- 
- static bool
--parse_date_time_constants(const char *str, time_t *time_start_out, time_t *time_end_out) {
-+parse_date_time_constants(const char *str, int64_t *time_start_out, int64_t *time_end_out) {
-     struct tm tm_start = {};
-     struct tm tm_end = {};
- 
-@@ -469,7 +469,7 @@ round_down_tm_to_reference_with_date_tim
- }
- 
- bool
--fsearch_date_time_parse_interval(const char *str, time_t *time_start_out, time_t *time_end_out) {
-+fsearch_date_time_parse_interval(const char *str, int64_t *time_start_out, int64_t *time_end_out) {
-     if (parse_date_time_constants(str, time_start_out, time_end_out)) {
-         return true;
-     }
---- a/src/fsearch_time_utils.h
-+++ b/src/fsearch_time_utils.h
-@@ -1,7 +1,7 @@
- #pragma once
- 
- #include <stdbool.h>
--#include <time.h>
-+#include <stdint.h>
- 
- bool
--fsearch_date_time_parse_interval(const char *str, time_t *time_start_out, time_t *time_end_out);
-\ No newline at end of file
-+fsearch_date_time_parse_interval(const char *str, int64_t *time_start_out, int64_t *time_end_out);
---- a/src/tests/test_time_utils.c
-+++ b/src/tests/test_time_utils.c
-@@ -49,8 +49,8 @@ test_parse_time_interval(void) {
- 
-     for (gint i = 0; i < G_N_ELEMENTS(strings); ++i) {
-         FsearchTestTimeIntervalParseContext *ctx = &strings[i];
--        time_t time_start = 0;
--        time_t time_end = 0;
-+        int64_t time_start = 0;
-+        int64_t time_end = 0;
- 
-         gboolean res = fsearch_date_time_parse_interval(ctx->string, &time_start, &time_end);
-         g_assert_true(res == ctx->expected_success);
+diff --git a/src/fsearch_database_scan.c b/src/fsearch_database_scan.c
+index 5f1628ef..f6343847 100644
+--- a/src/fsearch_database_scan.c
++++ b/src/fsearch_database_scan.c
+@@ -75,7 +75,7 @@ add_folder(DatabaseWalkContext *walk_context, const char *name, const char *path
+                                                                       parent,
+                                                                       DATABASE_ENTRY_TYPE_FOLDER,
+                                                                       DATABASE_INDEX_PROPERTY_MODIFICATION_TIME,
+-                                                                      mtime,
++                                                                      (int64_t)mtime,
+                                                                       DATABASE_INDEX_PROPERTY_NONE);
+     if (!folder_entry) {
+         return NULL;
+@@ -101,9 +101,9 @@ add_file(DatabaseWalkContext *walk_context, const char *name, off_t size, time_t
+                                                                     parent,
+                                                                     DATABASE_ENTRY_TYPE_FILE,
+                                                                     DATABASE_INDEX_PROPERTY_SIZE,
+-                                                                    size,
++                                                                    (int64_t)size,
+                                                                     DATABASE_INDEX_PROPERTY_MODIFICATION_TIME,
+-                                                                    mtime,
++                                                                    (int64_t)mtime,
+                                                                     DATABASE_INDEX_PROPERTY_NONE);
+     if (!file_entry) {
+         return NULL;

--- a/srcpkgs/fsearch/template
+++ b/srcpkgs/fsearch/template
@@ -1,13 +1,23 @@
 # Template file for 'fsearch'
 pkgname=fsearch
-version=0.2.3
+version=0.3.1
 revision=1
 build_style=meson
-hostmakedepends="gettext glib-devel pkg-config"
-makedepends="gtk+3-devel pcre2-devel"
+build_helper="qemu"
+hostmakedepends="gettext glib-devel pkg-config itstool"
+makedepends="gtk+3-devel pcre2-devel intltool icu-devel"
 short_desc="Fast file search utility based on GTK+3"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="https://cboxdoerfer.github.io/fsearch/"
 distfiles="https://github.com/cboxdoerfer/fsearch/archive/${version}.tar.gz"
-checksum=b3c576bf1230da7c374d00bb32d72686b940b4dee80d941495acfdd5437bf117
+checksum=b16ab75556d841bf858633710d71c92f35d34362614b8584b0a5b71690a72c39
+
+if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
+	CFLAGS+=" -D_LARGEFILE64_SOURCE"
+fi
+
+post_extract() {
+	sed -i '/#include <linux\/fanotify.h>/d' \
+		src/fsearch_folder_monitor_fanotify.c
+}


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)
 - I built this PR locally for these architectures (crossbuilds): aarch64, i686 (builds fine locally)


Notes:

Due to build errors I added the packages `itstool intltool icu-devel`.
Due to cross-build error I added `build_helper="qemu"`.


[Edit]

Added @ihateemoji's solution to solve the 64bit-musl cross-build error.

[/Edit]