### PR TITLE
dnsrecon related updates

### DIFF
--- a/srcpkgs/python3-annotated_doc/template
+++ b/srcpkgs/python3-annotated_doc/template
@@ -1,16 +1,16 @@
 # Template file for 'python3-annotated_doc'
 pkgname=python3-annotated_doc
-version=0.0.4
+version=0.0.5
 revision=1
 build_style=python3-pep517
 hostmakedepends="python3-pdm-backend"
+checkdepends="python3-pytest python3-smokeshow"
 short_desc="Document parameters, class attributes, return types, variables inline"
 maintainer="Jason Elswick <jason@jasondavid.us>"
 license="MIT"
 homepage="https://github.com/fastapi/annotated-doc"
 distfiles="https://github.com/fastapi/annotated-doc/archive/refs/tags/${version}.tar.gz"
-checksum=f23767d1df005c26f25a1fc203d89b5d46b75a120227c97dd1094d1e16733336
-make_check=no # unpackaged dependency python3-smokeshow
+checksum=b1df640b7d5658b8d3807b42d51291ed3f24e43d4a059092c11495a3f7714fc9
 
 post_install() {
 	vlicense LICENSE

--- a/srcpkgs/python3-fastapi/template
+++ b/srcpkgs/python3-fastapi/template
@@ -1,6 +1,6 @@
 # Template file for 'python3-fastapi'
 pkgname=python3-fastapi
-version=0.139.2
+version=0.141.1
 revision=1
 build_style=python3-pep517
 hostmakedepends="python3-pdm-backend"
@@ -10,7 +10,7 @@ maintainer="Jason Elswick <jason@jasondavid.us>"
 license="MIT"
 homepage="https://github.com/FastAPI/FastAPI"
 distfiles="https://github.com/fastapi/fastapi/archive/refs/tags/${version}.tar.gz"
-checksum=870e849818e04f533fa7dec8537026b4af24feb137a18b8c3e195a1dc923bc6d
+checksum=c52580c47877162cffe6f880430fa9e5d84caf232258be26cde5e63e85eb0d6a
 make_check=no # too many unpackaged dependencies
 
 post_install() {

--- a/srcpkgs/python3-smokeshow/template
+++ b/srcpkgs/python3-smokeshow/template
@@ -1,0 +1,21 @@
+# Template file for 'python3-smokeshow'
+pkgname=python3-smokeshow
+version=0.5
+revision=1
+build_style=python3-pep517
+build_wrksrc=cli
+make_check_args="--deselect tests/test_cli.py::test_upload_error --deselect tests/test_cli.py::test_upload_http_error"
+hostmakedepends="hatchling"
+depends="python3-httpx python3-typer"
+checkdepends="${depends} python3-pytest python3-pytest-mock python3-dirty-equals python3-aiohttp"
+short_desc="CLI to deploy ephemeral websites"
+maintainer="Jason Elswick <jason@jasondavid.us>"
+license="MIT"
+homepage="https://smokeshow.helpmanual.io"
+changelog="https://github.com/samuelcolvin/smokeshow/releases"
+distfiles="https://github.com/samuelcolvin/smokeshow/archive/refs/tags/v${version}.tar.gz"
+checksum=e5383dd7b3c1db14204ad251b58a77ee459f3096fb78e2927b707fbf43d8ab50
+
+post_install() {
+	vlicense LICENSE
+}

--- a/srcpkgs/python3-typer/template
+++ b/srcpkgs/python3-typer/template
@@ -1,0 +1,20 @@
+# Template file for 'python3-typer'
+pkgname=python3-typer
+version=0.27.2
+revision=1
+build_style=python3-pep517
+make_check_args="--deselect tests/test_tutorial --deselect tests/test_types_file.py::test_file_error --deselect tests/test_types_file.py::test_binary_stderr"
+hostmakedepends="python3-pdm-backend"
+depends="python3-click python3-rich python3-shellingham python3-typing_extensions python3-annotated_doc"
+checkdepends="${depends} python3-pytest python3-pytest-cov python3-pytest-xdist python3-pytest-sugar python3-mypy"
+short_desc="Build great CLIs - Based on Python type hints"
+maintainer="Jason Elswick <jason@jasondavid.us>"
+license="MIT"
+homepage="https://github.com/fastapi/typer"
+distfiles="https://github.com/fastapi/typer/archive/refs/tags/${version}.tar.gz"
+checksum=0f57d0e366c328c7c6fd636c7d9aa49d25f08fa79c9de642038a8877c81e55c9
+
+post_install() {
+	vlicense LICENSE
+	mv "${DESTDIR}/usr/bin/typer" "${DESTDIR}/usr/bin/python-typer"
+}


### PR DESCRIPTION
- **python3-fastapi: update to 0.141.1.**
- **python3-annotated_doc: update to 0.0.5, add tests.**
- **New package: python3-typer-0.27.2**
- **New package: python3-smokeshow-0.5**

#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-libc

Interestingly dnsrecon itself cannot be updated right now due to setuptools still being on 80.x.
