### PR TITLE
go: update to 1.27.1.

### DIFF
--- a/srcpkgs/anubis/template
+++ b/srcpkgs/anubis/template
@@ -1,6 +1,6 @@
 # Template file for 'anubis'
 pkgname=anubis
-version=1.25.0
+version=1.27.0
 revision=1
 build_style=go
 go_import_path="github.com/TecharoHQ/anubis"
@@ -14,7 +14,7 @@ license="MIT"
 homepage="https://anubis.techaro.lol/"
 changelog="https://github.com/TecharoHQ/anubis/releases"
 distfiles="https://github.com/TecharoHQ/anubis/archive/refs/tags/v${version}.tar.gz"
-checksum=e281562dea0b49d0639c3c5e9b0a2a7fe522b1a359e3cec470db06493835bbe7
+checksum=5a3f93d5b763283e2432f2574f30d30434befd5e1788990bd031bdf0696e78b3
 
 system_accounts="_anubis"
 

--- a/srcpkgs/go/template
+++ b/srcpkgs/go/template
@@ -1,6 +1,6 @@
 # Template file for 'go'
 pkgname=go
-version=1.26.5
+version=1.27.1
 revision=1
 _bootstrap="1.24.6"
 create_wrksrc=yes
@@ -13,7 +13,7 @@ license="BSD-3-Clause"
 homepage="https://go.dev/"
 changelog="https://go.dev/doc/devel/release.html"
 distfiles="https://go.dev/dl/go${version}.src.tar.gz"
-checksum=495be4bc87176ac567392e5b4116abd98466d33d7b49d41e764ccc6976b2dc42
+checksum=4e408abae126d916b6164627193f2c54f0e3ca1312d693b86db45f862ab238b1
 nostrip=yes
 noverifyrdeps=yes
 # on CI it tries to use `git submodule`, which is not part of chroot-git

--- a/srcpkgs/goreleaser/template
+++ b/srcpkgs/goreleaser/template
@@ -1,6 +1,6 @@
 # Template file for 'goreleaser'
 pkgname=goreleaser
-version=2.16.0
+version=2.18.1
 revision=1
 build_style=go
 build_helper="qemu"
@@ -11,7 +11,7 @@ maintainer="Michael Aldridge <maldridge@voidlinux.org>"
 license="MIT"
 homepage="https://goreleaser.com/"
 distfiles="https://github.com/goreleaser/goreleaser/archive/refs/tags/v$version.tar.gz"
-checksum=601bb9fec2feed2689c11eb5768bd8124dec8959bebfed89125487c772d84d3a
+checksum=5f47712f272842b1b51f599403a266e1a304b9689cfb31da22bd279c79af5afc
 
 post_install() {
 	vlicense LICENSE.md

--- a/srcpkgs/sops/template
+++ b/srcpkgs/sops/template
@@ -1,6 +1,6 @@
 # Template file for 'sops'
 pkgname=sops
-version=3.13.1
+version=3.13.3
 revision=1
 build_style=go
 go_import_path="github.com/getsops/sops/v3"
@@ -11,5 +11,5 @@ license="MPL-2.0"
 homepage="https://github.com/getsops/sops"
 changelog="https://raw.githubusercontent.com/getsops/sops/main/CHANGELOG.rst"
 distfiles="https://github.com/getsops/sops/archive/refs/tags/v${version}.tar.gz"
-checksum=60408fa04a024328e6142c7dc67d08810a470aaa440b9f6cb7b3a358359636e9
+checksum=49811c5ed80f6b4d4e98cef98e3f7378406aa692fd773dfb72ad1b4dfb940448
 make_check=no # tests require a running docker daemon


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **NO**

Version bump 1.26.5 → 1.27.1.