### PR TITLE
logisim-evolution: update to 5.0.0.

### DIFF
--- a/srcpkgs/logisim-evolution/patches/gradle.patch
+++ b/srcpkgs/logisim-evolution/patches/gradle.patch
@@ -1,0 +1,24 @@
+From 26ccdf7afede017f388608e45c96683e43ea474f Mon Sep 17 00:00:00 2001
+From: Voidbert <humbertogilgomes@protonmail.com>
+Date: Sat, 12 Sep 2026 16:14:55 +0100
+Subject: [PATCH] Fix build on older Gradle versions
+
+---
+ build.gradle.kts | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/build.gradle.kts b/build.gradle.kts
+index 481b7a4b9..c59b3e138 100644
+--- a/build.gradle.kts
++++ b/build.gradle.kts
+@@ -21,7 +21,7 @@ plugins {
+   id("io.github.ben-manes.versions") version "0.61.0"
+   java
+   application
+-  id("com.gradleup.shadow") version "9.6.1"
++  id("com.gradleup.shadow") version "9.3.1"
+   id("org.sonarqube") version "7.5.0.8588"
+ }
+ 
+-- 
+2.55.0

--- a/srcpkgs/logisim-evolution/template
+++ b/srcpkgs/logisim-evolution/template
@@ -1,6 +1,6 @@
 # Template file for 'logisim-evolution'
 pkgname=logisim-evolution
-version=4.1.0
+version=5.0.0
 revision=1
 hostmakedepends="openjdk21 gradle"
 depends="openjdk21-jre"
@@ -8,9 +8,9 @@ short_desc="Digital logic design tool and simulator"
 maintainer="voidbert <humbertogilgomes@protonmail.com>"
 license="GPL-3.0-or-later"
 homepage="https://github.com/logisim-evolution/logisim-evolution"
-changelog="https://github.com/logisim-evolution/logisim-evolution/raw/master/CHANGES.md"
+changelog="https://github.com/logisim-evolution/logisim-evolution/raw/main/CHANGES.md"
 distfiles="https://github.com/logisim-evolution/logisim-evolution/archive/refs/tags/v${version}.tar.gz"
-checksum=1e659781d19492b7d8c0710e5802f827ed1acf33cedf77a7cb605a42d4e5560c
+checksum=f988340da25e65ae3e8e8b29e6b16b4014661ed730a8952fc5c618337828f9ca
 
 do_build() {
 	. /etc/profile.d/jdk.sh


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-musl)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64

#### Patch notes

To support Gradle 8.11.1, the current version on Void's repos, the `com.gradleup.shadow` library must be downgraded. I used the version on Logisim 4.1, which was known to be working.

For `gradlew` use (or for future Gradle updates), https://github.com/gradle/gradle/issues/32262 may become a problem.