### PR TITLE
keymapper: update to 5.7.2.

### DIFF
--- a/srcpkgs/keymapper/template
+++ b/srcpkgs/keymapper/template
@@ -1,6 +1,6 @@
 # Template file for 'keymapper'
 pkgname=keymapper
-version=5.7.1
+version=5.7.2
 revision=1
 build_style=cmake
 configure_args="-DVERSION=${version}"
@@ -12,7 +12,7 @@ license="GPL-3.0-only"
 homepage="https://github.com/houmain/keymapper"
 changelog="https://raw.githubusercontent.com/houmain/keymapper/main/CHANGELOG.md"
 distfiles="https://github.com/houmain/keymapper/archive/refs/tags/${version}.tar.gz"
-checksum=912041946525431a5db188c0e8827028039185895580f348a0f904918b7cc469
+checksum=223d2f5b28452fe879370cb7a42627d0e385fd29c0ed4ee35e92afe7775a2491
 
 post_install() {
 	vsv keymapperd


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, x86_64
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl (cross)
  - armv6l (cross)
