### PR TITLE
gom: update to 0.5.6, adopt.

### DIFF
--- a/srcpkgs/gom/template
+++ b/srcpkgs/gom/template
@@ -1,12 +1,11 @@
 # Template file for 'gom'
 pkgname=gom
-version=0.4
-revision=7
+version=0.5.6
+revision=1
 build_style=meson
 build_helper="gir"
 configure_args="-Denable-introspection=$(vopt_if gir true false)
  -Denable-gtk-doc=false"
-pycompile_module="gi"
 hostmakedepends="pkg-config"
 makedepends="sqlite-devel gettext-devel libglib-devel gdk-pixbuf-devel
  $(vopt_if gir 'gobject-introspection python3-gobject-devel')"
@@ -14,8 +13,8 @@ short_desc="GObject Data Mapper"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="LGPL-2.1-or-later"
 homepage="https://wiki.gnome.org/Projects/Gom"
-distfiles="${GNOME_SITE}/${pkgname}/${version}/${pkgname}-${version}.tar.xz"
-checksum=68d08006aaa3b58169ce7cf1839498f45686fba8115f09acecb89d77e1018a9d
+distfiles="https://gitlab.gnome.org/GNOME/gom/-/archive/${version}/gom-${version}.tar.gz"
+checksum=0f091c15d06bed82bcac1d079a87e0bbab4f78f90ec135fdf71050b742d92f22
 
 # Package build options
 build_options="gir"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-libc) **YES**
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl **YES**
  - aarch64-libc **YES**
  - aarch64-musl **YES**


