### PR TITLE
ctpl: update to 0.3.5

### DIFF
--- a/srcpkgs/ctpl/template
+++ b/srcpkgs/ctpl/template
@@ -1,7 +1,7 @@
 # Template file for 'ctpl'
 pkgname=ctpl
-version=0.3.4
-revision=3
+version=0.3.5
+revision=1
 build_style=gnu-configure
 configure_args="--disable-static"
 hostmakedepends="pkg-config"
@@ -10,8 +10,8 @@ short_desc="Template library written in C"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-3.0-or-later"
 homepage="http://ctpl.tuxfamily.org/"
-distfiles="http://download.tuxfamily.org/${pkgname}/releases/${pkgname}-${version}.tar.gz"
-checksum=3a95fdd03437ed3ae222339cb0de2d2c1240d627faa6c77bf46f1a9b761729fb
+distfiles="http://download.tuxfamily.org/ctpl/releases/ctpl-${version}.tar.gz"
+checksum=21108fc7567ed216deea4591adbfece8e88b1f4bb1ca77c37400920644d756be
 
 ctpl-devel_package() {
 	depends="${makedepends} ${sourcepkg}>=${version}_${revision}"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: YES

#### Local build testing
- I built this PR locally for my native architecture: x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl (masterdir)
  - i686 (masterdir)
  - aarch64 (cross)
  - aarch64-musl (cross)
  - armv6l (cross)
  - armv6l-musl (cross)
  - armv7l (cross)
  - armv7l-musl (cross)

