### PR TITLE
czkawka: update to 12.0.1

### DIFF
--- a/srcpkgs/czkawka/template
+++ b/srcpkgs/czkawka/template
@@ -1,11 +1,11 @@
 # Template file for 'czkawka'
 pkgname=czkawka
-version=11.0.1
+version=12.0.1
 revision=1
 build_style=cargo
-configure_args="--bin czkawka_cli --bin czkawka_gui --all-features"
+configure_args="--bin czkawka_cli --bin czkawka_gui --bin krokiet --features heif,libraw,libavif"
 hostmakedepends="pkg-config"
-makedepends="libdav1d-devel libheif-devel gtk4-devel libraw-devel"
+makedepends="libdav1d-devel libheif-devel gtk4-devel libraw-devel libavif-devel"
 depends="ffmpeg6"
 checkdepends="dbus xvfb-run"
 short_desc="App to find duplicates, empty folders, similar images, etc"
@@ -14,18 +14,23 @@ license="MIT"
 homepage="https://github.com/qarmin/czkawka"
 changelog="https://raw.githubusercontent.com/qarmin/czkawka/refs/heads/master/Changelog.md"
 distfiles="https://github.com/qarmin/czkawka/archive/refs/tags/${version}.tar.gz"
-checksum=8a6e3f634bfd2b6ed9b7f8634e7405ebb6d756f20bcdd99d15028ffb6b030eca
+checksum=0503f6969a2184fbe2b6b6d786a4ae1b50779f4ce62b57223d1407c70f500587
 make_check_pre="dbus-run-session xvfb-run"
 
 do_install() {
 	vbin target/${RUST_TARGET}/release/czkawka_cli
 	vbin target/${RUST_TARGET}/release/czkawka_gui
+	vbin target/${RUST_TARGET}/release/krokiet
 
 	vlicense czkawka_gui/LICENSE_MIT_APP_CODE
 
 	CZKAWKA_NAME="com.github.qarmin.czkawka"
+	KROKIET_NAME="io.github.qarmin.krokiet"
 	vinstall data/${CZKAWKA_NAME}.desktop 644 usr/share/applications
 	vinstall data/icons/${CZKAWKA_NAME}.svg 644 usr/share/icons/hicolor/scalable/apps
 	vinstall data/icons/${CZKAWKA_NAME}-symbolic.svg 644 usr/share/icons/hicolor/symbolic/apps
 	vinstall data/${CZKAWKA_NAME}.metainfo.xml 644 usr/share/metainfo
+	vinstall data/${KROKIET_NAME}.desktop 644 usr/share/applications
+	vinstall data/icons/${KROKIET_NAME}.svg 644 usr/share/icons/hicolor/scalable/apps
+	vinstall data/${KROKIET_NAME}.metainfo.xml 644 usr/share/metainfo
 }


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - armv6l (crossbuild)

#### Notes
Added the new binary `krokiet`, which is the new Slint GUI. The older GTK `czkawka_gui` is still there but according to upstream is no longer developed as of version 12.
