### PR TITLE
pipewire: update to 1.6.8.

### DIFF
--- a/srcpkgs/pipewire/template
+++ b/srcpkgs/pipewire/template
@@ -1,6 +1,6 @@
 # Template file for 'pipewire'
 pkgname=pipewire
-version=1.6.7
+version=1.6.8
 revision=1
 build_style=meson
 configure_args="
@@ -46,7 +46,7 @@ license="MIT"
 homepage="https://pipewire.org/"
 changelog="https://gitlab.freedesktop.org/pipewire/pipewire/-/raw/master/NEWS"
 distfiles="https://gitlab.freedesktop.org/pipewire/pipewire/-/archive/${version}/pipewire-${version}.tar.gz"
-checksum=a618c0a159055e2443f638c5c9f4b904e6902b655c09a7ff84546fa2447aedf8
+checksum=8181172a1d95131f6af8bbc0b98f90b2a33349b042b84c3ce57dd5d11348cc58
 make_dirs="/var/lib/pipewire 0755 _pipewire _pipewire"
 system_accounts="_pipewire"
 


### PR DESCRIPTION
Update pipewire to 1.6.8.

Highlights in this release:
- pulse-server: avoid stack exhaustion via unbounded alloca (crash fix)
- various bug fixes and hardening

Built and tested locally via xbps-src.