### PR TITLE
unibilium: update to 2.1.4

### DIFF
--- a/srcpkgs/unibilium/template
+++ b/srcpkgs/unibilium/template
@@ -1,6 +1,6 @@
 # Template file for 'unibilium'
 pkgname=unibilium
-version=2.1.2
+version=2.1.4
 revision=1
 build_style=gnu-configure
 make_check_target="test"
@@ -11,7 +11,7 @@ license="LGPL-3.0-or-later"
 homepage="https://github.com/neovim/unibilium"
 changelog="https://raw.githubusercontent.com/neovim/unibilium/refs/heads/master/Changes"
 distfiles="https://github.com/neovim/unibilium/archive/v${version}.tar.gz"
-checksum=370ecb07fbbc20d91d1b350c55f1c806b06bf86797e164081ccc977fc9b3af7a
+checksum=7360907bcf79ba49f6fc4a504767ff86e93ab9018477026fcc70d5ab77e1f2c1
 
 pre_configure() {
 	autoreconf -fi


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: YES

#### Local build testing
- I built this PR locally for my native architecture: x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl (masterdir)
  - i686 (masterdir)
  - aarch64 (cross)
  - aarch64-musl (cross)
  - armv6l (cross)
  - armv6l-musl (cross)
  - armv7l (cross)
  - armv7l-musl (cross)

