### PR TITLE
rink: update to 0.9.0

### DIFF
--- a/srcpkgs/rink/template
+++ b/srcpkgs/rink/template
@@ -1,18 +1,29 @@
 # Template file for 'rink'
 pkgname=rink
-version=0.8.0
+version=0.9.0
 revision=1
 build_style=cargo
 make_install_args="--path cli"
-hostmakedepends="pkg-config"
-makedepends="openssl-devel"
+hostmakedepends="pkg-config ruby-asciidoctor"
+makedepends="libcurl-devel openssl-devel"
 short_desc="Unit-aware calculator and conversion tool"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="MPL-2.0, GPL-3.0-only"
-homepage="https://github.com/tiffany352/rink-rs"
-changelog="https://github.com/tiffany352/rink-rs/releases"
-distfiles="https://github.com/tiffany352/rink-rs/archive/refs/tags/v${version}.tar.gz"
-checksum=40048e84c2b606e50bf05dec2813acedeb48066cd48537d0dea453a72d000d60
+homepage="https://codeberg.org/tiffany/rink"
+changelog="https://codeberg.org/tiffany/rink/releases"
+distfiles="https://codeberg.org/tiffany/rink/archive/v${version}.tar.gz"
+checksum=1b00544f382d09b21365819305ccc7693812c1a3e039a01078907ac8ea9c8532
+
+post_install() {
+	for i in rink-dates.5 rink-defs.5 rink.1 rink.5 rink.7
+	do
+		asciidoctor -b manpage docs/$i.adoc
+		vman docs/$i
+	done
+
+	vinstall cli/rink.desktop 644 usr/share/applications
+	vinstall web/site/favicon.png 644 usr/share/pixmaps rink.png
+}
 
 case "$XBPS_TARGET_MACHINE" in
 	ppc64le*) ;;


### PR DESCRIPTION
(See the commit message for a description of the other changes).

I wanted to install the unit definitions to a separate file (instead of bundling them into the executable), as suggested in the [packaging guide](https://codeberg.org/tiffany/rink/src/tag/v0.9.0/PACKAGING.md#manual-packaging), but that causes the tests to fail.

In the install phase, it reports that two dependencies are yanked but those are only used in rink's web interface, which is not installed.

I am unsure if the choice of `changelog` is a good one, as it does not contain the actual changes.

I don't know if the build is still broken for big-endian PPC64.

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl (crossbuild)
  - armv7l (crossbuild)
  - armv6l-musl (crossbuild)