### PR TITLE
Tree sitter 0.27

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -4230,7 +4230,7 @@ libsword-1.9.0.so libsword-1.9.0_1
 libgivaro.so.9 givaro-4.1.1_1
 liblinbox.so.0 linbox-1.6.3_1
 libpari-gmp-tls.so.9 pari-2.17.0_1
-libtree-sitter.so.0.25 tree-sitter-0.25.2_1
+libtree-sitter.so.0.27 tree-sitter-0.27.0_1
 libplanarity.so.2 planarity-4.0.0.0_1
 libgap.so.11 gap-4.16.0_1
 libgtkdatabox.so.1 gtkdatabox3-1.0.0_1

--- a/srcpkgs/emacs/template
+++ b/srcpkgs/emacs/template
@@ -1,7 +1,7 @@
 # Template file for 'emacs'
 pkgname=emacs
 version=31.1
-revision=1
+revision=2
 create_wrksrc=required
 build_style=gnu-configure
 configure_args="--with-file-notification=inotify --with-modules

--- a/srcpkgs/neovim/template
+++ b/srcpkgs/neovim/template
@@ -1,7 +1,7 @@
 # Template file for 'neovim'
 pkgname=neovim
 version=0.12.5
-revision=1
+revision=2
 build_style=cmake
 build_helper="qemu"
 configure_args="-DCOMPILE_LUA=OFF -DENABLE_TRANSLATIONS=ON -DPREFER_LUA=$(vopt_if luajit OFF ON)"

--- a/srcpkgs/rizin/template
+++ b/srcpkgs/rizin/template
@@ -3,7 +3,7 @@
 # Rebuild cutter on update
 pkgname=rizin
 version=0.7.3
-revision=5
+revision=6
 build_style=meson
 configure_args="-D use_sys_capstone=enabled -D use_capstone_version=v5
  -D use_sys_magic=enabled -D use_sys_libzip=enabled -D use_sys_zlib=enabled

--- a/srcpkgs/tree-sitter-awk/template
+++ b/srcpkgs/tree-sitter-awk/template
@@ -1,7 +1,7 @@
 # Template file for 'tree-sitter-awk'
 pkgname=tree-sitter-awk
 version=0.7.2
-revision=1
+revision=2
 build_style=tree-sitter
 short_desc="Awk grammar for tree-sitter"
 maintainer="classabbyamp <void@placeviolette.net>"

--- a/srcpkgs/tree-sitter-bash/template
+++ b/srcpkgs/tree-sitter-bash/template
@@ -1,7 +1,7 @@
 # Template file for 'tree-sitter-bash'
 pkgname=tree-sitter-bash
 version=0.25.1
-revision=1
+revision=2
 build_style=tree-sitter
 short_desc="Bash grammar for tree-sitter"
 maintainer="classabbyamp <void@placeviolette.net>"

--- a/srcpkgs/tree-sitter-c/template
+++ b/srcpkgs/tree-sitter-c/template
@@ -1,7 +1,7 @@
 # Template file for 'tree-sitter-c'
 pkgname=tree-sitter-c
 version=0.24.2
-revision=1
+revision=2
 build_style=tree-sitter
 short_desc="C grammar for tree-sitter"
 maintainer="classabbyamp <void@placeviolette.net>"

--- a/srcpkgs/tree-sitter-comment/template
+++ b/srcpkgs/tree-sitter-comment/template
@@ -1,7 +1,7 @@
 # Template file for 'tree-sitter-comment'
 pkgname=tree-sitter-comment
 version=0.3.0
-revision=1
+revision=2
 build_style=tree-sitter
 short_desc="Comment grammar for tree-sitter"
 maintainer="classabbyamp <void@placeviolette.net>"

--- a/srcpkgs/tree-sitter-cpp/template
+++ b/srcpkgs/tree-sitter-cpp/template
@@ -1,7 +1,7 @@
 # Template file for 'tree-sitter-cpp'
 pkgname=tree-sitter-cpp
 version=0.23.4
-revision=1
+revision=2
 build_style=tree-sitter
 depends="tree-sitter-c"
 checkdepends="${depends}"

--- a/srcpkgs/tree-sitter-css/template
+++ b/srcpkgs/tree-sitter-css/template
@@ -1,7 +1,7 @@
 # Template file for 'tree-sitter-css'
 pkgname=tree-sitter-css
 version=0.25.0
-revision=1
+revision=2
 build_style=tree-sitter
 short_desc="CSS grammar for tree-sitter"
 maintainer="classabbyamp <void@placeviolette.net>"

--- a/srcpkgs/tree-sitter-diff/template
+++ b/srcpkgs/tree-sitter-diff/template
@@ -1,7 +1,7 @@
 # Template file for 'tree-sitter-diff'
 pkgname=tree-sitter-diff
 version=0.2.0
