### PR TITLE
ruby-tmuxinator: make tmuxinator use system ruby

### DIFF
--- a/srcpkgs/ruby-tmuxinator/template
+++ b/srcpkgs/ruby-tmuxinator/template
@@ -1,7 +1,7 @@
 # Template file for 'ruby-tmuxinator'
 pkgname=ruby-tmuxinator
 version=3.4.1
-revision=1
+revision=2
 build_style=gemspec
 depends="ruby-erubi>=1.13 ruby-thor>=1.4.0 tmux"
 short_desc="Create and manage complex tmux sessions easily"
@@ -11,6 +11,10 @@ homepage="https://github.com/tmuxinator/tmuxinator"
 changelog="https://raw.githubusercontent.com/tmuxinator/tmuxinator/master/CHANGELOG.md"
 distfiles="https://github.com/tmuxinator/tmuxinator/archive/refs/tags/v${version}.tar.gz"
 checksum=090589171e15f92d00b544c4f7fd23cf042468d813204e25951ebf45f6057548
+
+pre_configure() {
+	vsed -i bin/tmuxinator -e '1s|/usr/bin/env ruby|/usr/bin/ruby|'
+}
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)

The reason for this PR is that tools like `mise`, `rbenv`, etc. change `PATH` and `tmuxinator` may use shims, which may lack needed gems.