### PR TITLE
Signal-Desktop: update to 8.26.0.

### DIFF
--- a/srcpkgs/Signal-Desktop/template
+++ b/srcpkgs/Signal-Desktop/template
@@ -1,6 +1,6 @@
 # Template file for 'Signal-Desktop'
 pkgname=Signal-Desktop
-version=8.25.0
+version=8.26.0
 revision=1
 # *-musl could potentially work based on the Alpine port:
 # https://git.alpinelinux.org/aports/tree/testing/signal-desktop
@@ -13,7 +13,7 @@ maintainer="dkwo <npiazza@disroot.org>"
 license="AGPL-3.0-only"
 homepage="https://github.com/signalapp/Signal-Desktop"
 distfiles="https://github.com/signalapp/Signal-Desktop/archive/v${version}.tar.gz"
-checksum=d119d2a90d0c7de2f26587c4c34968e3365bb42032309bbabcda7ef83626cf32
+checksum=e09ea57cca7e0a1b8455f17b5402e30e4e0240af75a0e05bf2f4f2f31ba36925
 nostrip_files="signal-desktop"
 nocross="gyp -> aarch64-linux-gnu-gcc: error: unrecognized command-line option '-m64'"
 


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
