### PR TITLE
strawberry: update to 1.2.28, enable tests

### DIFF
--- a/srcpkgs/strawberry/template
+++ b/srcpkgs/strawberry/template
@@ -1,8 +1,9 @@
 # Template file for 'strawberry'
 pkgname=strawberry
-version=1.2.26
+version=1.2.28
 revision=1
 build_style=cmake
+make_check_target="run_strawberry_tests"
 configure_args="-DQT_HOST_PATH=/usr"
 hostmakedepends="pkg-config protobuf gettext qt6-base qt6-tools"
 makedepends="alsa-lib-devel boost-headers gnutls-devel fftw-devel
@@ -10,11 +11,13 @@ makedepends="alsa-lib-devel boost-headers gnutls-devel fftw-devel
  libmtp-devel protobuf-devel pulseaudio-devel taglib-devel qt6-base-devel
  qt6-base-private-devel qt6-plugin-mysql qt6-plugin-odbc qt6-plugin-pgsql
  qt6-plugin-sqlite KDSingleApplication libebur128-devel rapidjson sparsehash"
-depends="desktop-file-utils qt6-plugin-sqlite qt6-plugin-tls-openssl"
+depends="desktop-file-utils qt6-plugin-sqlite qt6-plugin-tls-openssl
+ gst-plugins-good1"
+checkdepends="gtest-devel gst-plugins-good1"
 short_desc="Audio player and music collection organizer"
 maintainer="Saksham <voidisnull@duck.com>"
 license="GPL-3.0-or-later"
 homepage="https://www.strawberrymusicplayer.org/"
 changelog="https://raw.githubusercontent.com/strawberrymusicplayer/strawberry/master/Changelog"
 distfiles="https://files.strawberrymusicplayer.org/${pkgname}-${version}.tar.xz"
-checksum=ab12eaa6139a4a5466bb40ea9dc22cad913c578090402eba5ef8410cb5772b46
+checksum=4a77d123f19055046a732bcb9550eaa5df67063890ece4ddf69ddea259e80b5b


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

ping @voidisnull 

I decided to include `gst-plugins-good1` in the runtime deps as upstream recommends doing so.

> Also install GStreamer plugins base, good, and optionally bad, ugly and libav for full codec support.
https://github.com/strawberrymusicplayer/strawberry#gear-requirements

#### Local build testing
- I built this PR locally for my native architecture: x86_64-glibc
- I also built it for x86_64-musl
