### PR TITLE
mdp: update to 1.0.19

### DIFF
--- a/srcpkgs/mdp/template
+++ b/srcpkgs/mdp/template
@@ -1,6 +1,6 @@
 # Template file for 'mdp'
 pkgname=mdp
-version=1.0.18
+version=1.0.19
 revision=1
 build_style=gnu-makefile
 makedepends="ncurses-devel"
@@ -9,4 +9,10 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-3.0-or-later"
 homepage="https://github.com/visit1985/mdp"
 distfiles="https://github.com/visit1985/mdp/archive/refs/tags/${version}.tar.gz"
-checksum=36861161513c508c0589014510cdafd940a6e661e517022a3bea48ecf8d5fac4
+checksum=4043838ff3048a5234ea6e24ab42301ab78ff3f51ed6ba19c0c4711414f6a74a
+
+pre_build() {
+	if [ -e ${FILESDIR}/config.h ]; then
+		cp ${FILESDIR}/config.h include/config.h
+	fi
+}


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: YES

I added a pre_build function that will copy over a config.h file if one is found.

#### Local build testing
- I built this PR locally for my native architecture: x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl (masterdir)
  - i686 (masterdir)
  - aarch64 (cross)
  - aarch64-musl (cross)
  - armv6l (cross)
  - armv6l-musl (cross)
  - armv7l (cross)
  - armv7l-musl (cross)