-revision=1
+revision=2
 build_style=tree-sitter
 short_desc="Diff grammar for tree-sitter"
 maintainer="classabbyamp <void@placeviolette.net>"

--- a/srcpkgs/tree-sitter-git-rebase/template
+++ b/srcpkgs/tree-sitter-git-rebase/template
@@ -1,7 +1,7 @@
 # Template file for 'tree-sitter-git-rebase'
 pkgname=tree-sitter-git-rebase
 version=1.0.0
-revision=1
+revision=2
 build_style=tree-sitter
 short_desc="Git rebase grammar for tree-sitter"
 maintainer="classabbyamp <void@placeviolette.net>"

--- a/srcpkgs/tree-sitter-gitcommit/template
+++ b/srcpkgs/tree-sitter-gitcommit/template
@@ -1,7 +1,7 @@
 # Template file for 'tree-sitter-gitcommit'
 pkgname=tree-sitter-gitcommit
 version=0.5.0
-revision=2
+revision=3
 build_style=tree-sitter
 depends="tree-sitter-diff tree-sitter-git-rebase"
 short_desc="Gitcommit grammar for tree-sitter"

--- a/srcpkgs/tree-sitter-go/template
+++ b/srcpkgs/tree-sitter-go/template
@@ -1,7 +1,7 @@
 # Template file for 'tree-sitter-go'
 pkgname=tree-sitter-go
 version=0.25.0
-revision=1
+revision=2
 build_style=tree-sitter
 short_desc="Go grammar for tree-sitter"
 maintainer="classabbyamp <void@placeviolette.net>"

--- a/srcpkgs/tree-sitter-grammars/template
+++ b/srcpkgs/tree-sitter-grammars/template
@@ -1,7 +1,7 @@
 # Template file for 'tree-sitter-grammars'
 pkgname=tree-sitter-grammars
 version=0.0.20260422
-revision=1
+revision=2
 metapackage=yes
 short_desc="Collection of tree-sitter grammars"
 maintainer="classabbyamp <void@placeviolette.net>"

--- a/srcpkgs/tree-sitter-hcl/template
+++ b/srcpkgs/tree-sitter-hcl/template
@@ -1,7 +1,7 @@
 # Template file for 'tree-sitter-hcl'
 pkgname=tree-sitter-hcl
 version=1.2.0
-revision=1
+revision=2
 build_style=tree-sitter
 short_desc="HCL grammar for tree-sitter"
 maintainer="classabbyamp <void@placeviolette.net>"

--- a/srcpkgs/tree-sitter-html/template
+++ b/srcpkgs/tree-sitter-html/template
@@ -1,7 +1,7 @@
 # Template file for 'tree-sitter-html'
 pkgname=tree-sitter-html
 version=0.23.2
-revision=1
+revision=2
 build_style=tree-sitter
 short_desc="HTML grammar for tree-sitter"
 maintainer="classabbyamp <void@placeviolette.net>"

--- a/srcpkgs/tree-sitter-javascript/template
+++ b/srcpkgs/tree-sitter-javascript/template
@@ -1,7 +1,7 @@
 # Template file for 'tree-sitter-javascript'
 pkgname=tree-sitter-javascript
 version=0.25.0
-revision=1
+revision=2
 build_style=tree-sitter
 short_desc="Javascript grammar for tree-sitter"
 maintainer="classabbyamp <void@placeviolette.net>"

--- a/srcpkgs/tree-sitter-jinja/template
+++ b/srcpkgs/tree-sitter-jinja/template
@@ -1,7 +1,7 @@
 # Template file for 'tree-sitter-jinja'
 pkgname=tree-sitter-jinja
 version=0.13.0
-revision=1
+revision=2
 build_wrksrc="tree-sitter-jinja"
 build_style=tree-sitter
 short_desc="Jinja grammar for tree-sitter"

--- a/srcpkgs/tree-sitter-json/template
+++ b/srcpkgs/tree-sitter-json/template
@@ -1,7 +1,7 @@
 # Template file for 'tree-sitter-json'
 pkgname=tree-sitter-json
 version=0.24.8
-revision=1
+revision=2
 build_style=tree-sitter
 short_desc="JSON grammar for tree-sitter"
 maintainer="classabbyamp <void@placeviolette.net>"

--- a/srcpkgs/tree-sitter-latex/template
+++ b/srcpkgs/tree-sitter-latex/template
@@ -1,7 +1,7 @@
 # Template file for 'tree-sitter-latex'
 pkgname=tree-sitter-latex
 version=0.6.0
-revision=1
+revision=2
 build_style=tree-sitter
 hostmakedepends="tree-sitter-cli nodejs"
 short_desc="LaTeX grammar for tree-sitter"

