### PR TITLE
awesome: add DesktopNames and xdg-desktop-portal config support under…

### DIFF
--- a/srcpkgs/awesome/files/awesome-portals.conf
+++ b/srcpkgs/awesome/files/awesome-portals.conf
@@ -1,0 +1,2 @@
+[preferred]
+default=gtk;

--- a/srcpkgs/awesome/patches/awesome-desktop-names.patch
+++ b/srcpkgs/awesome/patches/awesome-desktop-names.patch
@@ -1,0 +1,6 @@
+--- a/awesome.desktop
++++ b/awesome.desktop
+@@ -5,3 +5,4 @@ TryExec=awesome
+ Exec=awesome
+ Type=Application
++DesktopNames=awesome;

--- a/srcpkgs/awesome/template
+++ b/srcpkgs/awesome/template
@@ -1,7 +1,7 @@
 # Template file for 'awesome'
 pkgname=awesome
 version=4.3
-revision=10
+revision=11
 build_style=cmake
 build_helper="qemu"
 configure_args="-DSYSCONFDIR=/etc"
@@ -50,4 +50,9 @@ pre_configure() {
 		vsed -e 's|LUA_COV_RUNNER lua\b|LUA_COV_RUNNER luajit|' \
 			-i tests/examples/CMakeLists.txt
 	fi
+}
+
+post_install() {
+	vmkdir usr/share/xdg-desktop-portal
+	vinstall ${FILESDIR}/awesome-portals.conf 644 usr/share/xdg-desktop-portal
 }


### PR DESCRIPTION
… awesomewm.

awesome: add DesktopNames and xdg-desktop-portal config

awesome does not currently set DesktopNames in its xsessions .desktop
entry, so XDG_CURRENT_DESKTOP is never set in the session. As a result,
xdg-desktop-portal finds no portal configuration for the session and
flatpak applications cannot use portals (OpenURI, FileChooser, etc.),
which breaks e.g. opening links from sandboxed applications.

This commit:

- adds DesktopNames=awesome; to awesome.desktop (patch), so
  XDG_CURRENT_DESKTOP=awesome is set at login;
- ships /usr/share/xdg-desktop-portal/awesome-portals.conf
  (post_install + files/), selecting xdg-desktop-portal-gtk as the
  default backend:

      [preferred]
      default=gtk;

Testing:
- built with ./xbps-src pkg awesome and installed from hostdir/binpkgs
- after re-login, xdg-desktop-portal loads gtk.portal for awesome and
  xdg-open inside a flatpak sandbox opens URLs on the host as expected.

Note for users: the D-Bus session bus must receive the session
environment for portal backends to start (on setups where the bus is
started before X, e.g. dbus-update-activation-environment --all at
session start). This is session configuration, outside the scope of
this change.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
