### PR TITLE
nnn: make support for readline optional

### DIFF
--- a/srcpkgs/nnn/template
+++ b/srcpkgs/nnn/template
@@ -1,11 +1,12 @@
 # Template file for 'nnn'
 pkgname=nnn
 version=5.3
-revision=1
+revision=2
 build_style=gnu-makefile
+make_build_args="$(vopt_if readline O_NORL=0)"
 make_install_target="install install-desktop"
 hostmakedepends="pkg-config"
-makedepends="ncurses-devel readline-devel"
+makedepends="ncurses-devel $(vopt_if readline readline-devel)"
 short_desc="Missing terminal file browser for X"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="BSD-2-Clause"
@@ -13,6 +14,9 @@ homepage="https://github.com/jarun/nnn"
 changelog="https://raw.githubusercontent.com/jarun/nnn/master/CHANGELOG"
 distfiles="https://github.com/jarun/nnn/archive/v${version}.tar.gz"
 checksum=79ee69f3ced7c0778d207df76b4d4d680636975ccda002eeb19d0917fcba3d36
+
+build_options="readline"
+desc_option_readline="Enable support for GNU readline"
 
 if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
 	makedepends+=" musl-fts-devel"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, **x86_64-glibc**

@sgn `nnn` defaults to not linking libreadline now (unless we want to re-enable it: `O_NORL=0`)
EDIT: Opted for adding a build option (default: disabled)
