### PR TITLE
2bwm: update to 0.4

### DIFF
--- a/srcpkgs/2bwm/template
+++ b/srcpkgs/2bwm/template
@@ -1,21 +1,20 @@
 # Template file for '2bwm'
 pkgname=2bwm
-version=0.3
+version=0.4
 revision=1
 build_style=gnu-makefile
+make_use_env=yes
 makedepends="libxcb-devel xcb-util-keysyms-devel xcb-util-wm-devel xcb-util-xrm-devel"
 short_desc="Fast floating window manager"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="ISC"
 homepage="https://github.com/venam/2bwm"
-distfiles="https://github.com/venam/${pkgname}/archive/v${version}.tar.gz"
-checksum=a4889ea4b01b1a3d4a508daa034b9d86676913cbbca1f977858df692a6e2af95
+distfiles="https://github.com/venam/2bwm/archive/v${version}.tar.gz"
+checksum=74f30e049dc43ed1bcd2667b75dcc9c9b6544a7851f29537d1fb58d04300da8e
 
 pre_build() {
+	[ -e ${FILESDIR}/config.h ] && cp ${FILESDIR}/config.h config.h
 	sed -i 's|-Os ||g' Makefile
-	sed -i 's|^CFLAGS+=|override CFLAGS +=|g' Makefile
-	sed -i 's|^LDFLAGS+=|override LDFLAGS +=|g' Makefile
-	sed -i '/#include <stdlib.h>/i#define _GNU_SOURCE' 2bwm.c
 	sed -n 1,17p 2bwm.c >LICENSE
 }
 do_install() {


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: YES

In the pre_build function I removed the two sed commands on line 16 and line 17 that added overrides to the Makefile and instead added make_use_env=yes.  The sed command on line 18 was removed since everything builds fine without _GNU_SOURCE. stdlib.h was removed from 2bwm.c in 0.2 so it hasn't been building with _GNU_SOURCE anyways. Also, since 2bwm is customized through a config.h file I thought it would be a good idea to include it if one is found in the files directory.

#### Local build testing
- I built this PR locally for my native architecture: x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl (masterdir)
  - i686 (masterdir)
  - aarch64 (cross)
  - aarch64-musl (cross)
  - armv6l (cross)
  - armv6l-musl (cross)
  - armv7l (cross)
  - armv7l-musl (cross)

