### PR TITLE
unifdef: update to 2.12, adopt

### DIFF
--- a/srcpkgs/unifdef/template
+++ b/srcpkgs/unifdef/template
@@ -1,14 +1,14 @@
 # Template file for 'unifdef'
 pkgname=unifdef
-version=2.11
-revision=2
+version=2.12
+revision=1
 build_style=gnu-makefile
 short_desc="Selectively remove C preprocessor conditionals"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="BSD-2-Clause"
 homepage="http://dotat.at/prog/unifdef/"
 distfiles="${homepage}/unifdef-${version}.tar.xz"
-checksum=828ffc270ac262b88fe011136acef2780c05b0dc3c5435d005651740788d4537
+checksum=43ce0f02ecdcdc723b2475575563ddb192e988c886d368260bc0a63aee3ac400
 
 post_install() {
 	vlicense COPYING


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: YES

#### Local build testing
- I built this PR locally for my native architecture: x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl (masterdir)
  - i686 (masterdir)
  - aarch64 (cross)
  - aarch64-musl (cross)
  - armv6l (cross)
  - armv6l-musl (cross)
  - armv7l (cross)
  - armv7l-musl (cross)

