### PR TITLE
tombi: update to 1.5.2.

### DIFF
--- a/srcpkgs/tombi/template
+++ b/srcpkgs/tombi/template
@@ -1,6 +1,6 @@
 # Template file for 'tombi'
 pkgname=tombi
-version=1.2.0
+version=1.5.2
 revision=1
 build_style=cargo
 build_wrksrc="rust/tombi-cli"
@@ -11,7 +11,7 @@ license="MIT"
 homepage="https://tombi-toml.github.io/tombi/"
 changelog="https://github.com/tombi-toml/tombi/releases"
 distfiles="https://github.com/tombi-toml/tombi/archive/refs/tags/v${version}.tar.gz"
-checksum=207dd1e3febd28a970f99da140f375d60fd838d0017e0f641648b6b5b77cbc3f
+checksum=8090dafdc32a4e1cb8d7330a4ce87ed916da25155ec6957555e6da68827a502d
 
 export __TOMBI_VERSION=${version}
 export __TOMBI_TARGET_TRIPLE=${XBPS_RUST_TARGET}


### PR DESCRIPTION

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
