### PR TITLE
kew: update to 4.3.2.

### DIFF
--- a/srcpkgs/kew/template
+++ b/srcpkgs/kew/template
@@ -1,6 +1,6 @@
 # Template file for 'kew'
 pkgname=kew
-version=4.2.7
+version=4.3.2
 revision=1
 build_style=gnu-makefile
 make_use_env=yes
@@ -14,7 +14,7 @@ license="GPL-2.0-only"
 homepage="https://github.com/ravachol/kew"
 changelog="https://github.com/ravachol/kew/releases"
 distfiles="https://github.com/ravachol/kew/archive/refs/tags/v${version}.tar.gz"
-checksum=04e505bc7d9f9d13e65f1121556fffb14769f181961712c65732973982195577
+checksum=f9a21c55f161cbf5f2d7106e1b815aa73fbc31c8cf1cd2d03a9fe07e6566286c
 
 pre_build() {
 	if [ "$XBPS_CROSS_BUILD" ]; then


### PR DESCRIPTION

- I tested the changes in this PR: YES
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
