### PR TITLE
dbeaver: update to 26.2.0.

### DIFF
--- a/srcpkgs/dbeaver/template
+++ b/srcpkgs/dbeaver/template
@@ -1,6 +1,6 @@
 # Template file for 'dbeaver'
 pkgname=dbeaver
-version=26.1.5
+version=26.2.0
 revision=1
 _version=${version//./_}
 # the build downloads binaries linked to glibc
@@ -16,9 +16,9 @@ changelog="https://dbeaver.io/news/"
 distfiles="https://github.com/dbeaver/dbeaver/archive/${version}.tar.gz
  https://github.com/dbeaver/dbeaver-common/archive/refs/heads/release_${_version}.tar.gz>dbeaver-common-${version}.tar.gz
  https://github.com/dbeaver/dbeaver-jdbc-libsql/archive/refs/heads/release_${_version}.tar.gz>dbeaver-jdbc-libsql-${version}.tar.gz"
-checksum="ed5f852893ed9e4821bf7837a641e7f66a9fd77215fb9e957480a4630beff6e1
- f93e443d1668298d921a9b7babaa574e2c03bb95708671f844cb3fbd37d65812
- 18dfe8cf99020939e3b252e9650e80e1a6d242fa1092e5a7afab2e1dbc4b3590"
+checksum="7fa7c4e3e0558284f4533aef1a0506281597bf48d7bc531e08d781644aca64da
+ 8a21511061efd4b0ce3fba472e0913b4b3a6773fe2e966f8b9fbb40f30bf8c8a
+ 1379baf0ae069f7bd55c28070a6a23b2b6c53c74037a7dee4b44be827db6e5ce"
 nopie=true
 
 post_extract() {


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
