### PR TITLE
wireplumber: update to 0.5.17.

### DIFF
--- a/srcpkgs/wireplumber/template
+++ b/srcpkgs/wireplumber/template
@@ -1,6 +1,6 @@
 # Template file for 'wireplumber'
 pkgname=wireplumber
-version=0.5.15
+version=0.5.17
 revision=1
 build_style=meson
 build_helper=gir
@@ -14,7 +14,7 @@ license="MIT"
 homepage="https://pipewire.pages.freedesktop.org/wireplumber"
 changelog="https://gitlab.freedesktop.org/pipewire/wireplumber/-/raw/master/NEWS.rst"
 distfiles="https://gitlab.freedesktop.org/pipewire/wireplumber/-/archive/$version/wireplumber-$version.tar.gz"
-checksum=baa121bc918df5fa0e0e70755bb1c99ffab0ab107225ecf99aa470e2c6ba5e7b
+checksum=13d1e4456e64bcc81111ec5a4af75d0bd6316040c5718b388b14103a8a77cc6b
 provides="pipewire-session-manager-0_1"
 
 post_install() {


### PR DESCRIPTION
Update wireplumber to 0.5.17.

Highlights (0.5.16/0.5.17):
- WpClientContext: second dedicated PipeWire connection, fixes Lua hook deadlocks
- WpDynamicRules: dynamic rules support
- module unload via script
- monitor and permission-manager fixes

Built and tested locally via xbps-src.