### PR TITLE
gemget: update to 1.9.0

### DIFF
--- a/srcpkgs/gemget/template
+++ b/srcpkgs/gemget/template
@@ -1,7 +1,7 @@
 # Template file for 'gemget'
 pkgname=gemget
-version=1.8.0
-revision=4
+version=1.9.0
+revision=1
 build_style=go
 go_import_path="github.com/makeworld-the-better-one/gemget"
 short_desc="Command line downloader for the Gemini protocol"
@@ -9,7 +9,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
 homepage="https://github.com/makeworld-the-better-one/gemget/"
 distfiles="https://github.com/makeworld-the-better-one/gemget/archive/v$version.tar.gz"
-checksum=52578dfc33c0275d71658d6afc0e0d91b3734032a6ed5b760d2695001b178c5a
+checksum=ded2b0d86e24d0a35a35ea412d08ebff636698fa5114e0da80b5b4c1b003e431
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: YES

#### Local build testing
- I built this PR locally for my native architecture: x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl (masterdir)
  - i686 (masterdir)
  - aarch64 (cross)
  - aarch64-musl (cross)
  - armv6l (cross)
  - armv6l-musl (cross)
  - armv7l (cross)
  - armv7l-musl (cross)