--- a/srcpkgs/tree-sitter-lua/template
+++ b/srcpkgs/tree-sitter-lua/template
@@ -1,7 +1,7 @@
 # Template file for 'tree-sitter-lua'
 pkgname=tree-sitter-lua
 version=0.5.0
-revision=1
+revision=2
 build_style=tree-sitter
 short_desc="Lua grammar for tree-sitter"
 maintainer="classabbyamp <void@placeviolette.net>"

--- a/srcpkgs/tree-sitter-markdown/template
+++ b/srcpkgs/tree-sitter-markdown/template
@@ -1,7 +1,7 @@
 # Template file for 'tree-sitter-markdown'
 pkgname=tree-sitter-markdown
 version=0.5.3
-revision=1
+revision=2
 build_style=tree-sitter
 build_wrksrc="tree-sitter-markdown"
 short_desc="Markdown grammar for tree-sitter"

--- a/srcpkgs/tree-sitter-meson/template
+++ b/srcpkgs/tree-sitter-meson/template
@@ -1,7 +1,7 @@
 # Template file for 'tree-sitter-meson'
 pkgname=tree-sitter-meson
 version=1.3.0
-revision=1
+revision=2
 build_style=tree-sitter
 short_desc="Meson grammar for tree-sitter"
 maintainer="classabbyamp <void@placeviolette.net>"

--- a/srcpkgs/tree-sitter-nginx/template
+++ b/srcpkgs/tree-sitter-nginx/template
@@ -1,7 +1,7 @@
 # Template file for 'tree-sitter-nginx'
 pkgname=tree-sitter-nginx
 version=1.0.1
-revision=1
+revision=2
 build_style=tree-sitter
 short_desc="Nginx grammar for tree-sitter"
 maintainer="classabbyamp <void@placeviolette.net>"

--- a/srcpkgs/tree-sitter-printf/template
+++ b/srcpkgs/tree-sitter-printf/template
@@ -1,7 +1,7 @@
 # Template file for 'tree-sitter-printf'
 pkgname=tree-sitter-printf
 version=0.5.1
-revision=1
+revision=2
 build_style=tree-sitter
 short_desc="Printf grammar for tree-sitter"
 maintainer="classabbyamp <void@placeviolette.net>"

--- a/srcpkgs/tree-sitter-python/template
+++ b/srcpkgs/tree-sitter-python/template
@@ -1,7 +1,7 @@
 # Template file for 'tree-sitter-python'
 pkgname=tree-sitter-python
 version=0.25.0
-revision=1
+revision=2
 build_style=tree-sitter
 short_desc="Python grammar for tree-sitter"
 maintainer="classabbyamp <void@placeviolette.net>"

--- a/srcpkgs/tree-sitter-qmljs/template
+++ b/srcpkgs/tree-sitter-qmljs/template
@@ -1,7 +1,7 @@
 # Template file for 'tree-sitter-qmljs'
 pkgname=tree-sitter-qmljs
 version=0.3.1
-revision=1
+revision=2
 build_style=tree-sitter
 depends="tree-sitter-javascript tree-sitter-typescript"
 checkdepends="${depends}"

--- a/srcpkgs/tree-sitter-query/template
+++ b/srcpkgs/tree-sitter-query/template
@@ -1,7 +1,7 @@
 # Template file for 'tree-sitter-query'
 pkgname=tree-sitter-query
 version=0.8.0
-revision=1
+revision=2
 build_style=tree-sitter
 short_desc="TS query grammar for tree-sitter"
 maintainer="classabbyamp <void@placeviolette.net>"

--- a/srcpkgs/tree-sitter-rust/template
+++ b/srcpkgs/tree-sitter-rust/template
@@ -1,7 +1,7 @@
 # Template file for 'tree-sitter-rust'
 pkgname=tree-sitter-rust
 version=0.24.2
-revision=1
+revision=2
 build_style=tree-sitter
 short_desc="Rust grammar for tree-sitter"
 maintainer="classabbyamp <void@placeviolette.net>"

--- a/srcpkgs/tree-sitter-toml/template
+++ b/srcpkgs/tree-sitter-toml/template
@@ -1,7 +1,7 @@
 # Template file for 'tree-sitter-toml'
 pkgname=tree-sitter-toml
 version=0.7.0
-revision=1
+revision=2
 build_style=tree-sitter
 short_desc="TOML grammar for tree-sitter"
 maintainer="classabbyamp <void@placeviolette.net>"

--- a/srcpkgs/tree-sitter-typescript/template
+++ b/srcpkgs/tree-sitter-typescript/template
@@ -1,7 +1,7 @@
 # Template file for 'tree-sitter-typescript'
 pkgname=tree-sitter-typescript
 version=0.23.2
