### PR TITLE
treeline: add missing `depends`

### DIFF
--- a/srcpkgs/treeline/template
+++ b/srcpkgs/treeline/template
@@ -1,10 +1,10 @@
 # Template file for 'treeline'
 pkgname=treeline
 version=3.2.1
-revision=2
+revision=3
 pycompile_dirs="usr/share/treeline"
 hostmakedepends="python3"
-depends="python3-pyqt6"
+depends="python3-pyqt6 python3-pyqt6-widgets python3-pyqt6-gui python3-pyqt6-network python3-pyqt6-printsupport"
 short_desc="Information storage program"
 maintainer="newbluemoon <blaumolch@mailbox.org>"
 license="GPL-2.0-or-later"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-LIBC)

