### PR TITLE
openrazer-meta: update to 3.12.4.

### DIFF
--- a/srcpkgs/openrazer-meta/template
+++ b/srcpkgs/openrazer-meta/template
@@ -1,6 +1,6 @@
 # Template file for 'openrazer-meta'
 pkgname=openrazer-meta
-version=3.12.3
+version=3.12.4
 revision=1
 build_style=gnu-makefile
 make_install_target="setup_dkms udev_install daemon_install xdg_install
@@ -12,7 +12,7 @@ maintainer="Martin Dimov <martin@dmarto.com>"
 license="GPL-2.0-or-later"
 homepage="https://openrazer.github.io"
 distfiles="https://github.com/openrazer/openrazer/releases/download/v${version}/openrazer-${version}.tar.xz"
-checksum=f2cc75834bfe75a5ada6e11458212cea8b988668fa0e1a695c5ebb8c04514e65
+checksum=cda77f9213e9757bc1f874d1140df658681f5aafd0b88d216c2f509f2f0b3244
 
 do_build() {
 	:


### PR DESCRIPTION
Updated the meta package to 3.12.4, as otherwise the dkms module fails to build with the latest LTS kernel shipped by Void. 

- I tested the changes in this PR: YES

- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64
  - aarch64-musl

