### PR TITLE
winegui: update to 4.4.0

### DIFF
--- a/srcpkgs/winegui/template
+++ b/srcpkgs/winegui/template
@@ -1,19 +1,19 @@
 # Template file for 'winegui'
 pkgname=winegui
-version=4.2.1
+version=4.4.0
 revision=1
 archs="i686* x86_64*"
 build_style=cmake
 configure_args="-DCHECK_FOR_UPDATE=OFF"
 hostmakedepends="pkg-config"
 makedepends="gtkmm4-devel json-c++"
-depends="wine wget unzip 7zip cabextract zenity tar xz"
+depends="wine wget unzip 7zip cabextract zenity tar xz python3"
 short_desc="User-friendly WINE manager"
 maintainer="Melroy van den Berg <melroy@melroy.org>"
 license="AGPL-3.0-only"
 homepage="https://gitlab.melroy.org/melroy/winegui"
 distfiles="https://github.com/winegui/WineGUI/releases/download/v${version}/WineGUI-Source-v${version}.tar.gz"
-checksum=96ca36e776ea48e1182becf3ad6fabb58b9c51981d9abef2308145fe813390a7
+checksum=69d2ef640d2fd67f18cb9f26fb2c93c903a84c0aa7c484353d58cac314fecfca
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc

ps. `python3` is needed due to the [UMU launcher](https://github.com/Open-Wine-Components/umu-launcher) dependency in case users want to use a GE-Proton wine bottle.
