### PR TITLE
powertop: update to 2.16

### DIFF
--- a/srcpkgs/powertop/template
+++ b/srcpkgs/powertop/template
@@ -1,19 +1,15 @@
 # Template file for 'powertop'
 pkgname=powertop
-version=2.15
-revision=2
-build_style=gnu-configure
-hostmakedepends="automake autoconf-archive gettext-devel libtool pkg-config"
-makedepends="ncurses-devel pciutils-devel libnl3-devel"
+version=2.16
+revision=1
+build_style=meson
+hostmakedepends="gettext-devel libtool pkg-config"
+makedepends="ncurses-devel pciutils-devel libnl3-devel libtracefs-devel libtraceevent-devel"
 short_desc="Tool to diagnose issues with power consumption and power management"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-only"
 homepage="https://github.com/fenrus75/powertop"
 distfiles="https://github.com/fenrus75/powertop/archive/refs/tags/v${version}.tar.gz"
-checksum=e58ab3fd7b8ff5f4dd0d17f11848817e7d83c0a6918145ac81de03b5dccf8f49
+checksum=cf37e565b958a64f1e3086daeab82d7959566a372d01d40d3904cbca95cdf3d2
 
 LDFLAGS="-lpthread"
-
-pre_configure() {
-	./autogen.sh
-}


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: YES
Upstream changed the build system to meson and added libtracefs and libtraceevent as dependencies.

#### Local build testing
- I built this PR locally for my native architecture: x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl (masterdir)
  - i686 (masterdir)
  - aarch64 (cross)
  - aarch64-musl (cross)
  - armv6l (cross)
  - armv6l-musl (cross)
  - armv7l (cross)
  - armv7l-musl (cross)

