### PR TITLE
New package: eartag-1.0.3

### DIFF
--- a/srcpkgs/eartag/template
+++ b/srcpkgs/eartag/template
@@ -1,0 +1,22 @@
+# Template file for 'eartag'
+pkgname=eartag
+version=1.0.3
+revision=1
+build_style=meson
+hostmakedepends="blueprint-compiler gettext glib-devel gtk4-devel
+ libadwaita-devel python3"
+depends="python3-gobject python3-aiofiles python3-aiohttp python3-aiohttp-retry
+ python3-filetype python3-mutagen python3-Pillow python3-pyacoustid
+ python3-xxhash gtk4 libadwaita"
+checkdepends="$depends python3-pytest python3-pytest-asyncio AppStream
+ desktop-file-utils glib"
+short_desc="Small and simple audio file tag editor"
+maintainer="John Mitrich <johnmitrich@gmail.com>"
+license="MIT"
+homepage="https://gitlab.gnome.org/World/eartag"
+distfiles="https://gitlab.gnome.org/World/eartag/-/archive/$version/eartag-$version.tar.gz"
+checksum=80854b588af057c8b86f6f9f8bb8bcfb06a1c13997d0228cd3f6e6f56a1ec4c3
+
+post_install() {
+	vlicense COPYING
+}

--- a/srcpkgs/python3-aiohttp-retry/template
+++ b/srcpkgs/python3-aiohttp-retry/template
@@ -1,0 +1,19 @@
+# Template file for 'python3-aiohttp-retry'
+pkgname=python3-aiohttp-retry
+version=2.9.1
+revision=1
+build_style=python3-module
+hostmakedepends="python3-setuptools"
+depends="python3-aiohttp"
+short_desc="Simple retry client for aiohttp"
+maintainer="John Mitrich <johnmitrich@gmail.com>"
+license="MIT"
+homepage="https://github.com/inyutin/aiohttp_retry"
+distfiles="${PYPI_SITE}/a/aiohttp-retry/aiohttp_retry-${version}.tar.gz"
+checksum=8eb75e904ed4ee5c2ec242fefe85bf04240f685391c4879d8f541d6028ff01f1
+# tests/app.py (imported by the test suite) is not shipped in the sdist
+make_check=no
+
+post_install() {
+	vlicense LICENSE
+}


### PR DESCRIPTION
Includes python3-aiohttp-retry, a new runtime dependency that is not yet in
the repository.

#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - i686 (crossbuild)
  - aarch64 (crossbuild)
  - armv7l (crossbuild)
  - armv6l (crossbuild)
  - x86_64-musl (crossbuild)
  - aarch64-musl (crossbuild)
  - armv6l-musl (crossbuild)
