### PR TITLE
input-remapper: added missing depend gtksourceview4

### DIFF
--- a/srcpkgs/input-remapper/template
+++ b/srcpkgs/input-remapper/template
@@ -1,10 +1,10 @@
 # Template file for 'input-remapper'
 pkgname=input-remapper
 version=2.2.1
-revision=1
+revision=2
 build_style=python3-pep517
 hostmakedepends="python3-setuptools gettext"
-depends="dbus python3-evdev python3-gobject python3-psutil python3-dasbus python3-pydantic python3-packaging python3-cairo"
+depends="dbus python3-evdev python3-gobject python3-psutil python3-dasbus python3-pydantic python3-packaging python3-cairo gtksourceview4"
 short_desc="GUI Tool to change the behaviour of your input devices"
 maintainer="Soulful Sailer <soulful.sailer@entropic.pro>"
 license="GPL-3.0-or-later"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)

dependency is required for program to open