### PR TITLE
amber: update to 0.6.1

### DIFF
--- a/srcpkgs/amber/template
+++ b/srcpkgs/amber/template
@@ -1,6 +1,6 @@
 # Template file for 'amber'
 pkgname=amber
-version=0.6.0
+version=0.6.1
 revision=1
 build_style=cargo
 short_desc="Code search/replace tool"
@@ -8,7 +8,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
 homepage="https://github.com/dalance/amber"
 distfiles="https://github.com/dalance/amber/archive/refs/tags/v${version}.tar.gz"
-checksum=41908502077197f55ec86b3a4dd4059a78deae9833e9ba33302b1146cc1ec3f5
+checksum=58ca7d172e68acde06c80039762073f6fb700a75d1013aece84f310a4535c277
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: YES

#### Local build testing
- I built this PR locally for my native architecture: x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl (masterdir)
  - i686 (masterdir)
  - aarch64 (cross)
  - aarch64-musl (cross)
  - armv6l (cross)
  - armv6l-musl (cross)
  - armv7l (cross)
  - armv7l-musl (cross)

