### PR TITLE
python3-zipstream-ng: update to 1.9.3

### DIFF
--- a/srcpkgs/python3-zipstream-ng/template
+++ b/srcpkgs/python3-zipstream-ng/template
@@ -1,6 +1,6 @@
 # Template file for 'python3-zipstream-ng'
 pkgname=python3-zipstream-ng
-version=1.9.2
+version=1.9.3
 revision=1
 build_style=python3-pep517
 hostmakedepends="hatchling"
@@ -12,5 +12,5 @@ license="LGPL-3.0-only"
 homepage="https://github.com/pR0Ps/zipstream-ng"
 changelog="https://raw.githubusercontent.com/pR0Ps/zipstream-ng/refs/heads/master/CHANGELOG.md"
 distfiles="${PYPI_SITE}/z/zipstream_ng/zipstream_ng-${version}.tar.gz"
-checksum=116b7304b00f3251328cb300fa90f0f09d523b7faf2a06b3eaf7277dcb82cc3e
+checksum=6cebd055025699c0af594c76a9452cdf13f4be67ee005b6907f0d3c9c6f44ced
 conflicts="python3-zipstream"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)