-revision=2
+revision=3
 build_wrksrc="typescript"
 build_style=tree-sitter
 depends="tree-sitter-javascript"

--- a/srcpkgs/tree-sitter-vim/template
+++ b/srcpkgs/tree-sitter-vim/template
@@ -1,7 +1,7 @@
 # Template file for 'tree-sitter-vim'
 pkgname=tree-sitter-vim
 version=0.8.1
-revision=1
+revision=2
 build_style=tree-sitter
 short_desc="Vimscript grammar for tree-sitter"
 maintainer="classabbyamp <void@placeviolette.net>"

--- a/srcpkgs/tree-sitter-vimdoc/template
+++ b/srcpkgs/tree-sitter-vimdoc/template
@@ -1,7 +1,7 @@
 # Template file for 'tree-sitter-vimdoc'
 pkgname=tree-sitter-vimdoc
 version=4.1.0
-revision=1
+revision=2
 build_style=tree-sitter
 short_desc="Tree-sitter parser for Vim help files"
 maintainer="classabbyamp <void@placeviolette.net>"

--- a/srcpkgs/tree-sitter-xml/template
+++ b/srcpkgs/tree-sitter-xml/template
@@ -1,7 +1,7 @@
 # Template file for 'tree-sitter-xml'
 pkgname=tree-sitter-xml
 version=0.7.0
-revision=1
+revision=2
 build_wrksrc="xml"
 build_style=tree-sitter
 short_desc="XML grammar for tree-sitter"

--- a/srcpkgs/tree-sitter-yaml/template
+++ b/srcpkgs/tree-sitter-yaml/template
@@ -1,7 +1,7 @@
 # Template file for 'tree-sitter-yaml'
 pkgname=tree-sitter-yaml
 version=0.7.2
-revision=1
+revision=2
 build_style=tree-sitter
 short_desc="YAML grammar for tree-sitter"
 maintainer="classabbyamp <void@placeviolette.net>"

--- a/srcpkgs/tree-sitter/template
+++ b/srcpkgs/tree-sitter/template
@@ -1,21 +1,44 @@
 # Template file for 'tree-sitter'
 pkgname=tree-sitter
-version=0.25.10
-revision=2
+version=0.27.0
+revision=1
 build_style=cargo
-make_install_args="--path=cli"
+make_install_args="--path=crates/cli"
+hostmakedepends="clang"
 short_desc="Parser generator tool and incremental parsing library"
 maintainer="Érico Nogueira <ericonr@disroot.org>"
 license="MIT"
 homepage="https://tree-sitter.github.io"
 changelog="https://github.com/tree-sitter/tree-sitter/releases"
 distfiles="https://github.com/tree-sitter/tree-sitter/archive/refs/tags/v${version}.tar.gz"
-checksum=ad5040537537012b16ef6e1210a572b927c7cdc2b99d1ee88d44a7dcdc3ff44c
+checksum=d35c96e68736bd9569d2757c3cc71052485f33082c3825f1aed9d0e86013a159
 make_check=no # tests require generating fixtures from remote repositories
 
+_setup_env() {
+	# workaround the cc-rs mixing CFLAGS for host and target.
+	# https://github.com/rust-lang/cc-rs/issues/1469
+	export CFLAGS_${RUST_BUILD//-/_}="${CFLAGS_host}" \
+	       CXXFLAGS_${RUST_BUILD//-/_}="${CXXFLAGS_host}" \
+	       LDFLAGS_${RUST_BUILD//-/_}="${LDFLAGS_host}" \
+	       CFLAGS_${RUST_TARGET//-/_}="${CFLAGS}" \
+	       CXXFLAGS_${RUST_TARGET//-/_}="${CXXFLAGS}" \
+	       LDFLAGS_${RUST_TARGET//-/_}="${LDFLAGS}" \
+	       CFLAGS="" CXXFLAGS="" LDFLAGS=""
+}
+
+pre_build() {
+	_setup_env
+}
+
 post_build() {
+	_setup_env
+
 	# Build libtree-sitter, since do_build builds the tree-sitter CLI.
 	make
+}
+
+pre_install() {
+	_setup_env
 }
 
 post_install() {


### PR DESCRIPTION
Supersedes #58264

#### Testing the changes
- I tested the changes in this PR: **briefly**

**Neovim**: I've been using the new revision since yesterday, and `tree-sitter-cli` since the same.

**Emacs**: I'm not familiar with Emacs, but it did compile! I wondered if Emacs would still build and test properly without the patch in #58264, but that may indeed be necessary. I hope those more familiar with Emacs can speak to that.

**Rizin**: I'm not familiar with Rizin, but it did compile!

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)

