### PR TITLE
rustup: update to 1.29.1

### DIFF
--- a/srcpkgs/rustup/template
+++ b/srcpkgs/rustup/template
@@ -1,6 +1,6 @@
 # Template file for 'rustup'
 pkgname=rustup
-version=1.29.0
+version=1.29.1
 revision=1
 # rustup doesn't recognize this target
 archs="~armv*-musl"
@@ -16,7 +16,7 @@ license="Apache-2.0 OR MIT"
 homepage="https://www.rustup.rs"
 changelog="https://raw.githubusercontent.com/rust-lang/rustup/master/CHANGELOG.md"
 distfiles="https://github.com/rust-lang/rustup/archive/refs/tags/${version}.tar.gz"
-checksum=de73d1a62f4d5409a2f6bdb1c523d8dc08aa6d9d63588db62493c19ca8f8bf55
+checksum=00f79a02275fd0252be6928d7a44f96bfba706a0cc47a0c85557aa4a875d1181
 
 do_install() {
 	vbin target/${RUST_TARGET}/release/rustup-init


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
