### PR TITLE
vdirsyncer: generate man page, disable broken tests

### DIFF
--- a/srcpkgs/python3-plotly/template
+++ b/srcpkgs/python3-plotly/template
@@ -1,10 +1,10 @@
 # Template file for 'python3-plotly'
 pkgname=python3-plotly
 version=5.24.1
-revision=3
+revision=4
 build_style=python3-module
 hostmakedepends="python3-setuptools"
-depends="python3-six python3-requests python3-pytz python3-decorator python3-jupyter_nbformat python3-tenacity"
+depends="python3-six python3-requests python3-pytz python3-decorator python3-jupyter_nbformat python3-tenacity python3-packaging"
 short_desc="Python plotting library for collaborative, interactive graphs"
 maintainer="pulux <pulux@pf4sh.de>"
 license="MIT"

--- a/srcpkgs/python3-tenacity/template
+++ b/srcpkgs/python3-tenacity/template
@@ -1,15 +1,15 @@
 # Template file for 'python3-tenacity'
 pkgname=python3-tenacity
-version=8.2.2
-revision=4
+version=9.1.4
+revision=1
 build_style=python3-module
 hostmakedepends="python3-setuptools_scm python3-wheel"
-depends="python3-Sphinx python3-tornado python3-typeguard"
-checkdepends="python3-pytest ${depends}"
+depends="python3"
+checkdepends="python3-pytest python3-tornado python3-typeguard"
 short_desc="General-purpose retrying library for Python"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="Apache-2.0"
 homepage="https://github.com/jd/tenacity"
 changelog="https://tenacity.readthedocs.io/en/latest/changelog.html"
 distfiles="${PYPI_SITE}/t/tenacity/tenacity-${version}.tar.gz"
-checksum=43af037822bd0029025877f3b2d97cc4d7bb0c2991000a3d59d71517c5c969e0
+checksum=adb31d4c263f2bd041081ab33b498309a57c77f9acf2db65aadf0898179cf93a

--- a/srcpkgs/vdirsyncer/template
+++ b/srcpkgs/vdirsyncer/template
@@ -5,7 +5,7 @@ revision=2
 build_style=python3-pep517
 hostmakedepends="python3-setuptools_scm"
 depends="python3-click python3-click-log python3-requests python3-aiohttp
- python3-aiostream"
+ python3-aiostream python3-tenacity"
 checkdepends="python3-pytest-xdist python3-pytest-asyncio python3-trustme
  python3-aioresponses python3-pytest-httpserver python3-hypothesis
  python3-pytest-cov $depends"

--- a/srcpkgs/vdirsyncer/template
+++ b/srcpkgs/vdirsyncer/template
@@ -1,9 +1,10 @@
 # Template file for 'vdirsyncer'
 pkgname=vdirsyncer
-version=0.20.0
-revision=2
+version=0.21.0
+revision=1
 build_style=python3-pep517
-hostmakedepends="python3-setuptools_scm"
+make_check_args="--ignore=tests/storage/test_http.py --ignore=tests/storage/test_http_with_singlefile.py"
+hostmakedepends="python3-setuptools_scm python3-Sphinx"
 depends="python3-click python3-click-log python3-requests python3-aiohttp
  python3-aiostream python3-tenacity"
 checkdepends="python3-pytest-xdist python3-pytest-asyncio python3-trustme
@@ -15,9 +16,15 @@ license="BSD-3-Clause"
 homepage="https://vdirsyncer.pimutils.org/"
 changelog="https://github.com/pimutils/vdirsyncer/raw/main/CHANGELOG.rst"
 distfiles="${PYPI_SITE}/v/vdirsyncer/vdirsyncer-${version}.tar.gz"
-checksum=feb1a533500a95c14fd155733a1056fe359192553d82c07c6ba04fcbfc40b12d
+checksum=b6ac040b880da6758f65c17a369572f62e7323be8d21cd330c26fa134d1b1373
+
+post_build() {
+	PYTHONPATH="${PWD}/build/lib:$PYTHONPATH" \
+		sphinx-build -b man docs/ build/
+}
 
 post_install() {
+	vman build/vdirsyncer.1
 	vsconf config.example
 	vlicense LICENSE
 }


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
#### Notes
The HTTP storage tests mock requests via aioresponses, which does not pass the stream_writer keyword argument required by aiohttp >= 3.10.2, so every mocked response fails with:
```
TypeError: ClientResponse.__init__() missing 1 required
keyword-only argument: 'stream_writer'
```
aioresponses upstream has no release with the fix yet (https://github.com/pnuckowski/aioresponses/pull/288). Re-enable these tests once a compatible aioresponses release is packaged (or if vdirsyncer upstream switches to [aioresponses-ng](https://github.com/MountainGod2/aioresponses-ng)).