### PR TITLE
hstr: update to 3.2

### DIFF
--- a/srcpkgs/hstr/template
+++ b/srcpkgs/hstr/template
@@ -1,6 +1,6 @@
 # Template file for 'hstr'
 pkgname=hstr
-version=3.1
+version=3.2
 revision=1
 build_style=gnu-configure
 hostmakedepends="automake pkg-config"
@@ -10,8 +10,8 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="Apache-2.0"
 homepage="https://github.com/dvorka/hstr"
 changelog="https://raw.githubusercontent.com/dvorka/hstr/master/Changelog"
-distfiles="https://github.com/dvorka/hstr/archive/refs/tags/${version}.tar.gz"
-checksum=e5293d4fe2502662f19c793bef416e05ac020490218e71c75a5e92919c466071
+distfiles="https://github.com/dvorka/hstr/archive/refs/tags/v${version}.tar.gz"
+checksum=bceab1cb3c3b636d9ff4dfbaf8b035530e76a36d948767ed1735c4e79d7473eb
 
 pre_configure() {
 	vsed -i 's|ncursesw/curses.h|curses.h|g' src/include/hstr.h src/include/hstr_curses.h


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: YES

#### Local build testing
- I built this PR locally for my native architecture: x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl (masterdir)
  - i686 (masterdir)
  - aarch64 (cross)
  - aarch64-musl (cross)
  - armv6l (cross)
  - armv6l-musl (cross)
  - armv7l (cross)
  - armv7l-musl (cross)
