### PR TITLE
cproto: update to 4.8a

### DIFF
--- a/srcpkgs/cproto/template
+++ b/srcpkgs/cproto/template
@@ -1,6 +1,6 @@
 # Template file for 'cproto'
 pkgname=cproto
-version=4.7v
+version=4.8a
 revision=1
 build_style=gnu-configure
 hostmakedepends="flex"
@@ -10,4 +10,4 @@ license="Public Domain"
 homepage="https://invisible-island.net/cproto/cproto.html"
 changelog="https://invisible-island.net/cproto/CHANGES"
 distfiles="https://invisible-island.net/archives/cproto/cproto-${version}.tgz"
-checksum=f3dec3f6102770196976459c4b44ac27355f6120da76e5231ec1323e379d1511
+checksum=beb121e08c0d47b5bd719071c32a77edcc31dff992a84e3d9a59c0f7ec9fadd3


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: YES

#### Local build testing
- I built this PR locally for my native architecture: x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl (masterdir)
  - i686 (masterdir)
  - aarch64 (cross)
  - aarch64-musl (cross)
  - armv6l (cross)
  - armv6l-musl (cross)
  - armv7l (cross)
  - armv7l-musl (cross)

