### PR TITLE
qt6-tools: add qdoc

### DIFF
--- a/srcpkgs/qt6-tools/template
+++ b/srcpkgs/qt6-tools/template
@@ -1,13 +1,15 @@
 # Template file for 'qt6-tools'
 pkgname=qt6-tools
 version=6.11.1
-revision=1
+revision=2
 _llvmver=21
 build_style=cmake
 configure_args="-DEXTERNAL_GUMBO=ON -DLITEHTML_UTF8=ON -DUSE_ICU=ON
  -DQT_BUILD_SHARED_LIBS=ON -DQT_FEATURE_assistant=ON
  -DQT_FEATURE_pixeltool=ON -DLITEHTML_BUILD_TESTING=OFF
- -DQT_FEATURE_distancefieldgenerator=ON"
+ -DQT_FEATURE_distancefieldgenerator=ON -DQT_FEATURE_qdoc=ON
+ -DClang_DIR=${XBPS_CROSS_BASE}/usr/lib/llvm/${_llvmver}/lib/cmake/clang
+ -DLLVM_DIR=${XBPS_CROSS_BASE}/usr/lib/llvm/${_llvmver}/lib/cmake/llvm"
 hostmakedepends="qt6-base perl qt6-plugin-sqlite clang${_llvmver} clang-tools-extra${_llvmver}
  qt6-declarative-host-tools"
 makedepends="qt6-base-private-devel qt6-plugin-sqlite qt6-declarative-private-devel


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->
A useful first step for #42714. And it is just useful in general. Qt5 has qdoc.

Ping @Johnnynator 

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
