### PR TITLE
asahi-uboot: update to 2026.07

### DIFF
--- a/srcpkgs/asahi-uboot/template
+++ b/srcpkgs/asahi-uboot/template
@@ -1,6 +1,6 @@
 # Template file for 'asahi-uboot'
 pkgname=asahi-uboot
-version=2026.04+2
+version=2026.07+3
 revision=1
 archs="aarch64*"
 hostmakedepends="bison flex which python3 swig python3-devel
@@ -13,7 +13,7 @@ maintainer="dkwo <npiazza@disroot.org>, Will Springer <skirmisher@protonmail.com
 license="GPL-2.0-or-later, MIT"
 homepage="https://asahilinux.org"
 distfiles="https://github.com/AsahiLinux/u-boot/archive/refs/tags/asahi-v${version/+/-}.tar.gz"
-checksum=b3cdcc467afbf6737ad7c87d174daa8eb0dcc212feb275ee56c406c1e084768c
+checksum=87c73f6e925b1f200dabda00cfcd78fc618806cadbfa00dcf130401b83ff92a7
 make_check=no # missing python3-libfdt ?
 
 if [ "${CROSS_BUILD}" ]; then


### PR DESCRIPTION
- I tested the changes in this PR: **YES**
- I built this PR locally for my native architecture, (aarch64-gnu).