### PR TITLE
nethack: Add curses interface

### DIFF
--- a/srcpkgs/nethack/template
+++ b/srcpkgs/nethack/template
@@ -1,7 +1,7 @@
 # Template file for 'nethack'
 pkgname=nethack
 version=5.0.0
-revision=1
+revision=2
 conf_files="/etc/nethack/sysconf"
 make_dirs="/var/games/nethack/save 0775 nethack nethack"
 hostmakedepends="flex groff"
@@ -23,6 +23,7 @@ do_configure() {
 do_build() {
 	make all \
 		CC="$CC" LINK="$CC" LFLAGS="$LDFLAGS" LEX=flex \
+		WANT_WIN_CURSES=1 \
 		COLCMD="sed 's/.\x08//g'" \
 		HACKDIR="/var/games/nethack"
 }
@@ -43,6 +44,7 @@ do_install() {
 		GAMEPERM=0755 \
 		DIRPERM=0775 \
 		VARDIRPERM=0775 \
+		WANT_WIN_CURSES=1 \
 		CHOWN=: CHGRP=: LEX=Flex
 
 	mv $DESTDIR/usr/lib/nethack/nhdat $DESTDIR/var/games/nethack


### PR DESCRIPTION
This change builds Nethack with support for the (optional) curses interface, allowing you to use `OPTIONS=windowtype:curses` in your `.nethackrc`. This offers better support for larger terminal windows than the default tty interface.

#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)
- nethack cannot be cross compiled
