### PR TITLE
croc: update to 11.5.2

### DIFF
--- a/srcpkgs/croc/template
+++ b/srcpkgs/croc/template
@@ -1,15 +1,16 @@
 # Template file for 'croc'
 pkgname=croc
-version=10.4.14
+version=11.5.2
 revision=1
 build_style=go
 go_import_path="github.com/schollz/croc/v${version%%.*}"
+hostmakedepends="go>=1.27"
 short_desc="Easily and securely send things from one computer to another"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
 homepage="https://github.com/schollz/croc"
 distfiles="https://github.com/schollz/croc/archive/refs/tags/v${version}.tar.gz"
-checksum=3280b690b81520837e4b17bbc4fa3116ad8d534229e4d8ec2bdf017a2ca7755a
+checksum=2ceddb504be8b5912f4a3bfd76dc28bb18afda54191f2bebcf5b0fb24e63f774
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
update croc to 11.5.2 for the recent security fixes. I recomend landing this after go 1.27 is available; the current toolchain is 1.26.5.

updated the checksum and minimum build dependency. xlint and shell syntax checks pass; an xbps-src build and runtime test are still needed.
