### PR TITLE
tokei: update to 15.0.0, second attempt

### DIFF
--- a/srcpkgs/tokei/template
+++ b/srcpkgs/tokei/template
@@ -1,6 +1,6 @@
 # Template file for 'tokei'
 pkgname=tokei
-version=14.0.0
+version=15.0.0
 revision=1
 build_style=cargo
 configure_args="--features=all"
@@ -9,8 +9,9 @@ short_desc="Count lines of code"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="Apache-2.0 OR MIT"
 homepage="https://github.com/XAMPPRocky/tokei"
+changelog="https://raw.githubusercontent.com/XAMPPRocky/tokei/refs/heads/master/CHANGELOG.md"
 distfiles="https://github.com/XAMPPRocky/tokei/archive/refs/tags/v${version}.tar.gz"
-checksum=4e561dbb83ef1b46359714fc623fd45eddfb14821ece63a219470500fdd1cd26
+checksum=966da7b9a81ac6cb777b9f159f4c02e5b83a8b8bd30ebf5991007839926b600c
 
 post_install() {
 	vlicense LICENCE-APACHE


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: YES

#### Local build testing
- I built this PR locally for my native architecture: x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl (masterdir)
  - i686 (masterdir)

