### PR TITLE
libinput: install lua plugin examples w/ vsconf

### DIFF
--- a/srcpkgs/libinput/template
+++ b/srcpkgs/libinput/template
@@ -2,7 +2,7 @@
 # keep in sync with libinput-debug-gui
 pkgname=libinput
 version=1.31.3
-revision=1
+revision=2
 build_style=meson
 configure_args="-Db_ndebug=false -Ddebug-gui=false"
 hostmakedepends="pkg-config"
@@ -27,9 +27,7 @@ post_install() {
 	vlicense COPYING
 
 	local p
-	for p in plugins/*.lua; do
-		vinstall $p 0644 usr/lib/libinput/plugins
-	done
+	for p in plugins/*.lua; do vsconf $p; done
 }
 
 libinput-devel_package() {


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, **x86_64-glibc**

Example plugin examples:

<details>
<summary>10-logitech-mx-master-horiz-scroll.lua</summary>

```
-- SPDX-License-Identifier: MIT
--
-- This plugin inverts the horizontal scroll direction of
-- the Logitech MX Master mouse. OOTB the mouse scrolls
-- in the opposite direction to all other mice out there.
--
-- This plugin is only needed when the mouse is connected
-- to the Logitech Bolt receiver - on that receiver we cannot
-- tell which device is connected.
--
-- For the Logitech Unifying receiver and Bluetooth please
-- add the ModelInvertHorizontalScrolling=1 quirk
-- in quirks/30-vendor-logitech.quirks.
--
--
-- Install this file in /etc/libinput/plugins and
--
-- UNCOMMENT THIS LINE TO ACTIVATE THE PLUGIN
-- libinput:register({1})
libinput:connect("new-evdev-device", function (device)
    local info = device:info()
    if info.vid == 0x046D and info.pid == 0xC548 then
        device:connect("evdev-frame", function (device, frame, timestamp)
            for _, event in ipairs(frame) do
                if event.usage == evdev.REL_HWHEEL or event.usage == evdev.REL_HWHEEL_HI_RES then
                    event.value = -event.value
                end
            end
            return frame
        end)
    end
end)
```

</details>
<details>
<summary>10-wheel-to-button.lua</summary>

```
-- SPDX-License-Identifier: MIT
--
-- This is an example libinput plugin
--
-- This plugin maps a downwards mouse wheel to a button down event and
-- an upwards wheel movement to a button up event.

-- UNCOMMENT THIS LINE TO ACTIVATE THE PLUGIN
-- libinput:register({1})

-- The button we want to press on wheel events
local wheel_button = evdev.BTN_EXTRA
local button_states = {}

local function evdev_frame(device, frame, timestamp)
    local events = {}
    local modified = false

    for _, v in ipairs(frame) do
        if v.usage == evdev.REL_WHEEL then
            -- REL_WHEEL is inverted, neg value -> down, pos value -> up
            if v.value < 0 then
                if not button_states[device] then
                    table.insert(events, { usage = wheel_button, value = 1 })
                    button_states[device] = true
                end
            else
                if button_states[device] then
                    table.insert(events, { usage = wheel_button, value = 0 })
                    button_states[device] = false
                end
            end
            modified = true
        -- Because REL_WHEEL is no longer a wheel, the high-res
        -- events are dropped
        elseif v.usage == evdev.REL_WHEEL_HI_RES then
            modified = true
        else
            table.insert(events, v)
        end
    end

    if modified then
        return events
    else
        return nil
    end
end

local function device_new(device)
    local usages = device:usages()
    if usages[evdev.REL_WHEEL] then
        button_states[device] = false
        if not usages[wheel_button] then
            device:enable_evdev_usage(wheel_button)
        end
        device:connect("evdev-frame", evdev_frame)
        device:connect("device-removed", function(dev)
            button_states[dev] = nil
        end)
    end
end

libinput:connect("new-evdev-device", device_new)
```

</details>

Installing them directly into `/etc/libinput/plugins` instead, would produce the same error messages, obviously