### PR TITLE
pacman: update to 7.1.0, fix deadlock with curl 8.20+.

### DIFF
--- a/srcpkgs/pacman/patches/0001-libalpm-invalidate-curl-data-in-child.patch
+++ b/srcpkgs/pacman/patches/0001-libalpm-invalidate-curl-data-in-child.patch
@@ -1,0 +1,32 @@
+From 21b8d8a21a03e0d44294626f7222adda6b48dfac Mon Sep 17 00:00:00 2001
+From: Christian Hesse <mail@eworm.de>
+Date: Thu, 30 Apr 2026 12:31:13 +0200
+Subject: [PATCH 1/1] libalpm: invalidate curl data in child
+
+Touching that data inside the child makes it crash. So let's invalidate
+and ignore it there.
+
+https://github.com/curl/curl/issues/21466
+
+---
+ lib/libalpm/util.c | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+Taken from https://gitlab.archlinux.org/archlinux/packaging/packages/pacman/-/commit/387ebf06060fd5f
+
+diff --git a/lib/libalpm/util.c b/lib/libalpm/util.c
+index 6739161b..8a99ef87 100644
+--- a/lib/libalpm/util.c
++++ b/lib/libalpm/util.c
+@@ -673,6 +673,11 @@ int _alpm_run_chroot(alpm_handle_t *handle, const char *cmd, char *const argv[],
+ 			close(cwdfd);
+ 		}
+ 
++#ifdef HAVE_LIBCURL
++		/* invalidate the curl data - we must not touch it in child */
++		handle->curlm = NULL;
++#endif
++
+ 		/* use fprintf instead of _alpm_log to send output through the parent */
+ 		/* don't chroot() to "/": this allows running with less caps when the
+ 		 * caller puts us in the right root */

--- a/srcpkgs/pacman/template
+++ b/srcpkgs/pacman/template
@@ -1,7 +1,7 @@
 # Template file for 'pacman'
 pkgname=pacman
-version=7.0.0
-revision=2
+version=7.1.0
+revision=1
 make_dirs="/var/lib/pacman 0755 root root
  /usr/var/cache/pacman/pkg 0755 root root
  /usr/share/libalpm/hooks 0755 root root"
@@ -17,7 +17,7 @@ maintainer="oreo639 <oreo6391@gmail.com>"
 license="GPL-2.0-or-later"
 homepage="https://www.archlinux.org/pacman/"
 distfiles="https://gitlab.archlinux.org/pacman/pacman/-/releases/v${version}/downloads/pacman-${version}.tar.xz"
-checksum=61cbd445d1381b4b184bc7c4e2791f07a79f0f2807b7c600399d0d08e8cd28cf
+checksum=530e50d7edbb2a22581c6d6707d2113240276c1bec4ee39a99488e1243c32171
 make_check=ci-skip # Some tests fail when run in CI
 
 if [ "$XBPS_TARGET_LIBC" = musl ]; then


### PR DESCRIPTION
curl 8.20+ introduced a deadlock in pacman when using curl after calling fork.
This was ultimately determined to be the result of improper usage of the library: https://github.com/curl/curl/issues/21466

A patch was submitted to pacman, but it has not been merged:
https://gitlab.archlinux.org/pacman/pacman/-/merge_requests/360
https://gitlab.archlinux.org/pacman/pacman/-/merge_requests/361

Arch Linux patches it downstream (along with most other distros): https://gitlab.archlinux.org/archlinux/packaging/packages/pacman/-/commit/387ebf06060fd5f4ccd2b5281789b11d30c09358

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
