### PR TITLE
Converseen: update to 0.15.2.8

### DIFF
--- a/srcpkgs/Converseen/template
+++ b/srcpkgs/Converseen/template
@@ -1,6 +1,6 @@
 # Template file for 'Converseen'
 pkgname=Converseen
-version=0.15.2.7
+version=0.15.2.8
 revision=1
 build_style=cmake
 configure_args="-DUSE_QT6=yes -Wunused-result=yes"
@@ -10,6 +10,6 @@ short_desc="Free batch image processor"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-3.0-or-later"
 homepage="https://github.com/Faster3ck/Converseen"
-changelog="https://github.com/Faster3ck/Converseen/blob/main/CHANGELOG"
+changelog="https://raw.githubusercontent.com/Faster3ck/Converseen/refs/heads/main/CHANGELOG"
 distfiles="https://github.com/Faster3ck/Converseen/archive/refs/tags/v${version}.tar.gz"
-checksum=1e2be90695f802e038c385346c19fd438185aac4eda83124af71fbc2854871f2
+checksum=bb29870f5d69aa8decb462aba67365f84cccda45a3a5225d8d3638979bc2b8bf


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: YES

#### Local build testing
- I built this PR locally for my native architecture: x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl (masterdir)
  - i686 (masterdir)
  - aarch64 (cross)
  - aarch64-musl (cross)
  - armv6l (cross)
  - armv6l-musl (cross)
  - armv7l (cross)
  - armv7l-musl (cross)

