### PR TITLE
bitwise: update to 0.70, adopt

### DIFF
--- a/srcpkgs/bitwise/patches/tests-use-bcunit.patch
+++ b/srcpkgs/bitwise/patches/tests-use-bcunit.patch
@@ -1,24 +1,22 @@
-diff '--color=auto' -ruN bitwise-v0.42/Makefile.in bitwise-v0.42_new/Makefile.in
---- a/Makefile.in	2021-04-16 17:21:30.000000000 +0200
-+++ b/Makefile.in	2021-04-17 09:36:46.661320033 +0200
-@@ -518,7 +518,7 @@
- 								   src/misc.c \
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -573,7 +573,7 @@
+ 				   src/misc.c src/compat.c \
                                     tests/test-shunting-yard.c
  
 -tests_test_shunting_yard_LDADD = -lcunit
 +tests_test_shunting_yard_LDADD = -lbcunit
- TESTS = $(check_PROGRAMS)
- all: all-am
- 
-diff '--color=auto' -ruN bitwise-v0.42/tests/test-shunting-yard.c bitwise-v0.42_new/tests/test-shunting-yard.c
---- a/tests/test-shunting-yard.c	2021-04-16 17:17:19.000000000 +0200
-+++ b/tests/test-shunting-yard.c	2021-04-17 09:36:46.660320033 +0200
+ @COND_FUZZER_TRUE@tests_fuzz_shunting_yard_SOURCES = src/shunting-yard.c inc/shunting-yard.h \
+ @COND_FUZZER_TRUE@                                   src/stack.c inc/stack.h inc/bitwise.h \
+ @COND_FUZZER_TRUE@				   src/misc.c src/compat.c \
+--- a/tests/test-shunting-yard.c
++++ b/tests/test-shunting-yard.c
 @@ -7,7 +7,7 @@
  
- #include "../inc/shunting-yard.h"
+ #include "shunting-yard.h"
  
 -#include <CUnit/Basic.h>
 +#include <BCUnit/Basic.h>
+ #include <stdint.h>
  #include <stdlib.h>
- 
- #define ASSERT_RESULT(expression, expected) \
+ #include <string.h>

--- a/srcpkgs/bitwise/template
+++ b/srcpkgs/bitwise/template
@@ -1,13 +1,14 @@
 # Template file for 'bitwise'
 pkgname=bitwise
-version=0.60
+version=0.70
 revision=1
 build_style=gnu-configure
 makedepends="ncurses-devel readline-devel"
 checkdepends="bcunit-devel"
 short_desc="Terminal based bit manipulator in ncurses"
-maintainer="Orphaned <orphan@voidlinux.org>"
+maintainer="Brandon Pribula <brandon.pribs11@gmail.com>"
 license="GPL-3.0-only"
 homepage="https://github.com/mellowcandle/bitwise"
+changelog="https://github.com/mellowcandle/bitwise/blob/master/ChangeLog"
 distfiles="${homepage}/releases/download/v${version}/bitwise-v${version}.tar.gz"
-checksum=0455a0eb67f3a33b727b94400d2cc826d11ed680aa5c96971fccbd5e20c2bfbd
+checksum=b8f41f49b9b73ac3abb1e7533a410504f759673fc6e7f35acf56fc82e39cdf37


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: YES

There were changes to Makefile.in so the patch needed to be updated.

#### Local build testing
- I built this PR locally for my native architecture: x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl (masterdir)
  - i686 (masterdir)
  - aarch64 (cross)
  - aarch64-musl (cross)
  - armv6l (cross)
  - armv6l-musl (cross)
  - armv7l (cross)
  - armv7l-musl (cross)

