### PR TITLE
obs-pipewire-audio-capture: new package, version 1.2.1.

### DIFF
--- a/srcpkgs/obs-pipewire-audio-capture/template
+++ b/srcpkgs/obs-pipewire-audio-capture/template
@@ -1,0 +1,13 @@
+# Template file for 'obs-pipewire-audio-capture'
+pkgname=obs-pipewire-audio-capture
+version=1.2.1
+revision=1
+build_style=cmake
+hostmakedepends="ninja pkg-config"
+makedepends="obs-devel pipewire-devel simde"
+short_desc="Audio device and application capture for OBS Studio using PipeWire"
+maintainer="delphus <delphus@delphus.org>"
+license="GPL-2.0-only"
+homepage="https://github.com/dimtpap/obs-pipewire-audio-capture"
+distfiles="https://github.com/dimtpap/obs-pipewire-audio-capture/archive/${version}.tar.gz"
+checksum=70107cafd2020437fc0b663fdf6a94598b474942a0582b24719a0e76a9f73a50


### PR DESCRIPTION
New package: [obs-pipewire-audio-capture](https://github.com/dimtpap/obs-pipewire-audio-capture) 1.2.1 — audio device and **application** capture for OBS Studio using PipeWire natively (per-app audio sources, no PulseAudio dependency).

Built and tested locally via xbps-src against obs 32.2.1.