### PR TITLE
cryptsetup: update to 2.8.8

### DIFF
--- a/srcpkgs/cryptsetup/template
+++ b/srcpkgs/cryptsetup/template
@@ -1,6 +1,6 @@
 # Template file for 'cryptsetup'
 pkgname=cryptsetup
-version=2.8.7
+version=2.8.8
 revision=1
 build_style=gnu-configure
 configure_args="--with-crypto_backend=openssl --disable-asciidoc
@@ -16,7 +16,7 @@ license="GPL-2.0-or-later"
 homepage="https://gitlab.com/cryptsetup/cryptsetup"
 changelog="https://gitlab.com/cryptsetup/cryptsetup/raw/master/docs/v${version}-ReleaseNotes"
 distfiles="${KERNEL_SITE}/utils/cryptsetup/v${version%.*}/cryptsetup-${version}.tar.xz"
-checksum=e776f0d381e86ca61042c457069491fe8e0ac286780c7c3b1e4f9921abc961da
+checksum=3acfa685f2dd7fcc832e0b77bc7093aa7da554a51ce8dafbb4138eaa854eee35
 subpackages="libcryptsetup cryptsetup-devel"
 build_options="pwquality"
 desc_option_pwquality="Enable support for checking password quality via libpwquality"


### PR DESCRIPTION
- I tested the changes in this PR: **YES**
- I built this PR locally for my native architecture, (aarch64-gnu)

cc @daniel-eys 