### PR TITLE
llvm19: backport a fix for const analysis crash on fp128

### DIFF
--- a/srcpkgs/llvm19/patches/llvm-007-constantfolding-null-tli-fp128.patch
+++ b/srcpkgs/llvm19/patches/llvm-007-constantfolding-null-tli-fp128.patch
@@ -1,0 +1,17 @@
+Backport of upstream commit 83a5c7cb62e404a713a35445b755cf0109650279
+"[ConstantFolding] Ensure TLI is valid when simplifying fp128 intrinsics"
+
+The inliner's cost analysis calls ConstantFoldCall without a TargetLibraryInfo.
+When the host build has logf128, the fp128 folding path dereferences TLI and segfaults.
+
+--- a/llvm/lib/Analysis/ConstantFolding.cpp
++++ b/llvm/lib/Analysis/ConstantFolding.cpp
+@@ -2124,7 +2124,7 @@
+       }
+ 
+       LibFunc Fp128Func = NotLibFunc;
+-      if (TLI->getLibFunc(Name, Fp128Func) && TLI->has(Fp128Func) &&
++      if (TLI && TLI->getLibFunc(Name, Fp128Func) && TLI->has(Fp128Func) &&
+           Fp128Func == LibFunc_logl)
+         return ConstantFoldFP128(logf128, Op->getValueAPF(), Ty);
+     }

--- a/srcpkgs/llvm19/template
+++ b/srcpkgs/llvm19/template
@@ -1,7 +1,7 @@
 # Template file for 'llvm19'
 pkgname=llvm19
 version=19.1.4
-revision=8
+revision=9
 build_wrksrc=llvm
 build_style=cmake
 _llvm_prefix=lib/llvm/19


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly** (the repro below compiles with this patch)

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl (cross)
  - aarch64-glibc (cross)

#### Summary
This fix was not backported to LLVM 19 and only landed in `20.1.0-rc1`: https://github.com/llvm/llvm-project/commit/83a5c7cb62e404a713a35445b755cf0109650279

A simple repro that triggers this bug, compiled with `clang-19 -O1 -c repro.c`:
```c
__float128 f128_abs(__float128 x) { return __builtin_fabsf128(x); }

__float128 caller(void) { return f128_abs(0); }
```
cc @Calandracas606 

[skip ci]